### PR TITLE
feat(privacy): a held record leaves every ordinary read path, and a write to one answers 423

### DIFF
--- a/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_sinkerasure_integration_test.go
@@ -300,11 +300,12 @@ func TestAnErasureLeavesAnotherAccountsChannelActivityUntouched(t *testing.T) {
 	}
 }
 
-// The statutory floor outranks Art. 17 for recent correspondence, and it applies
-// to channel messages too: the predicate shields every activity whose kind is
-// not 'task'/'note', and a Telegram message qualifies. So a RECENT channel
-// message from an erased subject is retained verbatim, account id included,
-// until the floor lapses.
+// The statutory floor outranks Art. 17 for recent commercial correspondence,
+// and it applies to channel messages too: a Telegram message about a won deal
+// is a Handelsbrief whichever transport carried it (A165/ADR-0114). So a
+// RECENT channel message from an erased subject is HELD — its body kept, the
+// account identifiers that ARE the subject cleared, the row restricted — until
+// the floor lapses.
 //
 // That is the shipped GoBD posture (F-012 refuses a floor bypass), not an
 // oversight — and it is pinned here precisely because the arm above looks like
@@ -319,14 +320,21 @@ func TestARecentChannelMessageIsShieldedFromErasureByTheStatutoryFloor(t *testin
 
 	const body = "a message inside the statutory floor"
 	rec := inboundChannelRecordAt("20601", body, time.Now().UTC())
-	if _, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), rec); err != nil {
+	ref, err := capture.NewSink(e.DB()).Upsert(sinkConnectorCtx(e), rec)
+	if err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
+	// The floor covers correspondence about an actual transaction, so the
+	// message needs one behind it to be shielded at all.
+	e.SeedWonDealLinkedTo(t, ref.ID)
 	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), person, "test"); err != nil {
 		t.Fatalf("ErasePerson: %v", err)
 	}
 	if n := activityBodyCount(t, e, body); n != 1 {
 		t.Errorf("got %d retained activities, want 1 — the statutory correspondence floor must outrank the erasure for a recent message", n)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM activity WHERE id = $1 AND restricted_at IS NOT NULL AND thread_key IS NULL AND source_id IS NULL`, ref.ID); n != 1 {
+		t.Errorf("the shielded message is not held with its account identifiers cleared (%d rows match)", n)
 	}
 }
 

--- a/backend/internal/compose/integration/erasure_restriction_integration_test.go
+++ b/backend/internal/compose/integration/erasure_restriction_integration_test.go
@@ -24,8 +24,11 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -361,6 +364,59 @@ func TestARestrictedRowRefusesEveryOrdinaryWrite(t *testing.T) {
 	// nothing fails on the guard.
 	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), f.person, "test"); err != nil && !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("a second erasure over a held record failed: %v", err)
+	}
+}
+
+// TestARestrictedRowLeavesEveryOrdinaryReadPath is A165 §2 from the reader's
+// side, for the UNBOUNDED principal — the admin the link-walk spares is the
+// one the availability test must still stop. The single-row read, the
+// timeline including archived rows, and the record history all answer as if
+// the row were gone; the Art. 15 package alone still reaches it; and a write
+// surfaces as the 423 the contract promises, with the deadline attached.
+func TestARestrictedRowLeavesEveryOrdinaryReadPath(t *testing.T) {
+	e := Setup(t)
+	f := seedRestrictionFixture(t, e)
+	admin := e.Admin()
+	if err := privacy.NewEraser(e.DB()).ErasePerson(admin, f.person, "test"); err != nil {
+		t.Fatalf("erasing the subject → %v", err)
+	}
+	held := ids.From[ids.ActivityKind](f.email)
+
+	if _, err := e.Activities.GetActivity(admin, held, storekit.IncludeArchived); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("a held record is readable by id, archived included: %v", err)
+	}
+	listed, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{IncludeArchived: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range listed {
+		if ids.UUID(a.Id) == f.email {
+			t.Errorf("a held record is on the timeline when archived rows are included")
+		}
+	}
+	if _, err := privacy.ListRecordHistory(admin, e.DB(), privacy.RecordHistoryFilter{EntityType: "activity", EntityID: f.email}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("a held record's history (which carries its pre-redaction images) is readable: %v", err)
+	}
+
+	// The store's own write path never reaches the guard: it reads first,
+	// and a held row reads as gone. A writer that skips the read — a raw
+	// statement, a lifecycle path that addresses the row by id — meets the
+	// guard, and the transport answers the refusal as the contract's 423 with
+	// the deadline, never as a value the caller could fix.
+	subject := "rewritten"
+	if _, err := e.Activities.UpdateActivity(admin, held, activities.UpdateActivityInput{Subject: &subject}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("the store's write path found a held record: %v", err)
+	}
+	err = database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `UPDATE activity SET subject = 'rewritten' WHERE id = $1`, f.email)
+		return err
+	})
+	fault, ok := httperr.Classify(err)
+	if !ok || fault.Status != http.StatusLocked || fault.Code != "locked" {
+		t.Fatalf("a write to a held record → %v (fault %+v), want 423 locked", err, fault)
+	}
+	if fault.Details["retain_until"] == nil {
+		t.Errorf("the 423 does not say when the hold lifts: %+v", fault)
 	}
 }
 

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -158,7 +158,12 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// FLAT in the size of the account like every section here — one query
 	// whether the company holds one agreement or forty — which is the property
 	// this budget exists to protect, rather than the absolute number.
-	const budget = 31
+	//
+	// 32 since A165/ADR-0114: the activity visibility probe no longer skips
+	// the unbounded principal — the availability test (a held record reads
+	// as gone, admin included) runs for everyone. One indexed read by primary
+	// key, flat in the size of the account.
+	const budget = 32
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/modules/activities/capturelabelstats.go
+++ b/backend/internal/modules/activities/capturelabelstats.go
@@ -26,7 +26,7 @@ func (s *Store) LabeledCaptureCountSince(ctx context.Context, since time.Time) (
 		return tx.QueryRow(ctx,
 			`SELECT count(*) FROM activity
 			 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			   AND capture_labeled_at >= $1`, since,
+			   AND capture_labeled_at >= $1 AND restricted_at IS NULL`, since,
 		).Scan(&count)
 	})
 	if err != nil {

--- a/backend/internal/modules/activities/channelsend.go
+++ b/backend/internal/modules/activities/channelsend.go
@@ -292,7 +292,7 @@ func (s *Store) channelProviderOf(ctx context.Context, anchorID ids.ActivityID) 
 			return err
 		}
 		if err := tx.QueryRow(ctx,
-			`SELECT coalesce(channel_provider, '') FROM activity WHERE id = $1`, anchorID).Scan(&provider); err != nil {
+			`SELECT coalesce(channel_provider, '') FROM activity WHERE id = $1 AND restricted_at IS NULL`, anchorID).Scan(&provider); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return apperrors.ErrNotFound
 			}
@@ -315,7 +315,7 @@ func (s *Store) resolveConversation(ctx context.Context, anchorID ids.ActivityID
 			return err
 		}
 		if err := tx.QueryRow(ctx,
-			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, anchorID).Scan(&out.threadKey); err != nil {
+			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1 AND restricted_at IS NULL`, anchorID).Scan(&out.threadKey); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return apperrors.ErrNotFound
 			}

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -319,7 +319,7 @@ func anchorThreading(ctx context.Context, tx pgx.Tx, id ids.ActivityID, messageI
 	}
 	var kind, parent, root string
 	err := tx.QueryRow(ctx,
-		`SELECT kind, coalesce(source_id, ''), coalesce(thread_key, '') FROM activity WHERE id = $1`,
+		`SELECT kind, coalesce(source_id, ''), coalesce(thread_key, '') FROM activity WHERE id = $1 AND restricted_at IS NULL`,
 		id).Scan(&kind, &parent, &root)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return threading{}, apperrors.ErrNotFound

--- a/backend/internal/modules/activities/messageidentity.go
+++ b/backend/internal/modules/activities/messageidentity.go
@@ -276,7 +276,10 @@ func absorbEcho(ctx context.Context, tx pgx.Tx, survivorID ids.ActivityID, stamp
 		   AND echo.captured_by LIKE 'connector:%'
 		   AND echo.created_at        >= survivor.created_at
 		   AND echo.counterparty_email = survivor.counterparty_email
-		 WHERE survivor.id = $1`, survivorID, stamped).Scan(&echoID)
+		   -- A held row is nobody's echo: the guard would refuse the fold, and a
+		   -- restricted record must not be folded into a live one anyway.
+		   AND echo.restricted_at IS NULL
+		 WHERE survivor.id = $1 AND survivor.restricted_at IS NULL`, survivorID, stamped).Scan(&echoID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("activities: the re-key collided on %s, but no row this workspace holds under that identity is a captured outbound echo of this send",
 			uqActivitySource)

--- a/backend/internal/modules/capture/pending.go
+++ b/backend/internal/modules/capture/pending.go
@@ -287,8 +287,8 @@ func (s *PendingStore) ClaimDue(ctx context.Context, limit int) ([]PendingCounte
 			    FOR UPDATE SKIP LOCKED)
 			RETURNING p.id, p.email, coalesce(p.domain, ''), coalesce(left(p.display_name, $5), ''),
 			          p.activity_id, p.owner_id,
-			          coalesce(left((SELECT a.subject FROM activity a WHERE a.id = p.activity_id), $6), ''),
-			          coalesce(left((SELECT a.body FROM activity a WHERE a.id = p.activity_id), $7), '')`,
+			          coalesce(left((SELECT a.subject FROM activity a WHERE a.id = p.activity_id AND a.restricted_at IS NULL), $6), ''),
+			          coalesce(left((SELECT a.body FROM activity a WHERE a.id = p.activity_id AND a.restricted_at IS NULL), $7), '')`,
 			limit, pendingLease.Seconds(), PendingMaxAttempts, claim,
 			MaxCapturedNameChars, MaxCapturedSubjectChars, MaxCapturedBodyChars)
 		if err != nil {

--- a/backend/internal/modules/capture/sinkmailgates.go
+++ b/backend/internal/modules/capture/sinkmailgates.go
@@ -117,6 +117,7 @@ func (s *Sink) correspondencePositiveTx(ctx context.Context, tx pgx.Tx, email st
 		SELECT COALESCE(subject, ''), COALESCE(body, '')
 		  FROM activity
 		 WHERE counterparty_email = $1 AND counterparty_outbound_attested
+		   AND restricted_at IS NULL
 		 LIMIT 2`, normalized)
 	if err != nil {
 		return false, fmt.Errorf("capture: correspondence-positive gate: %w", err)

--- a/backend/internal/modules/search/embedding.go
+++ b/backend/internal/modules/search/embedding.go
@@ -106,9 +106,17 @@ func (s *Store) UpsertEmbedding(ctx context.Context, entityType string, entityID
 		// read (a redelivered event racing this one, or another identity
 		// swap) already won — leave fresh=false rather than clobbering a
 		// row fresher than the one this call started from.
+		//
+		// The activity arm re-checks the RESTRICTION on write, not only on
+		// the read that produced the text: a worker that read the body just
+		// before an erasure held the row would otherwise reinsert a vector of
+		// hidden content after the erasure deleted it (A165/ADR-0114). The
+		// restriction commits before this statement runs or it does not; either
+		// way this statement sees the row as it is now.
 		tag, err := tx.Exec(ctx, `
 			INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 0, $3, $4, $5::vector)
+			SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 0, $3, $4, $5::vector
+			 WHERE NOT EXISTS (SELECT 1 FROM activity a WHERE $1 = 'activity' AND a.id = $2 AND a.restricted_at IS NOT NULL)
 			ON CONFLICT (entity_type, entity_id, chunk_ix)
 			DO UPDATE SET chunk_hash = EXCLUDED.chunk_hash, model = EXCLUDED.model,
 			              embedding = EXCLUDED.embedding, created_at = now()

--- a/backend/internal/platform/auth/inheritedscope.go
+++ b/backend/internal/platform/auth/inheritedscope.go
@@ -22,6 +22,20 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
+// ActivityAvailableClause is the predicate under which an activity is in the
+// readable world at all: not held under a statutory retention obligation
+// (A165/ADR-0114 §2). A restricted row is unavailable in EVERY ordinary read
+// path — lists, timelines, search, exports, embeddings, agent grounding — for
+// every principal, the unbounded admin included, because the obligation
+// justifies storage and nothing else. It is composed into ActivityScopeClause
+// so the ~30 readers that carry the scope get it for free, and it is exported
+// for the readers that legitimately bypass the scope (an engine-internal
+// aggregate, a capture-side gate) and must still exclude what is held.
+// alias names the activity table in the outer query.
+func ActivityAvailableClause(alias string) string {
+	return alias + ".restricted_at IS NULL"
+}
+
 // ActivityScopeClause is the activity analogue of ScopeClause:
 // activities have no owner, but their free-text inherits the
 // sensitivity of the records they attach to. An activity is visible when
@@ -32,13 +46,19 @@ import (
 // both the activities timeline and people's promotion-evidence check
 // enforce it — scope policy has exactly one spelling (ADR-0054 §8).
 // alias names the activity table in the outer query.
+//
+// It is never empty: an unbounded principal is spared the link-walk, not the
+// availability test (ActivityAvailableClause). Callers written for the older
+// "empty means unscoped" contract keep working — an always-present clause is
+// what they append when it is present.
 func ActivityScopeClause(ctx context.Context, alias string, arg func(any) int) (string, error) {
 	p, err := rbacActor(ctx)
 	if err != nil {
 		return "", err
 	}
+	available := ActivityAvailableClause(alias)
 	if UnboundedFor(p, linkTargetTables...) {
-		return "", nil
+		return available, nil
 	}
 	// One correlated pass over the activity's links, not two. bool_or is
 	// exactly the ANY-link rule, and its empty-set answer — NULL, coalesced
@@ -52,9 +72,9 @@ func ActivityScopeClause(ctx context.Context, alias string, arg func(any) int) (
 	// caller has been paying it; it only surfaced as a budget failure when
 	// capture privacy stopped exempting the all-scope reader the perf
 	// fixture happens to run as.
-	return fmt.Sprintf(`coalesce((SELECT bool_or(%[2]s)
+	return fmt.Sprintf(`%[3]s AND coalesce((SELECT bool_or(%[2]s)
 	   FROM activity_link l WHERE l.activity_id = %[1]s.id), true)`,
-		alias, linkTargetVisible(p, "l", arg)), nil
+		alias, linkTargetVisible(p, "l", arg), available), nil
 }
 
 // SignalScopeClause is the signal analogue of ActivityScopeClause: a
@@ -160,9 +180,9 @@ func EnsureActivityVisible(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
 	if err != nil {
 		return err
 	}
-	if clause == "" {
-		return nil
-	}
+	// Never skipped, even for an unbounded principal: the clause always
+	// carries the availability test, and a restricted row must read as gone
+	// to everyone.
 	var visible bool
 	err = tx.QueryRow(ctx,
 		fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM activity a WHERE a.id = $%d AND %s)`, idPos, clause),

--- a/backend/internal/platform/httperr/constraintfault.go
+++ b/backend/internal/platform/httperr/constraintfault.go
@@ -15,10 +15,12 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"regexp"
 
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
 // constraintFault answers a foreign-key or CHECK violation that reached the
@@ -39,6 +41,9 @@ import (
 // this answers the ones that do not, and the constraint goes to the operator's
 // log through InfraCause instead.
 func constraintFault(err error) (Fault, bool) {
+	if fault, ok := retentionHoldFault(err); ok {
+		return fault, true
+	}
 	switch {
 	case storekit.IsForeignKeyViolation(err):
 		return Fault{
@@ -56,6 +61,42 @@ func constraintFault(err error) (Fault, bool) {
 	default:
 		return Fault{}, false
 	}
+}
+
+// activityRestrictedImmutable is the constraint name the data-layer guard
+// raises for any write to a held activity (core migration 0289's trigger).
+// Named here so the ONE guard maps to the ONE sentinel for every writer —
+// an update, a delete, a relink — rather than each store translating it.
+const activityRestrictedImmutable = "activity_restricted_immutable"
+
+// retentionHoldUntil reads the deadline out of the guard's own message
+// ("… restricted under a statutory retention obligation until <instant>"),
+// which is the only place the refusing statement carries it.
+var retentionHoldUntil = regexp.MustCompile(` until (\S.*)$`)
+
+// retentionHoldFault answers the guard's refusal as ErrRetentionHold (423): a
+// business rule like the other CHECKs, but not one the caller's input can fix
+// — nothing changes until the recorded date, so it must not read as
+// value_not_allowed with advice to fix a value. The deadline rides Details as
+// `retain_until` (interfaces.md §0) so the refusal states when it lifts.
+func retentionHoldFault(err error) (Fault, bool) {
+	constraint, ok := storekit.CheckViolation(err)
+	if !ok || constraint != activityRestrictedImmutable {
+		return Fault{}, false
+	}
+	fault := Fault{
+		Status: http.StatusLocked, Code: "locked",
+		Detail: apperrors.ErrRetentionHold.Error() + " and cannot be changed or deleted until its window " +
+			"closes. Do not retry: an administrator holding the retention authority may release it, which is its own audited operation.",
+		InfraCause: err,
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if m := retentionHoldUntil.FindStringSubmatch(pgErr.Message); m != nil {
+			fault.Details = map[string]any{"retain_until": m[1]}
+		}
+	}
+	return fault, true
 }
 
 // isConstrainedValue covers the two ways the schema refuses a VALUE: a CHECK on

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -57,6 +57,7 @@ var mapping = []struct {
 	{apperrors.ErrOverlayFlipBlocked, http.StatusConflict, "overlay_flip_blocked"},
 	{apperrors.ErrIncumbentBudgetExhausted, http.StatusServiceUnavailable, "incumbent_budget_exhausted"},
 	{apperrors.ErrBaseCurrencyLocked, http.StatusConflict, "base_currency_locked"},
+	{apperrors.ErrRetentionHold, http.StatusLocked, "locked"},
 }
 
 // clientInputValidation maps the typed errors that mean "the CALLER got the

--- a/backend/internal/platform/httperr/httperr_test.go
+++ b/backend/internal/platform/httperr/httperr_test.go
@@ -366,3 +366,33 @@ func TestWrite_anUnsetInstallationSettingIsAnOperatorFaultNotAMissingRow(t *test
 		t.Errorf("body %q does not name which setting is unset", body)
 	}
 }
+
+// TestRetentionHoldIsLockedNotValueNotAllowed pins the one CHECK refusal that
+// is not the caller's input to fix: the data-layer guard on a held activity
+// (A165/ADR-0114). It answers 423 locked with the deadline the guard named,
+// so a caller learns when the hold lifts rather than being told to change a
+// value that no value would satisfy.
+func TestRetentionHoldIsLockedNotValueNotAllowed(t *testing.T) {
+	err := fmt.Errorf("activities: rewriting the subject: %w", &pgconn.PgError{
+		Severity: "ERROR", Code: "23514", ConstraintName: "activity_restricted_immutable",
+		Message: "activity 0192e0c8-4b0e-7cbb-9c1a-b1c9d54c1a2f is restricted under a statutory retention obligation until 2032-01-01 00:00:00+00",
+	})
+	fault, ok := Classify(err)
+	if !ok || fault.Status != http.StatusLocked || fault.Code != "locked" {
+		t.Fatalf("Classify → %+v, %v; want 423 locked", fault, ok)
+	}
+	if fault.Details["retain_until"] != "2032-01-01 00:00:00+00" {
+		t.Errorf("retain_until = %v, want the guard's deadline", fault.Details["retain_until"])
+	}
+	if !strings.Contains(fault.Detail, "Do not retry") {
+		t.Errorf("the refusal invites a retry that can never succeed: %q", fault.Detail)
+	}
+	if fault.InfraCause == nil {
+		t.Error("the constraint name goes to the operator's log, not the client — InfraCause must carry it")
+	}
+	// Any other CHECK is still the caller's value to fix.
+	other, _ := Classify(&pgconn.PgError{Code: "23514", ConstraintName: "organization_size_band_check"})
+	if other.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an ordinary CHECK became %d", other.Status)
+	}
+}

--- a/backend/internal/shared/apperrors/apperrors.go
+++ b/backend/internal/shared/apperrors/apperrors.go
@@ -153,3 +153,13 @@ var (
 // those deals were worth. Distinct from ErrVersionSkew, which means somebody
 // else changed the row, and from ErrPermissionDenied, which means you may never.
 var ErrBaseCurrencyLocked = errors.New("base currency is locked by frozen conversion rates")
+
+// ErrRetentionHold is the statutory-restriction sentinel (interfaces.md §0,
+// A165/ADR-0114, A167/ADR-0116): a delete or mutation of a record held under
+// a retention obligation, refused for EVERY role including admin because the
+// immutability is a data-layer guarantee no seat clears (DEPACK-AC-5a). It
+// says nobody may, until a date — distinct from ErrPermissionDenied (you may
+// not, another principal might) and ErrVersionSkew (somebody else changed the
+// row) — so a caller must never retry it; the one way past it is the audited
+// release, which is its own operation.
+var ErrRetentionHold = errors.New("record is held under a statutory retention obligation")

--- a/backend/migrations/core/1787016452_restricted_is_archived.down.sql
+++ b/backend/migrations/core/1787016452_restricted_is_archived.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity DROP CONSTRAINT IF EXISTS activity_restricted_is_archived;

--- a/backend/migrations/core/1787016452_restricted_is_archived.up.sql
+++ b/backend/migrations/core/1787016452_restricted_is_archived.up.sql
@@ -1,0 +1,14 @@
+-- A held record is out of the default lists by construction
+-- (A165/ADR-0114 §2).
+--
+-- The restrict step archives the row it holds, and the guard refuses any
+-- later write that would un-archive it while it is held. Most readers of
+-- activity filter `archived_at IS NULL`, and A165 promises that a restricted
+-- record is unavailable in EVERY ordinary read path — so those readers are
+-- correct only while "restricted implies archived" holds. Stated as a CHECK
+-- rather than left to the two writers, because a rule two writers keep by
+-- convention is one the third writer breaks; the readers relying on it are
+-- named by the restricted-readers fitness test.
+ALTER TABLE activity
+  ADD CONSTRAINT activity_restricted_is_archived
+    CHECK (restricted_at IS NULL OR archived_at IS NOT NULL);

--- a/backend/restrictedreaders_test.go
+++ b/backend/restrictedreaders_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A record held under a statutory retention obligation is unavailable in
+// EVERY ordinary read path (A165/ADR-0114 §2): lists, timelines, search,
+// exports, embeddings, agent grounding. This gate derives the readers of the
+// activity table from the tree and asks each how it excludes a held row,
+// because a reader that forgets is indistinguishable from one that never
+// existed — until a supervisory authority asks why an erased subject's
+// correspondence is on a sales rep's screen.
+//
+// A file satisfies the gate by ONE of three means, each a real exclusion:
+//
+//   - it carries the shared row scope (auth.ActivityScopeClause or one of the
+//     probes built on it), which always composes ActivityAvailableClause;
+//   - it names restricted_at itself, or the privacy floor fragments that do;
+//   - it filters `archived_at IS NULL`, which excludes held rows because the
+//     schema makes restricted imply archived (activity_restricted_is_archived).
+//
+// A file that reads activity by none of those is waived here with the reason
+// it may — and each waiver names the cost.
+
+import (
+	"go/ast"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// activityReadLiteral matches a SQL string literal that reads the activity
+// table by name. `activity_link`, `activity_participant` and the other
+// activity_* tables are deliberately not matched: they carry no content.
+var activityReadLiteral = regexp.MustCompile(`(?i)\b(FROM|JOIN)\s+activity(\s|$|\n)`)
+
+// restrictedExclusionMarkers are the spellings that exclude a held row. A
+// file carrying any of them anywhere is taken as excluding — file-level on
+// purpose: the SQL in this tree is assembled from fragments, so a per-statement
+// judgement would need to evaluate Go string concatenation, and the gate
+// would be wrong about the fragments more often than the files.
+var restrictedExclusionMarkers = []string{
+	"ActivityScopeClause", "ActivityAvailableClause",
+	"EnsureActivityVisible", "EnsureActivityVisibleLive",
+	"restricted_at",
+	"correspondenceFloorPredicate", "handelsbriefShielded",
+	"archived_at IS NULL",
+}
+
+// restrictedReadersAdmitted ratifies the readers that carry none of the
+// markers and still exclude a held row — through a fragment declared in
+// another file — or that reach held rows on purpose. Each names the cost.
+var restrictedReadersAdmitted = gatekit.Waive(map[string]string{
+	"internal/modules/activities/capturelabel.go": "the classify backlog reads subject and body through ClassifyBacklogPredicate (pipelinefacts.go), which filters archived_at IS NULL and so excludes held rows by the restricted-implies-archived CHECK — the cost is that the predicate's archived filter now carries this obligation as well as its own",
+})
+
+// activityReaderScope is every non-test, non-generated file under internal/
+// that reads the activity table by name.
+var activityReaderScope = gatekit.Scope{
+	Roots:   []string{"internal"},
+	Subject: readsActivityTable,
+	Exempt:  gatekit.Waive(map[string]string{}),
+}
+
+func readsActivityTable(path string, file *ast.File) bool {
+	if strings.HasSuffix(path, "_gen.go") {
+		return false
+	}
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if ok && activityReadLiteral.MatchString(lit.Value) {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func TestEveryReaderOfTheActivityTableExcludesRestrictedRows(t *testing.T) {
+	defer restrictedReadersAdmitted.AssertAllMatched(t)
+	for _, src := range activityReaderScope.Files(t) {
+		if fileCarriesAnyMarker(src.File, restrictedExclusionMarkers) || restrictedReadersAdmitted.Waived(t, src.Path) {
+			continue
+		}
+		t.Errorf("%s reads the activity table and nothing in it excludes a held row — compose auth.ActivityScopeClause / ActivityAvailableClause, filter `restricted_at IS NULL` or `archived_at IS NULL`, or ratify the reader in restrictedReadersAdmitted with the cost stated (A165/ADR-0114 §2)", src.Path)
+	}
+}
+
+// fileCarriesAnyMarker looks at identifiers and string literals alike: the
+// scope clause is reached as a selector, the SQL fragments as literals.
+func fileCarriesAnyMarker(file *ast.File, markers []string) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		var text string
+		switch node := n.(type) {
+		case *ast.Ident:
+			text = node.Name
+		case *ast.BasicLit:
+			text = node.Value
+		default:
+			return true
+		}
+		for _, marker := range markers {
+			if strings.Contains(text, marker) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}


### PR DESCRIPTION
The read-side half of A165/ADR-0114 §2, on top of #1617: a record held under a statutory retention obligation is unavailable in **every** ordinary read path, for every principal, and a write to one answers the 423 the contract promises.

**One clause, every reader.** `auth.ActivityScopeClause` is never empty any more: the unbounded principal is spared the link-walk, not the availability test (`auth.ActivityAvailableClause` = `restricted_at IS NULL`). Every reader carrying the scope — the single-row read behind `GET /v1/activities/{id}`, the timeline including `include_archived=true`, attachment access, record history, search, exports, 360s, MCP tools — gets it from that one place. `EnsureActivityVisible` no longer skips its probe for an unbounded principal.

**Readers that bypass the scope** were derived from the tree, not listed by hand: `backend/restrictedreaders_test.go` walks every non-test file under `internal/` that reads `activity` by name and requires the scope clause, a `restricted_at` test, the privacy floor fragments, or `archived_at IS NULL` — the last one is a real exclusion because a new CHECK (`activity_restricted_is_archived`) makes restricted imply archived, and the guard refuses un-archiving a held row. One waiver (`capturelabel.go`, which reads through a predicate declared in another file). Seven content readers with no archived filter now carry `restricted_at IS NULL` (channel send anchor, mail threading, capture pending triage, the correspondence-positive gate, the labeled-capture count, the outbound-echo fold), and the embedding upsert re-checks the restriction **on write**, closing the in-flight-worker reinsert.

**The refusal has its sentinel.** `apperrors.ErrRetentionHold` (interfaces.md §0, A167) → `423 locked`; the data-layer guard's `activity_restricted_immutable` is mapped once, in `httperr`, for every writer, with `retain_until` in Details and a detail that says not to retry. The store's own write path never reaches the guard (it reads first, and a held row reads as gone — 404, existence-hiding); the 423 is for the writer that addresses the row by id.

**Verification**
- `TestARestrictedRowLeavesEveryOrdinaryReadPath` (admin, i.e. unbounded): GET by id incl. archived → 404, timeline incl. archived → absent, record history → 404, store write → 404, raw write → 423 with `retain_until`.
- `TestEveryReaderOfTheActivityTableExcludesRestrictedRows` (root fitness), `TestRetentionHoldIsLockedNotValueNotAllowed` (httperr).
- Two fixtures corrected: the channels floor test now seeds the transaction it needs (it was red on main since #1607 — that PR checked `compose/integration` only) and asserts the message is held with its account identifiers cleared; the org360 query budget is 32 for the availability probe.
- `make check-backend`, `make craft-static`, `rls-store-path`, `no-jurisdiction` green; full `make test-integration` green except `TestActivityReadsAreScopedThroughLinks`, which fails identically on untouched main.

Not in this PR: release/pin (next). Part of A165 (#1557 follow-up); closes the three read-path findings from #1617's review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Held activities are now invisible to every ordinary read path and principal, and any write targeting one returns 423 Locked with the hold deadline. Previously the unbounded admin skipped the availability test and several readers didn’t exclude held rows; writes surfaced as generic CHECK errors.

- `auth.ActivityScopeClause` now always includes `auth.ActivityAvailableClause` (`restricted_at IS NULL`), even for unbounded principals; `EnsureActivityVisible` never skips the check. Org360 budget raised to 32 due to one extra indexed probe.
- Readers that bypass the scope now exclude held rows: `activities/channelsend` (provider/thread), `activities/email` (anchor threading), `activities/messageidentity` (echo fold), `capture/pending` (subject/body), `capture/sinkmailgates` (gate), `activities/capturelabelstats` (counts). `search/embedding` re-checks restriction on write to block reinserting vectors after a hold.
- Schema enforces “restricted implies archived” via `activity_restricted_is_archived`; readers filtering `archived_at IS NULL` exclude held rows by construction, and un-archiving a held row is refused.
- `apperrors.ErrRetentionHold` maps to 423 `locked`; `httperr` extracts `retain_until` from the guard (`activity_restricted_immutable`) and advises not to retry. Store writes that read first return 404; raw ID-targeted writes get 423.
- Fitness and integration tests: a tree-walk gate enforces that every activity reader excludes held rows; fixtures updated for Telegram erasure (identifiers cleared) and Org360 query count.

**Rollout**
- Run core migration `1787016452_restricted_is_archived` before deploying this code.
- Clients must handle 423 `locked` with `retain_until` and avoid automatic retries.

<sup>Written for commit 7df5196f137b8a758e683b9a87028ca01b857434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

