### PR TITLE
fix(frontend): a list pager the reader can navigate by page number

### DIFF
--- a/frontend/src/design-system/listtable.css
+++ b/frontend/src/design-system/listtable.css
@@ -781,6 +781,19 @@
   cursor: default;
 }
 
+/* A skipped-page marker, and the bare room for one. Both hold a button's width
+ * so the strip is the same size at every page: a pager that changed width would
+ * move Next out from under the reader between clicks. */
+.lt-gap {
+  min-width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12.5px;
+  color: var(--textTertiary);
+}
+
 .lt-perpage .select-control {
   font: inherit;
   font-size: 12px;

--- a/frontend/src/design-system/listtable.stories.tsx
+++ b/frontend/src/design-system/listtable.stories.tsx
@@ -160,11 +160,13 @@ export const Paged: Story = {
   render: () => <Surface rows={companies(60)} />,
 };
 
-// hasMore is what a keyset cursor reports: there is no total and no arbitrary
-// page to jump to, so Next stays enabled on the last loaded page and fetches
-// the next one instead of the pager inventing a page count.
+// hasMore is what a keyset cursor reports: no total, so the pager numbers the
+// pages in hand and Next stays enabled on the last of them to fetch the next
+// rather than the strip inventing a page count. Six pages in hand is enough to
+// show the whole strip: page one anchored, the window around the current page,
+// and a gap standing for the pages between them.
 export const MoreToFetch: Story = {
-  render: () => <Surface rows={companies(30)} hasMore />,
+  render: () => <Surface rows={companies(150)} hasMore />,
 };
 
 // The first page is in flight. The header, the dials and the primary action

--- a/frontend/src/design-system/listtable.test.tsx
+++ b/frontend/src/design-system/listtable.test.tsx
@@ -21,6 +21,7 @@ import {
   type ListColumn,
   ListTable,
   type ListView,
+  pagerSlots,
 } from "./listtable";
 import { pickOption } from "./select-testing";
 
@@ -690,6 +691,71 @@ describe("pagination", () => {
     expect(
       screen.getByRole("combobox", { name: "Rows per page" }),
     ).toHaveProperty("disabled", true);
+  });
+
+  it("puts the current page between its neighbours and keeps page one reachable", () => {
+    // Page one is where a reader who has lost their place goes back to, and
+    // walking there one Prev at a time is not going back.
+    expect(pagerSlots(1, 6)).toEqual(["room", "room", 1, 2, 3, "gap"]);
+    expect(pagerSlots(4, 6)).toEqual([1, "gap", 3, 4, 5, "gap"]);
+    expect(pagerSlots(6, 6)).toEqual([1, "gap", 4, 5, 6, "room"]);
+  });
+
+  it("marks skipped pages only, so a gap never stands for a page nobody fetched", () => {
+    // Every page in hand is on the strip, so nothing is being held back. A gap
+    // here would read as hidden pages rather than unfetched ones, which is
+    // Next's to say.
+    expect(pagerSlots(2, 3)).toEqual(["room", "room", 1, 2, 3, "room"]);
+    expect(pagerSlots(1, 2)).toEqual(["room", "room", 1, 2, "room", "room"]);
+  });
+
+  it("holds one width so Next stays where the reader clicked it", () => {
+    for (const [current, lastPage] of [
+      [1, 1],
+      [1, 3],
+      [2, 6],
+      [4, 6],
+      [6, 6],
+      [9, 40],
+    ]) {
+      expect(pagerSlots(current, lastPage)).toHaveLength(6);
+    }
+  });
+
+  it("reaches page one from the strip rather than by walking Prev", async () => {
+    const { container } = render(
+      <ListTable
+        rows={testRows(100)}
+        columns={columns}
+        rowKey={(row) => row.id}
+        unit="rows"
+      />,
+    );
+    const slots = () => container.querySelectorAll(".lt-pager > *").length;
+    const atFirstPage = slots();
+
+    await userEvent.click(screen.getByRole("button", { name: "3" }));
+    // The room a gap would take is rendered, not merely counted, so the strip
+    // holds its width and Next stays where the reader clicked it.
+    expect(slots()).toBe(atFirstPage);
+
+    await userEvent.click(screen.getByRole("button", { name: "1" }));
+    expect(
+      screen.getByRole("button", { name: "1" }).getAttribute("aria-current"),
+    ).toBe("page");
+  });
+
+  it("stops the window at the ends rather than numbering pages it has no rows for", () => {
+    render(
+      <ListTable
+        rows={testRows(60)}
+        columns={columns}
+        rowKey={(row) => row.id}
+        unit="rows"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "3" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "4" })).toBeNull();
   });
 
   it("disables Next on the last loaded page when hasMore is false, and enables it (calling onLoadMore) when hasMore is true", async () => {

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -68,17 +68,18 @@ export type ListColumn<Row> = {
 };
 
 /**
- * Never larger than the page the list endpoints return (50). A bigger choice
- * cannot be filled from one response, so the table would hold the reader on a
- * page it has no rows for until enough cursor pages had been walked — a size
- * the server cannot serve is not a size worth offering.
- */
-/**
- * Page sizes the footer offers. The table does NOT slice rows to this — it is
- * the size the caller asks the SERVER for, so the page rendered is the page
- * that was fetched.
+ * Page sizes the footer offers. This is the size of a RENDERED page: the caller
+ * fetches several of them per read (`listFetchLimit`) and the table slices the
+ * rows it holds into pages of this size.
+ *
+ * The two numbers stay in step because the fetch is always a whole multiple of
+ * this one. A buffer sized independently of the page is what once made a list
+ * say "1-25 of 50 loaded so far" — two unrelated page sizes on one screen.
  */
 const PAGE_SIZES = [25, 50, 100] as const;
+
+/** Page numbers around the current one, which sits in the middle of them. */
+const PAGE_WINDOW = 3;
 
 /** Narrow enough to tuck a column away, wide enough to still read a header. */
 const MIN_COLUMN_WIDTH = 72;
@@ -274,9 +275,8 @@ export function ListTable<Row>({
   hasMore?: boolean;
   onLoadMore?: () => void;
   /**
-   * Rows per page. This is the size the CALLER asked the server for, so the
-   * table renders whole fetched pages rather than re-slicing them: one number
-   * decides both what is fetched and what is shown.
+   * Rows per RENDERED page. The caller fetches a whole multiple of it, so the
+   * table divides the rows it holds on boundaries the fetch already respects.
    */
   perPage?: number;
   /**
@@ -332,11 +332,9 @@ export function ListTable<Row>({
   // dismiss is one a keyboard reader is stuck inside.
   useCloseOnEscape(columnsOpen ? "columns" : null, () => setColumnsOpen(false));
 
-  // Each fetched page is one rendered page. The rows the caller holds are whole
-  // server pages (keyset, `perPage` per request), so slicing them again by a
-  // second, unrelated page size is what made a list say "1-25 of 50 loaded so
-  // far" — two page sizes in one screen, and a pager whose numbers counted the
-  // buffer rather than the list.
+  // One read carries several rendered pages, so the rows the caller holds are a
+  // whole multiple of `perPage` and dividing them here lands on page boundaries
+  // the reader can reach without waiting for a round trip each.
   const lastPage = Math.max(1, Math.ceil(rows.length / perPage));
   const current = Math.min(page, lastPage);
   const from = (current - 1) * perPage;
@@ -971,8 +969,48 @@ function TableTools<Row>({
 }
 
 /**
- * The pager: every loaded page as its own button, prev/next either side, and the
- * page size on the right. Next stays enabled on the last loaded page while the
+ * A slot in the pager: a page to jump to, a gap where pages were skipped, or
+ * the room a gap would take.
+ */
+export type PagerSlot = number | "gap" | "room";
+
+/**
+ * What the pager shows: page one, then the current page between its two
+ * neighbours, with gaps marking whatever was skipped between them.
+ *
+ * Page one is always reachable because it is where a reader who has lost their
+ * place goes back to, and walking there one Prev at a time is not going back.
+ * The rest is a window rather than every page: a strip that grew a number per
+ * read would end up longer than the table it belongs to.
+ *
+ * A gap marks pages the window skipped and nothing else. Pages the cursor could
+ * still fetch are Next's to speak for: marking those with the same dots would
+ * give one symbol two meanings, and the reader cannot tell from a gap on the
+ * last page whether numbers were hidden or merely never asked for.
+ *
+ * The slots are a fixed six wide at every position — a gap and the bare ROOM
+ * for one are the same width — because a strip that changed width would slide
+ * Next out from under the reader between one click and the next.
+ */
+export function pagerSlots(current: number, lastPage: number): PagerSlot[] {
+  const first = Math.min(
+    Math.max(1, current - Math.floor(PAGE_WINDOW / 2)),
+    Math.max(1, lastPage - PAGE_WINDOW + 1),
+  );
+  const span = Math.min(PAGE_WINDOW, lastPage - first + 1);
+  const window = Array.from({ length: span }, (_, index) => first + index);
+  return [
+    first > 1 ? 1 : "room",
+    first > 2 ? "gap" : "room",
+    ...window,
+    ...Array.from({ length: PAGE_WINDOW - span }, () => "room" as const),
+    window[span - 1] < lastPage ? "gap" : "room",
+  ];
+}
+
+/**
+ * The pager: the pages in hand as numbers, prev/next either side, and the page
+ * size on the right. Next stays enabled on the last loaded page while the
  * cursor still has rows to give, which is how the set grows without a total.
  */
 function Pager({
@@ -1001,17 +1039,28 @@ function Pager({
         >
           {t("table.prev")}
         </button>
-        {Array.from({ length: lastPage }, (_, index) => index + 1).map(
-          (number) => (
+        {pagerSlots(current, lastPage).map((slot, index) =>
+          typeof slot === "number" ? (
             <button
               type="button"
-              key={number}
-              className={number === current ? "on" : undefined}
-              aria-current={number === current ? "page" : undefined}
-              onClick={() => onGoto(number)}
+              key={slot}
+              className={slot === current ? "on" : undefined}
+              aria-current={slot === current ? "page" : undefined}
+              onClick={() => onGoto(slot)}
             >
-              {number}
+              {slot}
             </button>
+          ) : (
+            <span
+              // Slots are positional: two of them can hold the same kind of
+              // nothing, and neither carries an identity of its own.
+              // biome-ignore lint/suspicious/noArrayIndexKey: the position IS the identity
+              key={`${slot}-${index}`}
+              className="lt-gap"
+              aria-hidden="true"
+            >
+              {slot === "gap" ? "…" : ""}
+            </span>
           ),
         )}
         <button

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -52,6 +52,7 @@ import {
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
 } from "./listquery";
 import { LogActivity } from "./logactivity";
@@ -151,7 +152,7 @@ async function fetchLeadsPage(
         sort: query.sort || undefined,
         include_archived: query.includeArchived || undefined,
         cursor: cursor || undefined,
-        limit: query.perPage,
+        limit: listFetchLimit(query.perPage),
         ...query.filters,
       },
     },

--- a/frontend/src/screens/list-page-size-coverage.test.ts
+++ b/frontend/src/screens/list-page-size-coverage.test.ts
@@ -8,11 +8,16 @@ import { describe, expect, it } from "vitest";
 
 // Fitness function for the ONE page size.
 //
-// `ListQuery.perPage` is the size the reader picks in the table footer AND the
-// `limit` the fetcher asks the server for. A screen that keeps a literal limit
+// `ListQuery.perPage` is the size the reader picks in the table footer, and
+// every fetcher's `limit` is derived from it through `listFetchLimit` — a whole
+// number of rendered pages per read. A screen that keeps a literal limit
 // instead renders a page size the server never returned: the footer offers 100,
 // the response holds 50, and the count line says "1-50 of 100 loaded so far" —
 // the exact reading that made the company list look like a broken pager.
+//
+// A limit that is `query.perPage` itself is the same defect in the other
+// direction: one page per read is what leaves the pager unable to offer a
+// second number until the reader has already asked for it.
 //
 // Four screens (leads, partners, products, offer templates) carried that
 // mismatch for a whole release after the shared wrapper had already been fixed,
@@ -66,6 +71,6 @@ describe("every list fetcher asks for the page size the reader picked", () => {
       fetcher?.[1],
       `${file} sends a fixed page limit, so the footer's page size and the ` +
         `server's page size can disagree`,
-    ).toBe("query.perPage");
+    ).toBe("listFetchLimit(query.perPage)");
   });
 });

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -17,9 +17,11 @@ import { LocaleProvider } from "../i18n";
 import { ProblemError } from "./common";
 import {
   type FilterSpec,
+  LIST_PAGE_SIZES,
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
   type ViewSpec,
 } from "./listquery";
@@ -381,6 +383,24 @@ describe("removing an applied filter", () => {
         "status",
       ),
     );
+  });
+});
+
+describe("listFetchLimit — one read carries several rendered pages", () => {
+  it("fetches whole rendered pages, never a remainder, for every offered size", () => {
+    for (const perPage of LIST_PAGE_SIZES) {
+      const limit = listFetchLimit(perPage);
+      // A remainder would leave a last page shorter than the size the footer
+      // names; over the ceiling the server clamps and the pager offers numbers
+      // with no rows behind them.
+      expect(limit % perPage).toBe(0);
+      expect(limit).toBeLessThanOrEqual(200);
+      expect(limit).toBeGreaterThan(200 - perPage);
+    }
+  });
+
+  it("fills the default page size's strip in one read", () => {
+    expect(listFetchLimit(25) / 25).toBe(8);
   });
 });
 

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -42,16 +42,40 @@ export type ListQuery = {
   includeArchived: boolean;
   filters: Record<string, string>;
   /**
-   * Rows per page, chosen by the reader in the table footer and sent to the
-   * server as the page limit. One number: the table renders exactly the page
-   * the server answered, so "25 of 50 loaded so far" — a count that reads as
-   * two different page sizes in one screen — cannot happen.
+   * Rows per page, chosen by the reader in the table footer. It is the size of
+   * a RENDERED page, not of a read: one read fetches several of these at once
+   * (see `listFetchLimit`) so the pager can offer them as numbers the reader
+   * reaches without waiting.
    */
   perPage: number;
 };
 
 /** The page sizes the footer offers; the first is the default. */
 export const LIST_PAGE_SIZES = [25, 50, 100] as const;
+
+/** The most rows one list read may ask for (the contract's CAP-PAGE ceiling). */
+const MAX_ROWS_PER_READ = 200;
+
+/**
+ * How many rows to fetch for a footer page size of `perPage`: as many WHOLE
+ * rendered pages as one read is allowed to carry.
+ *
+ * A keyset cursor can only walk forward one read at a time, so a pager can
+ * only number the pages already in hand. Reading a page at a time therefore
+ * numbers exactly one, and every further number has to be earned by a round
+ * trip — which is what made a second page appear only after the reader had
+ * been told none existed. Reading in whole multiples instead puts several
+ * numbered pages in hand at once, each of them a slice of ONE response, so
+ * they are also one consistent snapshot: no row shows up twice and none is
+ * skipped between them.
+ *
+ * Whole multiples matter. A remainder would leave a last page shorter than the
+ * size the footer names, and asking for more than the ceiling gets silently
+ * clamped, leaving the pager offering numbers the response has no rows for.
+ */
+export function listFetchLimit(perPage: number): number {
+  return Math.max(1, Math.floor(MAX_ROWS_PER_READ / perPage)) * perPage;
+}
 
 export type ListPage<Row> = {
   data: Row[];

--- a/frontend/src/screens/offertemplates.tsx
+++ b/frontend/src/screens/offertemplates.tsx
@@ -15,6 +15,7 @@ import {
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
 } from "./listquery";
 import "./listsection.css";
@@ -31,7 +32,7 @@ async function fetchTemplatesPage(
         sort: query.sort || undefined,
         include_archived: query.includeArchived || undefined,
         cursor: cursor || undefined,
-        limit: query.perPage,
+        limit: listFetchLimit(query.perPage),
         ...query.filters,
       },
     },

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -16,6 +16,7 @@ import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { AssistantPanel } from "./assistant";
 import { SuggestionsSection } from "./company360";
+import { listFetchLimit } from "./listquery";
 import {
   CompaniesScreen,
   CompanyScreen,
@@ -723,12 +724,17 @@ describe("CompaniesScreen — list dials reach the server (P-14)", () => {
     );
   });
 
-  it("requests the page size the reader picked", async () => {
+  it("reads whole rendered pages at whatever size the reader picked", async () => {
     const user = userEvent.setup();
     const { urls } = stubFetch(async () => emptyPage());
     render(<CompaniesScreen />);
+    // One read carries several rendered pages, so the limit is a multiple of
+    // the footer's size and never the size itself — that is what lets the
+    // pager offer page 2 before the reader has asked for it.
     await waitFor(() =>
-      expect(urls.some((url) => url.includes("limit=25"))).toBe(true),
+      expect(
+        urls.some((url) => url.includes(`limit=${listFetchLimit(25)}`)),
+      ).toBe(true),
     );
 
     await pickOption(
@@ -737,17 +743,22 @@ describe("CompaniesScreen — list dials reach the server (P-14)", () => {
       "50 per page",
     );
 
-    // Fetched and rendered are the same number. They were not: the screen
-    // asked for 50 and drew 25, and said so — "1-25 of 50 loaded so far".
+    // The read follows the reader's size rather than a literal. It did not:
+    // the screen asked for 50 and drew 25, and said so — "1-25 of 50 loaded
+    // so far".
+    const resized = `limit=${listFetchLimit(50)}`;
     await waitFor(() =>
-      expect(urls.some((url) => url.includes("limit=50"))).toBe(true),
+      expect(urls.some((url) => url.includes(resized))).toBe(true),
     );
 
     // A new page size restarts the keyset walk. Carrying the old cursor over
     // would continue a walk taken at the previous size, so the reader would
     // resume mid-list while believing they were on page one.
-    const resized = urls.filter((url) => url.includes("limit=50"));
-    expect(resized.every((url) => !url.includes("cursor="))).toBe(true);
+    expect(
+      urls
+        .filter((url) => url.includes(resized))
+        .every((url) => !url.includes("cursor=")),
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -115,6 +115,7 @@ import {
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
   useOwnerChips,
 } from "./listquery";
@@ -185,7 +186,7 @@ async function fetchOrganizationsPage(
         sort: query.sort || undefined,
         include_archived: query.includeArchived || undefined,
         cursor: cursor || undefined,
-        limit: query.perPage,
+        limit: listFetchLimit(query.perPage),
         ...query.filters,
       },
     },

--- a/frontend/src/screens/partners.tsx
+++ b/frontend/src/screens/partners.tsx
@@ -23,6 +23,7 @@ import {
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
 } from "./listquery";
 
@@ -502,7 +503,7 @@ async function fetchPartnersPage(
       query: {
         sort: query.sort || undefined,
         cursor: cursor || undefined,
-        limit: query.perPage,
+        limit: listFetchLimit(query.perPage),
         partner_role: asPartnerRole(query.filters.partner_role ?? ""),
         cert_status: asCertStatus(query.filters.cert_status ?? ""),
       },

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -35,6 +35,7 @@ import {
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
   useOwnerChips,
 } from "./listquery";
@@ -78,7 +79,7 @@ async function fetchPeoplePage(
         sort: query.sort || undefined,
         include_archived: query.includeArchived || undefined,
         cursor: cursor || undefined,
-        limit: query.perPage,
+        limit: listFetchLimit(query.perPage),
         ...query.filters,
       },
     },

--- a/frontend/src/screens/products.tsx
+++ b/frontend/src/screens/products.tsx
@@ -15,6 +15,7 @@ import {
   type ListPage,
   type ListQuery,
   ListTable,
+  listFetchLimit,
   useListQuery,
 } from "./listquery";
 import "./listsection.css";
@@ -32,7 +33,7 @@ async function fetchProductsPage(
         sort: query.sort || undefined,
         include_archived: query.includeArchived || undefined,
         cursor: cursor || undefined,
-        limit: query.perPage,
+        limit: listFetchLimit(query.perPage),
         ...query.filters,
       },
     },


### PR DESCRIPTION
## What changed

A list read fetched exactly the page it rendered, so the pager could only number the one page it held: a list showed a lone `1`, and Next made a `2` appear where the reader had been told nothing existed.

One read now carries as many whole rendered pages as the contract's CAP-PAGE ceiling allows (200 rows, so eight pages at the default size), and the pager numbers them.

```
page 1:  ‹ Prev  1 2 3 …          Next ›
page 4:  ‹ Prev  1 … 3 4 5 …      Next ›
page 8:  ‹ Prev  1 … 6 7 8        Next ›
page 9:  ‹ Prev  1 … 8 9 10 …     Next ›
```

- **Page one is always reachable.** It is where a reader who has lost their place goes back to, and walking there one Prev at a time is not going back.
- **The current page sits between its two neighbours**, so the strip stays short instead of gaining a number per read.
- **A gap marks skipped pages and nothing else.** Pages the cursor has not fetched are Next's to speak for; one symbol meaning both makes the last page look like it is hiding numbers.
- **Six slots at every position**, a gap and the bare room for one being the same width, so Next does not slide out from under the reader between clicks.

## The tradeoff, recorded

A keyset cursor learns no total (`PageInfo` carries `has_more` only), so the strip is drawn from pages in hand and stops there — no `1 2 3 … 23`, because nothing counts the rows.

Within one read the numbers are exact: all eight pages are slices of a single response, so no row repeats and none is skipped between them. **At the boundary between reads that guarantee ends** — a row written while the reader is paging can cross it. This is the anomaly keyset pagination exists to prevent, and buffering reintroduces it at one seam. It is invisible at the list sizes this product holds today and is accepted deliberately; a true page count and arbitrary page jumps would need a `total` on the list envelope and offset paging, which contradicts the cursor-only rule in `specs/architecture/api-conventions.md` (API-LIST-1..6) and belongs upstream, not here.

Prior art for the shape: GOV.UK's pagination component (page one anchored, window, ellipses, no total). Shopify Polaris, whose backend is likewise cursor-based, ships prev/next only and models no page numbers at all.

## Where it lands

- `design-system/listtable.tsx` — `pagerSlots` decides the strip; the table divides the rows it holds on `perPage` boundaries the fetch already respects.
- `screens/listquery.tsx` — `listFetchLimit(perPage)` is the one place the read size is derived: whole rendered pages per read, never a remainder, never over the ceiling.
- The six list screens read their `limit` through it; `list-page-size-coverage.test.ts` (the fitness function that derives the screen census from the directory) now asserts that shape.

## Verification

- `make check-fe` green: 231 files, 2945 tests.
- Walked pages 1 → 9 in the running app and confirmed each strip state above, including the last fetched page dropping its trailing gap while Next stays live.
- The listtable suite tests `pagerSlots` directly rather than clicking page by page; it runs in 1.2s, below its 5.3s cost before this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the reader navigate lists by page number by buffering multiple rendered pages per read. Previously we fetched and rendered one page at a time, so the pager showed only “1” and “2” appeared only after Next; now we fetch whole multiples of the selected page size up to the 200-row ceiling and number the pages in hand, with fixed-width gaps and page 1 always reachable.

- Pager logic lives in `pagerSlots`; the strip is always six slots wide and uses a `.lt-gap` span for ellipses and spacing. The window shows page 1 and the current page between its neighbors. No total is shown; Next stays enabled on the last loaded page while `hasMore` is true.
- List fetchers now derive `limit` via `listFetchLimit(query.perPage)` so one read carries several rendered pages and never a remainder. Tests assert this shape and that the strip does not grow or shift.
- Tradeoff: pages are exact within a read; across reads, a row written during paging can cross the seam. This preserves keyset pagination and avoids totals.

**Migration**
- When adding a new list, set the server `limit` to `listFetchLimit(query.perPage)` instead of `query.perPage` or a literal.

<sup>Written for commit 147419557bfbfb96089d2c94f96d5bc1a56afab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

