### PR TITLE
refactor(deals): the deal spine drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -50,8 +50,8 @@ type closeDateEnv struct {
 func setupCloseDate(t *testing.T) *closeDateEnv {
 	t.Helper()
 	e := &closeDateEnv{Env: integration.Setup(t), owner: integration.OwnerConn(t)}
-	e.pipeline = integration.SeedRow(t, e.owner,
-		`INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Hygiene', true, 0)`, e.WS)
+	e.pipeline = integration.SeedIDRow(t, e.owner,
+		`INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Hygiene', true, 0)`)
 	ctx := context.Background()
 	for _, stage := range []struct {
 		id          *ids.UUID
@@ -60,9 +60,9 @@ func setupCloseDate(t *testing.T) *closeDateEnv {
 	}{{&e.early, 0, 20}, {&e.late, 1, 60}} {
 		*stage.id = ids.NewV7()
 		if _, err := e.owner.Exec(ctx,
-			`INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-			 VALUES ($1, $2, $3, $4, $5, 'open', $6)`,
-			*stage.id, e.WS, e.pipeline, fmt.Sprintf("Stage %d", stage.position), stage.position, stage.probability); err != nil {
+			`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+			 VALUES ($1, $2, $3, $4, 'open', $5)`,
+			*stage.id, e.pipeline, fmt.Sprintf("Stage %d", stage.position), stage.position, stage.probability); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -96,11 +96,10 @@ func (e *closeDateEnv) seedSweepDeal(t *testing.T, name string, stage ids.UUID, 
 	}
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency,
-		                   forecast_category, expected_close_date, last_activity_at, created_at, source, captured_by)
-		 VALUES ($1, $2, $3, $4, $5, 10000, 'EUR', $6, $7,
-		         now() - make_interval(days => $8), now() - interval '120 days', 'manual', 'human:x')`,
-		id, e.WS, name, e.pipeline, stage, category, expectedClose, lastActivityDaysAgo); err != nil {
+		`INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, forecast_category, expected_close_date, last_activity_at, created_at, source, captured_by)
+		 VALUES ($1, $2, $3, $4, 10000, 'EUR', $5, $6,
+		         now() - make_interval(days => $7), now() - interval '120 days', 'manual', 'human:x')`,
+		id, name, e.pipeline, stage, category, expectedClose, lastActivityDaysAgo); err != nil {
 		t.Fatalf("seeding deal %q: %v", name, err)
 	}
 	return id
@@ -411,8 +410,8 @@ func TestCloseDateSweepLeavesNoOpenDealWithPastCloseDate(t *testing.T) {
 
 	var openPast int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM deal WHERE workspace_id = $1 AND status = 'open' AND archived_at IS NULL
-		   AND expected_close_date < current_date`, e.WS).Scan(&openPast); err != nil {
+		`SELECT count(*) FROM deal WHERE status = 'open' AND archived_at IS NULL
+		   AND expected_close_date < current_date`).Scan(&openPast); err != nil {
 		t.Fatal(err)
 	}
 	if openPast != 0 {
@@ -420,8 +419,8 @@ func TestCloseDateSweepLeavesNoOpenDealWithPastCloseDate(t *testing.T) {
 	}
 	var openMissing int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM deal WHERE workspace_id = $1 AND status = 'open' AND archived_at IS NULL
-		   AND expected_close_date IS NULL`, e.WS).Scan(&openMissing); err != nil {
+		`SELECT count(*) FROM deal WHERE status = 'open' AND archived_at IS NULL
+		   AND expected_close_date IS NULL`).Scan(&openMissing); err != nil {
 		t.Fatal(err)
 	}
 	if openMissing != 0 {

--- a/backend/internal/compose/flipreconcile.go
+++ b/backend/internal/compose/flipreconcile.go
@@ -77,6 +77,22 @@ func (w *flipWriters) ReconcileIdentities(ctx context.Context) error {
 // identity map does not yet know about. The prefix is scoped to
 // incumbent and class, not to a run: another attempt's orphan is
 // exactly what this is meant to adopt.
+// flipTenantScope is the workspace predicate for the ONE query this file
+// templates over five native tables, and it is per-object because ADR-0091 §8
+// phase D removes the column from them at different times — deal already, the
+// rest still to come. A predicate spelled for all five fails the statement
+// outright for whichever has lost it; spelled for none, a reconstruction adopts
+// the EXPORTING installation's records as its own. Each entry drops out as its
+// slice lands, and the function goes with the last one.
+func flipTenantScope(object string) string {
+	switch object {
+	case flipObjectPerson, flipObjectOrganization, flipObjectLead, flipObjectActivity:
+		return "\n\t\t\t  AND n.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid"
+	default:
+		return ""
+	}
+}
+
 func (w *flipWriters) orphanedIdentities(ctx context.Context, object string) ([]migration.IdentityPair, error) {
 	if !flipImportable(object) {
 		// The allowlist is what keeps the class out of the format string
@@ -99,13 +115,8 @@ func (w *flipWriters) orphanedIdentities(ctx context.Context, object string) ([]
 			  ON m.source_system = $2
 			 AND m.object = $3
 			 AND m.external_id = right(n.source, -length($1::text))
-			-- Scoped to the workspace this run imports into. Tenant isolation
-			-- used to bound the scan, so a previous attempt's rows meant rows
-			-- THIS installation wrote; without it a reconstruction adopts the
-			-- exporting installation's records as its own (ADR-0091 §8 phase A).
-			WHERE n.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			  AND starts_with(n.source, $1) AND m.native_id IS NULL
-			  AND %s`, object, liveClause(object)),
+			WHERE starts_with(n.source, $1) AND m.native_id IS NULL%s
+			  AND %s`, object, flipTenantScope(object), liveClause(object)),
 			prefix, w.incumbent, object)
 		if err != nil {
 			return err

--- a/backend/internal/compose/flipstages.go
+++ b/backend/internal/compose/flipstages.go
@@ -149,13 +149,8 @@ func (w *flipWriters) stageCatalog(ctx context.Context) (*flipStageCatalog, erro
 	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT s.id, s.pipeline_id, s.name, s.semantic, p.is_default
-			FROM stage s JOIN pipeline p ON p.id = s.pipeline_id AND p.workspace_id = s.workspace_id
-			-- Scoped to the workspace the rebuild lands in: tenant isolation
-			-- used to supply it, and without it the catalog offers another
-			-- installation's stages, which the deal write then rejects
-			-- (ADR-0091 §8 phase A).
-			WHERE s.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			  AND s.archived_at IS NULL AND p.archived_at IS NULL
+			FROM stage s JOIN pipeline p ON p.id = s.pipeline_id
+			WHERE s.archived_at IS NULL AND p.archived_at IS NULL
 			ORDER BY p.is_default DESC, s.position`)
 		if err != nil {
 			return fmt.Errorf("flip import: reading the native stage catalog: %w", err)

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -201,18 +201,18 @@ func TestCoverageNamesItsColleaguesForTheAgent(t *testing.T) {
 		// The harness seeds no pipeline, so this test brings its own.
 		var pipelineID, stageID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO pipeline (workspace_id, name) VALUES (`+ws+`, 'Coverage Test')
+			INSERT INTO pipeline (name) VALUES ( 'Coverage Test')
 			RETURNING id`).Scan(&pipelineID); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO stage (workspace_id, pipeline_id, name, position)
-			VALUES (`+ws+`, $1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
+			INSERT INTO stage (pipeline_id, name, position)
+			VALUES ( $1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO deal (workspace_id, name, stage_id, pipeline_id, owner_id, source, captured_by)
-			VALUES (`+ws+`, 'Covered', $1, $2, $3, 'manual', 'human:test')
+			INSERT INTO deal (name, stage_id, pipeline_id, owner_id, source, captured_by)
+			VALUES ( 'Covered', $1, $2, $3, 'manual', 'human:test')
 			RETURNING id`, stageID, pipelineID, e.Rep1).Scan(&dealID); err != nil {
 			return err
 		}

--- a/backend/internal/compose/integration/activitycontext_integration_test.go
+++ b/backend/internal/compose/integration/activitycontext_integration_test.go
@@ -88,23 +88,23 @@ type meetingFixture struct {
 func seedMeetingFixture(t *testing.T, e *SearchEnv) meetingFixture {
 	t.Helper()
 	var f meetingFixture
-	f.pipeline = e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
-		VALUES ($1, $2, 'Sales', true, 0)`)
-	f.stage = e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, f.pipeline)
+	f.pipeline = e.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position)
+		VALUES ($1, 'Sales', true, 0)`)
+	f.stage = e.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, f.pipeline)
 
 	// Seeded rep3-first on purpose: ids are time-ordered, so the record the
 	// caller may NOT see sorts ahead of the one they may. A walk that skipped
 	// the per-subject visibility probe would prep against it.
 	f.rep3Org = e.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Other Team GmbH', 'manual', 'human:x')`, e.Rep3)
-	f.rep3Deal = e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
-		VALUES ($1, $2, $3, 'Other Team Renewal', $4, $5, $6, 'manual', 'human:x')`,
+	f.rep3Deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
+		VALUES ($1, $2, 'Other Team Renewal', $3, $4, $5, 'manual', 'human:x')`,
 		e.Rep3, f.pipeline, f.stage, f.rep3Org)
 	f.rep1Org = e.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Turbinenbau AG', 'manual', 'human:x')`, e.Rep1)
-	f.rep1Deal = e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
-		VALUES ($1, $2, $3, 'Turbinenbau Renewal', $4, $5, $6, 'manual', 'human:x')`,
+	f.rep1Deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
+		VALUES ($1, $2, 'Turbinenbau Renewal', $3, $4, $5, 'manual', 'human:x')`,
 		e.Rep1, f.pipeline, f.stage, f.rep1Org)
 	f.organizer = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Annegret Weiss', 'manual', 'human:x')`, e.Rep1)

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -66,8 +66,8 @@ type exportFixture struct {
 
 func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 	t.Helper()
-	pipelineID := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stageID := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
+	pipelineID := e.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`)
+	stageID := e.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipelineID)
 
 	var f exportFixture
 	// rep1 (team1) carries a social row to prove the child relation
@@ -82,10 +82,10 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 		VALUES ($1, $2, $3, 'Rep1 Org', 'manual', 'human:x')`, e.Rep1)
 	f.rep3Org = e.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep3 Org', 'manual', 'human:x')`, e.Rep3)
-	f.rep1Deal = e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, $3, 'Rep1 Deal', $4, $5, $6, 100000, 'EUR', 'manual', 'human:x')`, e.Rep1, pipelineID, stageID, f.rep1Org)
-	f.rep3Deal = e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, $3, 'Rep3 Deal', $4, $5, $6, 200000, 'EUR', 'manual', 'human:x')`, e.Rep3, pipelineID, stageID, f.rep3Org)
+	f.rep1Deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, $2, 'Rep1 Deal', $3, $4, $5, 100000, 'EUR', 'manual', 'human:x')`, e.Rep1, pipelineID, stageID, f.rep1Org)
+	f.rep3Deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, $2, 'Rep3 Deal', $3, $4, $5, 200000, 'EUR', 'manual', 'human:x')`, e.Rep3, pipelineID, stageID, f.rep3Org)
 	f.rep1Lead = e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep1 Lead', 'manual', 'human:x')`, e.Rep1)
 	f.rep3Lead = e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -61,12 +61,12 @@ type filteredDealFixture struct {
 
 func (e *SearchEnv) seedFilteredDeals(t *testing.T) filteredDealFixture {
 	t.Helper()
-	pipelineID := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stageID := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
+	pipelineID := e.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`)
+	stageID := e.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipelineID)
 
 	deal := func(owner ids.UUID, name, forecast string) ids.UUID {
-		return e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, forecast_category, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, 'manual', 'human:x')`, owner, name, pipelineID, stageID, forecast)
+		return e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, forecast_category, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5, $6, 'manual', 'human:x')`, owner, name, pipelineID, stageID, forecast)
 	}
 	return filteredDealFixture{
 		matchOwn:   deal(e.Rep1, "Match Own", "commit"),

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -412,23 +412,22 @@ func (e *Env) SeedWonDealLinkedTo(t *testing.T, activities ...ids.UUID) ids.UUID
 	pipeline, stage, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-		if _, err := tx.Exec(ctx, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
-			VALUES ($1, `+ws+`, 'Floor fixture', false, 90)`, pipeline); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO pipeline (id, name, is_default, position)
+			VALUES ($1, 'Floor fixture', false, 90)`, pipeline); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(ctx, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-			VALUES ($1, `+ws+`, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(ctx, `INSERT INTO deal (id, workspace_id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
-			VALUES ($1, `+ws+`, 'Floor fixture deal', 'won', $2, $3, now(), 'manual', 'human:x')`,
+		if _, err := tx.Exec(ctx, `INSERT INTO deal (id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
+			VALUES ($1, 'Floor fixture deal', 'won', $2, $3, now(), 'manual', 'human:x')`,
 			deal, pipeline, stage); err != nil {
 			return err
 		}
 		for _, a := range activities {
 			if _, err := tx.Exec(ctx, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-				VALUES (`+ws+`, $1, 'deal', $2)`, a, deal); err != nil {
+				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'deal', $2)`, a, deal); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/integration/installation_settings_integration_test.go
+++ b/backend/internal/compose/integration/installation_settings_integration_test.go
@@ -189,11 +189,11 @@ func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
 	// INSERT..SELECT that matches nothing SUCCEEDS, so a missing fixture would
 	// leave this test asserting a freeze that never had a deal to fire on —
 	// passing or failing for the wrong reason either way.
-	pipeline := e.Seed(t, `
-		INSERT INTO pipeline (id, workspace_id, name, is_default) VALUES ($1, $2, 'Freeze fixture', false)`)
-	stage := e.Seed(t, `
-		INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Won', 1, 'won', 100)`, pipeline)
+	pipeline := e.SeedID(t, `
+		INSERT INTO pipeline (id, name, is_default) VALUES ($1, 'Freeze fixture', false)`)
+	stage := e.SeedID(t, `
+		INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Won', 1, 'won', 100)`, pipeline)
 	// Every CHECK on `deal` has to be satisfied for the row to land, and the
 	// row landing is the whole point of this fixture:
 	//   deal_amount_currency_pair — amount and currency are set together
@@ -202,10 +202,9 @@ func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
 	//   deal_lost_reason          — not reached; 'won', not 'lost'
 	// The frozen rate is the one this test actually needs; the rest are the
 	// price of a valid closed deal.
-	e.Seed(t, `
-		INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, source, captured_by,
-		                  amount_minor, currency, fx_rate_to_base, status, closed_at)
-		VALUES ($1, $2, 'Converted deal', $3, $4, 'seed', 'system:test',
+	e.SeedID(t, `
+		INSERT INTO deal (id, name, pipeline_id, stage_id, source, captured_by, amount_minor, currency, fx_rate_to_base, status, closed_at)
+		VALUES ($1, 'Converted deal', $2, $3, 'seed', 'system:test',
 		        100000, 'EUR', 1.0850000000, 'won', now())`,
 		pipeline, stage)
 
@@ -268,15 +267,14 @@ func TestBaseCurrencyFreezesOnASentOfferWithNoClosedDeal(t *testing.T) {
 
 	// An OPEN deal — it carries no frozen rate itself, so anything the probe
 	// reports here comes from the offer and not from the deal it hangs off.
-	pipeline := e.Seed(t, `
-		INSERT INTO pipeline (id, workspace_id, name, is_default) VALUES ($1, $2, 'Offer fixture', false)`)
-	stage := e.Seed(t, `
-		INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualified', 1, 'open', 40)`, pipeline)
-	deal := e.Seed(t, `
-		INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, source, captured_by,
-		                  amount_minor, currency, status)
-		VALUES ($1, $2, 'Open deal', $3, $4, 'seed', 'system:test', 100000, 'EUR', 'open')`,
+	pipeline := e.SeedID(t, `
+		INSERT INTO pipeline (id, name, is_default) VALUES ($1, 'Offer fixture', false)`)
+	stage := e.SeedID(t, `
+		INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualified', 1, 'open', 40)`, pipeline)
+	deal := e.SeedID(t, `
+		INSERT INTO deal (id, name, pipeline_id, stage_id, source, captured_by, amount_minor, currency, status)
+		VALUES ($1, 'Open deal', $2, $3, 'seed', 'system:test', 100000, 'EUR', 'open')`,
 		pipeline, stage)
 	e.SeedID(t, `
 		INSERT INTO offer (id, deal_id, offer_number, currency, status,

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -35,14 +35,14 @@ const rollupOpenWinProbability = 40
 func seedRollupStages(t *testing.T, e *Env) rollupStages {
 	t.Helper()
 	st := rollupStages{pipeline: ids.NewV7(), open: ids.NewV7(), won: ids.NewV7()}
-	e.WsExec(t, `INSERT INTO pipeline (id, workspace_id, name) VALUES ($1, $2, 'Rollup Pipeline')`,
-		st.pipeline, e.WS)
-	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualified', 1, 'open', $4)`,
-		st.open, e.WS, st.pipeline, rollupOpenWinProbability)
-	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Won', 2, 'won', 100)`,
-		st.won, e.WS, st.pipeline)
+	e.WsExec(t, `INSERT INTO pipeline (id, name) VALUES ($1, 'Rollup Pipeline')`,
+		st.pipeline)
+	e.WsExec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualified', 1, 'open', $3)`,
+		st.open, st.pipeline, rollupOpenWinProbability)
+	e.WsExec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Won', 2, 'won', 100)`,
+		st.won, st.pipeline)
 	return st
 }
 
@@ -62,9 +62,9 @@ func seedRollupOrg(t *testing.T, e *Env, name string, owner, parent *ids.UUID) i
 // seeds the honest half-empty deal the weighted sum must count as 0.
 func seedRollupOpenDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID, amountMinor *int64, currency *string) {
 	t.Helper()
-	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, amount_minor, currency, pipeline_id, stage_id, organization_id, status, source, captured_by)
-		VALUES ($1, $2, 'Open Deal', $3, $4, $5, $6, $7, 'open', 'manual', 'human:test')`,
-		ids.NewV7(), e.WS, amountMinor, currency, st.pipeline, st.open, org)
+	e.WsExec(t, `INSERT INTO deal (id, name, amount_minor, currency, pipeline_id, stage_id, organization_id, status, source, captured_by)
+		VALUES ($1, 'Open Deal', $2, $3, $4, $5, $6, 'open', 'manual', 'human:test')`,
+		ids.NewV7(), amountMinor, currency, st.pipeline, st.open, org)
 }
 
 // seedRollupWonDeal closes a deal with the frozen FX rate the
@@ -73,9 +73,9 @@ func seedRollupWonDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID,
 	amountMinor int64, currency, fxRateToBase string, closedAt time.Time,
 ) {
 	t.Helper()
-	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, amount_minor, currency, fx_rate_to_base, pipeline_id, stage_id, organization_id, status, closed_at, source, captured_by)
-		VALUES ($1, $2, 'Won Deal', $3, $4, $5, $6, $7, $8, 'won', $9, 'manual', 'human:test')`,
-		ids.NewV7(), e.WS, amountMinor, currency, fxRateToBase, st.pipeline, st.won, org, closedAt)
+	e.WsExec(t, `INSERT INTO deal (id, name, amount_minor, currency, fx_rate_to_base, pipeline_id, stage_id, organization_id, status, closed_at, source, captured_by)
+		VALUES ($1, 'Won Deal', $2, $3, $4, $5, $6, $7, 'won', $8, 'manual', 'human:test')`,
+		ids.NewV7(), amountMinor, currency, fxRateToBase, st.pipeline, st.won, org, closedAt)
 }
 
 func seedRollupFxRate(t *testing.T, e *Env, fromCurrency, rate string, day time.Time) {
@@ -102,9 +102,9 @@ func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.T
 func seedRollupDealLinkedActivity(t *testing.T, e *Env, st rollupStages, org ids.UUID, occurredAt time.Time) {
 	t.Helper()
 	dealID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, status, source, captured_by)
-		VALUES ($1, $2, 'Deal With Mail', $3, $4, $5, 'open', 'manual', 'human:test')`,
-		dealID, e.WS, st.pipeline, st.open, org)
+	e.WsExec(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, status, source, captured_by)
+		VALUES ($1, 'Deal With Mail', $2, $3, $4, 'open', 'manual', 'human:test')`,
+		dealID, st.pipeline, st.open, org)
 	activityID := ids.NewV7()
 	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'email', 'deal thread', $3, 'manual', 'human:test')`,
@@ -506,9 +506,9 @@ func TestOrgRollupCountsAnActivityReachingTheTreeTwiceOnlyOnce(t *testing.T) {
 	now := time.Now().UTC()
 
 	dealID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, status, source, captured_by)
-		VALUES ($1, $2, 'Both Links', $3, $4, $5, 'open', 'manual', 'human:test')`,
-		dealID, e.WS, st.pipeline, st.open, org)
+	e.WsExec(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, status, source, captured_by)
+		VALUES ($1, 'Both Links', $2, $3, $4, 'open', 'manual', 'human:test')`,
+		dealID, st.pipeline, st.open, org)
 	activityID := ids.NewV7()
 	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'email', 'filed twice', $3, 'manual', 'human:test')`,

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -177,13 +177,12 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 	}
 	assertCount("reconstructed persons", `SELECT count(*) FROM person WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source LIKE 'mirror:hubspot:%'`, 3)
 	assertCount("reconstructed organizations", `SELECT count(*) FROM organization WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source LIKE 'mirror:hubspot:%'`, 2)
-	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source LIKE 'mirror:hubspot:%'`, 2)
+	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed leads", `SELECT count(*) FROM lead WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed activities", `SELECT count(*) FROM activity WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed deal→org FK", `
-		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id AND o.workspace_id = d.workspace_id
-		WHERE d.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`, 1)
+		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id
+		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`, 1)
 	assertCount("reconstructed employment", `
 		SELECT count(*) FROM relationship r JOIN person p ON p.id = r.person_id AND p.workspace_id = r.workspace_id
 		WHERE r.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
@@ -243,10 +242,29 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 	// Named tables rather than the workspace row: app_user and the rest do not
 	// cascade from it, and this fixture only has to clear what now collides
 	// installation-wide.
-	for _, table := range []string{"deal", "stage", "pipeline", "organization", "person", "lead", "activity"} {
-		if _, err := f.e.Owner.Exec(ctx,
-			"DELETE FROM "+table+" WHERE workspace_id = $1", f.wsID); err != nil {
-			t.Fatalf("retiring the source estate's %s rows before the rebuild: %v", table, err)
+	// The order is the foreign keys' — a deal points at its stage, its pipeline
+	// and its organization — and the predicate is per table because ADR-0091 §8
+	// phase D has reached some of these and not others. A `workspace_id = $1`
+	// spelled for all seven fails outright on the three that no longer have it.
+	for _, t2 := range []struct {
+		table        string
+		tenantScoped bool
+	}{
+		{"deal", false},
+		{"stage", false},
+		{"pipeline", false},
+		{"organization", true},
+		{"person", true},
+		{"lead", true},
+		{"activity", true},
+	} {
+		sql, args := "DELETE FROM "+t2.table, []any(nil)
+		if t2.tenantScoped {
+			sql += " WHERE workspace_id = $1"
+			args = []any{f.wsID}
+		}
+		if _, err := f.e.Owner.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("retiring the source estate's %s rows before the rebuild: %v", t2.table, err)
 		}
 	}
 	// The identity ledger goes with the estate, for the same reason and by the

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -496,7 +496,7 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 		}
 	}
 	assertOne("deal→organization FK", `
-		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id AND o.workspace_id = d.workspace_id
+		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id
 		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`)
 	assertOne("primary employment relationship", `
 		SELECT count(*) FROM relationship r
@@ -772,11 +772,11 @@ func TestAFlipAdoptsAHalfLandedDealAndFinishesClosingIt(t *testing.T) {
 
 	f.inWorkspaceTx(t, func(tx pgx.Tx) error {
 		_, err := tx.Exec(f.adminCtx, `
-			INSERT INTO deal (workspace_id, name, pipeline_id, stage_id, status, source, captured_by)
-			SELECT p.workspace_id, 'Half-landed estate deal', p.id, s.id, 'open',
+			INSERT INTO deal (name, pipeline_id, stage_id, status, source, captured_by)
+			SELECT 'Half-landed estate deal', p.id, s.id, 'open',
 			       'mirror:hubspot:deal:d-won', $1
 			FROM pipeline p
-			JOIN stage s ON s.pipeline_id = p.id AND s.workspace_id = p.workspace_id
+			JOIN stage s ON s.pipeline_id = p.id
 			WHERE p.is_default AND s.semantic = 'open'
 			ORDER BY s.position LIMIT 1`, f.adminID)
 		return err

--- a/backend/internal/compose/integration/queryplan_integration_test.go
+++ b/backend/internal/compose/integration/queryplan_integration_test.go
@@ -123,9 +123,9 @@ type queryFixture struct {
 
 func (q *queryEnv) seedFixture(t *testing.T) queryFixture {
 	t.Helper()
-	pipeline := q.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stage := q.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipeline)
+	pipeline := q.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`)
+	stage := q.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipeline)
 
 	var f queryFixture
 	f.rep1Org = q.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, address_city, source, captured_by)
@@ -137,17 +137,17 @@ func (q *queryEnv) seedFixture(t *testing.T) queryFixture {
 	f.project = q.SeedID(t, `INSERT INTO project (id, owner_id, name, organization_id, source, captured_by)
 		VALUES ($1, $2, 'Rollout', $3, 'manual', 'human:x')`, q.Rep1, f.rep1Org)
 
-	f.rep1Deal = q.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, project_id, amount_minor, currency, status, expected_close_date, source, captured_by)
-		VALUES ($1, $2, $3, 'Rollout', $4, $5, $6, $7, 100000, 'EUR', 'open', '2026-12-01', 'manual', 'human:x')`,
+	f.rep1Deal = q.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, project_id, amount_minor, currency, status, expected_close_date, source, captured_by)
+		VALUES ($1, $2, 'Rollout', $3, $4, $5, $6, 100000, 'EUR', 'open', '2026-12-01', 'manual', 'human:x')`,
 		q.Rep1, pipeline, stage, f.rep1Org, f.project)
-	f.rep3Deal = q.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, status, expected_close_date, source, captured_by)
-		VALUES ($1, $2, $3, 'Logistik Rahmenvertrag', $4, $5, $6, 250000, 'EUR', 'open', '2026-11-01', 'manual', 'human:x')`,
+	f.rep3Deal = q.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, status, expected_close_date, source, captured_by)
+		VALUES ($1, $2, 'Logistik Rahmenvertrag', $3, $4, $5, 250000, 'EUR', 'open', '2026-11-01', 'manual', 'human:x')`,
 		q.Rep3, pipeline, stage, f.rep3Org)
 	// An ownerless deal is workspace-shared and visible at every tier — the
 	// control that keeps "the rep sees fewer rows" from being read as "the rep
 	// sees only their own".
-	f.sharedDeal = q.Seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, status, source, captured_by)
-		VALUES ($1, $2, 'Unowned Deal', $3, $4, 50000, 'EUR', 'open', 'manual', 'human:x')`, pipeline, stage)
+	f.sharedDeal = q.SeedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, status, source, captured_by)
+		VALUES ($1, 'Unowned Deal', $2, $3, 50000, 'EUR', 'open', 'manual', 'human:x')`, pipeline, stage)
 	return f
 }
 

--- a/backend/internal/compose/integration/quotas_attainment_integration_test.go
+++ b/backend/internal/compose/integration/quotas_attainment_integration_test.go
@@ -59,10 +59,9 @@ func seedAttainmentDeal(t *testing.T, e *Env, st rollupStages, d attainmentDealS
 		stage = st.open
 	}
 	id := ids.NewV7()
-	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, owner_id, amount_minor, currency, fx_rate_to_base,
-			pipeline_id, stage_id, status, closed_at, lost_reason, archived_at, source, captured_by)
-		VALUES ($1, $2, 'Attainment Deal', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'manual', 'human:test')`,
-		id, e.WS, d.owner, d.amount, d.currency, d.fx, st.pipeline, stage, d.status,
+	e.WsExec(t, `INSERT INTO deal (id, name, owner_id, amount_minor, currency, fx_rate_to_base, pipeline_id, stage_id, status, closed_at, lost_reason, archived_at, source, captured_by)
+		VALUES ($1, 'Attainment Deal', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'manual', 'human:test')`,
+		id, d.owner, d.amount, d.currency, d.fx, st.pipeline, stage, d.status,
 		d.closedAt, d.lostReason, d.archivedAt)
 	return id
 }

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -31,12 +31,12 @@ import (
 // and n open deals owned by the given user (nil = ownerless).
 func (e *SearchEnv) seedDealFixtures(t *testing.T, n int, owner *ids.UUID) {
 	t.Helper()
-	pipelineID := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stageID := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
+	pipelineID := e.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`)
+	stageID := e.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipelineID)
 	orgID := e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Report Org', 'manual', 'human:x')`)
 	for i := 0; i < n; i++ {
-		e.Seed(t, fmt.Sprintf(`INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, owner_id, amount_minor, currency, source, captured_by)
-			VALUES ($1, $2, 'Deal %d', $3, $4, $5, $6, 100000, 'EUR', 'manual', 'human:x')`, i),
+		e.SeedID(t, fmt.Sprintf(`INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, owner_id, amount_minor, currency, source, captured_by)
+			VALUES ($1, 'Deal %d', $2, $3, $4, $5, 100000, 'EUR', 'manual', 'human:x')`, i),
 			pipelineID, stageID, orgID, owner)
 	}
 }
@@ -241,8 +241,8 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 	}
 
 	// An anchor outside the caller's row scope assembles nothing.
-	foreignDeal := e.Seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id, source, captured_by)
-		SELECT $1, $2, 'Foreign Deal', pipeline_id, stage_id, $3, 'manual', 'human:x' FROM deal LIMIT 1`, e.Rep3)
+	foreignDeal := e.SeedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, source, captured_by)
+		SELECT $1, 'Foreign Deal', pipeline_id, stage_id, $2, 'manual', 'human:x' FROM deal LIMIT 1`, e.Rep3)
 	if _, err := retriever.AssembleContext(e.AsTeamRep(e.Rep1, e.Team1),
 		datasource.EntityRef{Type: datasource.EntityDeal, ID: foreignDeal}, retrieval.AssembleOptions{}); err == nil {
 		t.Fatal("foreign anchor must be absent, not assembled")

--- a/backend/internal/compose/integration/retention_integration_test.go
+++ b/backend/internal/compose/integration/retention_integration_test.go
@@ -67,20 +67,19 @@ func seedOverAgeRecords(t *testing.T, e *Env) (staleLead, heldLead, staleDeal, t
 	// A pipeline+stage pair carries the aged-out lost deal.
 	pipelineID, stageID := ids.NewV7(), ids.NewV7()
 	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(context.Background(),
-			`INSERT INTO pipeline (id, workspace_id, name, is_default) VALUES ($1, `+wsClause+`, 'Retention P', true)`,
+			`INSERT INTO pipeline (id, name, is_default) VALUES ($1, 'Retention P', true)`,
 			pipelineID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(context.Background(),
-			`INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic) VALUES ($1, `+wsClause+`, $2, 'Lost', 1, 'lost')`,
+			`INSERT INTO stage (id, pipeline_id, name, position, semantic) VALUES ($1, $2, 'Lost', 1, 'lost')`,
 			stageID, pipelineID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, status, lost_reason, closed_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'Retention Deal', $2, $3, 'lost', 'stale', now() - interval '2000 days', 'manual', 'human:x')`,
+			INSERT INTO deal (id, name, pipeline_id, stage_id, status, lost_reason, closed_at, source, captured_by)
+			VALUES ($1, 'Retention Deal', $2, $3, 'lost', 'stale', now() - interval '2000 days', 'manual', 'human:x')`,
 			staleDeal, pipelineID, stageID)
 		return err
 	})

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -103,18 +103,18 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		// hangs off, so the fixture has to supply one or it proves nothing.
 		pipeline, stage, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO pipeline (id, workspace_id, name, is_default, position)
-			VALUES ($1, `+wsClause+`, 'Default', true, 0)`, pipeline); err != nil {
+			INSERT INTO pipeline (id, name, is_default, position)
+			VALUES ($1, 'Default', true, 0)`, pipeline); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-			VALUES ($1, `+wsClause+`, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
+			INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, $2, 'Closed Won', 0, 'won', 100)`, stage, pipeline); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO deal (id, workspace_id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'Acme rollout', 'won', $2, $3, now(), 'api', 'human:t')`,
+			INSERT INTO deal (id, name, status, pipeline_id, stage_id, closed_at, source, captured_by)
+			VALUES ($1, 'Acme rollout', 'won', $2, $3, now(), 'api', 'human:t')`,
 			deal, pipeline, stage); err != nil {
 			return err
 		}

--- a/backend/internal/compose/integration/retention_stamp_integration_test.go
+++ b/backend/internal/compose/integration/retention_stamp_integration_test.go
@@ -37,12 +37,12 @@ type stampFixture struct {
 func seedStampFixture(t *testing.T, e *Env) stampFixture {
 	t.Helper()
 	pipeline, openStage, wonStage, email := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
-	e.WsExec(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
-		VALUES ($1, $2, 'Stamp fixture', false, 91)`, pipeline, e.WS)
-	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, openStage, e.WS, pipeline)
-	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Closed Won', 1, 'won', 100)`, wonStage, e.WS, pipeline)
+	e.WsExec(t, `INSERT INTO pipeline (id, name, is_default, position)
+		VALUES ($1, 'Stamp fixture', false, 91)`, pipeline)
+	e.WsExec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, openStage, pipeline)
+	e.WsExec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Closed Won', 1, 'won', 100)`, wonStage, pipeline)
 
 	deal := e.SeedDeal(t, "Acme rollout",
 		ids.PipelineID{UUID: pipeline}, ids.StageID{UUID: openStage}, nil)
@@ -134,9 +134,9 @@ func TestReopeningAWonDealLeavesTheStampStanding(t *testing.T) {
 	f := seedStampFixture(t, e)
 
 	openAgain := ids.NewV7()
-	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, (SELECT pipeline_id FROM stage WHERE id = $3), 'Reopened', 2, 'open', 40)`,
-		openAgain, e.WS, f.wonStage.UUID)
+	e.WsExec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, (SELECT pipeline_id FROM stage WHERE id = $2), 'Reopened', 2, 'open', 40)`,
+		openAgain, f.wonStage.UUID)
 
 	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.DealID{UUID: f.deal}, wonInput(f.wonStage)); err != nil {
 		t.Fatalf("advancing to won: %v", err)

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -141,6 +141,19 @@ func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID, args ...any
 	return id
 }
 
+// SeedIDRow is SeedRow for a table that no longer has a workspace to bind: it
+// mints the id and nothing else. ADR-0091 §8 phase D removes the column table
+// by table, so the set of fixtures needing this form only grows — and when the
+// last table loses it, this becomes the only form and SeedRow goes.
+func SeedIDRow(t *testing.T, owner *pgx.Conn, sql string, args ...any) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(), sql, append([]any{id}, args...)...); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return id
+}
+
 // LinkToOrg attaches an activity directly to an account (LinkActivity above
 // covers only the person and deal columns).
 func LinkToOrg(t *testing.T, e *Env, activity, org ids.UUID) {

--- a/backend/internal/compose/integration/writeauthority_integration_test.go
+++ b/backend/internal/compose/integration/writeauthority_integration_test.go
@@ -332,13 +332,13 @@ func TestAnExpiredWriteShareConfersNothing(t *testing.T) {
 // not on the record being written but on the record it belongs to.
 func TestAReadShareOfADealCannotEditItsOffer(t *testing.T) {
 	e := SetupSearch(t)
-	pipeline := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
-		VALUES ($1, $2, 'Sales', true, 0)`)
-	stage := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipeline)
-	deal := e.Seed(t,
-		`INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, source, captured_by)
-		 VALUES ($1, $2, $3, 'Shared Deal', $4, $5, 'manual', 'human:x')`, e.Rep3, pipeline, stage)
+	pipeline := e.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position)
+		VALUES ($1, 'Sales', true, 0)`)
+	stage := e.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipeline)
+	deal := e.SeedID(t,
+		`INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, source, captured_by)
+		 VALUES ($1, $2, 'Shared Deal', $3, $4, 'manual', 'human:x')`, e.Rep3, pipeline, stage)
 	offer := ids.NewV7()
 	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO offer (id, deal_id, offer_number, currency, source, captured_by)

--- a/backend/internal/compose/integration/writeauthorityreview_integration_test.go
+++ b/backend/internal/compose/integration/writeauthorityreview_integration_test.go
@@ -74,9 +74,9 @@ func TestAReadShareOfADealCannotRewriteItsContracts(t *testing.T) {
 	e.WsExec(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Anchor GmbH', 'manual', 'human:x')`, org, e.WS, e.Rep3)
 	deal := ids.NewV7()
-	e.WsExec(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
-		VALUES ($1, $2, $3, 'Anchored Deal', $4, $5, $6, 'manual', 'human:x')`,
-		deal, e.WS, e.Rep3, pipeline, open, org)
+	e.WsExec(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
+		VALUES ($1, $2, 'Anchored Deal', $3, $4, $5, 'manual', 'human:x')`,
+		deal, e.Rep3, pipeline, open, org)
 
 	store := contracts.NewStore(e.DB())
 	// Fixed, because nothing here is about WHEN: the term's dates never reach an

--- a/backend/internal/compose/networktools_integration_test.go
+++ b/backend/internal/compose/networktools_integration_test.go
@@ -187,18 +187,18 @@ func seedOpenDeal(t *testing.T, e *integration.Env) ids.UUID {
 	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
 		var pipelineID, stageID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO pipeline (workspace_id, name) VALUES (`+wsGUC+`, 'At-risk test')
+			INSERT INTO pipeline (name) VALUES ( 'At-risk test')
 			RETURNING id`).Scan(&pipelineID); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO stage (workspace_id, pipeline_id, name, position)
-			VALUES (`+wsGUC+`, $1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
+			INSERT INTO stage (pipeline_id, name, position)
+			VALUES ( $1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
 			return err
 		}
 		return tx.QueryRow(ctx, `
-			INSERT INTO deal (workspace_id, name, stage_id, pipeline_id, owner_id, source, captured_by)
-			VALUES (`+wsGUC+`, 'Threadless', $1, $2, $3, 'manual', 'human:test')
+			INSERT INTO deal (name, stage_id, pipeline_id, owner_id, source, captured_by)
+			VALUES ( 'Threadless', $1, $2, $3, 'manual', 'human:test')
 			RETURNING id`, stageID, pipelineID, e.Rep1).Scan(&dealID)
 	}, "seeding the deal")
 	return dealID

--- a/backend/internal/compose/org360/deals.go
+++ b/backend/internal/compose/org360/deals.go
@@ -9,7 +9,6 @@ package org360
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -57,7 +56,7 @@ func dealsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now 
 		       to_char(d.expected_close_date, 'YYYY-MM-DD'),
 		       d.created_at, d.last_activity_at, d.wait_until
 		FROM deal d
-		LEFT JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id
+		LEFT JOIN stage s ON s.id = d.stage_id
 		%s
 		ORDER BY d.created_at DESC, d.id DESC
 		LIMIT %d`, openDealsWhere(orgPos, dealScope), sectionLimit+1), args...)
@@ -135,20 +134,14 @@ func closedTotals(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
 		       count(*) FILTER (WHERE d.status = 'lost')
 		FROM deal d
 		WHERE d.organization_id = $%d AND d.archived_at IS NULL
-		  AND d.status IN ('won','lost') AND (%s)
-		GROUP BY d.workspace_id`, orgPos, dealScope), args...).Scan(&wonMinor, &lost)
-	if errors.Is(err, pgx.ErrNoRows) {
-		// No closed deal on this account yet: an honest zero in the
-		// installation's own currency, not a missing figure.
-		return installationZero(baseCurrency)
-	}
+		  AND d.status IN ('won','lost') AND (%s)`, orgPos, dealScope), args...).Scan(&wonMinor, &lost)
+	// No GROUP BY, so no empty result to handle: an ungrouped aggregate returns
+	// exactly one row whatever it counted, and the coalesce above makes that row
+	// an honest zero in the installation's own currency for an account with no
+	// closed deal. The clause used to group by the tenant, which produced no row
+	// at all in that case.
 	if err != nil {
 		return crmcontracts.Money{}, 0, err
 	}
 	return crmcontracts.Money{AmountMinor: &wonMinor, Currency: &baseCurrency}, lost, nil
-}
-
-func installationZero(baseCurrency string) (crmcontracts.Money, int, error) {
-	zero := int64(0)
-	return crmcontracts.Money{AmountMinor: &zero, Currency: &baseCurrency}, 0, nil
 }

--- a/backend/internal/compose/org360/graphreads.go
+++ b/backend/internal/compose/org360/graphreads.go
@@ -104,7 +104,7 @@ func (g *graphAssembly) readOpenDeals() error {
 	rows, err := g.tx.Query(g.ctx, fmt.Sprintf(`
 		SELECT d.id, d.name, s.name, d.amount_minor, count(*) OVER () AS open_total
 		FROM deal d
-		LEFT JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id
+		LEFT JOIN stage s ON s.id = d.stage_id
 		%s
 		ORDER BY d.amount_minor DESC NULLS LAST, d.id
 		LIMIT %d`, openDealsWhere(orgPos, dealScope), graphDealCap), args...)

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -337,7 +337,7 @@ func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, 
 	rows, err := tx.Query(ctx, `
 		SELECT d.amount_minor, d.currency, s.win_probability
 		FROM deal d
-		JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id
+		JOIN stage s ON s.id = d.stage_id
 		WHERE d.organization_id = ANY($1) AND d.status = 'open' AND d.archived_at IS NULL`,
 		included)
 	if err != nil {

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -131,10 +131,10 @@ func TestDealsByStageDerivationHonorsRowScope(t *testing.T) {
 
 func TestDealsByStageGroupsByCurrencySeparately(t *testing.T) {
 	e := setupForecast(t)
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, 'EUR deal', $3, $4, 100000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60])
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, 'USD deal', $3, $4, 50000, 'USD', 'manual', 'human:x')`, e.pipeline, e.stages[60])
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'EUR deal', $2, $3, 100000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60])
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'USD deal', $2, $3, 50000, 'USD', 'manual', 'human:x')`, e.pipeline, e.stages[60])
 
 	result := e.runReport(e.Admin(), t, "deals-by-stage",
 		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`)
@@ -164,10 +164,10 @@ func TestDealsByStageFiltersByOrganizationID(t *testing.T) {
 	e := setupForecast(t)
 	orgA := e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'A', 'manual', 'human:x')`)
 	orgB := e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'B', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, 'Deal A', $3, $4, $5, 10000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], orgA)
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, 'Deal B', $3, $4, $5, 20000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], orgB)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Deal A', $2, $3, $4, 10000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], orgA)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Deal B', $2, $3, $4, 20000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], orgB)
 
 	result := e.runReport(e.Admin(), t, "deals-by-stage", fmt.Sprintf(
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}],"filters":{"organization_id":%q}}`,
@@ -184,10 +184,10 @@ func TestDealsByStageFiltersByOrganizationID(t *testing.T) {
 func TestDealsByStageFiltersByPartnerSourced(t *testing.T) {
 	e := setupForecast(t)
 	partner := e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Partner', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, partner_org_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, 'Sourced', $3, $4, $5, 10000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], partner)
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, $2, 'Direct', $3, $4, 20000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60])
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Sourced', $2, $3, $4, 10000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], partner)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Direct', $2, $3, 20000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60])
 
 	result := e.runReport(e.Admin(), t, "deals-by-stage",
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}],"filters":{"partner_sourced":true}}`)
@@ -207,8 +207,8 @@ func TestDealsByStageFiltersByPartnerSourced(t *testing.T) {
 // 500s before ever reaching the assertions below.
 func TestDealsByStageStalledFilterWorksUnderTheStageJoin(t *testing.T) {
 	e := setupForecast(t)
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by, created_at)
-		VALUES ($1, $2, 'Idle', $3, $4, 10000, 'EUR', 'manual', 'human:x', now() - interval '90 days')`, e.pipeline, e.stages[60])
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, source, captured_by, created_at)
+		VALUES ($1, 'Idle', $2, $3, 10000, 'EUR', 'manual', 'human:x', now() - interval '90 days')`, e.pipeline, e.stages[60])
 	e.seedOpenDeal(t, "Fresh", 60, nil, int64p(20000), stringp("commit"))
 
 	result := e.runReport(e.Admin(), t, "deals-by-stage",
@@ -245,8 +245,8 @@ func TestDealsByStageStalledFilterAgreesWithIsStalled(t *testing.T) {
 		{"expired wait un-suppresses", days(-90), timep(days(-80)), timep(days(-5))},
 	}
 	for _, c := range cases {
-		e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, created_at, last_activity_at, wait_until, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, 1000, 'EUR', $6, $7, $8, 'manual', 'human:x')`,
+		e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, created_at, last_activity_at, wait_until, source, captured_by)
+			VALUES ($1, $2, $3, $4, 1000, 'EUR', $5, $6, $7, 'manual', 'human:x')`,
 			c.name, e.pipeline, e.stages[60], c.created, c.lastAct, c.wait)
 	}
 

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -108,10 +108,10 @@ func setupForecast(t *testing.T) *forecastEnv {
 		}
 	}
 
-	e.pipeline = e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
+	e.pipeline = e.seedID(t, `INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`)
 	for position, probability := range map[int]int{0: 20, 1: 55, 2: 60} {
-		e.stages[probability] = e.seed(t,
-			`INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, $4, $5, 'open', $6)`,
+		e.stages[probability] = e.seedID(t,
+			`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, $4, 'open', $5)`,
 			e.pipeline, fmt.Sprintf("Stage %d", position), position, probability)
 	}
 
@@ -136,14 +136,27 @@ func (e *forecastEnv) seed(t *testing.T, sql string, args ...any) ids.UUID {
 	return id
 }
 
+// seedID is seed for a table that no longer has a workspace to bind — it mints
+// the id and nothing else. ADR-0091 §8 phase D removes the column table by
+// table, so this env seeds some of its fixtures one way and some the other
+// until the last one goes.
+func (e *forecastEnv) seedID(t *testing.T, sql string, args ...any) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), sql, append([]any{id}, args...)...); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return id
+}
+
 // seedOpenDeal plants one live open deal; amountMinor/category/owner may
 // be nil (the honest NULL cases every roll-up must survive). The close
 // date is comfortably future so the §11 hygiene exclusion stays out of
 // these roll-up suites — the exclusion has its own suite.
 func (e *forecastEnv) seedOpenDeal(t *testing.T, name string, probability int, owner *ids.UUID, amountMinor *int64, category *string) ids.UUID {
 	t.Helper()
-	return e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, forecast_category, expected_close_date, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, CASE WHEN $7::bigint IS NULL THEN NULL ELSE 'EUR' END, $8, (now() + interval '30 days')::date, 'manual', 'human:x')`,
+	return e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, forecast_category, expected_close_date, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, $6, CASE WHEN $6::bigint IS NULL THEN NULL ELSE 'EUR' END, $7, (now() + interval '30 days')::date, 'manual', 'human:x')`,
 		name, e.pipeline, e.stages[probability], owner, amountMinor, category)
 }
 
@@ -269,10 +282,10 @@ func TestForecastRollupReconcilesToConstituentDeals(t *testing.T) {
 		e.seedOpenDeal(t, fmt.Sprintf("Deal %d", i), int(c.probability), nil, c.amount, c.category)
 	}
 	// Closed and archived deals are not forecast.
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, status, closed_at, source, captured_by)
-		VALUES ($1, $2, 'Won already', $3, $4, 'won', now(), 'manual', 'human:x')`, e.pipeline, e.stages[60])
-	e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, archived_at, source, captured_by)
-		VALUES ($1, $2, 'Archived', $3, $4, 77777, 'EUR', now(), 'manual', 'human:x')`, e.pipeline, e.stages[60])
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, status, closed_at, source, captured_by)
+		VALUES ($1, 'Won already', $2, $3, 'won', now(), 'manual', 'human:x')`, e.pipeline, e.stages[60])
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, archived_at, source, captured_by)
+		VALUES ($1, 'Archived', $2, $3, 77777, 'EUR', now(), 'manual', 'human:x')`, e.pipeline, e.stages[60])
 
 	result := e.runReport(e.Admin(), t, "forecast", `{"group_by":["forecast_category"]}`)
 	if len(result.Rows) != 3 {

--- a/backend/internal/compose/report_winloss_integration_test.go
+++ b/backend/internal/compose/report_winloss_integration_test.go
@@ -47,10 +47,8 @@ func (e *forecastEnv) seedClosedDealWith(t *testing.T, name, status, source, clo
 	if lostReason != "" {
 		reason = &lostReason
 	}
-	e.seed(t, `INSERT INTO deal
-		(id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency,
-		 status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, 'EUR', $7, $8::timestamptz, $9, 1.0, $10, 'human:x')`,
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, 'EUR', $6, $7::timestamptz, $8, 1.0, $9, 'human:x')`,
 		name, e.pipeline, e.stages[60], amountMinor, status, closedAt, reason, source)
 }
 
@@ -280,10 +278,8 @@ func TestAnEmptyTextGroupKeyIsNotTheSameAsAnAbsentOne(t *testing.T) {
 func TestTheWinLossDefaultNeverSumsAcrossCurrencies(t *testing.T) {
 	e := setupForecast(t)
 	e.seedClosedDeal(t, "In euros", "won", "2025-03-04T10:00:00Z", 10000)
-	e.seed(t, `INSERT INTO deal
-		(id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency,
-		 status, closed_at, fx_rate_to_base, source, captured_by)
-		VALUES ($1, $2, 'In dollars', $3, $4, 10000, 'USD', 'won', now(), 1.0, 'manual', 'human:x')`,
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, status, closed_at, fx_rate_to_base, source, captured_by)
+		VALUES ($1, 'In dollars', $2, $3, 10000, 'USD', 'won', now(), 1.0, 'manual', 'human:x')`,
 		e.pipeline, e.stages[60])
 
 	result := e.runReport(e.Admin(), t, "win-loss", `{}`)

--- a/backend/internal/compose/signalproposals_integration_test.go
+++ b/backend/internal/compose/signalproposals_integration_test.go
@@ -341,10 +341,9 @@ func seedDealOwnedBy(t *testing.T, e *integration.Env, owner ids.UUID) ids.UUID 
 	deal := ids.NewV7()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id,
-			                  source, captured_by)
-			VALUES ($1, $2, 'Their renewal', $3, $4, $5, 'manual', 'human:seed')`,
-			deal, e.WS, pipeline, stage, owner)
+			INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, source, captured_by)
+			VALUES ($1, 'Their renewal', $2, $3, $4, 'manual', 'human:seed')`,
+			deal, pipeline, stage, owner)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/activities/commitments_integration_test.go
+++ b/backend/internal/modules/activities/commitments_integration_test.go
@@ -136,17 +136,16 @@ func (e *promiseEnv) seedSplitTask(t *testing.T) (taskID, hiddenDealID ids.UUID)
 
 	e.exec(t, `INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Zeta GmbH', $3, 'seed', 'system')`, orgID, e.ws, e.rep)
-	e.exec(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position)
-		VALUES ($1, $2, 'Default', true, 1)`, pipelineID, e.ws)
-	e.exec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, win_probability)
-		VALUES ($1, $2, $3, 'Qualified', 1, 20)`, stageID, e.ws, pipelineID)
+	e.exec(t, `INSERT INTO pipeline (id, name, is_default, position)
+		VALUES ($1, 'Default', true, 1)`, pipelineID)
+	e.exec(t, `INSERT INTO stage (id, pipeline_id, name, position, win_probability)
+		VALUES ($1, $2, 'Qualified', 1, 20)`, stageID, pipelineID)
 	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		VALUES ($1, $2, $3, $4, 'seed', 'system')`, personID, e.ws, visiblePersonNam, e.rep)
 	// Owned by the OTHER rep, so an own-scoped caller cannot read it.
-	e.exec(t, `INSERT INTO deal (id, workspace_id, name, organization_id, owner_id,
-			pipeline_id, stage_id, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, 'seed', 'system')`,
-		hiddenDealID, e.ws, hiddenDealName, orgID, e.other, pipelineID, stageID)
+	e.exec(t, `INSERT INTO deal (id, name, organization_id, owner_id, pipeline_id, stage_id, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, $6, 'seed', 'system')`,
+		hiddenDealID, hiddenDealName, orgID, e.other, pipelineID, stageID)
 
 	e.exec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at,
 			assignee_id, is_done, source, captured_by)

--- a/backend/internal/modules/automation/automationpreview_integration_test.go
+++ b/backend/internal/modules/automation/automationpreview_integration_test.go
@@ -33,11 +33,11 @@ type dealFixture struct {
 func seedDealBoard(t *testing.T, fx *autoFixture) dealFixture {
 	t.Helper()
 	pipeline, openStage, wonStage := ids.NewV7(), ids.NewV7(), ids.NewV7()
-	fx.exec(t, `INSERT INTO pipeline (id, workspace_id, name, is_default) VALUES ($1, $2, 'Sales', true)`, pipeline, fx.ws)
-	fx.exec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Qualify', 1, 'open', 20)`, openStage, fx.ws, pipeline)
-	fx.exec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
-		VALUES ($1, $2, $3, 'Won', 2, 'won', 100)`, wonStage, fx.ws, pipeline)
+	fx.exec(t, `INSERT INTO pipeline (id, name, is_default) VALUES ($1, 'Sales', true)`, pipeline)
+	fx.exec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 1, 'open', 20)`, openStage, pipeline)
+	fx.exec(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Won', 2, 'won', 100)`, wonStage, pipeline)
 
 	seedDeal := func(owner ids.UUID, status string, archived bool) ids.UUID {
 		id := ids.NewV7()
@@ -51,9 +51,9 @@ func seedDealBoard(t *testing.T, fx *autoFixture) dealFixture {
 			archivedAt = &ts
 		}
 		fx.exec(t, `
-			INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id, status, closed_at, archived_at, source, captured_by)
-			VALUES ($1, $2, 'Deal', $3, $4, $5, $6, $7, $8, 'manual', 'human:test')`,
-			id, fx.ws, pipeline, openStage, owner, status, closedAt, archivedAt)
+			INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, status, closed_at, archived_at, source, captured_by)
+			VALUES ($1, 'Deal', $2, $3, $4, $5, $6, $7, 'manual', 'human:test')`,
+			id, pipeline, openStage, owner, status, closedAt, archivedAt)
 		return id
 	}
 	own := seedDeal(fx.rep1, "open", false)
@@ -75,8 +75,8 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 	now := time.Now().UTC()
 	moveAt := func(stage ids.UUID, at time.Time) {
 		fx.exec(t, `
-			INSERT INTO deal_stage_history (workspace_id, deal_id, to_stage_id, changed_by, changed_at)
-			VALUES ($1, $2, $3, 'human:test', $4)`, fx.ws, board.ownDeal, stage, at)
+			INSERT INTO deal_stage_history (deal_id, to_stage_id, changed_by, changed_at)
+			VALUES ( $1, $2, 'human:test', $3)`, board.ownDeal, stage, at)
 	}
 	moveAt(board.openStage, now.AddDate(0, 0, -1))
 	moveAt(board.openStage, now.AddDate(0, 0, -5))

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -126,9 +126,9 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 		// rationale). Won/lost stages carry their semantic 100/0 in the same
 		// column, so terminal moves snapshot too.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO deal_stage_history (workspace_id, deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change, win_probability_at_change)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			storekit.MustWorkspace(ctx), id, ids.UUID(*current.StageId), in.ToStageID, by,
+			`INSERT INTO deal_stage_history (deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change, win_probability_at_change)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			id, ids.UUID(*current.StageId), in.ToStageID, by,
 			current.AmountMinor, current.Currency, winProbability); err != nil {
 			return fmt.Errorf("record stage history: %w", err)
 		}

--- a/backend/internal/modules/deals/deal_create.go
+++ b/backend/internal/modules/deals/deal_create.go
@@ -123,7 +123,6 @@ func (s *Store) readyDealCreate(ctx context.Context, in CreateDealInput) (string
 // visible organization), inserts the deal with its first stage-history
 // row, and runs the write shape — all inside the caller's transaction.
 func (s *Store) createDealInTx(ctx context.Context, tx pgx.Tx, in CreateDealInput, by string, active []fieldcatalog.Column) (crmcontracts.Deal, error) {
-	wsID := storekit.MustWorkspace(ctx)
 
 	if err := ensureOpenBirthStage(ctx, tx, in.StageID, in.PipelineID); err != nil {
 		return crmcontracts.Deal{}, err
@@ -156,13 +155,13 @@ func (s *Store) createDealInTx(ctx context.Context, tx pgx.Tx, in CreateDealInpu
 
 	id := ids.New[ids.DealKind]()
 	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
-		id, wsID, in.Name, in.AmountMinor, in.Currency, in.PipelineID, in.StageID,
+		id, in.Name, in.AmountMinor, in.Currency, in.PipelineID, in.StageID,
 		in.OrganizationID, in.ProjectID, in.OwnerID, in.ExpectedClose, in.Source, by,
 	})
 	_, err := tx.Exec(ctx,
-		`INSERT INTO deal (id, workspace_id, name, amount_minor, currency, pipeline_id, stage_id,
+		`INSERT INTO deal (id, name, amount_minor, currency, pipeline_id, stage_id,
 		                   organization_id, project_id, owner_id, expected_close_date, source, captured_by`+cfCols+`)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13`+cfHolders+`)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12`+cfHolders+`)`,
 		args...)
 	if err != nil {
 		// Covers the remaining FKs (pipeline, owner); the stage/pipeline
@@ -177,9 +176,9 @@ func (s *Store) createDealInTx(ctx context.Context, tx pgx.Tx, in CreateDealInpu
 	}
 
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO deal_stage_history (workspace_id, deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change)
-		 VALUES ($1, $2, NULL, $3, $4, $5, $6)`,
-		wsID, id, in.StageID, by, in.AmountMinor, in.Currency); err != nil {
+		`INSERT INTO deal_stage_history (deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change)
+		 VALUES ($1, NULL, $2, $3, $4, $5)`,
+		id, in.StageID, by, in.AmountMinor, in.Currency); err != nil {
 		return crmcontracts.Deal{}, fmt.Errorf("record stage history: %w", err)
 	}
 

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -173,7 +173,7 @@ func appendDealFilters(where []string, in ListDealsInput, arg func(any) int) []s
 	return where
 }
 
-const dealColumns = `id, workspace_id, name, amount_minor, currency, pipeline_id, stage_id,
+const dealColumns = `id, name, amount_minor, currency, pipeline_id, stage_id,
 	organization_id, project_id, owner_id, partner_org_id, status, lost_reason,
 	won_without_contract_reason, won_without_contract_detail,
 	expected_close_date, close_date_provisional, closed_at, forecast_category, wait_until, last_activity_at,
@@ -199,7 +199,7 @@ func readDeal(ctx context.Context, tx pgx.Tx, id ids.DealID, archived storekit.A
 // cursor key).
 func scanDeal(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontracts.Deal, error) {
 	var d crmcontracts.Deal
-	var id, wsID, pipelineID, stageID ids.UUID
+	var id, pipelineID, stageID ids.UUID
 	var orgID, projectID, ownerID, partnerID *ids.UUID
 	var status string
 	var forecastCat *string
@@ -209,7 +209,7 @@ func scanDeal(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontr
 
 	var wonReason *string
 	dests := []any{
-		&id, &wsID, &d.Name, &d.AmountMinor, &d.Currency, &pipelineID, &stageID,
+		&id, &d.Name, &d.AmountMinor, &d.Currency, &pipelineID, &stageID,
 		&orgID, &projectID, &ownerID, &partnerID, &status, &d.LostReason,
 		&wonReason, &d.WonWithoutContractDetail,
 		&expectedClose, &closeDateProvisional, &d.ClosedAt, &forecastCat, &waitUntil, &d.LastActivityAt,

--- a/backend/internal/modules/deals/forecasthistory.go
+++ b/backend/internal/modules/deals/forecasthistory.go
@@ -83,9 +83,9 @@ func recordForecastMovement(ctx context.Context, tx pgx.Tx, id ids.DealID,
 	}
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO deal_forecast_history
-		   (workspace_id, deal_id, changed_by, amount_minor_at_change, currency_at_change, close_date_at_change)
-		 VALUES ($1, $2, $3, $4, $5, $6)`,
-		storekit.MustWorkspace(ctx), id, by, amount, currency, closeDate); err != nil {
+		   (deal_id, changed_by, amount_minor_at_change, currency_at_change, close_date_at_change)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		id, by, amount, currency, closeDate); err != nil {
 		return fmt.Errorf("record forecast history: %w", err)
 	}
 	return nil

--- a/backend/internal/modules/deals/pipeline.go
+++ b/backend/internal/modules/deals/pipeline.go
@@ -54,11 +54,10 @@ func (s *Store) CreatePipeline(ctx context.Context, in CreatePipelineInput) (crm
 // atomic bootstrap seeds defaults in the same transaction that mints the
 // workspace (C5), so a seed failure rolls the whole tenant back.
 func createPipelineTx(ctx context.Context, tx pgx.Tx, in CreatePipelineInput) (crmcontracts.Pipeline, error) {
-	wsID := storekit.MustWorkspace(ctx)
 	id := ids.New[ids.PipelineKind]()
 	_, err := tx.Exec(ctx,
-		`INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, $3, $4, $5)`,
-		id, wsID, in.Name, in.IsDefault, in.Position)
+		`INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, $2, $3, $4)`,
+		id, in.Name, in.IsDefault, in.Position)
 	if err != nil {
 		if storekit.IsUniqueViolation(err) {
 			return crmcontracts.Pipeline{}, apperrors.ErrConflict
@@ -68,9 +67,9 @@ func createPipelineTx(ctx context.Context, tx pgx.Tx, in CreatePipelineInput) (c
 
 	for _, st := range in.Stages {
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO stage (workspace_id, pipeline_id, name, position, semantic, win_probability)
-			 VALUES ($1, $2, $3, $4, $5, $6)`,
-			wsID, id, st.Name, st.Position, st.Semantic, st.WinProbability); err != nil {
+			`INSERT INTO stage (pipeline_id, name, position, semantic, win_probability)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			id, st.Name, st.Position, st.Semantic, st.WinProbability); err != nil {
 			return crmcontracts.Pipeline{}, fmt.Errorf("insert stage: %w", err)
 		}
 	}
@@ -207,15 +206,15 @@ func readPipelineWith(
 	ctx context.Context, tx pgx.Tx, id ids.PipelineID, archived storekit.ArchivedFilter,
 ) (crmcontracts.Pipeline, error) {
 	var p crmcontracts.Pipeline
-	var pid, wsID ids.UUID
+	var pid ids.UUID
 	live := ""
 	if archived == storekit.LiveOnly {
 		live = liveRowsClause
 	}
 	err := tx.QueryRow(ctx,
-		`SELECT id, workspace_id, name, is_default, position, created_at, updated_at, archived_at
+		`SELECT id, name, is_default, position, created_at, updated_at, archived_at
 		 FROM pipeline WHERE id = $1`+live, id).
-		Scan(&pid, &wsID, &p.Name, &p.IsDefault, &p.Position, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt)
+		Scan(&pid, &p.Name, &p.IsDefault, &p.Position, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return p, apperrors.ErrNotFound
 	}
@@ -225,7 +224,7 @@ func readPipelineWith(
 	p.Id = openapi_types.UUID(pid)
 
 	rows, err := tx.Query(ctx,
-		`SELECT id, workspace_id, pipeline_id, name, position, semantic, win_probability, created_at, updated_at
+		`SELECT id, pipeline_id, name, position, semantic, win_probability, created_at, updated_at
 		 FROM stage WHERE pipeline_id = $1 AND archived_at IS NULL ORDER BY position`, id)
 	if err != nil {
 		return p, err
@@ -235,9 +234,9 @@ func readPipelineWith(
 	stages := []crmcontracts.Stage{}
 	for rows.Next() {
 		var st crmcontracts.Stage
-		var stID, stWs, stPipeline ids.UUID
+		var stID, stPipeline ids.UUID
 		var semantic string
-		if err := rows.Scan(&stID, &stWs, &stPipeline, &st.Name, &st.Position, &semantic, &st.WinProbability, &st.CreatedAt, &st.UpdatedAt); err != nil {
+		if err := rows.Scan(&stID, &stPipeline, &st.Name, &st.Position, &semantic, &st.WinProbability, &st.CreatedAt, &st.UpdatedAt); err != nil {
 			return p, err
 		}
 		st.Id = openapi_types.UUID(stID)

--- a/backend/internal/modules/deals/stages.go
+++ b/backend/internal/modules/deals/stages.go
@@ -144,8 +144,8 @@ func (s *Store) CreateStage(ctx context.Context, in CreateStageInput) (crmcontra
 		}
 		var stageID ids.StageID
 		err := tx.QueryRow(ctx, `
-			INSERT INTO stage (workspace_id, pipeline_id, name, position, semantic, win_probability)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
+			INSERT INTO stage (pipeline_id, name, position, semantic, win_probability)
+			VALUES ($1, $2, $3, $4, $5)
 			RETURNING id`,
 			in.PipelineID, in.Name, in.Position, in.Semantic, probability).Scan(&stageID)
 		if err != nil {
@@ -366,14 +366,14 @@ func stageUpdatedPayload(pipelineID ids.PipelineID, in UpdateStageInput) crmcont
 }
 
 func readStage(ctx context.Context, tx pgx.Tx, id ids.StageID, archived storekit.ArchivedFilter) (crmcontracts.Stage, error) {
-	q := `SELECT id, workspace_id, pipeline_id, name, position, semantic, win_probability, created_at, updated_at, archived_at
+	q := `SELECT id, pipeline_id, name, position, semantic, win_probability, created_at, updated_at, archived_at
 	      FROM stage WHERE id = $1`
 	if archived == storekit.LiveOnly {
 		q += ` AND archived_at IS NULL`
 	}
 	var out crmcontracts.Stage
-	var stageID, wsID, pipelineID ids.UUID
-	err := tx.QueryRow(ctx, q, id).Scan(&stageID, &wsID, &pipelineID, &out.Name, &out.Position,
+	var stageID, pipelineID ids.UUID
+	err := tx.QueryRow(ctx, q, id).Scan(&stageID, &pipelineID, &out.Name, &out.Position,
 		&out.Semantic, &out.WinProbability, &out.CreatedAt, &out.UpdatedAt, &out.ArchivedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return crmcontracts.Stage{}, apperrors.ErrNotFound

--- a/backend/internal/modules/people/demote_integration_test.go
+++ b/backend/internal/modules/people/demote_integration_test.go
@@ -152,9 +152,9 @@ func TestDemoteRefusesWhenThePersonIsOnALiveDeal(t *testing.T) {
 		sql  string
 		args []any
 	}{
-		{`INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`, []any{pipeline, e.ws}},
-		{`INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, []any{stage, e.ws, pipeline}},
-		{`INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, source, captured_by) VALUES ($1, $2, $3, 'Rollout', $4, $5, 'manual', 'human:x')`, []any{deal, e.ws, e.user, pipeline, stage}},
+		{`INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`, []any{pipeline}},
+		{`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, []any{stage, pipeline}},
+		{`INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, source, captured_by) VALUES ($1, $2, 'Rollout', $3, $4, 'manual', 'human:x')`, []any{deal, e.user, pipeline, stage}},
 		{`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, source, captured_by) VALUES ($1, 'deal_stakeholder', $2, $3, 'manual', 'human:x')`, []any{e.ws, ids.UUID(person.Id), deal}},
 	} {
 		if _, err := e.owner.Exec(ctx, q.sql, q.args...); err != nil {

--- a/backend/internal/modules/privacy/retentionselectors.go
+++ b/backend/internal/modules/privacy/retentionselectors.go
@@ -57,8 +57,7 @@ var retentionSelectors = map[string]string{
 		        WHERE r.kind = 'deal_stakeholder' AND r.person_id = p.id AND r.archived_at IS NULL)
 		LIMIT $2`,
 	"deal/lost": `SELECT id FROM deal
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND status = 'lost' AND archived_at IS NULL AND NOT legal_hold
+		WHERE status = 'lost' AND archived_at IS NULL AND NOT legal_hold
 		  AND closed_at < now() - make_interval(days => $1) LIMIT $2`,
 	// deal/won is authorable but NOT seeded: no DM-SEED row plants it, because
 	// a won deal is the commercial record of the relationship and the product
@@ -67,8 +66,7 @@ var retentionSelectors = map[string]string{
 	// deal/won after a shorter period than the default") — without a selector
 	// the use case's own worked example could not be performed.
 	"deal/won": `SELECT id FROM deal
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND status = 'won' AND archived_at IS NULL AND NOT legal_hold
+		WHERE status = 'won' AND archived_at IS NULL AND NOT legal_hold
 		  AND closed_at < now() - make_interval(days => $1) LIMIT $2`,
 	"ai_call_payload/content": `SELECT id FROM ai_call_payload
 		WHERE occurred_at < now() - make_interval(days => $1) LIMIT $2`,

--- a/backend/internal/modules/search/pending.go
+++ b/backend/internal/modules/search/pending.go
@@ -44,7 +44,7 @@ type pendingSource struct {
 var pendingSources = map[string]pendingSource{
 	entityPerson:       {table: entityPerson, text: "t.full_name", tenantScoped: true},
 	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)", tenantScoped: true},
-	entityDeal:         {table: entityDeal, text: "t.name", tenantScoped: true},
+	entityDeal:         {table: entityDeal, text: "t.name"},
 	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)", tenantScoped: true},
 	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)", tenantScoped: true},
 	entityProject:      {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},

--- a/backend/migrations/core/1787021916_deal_spine_drop_workspace.down.sql
+++ b/backend/migrations/core/1787021916_deal_spine_drop_workspace.down.sql
@@ -1,0 +1,67 @@
+-- Reverse of 1787021916: the deal spine carries the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE deal ADD COLUMN workspace_id uuid;
+ALTER TABLE pipeline ADD COLUMN workspace_id uuid;
+ALTER TABLE stage ADD COLUMN workspace_id uuid;
+ALTER TABLE deal_stage_history ADD COLUMN workspace_id uuid;
+ALTER TABLE deal_forecast_history ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'deal', 'pipeline', 'stage', 'deal_stage_history', 'deal_forecast_history'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE deal ADD CONSTRAINT deal_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE pipeline ADD CONSTRAINT pipeline_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE stage ADD CONSTRAINT stage_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE deal_stage_history ADD CONSTRAINT deal_stage_history_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE deal_forecast_history ADD CONSTRAINT deal_forecast_history_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+-- Each restored as UNIQUE (id), which is the shape the migration before this one
+-- left: phase B collapsed all four from their composite forms, and this returns
+-- that state rather than the pre-phase-B one.
+ALTER TABLE deal ADD CONSTRAINT uq_deal_ws_id UNIQUE (id);
+ALTER TABLE pipeline ADD CONSTRAINT uq_pipeline_ws_id UNIQUE (id);
+ALTER TABLE stage ADD CONSTRAINT uq_stage_ws_id UNIQUE (id);
+ALTER TABLE stage ADD CONSTRAINT uq_stage_ws_id_pipeline UNIQUE (id, pipeline_id);
+
+DROP INDEX idx_deal_close;
+DROP INDEX idx_deal_owner;
+DROP INDEX idx_deal_partner;
+DROP INDEX idx_deal_project;
+DROP INDEX idx_deal_stalled;
+DROP INDEX idx_dsh_ws_time;
+DROP INDEX idx_deal_forecast_history_deal;
+
+CREATE INDEX idx_deal_close ON deal (workspace_id, expected_close_date) WHERE status = 'open' AND archived_at IS NULL;
+CREATE INDEX idx_deal_owner ON deal (workspace_id, owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_deal_partner ON deal (workspace_id, partner_org_id) WHERE partner_org_id IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_deal_project ON deal (workspace_id, project_id) WHERE project_id IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_deal_stalled ON deal (workspace_id, last_activity_at) WHERE status = 'open' AND archived_at IS NULL;
+CREATE INDEX idx_deal_ws_live ON deal (workspace_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_dsh_ws_time ON deal_stage_history (workspace_id, changed_at);
+CREATE INDEX idx_deal_forecast_history_deal ON deal_forecast_history (workspace_id, deal_id, changed_at);

--- a/backend/migrations/core/1787021916_deal_spine_drop_workspace.up.sql
+++ b/backend/migrations/core/1787021916_deal_spine_drop_workspace.up.sql
@@ -1,0 +1,57 @@
+-- 1787021916: the deal spine drops the tenant column (ADR-0091 §8 phase D).
+--
+-- The last five of the deals module's twelve, and the ones every other module
+-- reaches into: deal, its pipeline and stage catalogue, and the two histories
+-- that record how a deal moved.
+--
+--   deal                   the record itself
+--   pipeline, stage        the catalogue it is placed in
+--   deal_stage_history     every placement it has had
+--   deal_forecast_history  every forecast it has carried
+--
+-- Their keys already name something narrower than the tenant, and phase B put
+-- them there: a pipeline's name is unique installation-wide, its default is a
+-- `UNIQUE ((true))` singleton, a stage is unique by (pipeline_id, position).
+--
+-- Four leftovers go with the column. uq_deal_ws_id, uq_pipeline_ws_id and
+-- uq_stage_ws_id are each a second copy of their table's own primary key, and
+-- uq_stage_ws_id_pipeline duplicates stage_id_pipeline_unique. All four were
+-- composite foreign-key targets that phase C rewrote away; none is referenced
+-- by any foreign key today, and none indexes anything its sibling does not.
+-- stage_id_pipeline_unique STAYS: deal_stage_in_pipeline still points at it,
+-- and it is what stops a deal naming a stage from another pipeline.
+
+ALTER TABLE deal_forecast_history DROP CONSTRAINT deal_forecast_history_workspace_id_fkey;
+ALTER TABLE deal_forecast_history DROP COLUMN workspace_id;
+
+ALTER TABLE deal_stage_history DROP CONSTRAINT deal_stage_history_workspace_id_fkey;
+ALTER TABLE deal_stage_history DROP COLUMN workspace_id;
+
+ALTER TABLE deal DROP CONSTRAINT uq_deal_ws_id;
+ALTER TABLE deal DROP CONSTRAINT deal_workspace_id_fkey;
+ALTER TABLE deal DROP COLUMN workspace_id;
+
+ALTER TABLE stage DROP CONSTRAINT uq_stage_ws_id;
+ALTER TABLE stage DROP CONSTRAINT uq_stage_ws_id_pipeline;
+ALTER TABLE stage DROP CONSTRAINT stage_workspace_id_fkey;
+ALTER TABLE stage DROP COLUMN workspace_id;
+
+ALTER TABLE pipeline DROP CONSTRAINT uq_pipeline_ws_id;
+ALTER TABLE pipeline DROP CONSTRAINT pipeline_workspace_id_fkey;
+ALTER TABLE pipeline DROP COLUMN workspace_id;
+
+-- The indexes that led with the column, recreated on what actually selects
+-- rows: a close date, an owner, a partner, a project, a stalled deal's last
+-- activity, a history's deal and moment.
+--
+-- idx_deal_ws_live is NOT recreated. It was (workspace_id) WHERE archived_at IS
+-- NULL, and an index on the tenant alone has no narrowed form — without the
+-- column the predicate is the whole selection, which is not something an index
+-- can be. Same reading idx_quota_ws_live and idx_offer_template_ws got.
+CREATE INDEX idx_deal_close ON deal (expected_close_date) WHERE status = 'open' AND archived_at IS NULL;
+CREATE INDEX idx_deal_owner ON deal (owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_deal_partner ON deal (partner_org_id) WHERE partner_org_id IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_deal_project ON deal (project_id) WHERE project_id IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_deal_stalled ON deal (last_activity_at) WHERE status = 'open' AND archived_at IS NULL;
+CREATE INDEX idx_dsh_ws_time ON deal_stage_history (changed_at);
+CREATE INDEX idx_deal_forecast_history_deal ON deal_forecast_history (deal_id, changed_at);

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -104,7 +104,7 @@ BEGIN
   -- only touches rows that are still ownerless.
   UPDATE person       SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;
   UPDATE organization SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;
-  UPDATE deal         SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;
+  UPDATE deal         SET owner_id = admin_id WHERE owner_id IS NULL;
   UPDATE lead         SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;
 
   -- 2nd full-seat user so the Share picker / "who has access" have a real


### PR DESCRIPTION
The last five of the deals module's twelve, and the ones every other module reaches into: `deal`, its `pipeline`/`stage` catalogue, and the two histories that record how a deal moved.

Their keys already name something narrower than the tenant, and phase B put them there: a pipeline's name is unique installation-wide, its default is a `UNIQUE ((true))` singleton, a stage is unique by `(pipeline_id, position)`.

**Four leftovers go with the column.** `uq_deal_ws_id`, `uq_pipeline_ws_id` and `uq_stage_ws_id` are each a second copy of their table's own primary key; `uq_stage_ws_id_pipeline` duplicates `stage_id_pipeline_unique`. All four were composite foreign-key targets phase C rewrote away, none is referenced by any foreign key today (checked against `pg_constraint`), and none indexes anything its sibling does not. `stage_id_pipeline_unique` **stays**: `deal_stage_in_pipeline` points at it, and it is what stops a deal naming a stage from another pipeline.

`idx_deal_ws_live` is not recreated — it was `(workspace_id) WHERE archived_at IS NULL`, and an index on the tenant alone has no narrowed form.

## Two more statements templated over mixed tables

`flipreconcile`'s orphan scan runs one query per native class over five tables; `deal` has lost the column, the other four have not. Same shape as `pendingSources` in the last slice, and the same answer: the predicate is per-object behind `flipTenantScope`, dropping out class by class as their slices land. Spelled for all five it fails outright on `deal`; spelled for none, a reconstruction adopts the **exporting** installation's records as its own.

`search`'s `pendingSources` gains `deal` for the same reason, and the cutover fixture's estate wipe is the third — it deletes seven tables by workspace, three of which no longer have one.

## An ungrouped aggregate

org360's won/lost rollup grouped by `d.workspace_id`, which produced **no row** for an account with no closed deal — the `ErrNoRows` branch beside it returned an honest zero. Ungrouped, the aggregate returns exactly one row whatever it counted and the `coalesce` already makes that row the same zero, so the branch and the helper it called are gone rather than left unreachable.

## About the fixture churn

~90 test INSERTs changed. They were rewritten mechanically and then checked mechanically: a small static pass compares each SQL literal's highest `$N` against the arguments its call supplies, accounting for the helpers that prepend `id`/`workspace`. That is what caught the two `INSERT … SELECT` forms and the several helpers with their own prepending, rather than a round-trip through the integration lane per mistake.

## Verification

- Lane applied to an empty database; the down restores all five columns with their foreign keys, all four uniques and the eight wide indexes.
- `make check-backend` green; `make test-integration` green.

Phase D: 54 → 49 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes workspace_id from `deal`, `pipeline`, `stage`, `deal_stage_history`, and `deal_forecast_history` per ADR-0091 §8 phase D. This makes these tables installation-scoped, replaces tenant-wide indexes with targeted ones, and updates read/write paths accordingly. org360 closed totals now always return zero for accounts with no closed deals (previously could return no row and required special handling).

- Drops the column and FK from the five tables; removes duplicate uniques `uq_deal_ws_id`, `uq_pipeline_ws_id`, `uq_stage_ws_id`, and `uq_stage_ws_id_pipeline` (keeps `stage_id_pipeline_unique`). Replaces wide `(workspace_id, …)` indexes with focused indexes on close date, owner, partner, project, stall time, and history deal/time. Down migration backfills from the live workspace and restores constraints/indexes.
- Updates create/read/advance paths to omit the tenant column and history writes; removes workspace joins in deal↔stage/pipeline reads; adds per-object scoping in `flipreconcile` (`flipTenantScope`) so mixed classes continue to filter by workspace until their slices land; marks deals as not tenant-scoped in `search` pending sources; adjusts cutover cleanup to delete deals without a workspace predicate. Introduces `SeedIDRow`/`seedID` helpers and rewrites fixtures; `seed-dev.sql` now sets deal owners without a workspace filter.

<sup>Written for commit e1e6ee6640cfab13dcb7c8c6cdb60507650b0262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

