### PR TITLE
feat(leads): correct a lead's details where they stand

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1282,6 +1282,10 @@ export const de = {
   "lead.filterScoreHot": "Ab 80",
   "lead.filterScoreWarm": "Ab 60",
   "lead.filterScoreCool": "Ab 40",
+  "lead.details": "Details",
+  "lead.detailsUnset": "Nicht gesetzt",
+  "lead.terminalReadOnly":
+    "Dieser Lead ist abgeschlossen und nimmt keine Änderungen an.",
   "lead.boardTerminalOnly":
     "Das Board zeigt nur offene Leads. Diese Leads sind übernommen oder disqualifiziert.",
   "person.fromLead": "Aus Lead übernommen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1291,6 +1291,9 @@ export const en = {
   "lead.filterScoreHot": "80 and up",
   "lead.filterScoreWarm": "60 and up",
   "lead.filterScoreCool": "40 and up",
+  "lead.details": "Details",
+  "lead.detailsUnset": "Not set",
+  "lead.terminalReadOnly": "This lead is closed and takes no changes.",
   "lead.boardTerminalOnly":
     "The board shows open leads only. These leads are promoted or disqualified.",
   "person.fromLead": "From lead",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1283,6 +1283,10 @@ export const vi = {
   "lead.filterScoreHot": "Từ 80",
   "lead.filterScoreWarm": "Từ 60",
   "lead.filterScoreCool": "Từ 40",
+  "lead.details": "Chi tiết",
+  "lead.detailsUnset": "Chưa đặt",
+  "lead.terminalReadOnly":
+    "Khách hàng tiềm năng này đã đóng và không nhận thay đổi.",
   "lead.boardTerminalOnly":
     "Bảng chỉ hiện khách hàng tiềm năng đang mở. Những mục này đã chuyển hoặc bị loại.",
   "person.fromLead": "Từ khách hàng tiềm năng",

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -293,6 +293,58 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
   });
 
+  it("edits a lead field in place, sending If-Match", async () => {
+    // The Edit modal is four clicks and a context switch to fix a misspelled
+    // company name. It stays for wholesale edits; the fields a rep corrects
+    // while reading are corrected while reading.
+    type Patched = { body: unknown; ifMatch: string | null };
+    const patched: Patched[] = [];
+    stubFetch(async (_url: string, method: string, request) => {
+      if (method === "PATCH") {
+        patched.push({
+          body: await request.json(),
+          ifMatch: request.headers.get("If-Match"),
+        });
+        return jsonResponse({ ...lead, company_name: "Nordwind GmbH" });
+      }
+      return jsonResponse(lead);
+    });
+    render(<LeadScreen id="l-1" />);
+
+    // The row reads as its value; pressing it opens the field.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Change Company" }),
+    );
+    const field = await screen.findByDisplayValue("Nordwind Logistik");
+    await userEvent.clear(field);
+    await userEvent.type(field, "Nordwind GmbH");
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => expect(patched.length).toBe(1));
+    expect(patched[0].body).toMatchObject({ company_name: "Nordwind GmbH" });
+    expect(patched[0].ifMatch).toBe("1");
+  });
+
+  it("a terminal lead's fields are read-only with the reason, not missing", async () => {
+    // STATE-4a: the reason is the information. A field that simply vanished on
+    // a closed lead would hide the fact the reader came for.
+    stubFetch(async () =>
+      jsonResponse({
+        ...lead,
+        status: "disqualified",
+        archived_at: "2026-07-13T00:00:00Z",
+      }),
+    );
+    render(<LeadScreen id="l-1" />);
+
+    // The value is still shown — as text, with no control to press.
+    expect(
+      (await screen.findAllByText("Nordwind Logistik")).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Change Company" })).toBeNull();
+    expect(screen.queryByDisplayValue("Nordwind Logistik")).toBeNull();
+  });
+
   it("a promoted lead keeps its page and says what the promotion did", async () => {
     // AC-leaddetail-5 (ADR-0119/A170). The page used to redirect here, which
     // told the reader the lead had ceased to exist — untrue of a record this
@@ -780,7 +832,11 @@ describe("LeadScreen — edit with If-Match (P-1)", () => {
         .getAllByText("Working")
         .some((el) => el.classList.contains("badge")),
     ).toBe(true);
-    expect(screen.getByText("Nordwind Logistik")).toBeTruthy();
+    expect(
+      screen
+        .getAllByText("Nordwind Logistik")
+        .some((el) => el.classList.contains("badge")),
+    ).toBe(true);
   });
 });
 
@@ -873,7 +929,11 @@ describe("LeadScreen — overlay mode write affordances", () => {
     await userEvent.type(fullName, "Jonas Petersen-Berg");
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(await screen.findByText("Jonas Petersen-Berg")).toBeTruthy();
+    // The saved name now reads in two places — the record header and the
+    // inline Details row — which is the point of the grid, not a duplicate.
+    expect(
+      (await screen.findAllByText("Jonas Petersen-Berg")).length,
+    ).toBeGreaterThan(0);
   });
 
   it("names the partial write-back in the edit form", async () => {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -21,6 +21,7 @@ import {
   PipelineBoard,
   RecordView,
 } from "../design-system/composed";
+import { InlineText } from "../design-system/inlinechoice";
 import type { ListChip } from "../design-system/listtable";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useRecordTimeline } from "../design-system/recordtimeline";
@@ -1143,6 +1144,67 @@ function LeadScorePanel({
   );
 }
 
+/**
+ * The lead's own words, editable where they stand.
+ *
+ * Everything here was previously reachable only through the Edit modal, which
+ * is four clicks and a context switch to fix a misspelled company name. The
+ * modal stays — it is how a lead is edited wholesale, and how the fields this
+ * grid does NOT carry are reached — but the four a rep corrects while reading
+ * are corrected while reading.
+ *
+ * Every row saves through the SAME patch the lifecycle card uses, so one
+ * inline edit and another cannot invalidate different caches or send a
+ * different If-Match.
+ */
+function LeadIdentityFields({
+  lead,
+  save,
+  readOnlyReason,
+}: Readonly<{
+  lead: Lead;
+  save: (body: UpdateLeadRequest) => Promise<void>;
+  readOnlyReason?: string;
+}>) {
+  const t = useT();
+  const canEdit = !readOnlyReason;
+  return (
+    <Panel title={t("lead.details")}>
+      <PanelBody>
+        <InlineText
+          label={t("create.fullName")}
+          value={lead.full_name ?? ""}
+          placeholder={t("lead.detailsUnset")}
+          canEdit={canEdit}
+          readOnlyReason={readOnlyReason}
+          onSave={(next) => save({ full_name: next.trim() || null })}
+        />
+        <InlineText
+          label={t("create.personTitle")}
+          value={lead.title ?? ""}
+          placeholder={t("lead.detailsUnset")}
+          canEdit={canEdit}
+          readOnlyReason={readOnlyReason}
+          onSave={(next) => save({ title: next.trim() || null })}
+        />
+        <InlineText
+          label={t("create.companyName")}
+          value={lead.company_name ?? ""}
+          placeholder={t("lead.detailsUnset")}
+          canEdit={canEdit}
+          readOnlyReason={readOnlyReason}
+          onSave={(next) => save({ company_name: next.trim() || null })}
+        />
+        {/* Email is NOT here. It is the lead's dedupe key: changing it can
+            collide with a live lead and answer 409 with an incumbent id, which
+            is a conversation (view the existing record) rather than a field
+            edit. The Edit modal owns it, where that answer has somewhere to
+            render. */}
+      </PanelBody>
+    </Panel>
+  );
+}
+
 function LeadLifecycle({
   lead,
   id,
@@ -1196,6 +1258,13 @@ function LeadLifecycle({
 
   const meId = me.data?.user?.id;
 
+  // The inline rows await their save and render what it throws, so they need a
+  // promise rather than the mutation's fire-and-forget. mutateAsync is that
+  // same mutation — one PATCH shape, one If-Match, one invalidation.
+  const saveField = async (body: UpdateLeadRequest) => {
+    await patch.mutateAsync(body);
+  };
+
   return (
     <Card
       as="div"
@@ -1207,6 +1276,12 @@ function LeadLifecycle({
         gap: "var(--space-3)",
       }}
     >
+      <LeadIdentityFields
+        lead={lead}
+        save={saveField}
+        readOnlyReason={readOnly ? t("lead.terminalReadOnly") : undefined}
+      />
+
       {isOpenStatus(lead.status) && (
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
           <span className="t-caption">{t("lead.setStatus")}</span>


### PR DESCRIPTION
Every change to a lead's name, title or company went through the Edit modal:
four clicks and a context switch to fix a misspelling a rep noticed while
reading. The three fields corrected while reading are corrected while reading.

The modal stays. It is how a lead is edited wholesale, and how the fields this
grid does not carry are reached.

Email is deliberately not inline. It is the lead's dedupe key, so changing it
can collide with a live lead and answer 409 with the incumbent's id — that is a
conversation (view the existing record), not a field edit, and the modal is
where that answer already has somewhere to render.

Every row saves through the SAME patch the lifecycle card uses, so one inline
edit and another cannot send a different If-Match or invalidate a different
cache. On a terminal lead the rows are read-only WITH the reason rather than
absent: a field that vanished on a closed lead would hide the fact the reader
came for (STATE-4a).

Verified live: a single-field PATCH with If-Match returns the new version, and
clearing a field to null is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Edit lead name, title, and company inline in the Details panel to avoid the modal-only flow. Previously these fields required the Edit modal; now they are editable in place, while the modal remains for wholesale edits and for fields not shown. Closed leads render these fields read-only with a reason, and email stays modal-only because it’s the dedupe key.

**Review notes**
- UI: new Details panel renders three `InlineText` rows with “Not set” placeholders; press to edit, Enter to save.
- Data: inline saves call the same lead PATCH mutation as the lifecycle card via `mutateAsync`, sending a single PATCH with the existing If-Match and unified cache invalidation.
- Constraints: email is excluded from inline editing to handle 409s and incumbent resolution in the modal.
- I18n: adds `lead.details`, `lead.detailsUnset`, and `lead.terminalReadOnly` in `en`, `de`, and `vi`.
- Tests: verify inline edit sends If-Match and updates, terminal leads show read-only values with the reason, and expected duplicate renders (header + Details) are accounted for.

<sup>Written for commit 86138f125b0a858da90f836c2da9f6fe17a53db0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

