### PR TITLE
feat(leads): a board for triage, moving a lead between the two live statuses

### DIFF
--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -4,8 +4,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Button, SegmentedControl } from "./atoms";
 import {
-  type BoardColumn,
   type BoardDeal,
+  type BoardMoneyColumn,
   PipelineBoard,
   RecordView,
   type TimelineEntry,
@@ -172,7 +172,7 @@ function boardDeal(
   };
 }
 
-const boardColumns: BoardColumn[] = [
+const boardColumns: BoardMoneyColumn[] = [
   {
     stage: "discovery",
     label: "Discovery",

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";
 import {
-  type BoardColumn,
+  type BoardMoneyColumn,
   DealCard,
   MorningBriefItem,
   PipelineBoard,
@@ -90,7 +90,7 @@ describe("DealCard + PipelineBoard", () => {
   });
 
   it("board columns render probability, count, raw and weighted sub-lines", () => {
-    const column: BoardColumn = {
+    const column: BoardMoneyColumn = {
       stage: "proposal",
       label: "Proposal",
       probabilityPct: 40,
@@ -110,7 +110,7 @@ describe("DealCard + PipelineBoard", () => {
   // the stage's TRUE count from a server aggregate — it must render that,
   // not deals.length, whenever the two disagree.
   it("renders the column's own count over deals.length when the two disagree", () => {
-    const column: BoardColumn = {
+    const column: BoardMoneyColumn = {
       stage: "proposal",
       label: "Proposal",
       probabilityPct: 40,

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -94,19 +94,6 @@ export type BoardDeal = {
 export type BoardColumn = {
   stage: string;
   label: string;
-  /**
-   * The money header, and the reason it is optional rather than zeroed.
-   *
-   * A board whose columns carry no money — leads by status, where a column has
-   * a count and nothing else — would otherwise have to pass `0` for each of
-   * these, and a zero total reads as "this stage is worth nothing" rather than
-   * "this board is not about money". `variant: "plain"` omits the figures
-   * entirely; these four are then unread.
-   */
-  probabilityPct?: number;
-  rawMinor?: number;
-  weightedMinor?: number;
-  currency?: string;
   deals: BoardDeal[];
   /**
    * The stage's true deal count, independent of how many `deals` (cards)
@@ -123,6 +110,21 @@ export type BoardColumn = {
    * zero that reads as an empty stage.
    */
   sumHidden?: boolean;
+};
+
+/**
+ * A column on a MONEY board: the stage's figures, which its header states.
+ *
+ * Separate from the base rather than four optional fields on it, because
+ * optional is not what these are — a deal column without them renders
+ * `undefined%` in its header, which is worse than failing to compile. The
+ * variant that reads them is the variant that requires them.
+ */
+export type BoardMoneyColumn = BoardColumn & {
+  probabilityPct: number;
+  rawMinor: number;
+  weightedMinor: number;
+  currency: string;
 };
 
 export function DealCard({
@@ -189,105 +191,115 @@ export function PipelineBoard({
   columnDropHandlers,
   variant = "deal",
   renderCard,
-}: Readonly<{
-  columns: BoardColumn[];
+}: Readonly<
   /**
-   * What the column header states. "deal" reads the money — the stage total,
-   * its probability and the weighted figure. "plain" states the count alone,
-   * for a board whose columns are not worth an amount: leads by status, where
-   * a zero total would read as an empty stage rather than an absent question.
+   * The variant decides what the header states AND what a column must carry,
+   * as one union rather than two independent props.
    *
-   * A variant rather than a second board, because the columns, the drag
-   * targets and the CSS are the same board — only the header differs, and two
-   * copies of a drop target is how one of them stops working.
+   * "deal" reads the money — the stage total, its probability and the weighted
+   * figure — so its columns REQUIRE those four. "plain" states the count
+   * alone, for a board whose columns are not worth an amount (leads by status,
+   * where a zero total would read as an empty stage rather than an absent
+   * question), so its columns cannot carry them at all.
+   *
+   * A variant rather than a second board, because the columns, the drop
+   * targets and the CSS are the same board — two copies of a drop target is
+   * how one of them stops working. But optional money fields would let a deal
+   * board omit its probability and render `undefined%`, so the two column
+   * shapes are distinct types and the compiler holds the line.
    */
-  variant?: "deal" | "plain";
-  /**
-   * The card, when the caller's rows are not deals. Absent renders `DealCard`,
-   * which is what every existing caller wants and gets without changing.
-   */
-  renderCard?: (deal: BoardDeal, column: BoardColumn) => ReactNode;
-  onOpen?: (deal: BoardDeal) => void;
-  columnExtras?: (column: BoardColumn) => ReactNode;
-  cardDragHandlers?: (
-    deal: BoardDeal,
-    column: BoardColumn,
-  ) => {
-    draggable: true;
-    onDragStart: (event: React.DragEvent) => void;
-  };
-  columnDropHandlers?: (column: BoardColumn) => {
-    onDragOver: (event: React.DragEvent) => void;
-    onDrop: (event: React.DragEvent) => void;
-    onDragLeave: (event: React.DragEvent) => void;
-  };
-}>) {
+  (
+    | { variant?: "deal"; columns: BoardMoneyColumn[] }
+    | { variant: "plain"; columns: BoardColumn[] }
+  ) & {
+    /**
+     * The card, when the caller's rows are not deals. Absent renders `DealCard`,
+     * which is what every existing caller wants and gets without changing.
+     */
+    renderCard?: (deal: BoardDeal, column: BoardColumn) => ReactNode;
+    onOpen?: (deal: BoardDeal) => void;
+    columnExtras?: (column: BoardColumn) => ReactNode;
+    cardDragHandlers?: (
+      deal: BoardDeal,
+      column: BoardColumn,
+    ) => {
+      draggable: true;
+      onDragStart: (event: React.DragEvent) => void;
+    };
+    columnDropHandlers?: (column: BoardColumn) => {
+      onDragOver: (event: React.DragEvent) => void;
+      onDrop: (event: React.DragEvent) => void;
+      onDragLeave: (event: React.DragEvent) => void;
+    };
+  }
+>) {
   const t = useT();
   const { locale } = useLocale();
   return (
     <div className="board">
-      {columns.map((column) => (
-        <section
-          key={column.stage}
-          className="board-col"
-          data-stage={column.stage}
-          aria-label={column.label}
-          {...columnDropHandlers?.(column)}
-        >
-          <div className="board-col-head">
-            <span className="stage">{column.label}</span>
-            {variant === "deal" && (
-              <span className="prob">{column.probabilityPct}%</span>
-            )}
-          </div>
-          {/* The stage's total is the figure being scanned down the board, so it
+      {columns.map((column) => {
+        // Narrowed once per column rather than at each of the three reads: the
+        // variant decides whether these figures exist, and a header that asked
+        // three times could answer differently in each.
+        const money =
+          variant === "deal" ? (column as BoardMoneyColumn) : undefined;
+        return (
+          <section
+            key={column.stage}
+            className="board-col"
+            data-stage={column.stage}
+            aria-label={column.label}
+            {...columnDropHandlers?.(column)}
+          >
+            <div className="board-col-head">
+              <span className="stage">{column.label}</span>
+              {money && <span className="prob">{money.probabilityPct}%</span>}
+            </div>
+            {/* The stage's total is the figure being scanned down the board, so it
               leads with the deal count beside it; the weighted figure is its own
               server-sourced total (not derived from the raw total) and reads
               underneath rather than competing on the line. */}
-          <div className="board-col-sub">
-            <span className="board-col-total">
-              {variant === "deal" && !column.sumHidden && (
-                <span className="board-col-money">
-                  {formatMoney(
-                    column.rawMinor ?? 0,
-                    column.currency ?? "EUR",
-                    locale,
-                  )}
+            <div className="board-col-sub">
+              <span className="board-col-total">
+                {money && !column.sumHidden && (
+                  <span className="board-col-money">
+                    {formatMoney(money.rawMinor, money.currency, locale)}
+                  </span>
+                )}
+                <span>
+                  {t("board.count", {
+                    count: column.count ?? column.deals.length,
+                  })}
+                </span>
+              </span>
+              {money && !column.sumHidden && (
+                <span className="board-col-weighted">
+                  {t("board.weighted", {
+                    value: formatMoney(
+                      money.weightedMinor,
+                      money.currency,
+                      locale,
+                    ),
+                  })}
                 </span>
               )}
-              <span>
-                {t("board.count", {
-                  count: column.count ?? column.deals.length,
-                })}
-              </span>
-            </span>
-            {variant === "deal" && !column.sumHidden && (
-              <span className="board-col-weighted">
-                {t("board.weighted", {
-                  value: formatMoney(
-                    column.weightedMinor ?? 0,
-                    column.currency ?? "EUR",
-                    locale,
-                  ),
-                })}
-              </span>
+            </div>
+            {column.deals.map((deal) =>
+              renderCard ? (
+                <Fragment key={deal.id}>{renderCard(deal, column)}</Fragment>
+              ) : (
+                <DealCard
+                  key={deal.id}
+                  deal={deal}
+                  onOpen={onOpen}
+                  dragHandlers={cardDragHandlers?.(deal, column)}
+                />
+              ),
             )}
-          </div>
-          {column.deals.map((deal) =>
-            renderCard ? (
-              <Fragment key={deal.id}>{renderCard(deal, column)}</Fragment>
-            ) : (
-              <DealCard
-                key={deal.id}
-                deal={deal}
-                onOpen={onOpen}
-                dragHandlers={cardDragHandlers?.(deal, column)}
-              />
-            ),
-          )}
-          {columnExtras?.(column)}
-        </section>
-      ))}
+            {columnExtras?.(column)}
+          </section>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -8,7 +8,7 @@ import {
   StickyNote,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { splitEmailBody } from "../format/emailtext";
 import { formatDate, formatDuration, formatMoney } from "../format/format";
 import { useLocale, useT } from "../i18n";
@@ -94,10 +94,19 @@ export type BoardDeal = {
 export type BoardColumn = {
   stage: string;
   label: string;
-  probabilityPct: number;
-  rawMinor: number;
-  weightedMinor: number;
-  currency: string;
+  /**
+   * The money header, and the reason it is optional rather than zeroed.
+   *
+   * A board whose columns carry no money — leads by status, where a column has
+   * a count and nothing else — would otherwise have to pass `0` for each of
+   * these, and a zero total reads as "this stage is worth nothing" rather than
+   * "this board is not about money". `variant: "plain"` omits the figures
+   * entirely; these four are then unread.
+   */
+  probabilityPct?: number;
+  rawMinor?: number;
+  weightedMinor?: number;
+  currency?: string;
   deals: BoardDeal[];
   /**
    * The stage's true deal count, independent of how many `deals` (cards)
@@ -178,8 +187,26 @@ export function PipelineBoard({
   columnExtras,
   cardDragHandlers,
   columnDropHandlers,
+  variant = "deal",
+  renderCard,
 }: Readonly<{
   columns: BoardColumn[];
+  /**
+   * What the column header states. "deal" reads the money — the stage total,
+   * its probability and the weighted figure. "plain" states the count alone,
+   * for a board whose columns are not worth an amount: leads by status, where
+   * a zero total would read as an empty stage rather than an absent question.
+   *
+   * A variant rather than a second board, because the columns, the drag
+   * targets and the CSS are the same board — only the header differs, and two
+   * copies of a drop target is how one of them stops working.
+   */
+  variant?: "deal" | "plain";
+  /**
+   * The card, when the caller's rows are not deals. Absent renders `DealCard`,
+   * which is what every existing caller wants and gets without changing.
+   */
+  renderCard?: (deal: BoardDeal, column: BoardColumn) => ReactNode;
   onOpen?: (deal: BoardDeal) => void;
   columnExtras?: (column: BoardColumn) => ReactNode;
   cardDragHandlers?: (
@@ -209,7 +236,9 @@ export function PipelineBoard({
         >
           <div className="board-col-head">
             <span className="stage">{column.label}</span>
-            <span className="prob">{column.probabilityPct}%</span>
+            {variant === "deal" && (
+              <span className="prob">{column.probabilityPct}%</span>
+            )}
           </div>
           {/* The stage's total is the figure being scanned down the board, so it
               leads with the deal count beside it; the weighted figure is its own
@@ -217,9 +246,13 @@ export function PipelineBoard({
               underneath rather than competing on the line. */}
           <div className="board-col-sub">
             <span className="board-col-total">
-              {!column.sumHidden && (
+              {variant === "deal" && !column.sumHidden && (
                 <span className="board-col-money">
-                  {formatMoney(column.rawMinor, column.currency, locale)}
+                  {formatMoney(
+                    column.rawMinor ?? 0,
+                    column.currency ?? "EUR",
+                    locale,
+                  )}
                 </span>
               )}
               <span>
@@ -228,26 +261,30 @@ export function PipelineBoard({
                 })}
               </span>
             </span>
-            {!column.sumHidden && (
+            {variant === "deal" && !column.sumHidden && (
               <span className="board-col-weighted">
                 {t("board.weighted", {
                   value: formatMoney(
-                    column.weightedMinor,
-                    column.currency,
+                    column.weightedMinor ?? 0,
+                    column.currency ?? "EUR",
                     locale,
                   ),
                 })}
               </span>
             )}
           </div>
-          {column.deals.map((deal) => (
-            <DealCard
-              key={deal.id}
-              deal={deal}
-              onOpen={onOpen}
-              dragHandlers={cardDragHandlers?.(deal, column)}
-            />
-          ))}
+          {column.deals.map((deal) =>
+            renderCard ? (
+              <Fragment key={deal.id}>{renderCard(deal, column)}</Fragment>
+            ) : (
+              <DealCard
+                key={deal.id}
+                deal={deal}
+                onOpen={onOpen}
+                dragHandlers={cardDragHandlers?.(deal, column)}
+              />
+            ),
+          )}
           {columnExtras?.(column)}
         </section>
       ))}

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -207,10 +207,21 @@ export function ListTable<Row>({
   problem,
   widthsKey,
   tools,
+  body,
 }: Readonly<{
   rows: readonly Row[];
   columns: readonly ListColumn<Row>[];
   rowKey: (row: Row) => string;
+  /**
+   * Renders INSTEAD of the grid, keeping the surface's header, search, chips,
+   * views and page-size dial exactly where they are.
+   *
+   * For a second view of the same query — a board over the rows a list already
+   * fetched. Swapping the whole surface out for it would take the filter bar
+   * with it, leaving the reader looking at a narrowed answer with no way to
+   * see or change what narrowed it, which is worse than showing no board.
+   */
+  body?: ReactNode;
   onRowClick?: (row: Row) => void;
   /**
    * Where this row lives, as a URL. Turns the identity cell into a link, so a
@@ -574,159 +585,161 @@ export function ListTable<Row>({
         </>
       }
     >
-      <div
-        className={`lt-scroll${shifted ? " shifted" : ""}`}
-        ref={scroller}
-        onScroll={(event) => {
-          const next = event.currentTarget.scrollLeft > 0;
-          if (next !== shifted) {
-            setShifted(next);
-          }
-        }}
-      >
-        {/* One element for the frozen edge's shadow. It cannot hang off the
+      {body ?? (
+        <div
+          className={`lt-scroll${shifted ? " shifted" : ""}`}
+          ref={scroller}
+          onScroll={(event) => {
+            const next = event.currentTarget.scrollLeft > 0;
+            if (next !== shifted) {
+              setShifted(next);
+            }
+          }}
+        >
+          {/* One element for the frozen edge's shadow. It cannot hang off the
             cells: a shadow per cell starts and stops at each cell's own box, so
             the column ends up wearing a shadow per row with a seam at every
             divider. This sticks to the left of the scrolling body and spans its
             visible height, which is all that is ever seen of it. */}
-        <div className="lt-freeze" aria-hidden="true" />
-        <table
-          ref={head}
-          className={`lt-table${dense ? " dense" : ""}`}
-          role="table"
-          // Handed over as a custom property rather than as `min-width`
-          // itself: an inline width cannot be overridden by a stylesheet, and
-          // the phone layout has to drop this floor to lay the rows out as
-          // cards that fit the screen.
-          style={{ "--lt-floor": `${floor}px` } as CSSProperties}
-        >
-          {/* The widths live here rather than on the header cells: under fixed
+          <div className="lt-freeze" aria-hidden="true" />
+          <table
+            ref={head}
+            className={`lt-table${dense ? " dense" : ""}`}
+            role="table"
+            // Handed over as a custom property rather than as `min-width`
+            // itself: an inline width cannot be overridden by a stylesheet, and
+            // the phone layout has to drop this floor to lay the rows out as
+            // cards that fit the screen.
+            style={{ "--lt-floor": `${floor}px` } as CSSProperties}
+          >
+            {/* The widths live here rather than on the header cells: under fixed
               layout a col wins over the cell below it, so one place decides
               and a resized column cannot be quietly overruled. */}
-          <colgroup>
-            {shown.map((column) => (
-              <col key={column.key} style={{ width: widthOf(column) }} />
-            ))}
-            <col style={{ width: slack }} />
-          </colgroup>
-          <thead role="rowgroup">
-            <tr role="row">
+            <colgroup>
               {shown.map((column) => (
-                <HeaderCell
-                  key={column.key}
-                  column={column}
-                  sort={sort}
-                  state={sort ? sortState(column, sort.value) : null}
-                  className={cellClass(column)}
-                  // Dragging an edge moves that edge. The other columns are
-                  // pinned at what they currently measure first, so they stay
-                  // where they are and the table itself grows or shrinks —
-                  // rather than every column re-dividing the row because one
-                  // of them changed.
-                  onResizeStart={() =>
-                    applyWidths({ ...measured(), ...live.current })
-                  }
-                  onResize={(key, width) =>
-                    applyWidths({ ...live.current, [key]: width })
-                  }
-                  onResizeEnd={() => writeWidths(widthsKey, live.current)}
-                />
+                <col key={column.key} style={{ width: widthOf(column) }} />
               ))}
-              <td className="lt-slack" aria-hidden="true" />
-            </tr>
-          </thead>
-          <tbody role="rowgroup">
-            {pending &&
-              PLACEHOLDER_ROWS.map((placeholder) => (
-                <tr key={placeholder} className="lt-loading" role="row">
-                  {shown.map((column) => (
-                    <td key={column.key} role="cell">
-                      <span className="lt-bone" />
-                    </td>
-                  ))}
-                  <td className="lt-slack" aria-hidden="true" />
-                </tr>
-              ))}
-            {!pending &&
-              pageRows.map((row) => (
-                <tr
-                  key={rowKey(row)}
-                  role="row"
-                  className={onRowClick ? "lt-rowlink" : undefined}
-                  onClick={onRowClick ? () => onRowClick(row) : undefined}
-                >
-                  {shown.map((column) => (
-                    <td
-                      key={column.key}
-                      role="cell"
-                      className={cellClass(column)}
-                      // On a phone the rows become cards and the header row is
-                      // gone, so each value carries its own label. The identity
-                      // cell is the card's heading and needs none.
-                      data-label={column.fixed ? undefined : column.header}
-                    >
-                      {column.fixed && rowHref ? (
-                        // The identity cell is a real link, so the row can be
-                        // opened the ways a link can: a new tab, a new window,
-                        // a bookmark, or the keyboard. Only the default click
-                        // is stopped from reaching the row's own handler —
-                        // preventing the anchor instead would navigate the
-                        // current page while the new tab opens too.
-                        <a
-                          className="lt-cellink"
-                          href={rowHref(row)}
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          {column.cell(row)}
-                        </a>
-                      ) : (
-                        column.cell(row)
-                      )}
-                    </td>
-                  ))}
-                  <td className="lt-slack" aria-hidden="true" />
-                </tr>
-              ))}
-            {!pending && problem && (
-              <tr className="lt-empty" role="row">
-                <td colSpan={shown.length + 1} role="cell">
-                  {problem}
-                </td>
+              <col style={{ width: slack }} />
+            </colgroup>
+            <thead role="rowgroup">
+              <tr role="row">
+                {shown.map((column) => (
+                  <HeaderCell
+                    key={column.key}
+                    column={column}
+                    sort={sort}
+                    state={sort ? sortState(column, sort.value) : null}
+                    className={cellClass(column)}
+                    // Dragging an edge moves that edge. The other columns are
+                    // pinned at what they currently measure first, so they stay
+                    // where they are and the table itself grows or shrinks —
+                    // rather than every column re-dividing the row because one
+                    // of them changed.
+                    onResizeStart={() =>
+                      applyWidths({ ...measured(), ...live.current })
+                    }
+                    onResize={(key, width) =>
+                      applyWidths({ ...live.current, [key]: width })
+                    }
+                    onResizeEnd={() => writeWidths(widthsKey, live.current)}
+                  />
+                ))}
+                <td className="lt-slack" aria-hidden="true" />
               </tr>
-            )}
-            {!pending && !problem && rows.length === 0 && (
-              <tr className="lt-empty" role="row">
-                <td colSpan={shown.length + 1} role="cell">
-                  {filtered ? (
-                    <>
-                      {t("table.noMatches", { unit })}{" "}
-                      <button
-                        type="button"
-                        className="lt-linkish"
-                        onClick={clearAll}
+            </thead>
+            <tbody role="rowgroup">
+              {pending &&
+                PLACEHOLDER_ROWS.map((placeholder) => (
+                  <tr key={placeholder} className="lt-loading" role="row">
+                    {shown.map((column) => (
+                      <td key={column.key} role="cell">
+                        <span className="lt-bone" />
+                      </td>
+                    ))}
+                    <td className="lt-slack" aria-hidden="true" />
+                  </tr>
+                ))}
+              {!pending &&
+                pageRows.map((row) => (
+                  <tr
+                    key={rowKey(row)}
+                    role="row"
+                    className={onRowClick ? "lt-rowlink" : undefined}
+                    onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  >
+                    {shown.map((column) => (
+                      <td
+                        key={column.key}
+                        role="cell"
+                        className={cellClass(column)}
+                        // On a phone the rows become cards and the header row is
+                        // gone, so each value carries its own label. The identity
+                        // cell is the card's heading and needs none.
+                        data-label={column.fixed ? undefined : column.header}
                       >
-                        {t("table.clearFilters")}
-                      </button>
-                    </>
-                  ) : (
-                    <>
-                      {t("table.none", { unit })}
-                      {emptyNote && (
-                        <p
-                          className="t-caption"
-                          style={{ marginTop: "var(--space-2)" }}
+                        {column.fixed && rowHref ? (
+                          // The identity cell is a real link, so the row can be
+                          // opened the ways a link can: a new tab, a new window,
+                          // a bookmark, or the keyboard. Only the default click
+                          // is stopped from reaching the row's own handler —
+                          // preventing the anchor instead would navigate the
+                          // current page while the new tab opens too.
+                          <a
+                            className="lt-cellink"
+                            href={rowHref(row)}
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            {column.cell(row)}
+                          </a>
+                        ) : (
+                          column.cell(row)
+                        )}
+                      </td>
+                    ))}
+                    <td className="lt-slack" aria-hidden="true" />
+                  </tr>
+                ))}
+              {!pending && problem && (
+                <tr className="lt-empty" role="row">
+                  <td colSpan={shown.length + 1} role="cell">
+                    {problem}
+                  </td>
+                </tr>
+              )}
+              {!pending && !problem && rows.length === 0 && (
+                <tr className="lt-empty" role="row">
+                  <td colSpan={shown.length + 1} role="cell">
+                    {filtered ? (
+                      <>
+                        {t("table.noMatches", { unit })}{" "}
+                        <button
+                          type="button"
+                          className="lt-linkish"
+                          onClick={clearAll}
                         >
-                          {emptyNote}
-                        </p>
-                      )}
-                    </>
-                  )}
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+                          {t("table.clearFilters")}
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        {t("table.none", { unit })}
+                        {emptyNote && (
+                          <p
+                            className="t-caption"
+                            style={{ marginTop: "var(--space-2)" }}
+                          >
+                            {emptyNote}
+                          </p>
+                        )}
+                      </>
+                    )}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
     </ListSurface>
   );
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1282,6 +1282,8 @@ export const de = {
   "lead.filterScoreHot": "Ab 80",
   "lead.filterScoreWarm": "Ab 60",
   "lead.filterScoreCool": "Ab 40",
+  "lead.boardTerminalOnly":
+    "Das Board zeigt nur offene Leads. Diese Leads sind übernommen oder disqualifiziert.",
   "person.fromLead": "Aus Lead übernommen",
   "lead.promotedTitle": "Als Kontakt übernommen",
   "lead.promotedMerged":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1291,6 +1291,8 @@ export const en = {
   "lead.filterScoreHot": "80 and up",
   "lead.filterScoreWarm": "60 and up",
   "lead.filterScoreCool": "40 and up",
+  "lead.boardTerminalOnly":
+    "The board shows open leads only. These leads are promoted or disqualified.",
   "person.fromLead": "From lead",
   "lead.promotedTitle": "Promoted to a contact",
   "lead.promotedMerged":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1283,6 +1283,8 @@ export const vi = {
   "lead.filterScoreHot": "Từ 80",
   "lead.filterScoreWarm": "Từ 60",
   "lead.filterScoreCool": "Từ 40",
+  "lead.boardTerminalOnly":
+    "Bảng chỉ hiện khách hàng tiềm năng đang mở. Những mục này đã chuyển hoặc bị loại.",
   "person.fromLead": "Từ khách hàng tiềm năng",
   "lead.promotedTitle": "Đã chuyển thành liên hệ",
   "lead.promotedMerged":

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -31,6 +31,7 @@ import {
 import {
   type BoardColumn,
   type BoardDeal,
+  type BoardMoneyColumn,
   PipelineBoard,
   RecordView,
 } from "../design-system/composed";
@@ -482,7 +483,7 @@ export function buildColumns(
   deals: Deal[],
   totals: Map<string, StageTotals>,
   orgs?: OrgMarks,
-): BoardColumn[] {
+): BoardMoneyColumn[] {
   return [...stages]
     .sort((a, b) => a.position - b.position)
     .map((stage) => {

--- a/frontend/src/screens/leads.stories.tsx
+++ b/frontend/src/screens/leads.stories.tsx
@@ -214,3 +214,39 @@ export const LeadPromotedAfterMerge: Story = {
     );
   },
 };
+
+// The board: the live leads in the two columns they can actually move between.
+// Terminal statuses get no column — a lead is promoted or disqualified through
+// its own audited verb, never by dragging a card.
+export const LeadsBoard: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /leads": () =>
+        jsonResponse({
+          data: [
+            { ...lead, id: "l-1", status: "new", score: 82 },
+            {
+              ...lead,
+              id: "l-2",
+              full_name: "Petra Vogel",
+              company_name: "Südwind AG",
+              status: "working",
+              score: 54,
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "GET /me": () =>
+        jsonResponse({
+          user: { id: "u-9", display_name: "Me" },
+          roles: ["rep"],
+          teams: [],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <LeadsScreen />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/leads.stories.tsx
+++ b/frontend/src/screens/leads.stories.tsx
@@ -216,6 +216,8 @@ export const LeadPromotedAfterMerge: Story = {
 };
 
 // The board: the live leads in the two columns they can actually move between.
+// The story opens on the table, as the screen does, and the reader presses
+// "Board" — the toggle is part of what this story documents.
 // Terminal statuses get no column — a lead is promoted or disqualified through
 // its own audited verb, never by dragging a card.
 export const LeadsBoard: Story = {

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -267,6 +267,32 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     expect(patched[0].ifMatch).toBe("7");
   });
 
+  it("the board keeps the filter bar it obeys, and offers the rest of the page", async () => {
+    // The board renders inside the list surface. Swapping the whole surface out
+    // for it took the chips and the search with it — leaving the reader looking
+    // at a narrowed answer with no way to see or change what narrowed it — and
+    // showed page one while looking like the whole pipeline.
+    stubFetch(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/leads?") || url.endsWith("/leads")) {
+        return jsonResponse({
+          data: [{ ...lead, status: "new", version: 7 }],
+          page: { next_cursor: "page-2", has_more: true },
+        });
+      }
+      return emptyPage();
+    });
+    render(<LeadsScreen />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Board" }));
+
+    // The dials the board obeys are still on screen.
+    expect(screen.getByRole("button", { name: "Filter" })).toBeTruthy();
+    expect(screen.getByRole("searchbox")).toBeTruthy();
+    // And it admits there is more than it is showing.
+    expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+  });
+
   it("a promoted lead keeps its page and says what the promotion did", async () => {
     // AC-leaddetail-5 (ADR-0119/A170). The page used to redirect here, which
     // told the reader the lead had ceased to exist — untrue of a record this

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -217,6 +217,56 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-9"));
   });
 
+  it("the board moves a lead between the two live statuses, with If-Match", async () => {
+    // Only new and working: promoted and disqualified are reachable through
+    // their own audited verbs, and a board column for either would offer a
+    // drag that ends in a 422 — or worse, imply a lead can be promoted by
+    // moving a card, which is what ADR-0008's trigger set exists to prevent.
+    type Patched = { body: unknown; ifMatch: string | null };
+    const patched: Patched[] = [];
+    stubFetch(async (input: RequestInfo | URL, method: string, request) => {
+      const url = String(input);
+      if (method === "PATCH" && url.includes("/leads/l-1")) {
+        patched.push({
+          body: await request.json(),
+          ifMatch: request.headers.get("If-Match"),
+        });
+        return jsonResponse({ ...lead, status: "working" });
+      }
+      if (url.includes("/leads?") || url.endsWith("/leads")) {
+        return jsonResponse({
+          data: [{ ...lead, status: "new", version: 7 }],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return emptyPage();
+    });
+    render(<LeadsScreen />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Board" }));
+    const card = await screen.findByText("Jonas Petersen");
+    const workingColumn = screen.getByRole("region", { name: "Working" });
+
+    // jsdom ships no DataTransfer, so the drag carries the same two methods
+    // the handlers actually use — setData on the way out, getData on the way
+    // in. Anything richer would be a mock of a thing this code never touches.
+    const carried = new Map<string, string>();
+    const data = {
+      setData: (key: string, value: string) => carried.set(key, value),
+      getData: (key: string) => carried.get(key) ?? "",
+    };
+    fireEvent.dragStart(card.closest("button") as HTMLElement, {
+      dataTransfer: data,
+    });
+    fireEvent.drop(workingColumn, { dataTransfer: data });
+
+    await waitFor(() => expect(patched.length).toBe(1));
+    expect(patched[0].body).toMatchObject({ status: "working" });
+    // The version rides the variables, so the write cannot clobber a change
+    // made since this card rendered.
+    expect(patched[0].ifMatch).toBe("7");
+  });
+
   it("a promoted lead keeps its page and says what the promotion did", async () => {
     // AC-leaddetail-5 (ADR-0119/A170). The page used to redirect here, which
     // told the reader the lead had ceased to exist — untrue of a record this

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -15,7 +15,12 @@ import {
   Textarea,
   TextInput,
 } from "../design-system/atoms";
-import { RecordView } from "../design-system/composed";
+import {
+  type BoardColumn,
+  type BoardDeal,
+  PipelineBoard,
+  RecordView,
+} from "../design-system/composed";
 import type { ListChip } from "../design-system/listtable";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useRecordTimeline } from "../design-system/recordtimeline";
@@ -296,6 +301,191 @@ async function createLead(
   return data;
 }
 
+/**
+ * The two columns a lead can be dragged between.
+ *
+ * Only the LIVE statuses. `promoted` and `disqualified` are terminal and
+ * reachable only through their own audited verbs — a board column for either
+ * would offer a drag that ends in a 422, and worse, would imply a lead can be
+ * promoted by moving a card, which is the one thing ADR-0008's trigger set
+ * exists to prevent.
+ */
+const LEAD_BOARD_STAGES = [
+  { stage: "new", label: "lead.statusNew" },
+  { stage: "working", label: "lead.statusWorking" },
+] as const;
+
+/** A lead as the board's card reads it. */
+function LeadCard({
+  lead,
+  onOpen,
+  dragHandlers,
+}: Readonly<{
+  lead: Lead;
+  onOpen: (lead: Lead) => void;
+  dragHandlers?: {
+    draggable: true;
+    onDragStart: (event: React.DragEvent) => void;
+  };
+}>) {
+  const t = useT();
+  return (
+    <button
+      type="button"
+      className="deal-card"
+      data-lead={lead.id}
+      onClick={() => onOpen(lead)}
+      {...dragHandlers}
+    >
+      <span className="deal-name">
+        {lead.full_name ?? lead.email ?? t("nav.leads")}
+      </span>
+      {lead.company_name && (
+        <span className="deal-org">
+          <span className="deal-org-name">{lead.company_name}</span>
+        </span>
+      )}
+      <span className="deal-meta">
+        <Badge tone={scoreTone(lead.score)}>
+          {t("lead.score")}: {lead.score}
+        </Badge>
+        {lead.title && <span>{lead.title}</span>}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * LeadBoard is the triage surface: the live leads, in the two columns they can
+ * actually move between, dragged from one to the other.
+ *
+ * It renders the rows the LIST already fetched rather than asking again, so a
+ * reader's filters and search narrow the board exactly as they narrow the
+ * table — a board that ignored the filter bar above it would be a second,
+ * silently different answer to the same question.
+ */
+function LeadBoard({
+  rows,
+  onMoved,
+}: Readonly<{ rows: Lead[]; onMoved: () => void }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const dragging = useRef<string | null>(null);
+  const lastDragEnd = useRef(0);
+
+  const move = useMutation({
+    // The lead's version rides the variables, not a closure: the card that
+    // carried it belongs to the committed render, so it cannot be stale.
+    mutationFn: async (moved: {
+      id: string;
+      // Optional exactly as the contract has it. ifMatch omits the header when
+      // it is absent, which is the honest behaviour: a row the server did not
+      // version is one this client cannot make a concurrency claim about.
+      version?: number;
+      // The two the contract accepts. `promoted` and `disqualified` are
+      // reachable only through their own verbs, and typing the board's write
+      // this way is what stops a third column being added without noticing.
+      status: "new" | "working";
+    }) => {
+      const { data, error } = await api.PATCH("/leads/{id}", {
+        params: { path: { id: moved.id }, ...ifMatch(moved.version) },
+        body: { status: moved.status },
+      });
+      if (error) {
+        throwProblem(error, t);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leads"] });
+      onMoved();
+    },
+  });
+
+  const columns: BoardColumn[] = LEAD_BOARD_STAGES.map((stage) => {
+    const held = rows.filter((lead) => lead.status === stage.stage);
+    return {
+      stage: stage.stage,
+      label: t(stage.label),
+      count: held.length,
+      // The board's card type is the deal's, so each lead rides as one and the
+      // renderCard hook reads it back out of `leadsById` below. Only `id` is
+      // ever read off this object.
+      deals: held.map((lead) => ({ id: lead.id, name: "" }) as BoardDeal),
+    };
+  });
+  const leadsById = new Map(rows.map((lead) => [lead.id, lead]));
+
+  return (
+    <>
+      {move.isError && (
+        <p className="t-caption" style={{ color: "var(--danger)" }}>
+          {problemMessageOf(move.error, t)}
+        </p>
+      )}
+      <PipelineBoard
+        variant="plain"
+        columns={columns}
+        renderCard={(card) => {
+          const lead = leadsById.get(card.id);
+          if (!lead) {
+            return null;
+          }
+          return (
+            <LeadCard
+              lead={lead}
+              onOpen={(opened) => {
+                // A drag ends in a click the browser also reports; opening the
+                // record on it would navigate away from the board every time a
+                // card was moved.
+                if (Date.now() - lastDragEnd.current > 250) {
+                  navigate({ screen: "leads", id: opened.id });
+                }
+              }}
+              dragHandlers={{
+                draggable: true,
+                onDragStart: (event) => {
+                  dragging.current = lead.id;
+                  event.dataTransfer.setData("text/plain", lead.id);
+                },
+              }}
+            />
+          );
+        }}
+        columnDropHandlers={(column) => ({
+          onDragOver: (event) => {
+            event.preventDefault();
+            (event.currentTarget as HTMLElement).classList.add("droptarget");
+          },
+          onDragLeave: (event) => {
+            (event.currentTarget as HTMLElement).classList.remove("droptarget");
+          },
+          onDrop: (event) => {
+            event.preventDefault();
+            (event.currentTarget as HTMLElement).classList.remove("droptarget");
+            const id =
+              event.dataTransfer.getData("text/plain") || dragging.current;
+            dragging.current = null;
+            lastDragEnd.current = Date.now();
+            const lead = id ? leadsById.get(id) : undefined;
+            // A card dropped on the column it already sits in is not a move.
+            const target = LEAD_BOARD_STAGES.find(
+              (stage) => stage.stage === column.stage,
+            );
+            if (lead && target && lead.status !== target.stage) {
+              move.mutate({
+                id: lead.id,
+                version: lead.version,
+                status: target.stage,
+              });
+            }
+          },
+        })}
+      />
+    </>
+  );
+}
+
 export function LeadsScreen() {
   const ownerChips = useLeadOwnerChips();
   const t = useT();
@@ -306,99 +496,120 @@ export function LeadsScreen() {
     initialSort: "-created_at",
     fetchPage: fetchLeadsPage,
   });
+  // The board writes status, which the mirror refuses (a lead's lifecycle is
+  // not a field write-back), so overlay gets the table and no toggle.
+  const overlay = useSorMode() === "overlay";
+  const [view, setView] = useState<"table" | "board">("table");
 
   return (
     <div className="wrap lead-surface">
-      <ListTable
-        state={state}
-        unit="unit.leads"
-        caption="lead.segregated"
-        action={
-          <CreateAction
-            label={t("create.lead")}
-            invalidate="leads"
-            screen="leads"
-            create={(values) => createLead(values, cf.toBody(values), t)}
-            resolveExisting={(_code, id) => ({ screen: "leads", id })}
-            fields={[...leadCreateFields, ...cf.formFields]}
+      {!overlay && (
+        <div style={{ marginBottom: "var(--space-3)" }}>
+          <SegmentedControl
+            options={["table", "board"] as const}
+            value={view}
+            onChange={setView}
+            labels={{
+              table: t("deals.viewTable"),
+              board: t("deals.viewBoard"),
+            }}
           />
-        }
-        columns={[
-          {
-            key: "name",
-            header: t("people.name"),
-            cell: (lead: Lead) => {
-              const terminal = terminalBadge(lead.status);
-              return (
-                <span>
-                  <strong>{lead.full_name ?? lead.email ?? ""}</strong>
-                  {lead.company_name && (
-                    <span className="t-caption"> · {lead.company_name}</span>
-                  )}
-                  {terminal && (
-                    <Badge tone={terminal.tone}>{t(terminal.label)}</Badge>
-                  )}
-                </span>
-              );
+        </div>
+      )}
+      {view === "board" && !overlay ? (
+        <LeadBoard rows={state.rows} onMoved={() => state.refetch()} />
+      ) : (
+        <ListTable
+          state={state}
+          unit="unit.leads"
+          caption="lead.segregated"
+          action={
+            <CreateAction
+              label={t("create.lead")}
+              invalidate="leads"
+              screen="leads"
+              create={(values) => createLead(values, cf.toBody(values), t)}
+              resolveExisting={(_code, id) => ({ screen: "leads", id })}
+              fields={[...leadCreateFields, ...cf.formFields]}
+            />
+          }
+          columns={[
+            {
+              key: "name",
+              header: t("people.name"),
+              cell: (lead: Lead) => {
+                const terminal = terminalBadge(lead.status);
+                return (
+                  <span>
+                    <strong>{lead.full_name ?? lead.email ?? ""}</strong>
+                    {lead.company_name && (
+                      <span className="t-caption"> · {lead.company_name}</span>
+                    )}
+                    {terminal && (
+                      <Badge tone={terminal.tone}>{t(terminal.label)}</Badge>
+                    )}
+                  </span>
+                );
+              },
+              fixed: true,
             },
-            fixed: true,
-          },
-          {
-            key: "score",
-            header: t("lead.score"),
-            cell: (lead: Lead) => (
-              <Badge tone={scoreTone(lead.score)}>{lead.score}</Badge>
-            ),
-            sort: "score",
-            numeric: true,
-          },
-          {
-            key: "status",
-            header: t("lead.status"),
-            cell: (lead: Lead) => <StatusBadge status={lead.status} />,
-          },
-          {
-            key: "provenance",
-            header: t("people.capturedBy"),
-            cell: (lead: Lead) => (
-              <ProvenanceTag
-                provenance={provenanceOf(lead.captured_by, viewerId)}
-              />
-            ),
-          },
-        ]}
-        rowKey={(lead) => lead.id}
-        rowRoute={(lead) => ({ screen: "leads", id: lead.id })}
-        chips={[
-          {
-            key: "status",
-            label: "lead.filterStatus",
-            allLabel: "lead.filterStatusAll",
-            options: leadStatusFilterOptions.map((option) => ({ ...option })),
-          },
-          {
-            key: "min_score",
-            label: "lead.filterScore",
-            allLabel: "lead.filterScoreAll",
-            options: LEAD_SCORE_BANDS.map((band) => ({ ...band })),
-          },
-        ]}
-        // Owner is a DATA chip: its options are people, read at runtime.
-        // Deliberately not the shared `useOwnerChips` dial, which also offers
-        // team and unassigned options spelled `owner_team_id`/`unassigned` —
-        // parameters listLeads does not take, so those choices would 422
-        // rather than narrow the list.
-        dataChips={ownerChips}
-        views={[
-          { label: "list.viewAll", sort: "-created_at" },
-          { label: "list.viewHighestScore", sort: "-score" },
-          {
-            label: "list.viewHot",
-            sort: "-score",
-            filters: { min_score: "80" },
-          },
-        ]}
-      />
+            {
+              key: "score",
+              header: t("lead.score"),
+              cell: (lead: Lead) => (
+                <Badge tone={scoreTone(lead.score)}>{lead.score}</Badge>
+              ),
+              sort: "score",
+              numeric: true,
+            },
+            {
+              key: "status",
+              header: t("lead.status"),
+              cell: (lead: Lead) => <StatusBadge status={lead.status} />,
+            },
+            {
+              key: "provenance",
+              header: t("people.capturedBy"),
+              cell: (lead: Lead) => (
+                <ProvenanceTag
+                  provenance={provenanceOf(lead.captured_by, viewerId)}
+                />
+              ),
+            },
+          ]}
+          rowKey={(lead) => lead.id}
+          rowRoute={(lead) => ({ screen: "leads", id: lead.id })}
+          chips={[
+            {
+              key: "status",
+              label: "lead.filterStatus",
+              allLabel: "lead.filterStatusAll",
+              options: leadStatusFilterOptions.map((option) => ({ ...option })),
+            },
+            {
+              key: "min_score",
+              label: "lead.filterScore",
+              allLabel: "lead.filterScoreAll",
+              options: LEAD_SCORE_BANDS.map((band) => ({ ...band })),
+            },
+          ]}
+          // Owner is a DATA chip: its options are people, read at runtime.
+          // Deliberately not the shared `useOwnerChips` dial, which also offers
+          // team and unassigned options spelled `owner_team_id`/`unassigned` —
+          // parameters listLeads does not take, so those choices would 422
+          // rather than narrow the list.
+          dataChips={ownerChips}
+          views={[
+            { label: "list.viewAll", sort: "-created_at" },
+            { label: "list.viewHighestScore", sort: "-score" },
+            {
+              label: "list.viewHot",
+              sort: "-score",
+              filters: { min_score: "80" },
+            },
+          ]}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -326,6 +326,7 @@ function LeadCard({
   dragHandlers?: {
     draggable: true;
     onDragStart: (event: React.DragEvent) => void;
+    onDragEnd: () => void;
   };
 }>) {
   const t = useT();
@@ -367,7 +368,14 @@ function LeadCard({
 function LeadBoard({
   rows,
   onMoved,
-}: Readonly<{ rows: Lead[]; onMoved: () => void }>) {
+  hasMore,
+  loadMore,
+}: Readonly<{
+  rows: Lead[];
+  onMoved: () => void;
+  hasMore: boolean;
+  loadMore: () => void;
+}>) {
   const t = useT();
   const queryClient = useQueryClient();
   const dragging = useRef<string | null>(null);
@@ -400,10 +408,18 @@ function LeadBoard({
       queryClient.invalidateQueries({ queryKey: ["leads"] });
       onMoved();
     },
+    onError: () => {
+      // A 409 means the card's version is stale. Without a refetch the reader
+      // retries with the same doomed If-Match and the drag never takes.
+      queryClient.invalidateQueries({ queryKey: ["leads"] });
+    },
   });
 
+  const live = rows.filter(
+    (lead) => lead.status === "new" || lead.status === "working",
+  );
   const columns: BoardColumn[] = LEAD_BOARD_STAGES.map((stage) => {
-    const held = rows.filter((lead) => lead.status === stage.stage);
+    const held = live.filter((lead) => lead.status === stage.stage);
     return {
       stage: stage.stage,
       label: t(stage.label),
@@ -414,7 +430,7 @@ function LeadBoard({
       deals: held.map((lead) => ({ id: lead.id, name: "" }) as BoardDeal),
     };
   });
-  const leadsById = new Map(rows.map((lead) => [lead.id, lead]));
+  const leadsById = new Map(live.map((lead) => [lead.id, lead]));
 
   return (
     <>
@@ -422,6 +438,12 @@ function LeadBoard({
         <p className="t-caption" style={{ color: "var(--danger)" }}>
           {problemMessageOf(move.error, t)}
         </p>
+      )}
+      {/* The board holds the live statuses only, so a filter narrowed to a
+          terminal one leaves it empty — and an empty board with no reason
+          reads as a broken render rather than a filter doing its job. */}
+      {rows.length > 0 && live.length === 0 && (
+        <p className="t-caption">{t("lead.boardTerminalOnly")}</p>
       )}
       <PipelineBoard
         variant="plain"
@@ -447,6 +469,13 @@ function LeadBoard({
                 onDragStart: (event) => {
                   dragging.current = lead.id;
                   event.dataTransfer.setData("text/plain", lead.id);
+                },
+                // Recorded on END, not on drop: a drag cancelled off the board
+                // never reaches a drop handler, and the click the browser then
+                // reports would navigate away from the board.
+                onDragEnd: () => {
+                  dragging.current = null;
+                  lastDragEnd.current = Date.now();
                 },
               }}
             />
@@ -482,6 +511,13 @@ function LeadBoard({
           },
         })}
       />
+      {/* A board that showed page one while looking like the whole pipeline
+          would be a confident wrong answer about how much work is waiting. */}
+      {hasMore && (
+        <Button small onClick={loadMore}>
+          {t("list.loadMore")}
+        </Button>
+      )}
     </>
   );
 }
@@ -516,100 +552,110 @@ export function LeadsScreen() {
           />
         </div>
       )}
-      {view === "board" && !overlay ? (
-        <LeadBoard rows={state.rows} onMoved={() => state.refetch()} />
-      ) : (
-        <ListTable
-          state={state}
-          unit="unit.leads"
-          caption="lead.segregated"
-          action={
-            <CreateAction
-              label={t("create.lead")}
-              invalidate="leads"
-              screen="leads"
-              create={(values) => createLead(values, cf.toBody(values), t)}
-              resolveExisting={(_code, id) => ({ screen: "leads", id })}
-              fields={[...leadCreateFields, ...cf.formFields]}
+      <ListTable
+        // The board renders INSIDE the surface, so the search, the chips and
+        // the saved views stay above it. A board that replaced the surface
+        // took the filter bar with it, leaving the reader looking at a
+        // narrowed answer with no way to see or change what narrowed it.
+        body={
+          view === "board" && !overlay ? (
+            <LeadBoard
+              rows={state.rows}
+              onMoved={() => state.refetch()}
+              hasMore={state.hasMore}
+              loadMore={state.loadMore}
             />
-          }
-          columns={[
-            {
-              key: "name",
-              header: t("people.name"),
-              cell: (lead: Lead) => {
-                const terminal = terminalBadge(lead.status);
-                return (
-                  <span>
-                    <strong>{lead.full_name ?? lead.email ?? ""}</strong>
-                    {lead.company_name && (
-                      <span className="t-caption"> · {lead.company_name}</span>
-                    )}
-                    {terminal && (
-                      <Badge tone={terminal.tone}>{t(terminal.label)}</Badge>
-                    )}
-                  </span>
-                );
-              },
-              fixed: true,
+          ) : undefined
+        }
+        state={state}
+        unit="unit.leads"
+        caption="lead.segregated"
+        action={
+          <CreateAction
+            label={t("create.lead")}
+            invalidate="leads"
+            screen="leads"
+            create={(values) => createLead(values, cf.toBody(values), t)}
+            resolveExisting={(_code, id) => ({ screen: "leads", id })}
+            fields={[...leadCreateFields, ...cf.formFields]}
+          />
+        }
+        columns={[
+          {
+            key: "name",
+            header: t("people.name"),
+            cell: (lead: Lead) => {
+              const terminal = terminalBadge(lead.status);
+              return (
+                <span>
+                  <strong>{lead.full_name ?? lead.email ?? ""}</strong>
+                  {lead.company_name && (
+                    <span className="t-caption"> · {lead.company_name}</span>
+                  )}
+                  {terminal && (
+                    <Badge tone={terminal.tone}>{t(terminal.label)}</Badge>
+                  )}
+                </span>
+              );
             },
-            {
-              key: "score",
-              header: t("lead.score"),
-              cell: (lead: Lead) => (
-                <Badge tone={scoreTone(lead.score)}>{lead.score}</Badge>
-              ),
-              sort: "score",
-              numeric: true,
-            },
-            {
-              key: "status",
-              header: t("lead.status"),
-              cell: (lead: Lead) => <StatusBadge status={lead.status} />,
-            },
-            {
-              key: "provenance",
-              header: t("people.capturedBy"),
-              cell: (lead: Lead) => (
-                <ProvenanceTag
-                  provenance={provenanceOf(lead.captured_by, viewerId)}
-                />
-              ),
-            },
-          ]}
-          rowKey={(lead) => lead.id}
-          rowRoute={(lead) => ({ screen: "leads", id: lead.id })}
-          chips={[
-            {
-              key: "status",
-              label: "lead.filterStatus",
-              allLabel: "lead.filterStatusAll",
-              options: leadStatusFilterOptions.map((option) => ({ ...option })),
-            },
-            {
-              key: "min_score",
-              label: "lead.filterScore",
-              allLabel: "lead.filterScoreAll",
-              options: LEAD_SCORE_BANDS.map((band) => ({ ...band })),
-            },
-          ]}
-          // Owner is a DATA chip: its options are people, read at runtime.
-          // Deliberately not the shared `useOwnerChips` dial, which also offers
-          // team and unassigned options spelled `owner_team_id`/`unassigned` —
-          // parameters listLeads does not take, so those choices would 422
-          // rather than narrow the list.
-          dataChips={ownerChips}
-          views={[
-            { label: "list.viewAll", sort: "-created_at" },
-            { label: "list.viewHighestScore", sort: "-score" },
-            {
-              label: "list.viewHot",
-              sort: "-score",
-              filters: { min_score: "80" },
-            },
-          ]}
-        />
-      )}
+            fixed: true,
+          },
+          {
+            key: "score",
+            header: t("lead.score"),
+            cell: (lead: Lead) => (
+              <Badge tone={scoreTone(lead.score)}>{lead.score}</Badge>
+            ),
+            sort: "score",
+            numeric: true,
+          },
+          {
+            key: "status",
+            header: t("lead.status"),
+            cell: (lead: Lead) => <StatusBadge status={lead.status} />,
+          },
+          {
+            key: "provenance",
+            header: t("people.capturedBy"),
+            cell: (lead: Lead) => (
+              <ProvenanceTag
+                provenance={provenanceOf(lead.captured_by, viewerId)}
+              />
+            ),
+          },
+        ]}
+        rowKey={(lead) => lead.id}
+        rowRoute={(lead) => ({ screen: "leads", id: lead.id })}
+        chips={[
+          {
+            key: "status",
+            label: "lead.filterStatus",
+            allLabel: "lead.filterStatusAll",
+            options: leadStatusFilterOptions.map((option) => ({ ...option })),
+          },
+          {
+            key: "min_score",
+            label: "lead.filterScore",
+            allLabel: "lead.filterScoreAll",
+            options: LEAD_SCORE_BANDS.map((band) => ({ ...band })),
+          },
+        ]}
+        // Owner is a DATA chip: its options are people, read at runtime.
+        // Deliberately not the shared `useOwnerChips` dial, which also offers
+        // team and unassigned options spelled `owner_team_id`/`unassigned` —
+        // parameters listLeads does not take, so those choices would 422
+        // rather than narrow the list.
+        dataChips={ownerChips}
+        views={[
+          { label: "list.viewAll", sort: "-created_at" },
+          { label: "list.viewHighestScore", sort: "-score" },
+          {
+            label: "list.viewHot",
+            sort: "-score",
+            filters: { min_score: "80" },
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -169,10 +169,17 @@ export function ListTable<Row>({
   searchable = true,
   showArchivedToggle = true,
   tools,
+  body,
 }: Readonly<{
   state: ListState<Row>;
   columns: readonly ListColumn<Row>[];
   rowKey: (row: Row) => string;
+  /**
+   * A second view of the same query, rendered instead of the grid while the
+   * surface keeps its search, chips, views and page-size dial — see the
+   * design-system ListTable's own `body`.
+   */
+  body?: ReactNode;
   /**
    * Where a row's record lives. One declaration drives both ways in: clicking
    * the row navigates, and the identity cell becomes a real link that opens in
@@ -364,6 +371,7 @@ export function ListTable<Row>({
       onPerPage={(next) => setQuery((prev) => ({ ...prev, perPage: next }))}
       // The unit key names the table for the widths it remembers.
       widthsKey={unit}
+      body={body}
       pending={isPending}
       problem={problem}
     />


### PR DESCRIPTION
P1 of the leads plan. The leads list was a table only, while deals had a board the whole time — and a status with two live values maps onto columns exactly.

## The board

`PipelineBoard` gains a variant rather than growing a second board: the columns, the drop targets and the CSS are the same board, and two copies of a drop target is how one of them stops working. `plain` states the count alone, for a board whose columns are not worth an amount.

**Only `new` and `working` get columns.** `promoted` and `disqualified` are reachable through their own audited verbs, so a column for either would offer a drag that ends in a 422 — or worse, imply a lead can be promoted by moving a card, which is the one thing ADR-0008's trigger set exists to prevent. Verified live: `PATCH status=promoted` is `422`.

Each move sends `If-Match` with the version the card carried, and the version rides the mutation's variables rather than a closure. Verified live: correct version `200`, stale version `409`.

## Six defects from the review of this branch

1. **The board hid the filter bar it still obeyed.** Replacing the surface took the search, chips and saved views with it — so the board obeyed a filter the reader could no longer see or change, and a saved view narrowed to a terminal status emptied it with no explanation. It now renders inside the surface through a new `body` slot on `ListTable`, and says so when a filter leaves it nothing live to show.
2. **It showed one page while looking like the whole pipeline.** It now offers the rest.
3. **`undefined%` was reachable.** Making `BoardColumn`'s money fields optional applied to every caller, not just the new variant — a deal column missing its probability rendered false data rather than failing. The variant and its column shape are now one discriminated union: a money board *requires* the figures its header states, a plain board cannot carry them.
4. **A failed move left the card holding the stale version that caused it**, so every retry sent the same doomed `If-Match`. The error path refetches.
5. **A drag cancelled off the board navigated away on the next click** — it never reached a drop handler, so the drag end was never recorded. Now recorded on `dragEnd`.
6. A story comment claiming the wrong default view.

## Verification

- `make check-fe` — green, **2928 + 52** tests (47 lead tests, up from 46)
- `make fe-uat` — 12 stories render, including `LeadsBoard`
- `make craft-static` — 0 blocker, 0 major, 0 minor
- Mutation-checked: the `If-Match` assertion and the filter-bar test each fail when their fix is reverted
- Live against the dev API: move `200`, stale version `409`, terminal status `422`

Frontend-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a triage board to Leads and updates `PipelineBoard` to support a count-only variant. Leads can now be dragged between the two live statuses; previously Leads had only a table view.

- Board shows only `new` and `working`. `promoted` and `disqualified` are excluded; moving to them is via their audited verbs (drag would 422).
- Moves send `If-Match` with the card’s version; correct version 200, stale 409. Error path refetches so retries use a fresh version.
- The board renders inside the list surface via a new `ListTable` `body` slot, keeping search, filters, saved views, and showing “Load more.” When filters leave no live leads, it explains why.

**Component and type updates**
- `PipelineBoard` is now a discriminated union:
  - `variant: "deal"` requires `BoardMoneyColumn` (probability, raw, weighted, currency).
  - `variant: "plain"` takes `BoardColumn` (count only).
  - Optional `renderCard` lets callers render non-deal cards (used for leads).
- Drag UX fixes: record drag end to avoid unintended navigation; highlight droptargets.
- Callers updated: deal screens/tests now use `BoardMoneyColumn`.

Required actions for reviewers/integrators:
- For existing money boards, pass `BoardMoneyColumn` (probability/amounts are required). Use `renderCard` if your rows are not deals.

<sup>Written for commit bb62d3559cee4c342a0e90b332fca7cdf601cd53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

