### PR TITLE
docs(contract): listActivities documents the 404 its narrowing gate returns

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3433,6 +3433,17 @@ paths:
               schema: { $ref: '#/components/schemas/ActivityListResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '404':
+          description: >-
+            The `entity_type`/`entity_id` this read was narrowed TO is outside the caller's
+            row scope, or names nothing. Filtering BY a record is a read OF it, so an
+            unreadable one owes the same existence-hiding answer a direct read would — the
+            caller cannot tell "not yours" from "not there". Note this is the NARROWING
+            TARGET, not the activities: a readable target with no activities answers 200
+            with an empty page.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
     post:
       tags: [Activities]
       operationId: logActivity

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21506,6 +21506,15 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            /** @description The `entity_type`/`entity_id` this read was narrowed TO is outside the caller's row scope, or names nothing. Filtering BY a record is a read OF it, so an unreadable one owes the same existence-hiding answer a direct read would — the caller cannot tell "not yours" from "not there". Note this is the NARROWING TARGET, not the activities: a readable target with no activities answers 200 with an empty page. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     logActivity: {


### PR DESCRIPTION
`GET /activities` answers `ErrNotFound` when the `entity_type`/`entity_id` a read is narrowed **to** lies outside the caller's row scope — the gate #1604 added, and the behaviour #1633 settled. The contract listed `200`, `401` and `403`, so a routine filter produced a response no client was told to expect.

## Why the description says *which* record

That is the part a client can get wrong. The 404 is about the **narrowing target**, not the activities:

| request | answer |
|---|---|
| target readable, has activities | `200` + page |
| target readable, **no** activities | `200` + **empty page** |
| target unreadable or nonexistent | `404` |

A client that read `404` as "no activities on this record" would report the wrong thing to a user looking at a record they can perfectly well see.

## Provenance

Found while fixing #1634 from the other direction. I read the missing `404` as evidence the *code* was wrong and had a PR (#1636) that made the timeline answer an empty page; #1633 landed first with the opposite reading — that filtering **by** a record is a read **of** it, so an unreadable one owes existence-hiding. That is coherent and it is now settled, so I closed mine rather than re-litigating.

The behaviour is theirs. This only makes the contract describe it, which is true either way: an endpoint should not return a status its own contract omits.

`listOpenTasks` needs no equivalent — it feeds an agent seam and has no published operation.

## Verification

`make check` (contract drift gate regenerates `internal/contracts` and `frontend/src/api` cleanly) · `make fe-quality`.

## Follow-up, not in this PR

Per contract-first (P3) this belongs in the spec's `crm.yaml` too. It joins the batch already waiting for the foundation repo — ADR-0105, the change-password operation, `data_reset_available`, and the `staging` retirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the 404 response for `GET /activities` when a request is narrowed to an unreadable or non-existent record, aligning the contract with current behavior. The contract previously listed only 200/401/403, which could lead clients to misinterpret a 404 from routine filters.

- Clarifies that 404 refers to the narrowing target record, not the activities; a readable target with no activities still returns 200 with an empty page.
- Updates OpenAPI in `backend/api/crm.yaml` and regenerates `frontend/src/api/schema.d.ts`.

**Client impact**
- Update callers of `GET /activities` to handle 404 as existence-hiding for the target record. Do not treat 404 as “no activities”; show “record not found or not accessible” instead.

<sup>Written for commit 5e7e3bb247296d8b4d3f08bf0ce3a5ef01dfc119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented a `404 Not Found` response when an activity request targets an unreadable or nonexistent resource.
  - Clarified that readable resources with no activities return `200 OK` with an empty result page.
  - Added details for the standardized problem response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->