### PR TITLE
feat(seed-demo): seed the three partners and the accounts they work on

### DIFF
--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -29,6 +29,8 @@ type demoConfig struct {
 	Consent          []demoConsent       `json:"consent"`
 	FinanceCustomers []string            `json:"finance_customers"`
 	Lifecycle        map[string][]string `json:"lifecycle"`
+	Partners         []demoPartner       `json:"partners"`
+	PartnerEdges     []demoPartnerEdge   `json:"partner_edges"`
 }
 
 // anchorCompany is the installation's own company — the record that answers
@@ -226,4 +228,52 @@ type demoConsent struct {
 	PersonIndex int    `json:"person_index"`
 	Purpose     string `json:"purpose"`
 	State       string `json:"state"`
+}
+
+// demoPartner is one channel partner: a company the installation SELLS WITH
+// rather than sells to.
+//
+// Invented, and marked Synthetic so nothing mistakes one for a crawled
+// prospect: a partnership is a commercial agreement, and no amount of reading
+// a website reveals one. The three exist to fill the Partners screen, which is
+// built and would otherwise be demonstrated empty.
+//
+// PartnerRole, CertStatus, MarginTier and RelationshipStage are the product's
+// own enums (UpsertPartnerRequest in crm.yaml), not free text — the dataset
+// gives each partner a different value for all four so the screen shows range.
+type demoPartner struct {
+	Domain            string            `json:"domain"`
+	DisplayName       string            `json:"display_name"`
+	LegalName         string            `json:"legal_name"`
+	Industry          string            `json:"industry"`
+	Locale            string            `json:"locale"`
+	Synthetic         bool              `json:"synthetic"`
+	PartnerRole       string            `json:"partner_role"`
+	CertStatus        string            `json:"cert_status"`
+	MarginTier        string            `json:"margin_tier"`
+	RelationshipStage string            `json:"relationship_stage"`
+	NextStep          string            `json:"next_step"`
+	OwnerRef          string            `json:"owner_ref"`
+	People            []demoPartnerPers `json:"people"`
+}
+
+// demoPartnerPers is somebody at a partner company. Invented like the company
+// itself, so unlike a crawled person there is no published-versus-synthesized
+// distinction to preserve: the address is built from the partner's own
+// .example domain, which RFC 2606 reserves and nothing can deliver to.
+type demoPartnerPers struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// demoPartnerEdge ties a partner to an account it works on.
+//
+// Direction is not symmetric and the field names carry it: Organization is
+// the ACCOUNT and Partner is the counterparty, which is the shape the
+// contract states for partner_of / referred_by / co_sell_with. Reversing the
+// two would file the partner as somebody else's account.
+type demoPartnerEdge struct {
+	Partner      string `json:"partner"`      // a partner's domain
+	Organization string `json:"organization"` // the account's domain
+	Kind         string `json:"kind"`         // partner_of | referred_by | co_sell_with
 }

--- a/backend/tools/seed-demo/main.go
+++ b/backend/tools/seed-demo/main.go
@@ -108,14 +108,7 @@ func run() error {
 		return err
 	}
 
-	anchorRead, err := loadCompany(*dataset, demo.Anchor.Domain)
-	if err != nil {
-		return err
-	}
-	if err := seedAnchor(client, demo.Anchor, anchorRead, modeFor(*dryRun)); err != nil {
-		return err
-	}
-	if err := seed(client, companies, *dryRun); err != nil {
+	if err := seedTheCompanies(client, *dataset, demo, companies, modeFor(*dryRun)); err != nil {
 		return err
 	}
 
@@ -161,6 +154,33 @@ func loginAllowingAnEarlierSeed(baseURL, email string, password *string) (*clien
 	}
 	*password = seedAdminPassword
 	return client, nil
+}
+
+// seedTheCompanies writes every organization the installation holds: the
+// company it IS, the companies it sells TO, and the companies it sells WITH.
+//
+// The order is the dependency order. The anchor is first because it answers
+// "who are we?", and the channel is last of the three but still ahead of the
+// pipeline — ownership walks the organizations the pipeline refs find, and a
+// partner seeded after that pass would be the one ownerless company in the
+// installation, visible at every row scope.
+func seedTheCompanies(client *client, dataset string, demo demoConfig, companies []company, mode runMode) error {
+	anchorRead, err := loadCompany(dataset, demo.Anchor.Domain)
+	if err != nil {
+		return err
+	}
+	if err := seedAnchor(client, demo.Anchor, anchorRead, mode); err != nil {
+		return err
+	}
+	if err := seed(client, companies, mode == modeDryRun); err != nil {
+		return err
+	}
+	partners, err := seedPartners(client, demo, mode)
+	if err != nil {
+		return err
+	}
+	reportPartners(partners)
+	return nil
 }
 
 // seedWhatNeedsSQLAfterCompanies runs everything that needs the companies on

--- a/backend/tools/seed-demo/partners.go
+++ b/backend/tools/seed-demo/partners.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The channel: the companies the installation sells WITH.
+//
+// A partner is an ordinary organization carrying a partner extension row
+// (A41/ADR-0032) — identity is never duplicated. So this phase writes the
+// company the same way every other company is written, then PUTs the partner
+// row onto it, which is what promotes it and what fills the Partners screen.
+//
+// It runs BEFORE the pipeline phases on purpose. Ownership walks every
+// organization the installation holds, and an ownerless row is
+// workspace-shared — visible at every row scope. A partner seeded after that
+// pass would be the one company both SDRs could see.
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// partnerCounts is what one pass wrote. Organizations and promotions are
+// counted apart because they converge differently: the company is probed and
+// created once, while the partner row is an idempotent upsert that reports
+// nothing about whether it already existed.
+type partnerCounts struct {
+	orgs, promoted, people, links int
+}
+
+// seedPartners files the partner companies, their staff, and the partner row
+// that promotes each one.
+func seedPartners(c *client, cfg demoConfig, mode runMode) (partnerCounts, error) {
+	var n partnerCounts
+	for _, p := range cfg.Partners {
+		if p.Domain == "" || p.DisplayName == "" {
+			return n, fmt.Errorf("partner %q: a partner needs both a domain and a display name", p.DisplayName)
+		}
+		if mode == modeDryRun {
+			fmt.Printf("%-24s %-8s %s (partner)\n", p.Domain, outcomeDryRun, p.DisplayName)
+			n.orgs++
+			n.promoted++
+			// Each person is employed at the partner that names them, so the
+			// two counts move together — reporting people with no employments
+			// would read as the bug this phase exists to fix.
+			n.people += len(p.People)
+			n.links += len(p.People)
+			continue
+		}
+		orgID, existed, err := ensurePartnerOrganization(c, p)
+		if err != nil {
+			return n, fmt.Errorf("partner %s: %w", p.Domain, err)
+		}
+		if !existed {
+			n.orgs++
+		}
+		fmt.Printf("%-24s %-8s %s (partner)\n", p.Domain, companyOutcome(existed, mode), p.DisplayName)
+
+		if err := upsertPartnerRow(c, orgID, p); err != nil {
+			return n, fmt.Errorf("promoting %s to a partner: %w", p.Domain, err)
+		}
+		n.promoted++
+
+		staff, links, err := seedPartnerPeople(c, orgID, p)
+		if err != nil {
+			return n, fmt.Errorf("the staff at %s: %w", p.Domain, err)
+		}
+		n.people += staff
+		n.links += links
+	}
+	return n, nil
+}
+
+// ensurePartnerOrganization finds the partner company by domain and creates it
+// if absent — the same probe-then-create the crawled companies get, so a
+// re-run adds nothing twice.
+//
+// It does NOT set relationship_types: the partner upsert below writes the
+// live `partner` type itself, inside the transaction that writes the partner
+// row (ADR-0079). Setting it here would be the same fact recorded twice, and
+// the two could then disagree.
+func ensurePartnerOrganization(c *client, p demoPartner) (id string, existed bool, err error) {
+	if id, found, err := findOrganizationNamed(c, p.DisplayName); err != nil {
+		return "", false, err
+	} else if found {
+		return id, true, nil
+	}
+
+	body := jsonBody{
+		"display_name": p.DisplayName,
+		"source":       seedSource,
+		"domains":      []jsonBody{{"domain": p.Domain, "is_primary": true}},
+	}
+	addIfSet(body, "legal_name", p.LegalName)
+	addIfSet(body, "industry", p.Industry)
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := c.post("/v1/organizations", body, &out); err != nil {
+		if existing, ok := conflictingID(err); ok {
+			return existing, true, nil
+		}
+		return "", false, err
+	}
+	return out.ID, false, nil
+}
+
+// upsertPartnerRow promotes the company. PUT /organizations/{id}/partner
+// creates the row on first call and updates it after, so this converges
+// without a probe.
+//
+// The If-Match precondition is deliberately omitted. It guards a human
+// editing a partner against overwriting a change they did not see; the seeder
+// has no prior version in hand and is restating the dataset's own values,
+// which is the case the header exists to allow rather than to stop.
+func upsertPartnerRow(c *client, orgID string, p demoPartner) error {
+	body := jsonBody{"partner_role": p.PartnerRole}
+	addIfSet(body, "cert_status", p.CertStatus)
+	addIfSet(body, "margin_tier", p.MarginTier)
+	addIfSet(body, "relationship_stage", p.RelationshipStage)
+	addIfSet(body, "next_step", p.NextStep)
+	return c.put("/v1/organizations/"+orgID+"/partner", body, nil)
+}
+
+// seedPartnerPeople files the partner's own staff and employs them there.
+//
+// The address is built here rather than carried in the dataset, which is the
+// opposite of how a crawled person is handled — and for the opposite reason.
+// A crawled person is real, so the dataset keeps the published and the
+// synthesized address apart and the seeder never invents one. These people do
+// not exist, and their company's domain is under .example, which RFC 2606
+// reserves precisely so nothing can be delivered to it.
+func seedPartnerPeople(c *client, orgID string, p demoPartner) (people, links int, err error) {
+	for _, person := range p.People {
+		email := partnerEmail(person.Name, p.Domain)
+		if email == "" {
+			continue
+		}
+		personID, existed, err := ensurePerson(c, datasetPers{Name: person.Name, Role: person.Role}, email, false)
+		if err != nil {
+			return people, links, fmt.Errorf("person %q: %w", person.Name, err)
+		}
+		if !existed {
+			people++
+		}
+		linked, err := ensureEmployment(c, personID, orgID, person.Role, false)
+		if err != nil {
+			return people, links, fmt.Errorf("employment for %q: %w", person.Name, err)
+		}
+		if linked {
+			links++
+		}
+	}
+	return people, links, nil
+}
+
+// partnerEmail builds first.last@domain from a printed name.
+//
+// Diacritics are the norm rather than the exception here — two of the three
+// partners are Vietnamese and Korean — so the name is folded to ASCII before
+// it becomes a local part, and a name that folds to nothing yields no address
+// rather than an address of punctuation.
+func partnerEmail(name, domain string) string {
+	first, last := splitName(name)
+	parts := make([]string, 0, 2)
+	for _, part := range []string{first, last} {
+		if folded := asciiLocalPart(part); folded != "" {
+			parts = append(parts, folded)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ".") + "@" + domain
+}
+
+// asciiLocalPart reduces one name word to the letters and digits an address
+// may carry, lowercased. Anything else — a diacritic that did not decompose,
+// a hyphen, a space — is dropped.
+func asciiLocalPart(word string) string {
+	var b strings.Builder
+	// NFD splits an accented letter into its base plus a combining mark, so
+	// dropping everything outside a-z0-9 below removes the mark and keeps the
+	// letter: "Nguyễn" folds to "nguyen" rather than to "nguy".
+	for _, r := range norm.NFD.String(strings.ToLower(word)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// findOrganizationNamed is findOrganization for a company that has no crawled
+// read behind it — the search-then-match on display name, given the name
+// directly.
+func findOrganizationNamed(c *client, displayName string) (id string, found bool, err error) {
+	var page struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	query := url.Values{"q": {displayName}, "limit": {"25"}}
+	if err := c.get("/v1/organizations", query, &page); err != nil {
+		return "", false, fmt.Errorf("searching for %q: %w", displayName, err)
+	}
+	for _, row := range page.Data {
+		if strings.EqualFold(row.DisplayName, displayName) {
+			return row.ID, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// catalogueCounts is what the what-we-sell-and-how-we-file-it phases wrote.
+type catalogueCounts struct {
+	products, offers, surfaces, partnerEdges int
+}
+
+// seedCatalogue writes what the installation sells and the surfaces it files
+// records under: the rate card, the quotes drawn from it, the tags, lists,
+// custom fields, projects and quotas, and the edges tying each partner to the
+// accounts it works on.
+//
+// The partner edges sit here rather than with the partner companies, which
+// went in before the pipeline began: an edge needs the ids of BOTH ends, and
+// the crawled accounts they point at are only indexed once refs is loaded.
+func seedCatalogue(c *client, seats *sessions, cfg demoConfig, refs pipelineRefs, plan map[string]profile, mode runMode) (catalogueCounts, error) {
+	var n catalogueCounts
+	products, productsNew, err := seedProducts(c, cfg, mode)
+	if err != nil {
+		return n, err
+	}
+	n.products = productsNew
+	if n.offers, err = seedOffers(c, cfg, refs, products, mode); err != nil {
+		return n, err
+	}
+	if n.surfaces, err = seedSurfaces(c, seats, cfg, refs, plan, mode); err != nil {
+		return n, err
+	}
+	if n.partnerEdges, err = seedPartnerEdges(c, cfg, refs, mode); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// seedPartnerEdges files the org-to-org edges saying which accounts each
+// partner works on: referred_by (the partner brought us the account),
+// co_sell_with (we are selling into it together) and partner_of (the partner
+// serves it).
+//
+// It runs after the pipeline refs are loaded, because it needs the ids of
+// BOTH ends — the partners this file just wrote and the crawled accounts they
+// point at — and refs.orgsByDom holds every organization the installation has.
+//
+// A relationship has no natural key the server refuses twice on, so each edge
+// is probed before it is written. Without that a re-seed would file the same
+// referral again on every run.
+func seedPartnerEdges(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int, error) {
+	created := 0
+	for i, e := range cfg.PartnerEdges {
+		// A dry run wrote no partner companies, so neither end of the edge is
+		// on file and neither can be resolved. Counting the edge and moving on
+		// is the honest answer: the check below would otherwise report the
+		// dry run's own restraint as a broken dataset.
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		partnerID, ok := refs.orgsByDom[strings.ToLower(e.Partner)]
+		if !ok {
+			return created, fmt.Errorf("partner edge %d names partner %q, which is not seeded", i, e.Partner)
+		}
+		orgID, ok := refs.orgsByDom[strings.ToLower(e.Organization)]
+		if !ok {
+			return created, fmt.Errorf("partner edge %d names account %q, which is not seeded", i, e.Organization)
+		}
+		exists, err := partnerEdgeExists(c, e.Kind, orgID, partnerID)
+		if err != nil {
+			return created, fmt.Errorf("partner edge %d: %w", i, err)
+		}
+		if exists {
+			continue
+		}
+		body := jsonBody{
+			"kind":                e.Kind,
+			"organization_id":     orgID,
+			"counterparty_org_id": partnerID,
+			"source":              seedSource,
+		}
+		if err := c.post("/v1/relationships", body, nil); err != nil {
+			if isConflict(err) {
+				continue
+			}
+			return created, fmt.Errorf("partner edge %d (%s %s -> %s): %w", i, e.Kind, e.Organization, e.Partner, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// partnerEdgeExists asks whether this exact edge is already on file.
+//
+// The list filters by kind and by ONE organization; the counterparty is
+// matched here, because an account may carry edges to several partners and
+// the kind alone does not tell them apart.
+func partnerEdgeExists(c *client, kind, orgID, partnerID string) (bool, error) {
+	var page struct {
+		Data []struct {
+			CounterpartyOrgID string `json:"counterparty_org_id"`
+		} `json:"data"`
+	}
+	query := url.Values{
+		"kind":            {kind},
+		"organization_id": {orgID},
+		"limit":           {"100"},
+	}
+	if err := c.get("/v1/relationships", query, &page); err != nil {
+		return false, fmt.Errorf("checking for an existing %s edge: %w", kind, err)
+	}
+	for _, row := range page.Data {
+		if row.CounterpartyOrgID == partnerID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func reportPartners(n partnerCounts) {
+	fmt.Printf("partners:      %d organization(s) new, %d promoted, %d person/people, %d employment(s)\n",
+		n.orgs, n.promoted, n.people, n.links)
+}

--- a/backend/tools/seed-demo/partners_test.go
+++ b/backend/tools/seed-demo/partners_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import "testing"
+
+// TestPartnerEmailFoldsDiacritics pins the address built for a partner's own
+// staff. Two of the three partners are Vietnamese and Korean, so a name with
+// diacritics is the normal case rather than the edge one — and a local part
+// that dropped the accented letters entirely ("nguyn") would be a plausible
+// wrong answer nobody would notice in a demo.
+func TestPartnerEmailFoldsDiacritics(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		person string
+		domain string
+		want   string
+	}{
+		{"plain ascii", "Katrin Berger", "dachpartner.example", "katrin.berger@dachpartner.example"},
+		{"vietnamese", "Nguyễn Thanh Tùng", "vietnampartner.example", "nguyen.tung@vietnampartner.example"},
+		{"vietnamese with a given name in the middle", "Lê Thị Hồng Nhung", "vietnampartner.example", "le.nhung@vietnampartner.example"},
+		{"hyphenated korean", "Ji-woo Han", "koreapartner.example", "jiwoo.han@koreapartner.example"},
+		{"german umlaut", "Jürgen Groß", "dachpartner.example", "jurgen.gro@dachpartner.example"},
+		{"mononym", "Prince", "dachpartner.example", "prince@dachpartner.example"},
+		{"nothing addressable", "李", "dachpartner.example", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := partnerEmail(tc.person, tc.domain); got != tc.want {
+				t.Errorf("partnerEmail(%q, %q) = %q, want %q", tc.person, tc.domain, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPartnerEmailStaysOnAnUndeliverableDomain is the rule the dataset's whole
+// defang pass exists to hold: nothing the seeder writes may be mailable. The
+// partners sit on .example, which RFC 2606 reserves, so this checks the
+// address inherits that rather than acquiring a real domain along the way.
+func TestPartnerEmailStaysOnAnUndeliverableDomain(t *testing.T) {
+	got := partnerEmail("Seung-min Park", "koreapartner.example")
+	if want := "seungmin.park@koreapartner.example"; got != want {
+		t.Fatalf("partnerEmail = %q, want %q", got, want)
+	}
+}

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -84,15 +84,7 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 	if err != nil {
 		return err
 	}
-	products, productsNew, err := seedProducts(c, cfg, mode)
-	if err != nil {
-		return err
-	}
-	offers, err := seedOffers(c, cfg, refs, products, mode)
-	if err != nil {
-		return err
-	}
-	surfaces, err := seedSurfaces(c, seats, cfg, refs, plan, mode)
+	catalogue, err := seedCatalogue(c, seats, cfg, refs, plan, mode)
 	if err != nil {
 		return err
 	}
@@ -116,10 +108,11 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 		deals: deals, generatedDeals: generatedDeals,
 		stakeholders: stakeholders, activities: activities,
 		contracts: paper.contracts, generatedContracts: paper.generatedContracts,
-		products: productsNew, offers: offers,
+		products: catalogue.products, offers: catalogue.offers,
 		documents: paper.documents, looseDocs: paper.looseDocs,
-		consents: consents, lifecycles: lifecycles, surfaces: surfaces, fxRates: fxRates,
-		ownedOrgs: ownedOrgs, ownedPeople: ownedPeople,
+		consents: consents, lifecycles: lifecycles, surfaces: catalogue.surfaces, fxRates: fxRates,
+		partnerEdges: catalogue.partnerEdges,
+		ownedOrgs:    ownedOrgs, ownedPeople: ownedPeople,
 	})
 	return nil
 }
@@ -167,6 +160,7 @@ type pipelineCounts struct {
 	documents, looseDocs          int
 	consents, lifecycles          int
 	surfaces, fxRates             int
+	partnerEdges                  int
 	ownedOrgs, ownedPeople        int
 }
 
@@ -181,6 +175,7 @@ func reportPipeline(n pipelineCounts) {
 	fmt.Printf("documents:     %d uploaded (%d contract PDFs, %d account documents)\n", n.documents+n.looseDocs, n.documents, n.looseDocs)
 	fmt.Printf("fx rates:      %d loaded\n", n.fxRates)
 	fmt.Printf("surfaces:      %d new (tags, lists, custom fields, projects, quotas)\n", n.surfaces)
+	fmt.Printf("partner edges: %d new (referrals, co-sells, served accounts)\n", n.partnerEdges)
 	fmt.Printf("consent:       %d recorded\n", n.consents)
 	fmt.Printf("lifecycle:     %d changed\n", n.lifecycles)
 	fmt.Printf("owners:        %d organization(s), %d person/people\n", n.ownedOrgs, n.ownedPeople)

--- a/backend/tools/seed-demo/verify.go
+++ b/backend/tools/seed-demo/verify.go
@@ -43,6 +43,7 @@ func verifySeed(c *client, cfg demoConfig, mode runMode) error {
 		checkLifecycleIsSet,
 		checkCoverage,
 		checkTheSurfacesAreNotEmpty,
+		checkPartnersArePromoted,
 	} {
 		found, err := check(c, cfg)
 		if err != nil {
@@ -372,6 +373,56 @@ func checkTheSurfacesAreNotEmpty(c *client, _ demoConfig) ([]verifyFinding, erro
 		}
 	}
 	return findings, nil
+}
+
+// checkPartnersArePromoted reads the list the Partners screen reads.
+//
+// This rule exists because the screen shipped fully built and showing
+// nothing: demo.json named three partners, no code wrote them, and every
+// other count in the seeder's report was correct — so the hole was invisible
+// until somebody opened the screen.
+//
+// It asks /v1/partners rather than counting organizations, because that is
+// the question the screen asks. An org that was created but never promoted
+// answers this list with nothing, which is exactly the failure to catch.
+func checkPartnersArePromoted(c *client, cfg demoConfig) ([]verifyFinding, error) {
+	if len(cfg.Partners) == 0 {
+		return nil, nil
+	}
+	promoted := map[string]bool{}
+	err := c.getAll("/v1/partners", nil, func(raw json.RawMessage) error {
+		var rows []struct {
+			OrganizationID string `json:"organization_id"`
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			promoted[row.OrganizationID] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing partners: %w", err)
+	}
+	orgIDs, err := orgIDsByDomain(c)
+	if err != nil {
+		return nil, err
+	}
+	var missing []string
+	for _, p := range cfg.Partners {
+		id, seeded := orgIDs[strings.ToLower(p.Domain)]
+		if !seeded || !promoted[id] {
+			missing = append(missing, p.DisplayName)
+		}
+	}
+	if len(missing) == 0 {
+		return nil, nil
+	}
+	return []verifyFinding{{
+		Rule:   "the partners are promoted",
+		Detail: fmt.Sprintf("%d of %d named partners are absent from /v1/partners (%s) — the Partners screen renders empty", len(missing), len(cfg.Partners), sample(missing)),
+	}}, nil
 }
 
 // sample names the first few offenders, because a bare count sends the reader


### PR DESCRIPTION
The Partners screen was fully built and showed nothing. `demo.json` named
three partners — DACHPartner GmbH, VietnamPartner JSC, KoreaPartner Co., Ltd.
— and no code wrote them: `partner` and `organization_relationship_type` were
both empty tables.

## What this does

`seedPartners` writes each partner as an ordinary organization, then promotes
it with `PUT /organizations/{id}/partner`. That upsert writes the live
`partner` relationship type in its own transaction (ADR-0079 amending
ADR-0032 — the invariant is no longer `classification='partner'`), so the
seeder deliberately does **not** set `relationship_types` itself. Recording
the same fact twice is how the two come to disagree.

**Partners go in with the companies, ahead of the pipeline.** Ownership walks
the organizations the pipeline refs find, and an ownerless row is
workspace-shared — visible at every row scope. A partner seeded after that
pass would have been the one company both SDRs could see.

**Their staff get addresses built from the partner's own `.example` domain**,
which RFC 2606 reserves. The names fold through NFD first: two of the three
partners are Vietnamese and Korean, and dropping the accented letters rather
than the accents would have turned `Nguyễn` into `nguyn`.

**Nine org-to-org edges** (`referred_by`, `co_sell_with`, `partner_of`) tie
each partner to accounts in its own language. They live in the dataset's
`demo.json` rather than in Go, and are written after the pipeline refs load
because an edge needs the ids of both ends.

## The verify rule is the point

`checkPartnersArePromoted` reads `/v1/partners` — the exact list the screen
reads. Worth keeping in mind why: every count in the seeder's report was
already correct while the screen was empty. A rule that counted organizations
instead would also have passed.

## Verified against a live stack, not just built

- Three partners promoted with distinct values across all four enums
- Six people employed and owned; the `partner` relationship type on all three
- Nine edges in the right direction (`organization` = account, `partner` =
  counterparty)
- A second run created nothing — the convergence contract holds

Gates: `make craft-static`, `check-gofmt.sh`, `check-go-file-length.sh`,
`check-lint-modules.sh`, package tests. All green.

`seedTheCompanies` and `seedCatalogue` are extractions with no behavior
change — adding a phase to `run()` and `seedPipeline` pushed both past the
80-line cap.

## Needs the dataset commit

The `partner_edges` array lives in the dataset repo:
`margince-demo-database` `ffa746c`. Seeding this branch against an older
dataset checkout writes the three partners and zero edges.

## Still open

`deal.partner_org_id` is set on no deal (0 of 67). The edges say which
accounts a partner works on; nothing yet says which revenue it brought, so
the `partner_sourced` pipeline filter has nothing to show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds three channel partners and the accounts they work on so the Partners screen shows data. Previously the screen rendered empty; now each partner is created as an organization, promoted to a partner, assigned staff, and linked to accounts with partner edges.

- Writes partners via /v1/organizations and promotes each with PUT /organizations/{id}/partner; intentionally does not set relationship_types because the upsert records the live partner type.
- Runs partners with companies and before the pipeline; extracts seedTheCompanies for order and seedCatalogue for pipeline phases (partner edges included here).
- Creates partner staff and employments; builds emails as first.last@partner-domain using the partner’s .example domain with ASCII-folded names; tests pin the folding.
- Adds nine org-to-org partner edges (referred_by, co_sell_with, partner_of) via /v1/relationships after pipeline refs load; probes first for idempotency.
- Adds checkPartnersArePromoted to verify /v1/partners reflects promotions; seeder reports now include partner and partner-edge counts.

**Rollout**
- Requires the dataset entries for partners and partner_edges; seeding against an older dataset writes partners but zero edges.
- No API or schema migrations; re-running is safe due to upserts and existence checks.

<sup>Written for commit ac996ec54214a2e18d6ef504fee38577872abc66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

