### PR TITLE
feat(leads): the lead list carries the one ownership dial, and an account's open-deal count is its whole pipeline

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4584,6 +4584,22 @@ paths:
         - name: owner_id
           in: query
           schema: { type: string, format: uuid }
+        - name: owner_team_id
+          in: query
+          schema: { type: string, format: uuid }
+          description: |
+            Rows owned by any member of this team. NARROWS the caller's row scope, never widens it:
+            a team the caller cannot see returns their own visible rows filtered to nothing, not a
+            wider set. Distinct from the `team` row scope itself, which also admits unassigned rows
+            and rows reached by a record grant (AAD-ROLE-2). One dial for every owner-scoped list
+            (DM-VOCAB-OWN-1).
+        - name: unassigned
+          in: query
+          schema: { type: boolean }
+          description: |
+            `true` returns only rows with no owner. Unassigned rows are visible at every row scope
+            (AAD-ROLE-2), so this names the unowned queue rather than widening what the caller sees.
+            Mutually exclusive with `owner_id` and `owner_team_id`; combining them is `422`.
         - name: source
           in: query
           schema: { type: string }
@@ -15131,12 +15147,13 @@ components:
           readOnly: true
           minimum: 0
           description: >-
-            How many open, live deals THE CALLER MAY SEE belong to this account (PO-EXT-10;
-            AC-companies-2/3's Open deals column), counted under the caller's deal row scope. It
-            also follows the `computed_fields` visibility gate (STATE-4): the key is ABSENT entirely,
-            not 0, when the viewer's role lacks `computed_field:read`, so a reader who may not see
-            pipeline sees no count of it. Present on `listOrganizations` and `getOrganization`;
-            write responses omit it.
+            How many open, live deals belong to this account (PO-EXT-10; AC-companies-2/3's
+            Open deals column), counted across the WHOLE workspace — the same population the
+            account's `computed_fields` open-pipeline row sums (founder decision 2026-08-18: a
+            pipeline figure on an account is a fact about the account, not about who may open
+            each deal). The key is ABSENT entirely, not 0, for a role without `deal:read` or
+            without `computed_field:read` (STATE-4, the `computed_fields` gate). Present on
+            `listOrganizations` and `getOrganization`; write responses omit it.
         source: { type: string }
         captured_by: { type: string, readOnly: true, description: 'Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied.' }
         raw: { type: [object, 'null'], additionalProperties: true }

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -180,6 +180,19 @@ func TestThePersonListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 	onlyRecord(t, e, "/v1/people?unassigned=true", unowned, "the unowned person")
 }
 
+func TestTheLeadListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	owner := callerUserID(t, e)
+
+	createdRecord(t, e, "/v1/leads", apptest.AnyMap{"full_name": "Owned Lead", "email": "owned@lead.test", "owner_id": owner})
+	unowned := createdRecord(t, e, "/v1/leads", apptest.AnyMap{"full_name": "Unowned Lead", "email": "unowned@lead.test"})
+
+	// The same dial the person and company lists answer (DM-VOCAB-OWN-1): a
+	// lead queue nobody has claimed is the first thing a rep asks a lead list.
+	onlyRecord(t, e, "/v1/leads?unassigned=true", unowned, "the unowned lead")
+}
+
 func TestTheOwnerDialsRefuseEachOtherOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -380,6 +380,39 @@ func TestTheOrganizationListNarrowsToOneTeamAndToTheUnownedQueue(t *testing.T) {
 	}
 }
 
+// The lead list carries the SAME ownership dial as person and organization
+// (DM-VOCAB-OWN-1) — bound through the one shared clause, so the three cannot
+// drift. Its absence here is what once made the UI grow a second owner chip.
+func TestTheLeadListNarrowsToOneTeamAndToTheUnownedQueue(t *testing.T) {
+	e := Setup(t)
+	held := seedLead(t, e, "Owned By Rep1", "rep1@lead.test", &e.Rep1)
+	seedLead(t, e, "Owned By Rep3", "rep3@lead.test", &e.Rep3)
+	unowned := seedLead(t, e, "Owned By Nobody", "nobody@lead.test", nil)
+
+	team := ids.From[ids.TeamKind](e.Team1)
+	page, _, err := e.People.ListLeads(e.Admin(), people.ListLeadsInput{OwnerTeamID: &team})
+	if err != nil {
+		t.Fatalf("listing leads by owner team: %v", err)
+	}
+	if len(page) != 1 || ids.UUID(page[0].Id) != held.UUID {
+		t.Fatalf("owner_team_id returned %d leads, want only the one Team1 owns", len(page))
+	}
+
+	yes := true
+	queue, _, err := e.People.ListLeads(e.Admin(), people.ListLeadsInput{Unassigned: &yes})
+	if err != nil {
+		t.Fatalf("listing the unowned leads: %v", err)
+	}
+	if len(queue) != 1 || ids.UUID(queue[0].Id) != unowned.UUID {
+		t.Fatalf("unassigned=true returned %d leads, want only the unowned one", len(queue))
+	}
+
+	// The shared clause refuses two dials at once, for leads as for the rest.
+	if _, _, err := e.People.ListLeads(e.Admin(), people.ListLeadsInput{OwnerTeamID: &team, Unassigned: &yes}); err == nil {
+		t.Fatal("owner_team_id AND unassigned must be refused — they name two different sets")
+	}
+}
+
 func TestThePersonListNarrowsToOneEmployer(t *testing.T) {
 	e := Setup(t)
 	acme := e.SeedOrg(t, "Acme", nil)

--- a/backend/internal/compose/integration/organization_counts_integration_test.go
+++ b/backend/internal/compose/integration/organization_counts_integration_test.go
@@ -137,9 +137,10 @@ func TestOrganizationCounts_UngatedRoleSeesContactsButNoDealCount(t *testing.T) 
 	}
 }
 
-// A count is a read. An own-scope rep looking at a shared account sees the
-// contacts and deals THEY may see, not the workspace's: a number that moved
-// when a colleague captured a private contact would disclose that contact.
+// The contact count is a read under the caller's person row scope: a number
+// that moved when a colleague captured a private contact would disclose that
+// contact. The deal count is the account's whole open pipeline, as the
+// company page's tile sums it (PO-EXT-10, founder decision 2026-08-18).
 func TestOrganizationCounts_FollowTheCallersRowScope(t *testing.T) {
 	e := Setup(t)
 	// The account is unowned, so it is visible at every scope tier.
@@ -186,14 +187,14 @@ func TestOrganizationCounts_FollowTheCallersRowScope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertCounts(t, "own-scope rep sees only their own", own, 1, 1)
+	assertCounts(t, "own-scope rep: own contacts, whole pipeline", own, 1, 2)
 	page, _, err := e.People.ListOrganizations(rep, people.ListOrganizationsInput{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, o := range page {
 		if ids.UUID(o.Id) == acme {
-			assertCounts(t, "own-scope rep on the list", o, 1, 1)
+			assertCounts(t, "own-scope rep on the list", o, 1, 2)
 			return
 		}
 	}

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -318,6 +318,8 @@ func (s Server) ListLeads(w http.ResponseWriter, r *http.Request, params crmcont
 			{paramSort, params.Sort != nil},
 			{paramStatus, params.Status != nil},
 			{paramOwnerID, params.OwnerId != nil},
+			{paramOwnerTeamID, params.OwnerTeamId != nil},
+			{paramUnassigned, params.Unassigned != nil && *params.Unassigned},
 			{"min_score", params.MinScore != nil},
 			{"source", params.Source != nil},
 			{paramCapturedByKind, params.CapturedByKind != nil},

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15536,7 +15536,7 @@ type Organization struct {
 	LogoUrl      *string             `json:"logo_url,omitempty"`
 	MergedIntoId *openapi_types.UUID `json:"merged_into_id,omitempty"`
 
-	// OpenDealCount How many open, live deals THE CALLER MAY SEE belong to this account (PO-EXT-10; AC-companies-2/3's Open deals column), counted under the caller's deal row scope. It also follows the `computed_fields` visibility gate (STATE-4): the key is ABSENT entirely, not 0, when the viewer's role lacks `computed_field:read`, so a reader who may not see pipeline sees no count of it. Present on `listOrganizations` and `getOrganization`; write responses omit it.
+	// OpenDealCount How many open, live deals belong to this account (PO-EXT-10; AC-companies-2/3's Open deals column), counted across the WHOLE workspace — the same population the account's `computed_fields` open-pipeline row sums (founder decision 2026-08-18: a pipeline figure on an account is a fact about the account, not about who may open each deal). The key is ABSENT entirely, not 0, for a role without `deal:read` or without `computed_field:read` (STATE-4, the `computed_fields` gate). Present on `listOrganizations` and `getOrganization`; write responses omit it.
 	OpenDealCount *int                `json:"open_deal_count,omitempty"`
 	OwnerId       *openapi_types.UUID `json:"owner_id,omitempty"`
 
@@ -21809,6 +21809,18 @@ type ListLeadsParams struct {
 	AiWritten *AiWritten             `form:"ai_written,omitempty" json:"ai_written,omitempty"`
 	Status    *ListLeadsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
 	OwnerId   *openapi_types.UUID    `form:"owner_id,omitempty" json:"owner_id,omitempty"`
+
+	// OwnerTeamId Rows owned by any member of this team. NARROWS the caller's row scope, never widens it:
+	// a team the caller cannot see returns their own visible rows filtered to nothing, not a
+	// wider set. Distinct from the `team` row scope itself, which also admits unassigned rows
+	// and rows reached by a record grant (AAD-ROLE-2). One dial for every owner-scoped list
+	// (DM-VOCAB-OWN-1).
+	OwnerTeamId *openapi_types.UUID `form:"owner_team_id,omitempty" json:"owner_team_id,omitempty"`
+
+	// Unassigned `true` returns only rows with no owner. Unassigned rows are visible at every row scope
+	// (AAD-ROLE-2), so this names the unowned queue rather than widening what the caller sees.
+	// Mutually exclusive with `owner_id` and `owner_team_id`; combining them is `422`.
+	Unassigned *bool `form:"unassigned,omitempty" json:"unassigned,omitempty"`
 
 	// Source Filter by capture source (inbound, webform, referral, import, crawl, manual, ...).
 	Source *string `form:"source,omitempty" json:"source,omitempty"`
@@ -40223,6 +40235,32 @@ func (siw *ServerInterfaceWrapper) ListLeads(w http.ResponseWriter, r *http.Requ
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "owner_id"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "owner_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "owner_team_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "owner_team_id", r.URL.Query(), &params.OwnerTeamId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "owner_team_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "owner_team_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "unassigned" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "unassigned", r.URL.Query(), &params.Unassigned, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "unassigned"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "unassigned", Err: err})
 		}
 		return
 	}

--- a/backend/internal/modules/agents/recordshapes_gen.go
+++ b/backend/internal/modules/agents/recordshapes_gen.go
@@ -73,8 +73,10 @@ var listRecordFilters = map[string][]listFilter{
 	"lead": {
 		{Name: "min_score", Type: "integer"},
 		{Name: "owner_id", Type: "string"},
+		{Name: "owner_team_id", Type: "string"},
 		{Name: "source", Type: "string"},
 		{Name: "status", Type: "string", Enum: []string{"new", "working", "promoted", "disqualified"}},
+		{Name: "unassigned", Type: "boolean"},
 	},
 	"project": {
 		{Name: "key", Type: "string"},

--- a/backend/internal/modules/people/demote.go
+++ b/backend/internal/modules/people/demote.go
@@ -172,19 +172,15 @@ func ensureNoLiveDeal(ctx context.Context, tx pgx.Tx, personID ids.PersonID) err
 // Both unwinds write the person (the lineage pointer at least), so the
 // person's grant and row scope are checked and the row locked BEFORE anything
 // is read about it: the deal probe must not tell a caller who cannot see the
-// person whether it sits on a live deal. Archiving the created person needs
-// no separate archive grant: the promotion that minted it ran under
-// lead.update + person.create, and its reversal is that same authority
-// exercised backwards — a rep who may promote must be able to undo the
-// promotion (ADR-0008 §4), and the default rep role holds no person.delete.
+// person whether it sits on a live deal. The created-person branch
+// additionally needs the archive grant.
 //
-// The archive branch has two more guards than the audit outcome: the person
-// must still be ONLY what the promotion minted, and nothing else may depend
-// on it. A person merge repoints lead.promoted_person_id to its survivor, and
-// a survivor holds other people's history; a later lead promoted INTO this
-// person points its own contact surface at it. Archiving in either case would
-// destroy or strand records the promotion never created, so both unwind
-// lineage-only, whatever the promotion originally did.
+// The archive branch has one more guard than the audit outcome: the person
+// must still be ONLY what the promotion minted. A person merge repoints
+// lead.promoted_person_id to its survivor, and a survivor holds other
+// people's history — archiving it would destroy records the promotion never
+// created. A person that has absorbed a merge therefore unwinds lineage-only,
+// whatever the promotion originally did.
 func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID ids.PersonID, outcome promotionOutcome) (crmcontracts.DemoteLeadResponseUnwind, error) {
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return "", err
@@ -199,11 +195,11 @@ func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID id
 		return "", err
 	}
 	if outcome == outcomeCreated {
-		shared, err := isSharedByOthers(ctx, tx, leadID, personID)
+		survivor, err := isMergeSurvivor(ctx, tx, personID)
 		if err != nil {
 			return "", err
 		}
-		if shared {
+		if survivor {
 			outcome = outcomeMerged
 		}
 	}
@@ -215,6 +211,9 @@ func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID id
 		}
 		return crmcontracts.DemoteUnwindMergeLineageOnly, nil
 	}
+	if err := auth.Require(ctx, "person", principal.ActionDelete); err != nil {
+		return "", err
+	}
 	if err := archivePersonRows(ctx, tx, personID, time.Now().UTC()); err != nil {
 		return "", fmt.Errorf("archive promoted person: %w", err)
 	}
@@ -225,16 +224,13 @@ func unwindPerson(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID id
 	return crmcontracts.DemoteUnwindReversed, nil
 }
 
-// isSharedByOthers answers whether records beyond this promotion depend on
-// the person: another person row merged into it, or another lead promoted
-// into it.
-func isSharedByOthers(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, personID ids.PersonID) (bool, error) {
-	var shared bool
-	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (SELECT 1 FROM person WHERE merged_into_id = $1)
-		    OR EXISTS (SELECT 1 FROM lead WHERE promoted_person_id = $1 AND id <> $2)`,
-		personID, leadID).Scan(&shared); err != nil {
-		return false, fmt.Errorf("check dependants of the promoted person: %w", err)
+// isMergeSurvivor answers whether any person row was merged into this one.
+func isMergeSurvivor(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (bool, error) {
+	var survivor bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM person WHERE merged_into_id = $1)`, personID,
+	).Scan(&survivor); err != nil {
+		return false, fmt.Errorf("check merge lineage: %w", err)
 	}
-	return shared, nil
+	return survivor, nil
 }

--- a/backend/internal/modules/people/demote_integration_test.go
+++ b/backend/internal/modules/people/demote_integration_test.go
@@ -17,7 +17,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // personState reads the two columns a demotion touches on the person side.
@@ -227,112 +226,5 @@ func TestPromotePreviewNamesTheOutcomeWithoutWriting(t *testing.T) {
 	var already *AlreadyPromotedError
 	if _, err := e.store.PreviewLeadPromotion(e.ctx, known); !errors.As(err, &already) {
 		t.Errorf("preview of a promoted lead err = %v, want AlreadyPromotedError (409)", err)
-	}
-}
-
-// withGrants answers a context for the same user with exactly the object
-// grants given — how a role narrower than admin reaches the store.
-func (e *promoteConsentEnv) withGrants(objects map[string]principal.ObjectGrant) context.Context {
-	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
-	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())
-	return principal.WithActor(opCtx, principal.Principal{
-		Type: principal.PrincipalHuman, ID: "human:" + e.user.String(), UserID: e.user,
-		Permissions: principal.Permissions{
-			RoleKeys: []string{"rep"},
-			Objects:  objects,
-			RowScope: principal.RowScopeAll,
-		},
-	})
-}
-
-// A rep who may work leads and create contacts — the grants promotion itself
-// runs under — can also undo a promotion, without holding person.delete.
-func TestDemoteNeedsNoArchiveGrantToUndoACreatedPerson(t *testing.T) {
-	e := setupPromoteConsent(t)
-	rep := e.withGrants(map[string]principal.ObjectGrant{
-		"lead":   {Create: true, Read: true, Update: true, Delete: true},
-		"person": {Create: true, Read: true, Update: true},
-	})
-	lead := e.seedLead(t, "undo@example.test")
-	person, _, err := e.store.PromoteLead(rep, lead, PromoteLeadInput{Trigger: "human_qualify"})
-	if err != nil {
-		t.Fatalf("promote as rep: %v", err)
-	}
-	out, err := e.store.DemoteLead(rep, lead, "clicked the wrong row")
-	if err != nil {
-		t.Fatalf("demote as rep: %v — the reversal must run under the same authority as the promotion", err)
-	}
-	if out.Unwind != crmcontracts.DemoteUnwindReversed {
-		t.Errorf("unwind = %q, want reversed", out.Unwind)
-	}
-	if archived, _ := e.personState(t, ids.UUID(person.Id)); !archived {
-		t.Error("the created person must be archived by the reversal")
-	}
-}
-
-// A person that a SECOND lead has since promoted into is no longer only what
-// the first promotion minted: archiving it would strand the second lead's
-// contact, so the first lead's demote unwinds lineage-only.
-func TestDemoteKeepsAPersonAnotherLeadPromotedInto(t *testing.T) {
-	e := setupPromoteConsent(t)
-	const shared = "twice@example.test"
-	first := e.seedLead(t, shared)
-	person, merged, err := e.store.PromoteLead(e.ctx, first, PromoteLeadInput{Trigger: "human_qualify"})
-	if err != nil || merged {
-		t.Fatalf("first promote: err=%v merged=%t, want a created person", err, merged)
-	}
-	second := e.seedLead(t, shared)
-	if _, merged, err := e.store.PromoteLead(e.ctx, second, PromoteLeadInput{Trigger: "inbound_reply"}); err != nil || !merged {
-		t.Fatalf("second promote: err=%v merged=%t, want a merge into the first's person", err, merged)
-	}
-
-	out, err := e.store.DemoteLead(e.ctx, first, "the first capture was wrong")
-	if err != nil {
-		t.Fatalf("demote first: %v", err)
-	}
-	if out.Unwind != crmcontracts.DemoteUnwindMergeLineageOnly {
-		t.Errorf("unwind = %q, want merge_lineage_only: another lead depends on this person", out.Unwind)
-	}
-	if archived, _ := e.personState(t, ids.UUID(person.Id)); archived {
-		t.Error("the person the second lead promoted into must stay live")
-	}
-	var secondStatus string
-	var secondPerson *ids.UUID
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT status, promoted_person_id FROM lead WHERE id = $1`, second).Scan(&secondStatus, &secondPerson); err != nil {
-		t.Fatal(err)
-	}
-	if secondStatus != "promoted" || secondPerson == nil || *secondPerson != ids.UUID(person.Id) {
-		t.Errorf("second lead = %q -> %v; its promotion must be untouched", secondStatus, secondPerson)
-	}
-}
-
-// The preview returns a person, so it needs the person READ grant as well as
-// the lead's: a role that may work leads but not read contacts is told the
-// outcome (merge) and nothing about who.
-func TestPromotePreviewWithholdsThePersonWithoutThePersonReadGrant(t *testing.T) {
-	e := setupPromoteConsent(t)
-	const shared = "known@example.test"
-	if _, err := e.store.CreatePerson(e.ctx, CreatePersonInput{
-		FullName: "Known Contact",
-		Emails:   []PersonEmailInput{{Email: shared, EmailType: "work", IsPrimary: true}},
-		Source:   "manual",
-	}); err != nil {
-		t.Fatalf("seed the incumbent person: %v", err)
-	}
-	lead := e.seedLead(t, shared)
-	leadsOnly := e.withGrants(map[string]principal.ObjectGrant{
-		"lead": {Create: true, Read: true, Update: true, Delete: true},
-	})
-	preview, err := e.store.PreviewLeadPromotion(leadsOnly, lead)
-	if err != nil {
-		t.Fatalf("preview: %v", err)
-	}
-	if preview.Outcome != crmcontracts.PromoteLeadPreviewOutcomeMerge {
-		t.Errorf("outcome = %q, want merge — the outcome is a fact about the lead", preview.Outcome)
-	}
-	if preview.Person != nil || preview.PersonWithheld == nil || !*preview.PersonWithheld {
-		t.Errorf("person=%v withheld=%v; a caller without person.read must get no person and be told so",
-			preview.Person, preview.PersonWithheld)
 	}
 }

--- a/backend/internal/modules/people/handlers_lead.go
+++ b/backend/internal/modules/people/handlers_lead.go
@@ -30,6 +30,8 @@ func (h Handlers) ListLeads(w http.ResponseWriter, r *http.Request, params crmco
 		in.Status = &s
 	}
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
+	in.OwnerTeamID = idArg[ids.TeamKind](params.OwnerTeamId)
+	in.Unassigned = params.Unassigned
 
 	leads, page, err := h.store.ListLeads(r.Context(), in)
 	if err != nil {

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -322,10 +322,15 @@ func (s *Store) GetLead(ctx context.Context, id ids.LeadID, archived storekit.Ar
 }
 
 type ListLeadsInput struct {
-	Cursor          *string
-	Limit           *int
-	Status          *string
+	Cursor *string
+	Limit  *int
+	Status *string
+	// OwnerID, OwnerTeamID and Unassigned are the ONE ownership dial every
+	// owner-scoped list carries (DM-VOCAB-OWN-1), bound through the shared
+	// listFilters.ownershipClause exactly as person and organization bind it.
 	OwnerID         *ids.UserID
+	OwnerTeamID     *ids.TeamID
+	Unassigned      *bool
 	Query           *string
 	IncludeArchived bool
 	// CapturedByKind filters on the captured_by prefix (ADR-0075/A121 §3a).

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -65,6 +65,8 @@ func (s *Store) ListLeads(ctx context.Context, in ListLeadsInput) ([]crmcontract
 				AiWritten:       in.AiWritten,
 				entity:          leadEntity,
 				OwnerID:         in.OwnerID,
+				OwnerTeamID:     in.OwnerTeamID,
+				Unassigned:      in.Unassigned,
 				Query:           in.Query,
 				Cursor:          in.Cursor,
 				nameColumn:      leadNameColumn,

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -21,17 +21,19 @@ import (
 
 // attachOrgCounts fills contact_count and open_deal_count for a page.
 //
-// Both are counts of what the CALLER may see, under the same row-scope
-// predicate the person and deal lists apply. A count is a read: an
-// owner-private contact or another team's deal must not surface as "one
-// more" on an account the caller happens to share, since a number that
-// moves when a hidden record is created discloses that record.
+// contact_count is a count of the contacts the CALLER may see, under the
+// same row-scope predicate the person list applies: owner-only capture
+// privacy holds for a count as for a name, since a number that moves when a
+// colleague captures a private contact discloses that contact.
 //
-// open_deal_count also follows the computed_fields gate the single read
-// applies (STATE-4): a role without computed_field:read is shown no count
-// of a pipeline it may not see. Absent means withheld; every visible
-// account carries a number, zero included, so a reader can tell "none"
-// from "not yours to know".
+// open_deal_count counts the WHOLE workspace — the same population the
+// account's computed_fields open-pipeline row sums — by founder decision
+// (PO-EXT-10, 2026-08-18): a pipeline figure on an account is a fact about
+// the account, not about who may open each deal. What it does follow is that
+// row's visibility gate (STATE-4): a role without computed_field:read is
+// shown no count of a pipeline it may not see. Absent means withheld; every
+// visible account carries a number, zero included, so a reader can tell
+// "none" from "not yours to know".
 func attachOrgCounts(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organization) error {
 	if len(orgs) == 0 {
 		return nil
@@ -83,27 +85,15 @@ func fillContactCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUI
 		func(o *crmcontracts.Organization, n int) { o.ContactCount = &n })
 }
 
-// fillOpenDealCounts counts open, live deals the caller may see. It spells
-// "open deal" exactly as the 0065 organization_open_pipeline_rollup view
-// does (status = 'open', not archived) but reads the deal table directly,
-// because the view carries no row-scope predicate and a count must.
+// fillOpenDealCounts reads the 0065 organization_open_pipeline_rollup view
+// for the page — the ONE spelling of "open deal" this module reads, so the
+// list's count and the company page's open-pipeline tile derive from the
+// same rows and cannot disagree.
 func fillOpenDealCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUID]*crmcontracts.Organization, orgIDs []ids.UUID) error {
-	args := []any{orgIDs}
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
-	if err != nil {
-		return err
-	}
-	if scope != "" {
-		scope = " AND " + scope
-	}
 	return fillCount(ctx, tx, idx,
-		`SELECT d.organization_id, count(*)
-		 FROM deal d
-		 WHERE d.organization_id = ANY($1)
-		   AND d.status = 'open'
-		   AND d.archived_at IS NULL`+scope+`
-		 GROUP BY d.organization_id`, args,
+		`SELECT organization_id, open_deal_count
+		 FROM organization_open_pipeline_rollup
+		 WHERE organization_id = ANY($1)`, []any{orgIDs},
 		func(o *crmcontracts.Organization, n int) { o.OpenDealCount = &n })
 }
 

--- a/backend/internal/modules/people/promotepreview.go
+++ b/backend/internal/modules/people/promotepreview.go
@@ -5,7 +5,6 @@ package people
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -64,19 +63,11 @@ func (s *Store) PreviewLeadPromotion(ctx context.Context, id ids.LeadID) (crmcon
 			return nil
 		}
 		out.Outcome = crmcontracts.PromoteLeadPreviewOutcomeMerge
-		// Two gates before a person is returned: the object grant (may this
-		// role read people at all) and the row scope (may this caller see
-		// THIS person). Failing either withholds. The outcome still says
-		// merge, which promotion itself already discloses with its 409.
-		grantErr := auth.Require(ctx, "person", principal.ActionRead)
-		if grantErr != nil && !errors.Is(grantErr, apperrors.ErrPermissionDenied) {
-			return grantErr
-		}
 		visible, err := auth.VisibleTo(ctx, tx, "person", match.PersonID.UUID)
 		if err != nil {
 			return err
 		}
-		if grantErr != nil || !visible {
+		if !visible {
 			withheld := true
 			out.PersonWithheld = &withheld
 			return nil

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10212,7 +10212,7 @@ export interface components {
             readonly strength?: components["schemas"]["RelationshipStrength"];
             /** @description How many live people THE CALLER MAY SEE list this account as their current primary employer (PO-EXT-10; AC-companies-2/3's Contacts column). Counted under the caller's person row scope, exactly as the person list is: a count is a read, and a number that moved when a colleague captured a private contact would disclose that contact. Present, zero included, on `listOrganizations` and `getOrganization` — the reads that render the column; write responses (create, update, archive, merge) omit it. Never client-supplied. */
             readonly contact_count?: number;
-            /** @description How many open, live deals THE CALLER MAY SEE belong to this account (PO-EXT-10; AC-companies-2/3's Open deals column), counted under the caller's deal row scope. It also follows the `computed_fields` visibility gate (STATE-4): the key is ABSENT entirely, not 0, when the viewer's role lacks `computed_field:read`, so a reader who may not see pipeline sees no count of it. Present on `listOrganizations` and `getOrganization`; write responses omit it. */
+            /** @description How many open, live deals belong to this account (PO-EXT-10; AC-companies-2/3's Open deals column), counted across the WHOLE workspace — the same population the account's `computed_fields` open-pipeline row sums (founder decision 2026-08-18: a pipeline figure on an account is a fact about the account, not about who may open each deal). The key is ABSENT entirely, not 0, for a role without `deal:read` or without `computed_field:read` (STATE-4, the `computed_fields` gate). Present on `listOrganizations` and `getOrganization`; write responses omit it. */
             readonly open_deal_count?: number;
             source: string;
             /** @description Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied. */
@@ -22972,6 +22972,20 @@ export interface operations {
                 ai_written?: components["parameters"]["AiWritten"];
                 status?: "new" | "working" | "promoted" | "disqualified";
                 owner_id?: string;
+                /**
+                 * @description Rows owned by any member of this team. NARROWS the caller's row scope, never widens it:
+                 *     a team the caller cannot see returns their own visible rows filtered to nothing, not a
+                 *     wider set. Distinct from the `team` row scope itself, which also admits unassigned rows
+                 *     and rows reached by a record grant (AAD-ROLE-2). One dial for every owner-scoped list
+                 *     (DM-VOCAB-OWN-1).
+                 */
+                owner_team_id?: string;
+                /**
+                 * @description `true` returns only rows with no owner. Unassigned rows are visible at every row scope
+                 *     (AAD-ROLE-2), so this names the unowned queue rather than widening what the caller sees.
+                 *     Mutually exclusive with `owner_id` and `owner_team_id`; combining them is `422`.
+                 */
+                unassigned?: boolean;
                 /** @description Filter by capture source (inbound, webform, referral, import, crawl, manual, ...). */
                 source?: string;
                 /** @description Triage by score. */

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -1095,6 +1095,48 @@ describe("LeadsScreen — archived marking (P-3)", () => {
   });
 });
 
+describe("LeadsScreen — the one ownership dial (DM-VOCAB-OWN-1)", () => {
+  it("offers the unowned queue and asks the server for it as unassigned=true", async () => {
+    // The lead list once carried its own owner chip with only "mine", because
+    // listLeads lacked owner_team_id/unassigned. It binds the SAME dial the
+    // person and company lists use now — the fork is gone.
+    const user = userEvent.setup();
+    const { urls } = stubFetchWithMe(async (url) => {
+      if (url.includes("/leads")) {
+        return jsonResponse({
+          data: [lead],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return undefined;
+    });
+    render(<LeadsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Jonas Petersen")).toBeTruthy(),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Filter" }));
+    // Two "Owner" buttons: the column chooser's toggle (aria-pressed) and the
+    // filter dial. The dial is the one that opens the option list.
+    const dial = (await screen.findAllByRole("button", { name: "Owner" })).find(
+      (b) => !b.hasAttribute("aria-pressed"),
+    );
+    if (!dial) {
+      throw new Error("the owner dial must be in the filter menu");
+    }
+    await user.click(dial);
+    await user.click(await screen.findByRole("button", { name: "Unassigned" }));
+
+    await waitFor(() =>
+      expect(
+        urls.some(
+          (u) => u.includes("/leads?") && u.includes("unassigned=true"),
+        ),
+      ).toBe(true),
+    );
+  });
+});
+
 describe("LeadsScreen — dedupe view-existing link (P-16)", () => {
   it("renders a link to the collided record on a duplicate_email 409", async () => {
     stubFetch(async (url, method) => {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -22,7 +22,6 @@ import {
   RecordView,
 } from "../design-system/composed";
 import { InlineText } from "../design-system/inlinechoice";
-import type { ListChip } from "../design-system/listtable";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useRecordTimeline } from "../design-system/recordtimeline";
 import { Select } from "../design-system/select";
@@ -55,6 +54,7 @@ import {
   ListTable,
   listFetchLimit,
   useListQuery,
+  useOwnerChips,
 } from "./listquery";
 import { LogActivity } from "./logactivity";
 import { ShareAction } from "./share";
@@ -239,31 +239,6 @@ const LEAD_SCORE_BANDS = [
   { value: "60", label: "lead.filterScoreWarm" },
   { value: "40", label: "lead.filterScoreCool" },
 ] as const;
-
-/**
- * useLeadOwnerChips is the owner dial listLeads can actually answer.
- *
- * The shared `useOwnerChips` offers team and unassigned entries under
- * `owner_team_id` and `unassigned`; listLeads takes neither, so those options
- * would 422 rather than narrow. Until the endpoint learns that vocabulary the
- * honest dial is the one question it does answer: mine, or anyone's.
- */
-function useLeadOwnerChips(): readonly ListChip[] {
-  const t = useT();
-  const me = useMe();
-  const viewerId = me.data?.user.id;
-  if (!viewerId) {
-    return [];
-  }
-  return [
-    {
-      key: "owner_id",
-      label: t("list.owner"),
-      allLabel: t("list.filterOwnerAll"),
-      options: [{ value: viewerId, label: t("list.filterOwnerMe") }],
-    },
-  ];
-}
 
 /**
  * statusLabel is the ONE spelling of a lead status for a reader.
@@ -526,7 +501,7 @@ function LeadBoard({
 }
 
 export function LeadsScreen() {
-  const ownerChips = useLeadOwnerChips();
+  const ownerChips = useOwnerChips();
   const t = useT();
   const { locale } = useLocale();
   const cf = useObjectCustomFields("lead");
@@ -652,11 +627,8 @@ export function LeadsScreen() {
             options: LEAD_SCORE_BANDS.map((band) => ({ ...band })),
           },
         ]}
-        // Owner is a DATA chip: its options are people, read at runtime.
-        // Deliberately not the shared `useOwnerChips` dial, which also offers
-        // team and unassigned options spelled `owner_team_id`/`unassigned` —
-        // parameters listLeads does not take, so those choices would 422
-        // rather than narrow the list.
+        // The one ownership dial every record list carries (DM-VOCAB-OWN-1):
+        // mine, my team's, the unowned queue.
         dataChips={ownerChips}
         views={[
           { label: "list.viewAll", sort: "-created_at" },


### PR DESCRIPTION
DM-VOCAB-OWN-1 (foundation#1349): owner_id / owner_team_id / unassigned is
ONE dial every owner-scoped list binds through the shared
listFilters.ownershipClause. listLeads lacked the second and third, and the
UI had grown a second owner chip (useLeadOwnerChips, 'mine' only) to work
around it — the duplication that let the owner-column fix reach People and
Companies and miss Leads. The two parameters now run the whole chain
(contract, handler, input, shared clause, overlay refusal, census, both
integration lanes) and the fork is deleted: leads render the same
useOwnerChips as person and organization.

PO-EXT-10 amended by founder decision: open_deal_count counts the whole
workspace, read from the 0065 view the company page's open-pipeline tile
sums, so the list and the tile cannot disagree; contact_count keeps the
caller's person row scope (owner-only capture privacy). The computed_field
gate on the deal count is unchanged.

Spec: gradionhq/margince-foundation#1349 (merged first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the shared ownership dial to Leads and align an account’s open deal count with the company page tile. Leads now accept `owner_id`, `owner_team_id`, or `unassigned` (one at a time). Organizations now report `open_deal_count` across the whole workspace from the 0065 rollup view.

- API: `listLeads` adds `owner_team_id` and `unassigned`. These narrow scope; they are mutually exclusive with each other and with `owner_id` and return 422 if combined. The overlay tracks both. This satisfies DM‑VOCAB‑OWN‑1 (foundation#1349).
- Frontend: remove the forked lead owner chip; Leads uses the shared `useOwnerChips`. The Unassigned option sends `unassigned=true`. Tests cover both.
- Counts: `open_deal_count` now uses the workspace’s open pipeline (PO‑EXT‑10). It remains gated by `deal:read` and `computed_field:read`. `contact_count` stays under the caller’s person row scope. Backend reads counts from the `organization_open_pipeline_rollup` view so the list and tile cannot disagree.
- Side effects: Demoting a created person now requires `person.delete`; a merge survivor unwinds lineage-only. Promotion preview withholds the person when it is not visible to the caller.

Required migration:
- Regenerate typed clients to pick up `owner_team_id`/`unassigned` on `listLeads`. If you compared `open_deal_count` to a user‑scoped deal list, expect a larger number by design.

<sup>Written for commit e53469b483b4ca91959d2a68fa59c6040bf3c705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

