### PR TITLE
test: unbreak main — two gates left red by changes that moved behaviour past them

### DIFF
--- a/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
+++ b/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
@@ -211,13 +211,14 @@ func TestActivityReadsAreScopedThroughLinks(t *testing.T) {
 		t.Error("timeline lost a visible or workspace-shared activity")
 	}
 
+	// Filtering BY a record is a read OF it, so a record outside the caller's
+	// row scope owes the existence-hiding not-found rather than an empty page.
+	// An empty page hides the rows but answers "that record has nothing on it",
+	// which is a different sentence and one the caller was not entitled to.
 	entityType, entityID := "person", foreignPerson
-	probed, _, err := e.Activities.ListActivities(rep, activities.ListActivitiesInput{EntityType: &entityType, EntityID: &entityID})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(probed) != 0 {
-		t.Errorf("entity-filter probe on a foreign person returned %d activities, want 0", len(probed))
+	_, _, err = e.Activities.ListActivities(rep, activities.ListActivitiesInput{EntityType: &entityType, EntityID: &entityID})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("entity-filter probe on a foreign person = %v, want ErrNotFound", err)
 	}
 }
 

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -163,7 +163,15 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// the unbounded principal — the availability test (a held record reads
 	// as gone, admin included) runs for everyone. One indexed read by primary
 	// key, flat in the size of the account.
-	const budget = 32
+	//
+	// 34 since #1621: the organization read now carries how many people work at
+	// the account and how many deals are open on it. Two reads, both issued for
+	// the whole organization set at once rather than per row — the counts arrive
+	// grouped by organization_id, so they are flat in the size of the account
+	// exactly like every section above, which is the property this budget
+	// protects. The number moved without this line and the gate went red on main
+	// for every branch cut afterwards.
+	const budget = 34
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}


### PR DESCRIPTION
Two integration gates are red on `main` right now, and every branch cut since inherits both. Neither is caused by this PR; both were confirmed by running them against `origin/main` unmodified.

## 1. The 360 query budget counts two reads it did not know about

#1621 gave the organization read how many people work at the account and how many deals are open on it:

```
SELECT rel.organization_id, count(*) FROM relationship rel JOIN person p ...
SELECT d.organization_id, count(*) FROM deal d WHERE d.organization_id = ANY($1) ...
```

The 360 assembles an organization, so it pays both — 34 queries against a budget of 32.

Both are issued for the whole organization set at once and come back grouped by `organization_id`, so they are **flat in the size of the account** exactly like every section above them. That is the property this budget exists to protect, and it still holds: the sibling assertion (`largeCost != smallCost`) was never the failing half. Only the constant was stale, and the file asks that a raise carry its reason, so it does.

## 2. Filtering by a foreign record now answers not-found

#1604 gave the activity list's entity filter an `EnsureVisible` gate, so a filter naming a record outside the caller's row scope returns `ErrNotFound`. The test still asserted the older shape — an empty page.

The new behaviour is the documented one, so the test moves rather than the code: filtering **by** a record is a read **of** it, and a row-scope miss owes the existence-hiding 404 (README's review-loop rule 3). An empty page hides the rows but still answers "that record has nothing on it", which is a different sentence and one the caller was not entitled to.

## Verification

Both tests pass; both were reproduced failing against unmodified `origin/main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)