### PR TITLE
feat(seed-demo): what each company IS, a dual-role partner, and staff for the silent five

### DIFF
--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -31,6 +31,9 @@ type demoConfig struct {
 	Lifecycle        map[string][]string `json:"lifecycle"`
 	Partners         []demoPartner       `json:"partners"`
 	PartnerEdges     []demoPartnerEdge   `json:"partner_edges"`
+	DualRolePartners []demoDualPartner   `json:"dual_role_partners"`
+	InventedStaff    []demoInventedStaff `json:"invented_staff"`
+	RelTypes         demoRelTypes        `json:"relationship_types"`
 }
 
 // anchorCompany is the installation's own company — the record that answers
@@ -276,4 +279,43 @@ type demoPartnerEdge struct {
 	Partner      string `json:"partner"`      // a partner's domain
 	Organization string `json:"organization"` // the account's domain
 	Kind         string `json:"kind"`         // partner_of | referred_by | co_sell_with
+}
+
+// demoDualPartner promotes a REAL crawled company to a partner while it
+// stays a customer.
+//
+// The three synthetic <Country>Partner companies prove the Partners screen
+// renders; this proves a partner need not be a separate record from the
+// customer, which ADR-0079 calls the basis of the partner program. The
+// company keeps its invoices, deals, contracts and contacts and gains a
+// partner row on top.
+type demoDualPartner struct {
+	Company           string `json:"company"` // a domain under siteresults/
+	PartnerRole       string `json:"partner_role"`
+	CertStatus        string `json:"cert_status"`
+	MarginTier        string `json:"margin_tier"`
+	RelationshipStage string `json:"relationship_stage"`
+	NextStep          string `json:"next_step"`
+}
+
+// demoInventedStaff is people invented for a real company that publishes
+// none — the dataset's one deliberate exception to "real people come only
+// from the website reader".
+//
+// It is confined to five Asian customers that carry signed contracts and no
+// contacts, and every person it writes is marked: source is
+// inventedPersonSource rather than seedSource, so a query can always tell
+// them from the people the reader actually found.
+type demoInventedStaff struct {
+	Company string            `json:"company"`
+	People  []demoPartnerPers `json:"people"`
+}
+
+// demoRelTypes says what each company IS to us, as against where it stands.
+//
+// Only the exceptions are listed. The base type is derived from lifecycle so
+// a company ingested next month is covered with no edit — see
+// relationshipTypesFor.
+type demoRelTypes struct {
+	Overrides map[string][]string `json:"overrides"`
 }

--- a/backend/tools/seed-demo/partners.go
+++ b/backend/tools/seed-demo/partners.go
@@ -140,7 +140,7 @@ func seedPartnerPeople(c *client, orgID string, p demoPartner) (people, links in
 		if email == "" {
 			continue
 		}
-		personID, existed, err := ensurePerson(c, datasetPers{Name: person.Name, Role: person.Role}, email, false)
+		personID, existed, err := ensurePerson(c, datasetPers{Name: person.Name, Role: person.Role}, email, seedSource, false)
 		if err != nil {
 			return people, links, fmt.Errorf("person %q: %w", person.Name, err)
 		}

--- a/backend/tools/seed-demo/relationships.go
+++ b/backend/tools/seed-demo/relationships.go
@@ -207,7 +207,8 @@ func seedInventedStaff(c *client, cfg demoConfig, refs pipelineRefs, mode runMod
 			if email == "" {
 				return people, links, fmt.Errorf("invented staff at %s: %q yields no address", entry.Company, person.Name)
 			}
-			personID, existed, err := ensureInventedPerson(c, person, email)
+			personID, existed, err := ensurePerson(c,
+				datasetPers{Name: person.Name, Role: person.Role}, email, inventedPersonSource, false)
 			if err != nil {
 				return people, links, fmt.Errorf("person %q: %w", person.Name, err)
 			}
@@ -236,36 +237,6 @@ func seedInventedStaff(c *client, cfg demoConfig, refs pipelineRefs, mode runMod
 func inventedDomain(companyDomain string) string {
 	slug := strings.NewReplacer(".", "-").Replace(strings.ToLower(companyDomain))
 	return slug + ".example"
-}
-
-// ensureInventedPerson is ensurePerson with the invented source, so the
-// twelve people nobody published stay separable from the 780 who were.
-func ensureInventedPerson(c *client, person demoPartnerPers, email string) (id string, existed bool, err error) {
-	if id, found, err := findPerson(c, email); err != nil {
-		return "", false, err
-	} else if found {
-		return id, true, nil
-	}
-	first, last := splitName(person.Name)
-	body := jsonBody{
-		"full_name": person.Name,
-		"source":    inventedPersonSource,
-		"emails":    []jsonBody{{"email": email, "email_type": "work", "is_primary": true}},
-	}
-	addIfSet(body, "first_name", first)
-	addIfSet(body, "last_name", last)
-	addIfSet(body, "title", person.Role)
-
-	var out struct {
-		ID string `json:"id"`
-	}
-	if err := c.post("/v1/people", body, &out); err != nil {
-		if existing, ok := conflictingID(err); ok {
-			return existing, true, nil
-		}
-		return "", false, err
-	}
-	return out.ID, false, nil
 }
 
 // standingCounts is what the what-each-company-IS phases wrote.

--- a/backend/tools/seed-demo/relationships.go
+++ b/backend/tools/seed-demo/relationships.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// What each company IS to us, and the two demo states that needed inventing:
+// a company that is a customer and a partner at once, and staff for the
+// customers whose own sites publish none.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// inventedPersonSource marks a person nobody's website published.
+//
+// A different source from seedSource on purpose: 780 people in this
+// installation were read off a real company's own site, twelve were invented
+// because their employer publishes no staff directory, and no query should
+// have to guess which is which.
+const inventedPersonSource = "seed:invented"
+
+// relationshipTypesFor decides what one company is to us.
+//
+// A rule with a short exception list, not a list: the dataset grows, and a
+// company ingested next month must land with a type without anyone editing
+// anything. lifecycle already says where an account stands, and for all but a
+// handful of companies that answers what it is as well — a customer is a
+// customer, and a company nobody has sold to yet is `other` rather than a
+// pretend supplier.
+//
+// The overrides carry what the rule cannot know: that a company also resells
+// for us, that one is a vendor we buy from, that a lost account is now a
+// competitor.
+func relationshipTypesFor(domain, lifecycle string, cfg demoConfig) []string {
+	if types, ok := cfg.RelTypes.Overrides[strings.ToLower(domain)]; ok && len(types) > 0 {
+		return types
+	}
+	switch lifecycle {
+	case "customer", "former_customer":
+		return []string{"customer"}
+	default:
+		return []string{"other"}
+	}
+}
+
+// seedRelationshipTypes fills the multi-valued "what is this company to us"
+// on every organization.
+//
+// It runs AFTER seedLifecycle, because the type is derived from the stage.
+// Before this existed only the three synthetic partners carried a type and
+// the other 187 companies carried none, so the field the company header
+// renders was empty on every real account.
+//
+// A company that already carries `partner` keeps it. The type and the partner
+// row are two halves of one invariant (ADR-0079) and removing the type while
+// the row lives is refused with 422 — so a replace-set that forgot it would
+// not quietly drop the partner, it would fail the seed.
+func seedRelationshipTypes(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int, error) {
+	changed := 0
+	domains := make([]string, 0, len(refs.orgsByDom))
+	for domain := range refs.orgsByDom {
+		domains = append(domains, domain)
+	}
+	// Sorted so a re-run walks the same order and a failure names the same
+	// company twice rather than a different one each time.
+	sort.Strings(domains)
+
+	for _, domain := range domains {
+		if mode == modeDryRun {
+			changed++
+			continue
+		}
+		orgID := refs.orgsByDom[domain]
+		current, err := organizationTypes(c, orgID)
+		if err != nil {
+			return changed, fmt.Errorf("reading %s: %w", domain, err)
+		}
+		want := withPartnerKept(relationshipTypesFor(domain, current.Lifecycle, cfg), current.Types)
+		if sameTypes(current.Types, want) {
+			continue
+		}
+		body := jsonBody{"relationship_types": want, "if_version": current.Version}
+		if err := c.patch("/v1/organizations/"+orgID, body, nil); err != nil {
+			return changed, fmt.Errorf("typing %s as %s: %w", domain, strings.Join(want, "+"), err)
+		}
+		changed++
+	}
+	return changed, nil
+}
+
+// withPartnerKept adds `partner` to the desired set when the record already
+// carries it. relationship_types is a REPLACE-set, so a rule that computed
+// "customer" for a company that is also a partner would be asking the server
+// to drop the partner type — which it refuses (422) while the partner row
+// lives, because the two are one invariant.
+func withPartnerKept(want, current []string) []string {
+	for _, t := range current {
+		if t != "partner" {
+			continue
+		}
+		for _, w := range want {
+			if w == "partner" {
+				return want
+			}
+		}
+		return append(append([]string{}, want...), "partner")
+	}
+	return want
+}
+
+// sameTypes compares two type sets ignoring order, so a re-run that would
+// write the same answer writes nothing.
+func sameTypes(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	x := append([]string{}, a...)
+	y := append([]string{}, b...)
+	sort.Strings(x)
+	sort.Strings(y)
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func organizationTypes(c *client, orgID string) (struct {
+	Lifecycle string   `json:"lifecycle"`
+	Types     []string `json:"relationship_types"`
+	Version   int      `json:"version"`
+}, error) {
+	var out struct {
+		Lifecycle string   `json:"lifecycle"`
+		Types     []string `json:"relationship_types"`
+		Version   int      `json:"version"`
+	}
+	err := c.get("/v1/organizations/"+orgID, nil, &out)
+	return out, err
+}
+
+// seedDualRolePartners promotes real crawled companies that are already
+// customers.
+//
+// This is the case ADR-0079 exists for: "the partner program is built on
+// companies that are simultaneously partners and customers". The synthetic
+// <Country>Partner three prove the Partners screen renders; this proves a
+// partner need not be a separate record from the customer.
+//
+// It reuses the same upsert the synthetic partners take, so there is one
+// promotion path rather than two that can drift.
+func seedDualRolePartners(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int, error) {
+	promoted := 0
+	for i, dual := range cfg.DualRolePartners {
+		orgID, ok := refs.orgsByDom[strings.ToLower(dual.Company)]
+		if !ok {
+			return promoted, fmt.Errorf("dual-role partner %d names company %q, which is not seeded", i, dual.Company)
+		}
+		if mode == modeDryRun {
+			promoted++
+			continue
+		}
+		err := upsertPartnerRow(c, orgID, demoPartner{
+			PartnerRole:       dual.PartnerRole,
+			CertStatus:        dual.CertStatus,
+			MarginTier:        dual.MarginTier,
+			RelationshipStage: dual.RelationshipStage,
+			NextStep:          dual.NextStep,
+		})
+		if err != nil {
+			return promoted, fmt.Errorf("promoting %s to a partner: %w", dual.Company, err)
+		}
+		promoted++
+	}
+	return promoted, nil
+}
+
+// seedInventedStaff files people for real companies that publish none.
+//
+// The dataset's locked rule is that real people come only from the website
+// reader, and this is its one stated exception. It is confined to five Asian
+// customers that carry signed contracts and no contacts: the crawl is right
+// to have found nobody — Korean and Vietnamese manufacturers publish products
+// and certifications, not staff directories — but a demo that opens the
+// account, finds the paper and then finds an empty Contacts tab reads as a
+// broken product rather than an honest one.
+//
+// Everyone written here is marked with inventedPersonSource and sits on a
+// .example address, so they can never be mistaken for, or mailed as, one of
+// the 780 the reader actually found.
+func seedInventedStaff(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (people, links int, err error) {
+	for i, entry := range cfg.InventedStaff {
+		orgID, ok := refs.orgsByDom[strings.ToLower(entry.Company)]
+		if !ok {
+			return people, links, fmt.Errorf("invented staff %d names company %q, which is not seeded", i, entry.Company)
+		}
+		for _, person := range entry.People {
+			if mode == modeDryRun {
+				people++
+				links++
+				continue
+			}
+			email := partnerEmail(person.Name, inventedDomain(entry.Company))
+			if email == "" {
+				return people, links, fmt.Errorf("invented staff at %s: %q yields no address", entry.Company, person.Name)
+			}
+			personID, existed, err := ensureInventedPerson(c, person, email)
+			if err != nil {
+				return people, links, fmt.Errorf("person %q: %w", person.Name, err)
+			}
+			if !existed {
+				people++
+			}
+			linked, err := ensureEmployment(c, personID, orgID, person.Role, false)
+			if err != nil {
+				return people, links, fmt.Errorf("employment for %q: %w", person.Name, err)
+			}
+			if linked {
+				links++
+			}
+		}
+	}
+	return people, links, nil
+}
+
+// inventedDomain is the undeliverable domain an invented person's address
+// sits on: the company's own domain with its dots folded into hyphens, under
+// .example.
+//
+// NOT the company's real domain. These people do not work there in any sense
+// a mail server would agree with, and an address at the real domain would be
+// deliverable to whoever does read that mailbox.
+func inventedDomain(companyDomain string) string {
+	slug := strings.NewReplacer(".", "-").Replace(strings.ToLower(companyDomain))
+	return slug + ".example"
+}
+
+// ensureInventedPerson is ensurePerson with the invented source, so the
+// twelve people nobody published stay separable from the 780 who were.
+func ensureInventedPerson(c *client, person demoPartnerPers, email string) (id string, existed bool, err error) {
+	if id, found, err := findPerson(c, email); err != nil {
+		return "", false, err
+	} else if found {
+		return id, true, nil
+	}
+	first, last := splitName(person.Name)
+	body := jsonBody{
+		"full_name": person.Name,
+		"source":    inventedPersonSource,
+		"emails":    []jsonBody{{"email": email, "email_type": "work", "is_primary": true}},
+	}
+	addIfSet(body, "first_name", first)
+	addIfSet(body, "last_name", last)
+	addIfSet(body, "title", person.Role)
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := c.post("/v1/people", body, &out); err != nil {
+		if existing, ok := conflictingID(err); ok {
+			return existing, true, nil
+		}
+		return "", false, err
+	}
+	return out.ID, false, nil
+}
+
+// standingCounts is what the what-each-company-IS phases wrote.
+type standingCounts struct {
+	relTypes, dualPartners int
+}
+
+// seedWhatEachCompanyIs settles what every company is to us, as against where
+// it stands in the funnel — the two halves ADR-0079 split apart.
+//
+// The promotion comes BEFORE the typing, and the order is load-bearing. An org
+// IS a partner iff it carries the `partner` type AND has a partner row, and
+// the server enforces that in both directions: adding the type to a company
+// with no row is refused (422 `partner_row_missing`) exactly as removing the
+// type from one that has a row is. Typing bestit.de first is what stopped an
+// earlier seed dead.
+func seedWhatEachCompanyIs(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (standingCounts, error) {
+	var n standingCounts
+	var err error
+	if n.dualPartners, err = seedDualRolePartners(c, cfg, refs, mode); err != nil {
+		return n, err
+	}
+	// What a company IS follows where it STANDS, so this reads the stage
+	// seedLifecycle settled.
+	if n.relTypes, err = seedRelationshipTypes(c, cfg, refs, mode); err != nil {
+		return n, err
+	}
+	return n, nil
+}

--- a/backend/tools/seed-demo/relationships_test.go
+++ b/backend/tools/seed-demo/relationships_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import "testing"
+
+func cfgWithOverrides(o map[string][]string) demoConfig {
+	return demoConfig{RelTypes: demoRelTypes{Overrides: o}}
+}
+
+// TestRelationshipTypesDeriveFromLifecycle pins the rule that keeps a company
+// ingested next month from landing with no type at all — the state all 187
+// non-partner companies were in before this existed.
+func TestRelationshipTypesDeriveFromLifecycle(t *testing.T) {
+	cfg := cfgWithOverrides(nil)
+	for _, tc := range []struct {
+		lifecycle string
+		want      string
+	}{
+		{"customer", "customer"},
+		{"former_customer", "customer"},
+		{"prospect", "other"},
+		{"target", "other"},
+		{"opportunity", "other"},
+		{"unknown", "other"},
+	} {
+		got := relationshipTypesFor("example.com", tc.lifecycle, cfg)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Errorf("lifecycle %q gave %v, want [%s]", tc.lifecycle, got, tc.want)
+		}
+	}
+}
+
+// TestAnOverrideWinsOverTheRule covers the dual-role case ADR-0079 calls the
+// basis of the partner program: a company that is a customer AND a partner.
+func TestAnOverrideWinsOverTheRule(t *testing.T) {
+	cfg := cfgWithOverrides(map[string][]string{"bestit.de": {"customer", "partner"}})
+	got := relationshipTypesFor("bestit.de", "customer", cfg)
+	if len(got) != 2 || got[0] != "customer" || got[1] != "partner" {
+		t.Fatalf("got %v, want [customer partner]", got)
+	}
+	// The lookup is case-insensitive: refs index domains lowercased, and a
+	// dataset entry spelled otherwise must not silently miss its override.
+	if got := relationshipTypesFor("BestIT.de", "customer", cfg); len(got) != 2 {
+		t.Errorf("uppercase domain missed its override: %v", got)
+	}
+}
+
+// TestPartnerSurvivesAReplaceSet is the 422 this guards against.
+//
+// relationship_types is a replace-set and removing `partner` while the org
+// still has a partner row is refused, because the two are one invariant. A
+// rule that computed plain "customer" for a promoted company would be asking
+// the server to break it.
+func TestPartnerSurvivesAReplaceSet(t *testing.T) {
+	got := withPartnerKept([]string{"customer"}, []string{"customer", "partner"})
+	if len(got) != 2 || got[1] != "partner" {
+		t.Fatalf("partner was dropped: %v", got)
+	}
+	// Already asking for it: no duplicate.
+	if got := withPartnerKept([]string{"customer", "partner"}, []string{"partner"}); len(got) != 2 {
+		t.Errorf("partner duplicated: %v", got)
+	}
+	// Not a partner: nothing added.
+	if got := withPartnerKept([]string{"customer"}, []string{"customer"}); len(got) != 1 {
+		t.Errorf("partner invented from nothing: %v", got)
+	}
+}
+
+// TestSameTypesIgnoresOrder keeps a re-run from rewriting a record whose
+// types the server happened to return in another order.
+func TestSameTypesIgnoresOrder(t *testing.T) {
+	if !sameTypes([]string{"customer", "partner"}, []string{"partner", "customer"}) {
+		t.Error("order made two equal sets look different — every re-seed would rewrite them")
+	}
+	if sameTypes([]string{"customer"}, []string{"customer", "partner"}) {
+		t.Error("a longer set compared equal")
+	}
+}
+
+// TestInventedDomainIsUndeliverable is the rule that keeps invented people
+// unmailable. The real company domain would be deliverable to whoever reads
+// that mailbox, which is exactly the harm the dataset's defang pass exists to
+// prevent.
+func TestInventedDomainIsUndeliverable(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"tipa.or.kr", "tipa-or-kr.example"},
+		{"tinthanhphat.vn", "tinthanhphat-vn.example"},
+		{"mv21.kr", "mv21-kr.example"},
+	} {
+		if got := inventedDomain(tc.in); got != tc.want {
+			t.Errorf("inventedDomain(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// The whole point: an invented address never lands on the real domain.
+	if got := partnerEmail("Park Jun-seo", inventedDomain("tipa.or.kr")); got != "park.junseo@tipa-or-kr.example" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// TestADualRolePartnerIsPromotedBeforeItIsTyped pins a phase-ordering rule
+// the server taught us with a 422.
+//
+// An org IS a partner iff it carries the `partner` TYPE and has a partner
+// ROW, and that invariant binds both directions: adding the type to a company
+// with no row is refused `partner_row_missing`, just as removing the type
+// from one that has a row is refused. A first attempt typed bestit.de as
+// customer+partner before promoting it, and the seed stopped there.
+//
+// The test asserts the dataset's own consistency, which is what a reordering
+// would break: every company whose override claims `partner` must also be
+// named as a dual-role partner, so the row exists by the time the type is
+// written.
+func TestADualRolePartnerIsPromotedBeforeItIsTyped(t *testing.T) {
+	cfg := demoConfig{
+		RelTypes: demoRelTypes{Overrides: map[string][]string{
+			"bestit.de":      {"customer", "partner"},
+			"aws.amazon.com": {"supplier"},
+		}},
+		DualRolePartners: []demoDualPartner{{Company: "bestit.de", PartnerRole: "consulting"}},
+	}
+	promoted := map[string]bool{}
+	for _, d := range cfg.DualRolePartners {
+		promoted[d.Company] = true
+	}
+	for domain, types := range cfg.RelTypes.Overrides {
+		for _, tt := range types {
+			if tt != "partner" {
+				continue
+			}
+			if !promoted[domain] {
+				t.Errorf("%s is typed `partner` but nothing promotes it — the type write will 422 with partner_row_missing", domain)
+			}
+		}
+	}
+}

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -72,6 +72,15 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 	if err := refs.loadDeals(c, cfg); err != nil {
 		return err
 	}
+	// The invented staff go in BEFORE the committees are drawn. A deal's
+	// stakeholders come from its company's employees, and seedStakeholders
+	// skips a company that publishes nobody — so staffing these five after it
+	// left them the only staffed companies whose deals had no committee, which
+	// is exactly what the verify rule catches.
+	inventedPeople, inventedLinks, err := seedInventedStaff(c, cfg, refs, mode)
+	if err != nil {
+		return err
+	}
 	stakeholders, err := seedStakeholders(c, cfg, refs, mode)
 	if err != nil {
 		return err
@@ -96,6 +105,10 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 	if err != nil {
 		return err
 	}
+	standing, err := seedWhatEachCompanyIs(c, cfg, refs, mode)
+	if err != nil {
+		return err
+	}
 	// Ownership runs last: it walks every organization the installation holds,
 	// including any a previous run created, so it must see the finished set.
 	ownedOrgs, ownedPeople, err := assignOwners(c, cfg, refs, mode)
@@ -111,8 +124,9 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 		products: catalogue.products, offers: catalogue.offers,
 		documents: paper.documents, looseDocs: paper.looseDocs,
 		consents: consents, lifecycles: lifecycles, surfaces: catalogue.surfaces, fxRates: fxRates,
-		partnerEdges: catalogue.partnerEdges,
-		ownedOrgs:    ownedOrgs, ownedPeople: ownedPeople,
+		partnerEdges: catalogue.partnerEdges, relTypes: standing.relTypes,
+		dualPartners: standing.dualPartners, inventedPeople: inventedPeople, inventedLinks: inventedLinks,
+		ownedOrgs: ownedOrgs, ownedPeople: ownedPeople,
 	})
 	return nil
 }
@@ -160,7 +174,9 @@ type pipelineCounts struct {
 	documents, looseDocs          int
 	consents, lifecycles          int
 	surfaces, fxRates             int
-	partnerEdges                  int
+	partnerEdges, relTypes        int
+	dualPartners                  int
+	inventedPeople, inventedLinks int
 	ownedOrgs, ownedPeople        int
 }
 
@@ -176,6 +192,9 @@ func reportPipeline(n pipelineCounts) {
 	fmt.Printf("fx rates:      %d loaded\n", n.fxRates)
 	fmt.Printf("surfaces:      %d new (tags, lists, custom fields, projects, quotas)\n", n.surfaces)
 	fmt.Printf("partner edges: %d new (referrals, co-sells, served accounts)\n", n.partnerEdges)
+	fmt.Printf("rel. types:    %d set (what each company IS to us)\n", n.relTypes)
+	fmt.Printf("dual partners: %d customer(s) also promoted to partner\n", n.dualPartners)
+	fmt.Printf("invented staff:%d person/people, %d employment(s) — companies that publish none\n", n.inventedPeople, n.inventedLinks)
 	fmt.Printf("consent:       %d recorded\n", n.consents)
 	fmt.Printf("lifecycle:     %d changed\n", n.lifecycles)
 	fmt.Printf("owners:        %d organization(s), %d person/people\n", n.ownedOrgs, n.ownedPeople)

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -250,7 +250,7 @@ func seedCompany(c *client, comp company, dryRun bool) (counts, error) {
 			got.skipped++
 			continue
 		}
-		personID, existed, err := ensurePerson(c, person, email, dryRun)
+		personID, existed, err := ensurePerson(c, person, email, seedSource, dryRun)
 		if err != nil {
 			return got, fmt.Errorf("person %q: %w", person.Name, err)
 		}
@@ -372,7 +372,13 @@ func findOrganization(c *client, comp company) (id string, found bool, err error
 
 // ensurePerson finds someone by their address and creates them if absent.
 // The address is the natural key the product itself dedupes on.
-func ensurePerson(c *client, person datasetPers, email string, dryRun bool) (id string, existed bool, err error) {
+//
+// source says where this person came from, and is a parameter rather than a
+// constant because the answer is load-bearing: almost everyone here was read
+// off their employer's own website, while the twelve invented for companies
+// that publish no staff carry inventedPersonSource. A query must always be
+// able to tell the two apart.
+func ensurePerson(c *client, person datasetPers, email, source string, dryRun bool) (id string, existed bool, err error) {
 	if id, found, err := findPerson(c, email); err != nil {
 		return "", false, err
 	} else if found {
@@ -385,7 +391,7 @@ func ensurePerson(c *client, person datasetPers, email string, dryRun bool) (id 
 	first, last := splitName(person.Name)
 	body := jsonBody{
 		"full_name": person.Name,
-		"source":    seedSource,
+		"source":    source,
 		"emails":    []jsonBody{{"email": email, "email_type": "work", "is_primary": true}},
 	}
 	addIfSet(body, "first_name", first)


### PR DESCRIPTION
Three gaps, all of which only showed once a demo left the German half.

## `relationship_types` was empty on 187 of 190 companies

Only the three synthetic partners carried one, so the field the company
header renders — *what is this company to us* — was blank on every real
account.

It is now derived from `lifecycle`: `customer`/`former_customer` are
`customer`, everything else `other`. A rule rather than a list, so a company
ingested next month lands with a type and nobody edits anything.
`demo.json`'s `relationship_types.overrides` carries only what the rule
cannot know — `aws.amazon.com` is a supplier, `amplience.com` is a lost
account that competes with us now.

## Nothing was a customer AND a partner

ADR-0079 calls that pair the basis of the partner program — it is why
`relationship_types` is multi-valued — and nothing in the dataset exercised
it.

`bestit.de` now is both: a real crawled German e-commerce agency that keeps
its 40 EUR invoices, its deal, its contracts and its six contacts, and gains
a partner row on top. The three synthetic `<Country>Partner` companies prove
the Partners screen renders; this proves a partner need not be a separate
record from the customer.

## Five Asian customers had signed contracts and zero contacts

A demo opened the account, found the paper, and hit an empty Contacts tab
next to Akeneo's ten. Twelve people are now invented for `tipa.or.kr`,
`tinthanhphat.vn`, `mv21.kr`, `vinatechgroup.vn` and `tth-automation.com`.

This is a **stated exception** to the dataset's locked rule that real people
come only from the website reader, recorded as such in `STATE.md`, and
confined to those five. The crawl is right to have found nobody: Korean and
Vietnamese manufacturers publish products and certifications, not staff
directories.

Every one is marked `source=seed:invented` — separable from the 780 the
reader found — and sits on `<domain-slug>.example` rather than the real
domain, because an address at the real domain would be deliverable to
whoever reads that mailbox.

## Two orderings are load-bearing, and both were found by running it

1. **The partner row goes in before the partner type.** The invariant binds
   both ways: adding the `partner` type to a company with no row is refused
   `422 partner_row_missing`, exactly as removing the type from one that has
   a row is refused. Typing `bestit.de` first stopped the seed dead.
2. **The invented staff go in before the committees.** `seedStakeholders`
   skips a company that publishes nobody and `verify` exempts that case;
   staffing these five afterwards left them the only staffed companies whose
   deals had no stakeholders — which `verify` then caught.

Both are pinned by tests in `relationships_test.go`.

The partners' own `lifecycle` also stops contradicting their partner stage:
`target` says nobody has engaged them, which is false for an
`active_referring` partner.

## Verified against a live stack

- 169 relationship types set; all 190 companies now carry one
- 12 invented people employed and owned, `source=seed:invented`
- `best it` reads `customer+partner` with its 40 invoices intact
- `verify: OK` on a converged re-run (0 new for everything already written)

Gates: `make craft-static`, `check-gofmt.sh`, `check-go-file-length.sh`,
package tests. All green.

`seedWhatEachCompanyIs` is an extraction with no behavior change — the new
phases pushed `seedPipeline` past the 80-line cap.

## Needs the dataset commit

`relationship_types`, `dual_role_partners` and `invented_staff` live in the
dataset repo: `margince-demo-database` `b1fb161`. Seeding this branch against
an older checkout is a no-op for all three.

## Still open

`deal.partner_org_id` is set on no deal. `best it` makes that gap more
visible, not less — it is now a partner with 40 invoices and no
partner-sourced deal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives each organization’s `relationship_types` from lifecycle with overrides, promotes a real customer to a dual customer+partner, and invents staff for five customers that publish none; also refactors person creation to pass a `source` so invented people are separable. Previously 187/190 orgs had no type, no record exercised customer+partner, and some signed-contract accounts showed empty Contacts.

- Review notes
  - Adds `backend/tools/seed-demo/relationships.go` and `seedWhatEachCompanyIs`: compute `relationship_types` from lifecycle with exception overrides; keep existing `partner` in the replace-set; tested in `relationships_test.go`.
  - Introduces `seedDualRolePartners` (promote existing customers) and `seedInventedStaff` (file unmailable contacts with `source=seed:invented` and `<domain-slug>.example` emails).
  - Enforces phase order in `seedPipeline`: invented staff before committees; promotion before typing; reported via new counters.
  - Extends `demoConfig` with `dual_role_partners`, `invented_staff`, and `relationship_types.overrides`.
  - Refactors `ensurePerson` to take a `source` parameter; updates call sites in `seed.go` and `partners.go` to pass `seed:invented` or `seed:seed` accordingly; no behavior change.

- Rollout
  - Update the dataset checkout to include `dual_role_partners`, `invented_staff`, and `relationship_types.overrides`; without it these phases no-op.
  - No schema changes; re-runs are idempotent and preserve existing partner rows and invoices.

<sup>Written for commit faf60b9010b928d8d39b01e0da3d2a1173aa955a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

