### PR TITLE
fix(leads): a rep can undo the promotion they made, and a preview needs the person grant

### DIFF
--- a/backend/internal/modules/people/demote.go
+++ b/backend/internal/modules/people/demote.go
@@ -172,15 +172,19 @@ func ensureNoLiveDeal(ctx context.Context, tx pgx.Tx, personID ids.PersonID) err
 // Both unwinds write the person (the lineage pointer at least), so the
 // person's grant and row scope are checked and the row locked BEFORE anything
 // is read about it: the deal probe must not tell a caller who cannot see the
-// person whether it sits on a live deal. The created-person branch
-// additionally needs the archive grant.
+// person whether it sits on a live deal. Archiving the created person needs
+// no separate archive grant: the promotion that minted it ran under
+// lead.update + person.create, and its reversal is that same authority
+// exercised backwards — a rep who may promote must be able to undo the
+// promotion (ADR-0008 §4), and the default rep role holds no person.delete.
 //
-// The archive branch has one more guard than the audit outcome: the person
-// must still be ONLY what the promotion minted. A person merge repoints
-// lead.promoted_person_id to its survivor, and a survivor holds other
-// people's history — archiving it would destroy records the promotion never
-// created. A person that has absorbed a merge therefore unwinds lineage-only,
-// whatever the promotion originally did.
+// The archive branch has two more guards than the audit outcome: the person
+// must still be ONLY what the promotion minted, and nothing else may depend
+// on it. A person merge repoints lead.promoted_person_id to its survivor, and
+// a survivor holds other people's history; a later lead promoted INTO this
+// person points its own contact surface at it. Archiving in either case would
+// destroy or strand records the promotion never created, so both unwind
+// lineage-only, whatever the promotion originally did.
 func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID ids.PersonID, outcome promotionOutcome) (crmcontracts.DemoteLeadResponseUnwind, error) {
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return "", err
@@ -195,11 +199,11 @@ func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID id
 		return "", err
 	}
 	if outcome == outcomeCreated {
-		survivor, err := isMergeSurvivor(ctx, tx, personID)
+		shared, err := isSharedByOthers(ctx, tx, leadID, personID)
 		if err != nil {
 			return "", err
 		}
-		if survivor {
+		if shared {
 			outcome = outcomeMerged
 		}
 	}
@@ -211,9 +215,6 @@ func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID id
 		}
 		return crmcontracts.DemoteUnwindMergeLineageOnly, nil
 	}
-	if err := auth.Require(ctx, "person", principal.ActionDelete); err != nil {
-		return "", err
-	}
 	if err := archivePersonRows(ctx, tx, personID, time.Now().UTC()); err != nil {
 		return "", fmt.Errorf("archive promoted person: %w", err)
 	}
@@ -224,13 +225,16 @@ func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID id
 	return crmcontracts.DemoteUnwindReversed, nil
 }
 
-// isMergeSurvivor answers whether any person row was merged into this one.
-func isMergeSurvivor(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (bool, error) {
-	var survivor bool
-	if err := tx.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM person WHERE merged_into_id = $1)`, personID,
-	).Scan(&survivor); err != nil {
-		return false, fmt.Errorf("check merge lineage: %w", err)
+// isSharedByOthers answers whether records beyond this promotion depend on
+// the person: another person row merged into it, or another lead promoted
+// into it.
+func isSharedByOthers(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID ids.PersonID) (bool, error) {
+	var shared bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM person WHERE merged_into_id = $1)
+		    OR EXISTS (SELECT 1 FROM lead WHERE promoted_person_id = $1 AND id <> $2)`,
+		personID, leadID).Scan(&shared); err != nil {
+		return false, fmt.Errorf("check dependants of the promoted person: %w", err)
 	}
-	return survivor, nil
+	return shared, nil
 }

--- a/backend/internal/modules/people/demote_integration_test.go
+++ b/backend/internal/modules/people/demote_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // personState reads the two columns a demotion touches on the person side.
@@ -226,5 +227,112 @@ func TestPromotePreviewNamesTheOutcomeWithoutWriting(t *testing.T) {
 	var already *AlreadyPromotedError
 	if _, err := e.store.PreviewLeadPromotion(e.ctx, known); !errors.As(err, &already) {
 		t.Errorf("preview of a promoted lead err = %v, want AlreadyPromotedError (409)", err)
+	}
+}
+
+// withGrants answers a context for the same user with exactly the object
+// grants given — how a role narrower than admin reaches the store.
+func (e *promoteConsentEnv) withGrants(objects map[string]principal.ObjectGrant) context.Context {
+	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
+	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())
+	return principal.WithActor(opCtx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.user.String(), UserID: e.user,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects:  objects,
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// A rep who may work leads and create contacts — the grants promotion itself
+// runs under — can also undo a promotion, without holding person.delete.
+func TestDemoteNeedsNoArchiveGrantToUndoACreatedPerson(t *testing.T) {
+	e := setupPromoteConsent(t)
+	rep := e.withGrants(map[string]principal.ObjectGrant{
+		"lead":   {Create: true, Read: true, Update: true, Delete: true},
+		"person": {Create: true, Read: true, Update: true},
+	})
+	lead := e.seedLead(t, "undo@example.test")
+	person, _, err := e.store.PromoteLead(rep, lead, PromoteLeadInput{Trigger: "human_qualify"})
+	if err != nil {
+		t.Fatalf("promote as rep: %v", err)
+	}
+	out, err := e.store.DemoteLead(rep, lead, "clicked the wrong row")
+	if err != nil {
+		t.Fatalf("demote as rep: %v — the reversal must run under the same authority as the promotion", err)
+	}
+	if out.Unwind != crmcontracts.DemoteUnwindReversed {
+		t.Errorf("unwind = %q, want reversed", out.Unwind)
+	}
+	if archived, _ := e.personState(t, ids.UUID(person.Id)); !archived {
+		t.Error("the created person must be archived by the reversal")
+	}
+}
+
+// A person that a SECOND lead has since promoted into is no longer only what
+// the first promotion minted: archiving it would strand the second lead's
+// contact, so the first lead's demote unwinds lineage-only.
+func TestDemoteKeepsAPersonAnotherLeadPromotedInto(t *testing.T) {
+	e := setupPromoteConsent(t)
+	const shared = "twice@example.test"
+	first := e.seedLead(t, shared)
+	person, merged, err := e.store.PromoteLead(e.ctx, first, PromoteLeadInput{Trigger: "human_qualify"})
+	if err != nil || merged {
+		t.Fatalf("first promote: err=%v merged=%t, want a created person", err, merged)
+	}
+	second := e.seedLead(t, shared)
+	if _, merged, err := e.store.PromoteLead(e.ctx, second, PromoteLeadInput{Trigger: "inbound_reply"}); err != nil || !merged {
+		t.Fatalf("second promote: err=%v merged=%t, want a merge into the first's person", err, merged)
+	}
+
+	out, err := e.store.DemoteLead(e.ctx, first, "the first capture was wrong")
+	if err != nil {
+		t.Fatalf("demote first: %v", err)
+	}
+	if out.Unwind != crmcontracts.DemoteUnwindMergeLineageOnly {
+		t.Errorf("unwind = %q, want merge_lineage_only: another lead depends on this person", out.Unwind)
+	}
+	if archived, _ := e.personState(t, ids.UUID(person.Id)); archived {
+		t.Error("the person the second lead promoted into must stay live")
+	}
+	var secondStatus string
+	var secondPerson *ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT status, promoted_person_id FROM lead WHERE id = $1`, second).Scan(&secondStatus, &secondPerson); err != nil {
+		t.Fatal(err)
+	}
+	if secondStatus != "promoted" || secondPerson == nil || *secondPerson != ids.UUID(person.Id) {
+		t.Errorf("second lead = %q -> %v; its promotion must be untouched", secondStatus, secondPerson)
+	}
+}
+
+// The preview returns a person, so it needs the person READ grant as well as
+// the lead's: a role that may work leads but not read contacts is told the
+// outcome (merge) and nothing about who.
+func TestPromotePreviewWithholdsThePersonWithoutThePersonReadGrant(t *testing.T) {
+	e := setupPromoteConsent(t)
+	const shared = "known@example.test"
+	if _, err := e.store.CreatePerson(e.ctx, CreatePersonInput{
+		FullName: "Known Contact",
+		Emails:   []PersonEmailInput{{Email: shared, EmailType: "work", IsPrimary: true}},
+		Source:   "manual",
+	}); err != nil {
+		t.Fatalf("seed the incumbent person: %v", err)
+	}
+	lead := e.seedLead(t, shared)
+	leadsOnly := e.withGrants(map[string]principal.ObjectGrant{
+		"lead": {Create: true, Read: true, Update: true, Delete: true},
+	})
+	preview, err := e.store.PreviewLeadPromotion(leadsOnly, lead)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if preview.Outcome != crmcontracts.PromoteLeadPreviewOutcomeMerge {
+		t.Errorf("outcome = %q, want merge — the outcome is a fact about the lead", preview.Outcome)
+	}
+	if preview.Person != nil || preview.PersonWithheld == nil || !*preview.PersonWithheld {
+		t.Errorf("person=%v withheld=%v; a caller without person.read must get no person and be told so",
+			preview.Person, preview.PersonWithheld)
 	}
 }

--- a/backend/internal/modules/people/promotepreview.go
+++ b/backend/internal/modules/people/promotepreview.go
@@ -5,6 +5,7 @@ package people
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -63,11 +64,19 @@ func (s *Store) PreviewLeadPromotion(ctx context.Context, id ids.LeadID) (crmcon
 			return nil
 		}
 		out.Outcome = crmcontracts.PromoteLeadPreviewOutcomeMerge
+		// Two gates before a person is returned: the object grant (may this
+		// role read people at all) and the row scope (may this caller see
+		// THIS person). Failing either withholds. The outcome still says
+		// merge, which promotion itself already discloses with its 409.
+		grantErr := auth.Require(ctx, "person", principal.ActionRead)
+		if grantErr != nil && !errors.Is(grantErr, apperrors.ErrPermissionDenied) {
+			return grantErr
+		}
 		visible, err := auth.VisibleTo(ctx, tx, "person", match.PersonID.UUID)
 		if err != nil {
 			return err
 		}
-		if !visible {
+		if grantErr != nil || !visible {
 			withheld := true
 			out.PersonWithheld = &withheld
 			return nil


### PR DESCRIPTION
Three findings from the review of #1628. The preview returned the matched
person on the lead's read grant alone; it now also requires person.read and
withholds otherwise (the outcome still says merge, which promotion's own 409
already discloses). Demote required person.delete to archive the person a
promotion created — the default rep holds no such grant, so every rep who
could promote got 403 on the undo; the reversal now runs under the same
authority as the promotion (ADR-0008 §4). And a person another lead has since
promoted into is kept: archiving it would strand that lead's contact, so the
unwind downgrades to lineage-only, alongside the merge-survivor case.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Three fixes from the Codex review of #1628 (the same review's other findings are filed: #1647 concurrent stakeholder insert, #1648 lock order vs merge, #1649 replay person_id). Integration-tested (make test-it people: 8 demote/preview tests). Batman merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reps can undo a promotion they made without holding person.delete, and promotion preview now requires person.read to return the matched person. Previously demote returned 403 for default reps and preview leaked the person on lead.read; now demote runs under the same authority as the promotion, and preview withholds the person unless the caller can read that person.

- Demote: archives the created person when safe; downgrades to lineage-only if the person is shared (merge survivor or another lead references promoted_person_id). Authority is `lead.update` + `person.create`; no `person.delete` check.
- Preview: requires `person.read` and row visibility to include the person; otherwise sets PersonWithheld=true while still returning Outcome=merge.

**Rollout**
- If callers relied on seeing a person in preview without `person.read`, they must request that grant or handle PersonWithheld=true.

<sup>Written for commit b7cc98008856f4450840feeb5438c22c5569d689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

