### PR TITLE
fix: main is green again — a budget that moved, and a 404 the contract never had

### DIFF
--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -163,7 +163,14 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// the unbounded principal — the availability test (a held record reads
 	// as gone, admin included) runs for everyone. One indexed read by primary
 	// key, flat in the size of the account.
-	const budget = 32
+	// 34 since the companies list gained its two roll-up columns (#1621): the
+	// single organization read attaches contact_count and open_deal_count so
+	// the page a row opens into agrees with the row it came from, and the 360
+	// assembles through that read. Two queries, and both are FLAT — one per
+	// count for the whole page, which is one organization here — so the
+	// property this budget protects is untouched. The flatness assertion above
+	// is what proves that, and it passes; only the ceiling moved.
+	const budget = 34
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -280,8 +280,13 @@ func ListActivitiesTx(ctx context.Context, tx pgx.Tx, in ListActivitiesInput) ([
 	// visible person and a lead the caller may not read passes it — and
 	// filtering on that lead's id would then answer "this lead exists, and here
 	// is what happened on it" to someone with no right to either fact.
-	if err := ensureNarrowingTargetVisible(ctx, tx, in.EntityType, in.EntityID); err != nil {
+	switch visible, err := narrowingTargetVisible(ctx, tx, in.EntityType, in.EntityID); {
+	case err != nil:
 		return nil, storekit.Page{}, err
+	case !visible:
+		// Nothing the caller may see is linked to it, which is what an empty
+		// page says — and all it says.
+		return nil, storekit.Page{}, nil
 	}
 	limit := storekit.ClampLimit(in.Limit)
 	join, where, args, err := listActivitiesFilter(ctx, in)

--- a/backend/internal/modules/activities/commitments.go
+++ b/backend/internal/modules/activities/commitments.go
@@ -38,6 +38,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -114,7 +115,7 @@ func (s *Store) ListOpenTasks(ctx context.Context, in ListOpenTasksInput) ([]Ope
 }
 
 func listOpenTasks(ctx context.Context, tx pgx.Tx, in ListOpenTasksInput) ([]OpenTask, bool, error) {
-	if err := ensureNarrowingVisible(ctx, tx, in); err != nil {
+	if err := narrowingVisible(ctx, tx, in); err != nil {
 		return nil, false, err
 	}
 	limit := openTasksLimit(in.Limit)
@@ -163,26 +164,44 @@ func listOpenTasks(ctx context.Context, tx pgx.Tx, in ListOpenTasksInput) ([]Ope
 // narrowing record is visible is a different question from whether the task is,
 // and it is asked here rather than left to whichever caller remembers.
 //
-// Out of scope answers ErrNotFound, the same as an id that names nothing —
+// Out of scope answers ErrNotFound here, the same as an id that names nothing —
 // existence-hiding, exactly as reading the record directly would.
-func ensureNarrowingVisible(ctx context.Context, tx pgx.Tx, in ListOpenTasksInput) error {
-	return ensureNarrowingTargetVisible(ctx, tx, in.EntityType, in.EntityID)
+//
+// The TIMELINE answers the same question with an empty page instead, and the
+// difference is the surface rather than the rule: listActivities is a documented
+// HTTP list whose contract admits 200 and 403 and no 404, while this sweep feeds
+// an agent seam with no such published shape. Both hide existence — an empty
+// page is what a nonexistent id returns too — so each surface answers in the
+// shape its own callers are promised.
+func narrowingVisible(ctx context.Context, tx pgx.Tx, in ListOpenTasksInput) error {
+	visible, err := narrowingTargetVisible(ctx, tx, in.EntityType, in.EntityID)
+	if err != nil {
+		return err
+	}
+	if !visible {
+		return apperrors.ErrNotFound
+	}
+	return nil
 }
 
-// ensureNarrowingTargetVisible is the gate itself, over the (type, id) pair
-// alone, so the timeline read and the open-task sweep ask the identical
-// question. Held in one place because two spellings of an existence-hiding
-// rule is how one of them ends up missing a record type the other has.
-func ensureNarrowingTargetVisible(ctx context.Context, tx pgx.Tx, entityType *string, entityID *ids.UUID) error {
+// narrowingTargetVisible is the gate itself, over the (type, id) pair alone, so
+// the timeline read and the open-task sweep ask the identical question. Held in
+// one place because two spellings of an existence-hiding rule is how one of
+// them ends up missing a record type the other has.
+//
+// A filter naming no record at all is visible=true: there is nothing to gate,
+// and the filter simply matches nothing downstream. An unknown TYPE stays an
+// error, because that is a malformed request rather than an empty answer.
+func narrowingTargetVisible(ctx context.Context, tx pgx.Tx, entityType *string, entityID *ids.UUID) (bool, error) {
 	if entityType == nil || entityID == nil {
-		return nil
+		return true, nil
 	}
 	if linkColumn(*entityType) == "" {
-		return &InvalidLinkTypeError{EntityType: *entityType}
+		return false, &InvalidLinkTypeError{EntityType: *entityType}
 	}
 	// The record type IS the table name for every arm of this vocabulary, which
 	// is the same identity linkNameCoalesce reads.
-	return auth.EnsureVisible(ctx, tx, *entityType, *entityID)
+	return auth.VisibleTo(ctx, tx, *entityType, *entityID)
 }
 
 // openTasksFilter builds the predicate: the two columns that define an open

--- a/backend/internal/modules/activities/timelinescope_integration_test.go
+++ b/backend/internal/modules/activities/timelinescope_integration_test.go
@@ -23,14 +23,20 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// A lead owned by another rep is not readable, so asking for its timeline is
-// answered not-found — the same as an id that names nothing. Any other answer,
-// including an empty page, tells the caller the lead is there.
-func TestNarrowingTheTimelineToAnUnreadableLeadAnswersNotFound(t *testing.T) {
+// A lead owned by another rep is not readable, so its timeline comes back
+// EMPTY — the same answer an id that names nothing gets, and the same one a
+// readable lead with no activities gets. That is what makes it existence-hiding:
+// the caller cannot tell the three apart.
+//
+// It reads empty rather than not-found because listActivities documents 200 and
+// 403 and no 404 (crm.yaml), and because on a list "nothing you may see matches"
+// is the honest shape. An earlier version answered not-found on the reasoning
+// that an empty page "tells the caller the lead is there" — it does not, for the
+// reason above, and the 404 was an answer the contract never admitted.
+func TestNarrowingTheTimelineToAnUnreadableLeadIsEmpty(t *testing.T) {
 	e := setupPromises(t)
 	hiddenLeadID, visiblePersonID, activityID := ids.NewV7(), ids.NewV7(), ids.NewV7()
 
@@ -53,13 +59,19 @@ func TestNarrowingTheTimelineToAnUnreadableLeadAnswersNotFound(t *testing.T) {
 
 	leadType := "lead"
 	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
-	_, _, err := store.ListActivities(e.as(), ListActivitiesInput{
+	got, _, err := store.ListActivities(e.as(), ListActivitiesInput{
 		EntityType: &leadType, EntityID: &hiddenLeadID,
 	})
-	if !errors.Is(err, apperrors.ErrNotFound) {
-		t.Fatalf("narrowing the timeline to a lead owned by another rep → %v, want "+
-			"ErrNotFound — an answer of any kind confirms the lead exists and that "+
-			"this activity happened on it", err)
+	if err != nil {
+		t.Fatalf("narrowing the timeline to another rep's lead → %v, want an empty page", err)
+	}
+	// The activity IS readable through the visible person, so the any-link
+	// scope alone would hand it back. Empty proves the narrowing TARGET was
+	// gated, which is the whole point of the check.
+	if len(got) != 0 {
+		t.Fatalf("narrowing to a lead owned by another rep returned %d activities — "+
+			"the any-link scope admitted one through the person, and the narrowing "+
+			"target was never gated", len(got))
 	}
 }
 


### PR DESCRIPTION
Closes #1634. Two integration tests fail on a clean checkout of `main`, for unrelated reasons. Reproduced against a freshly created database, so neither is local-state drift.

## 1. The org360 query budget — raise it, with the reason

#1621 put `contact_count` and `open_deal_count` on the companies list, and attached them to the **single** organization read as well, *"so the page a row opens into agrees with the row"*. The 360 assembles through that read, so it now issues two more queries.

Both are **flat** — one per count for the whole page, which is one organization here — and the flatness assertion immediately above the ceiling still passes. That assertion is the property this test exists to protect; only the absolute ceiling moved. `32 → 34`, with the reason recorded, as the test's own comment asks of whoever raises it.

## 2. The timeline's narrowing gate — keep the fix, correct the shape

#1604 added something real, and it stays: the activity scope is an **any-link** rule, so an activity linked to both a visible person *and* a lead the caller may not read passes it. Narrowing to that lead's id would then answer *"this lead exists, and here is what happened on it."*

What it got wrong is the shape of the refusal. It answered `ErrNotFound`, but **`listActivities` documents 200 and 403 and no 404** — so a routine filter produced a response the contract never admitted. It also broke `TestActivityReadsAreScopedThroughLinks`, which has asserted the empty-page shape since #21.

The reasoning #1604 recorded does not hold:

> Any other answer, including an empty page, tells the caller the lead is there.

An empty page is exactly what an id naming **nothing** returns, and what a **readable** lead with no activities returns. The caller cannot tell the three apart — which is what existence-hiding means. Both shapes hide existence equally; only one of them is in the contract.

So the timeline answers empty, and its test now says why. **`ListOpenTasks` keeps `ErrNotFound`** — it feeds an agent seam with no published response set, so the difference is the *surface*, not the rule. The shared gate answers the visibility question; each surface answers in the shape its own callers are promised.

**Both properties are still proven.** The timeline case keeps its activity linked through a visible person, so an implementation that skipped the gate would hand it back and the test would fail.

## A judgment call worth flagging

I am reversing a deliberate decision from #1604 on the strength of the contract and the older test. If 404 is the intended answer for a narrowed list, the fix is the other one — document it in `crm.yaml` (spec-first, per P3) and update the #21 test — and I would rather be told that than have guessed silently. Either way `main` should not stay red while it is decided.

## Also worth knowing

`main`'s own CI shows only *Publish release* failing, not the integration lane — so main has been red in a way its own pipeline did not report. That is a separate question about which lanes run on push versus PR, and I have not touched it.

## Verification

`make check` · `craft-static` (3 roots, 0 findings) · `make test-integration` — *OK: integration passed with 0 skips (41 packages)*, against a fresh database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two unrelated integration failures on main: raises the org360 query budget after roll-up columns added two queries, and makes timeline narrowing return an empty page (200) instead of 404 to match the documented contract. This restores green main without changing visibility rules.

- org360: increase the query budget from 32 to 34. Flatness is still asserted; only the ceiling moved due to the new `contact_count` and `open_deal_count` columns.
- Timeline: when the narrowing target is not visible, `listActivities` now returns an empty page. The API admits 200/403 and no 404 in `crm.yaml`. Tests updated to assert emptiness.
- Gate reuse: introduce a shared `narrowingTargetVisible` check and call it from both surfaces.
- Tasks: `ListOpenTasks` keeps `ErrNotFound` for out-of-scope targets (agent seam; no published HTTP shape).

<sup>Written for commit f4c1afc52bbb36a2af74f5d5375a52e39fb1b312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

