### PR TITLE
refactor(activities): the activity spine drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/briefs/briefrank_integration_test.go
+++ b/backend/internal/compose/briefs/briefrank_integration_test.go
@@ -82,9 +82,9 @@ func setupBrief(t *testing.T) *briefEnv {
 
 	// Deal A's overnight change: one linked activity before the clock
 	// (no previous run → the overnight window is all-time).
-	b.activityOnA = integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'reply arrived', '2026-06-04T01:00:00Z', 'manual', 'human:x')`, e.WS)
-	integration.LinkActivity(t, owner, e.WS, b.activityOnA, "deal", b.dealA)
+	b.activityOnA = integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'reply arrived', '2026-06-04T01:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, b.activityOnA, "deal", b.dealA)
 	return b
 }
 
@@ -359,9 +359,9 @@ func TestBriefActedAndDismissedItemsLeaveTheNextQueue(t *testing.T) {
 	// A dismissed deal reappears only when it materially changed: a new
 	// linked activity after the mark makes Deal B re-eligible; Deal A
 	// (acted, unchanged) stays out.
-	fresh := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'they came back', '2026-06-04T10:00:00Z', 'manual', 'human:x')`, b.WS)
-	integration.LinkActivity(t, owner, b.WS, fresh, "deal", b.dealB)
+	fresh := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'they came back', '2026-06-04T10:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, fresh, "deal", b.dealB)
 
 	reranked, err := b.engine.Rank(b.repCtx, nextClock)
 	if err != nil {

--- a/backend/internal/compose/captureclassify_integration_test.go
+++ b/backend/internal/compose/captureclassify_integration_test.go
@@ -127,9 +127,9 @@ func seedUnlabeledEmail(t *testing.T, e *integration.Env, subject string) ids.UU
 	id := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'email', $3, 'body text', 'gmail', $4, 'gmail:'||$4, 'connector:gmail')`,
-			id, e.WS, subject, fmt.Sprintf("cls-%s", id))
+			INSERT INTO activity (id, kind, subject, body, source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', $2, 'body text', 'gmail', $3, 'gmail:'||$3, 'connector:gmail')`,
+			id, subject, fmt.Sprintf("cls-%s", id))
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/captureenrich_integration_test.go
+++ b/backend/internal/compose/captureenrich_integration_test.go
@@ -60,14 +60,14 @@ func seedEnrichPerson(t *testing.T, e *integration.Env, email, body string) ids.
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, direction, source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'email', 'hello', $3, 'inbound', 'gmail', $4, 'gmail:seed', 'connector:gmail')`,
-			activity, e.WS, body, activity.String()); err != nil {
+			INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'hello', $2, 'inbound', 'gmail', $3, 'gmail:seed', 'connector:gmail')`,
+			activity, body, activity.String()); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES ($1, $2, 'person', $3)`, e.WS, activity, person)
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, activity, person)
 		return err
 	})
 	if err != nil {
@@ -143,14 +143,14 @@ func TestSignatureEnrichPass(t *testing.T) {
 		err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 			ctx := context.Background()
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO activity (id, workspace_id, kind, subject, body, direction, occurred_at, source_system, source_id, source, captured_by)
-				VALUES ($1, $2, 'email', 'again', $3, 'inbound', now() + interval '1 hour', 'gmail', $4, 'gmail:seed', 'connector:gmail')`,
-				newer, e.WS, "Hi again,\n\nBob Person\nCTO\nAcme Holding GmbH", newer.String()); err != nil {
+				INSERT INTO activity (id, kind, subject, body, direction, occurred_at, source_system, source_id, source, captured_by)
+				VALUES ($1, 'email', 'again', $2, 'inbound', now() + interval '1 hour', 'gmail', $3, 'gmail:seed', 'connector:gmail')`,
+				newer, "Hi again,\n\nBob Person\nCTO\nAcme Holding GmbH", newer.String()); err != nil {
 				return err
 			}
 			_, err := tx.Exec(ctx, `
-				INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-				VALUES ($1, $2, 'person', $3)`, e.WS, newer, person)
+				INSERT INTO activity_link (activity_id, entity_type, person_id)
+				VALUES ( $1, 'person', $2)`, newer, person)
 			return err
 		})
 		if err != nil {

--- a/backend/internal/compose/captureparticipant_integration_test.go
+++ b/backend/internal/compose/captureparticipant_integration_test.go
@@ -229,15 +229,15 @@ func TestDeletingAPersonOrAUserIsNotBlockedByGraphRows(t *testing.T) {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (`+ws+`, 'email', 'Letzte Mail', 'outbound', now(), 'manual', 'human:test')
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES ( 'email', 'Letzte Mail', 'outbound', now(), 'manual', 'human:test')
 			RETURNING id`).Scan(&activityID); err != nil {
 			return err
 		}
 		// A user-ONLY participant row: no person arm, no address arm.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (`+ws+`, $1, $2, 'from')`, activityID, doomed); err != nil {
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, 'from')`, activityID, doomed); err != nil {
 			return err
 		}
 		// A CONFIRMED ghost pointing at the contact.
@@ -292,7 +292,6 @@ func TestDeletingAPersonOrAUserIsNotBlockedByGraphRows(t *testing.T) {
 func TestRelinkRepointsOnlyThePersonItDisplaced(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := context.Background()
-	ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 
 	linked := e.SeedPerson(t, "Linked Contact", &e.Rep1)
 	unlinked := e.SeedPerson(t, "Never Linked", &e.Rep1)
@@ -301,20 +300,20 @@ func TestRelinkRepointsOnlyThePersonItDisplaced(t *testing.T) {
 	var activityID ids.ActivityID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (`+ws+`, 'email', 'Verwechslung', 'inbound', now(), 'gmail:m-9', 'connector:gmail')
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES ( 'email', 'Verwechslung', 'inbound', now(), 'gmail:m-9', 'connector:gmail')
 			RETURNING id`).Scan(&activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES (`+ws+`, $1, 'person', $2)`, activityID, linked); err != nil {
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, activityID, linked); err != nil {
 			return err
 		}
 		// Two participants: one matching the link, one that never had a link.
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (`+ws+`, $1, $2, 'from'), (`+ws+`, $1, $3, 'cc')`, activityID, linked, unlinked)
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ($1, $2, 'from'), ($1, $3, 'cc')`, activityID, linked, unlinked)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding: %v", err)

--- a/backend/internal/compose/captureverdict_integration_test.go
+++ b/backend/internal/compose/captureverdict_integration_test.go
@@ -254,12 +254,10 @@ func seedMail(t *testing.T, e *integration.Env, from, subject string, bulkAttest
 	id := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, raw, direction,
-			                      source_system, source_id, source, captured_by, counterparty_email,
-			                      bulk_mail_attested)
-			VALUES ($1, $2, 'email', $3, 'the message body', '{"headers":"…"}'::jsonb, 'inbound',
-			        'gmail', $4, 'gmail:'||$4, 'connector:gmail', $5, $6)`,
-			id, e.WS, subject, "vrd-"+id.String(), from, bulkAttested)
+			INSERT INTO activity (id, kind, subject, body, raw, direction, source_system, source_id, source, captured_by, counterparty_email, bulk_mail_attested)
+			VALUES ($1, 'email', $2, 'the message body', '{"headers":"…"}'::jsonb, 'inbound',
+			        'gmail', $3, 'gmail:'||$3, 'connector:gmail', $4, $5)`,
+			id, subject, "vrd-"+id.String(), from, bulkAttested)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/compose/captureverdictnoise_integration_test.go
+++ b/backend/internal/compose/captureverdictnoise_integration_test.go
@@ -128,12 +128,10 @@ func seedOutboundMail(t *testing.T, e *integration.Env, to, subject string) ids.
 	id := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, direction,
-			                      source_system, source_id, source, captured_by,
-			                      counterparty_email, counterparty_outbound_attested)
-			VALUES ($1, $2, 'email', $3, 'our own words', 'outbound',
-			        'gmail', $4, 'gmail:'||$4, 'connector:gmail', $5, true)`,
-			id, e.WS, subject, "out-"+id.String(), to)
+			INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id, source, captured_by, counterparty_email, counterparty_outbound_attested)
+			VALUES ($1, 'email', $2, 'our own words', 'outbound',
+			        'gmail', $3, 'gmail:'||$3, 'connector:gmail', $4, true)`,
+			id, subject, "out-"+id.String(), to)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/channelprovider_axis_integration_test.go
+++ b/backend/internal/compose/channelprovider_axis_integration_test.go
@@ -99,11 +99,10 @@ func TestActivityChannelProviderReferencesTheRegistry(t *testing.T) {
 // would fail for the wrong reason and this test would report a passing FK it
 // never actually reached.
 func TestActivityChannelProviderFKRefusesAnUnregisteredProvider(t *testing.T) {
-	e := integration.Setup(t)
 
 	_, err := integration.OwnerConn(t).Exec(context.Background(), `
-		INSERT INTO activity (workspace_id, kind, channel_provider, source, captured_by)
-		VALUES ($1, 'message', 'no_such_transport', 'manual', 'test')`, e.WS)
+		INSERT INTO activity (kind, channel_provider, source, captured_by)
+		VALUES ( 'message', 'no_such_transport', 'manual', 'test')`)
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) || pgErr.ConstraintName != "activity_channel_provider_fkey" {
 		t.Fatalf("insert failed with %v, want a foreign_key_violation on activity_channel_provider_fkey specifically — "+

--- a/backend/internal/compose/channelprovider_migration_integration_test.go
+++ b/backend/internal/compose/channelprovider_migration_integration_test.go
@@ -86,12 +86,11 @@ func TestActivityKindAndChannelProviderAreSeededByMigration(t *testing.T) {
 // The FK is what does the real work: an unregistered kind is refused by the
 // database, not by an application-side list somebody has to remember.
 func TestActivityKindFKRefusesAnUnregisteredKind(t *testing.T) {
-	e := integration.Setup(t)
 	ctx := context.Background()
 
 	_, err := integration.OwnerConn(t).Exec(ctx, `
-		INSERT INTO activity (workspace_id, kind, source, captured_by)
-		VALUES ($1, 'dispact', 'manual', 'test')`, e.WS)
+		INSERT INTO activity (kind, source, captured_by)
+		VALUES ( 'dispact', 'manual', 'test')`)
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) || pgErr.ConstraintName != "activity_kind_fkey" {
 		t.Fatalf("insert failed with %v, want a foreign_key_violation on activity_kind_fkey specifically — "+

--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -91,8 +91,8 @@ func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	// mail, so the row has to be one.
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, direction, subject, occurred_at, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (id, kind, direction, subject, occurred_at, source, captured_by)
+			VALUES ($1,
 			        'email', 'inbound', 'Pricing question', now(), 'manual', 'human:x')`, anchorID)
 		return err
 	})

--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -190,8 +190,8 @@ func (e *estEnv) insertCall(t *testing.T, c callRow) {
 func (e *estEnv) insertLabeledActivity(t *testing.T, ws ids.UUID) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (workspace_id, kind, source, captured_by, capture_labeled_at)
-		VALUES ($1, 'email', 'gmail', 'system', $2)`, ws, inWindow); err != nil {
+		INSERT INTO activity (kind, source, captured_by, capture_labeled_at)
+		VALUES ( 'email', 'gmail', 'system', $1)`, inWindow); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/backend/internal/compose/deepreadtriage_integration_test.go
+++ b/backend/internal/compose/deepreadtriage_integration_test.go
@@ -68,9 +68,9 @@ func openTriageQuestion(t *testing.T, e *integration.Env, domain, email, display
 	activityID := ids.New[ids.ActivityKind]()
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, direction, source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'email', 'hi', 'inbound', 'gmail', $3, 'gmail:seed', 'connector:gmail')`,
-			activityID, e.WS, activityID.String())
+			INSERT INTO activity (id, kind, subject, direction, source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'hi', 'inbound', 'gmail', $2, 'gmail:seed', 'connector:gmail')`,
+			activityID, activityID.String())
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/erasuregraph_integration_test.go
+++ b/backend/internal/compose/erasuregraph_integration_test.go
@@ -67,27 +67,27 @@ func TestErasureRemovesTheSubjectFromTheRelationshipGraph(t *testing.T) {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (`+ws+`, 'email', 'Angebot', 'inbound', $1, 'manual', 'human:test')
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES ( 'email', 'Angebot', 'inbound', $1, 'manual', 'human:test')
 			RETURNING id`, now.AddDate(0, 0, -1)).Scan(&activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (`+ws+`, $1, $2, 'to')`, activityID, e.Rep1); err != nil {
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, 'to')`, activityID, e.Rep1); err != nil {
 			return err
 		}
 		// The subject appears twice: as a resolved person, and — on a second
 		// message — as a bare address, the row that exists for a party who
 		// never became a record.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, address, role)
-			VALUES (`+ws+`, $1, $2, $3, 'from')`, activityID, person, subjectEmail); err != nil {
+			INSERT INTO activity_participant (activity_id, person_id, address, role)
+			VALUES ( $1, $2, $3, 'from')`, activityID, person, subjectEmail); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES (`+ws+`, $1, 'person', $2)`, activityID, person); err != nil {
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, activityID, person); err != nil {
 			return err
 		}
 		return nil

--- a/backend/internal/compose/erasurequotations_integration_test.go
+++ b/backend/internal/compose/erasurequotations_integration_test.go
@@ -60,8 +60,8 @@ func transcriptSubject(t *testing.T, e *integration.Env) (ids.PersonID, ids.UUID
 
 	activityID := seedTranscript(t, e, "1: Tom: Where did we land on pricing?\n2: "+quotedTranscriptLine)
 	e.WsExec(t, `
-		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, 'person', $3)`, e.WS, activityID, person)
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ( $1, 'person', $2)`, activityID, person)
 	e.WsExec(t, `
 		INSERT INTO transcript_read (id, activity_id, status, line_count, requested_by, started_at, finished_at)
 		VALUES ($1, $2, 'done', 2, 'human:seed', now(), now())`, ids.NewV7(), activityID)
@@ -77,9 +77,9 @@ func seedTranscript(t *testing.T, e *integration.Env, body string) ids.UUID {
 	t.Helper()
 	activityID := ids.NewV7()
 	e.WsExec(t, `
-		INSERT INTO activity (id, workspace_id, kind, subject, body, source_system, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Quarterly review', $3, 'transcript', now(), 'manual', 'human:seed')`,
-		activityID, e.WS, body)
+		INSERT INTO activity (id, kind, subject, body, source_system, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Quarterly review', $2, 'transcript', now(), 'manual', 'human:seed')`,
+		activityID, body)
 	return activityID
 }
 
@@ -199,8 +199,8 @@ func TestErasureLeavesTheQuotationOfAMeetingItMayNotDestroy(t *testing.T) {
 	shared := seedTranscript(t, e, "1: "+quote)
 	for _, participant := range []any{subject, colleague} {
 		e.WsExec(t, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES ($1, $2, 'person', $3)`, e.WS, shared, participant)
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, shared, participant)
 	}
 	approvalID := stageQuotingProposal(t, e, shared, quote, "Loop in the renewal contact")
 

--- a/backend/internal/compose/flipreconcile.go
+++ b/backend/internal/compose/flipreconcile.go
@@ -86,7 +86,7 @@ func (w *flipWriters) ReconcileIdentities(ctx context.Context) error {
 // slice lands, and the function goes with the last one.
 func flipTenantScope(object string) string {
 	switch object {
-	case flipObjectPerson, flipObjectOrganization, flipObjectLead, flipObjectActivity:
+	case flipObjectPerson, flipObjectOrganization, flipObjectLead:
 		return "\n\t\t\t  AND n.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid"
 	default:
 		return ""

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -47,21 +47,20 @@ func seedExchange(t *testing.T, e *integration.Env, person ids.UUID) ids.UUID {
 	var id ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (`+ws+`, 'email', 'Alt', 'inbound', now() - interval '1 day', 'manual', 'human:test')
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES ( 'email', 'Alt', 'inbound', now() - interval '1 day', 'manual', 'human:test')
 			RETURNING id`).Scan(&id); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (`+ws+`, $1, $2, 'to')`, id, e.Rep1); err != nil {
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, 'to')`, id, e.Rep1); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (`+ws+`, $1, $2, 'from')`, id, person)
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'from')`, id, person)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding an exchange: %v", err)

--- a/backend/internal/compose/graphedge_integration_test.go
+++ b/backend/internal/compose/graphedge_integration_test.go
@@ -47,8 +47,8 @@ func (v edgeEnv) interaction(t *testing.T, user ids.UUID, person ids.PersonID, a
 	if err := database.WithWorkspaceTx(v.e.Admin(), v.e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES (
 			        'email', 'Betreff', $1, $2, 'manual', 'human:test')
 			RETURNING id`, direction, at).Scan(&activityID); err != nil {
 			return err
@@ -58,14 +58,14 @@ func (v edgeEnv) interaction(t *testing.T, user ids.UUID, person ids.PersonID, a
 			userRole = "to"
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, $3)`,
 			activityID, user, userRole); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, $3)`,
 			activityID, person, personRole)
 		return err
 	}); err != nil {
@@ -380,8 +380,8 @@ func TestOneMessageCountsOnceHoweverManyRolesItNames(t *testing.T) {
 	activityID := v.interaction(t, v.e.Rep1, contact, now.AddDate(0, 0, -1), "outbound", "to")
 	if err := database.WithWorkspaceTx(v.e.Admin(), v.e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 'cc')`,
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'cc')`,
 			activityID, contact)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/graphjobs_integration_test.go
+++ b/backend/internal/compose/graphjobs_integration_test.go
@@ -32,18 +32,16 @@ func legacyInteraction(t *testing.T, e *integration.Env, person ids.UUID, captur
 	var id ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at,
-			                      source, captured_by, counterparty_email)
-			VALUES (`+ws+`, 'email', 'Alt', 'outbound', now() - interval '3 days',
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by, counterparty_email)
+			VALUES ( 'email', 'Alt', 'outbound', now() - interval '3 days',
 			        'manual', $1, 'pat@counterparty.test')
 			RETURNING id`, capturedBy).Scan(&id); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES (`+ws+`, $1, 'person', $2)`, id, person)
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, id, person)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding a legacy activity: %v", err)
@@ -121,15 +119,14 @@ func TestTheReconcileWorkerRebuildsTheProjection(t *testing.T) {
 	// backfill runs with no consumer, or after a projection is lost.
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (`+ws+`, $1, $2, 'from')`, activityID, e.Rep1); err != nil {
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, 'from')`, activityID, e.Rep1); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (`+ws+`, $1, $2, 'to')`, activityID, person)
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'to')`, activityID, person)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding participants: %v", err)

--- a/backend/internal/compose/heldrelease_integration_test.go
+++ b/backend/internal/compose/heldrelease_integration_test.go
@@ -71,9 +71,9 @@ func seedHeldDraft(t *testing.T, e *integration.Env, svc *approvals.Service) hel
 	const to = draftRecipient
 	owner := integration.OwnerConn(t)
 	person := e.SeedPerson(t, "Anna Weber", nil)
-	anchor := integration.SeedRow(t, owner, `
-		INSERT INTO activity (id, workspace_id, kind, direction, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'inbound', 'Kickoff', now(), 'test', 'human:seed')`, e.WS)
+	anchor := integration.SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, direction, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'inbound', 'Kickoff', now(), 'test', 'human:seed')`)
 	// The purpose the send is gated against. Seeded with class
 	// business_correspondence, which is the class that is never consent-gated
 	// (ADR-0098 D1) — answering somebody who wrote to you rests on
@@ -96,11 +96,11 @@ func seedHeldDraft(t *testing.T, e *integration.Env, svc *approvals.Service) hel
 
 	// The counterparty on the thread, carrying the address a reply answers.
 	e.WsExec(t, `
-		INSERT INTO activity_participant (id, workspace_id, activity_id, role, person_id, address)
-		VALUES ($1, $2, $3, 'from', $4, $5)`, ids.NewV7(), e.WS, anchor, person, to)
+		INSERT INTO activity_participant (id, activity_id, role, person_id, address)
+		VALUES ($1, $2, 'from', $3, $4)`, ids.NewV7(), anchor, person, to)
 	e.WsExec(t, `
-		INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, $3, 'person', $4)`, ids.NewV7(), e.WS, anchor, person)
+		INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), anchor, person)
 
 	proposal := automation.HeldDraftProposal{
 		AnchorActivityID: anchor,

--- a/backend/internal/compose/integration/activity_links_and_query_integration_test.go
+++ b/backend/internal/compose/integration/activity_links_and_query_integration_test.go
@@ -28,13 +28,13 @@ func TestListActivitiesCarriesItsLinks(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	person := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'Renewal terms', now(), 'manual', 'human:x')`, e.WS)
+	activity := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Renewal terms', now(), 'manual', 'human:x')`)
 	// The organization arm is inserted here rather than through
 	// LinkActivity, whose column map covers person and deal only.
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, activity, org)
-	LinkActivity(t, owner, e.WS, activity, "person", person)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, activity, org)
+	LinkActivity(t, owner, activity, "person", person)
 
 	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{})
 	if err != nil {
@@ -79,10 +79,10 @@ func TestListActivitiesDropsLinksToRecordsOutOfRowScope(t *testing.T) {
 
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirDeal := e.SeedDeal(t, "Other team deal", pipeline, stage, &e.Rep3)
-	activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Joint call', now(), 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, activity, "person", mine)
-	LinkActivity(t, owner, e.WS, activity, "deal", theirDeal)
+	activity := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Joint call', now(), 'manual', 'human:x')`)
+	LinkActivity(t, owner, activity, "person", mine)
+	LinkActivity(t, owner, activity, "deal", theirDeal)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLinkRepPerms)
 	got, _, err := e.Activities.ListActivities(rep, activities.ListActivitiesInput{})
@@ -125,10 +125,10 @@ func TestListActivitiesAppliesTheDeclaredQueryFilter(t *testing.T) {
 	owner := OwnerConn(t)
 	admin := e.Admin()
 
-	wanted := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Renewal terms', 'they asked about multi-year pricing', now(), 'manual', 'human:x')`, e.WS)
-	SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Onboarding kickoff', 'introductions only', now(), 'manual', 'human:x')`, e.WS)
+	wanted := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Renewal terms', 'they asked about multi-year pricing', now(), 'manual', 'human:x')`)
+	SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Onboarding kickoff', 'introductions only', now(), 'manual', 'human:x')`)
 
 	bySubject := "Renewal"
 	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{Query: &bySubject})

--- a/backend/internal/compose/integration/activity_scope_integration_test.go
+++ b/backend/internal/compose/integration/activity_scope_integration_test.go
@@ -45,9 +45,9 @@ func TestActivityLifecycleMutatorsHonorRowScope(t *testing.T) {
 	// Team2's activity: linked to a person Rep3 owns, so Rep1's team scope
 	// hides it.
 	theirPerson := e.SeedPerson(t, "Their Contact", &e.Rep3)
-	theirActivity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'Q3 renewal terms', 'confidential body', now(), 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, theirActivity, "person", theirPerson)
+	theirActivity := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Q3 renewal terms', 'confidential body', now(), 'manual', 'human:x')`)
+	LinkActivity(t, owner, theirActivity, "person", theirPerson)
 	theirID := ids.From[ids.ActivityKind](theirActivity)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)

--- a/backend/internal/compose/integration/activitycontext_integration_test.go
+++ b/backend/internal/compose/integration/activitycontext_integration_test.go
@@ -116,20 +116,20 @@ func seedMeetingFixture(t *testing.T, e *SearchEnv) meetingFixture {
 // seedMeeting records one captured calendar event.
 func seedMeeting(t *testing.T, e *SearchEnv, subject string) ids.UUID {
 	t.Helper()
-	return e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', $3, now(), 'connector', 'connector:gcal')`, subject)
+	return e.SeedID(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', $2, now(), 'connector', 'connector:gcal')`, subject)
 }
 
 func linkMeeting(t *testing.T, e *SearchEnv, meeting ids.UUID, entityType, column string, target ids.UUID) {
 	t.Helper()
-	e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, `+column+`)
-		VALUES ($1, $2, $3, $4, $5)`, meeting, entityType, target)
+	e.SeedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, `+column+`)
+		VALUES ($1, $2, $3, $4)`, meeting, entityType, target)
 }
 
 func addParty(t *testing.T, e *SearchEnv, meeting ids.UUID, role string, person *ids.UUID, address string) {
 	t.Helper()
-	e.Seed(t, `INSERT INTO activity_participant (id, workspace_id, activity_id, role, person_id, address)
-		VALUES ($1, $2, $3, $4, $5, $6)`, meeting, role, person, address)
+	e.SeedID(t, `INSERT INTO activity_participant (id, activity_id, role, person_id, address)
+		VALUES ($1, $2, $3, $4, $5)`, meeting, role, person, address)
 }
 
 // The headline case: a meeting that names a deal is prepped against the deal,
@@ -331,8 +331,8 @@ func TestAColleagueOnTheInvitationIsNotAnUnresolvedAttendee(t *testing.T) {
 	f := seedMeetingFixture(t, e)
 	meeting := seedMeeting(t, e, "Internal prep")
 	linkMeeting(t, e, meeting, "deal", "deal_id", f.rep1Deal)
-	e.Seed(t, `INSERT INTO activity_participant (id, workspace_id, activity_id, role, user_id, address)
-		VALUES ($1, $2, $3, 'organizer', $4, 'rep0@search.test')`, meeting, e.Rep1)
+	e.SeedID(t, `INSERT INTO activity_participant (id, activity_id, role, user_id, address)
+		VALUES ($1, $2, 'organizer', $3, 'rep0@search.test')`, meeting, e.Rep1)
 
 	assembled, err := prepFor(e.Admin(), t, e, meeting)
 	if err != nil {
@@ -355,11 +355,11 @@ func TestTheOrganizerSurvivesAnOversizedInvitation(t *testing.T) {
 	if _, err := e.Owner.Exec(context.Background(), `
 		WITH room AS (
 		    INSERT INTO person (workspace_id, owner_id, full_name, source, captured_by)
-		    SELECT $1, $3, 'Attendee ' || n, 'manual', 'human:x' FROM generate_series(1, 60) n
+		    SELECT $1, $2, 'Attendee ' || n, 'manual', 'human:x' FROM generate_series(1, 60) n
 		    RETURNING id
 		)
-		INSERT INTO activity_participant (workspace_id, activity_id, role, person_id)
-		SELECT $1, $2, 'attendee', id FROM room`, e.WS, meeting, e.Rep1); err != nil {
+		INSERT INTO activity_participant (activity_id, role, person_id)
+		SELECT $3, 'attendee', id FROM room`, e.WS, e.Rep1, meeting); err != nil {
 		t.Fatalf("seeding the oversized invitation: %v", err)
 	}
 	organizer := e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)

--- a/backend/internal/compose/integration/approval_livetarget_integration_test.go
+++ b/backend/internal/compose/integration/approval_livetarget_integration_test.go
@@ -148,8 +148,8 @@ func TestAStagedApprovalStopsBeingDecidableOnceItsTargetIsArchived(t *testing.T)
 func seedUnlinkedActivity(t *testing.T, e *Env, subject string) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, source, captured_by)
-		VALUES ($1, $2, 'note', $3, 'manual', 'human:fixture')`, id, e.WS, subject)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, source, captured_by)
+		VALUES ($1, 'note', $2, 'manual', 'human:fixture')`, id, subject)
 	return id
 }
 

--- a/backend/internal/compose/integration/capture/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_scope_integration_test.go
@@ -147,8 +147,8 @@ func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t 
 		t.Fatal(err)
 	}
 	if _, err := e.Owner.Exec(context.Background(), `
-		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, 'person', $3)`, e.WS, activityID, foreign); err != nil {
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ( $1, 'person', $2)`, activityID, foreign); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
@@ -277,8 +277,8 @@ func TestCaptureTierGateHonorsCorrespondenceFromACRMOriginatedSend(t *testing.T)
 	anchorID := ids.NewV7()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1,
 			        'email', 'Intro', now(), 'manual', 'human:x')`, anchorID)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/integration/capture_shape_producers_integration_test.go
+++ b/backend/internal/compose/integration/capture_shape_producers_integration_test.go
@@ -246,8 +246,8 @@ func TestAConversationWithNoNameableReaderIsRefusedRatherThanShared(t *testing.T
 		 lifecycle = 'opportunity' WHERE id = $1`, org)
 	notice := seedUnlinkedMessage(t, e, "thread-nameless", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", captureShapeClock.Add(-48*time.Hour))
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, notice, org)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, notice, org)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}
@@ -284,8 +284,8 @@ func TestAPrivateAccountSuppliesTheReaderItsOwnMailAnswersTo(t *testing.T) {
 		 lifecycle = 'opportunity' WHERE id = $1`, org, e.Rep1)
 	notice := seedUnlinkedMessage(t, e, "thread-private-account", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", captureShapeClock.Add(-48*time.Hour))
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, notice, org)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, notice, org)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -122,16 +122,15 @@ func (c *channelSendEnv) seedInboundMessage(t *testing.T) {
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, channel_provider, body, occurred_at, direction,
-			                      source_system, source_id, source, captured_by, thread_key)
-			VALUES ($1, 'message', 'telegram', 'Is this still available?', now(), 'inbound',
-			        'telegram', '8100:770011:5', 'telegram:8100:770011:5', 'connector:telegram', $2)
-			RETURNING id`, c.ws, channelSendThreadKey).Scan(&c.activityID); err != nil {
+			INSERT INTO activity (kind, channel_provider, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key)
+			VALUES ( 'message', 'telegram', 'Is this still available?', now(), 'inbound',
+			        'telegram', '8100:770011:5', 'telegram:8100:770011:5', 'connector:telegram', $1)
+			RETURNING id`, channelSendThreadKey).Scan(&c.activityID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES ($1, $2, 'person', $3)`, c.ws, c.activityID, c.personID)
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, c.activityID, c.personID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the inbound conversation: %v", err)

--- a/backend/internal/compose/integration/dealhealth_integration_test.go
+++ b/backend/internal/compose/integration/dealhealth_integration_test.go
@@ -57,9 +57,9 @@ func seedHealthyDeal(t *testing.T, e *Env, owner *pgx.Conn) (deal ids.UUID, enga
 	}
 
 	// The recency evidence record: the freshest live activity on the deal.
-	freshest = SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'call', 'checkpoint', '2026-05-30T12:00:00Z', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, freshest, "deal", deal)
+	freshest = SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'call', 'checkpoint', '2026-05-30T12:00:00Z', 'manual', 'human:x')`)
+	LinkActivity(t, owner, freshest, "deal", deal)
 
 	// Two stakeholders with BOTH directions inside the 90-day window →
 	// engaged; a third who only ever received our outbound → not.
@@ -71,9 +71,9 @@ func seedHealthyDeal(t *testing.T, e *Env, owner *pgx.Conn) (deal ids.UUID, enga
 	// An open task due AFTER the clock: a commitment, but not overdue.
 	// Logged BEFORE the checkpoint call so the call stays the deal's
 	// freshest activity — the recency evidence the test pins.
-	pending := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at, source, captured_by)
-		VALUES ($1, $2, 'task', 'send proposal', '2026-05-25T12:00:00Z', '2026-06-08T12:00:00Z', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, pending, "deal", deal)
+	pending := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, source, captured_by)
+		VALUES ($1, 'task', 'send proposal', '2026-05-25T12:00:00Z', '2026-06-08T12:00:00Z', 'manual', 'human:x')`)
+	LinkActivity(t, owner, pending, "deal", deal)
 	return deal, engaged, freshest
 }
 
@@ -183,9 +183,9 @@ func TestStalledDealReadsAtRisk(t *testing.T) {
 		`UPDATE deal_stage_history SET changed_at = $2 WHERE deal_id = $1`, deal, idleSince); err != nil {
 		t.Fatal(err)
 	}
-	overdue := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at, source, captured_by)
-		VALUES ($1, $2, 'task', 'never followed up', '2026-03-06T12:00:00Z', '2026-03-20T12:00:00Z', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, overdue, "deal", deal)
+	overdue := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, source, captured_by)
+		VALUES ($1, 'task', 'never followed up', '2026-03-06T12:00:00Z', '2026-03-20T12:00:00Z', 'manual', 'human:x')`)
+	LinkActivity(t, owner, overdue, "deal", deal)
 
 	got, err := e.Deals.DealHealth(ctx, ids.From[ids.DealKind](deal), healthClock)
 	if err != nil {

--- a/backend/internal/compose/integration/documents_integration_test.go
+++ b/backend/internal/compose/integration/documents_integration_test.go
@@ -332,12 +332,12 @@ func seedActivityWithDeal(t *testing.T, e *Env, deal ids.UUID) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	e.WsExec(t, `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'Contract', $3::timestamptz, 'manual', 'human:test')`,
-		id, e.WS, activityOccurredAt)
+		INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Contract', $2::timestamptz, 'manual', 'human:test')`,
+		id, activityOccurredAt)
 	e.WsExec(t, `
-		INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-		VALUES ($1, $2, 'deal', $3)`, e.WS, id, deal)
+		INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		VALUES ( $1, 'deal', $2)`, id, deal)
 	return id
 }
 

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -61,13 +61,13 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 		}
 		activityID := ids.NewV7()
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-			 VALUES ($1, `+wsClause+`, 'note', 'Met Selma', now(), 'manual', 'human:x')`, activityID); err != nil {
+			`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			 VALUES ($1, 'note', 'Met Selma', now(), 'manual', 'human:x')`, activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			 VALUES (`+wsClause+`, $1, 'person', $2)`, activityID, personID); err != nil {
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ( $1, 'person', $2)`, activityID, personID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
@@ -289,32 +289,32 @@ func TestErasurePreservesActivityUnderTransitiveHold(t *testing.T) {
 		// carries no statutory floor, so its survival here is attributable to
 		// the legal_hold alone, not the GoBD floor this binary also arms.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'note', 'Contract terms', 'The signed terms are attached.', now(), 'manual', 'human:x')`,
+			`INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			 VALUES ($1, 'note', 'Contract terms', 'The signed terms are attached.', now(), 'manual', 'human:x')`,
 			heldActivity); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			 VALUES (`+ws+`, $1, 'person', $2)`, heldActivity, personID); err != nil {
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ( $1, 'person', $2)`, heldActivity, personID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-			 VALUES (`+ws+`, $1, 'organization', $2)`, heldActivity, orgID); err != nil {
+			`INSERT INTO activity_link (activity_id, entity_type, organization_id)
+			 VALUES ( $1, 'organization', $2)`, heldActivity, orgID); err != nil {
 			return err
 		}
 		// The sibling note: subject-only, NOT transitively held, and (being a
 		// note) not floor-shielded either — so it IS redacted.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'note', 'Lunch?', 'Free on Friday?', now(), 'manual', 'human:x')`,
+			`INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			 VALUES ($1, 'note', 'Lunch?', 'Free on Friday?', now(), 'manual', 'human:x')`,
 			freeActivity); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			 VALUES (`+ws+`, $1, 'person', $2)`, freeActivity, personID)
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ( $1, 'person', $2)`, freeActivity, personID)
 		return err
 	})
 	if err != nil {
@@ -388,26 +388,26 @@ func TestErasePersonHonoursCommercialCorrespondenceFloor(t *testing.T) {
 		}
 		// A recent external email — commercial correspondence within the floor.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'email', 'Invoice 2026-0042', 'Please find the invoice attached.', now() - interval '400 days', 'manual', 'human:x')`,
+			`INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			 VALUES ($1, 'email', 'Invoice 2026-0042', 'Please find the invoice attached.', now() - interval '400 days', 'manual', 'human:x')`,
 			email); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			 VALUES (`+ws+`, $1, 'person', $2)`, email, personID); err != nil {
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ( $1, 'person', $2)`, email, personID); err != nil {
 			return err
 		}
 		// A same-age internal note — no statutory floor.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'note', 'Internal jotting', 'Chase them next week.', now() - interval '400 days', 'manual', 'human:x')`,
+			`INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			 VALUES ($1, 'note', 'Internal jotting', 'Chase them next week.', now() - interval '400 days', 'manual', 'human:x')`,
 			note); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			 VALUES (`+ws+`, $1, 'person', $2)`, note, personID)
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ( $1, 'person', $2)`, note, personID)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/erasure_restriction_integration_test.go
+++ b/backend/internal/compose/integration/erasure_restriction_integration_test.go
@@ -59,21 +59,21 @@ func seedRestrictionFixture(t *testing.T, e *Env) restrictionFixture {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, raw, counterparty_email, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'email', 'Angebot 2026-0042', 'Our offer, as discussed.', '{"provider":"payload"}'::jsonb,
+			`INSERT INTO activity (id, kind, subject, body, raw, counterparty_email, occurred_at, source, captured_by)
+			 VALUES ($1, 'email', 'Angebot 2026-0042', 'Our offer, as discussed.', '{"provider":"payload"}'::jsonb,
 			         'held@example.test', now() - interval '400 days', 'manual', 'human:x')`, f.email); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'note', 'Internal jotting', 'Chase them next week.', now() - interval '400 days', 'manual', 'human:x')`,
+			`INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			 VALUES ($1, 'note', 'Internal jotting', 'Chase them next week.', now() - interval '400 days', 'manual', 'human:x')`,
 			f.note); err != nil {
 			return err
 		}
 		for _, a := range []ids.UUID{f.email, f.note} {
 			if _, err := tx.Exec(ctx,
-				`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-				 VALUES (`+ws+`, $1, 'person', $2)`, a, f.person); err != nil {
+				`INSERT INTO activity_link (activity_id, entity_type, person_id)
+				 VALUES ( $1, 'person', $2)`, a, f.person); err != nil {
 				return err
 			}
 		}
@@ -594,10 +594,9 @@ func TestAControllerPinsCorrespondenceTheDerivationCannotSee(t *testing.T) {
 	e := Setup(t)
 	supplierMail := ids.NewV7()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		_, err := tx.Exec(context.Background(),
-			`INSERT INTO activity (id, workspace_id, kind, subject, body, counterparty_email, occurred_at, source, captured_by)
-			 VALUES ($1, `+ws+`, 'email', 'Lieferschein 88-2026', 'Delivery note attached.', 'supplier@parts.test',
+			`INSERT INTO activity (id, kind, subject, body, counterparty_email, occurred_at, source, captured_by)
+			 VALUES ($1, 'email', 'Lieferschein 88-2026', 'Delivery note attached.', 'supplier@parts.test',
 			         now() - interval '30 days', 'manual', 'human:x')`, supplierMail)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -99,12 +99,12 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`, f.rep3Person, f.rep3Org)
 
 	// Activities scope through their links.
-	f.rep1Activity = e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Rep1 note', now(), 'manual', 'human:x')`)
-	e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep1Activity, f.rep1Person)
-	f.rep3Activity = e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Rep3 note', now(), 'manual', 'human:x')`)
-	e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep3Activity, f.rep3Person)
+	f.rep1Activity = e.SeedID(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Rep1 note', now(), 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id) VALUES ($1, $2, 'person', $3)`, f.rep1Activity, f.rep1Person)
+	f.rep3Activity = e.SeedID(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Rep3 note', now(), 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id) VALUES ($1, $2, 'person', $3)`, f.rep3Activity, f.rep3Person)
 
 	// Attachments on each rep's person — the files manifest source.
 	e.SeedID(t, `INSERT INTO attachment (id, entity_type, entity_id, filename, storage_key, source, captured_by)

--- a/backend/internal/compose/integration/fts_integration_test.go
+++ b/backend/internal/compose/integration/fts_integration_test.go
@@ -58,9 +58,9 @@ func TestSearchFoldsAccentsAndStemsByLanguage(t *testing.T) {
 	// German stemming: an activity captured as language=de matches the
 	// singular query against its plural body.
 	activityID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, language, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Unterlagen', 'Bitte die Verträge prüfen', 'de', now(), 'manual', 'human:x')`,
-		activityID, e.WS)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, body, language, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Unterlagen', 'Bitte die Verträge prüfen', 'de', now(), 'manual', 'human:x')`,
+		activityID)
 	page, err = searchStore.Search(admin, search.Input{Query: "Vertrag", Types: []string{"activity"}})
 	if err != nil {
 		t.Fatalf("search activities: %v", err)

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -426,8 +426,8 @@ func (e *Env) SeedWonDealLinkedTo(t *testing.T, activities ...ids.UUID) ids.UUID
 			return err
 		}
 		for _, a := range activities {
-			if _, err := tx.Exec(ctx, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'deal', $2)`, a, deal); err != nil {
+			if _, err := tx.Exec(ctx, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
+				VALUES ($1, 'deal', $2)`, a, deal); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/integration/lastactivity_integration_test.go
+++ b/backend/internal/compose/integration/lastactivity_integration_test.go
@@ -188,12 +188,12 @@ func TestLastActivity_ConcurrentWritersConvergeOnTheNewest(t *testing.T) {
 	insert := func(tx pgx.Tx, when time.Time) error {
 		id := ids.NewV7()
 		if _, err := tx.Exec(ctx, `INSERT INTO activity
-			(id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
-			VALUES ($1, $2, 'note', 'race', $3, $3, 'manual', 'human:x')`, id, e.WS, when); err != nil {
+			(id, kind, subject, occurred_at, created_at, source, captured_by)
+			VALUES ($1, 'note', 'race', $2, $2, 'manual', 'human:x')`, id, when); err != nil {
 			return err
 		}
-		_, err := tx.Exec(ctx, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES ($1, $2, 'person', $3)`, e.WS, id, staff)
+		_, err := tx.Exec(ctx, `INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ($1, 'person', $2)`, id, staff)
 		return err
 	}
 
@@ -315,12 +315,12 @@ func seedTimelineVolume(ctx context.Context, t *testing.T, owner *pgx.Conn, ws i
 		t.Fatalf("seeding the volume lead: %v", err)
 	}
 	if _, err := owner.Exec(ctx, `WITH act AS (
-		INSERT INTO activity (workspace_id, kind, subject, occurred_at, source, captured_by)
-		SELECT $1, 'note', 'volume ' || i, now() - (i || ' minutes')::interval, 'manual', 'human:x'
-		FROM generate_series(1, $3) AS i RETURNING id
+		INSERT INTO activity (kind, subject, occurred_at, source, captured_by)
+		SELECT 'note', 'volume ' || i, now() - (i || ' minutes')::interval, 'manual', 'human:x'
+		FROM generate_series(1, $2) AS i RETURNING id
 	)
-	INSERT INTO activity_link (workspace_id, activity_id, entity_type, lead_id)
-	SELECT $1, id, 'lead', $2 FROM act`, ws, lead, rows); err != nil {
+	INSERT INTO activity_link (activity_id, entity_type, lead_id)
+	SELECT id, 'lead', $1 FROM act`, lead, rows); err != nil {
 		t.Fatalf("seeding %d timeline rows: %v", rows, err)
 	}
 	// Without fresh statistics the planner sizes activity_link from whatever

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -43,11 +43,10 @@ func TestMeetingBriefRefusesACallerWithNoActivityGrant(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
-	meeting := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
-		        'manual', 'human:x')`, e.WS, roomTomorrow)
-	LinkActivity(t, owner, e.WS, meeting, "person", mine)
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Expansion review', $2,
+		        'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", mine)
 
 	perms := roomPerms
 	perms.Objects = map[string]principal.ObjectGrant{
@@ -70,11 +69,10 @@ func TestMeetingBriefRefusesACallerWithNoPersonGrant(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
-	meeting := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
-		        'manual', 'human:x')`, e.WS, roomTomorrow)
-	LinkActivity(t, owner, e.WS, meeting, "person", mine)
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Expansion review', $2,
+		        'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", mine)
 
 	perms := roomPerms
 	perms.Objects = map[string]principal.ObjectGrant{"activity": {Read: true}}
@@ -98,11 +96,10 @@ func TestMeetingBriefRefusesAMeetingItCannotReach(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
-	meeting := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Their review', $3,
-		        'manual', 'human:x')`, e.WS, roomTomorrow)
-	LinkActivity(t, owner, e.WS, meeting, "person", theirs)
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Their review', $2,
+		        'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", theirs)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 
@@ -126,20 +123,18 @@ func TestMeetingBriefDoesNotReportALastTouchTheCallerCannotRead(t *testing.T) {
 	attendee := e.SeedPerson(t, "Ana Roth", &e.Rep1)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
 
-	meeting := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Expansion review', $3,
-		        'manual', 'human:x')`, e.WS, roomTomorrow)
-	LinkActivity(t, owner, e.WS, meeting, "person", attendee)
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Expansion review', $2,
+		        'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", attendee)
 	seatInRoom(t, owner, e.WS, meeting, attendee)
 
 	// A conversation this caller may not read, which nonetheless names their
 	// attendee as a participant.
-	hidden := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'Cc: budget', $3,
-		        'manual', 'human:x')`, e.WS, roomAgo(3*24*time.Hour))
-	LinkActivity(t, owner, e.WS, hidden, "person", theirs)
+	hidden := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Cc: budget', $2,
+		        'manual', 'human:x')`, roomAgo(3*24*time.Hour))
+	LinkActivity(t, owner, hidden, "person", theirs)
 	seatInRoom(t, owner, e.WS, hidden, attendee)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
@@ -177,8 +172,8 @@ func TestMeetingBriefDoesNotReportALastTouchTheCallerCannotRead(t *testing.T) {
 func seatInRoom(t *testing.T, owner *pgx.Conn, ws, activity, person ids.UUID) {
 	t.Helper()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_participant (workspace_id, activity_id, role, person_id)
-		 VALUES ($1, $2, 'attendee', $3)`, ws, activity, person); err != nil {
+		`INSERT INTO activity_participant (activity_id, role, person_id)
+		 VALUES ( $1, 'attendee', $2)`, activity, person); err != nil {
 		t.Fatalf("seating a participant: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -227,9 +227,9 @@ func seedQuietTouch(t *testing.T, owner *pgx.Conn, ws ids.UUID) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, $2, 'email', 'Last genuine engagement', $3, 'manual', 'human:x')`,
-		id, ws, quietSince); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'email', 'Last genuine engagement', $2, 'manual', 'human:x')`,
+		id, quietSince); err != nil {
 		t.Fatalf("seeding the quiet touch: %v", err)
 	}
 	return id
@@ -254,8 +254,7 @@ func linkTouch(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityType 
 		t.Fatalf("no activity_link column for entity type %q", entityType)
 	}
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, `+column+`) VALUES ($1, $2, $3, $4)`,
-		ws, activity, entityType, entity); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, `+column+`) VALUES ( $1, $2, $3)`, activity, entityType, entity); err != nil {
 		t.Fatalf("linking the touch to %s %s: %v", entityType, entity, err)
 	}
 }

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -69,14 +69,13 @@ func seedDealContextActivity(t *testing.T, e *apptest.AppEnv, wsID, dealID, subj
 	t.Helper()
 	activityID := ids.NewV7()
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, $2, 'note', $3, '2026-07-01T10:00:00Z', 'manual', 'human:x')`,
-		activityID, wsID, subject); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'note', $2, '2026-07-01T10:00:00Z', 'manual', 'human:x')`,
+		activityID, subject); err != nil {
 		t.Fatalf("seed deal context activity: %v", err)
 	}
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id) VALUES ($1, $2, 'deal', $3)`,
-		wsID, activityID, dealID); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, deal_id) VALUES ( $1, 'deal', $2)`, activityID, dealID); err != nil {
 		t.Fatalf("link deal context activity: %v", err)
 	}
 	return "activity:" + activityID.String()

--- a/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
@@ -36,10 +36,9 @@ import (
 func accountMailAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject string, at time.Time) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	if _, err := owner.Exec(context.Background(), `INSERT INTO activity
-		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'inbound', $3, $4, $4, 'manual', 'human:x')`,
-		id, ws, subject, at); err != nil {
+	if _, err := owner.Exec(context.Background(), `INSERT INTO activity (id, kind, direction, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'email', 'inbound', $2, $3, $3, 'manual', 'human:x')`,
+		id, subject, at); err != nil {
 		t.Fatalf("seeding %q: %v", subject, err)
 	}
 	return id
@@ -119,13 +118,13 @@ func TestAccountTimelineReachesMailThroughItsContactsAndDeals(t *testing.T) {
 	direct := accountMailAt(t, owner, e.WS, "direct", org360Clock.Add(-1*time.Hour))
 	integration.LinkToOrg(t, e, direct, org)
 	viaContact := accountMailAt(t, owner, e.WS, "via a current employee", org360Clock.Add(-2*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, viaContact, "person", employee)
+	integration.LinkActivity(t, owner, viaContact, "person", employee)
 	viaDeal := accountMailAt(t, owner, e.WS, "via the deal", org360Clock.Add(-3*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, viaDeal, "deal", deal)
+	integration.LinkActivity(t, owner, viaDeal, "deal", deal)
 	viaLeaver := accountMailAt(t, owner, e.WS, "via a former employee", org360Clock.Add(-4*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, viaLeaver, "person", leaver)
+	integration.LinkActivity(t, owner, viaLeaver, "person", leaver)
 	viaStranger := accountMailAt(t, owner, e.WS, "via another account's contact", org360Clock.Add(-5*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, viaStranger, "person", stranger)
+	integration.LinkActivity(t, owner, viaStranger, "person", stranger)
 
 	listed, _ := accountTimeline(rep, t, e, org, 25, "")
 	for _, want := range []struct {
@@ -190,9 +189,9 @@ func TestTheAccountWalkDoesNotWidenTheCallersRowScope(t *testing.T) {
 	employAt(t, e, theirs, org, nil)
 
 	visible := accountMailAt(t, owner, e.WS, "terms", org360Clock.Add(-1*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, visible, "person", mine)
+	integration.LinkActivity(t, owner, visible, "person", mine)
 	hidden := accountMailAt(t, owner, e.WS, "confidential terms", org360Clock.Add(-2*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, hidden, "person", theirs)
+	integration.LinkActivity(t, owner, hidden, "person", theirs)
 
 	listed, _ := accountTimeline(rep, t, e, org, 25, "")
 	if containsActivity(listed, hidden) {
@@ -228,7 +227,7 @@ func TestAccountTimelinePagesWithoutDuplicatesOrOmissions(t *testing.T) {
 			integration.LinkToOrg(t, e, mail, org)
 		}
 		if i%2 == 1 || i == 2 {
-			integration.LinkActivity(t, owner, e.WS, mail, "person", contact)
+			integration.LinkActivity(t, owner, mail, "person", contact)
 		}
 		want = append(want, mail)
 	}
@@ -283,12 +282,12 @@ func TestSinceLastVisitCountsMailRolledUpThroughAContact(t *testing.T) {
 	// Mail that arrived BEFORE the visit is not new; the ack pins the baseline
 	// at the read's own instant.
 	before := accountMailAt(t, owner, e.WS, "old thread", org360Clock.Add(-time.Hour))
-	integration.LinkActivity(t, owner, e.WS, before, "person", contact)
+	integration.LinkActivity(t, owner, before, "person", contact)
 	if _, err := svc.Acknowledge(rep, orgID); err != nil {
 		t.Fatalf("acknowledging the visit: %v", err)
 	}
 	after := accountMailAt(t, owner, e.WS, "new thread", org360Clock.Add(time.Hour))
-	integration.LinkActivity(t, owner, e.WS, after, "person", contact)
+	integration.LinkActivity(t, owner, after, "person", contact)
 
 	view, err := svc.Assemble(rep, orgID)
 	if err != nil {
@@ -326,7 +325,7 @@ func TestLastTouchSeparatesWhoWroteLastAndWalksTheSameThreeLinks(t *testing.T) {
 	oldInbound := integration.AccountMailDirectedAt(t, owner, e.WS, "old reply", "inbound", org360Clock.Add(-90*time.Hour))
 	integration.LinkToOrg(t, e, oldInbound, org)
 	newInbound := integration.AccountMailDirectedAt(t, owner, e.WS, "their reply", "inbound", org360Clock.Add(-30*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, newInbound, "person", employee)
+	integration.LinkActivity(t, owner, newInbound, "person", employee)
 	outbound := integration.AccountMailDirectedAt(t, owner, e.WS, "our nudge", "outbound", org360Clock.Add(-2*time.Hour))
 	integration.LinkToOrg(t, e, outbound, org)
 

--- a/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
@@ -257,9 +257,9 @@ func TestOrganizationGraphIntroPathNamesTheWarmRoomsContact(t *testing.T) {
 	// Only the warm contact has qualifying interactions inside the §4 window,
 	// so the ranking has one honest answer rather than a tie.
 	for _, direction := range []string{"inbound", "outbound"} {
-		activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
-		integration.LinkActivity(t, owner, e.WS, activity, "person", warm)
+		activity := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+			VALUES ($1, 'email', 'terms', '2026-05-30T09:00:00Z', '`+direction+`', 'manual', 'human:x')`)
+		integration.LinkActivity(t, owner, activity, "person", warm)
 	}
 	signal := seedOpenSignal(t, owner, org)
 
@@ -321,9 +321,9 @@ func TestOrganizationGraphCitesAnOrganizationSubjectSignal(t *testing.T) {
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Warm Contact", &e.Rep1)
 	employ(t, e, contact, org, "cto")
-	activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
-	integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
+	activity := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, activity, "person", contact)
 	signal := seedOrgSubjectSignal(t, owner, org)
 
 	graph, err := svc.Graph(e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms),
@@ -351,9 +351,9 @@ func TestOrganizationGraphReportsNoIntroPathWithoutAnOpenSignal(t *testing.T) {
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Warm Contact", &e.Rep1)
 	employ(t, e, contact, org, "cto")
-	activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
-	integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
+	activity := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, activity, "person", contact)
 
 	graph, err := svc.Graph(e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
@@ -60,19 +60,18 @@ func seedMember(t *testing.T, owner *pgx.Conn, ws ids.UUID, name string) ids.UUI
 func seedTouch(t *testing.T, e *integration.Env, owner *pgx.Conn, kind string, colleague *ids.UUID, person ids.UUID) {
 	t.Helper()
 	ctx := context.Background()
-	ws := e.WS
 	id := ids.NewV7()
 	capturedBy := "connector:gmail"
 	if colleague != nil {
 		capturedBy = "human:" + colleague.String()
 	}
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, $3, 'terms', '2026-05-30T09:00:00Z', 'outbound', 'manual', $4)`,
-		id, ws, kind, capturedBy); err != nil {
+		INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+		VALUES ($1, $2, 'terms', '2026-05-30T09:00:00Z', 'outbound', 'manual', $3)`,
+		id, kind, capturedBy); err != nil {
 		t.Fatalf("seeding a %s: %v", kind, err)
 	}
-	integration.LinkActivity(t, owner, ws, id, "person", person)
+	integration.LinkActivity(t, owner, id, "person", person)
 
 	// Only a real exchange has participants. A task is intent and a note is a
 	// record of thinking; neither means the two people spoke, which is why
@@ -80,14 +79,14 @@ func seedTouch(t *testing.T, e *integration.Env, owner *pgx.Conn, kind string, c
 	if kind == "email" || kind == "call" || kind == "meeting" {
 		if colleague != nil {
 			if _, err := owner.Exec(ctx, `
-				INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-				VALUES ($1, $2, $3, 'from')`, ws, id, *colleague); err != nil {
+				INSERT INTO activity_participant (activity_id, user_id, role)
+				VALUES ( $1, $2, 'from')`, id, *colleague); err != nil {
 				t.Fatalf("seeding the our-side participant: %v", err)
 			}
 		}
 		if _, err := owner.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES ($1, $2, $3, 'to')`, ws, id, person); err != nil {
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'to')`, id, person); err != nil {
 			t.Fatalf("seeding the counterparty participant: %v", err)
 		}
 	}

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -147,9 +147,9 @@ func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
 	// Two qualifying interactions inside the §4 window, one each way, so
 	// the score is non-zero and reciprocity is balanced.
 	for _, direction := range []string{"inbound", "outbound"} {
-		activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
-		integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
+		activity := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+			VALUES ($1, 'email', 'terms', '2026-05-30T09:00:00Z', '`+direction+`', 'manual', 'human:x')`)
+		integration.LinkActivity(t, owner, activity, "person", contact)
 	}
 
 	purpose := seedConsentPurpose(t, owner, "marketing_email", "Marketing email")
@@ -314,10 +314,10 @@ func TestOrganization360NextStepsHideALinkedDealOutOfRowScope(t *testing.T) {
 	theirDeal := e.SeedDeal(t, "Other team deal", pipeline, stage, &e.Rep3)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, theirDeal, org)
 
-	task := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, is_done, source, captured_by)
-		VALUES ($1, $2, 'task', 'Send the renewal paperwork', now(), false, 'manual', 'human:x')`, e.WS)
-	integration.LinkActivity(t, owner, e.WS, task, "person", mine)
-	integration.LinkActivity(t, owner, e.WS, task, "deal", theirDeal)
+	task := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, is_done, source, captured_by)
+		VALUES ($1, 'task', 'Send the renewal paperwork', now(), false, 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, task, "person", mine)
+	integration.LinkActivity(t, owner, task, "deal", theirDeal)
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -362,9 +362,9 @@ func TestOrganization360NextMeetingSeparatesNoneFromWithheld(t *testing.T) {
 	// A meeting in the past is not the next one. Seeded before the future meeting
 	// so an ordering that ignored occurred_at would return this row.
 	past := seedMeeting(t, owner, e.WS, "Kickoff, already held", org360Clock.Add(-48*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, past, "organization", org)
+	integration.LinkActivity(t, owner, past, "organization", org)
 	future := seedMeeting(t, owner, e.WS, "Renewal review", org360Clock.Add(72*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, future, "organization", org)
+	integration.LinkActivity(t, owner, future, "organization", org)
 
 	view, err = svc.Assemble(granted, ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -415,18 +415,18 @@ func TestOrganization360NextMeetingParticipantsHonorRowScope(t *testing.T) {
 	}
 
 	meeting := seedMeeting(t, owner, e.WS, "Renewal review", org360Clock.Add(24*time.Hour))
-	integration.LinkActivity(t, owner, e.WS, meeting, "person", mine)
+	integration.LinkActivity(t, owner, meeting, "person", mine)
 	for _, person := range []ids.UUID{mine, theirs} {
-		e.WsExec(t, `INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES ($1, $2, $3, 'attendee')`, e.WS, meeting, person)
+		e.WsExec(t, `INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'attendee')`, meeting, person)
 	}
 	// The visible contact ALSO holds a second role. uq_activity_participant is
 	// unique on (activity, role, person), so one person legitimately has several
 	// rows on one meeting — a captured mail makes its sender both `from` and
 	// `attendee`. Without this the fixture has one row per person and cannot
 	// tell a correct answer from one that lists somebody once per role.
-	e.WsExec(t, `INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-		VALUES ($1, $2, $3, 'from')`, e.WS, meeting, mine)
+	e.WsExec(t, `INSERT INTO activity_participant (activity_id, person_id, role)
+		VALUES ( $1, $2, 'from')`, meeting, mine)
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -451,8 +451,8 @@ func seedMeeting(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject string, at 
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'meeting', $3, $4, 'manual', 'human:x')`, id, ws, subject, at); err != nil {
+		INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', $2, $3, 'manual', 'human:x')`, id, subject, at); err != nil {
 		t.Fatalf("seeding a meeting: %v", err)
 	}
 	return id

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -188,9 +188,9 @@ func seedAccount(t *testing.T, e *integration.Env, owner *pgx.Conn, name string,
 		contact := e.SeedPerson(t, name+" contact", &e.Rep1)
 		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
 			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
-		activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'touch', '2026-05-28T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
-		integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
+		activity := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+			VALUES ($1, 'email', 'touch', '2026-05-28T09:00:00Z', 'inbound', 'manual', 'human:x')`)
+		integration.LinkActivity(t, owner, activity, "person", contact)
 
 		deal := e.SeedDeal(t, name+" deal", pipeline, stage, &e.Rep1)
 		e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)

--- a/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
@@ -33,12 +33,11 @@ import (
 func seedUnansweredOutbound(t *testing.T, e *integration.Env, org ids.UUID) {
 	t.Helper()
 	owner := integration.OwnerConn(t)
-	sent := integration.SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'outbound', 'Proposal — following up',
-		        '2026-05-10T09:00:00Z', '2026-05-10T09:00:00Z', 'manual', 'human:x')`, e.WS)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, sent, org)
+	sent := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, direction, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'email', 'outbound', 'Proposal — following up',
+		        '2026-05-10T09:00:00Z', '2026-05-10T09:00:00Z', 'manual', 'human:x')`)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, sent, org)
 }
 
 // The rules must look PAST the section page cap.
@@ -60,15 +59,14 @@ func TestSuggestionsLookPastTheSectionPageCap(t *testing.T) {
 	// older notes would sort behind it and it would sit inside the page after all.
 	for i := range 30 {
 		note := ids.NewV7()
-		if _, err := owner.Exec(context.Background(), `INSERT INTO activity
-			(id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
-			VALUES ($1, $2, 'note', $3, $4, $4, 'manual', 'human:x')`,
-			note, e.WS, fmt.Sprintf("note %d", i),
+		if _, err := owner.Exec(context.Background(), `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by)
+			VALUES ($1, 'note', $2, $3, $3, 'manual', 'human:x')`,
+			note, fmt.Sprintf("note %d", i),
 			org360Clock.Add(-time.Duration(i)*time.Hour)); err != nil {
 			t.Fatalf("seeding note %d: %v", i, err)
 		}
-		e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-			VALUES ($1, $2, 'organization', $3)`, e.WS, note, org.UUID)
+		e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+			VALUES ( $1, 'organization', $2)`, note, org.UUID)
 	}
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), org)
@@ -229,14 +227,13 @@ func TestNoNextStepSeesATaskThePageDoesNot(t *testing.T) {
 
 	// One task, reachable only through the deal — never linked to the account.
 	task := ids.NewV7()
-	if _, err := owner.Exec(context.Background(), `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by, is_done)
-		VALUES ($1, $2, 'task', 'Call the CFO', $3, $3, 'manual', 'human:x', false)`,
-		task, e.WS, org360Clock); err != nil {
+	if _, err := owner.Exec(context.Background(), `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by, is_done)
+		VALUES ($1, 'task', 'Call the CFO', $2, $2, 'manual', 'human:x', false)`,
+		task, org360Clock); err != nil {
 		t.Fatalf("seeding the task: %v", err)
 	}
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-		VALUES ($1, $2, 'deal', $3)`, e.WS, task, deal)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		VALUES ( $1, 'deal', $2)`, task, deal)
 
 	view, err := svc.Assemble(rep, org)
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_visit_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_visit_integration_test.go
@@ -138,10 +138,10 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 	// accident rather than by design.
 	before := e.SeedDeal(t, "Old deal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, before, org.UUID)
-	old := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'before the visit', '2026-05-01T09:00:00Z', '2026-05-01T09:00:00Z', 'manual', 'human:x')`, e.WS)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, old, org.UUID)
+	old := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'note', 'before the visit', '2026-05-01T09:00:00Z', '2026-05-01T09:00:00Z', 'manual', 'human:x')`)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, old, org.UUID)
 
 	if _, err := svc.Acknowledge(admin, org); err != nil {
 		t.Fatalf("acknowledge: %v", err)
@@ -149,10 +149,10 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 
 	// Now: one new activity, one real stage move, and one NEW deal — whose
 	// creation writes a first-stage history row that must not count as a move.
-	fresh := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'after the visit', '2026-06-15T09:00:00Z', '2026-06-15T09:00:00Z', 'manual', 'human:x')`, e.WS)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, fresh, org.UUID)
+	fresh := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'note', 'after the visit', '2026-06-15T09:00:00Z', '2026-06-15T09:00:00Z', 'manual', 'human:x')`)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, fresh, org.UUID)
 	created := e.SeedDeal(t, "Brand new deal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, created, org.UUID)
 	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](before), deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: integration.WonByImport()}); err != nil {
@@ -190,10 +190,10 @@ func TestOrganization360CountsTheWholeHistoryOnAFirstVisit(t *testing.T) {
 	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	logged := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'first contact', now(), 'manual', 'human:x')`, e.WS)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, logged, org.UUID)
+	logged := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'first contact', now(), 'manual', 'human:x')`)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, logged, org.UUID)
 
 	view, err := svc.Assemble(e.Admin(), org)
 	if err != nil {

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -88,12 +88,11 @@ func seedRollupFxRate(t *testing.T, e *Env, fromCurrency, rate string, day time.
 func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.Time) {
 	t.Helper()
 	activityID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'rollup touch', $3, 'manual', 'human:test')`,
-		activityID, e.WS, occurredAt)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`,
-		e.WS, activityID, org)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'rollup touch', $2, 'manual', 'human:test')`,
+		activityID, occurredAt)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, activityID, org)
 }
 
 // seedRollupDealLinkedActivity files one activity against a DEAL of the
@@ -106,12 +105,11 @@ func seedRollupDealLinkedActivity(t *testing.T, e *Env, st rollupStages, org ids
 		VALUES ($1, 'Deal With Mail', $2, $3, $4, 'open', 'manual', 'human:test')`,
 		dealID, st.pipeline, st.open, org)
 	activityID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'deal thread', $3, 'manual', 'human:test')`,
-		activityID, e.WS, occurredAt)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-		VALUES ($1, $2, 'deal', $3)`,
-		e.WS, activityID, dealID)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'deal thread', $2, 'manual', 'human:test')`,
+		activityID, occurredAt)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		VALUES ( $1, 'deal', $2)`, activityID, dealID)
 }
 
 // seedRollupPersonLinkedActivity files one activity against a PERSON
@@ -129,12 +127,11 @@ func seedRollupPersonLinkedActivity(t *testing.T, e *Env, org ids.UUID, occurred
 		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:test')`,
 		ids.NewV7(), e.WS, personID, org)
 	activityID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'contact thread', $3, 'connector:gmail', 'connector:gmail')`,
-		activityID, e.WS, occurredAt)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, 'person', $3)`,
-		e.WS, activityID, personID)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'contact thread', $2, 'connector:gmail', 'connector:gmail')`,
+		activityID, occurredAt)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ( $1, 'person', $2)`, activityID, personID)
 }
 
 // rollupOrgReadPerms is the minimal caller the rollup admits: read on
@@ -510,13 +507,13 @@ func TestOrgRollupCountsAnActivityReachingTheTreeTwiceOnlyOnce(t *testing.T) {
 		VALUES ($1, 'Both Links', $2, $3, $4, 'open', 'manual', 'human:test')`,
 		dealID, st.pipeline, st.open, org)
 	activityID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'filed twice', $3, 'manual', 'human:test')`,
-		activityID, e.WS, now.Add(-24*time.Hour))
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, activityID, org)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-		VALUES ($1, $2, 'deal', $3)`, e.WS, activityID, dealID)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'filed twice', $2, 'manual', 'human:test')`,
+		activityID, now.Add(-24*time.Hour))
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, activityID, org)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		VALUES ( $1, 'deal', $2)`, activityID, dealID)
 
 	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, org, "self", fixedClock(now))
 	if err != nil {

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -179,7 +179,7 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 	assertCount("reconstructed organizations", `SELECT count(*) FROM organization WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed leads", `SELECT count(*) FROM lead WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source_system = 'mirror:hubspot'`, 1)
-	assertCount("reconstructed activities", `SELECT count(*) FROM activity WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source_system = 'mirror:hubspot'`, 1)
+	assertCount("reconstructed activities", `SELECT count(*) FROM activity WHERE source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed deal→org FK", `
 		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id
 		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`, 1)
@@ -256,7 +256,7 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 		{"organization", true},
 		{"person", true},
 		{"lead", true},
-		{"activity", true},
+		{"activity", false},
 	} {
 		sql, args := "DELETE FROM "+t2.table, []any(nil)
 		if t2.tenantScoped {

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -504,8 +504,8 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 		WHERE r.kind = 'employment' AND r.is_current_primary AND p.source = 'mirror:hubspot:person:p-1'`)
 	assertOne("activity link", `
 		SELECT count(*) FROM activity_link al
-		JOIN activity a ON a.id = al.activity_id AND a.workspace_id = al.workspace_id
-		JOIN person p ON p.id = al.person_id AND p.workspace_id = al.workspace_id
+		JOIN activity a ON a.id = al.activity_id
+		JOIN person p ON p.id = al.person_id
 		WHERE a.source_system = 'mirror:hubspot' AND p.source = 'mirror:hubspot:person:p-1'`)
 	assertOne("closed-won deal", `
 		SELECT count(*) FROM deal WHERE source = 'mirror:hubspot:deal:d-won' AND status = 'won'`)

--- a/backend/internal/compose/integration/participants_integration_test.go
+++ b/backend/internal/compose/integration/participants_integration_test.go
@@ -31,9 +31,8 @@ import (
 // seedInteraction records one captured email to hang participants off.
 func seedInteraction(t *testing.T, e *Env) ids.ActivityID {
 	t.Helper()
-	id := SeedRow(t, OwnerConn(t), `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'Q3 terms', '2026-08-01T09:00:00Z', 'inbound', 'gmail', 'connector:gmail')`, e.WS)
+	id := SeedIDRow(t, OwnerConn(t), `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', 'Q3 terms', '2026-08-01T09:00:00Z', 'inbound', 'gmail', 'connector:gmail')`)
 	return ids.From[ids.ActivityKind](id)
 }
 
@@ -164,9 +163,8 @@ func TestStampingTheSamePartiesTwiceAddsNothing(t *testing.T) {
 // must not see them.
 func TestANonInteractionKindStampsNoParties(t *testing.T) {
 	e := Setup(t)
-	note := ids.From[ids.ActivityKind](SeedRow(t, OwnerConn(t), `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'thinking', '2026-08-01T09:00:00Z', 'manual', 'human:x')`, e.WS))
+	note := ids.From[ids.ActivityKind](SeedIDRow(t, OwnerConn(t), `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'thinking', '2026-08-01T09:00:00Z', 'manual', 'human:x')`))
 
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -314,9 +314,8 @@ func seedBenchTier(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierSpe
 	// sides' row_numbers forces the planner into a nested loop that is
 	// pathological at the mid-market tier.
 	exec(`WITH act AS (
-	        INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, source, captured_by)
-	        SELECT $1,
-	               CASE WHEN i % 5 = 0 THEN 'task' ELSE 'email' END,
+	        INSERT INTO activity (kind, subject, body, occurred_at, source, captured_by)
+	        SELECT CASE WHEN i % 5 = 0 THEN 'task' ELSE 'email' END,
 	               'Subject ' || i || CASE WHEN i % 101 = 0 THEN ' Hamburg' ELSE '' END,
 	               'Body ' || i,
 	               now() - (i % 720 || ' hours')::interval,
@@ -330,8 +329,8 @@ func seedBenchTier(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierSpe
 	      ), people AS (
 	        SELECT id, row_number() OVER () AS rn FROM person WHERE workspace_id = $1
 	      )
-	      INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-	      SELECT $1, n.id, 'person', p.id
+	      INSERT INTO activity_link (activity_id, entity_type, person_id)
+	      SELECT n.id, 'person', p.id
 	      FROM numbered n JOIN people p ON p.rn = n.target_rn`, ws, spec.bulkActivities)
 
 	// Employment edges for the ADR-0021 edge-count evidence.
@@ -365,9 +364,8 @@ func seedBenchAnchor(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierS
 		t.Fatalf("seeding anchor: %v", err)
 	}
 	benchExec(t, owner, spec.tier, `WITH act AS (
-	        INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, source, captured_by)
-	        SELECT $1,
-	               CASE WHEN i % 4 = 0 THEN 'task' ELSE 'meeting' END,
+	        INSERT INTO activity (kind, subject, body, occurred_at, source, captured_by)
+	        SELECT CASE WHEN i % 4 = 0 THEN 'task' ELSE 'meeting' END,
 	               'Anchor touch ' || i, 'Anchor body ' || i,
 	               now() - (i || ' hours')::interval,
 	               'manual', 'human:bench'
@@ -378,14 +376,14 @@ func seedBenchAnchor(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierS
 	      ), numbered AS (
 	        SELECT id, (row_number() OVER () - 1) % (SELECT n FROM total) + 1 AS target_rn FROM act
 	      ), links AS (
-	        INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-	        SELECT $1, id, 'person', $2 FROM numbered
+	        INSERT INTO activity_link (activity_id, entity_type, person_id)
+	        SELECT id, 'person', $2 FROM numbered
 	        RETURNING activity_id
 	      ), orgs AS (
 	        SELECT id, row_number() OVER () AS rn FROM organization WHERE workspace_id = $1
 	      )
-	      INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-	      SELECT $1, n.id, 'organization', o.id
+	      INSERT INTO activity_link (activity_id, entity_type, organization_id)
+	      SELECT n.id, 'organization', o.id
 	      FROM numbered n JOIN orgs o ON o.rn = n.target_rn`, ws, anchor, spec.anchorTouches)
 	return anchor
 }

--- a/backend/internal/compose/integration/perfrecord_bench_test.go
+++ b/backend/internal/compose/integration/perfrecord_bench_test.go
@@ -215,10 +215,10 @@ func recordBenchSeeds(workspace string) []struct {
 		{"organizations", `INSERT INTO organization (workspace_id, display_name, source, captured_by)
 		   SELECT $1, 'Bench Org ' || i, 'manual', 'human:bench'
 		   FROM generate_series(1, $2) AS i`, []any{workspace, recordBenchOrganizations}},
-		{"activities", `INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, source, captured_by)
-		   SELECT $1, 'email', 'Bench subject ' || i, 'Bench body ' || i,
+		{"activities", `INSERT INTO activity (kind, subject, body, occurred_at, source, captured_by)
+		   SELECT 'email', 'Bench subject ' || i, 'Bench body ' || i,
 		          now() - (i % 720 || ' hours')::interval, 'manual', 'human:bench'
-		   FROM generate_series(1, $2) AS i`, []any{workspace, recordBenchActivities}},
+		   FROM generate_series(1, $1) AS i`, []any{recordBenchActivities}},
 		// The planner chooses differently against stale statistics, and a
 		// benchmark that measures the plan for an empty table is measuring the
 		// fixture rather than the product.

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -327,16 +327,14 @@ func TestPerson360AssemblesEverySectionFromRealRows(t *testing.T) {
 
 	// One inbound message and one open task: the timeline, the last-touch
 	// pair and the next-steps section each read a different slice of these.
-	inbound := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'Re: pricing', 'body', '2026-08-01T09:00:00Z',
-		        'inbound', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, inbound, "person", mine)
-	task := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, due_at, is_done, source, captured_by)
-		VALUES ($1, $2, 'task', 'Send the quote', '2026-07-28T09:00:00Z', '2026-07-30T09:00:00Z',
-		        false, 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, task, "person", mine)
+	inbound := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', 'Re: pricing', 'body', '2026-08-01T09:00:00Z',
+		        'inbound', 'manual', 'human:x')`)
+	LinkActivity(t, owner, inbound, "person", mine)
+	task := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, is_done, source, captured_by)
+		VALUES ($1, 'task', 'Send the quote', '2026-07-28T09:00:00Z', '2026-07-30T09:00:00Z',
+		        false, 'manual', 'human:x')`)
+	LinkActivity(t, owner, task, "person", mine)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 	page, err := personRoomService(e).Assemble(rep, ids.From[ids.PersonKind](mine))
@@ -396,11 +394,10 @@ func TestADismissalHoldsUntilTheEvidenceMoves(t *testing.T) {
 	owner := OwnerConn(t)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
 	// We wrote and they never answered: the gone-quiet rung.
-	outbound := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'Following up', 'body', $3,
-		        'outbound', 'manual', 'human:x')`, e.WS, roomAgo(20*24*time.Hour))
-	LinkActivity(t, owner, e.WS, outbound, "person", mine)
+	outbound := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', 'Following up', 'body', $2,
+		        'outbound', 'manual', 'human:x')`, roomAgo(20*24*time.Hour))
+	LinkActivity(t, owner, outbound, "person", mine)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 	svc := personRoomService(e)
@@ -432,11 +429,10 @@ func TestADismissalHoldsUntilTheEvidenceMoves(t *testing.T) {
 
 	// Now they reply. The evidence the dismissal was held against has moved,
 	// so the page must speak again rather than stay quiet about the new fact.
-	inbound := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', 'Re: Following up', 'body', $3,
-		        'inbound', 'manual', 'human:x')`, e.WS, roomAgo(time.Hour))
-	LinkActivity(t, owner, e.WS, inbound, "person", mine)
+	inbound := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', 'Re: Following up', 'body', $2,
+		        'inbound', 'manual', 'human:x')`, roomAgo(time.Hour))
+	LinkActivity(t, owner, inbound, "person", mine)
 
 	reArmed, err := svc.Assemble(rep, personID)
 	if err != nil {
@@ -472,10 +468,9 @@ func TestRelationshipChangesAreDerivedFromTheTimeline(t *testing.T) {
 	// A long silence, then their reply. roomFixedNow is 2026-08-04, so the
 	// silence the reply broke is 48 days and the reply itself is 3 days old.
 	for _, at := range []string{"2026-06-14T09:00:00Z", "2026-08-01T09:00:00Z"} {
-		id := SeedRow(t, owner, `INSERT INTO activity
-			(id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'thread', '`+at+`', 'inbound', 'manual', 'human:x')`, e.WS)
-		LinkActivity(t, owner, e.WS, id, "person", mine)
+		id := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+			VALUES ($1, 'email', 'thread', '`+at+`', 'inbound', 'manual', 'human:x')`)
+		LinkActivity(t, owner, id, "person", mine)
 	}
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
@@ -621,11 +616,10 @@ func TestThePerson360TimelineNamesTheTransportThatCarriedAMessage(t *testing.T) 
 	// telegram, because it is registered by the core migration on every
 	// installation — the FK on activity.channel_provider means an unregistered
 	// name could not be seeded at all, and this test is about the read.
-	message := SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, channel_provider, body, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'message', 'telegram', 'they wrote', '2026-08-01T09:00:00Z',
-		        'inbound', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, message, "person", mine)
+	message := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, channel_provider, body, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'message', 'telegram', 'they wrote', '2026-08-01T09:00:00Z',
+		        'inbound', 'manual', 'human:x')`)
+	LinkActivity(t, owner, message, "person", mine)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 	page, err := personRoomService(e).Assemble(rep, ids.From[ids.PersonKind](mine))

--- a/backend/internal/compose/integration/persongraph_integration_test.go
+++ b/backend/internal/compose/integration/persongraph_integration_test.go
@@ -70,20 +70,20 @@ func seedExchange(t *testing.T, e *Env, colleague, person ids.UUID, subject stri
 	ctx := context.Background()
 	id := ids.NewV7()
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-		VALUES ($1, $2, 'email', $3, now(), 'outbound', 'manual', 'human:x')`,
-		id, e.WS, subject); err != nil {
+		INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+		VALUES ($1, 'email', $2, now(), 'outbound', 'manual', 'human:x')`,
+		id, subject); err != nil {
 		t.Fatalf("seeding the exchange: %v", err)
 	}
-	LinkActivity(t, owner, e.WS, id, "person", person)
+	LinkActivity(t, owner, id, "person", person)
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-		VALUES ($1, $2, $3, 'from')`, e.WS, id, colleague); err != nil {
+		INSERT INTO activity_participant (activity_id, user_id, role)
+		VALUES ( $1, $2, 'from')`, id, colleague); err != nil {
 		t.Fatalf("seeding our side: %v", err)
 	}
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-		VALUES ($1, $2, $3, 'to')`, e.WS, id, person); err != nil {
+		INSERT INTO activity_participant (activity_id, person_id, role)
+		VALUES ( $1, $2, 'to')`, id, person); err != nil {
 		t.Fatalf("seeding their side: %v", err)
 	}
 	wsCtx := principal.WithWorkspaceID(ctx, e.WS)

--- a/backend/internal/compose/integration/pipelinetrace_integration_test.go
+++ b/backend/internal/compose/integration/pipelinetrace_integration_test.go
@@ -65,11 +65,9 @@ func seedTracedMessage(t *testing.T, e *Env, owner ids.UUID, in seed) seededMess
 	// key on this address.
 	counterparty := "dana-" + in.trace.SourceID + "@client.io"
 	e.WsExec(t, `
-		INSERT INTO activity (id, workspace_id, kind, occurred_at, source, captured_by,
-		                      counterparty_email, subject, channel_provider,
-		                      source_system, source_id)
-		VALUES ($1, $2, $3, now(), $4, $5, $6, 'Q3 pricing', nullif($7, ''), $4, $8)`,
-		activityID, e.WS, in.kind, in.trace.SourceSystem,
+		INSERT INTO activity (id, kind, occurred_at, source, captured_by, counterparty_email, subject, channel_provider, source_system, source_id)
+		VALUES ($1, $2, now(), $3, $4, $5, 'Q3 pricing', nullif($6, ''), $3, $7)`,
+		activityID, in.kind, in.trace.SourceSystem,
 		// The provenance the sink stamps when a granting human exists
 		// (connectorProvenance): connector:<CONNECTOR NAME>:<user>. The connector
 		// name, not the source system — they coincide for gmail and diverge for a
@@ -232,7 +230,7 @@ func TestTheTraceDoorWithholdsAnActivityOutsideTheReadersRowScope(t *testing.T) 
 	owner := OwnerConn(t)
 	msg := seedTracedMessage(t, e, e.Rep1, capturedMail("hidden-activity"))
 	theirPerson := e.SeedPerson(t, "Out Of Reach", &e.Rep3)
-	LinkActivity(t, owner, e.WS, msg.activityID, "person", theirPerson)
+	LinkActivity(t, owner, msg.activityID, "person", theirPerson)
 
 	narrow := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
 	got, err := ladderAssembler(e, false).ByTraceID(narrow, msg.traceID)
@@ -268,7 +266,7 @@ func TestTheActivityDoorRefusesAMessageOutsideTheReadersRowScope(t *testing.T) {
 	owner := OwnerConn(t)
 	msg := seedTracedMessage(t, e, e.Rep1, capturedMail("out-of-scope"))
 	theirPerson := e.SeedPerson(t, "Out Of Reach", &e.Rep3)
-	LinkActivity(t, owner, e.WS, msg.activityID, "person", theirPerson)
+	LinkActivity(t, owner, msg.activityID, "person", theirPerson)
 	narrow := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
 
 	_, err := ladderAssembler(e, false).ByActivityID(narrow, msg.activityID)

--- a/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
+++ b/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
@@ -78,18 +78,16 @@ func seedChannelDelivery(t *testing.T, e *Env, age, body, status string, person 
 	out := channelDelivery{person: person, activity: ids.NewV7(), delivery: ids.NewV7()}
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, channel_provider, body, direction, occurred_at,
-			                      source, captured_by, source_system, source_id)
-			VALUES ($1, `+wsClause+`, 'message', 'telegram', $2, 'outbound', now() - $3::interval,
+			INSERT INTO activity (id, kind, channel_provider, body, direction, occurred_at, source, captured_by, source_system, source_id)
+			VALUES ($1, 'message', 'telegram', $2, 'outbound', now() - $3::interval,
 			        'connector:telegram', 'human:x', 'telegram', $4)`,
 			out.activity, body, age, out.activity.String()); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			 VALUES (`+wsClause+`, $1, 'person', $2)`, out.activity, person); err != nil {
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ( $1, 'person', $2)`, out.activity, person); err != nil {
 			return err
 		}
 		// cc and references_chain are named as NULL for the reason

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -116,19 +116,17 @@ func seedAddressedDelivery(t *testing.T, e *Env, age, subject, body, status stri
 	out := delivered{person: linkTo, activity: ids.NewV7(), delivery: ids.NewV7(), subject: subject, status: status}
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, direction, occurred_at,
-			                      source, captured_by, source_system, source_id, counterparty_email)
-			VALUES ($1, `+wsClause+`, 'email', $2, $3, 'outbound', now() - $4::interval,
+			INSERT INTO activity (id, kind, subject, body, direction, occurred_at, source, captured_by, source_system, source_id, counterparty_email)
+			VALUES ($1, 'email', $2, $3, 'outbound', now() - $4::interval,
 			        'manual', 'human:x', 'gmail', $5, $6)`,
 			out.activity, subject, body, age, out.delivery.String()+"@margince.test", addr.counterparty); err != nil {
 			return err
 		}
 		if !linkTo.IsZero() {
 			if _, err := tx.Exec(ctx,
-				`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-				 VALUES (`+wsClause+`, $1, 'person', $2)`, out.activity, linkTo); err != nil {
+				`INSERT INTO activity_link (activity_id, entity_type, person_id)
+				 VALUES ( $1, 'person', $2)`, out.activity, linkTo); err != nil {
 				return err
 			}
 		}
@@ -388,8 +386,8 @@ func linkToHeldDeal(t *testing.T, e *Env, activityID ids.UUID) {
 	dealID := e.SeedDeal(t, "Disputed renewal", pipeline, open, nil)
 	e.WsExec(t, `UPDATE deal SET legal_hold = true WHERE id = $1`, dealID)
 	e.WsExec(t,
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-		 VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'deal', $2)`,
+		`INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		 VALUES ( $1, 'deal', $2)`,
 		activityID, dealID)
 }
 

--- a/backend/internal/compose/integration/recordcontext_http_integration_test.go
+++ b/backend/internal/compose/integration/recordcontext_http_integration_test.go
@@ -89,8 +89,8 @@ func seedMeetingLinkedTo(t *testing.T, e *apptest.AppEnv, personID string) strin
 		t.Fatalf("reading the workspace: %v", err)
 	}
 	if _, err := e.Owner.Exec(t.Context(), `
-		INSERT INTO activity_participant (workspace_id, activity_id, role, address)
-		VALUES ($1, $2, 'attendee', 'nobody@example.test')`, wsID, meeting.ID); err != nil {
+		INSERT INTO activity_participant (activity_id, role, address)
+		VALUES ( $1, 'attendee', 'nobody@example.test')`, meeting.ID); err != nil {
 		t.Fatalf("seeding the unmatched attendee: %v", err)
 	}
 	return meeting.ID

--- a/backend/internal/compose/integration/replyaddress_integration_test.go
+++ b/backend/internal/compose/integration/replyaddress_integration_test.go
@@ -36,9 +36,9 @@ type replyParty struct {
 func seedReplyThread(t *testing.T, e *Env, direction string, parties ...replyParty) ids.ActivityID {
 	t.Helper()
 	owner := OwnerConn(t)
-	activity := SeedRow(t, owner, `
-		INSERT INTO activity (id, workspace_id, kind, direction, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', '`+direction+`', 'Kickoff', now(), 'test', 'human:seed')`, e.WS)
+	activity := SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, direction, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', '`+direction+`', 'Kickoff', now(), 'test', 'human:seed')`)
 	for _, p := range parties {
 		var userID *ids.UUID
 		if p.ours {
@@ -46,9 +46,9 @@ func seedReplyThread(t *testing.T, e *Env, direction string, parties ...replyPar
 			userID = &id
 		}
 		e.WsExec(t, `
-			INSERT INTO activity_participant (id, workspace_id, activity_id, role, person_id, user_id, address)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-			ids.NewV7(), e.WS, activity, p.role, p.person, userID, p.address)
+			INSERT INTO activity_participant (id, activity_id, role, person_id, user_id, address)
+			VALUES ($1, $2, $3, $4, $5, $6)`,
+			ids.NewV7(), activity, p.role, p.person, userID, p.address)
 	}
 	return ids.From[ids.ActivityKind](activity)
 }

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -197,11 +197,11 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 		t.Fatal(err)
 	}
 	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Graph Contact', 'manual', 'human:x')`)
-	noteID := e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, source, captured_by) VALUES ($1, $2, 'note', 'Kickoff call', 'manual', 'human:x')`)
-	taskID := e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, is_done, source, captured_by) VALUES ($1, $2, 'task', 'Send offer', false, 'manual', 'human:x')`)
+	noteID := e.SeedID(t, `INSERT INTO activity (id, kind, subject, source, captured_by) VALUES ($1, 'note', 'Kickoff call', 'manual', 'human:x')`)
+	taskID := e.SeedID(t, `INSERT INTO activity (id, kind, subject, is_done, source, captured_by) VALUES ($1, 'task', 'Send offer', false, 'manual', 'human:x')`)
 	for _, activityID := range []ids.UUID{noteID, taskID} {
-		e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, deal_id) VALUES ($1, $2, $3, 'deal', $4)`, activityID, dealID)
-		e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, activityID, personID)
+		e.SeedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, deal_id) VALUES ($1, $2, 'deal', $3)`, activityID, dealID)
+		e.SeedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id) VALUES ($1, $2, 'person', $3)`, activityID, personID)
 	}
 
 	// AssembleContext never calls the embedder (it's Search's seam), but

--- a/backend/internal/compose/integration/retention_authoring_integration_test.go
+++ b/backend/internal/compose/integration/retention_authoring_integration_test.go
@@ -568,8 +568,8 @@ func TestRetentionAnonymizesAnUnattachedPersonAndArchivesAnAgedNote(t *testing.T
 	// it carries no statutory floor and the 1095-day archive reaches it. An email
 	// of the same age would be shielded, which is the boundary
 	// correspondenceFloorPredicate exists to draw.
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-		VALUES ($1, `+wsClause+`, 'note', 'Old internal note', 'nothing sensitive', now() - interval '1200 days', 'manual', 'human:x')`,
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Old internal note', 'nothing sensitive', now() - interval '1200 days', 'manual', 'human:x')`,
 		noteID)
 
 	svc := privacy.NewRetentionService(e.DB(), nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))

--- a/backend/internal/compose/integration/retention_integration_test.go
+++ b/backend/internal/compose/integration/retention_integration_test.go
@@ -50,8 +50,8 @@ func seedOverAgeRecords(t *testing.T, e *Env) (staleLead, heldLead, staleDeal, t
 				[]any{heldLead},
 			},
 			{
-				`INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, source_system, source_id, captured_by)
-			  VALUES ($1, ` + wsClause + `, 'note', 'Transcript', 'sensitive words', now() - interval '400 days', 'capture', 'transcript', 't-1', 'connector:t')`,
+				`INSERT INTO activity (id, kind, subject, body, occurred_at, source, source_system, source_id, captured_by)
+			  VALUES ($1, 'note', 'Transcript', 'sensitive words', now() - interval '400 days', 'capture', 'transcript', 't-1', 'connector:t')`,
 				[]any{transcript},
 			},
 		} {

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -48,21 +48,20 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 	unlinkedEmail := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO retention_policy (object_type, category, retain_days, action)
 			VALUES ('activity', NULL, 100, 'erase')`); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'email', 'Order confirmation', 'commercial content', now() - interval '400 days', 'capture', 'connector:t')`,
+			INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, 'email', 'Order confirmation', 'commercial content', now() - interval '400 days', 'capture', 'connector:t')`,
 			email); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'note', 'Old scratch note', 'ephemeral', now() - interval '400 days', 'capture', 'connector:t')`,
+			INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, 'note', 'Old scratch note', 'ephemeral', now() - interval '400 days', 'capture', 'connector:t')`,
 			note); err != nil {
 			return err
 		}
@@ -75,8 +74,8 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		// transport carried it. Pinned here so a later narrowing of the
 		// predicate to a NAMED list fails instead of silently unshielding it.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, channel_provider, subject, body, occurred_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'message', 'telegram', NULL, 'commercial content', now() - interval '400 days', 'capture', 'connector:t')`,
+			INSERT INTO activity (id, kind, channel_provider, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, 'message', 'telegram', NULL, 'commercial content', now() - interval '400 days', 'capture', 'connector:t')`,
 			message); err != nil {
 			return err
 		}
@@ -84,16 +83,16 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		// An occurrence-anchored 6y floor would already expose it; the
 		// calendar-year-end anchor keeps it until its year's end + 6y.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'email', 'January Handelsbrief', 'commercial content',
+			INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, 'email', 'January Handelsbrief', 'commercial content',
 			        date_trunc('year', now() - interval '6 years') + interval '14 days', 'capture', 'connector:t')`,
 			janEmail); err != nil {
 			return err
 		}
 		// The control: same age, same kind, no transaction behind it.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-			VALUES ($1, `+wsClause+`, 'email', 'Lunch next Tuesday?', 'no transaction here', now() - interval '400 days', 'capture', 'connector:t')`,
+			INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+			VALUES ($1, 'email', 'Lunch next Tuesday?', 'no transaction here', now() - interval '400 days', 'capture', 'connector:t')`,
 			unlinkedEmail); err != nil {
 			return err
 		}
@@ -120,8 +119,8 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		}
 		for _, a := range []ids.UUID{email, janEmail, message} {
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-				VALUES (`+wsClause+`, $1, 'deal', $2)`, a, deal); err != nil {
+				INSERT INTO activity_link (activity_id, entity_type, deal_id)
+				VALUES ( $1, 'deal', $2)`, a, deal); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/integration/retention_stamp_integration_test.go
+++ b/backend/internal/compose/integration/retention_stamp_integration_test.go
@@ -49,11 +49,11 @@ func seedStampFixture(t *testing.T, e *Env) stampFixture {
 
 	// Filed against the deal while it is still open, which is the ordinary
 	// order: the correspondence exists before the deal concludes.
-	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'Order confirmation', 'the agreed price was 4200 EUR', now(), 'manual', 'human:x')`,
-		email, e.WS)
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
-		VALUES ($1, $2, 'deal', $3)`, e.WS, email, deal)
+	e.WsExec(t, `INSERT INTO activity (id, kind, subject, body, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Order confirmation', 'the agreed price was 4200 EUR', now(), 'manual', 'human:x')`,
+		email)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		VALUES ( $1, 'deal', $2)`, email, deal)
 
 	return stampFixture{deal: deal, wonStage: ids.StageID{UUID: wonStage}, email: email}
 }

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -57,7 +57,7 @@ func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Heike Hamburg', 'manual', 'human:x')`)
 	e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Hamburg Logistics GmbH', 'manual', 'human:x')`)
 	e.Seed(t, `INSERT INTO lead (id, workspace_id, company_name, email, source, captured_by) VALUES ($1, $2, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
-	e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, source, captured_by) VALUES ($1, $2, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO activity (id, kind, subject, body, source, captured_by) VALUES ($1, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
 	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unrelated Munich', 'manual', 'human:x')`)
 
 	page, err := e.Store.Search(e.Admin(), search.Input{Query: "hamburg"})

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -73,19 +73,19 @@ func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, direc
 		// fixture input stays data even when a caller passes something unexpected.
 		touch := ids.NewV7()
 		if _, err := owner.Exec(context.Background(), `INSERT INTO activity
-			(id, workspace_id, kind, subject, occurred_at, created_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'touch', $3, $3, $4, 'manual', 'human:x')`,
-			touch, e.WS, stakeholderTouchedAt, direction); err != nil {
+			(id, kind, subject, occurred_at, created_at, direction, source, captured_by)
+			VALUES ($1, 'email', 'touch', $2, $2, $3, 'manual', 'human:x')`,
+			touch, stakeholderTouchedAt, direction); err != nil {
 			t.Fatalf("seeding %q touch: %v", direction, err)
 		}
-		LinkActivity(t, owner, e.WS, touch, "person", person)
+		LinkActivity(t, owner, touch, "person", person)
 	}
 	return person
 }
 
 // LinkActivity attaches an activity to a person or deal through the
 // polymorphic link table.
-func LinkActivity(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityType string, entity ids.UUID) {
+func LinkActivity(t *testing.T, owner *pgx.Conn, activity ids.UUID, entityType string, entity ids.UUID) {
 	t.Helper()
 	column := "deal_id"
 	switch entityType {
@@ -95,8 +95,8 @@ func LinkActivity(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityTy
 		column = "organization_id"
 	}
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, `+column+`) VALUES ($1, $2, $3, $4)`,
-		ws, activity, entityType, entity); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, `+column+`) VALUES ($1, $2, $3)`,
+		activity, entityType, entity); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -158,8 +158,8 @@ func SeedIDRow(t *testing.T, owner *pgx.Conn, sql string, args ...any) ids.UUID 
 // covers only the person and deal columns).
 func LinkToOrg(t *testing.T, e *Env, activity, org ids.UUID) {
 	t.Helper()
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, activity, org)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ($1, 'organization', $2)`, activity, org)
 }
 
 // AccountMailDirectedAt seeds one message with an explicit direction, which is
@@ -169,9 +169,9 @@ func AccountMailDirectedAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject, 
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(), `INSERT INTO activity
-		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
-		VALUES ($1, $2, 'email', $3, $4, $5, $5, 'manual', 'human:x')`,
-		id, ws, direction, subject, at); err != nil {
+		(id, kind, direction, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'email', $2, $3, $4, $4, 'manual', 'human:x')`,
+		id, direction, subject, at); err != nil {
 		t.Fatalf("seeding %q: %v", subject, err)
 	}
 	return id

--- a/backend/internal/compose/integration/signalextract_integration_test.go
+++ b/backend/internal/compose/integration/signalextract_integration_test.go
@@ -60,7 +60,7 @@ func (b *scriptedBrain) Complete(_ context.Context, _ model.Request) (model.Resp
 func seedMessage(t *testing.T, e *Env, contact ids.UUID, key, subject, body, direction string, at time.Time) ids.UUID {
 	t.Helper()
 	id := seedUnlinkedMessage(t, e, key, subject, body, direction, at)
-	LinkActivity(t, OwnerConn(t), e.WS, id, "person", contact)
+	LinkActivity(t, OwnerConn(t), id, "person", contact)
 	return id
 }
 
@@ -70,11 +70,9 @@ func seedMessage(t *testing.T, e *Env, contact ids.UUID, key, subject, body, dir
 func seedUnlinkedMessage(t *testing.T, e *Env, key, subject, body, direction string, at time.Time) ids.UUID {
 	t.Helper()
 	stamp := at.UTC().Format(time.RFC3339Nano)
-	return SeedRow(t, OwnerConn(t), `INSERT INTO activity
-		(id, workspace_id, kind, direction, subject, body, thread_key, occurred_at, created_at,
-		 source, captured_by)
-		VALUES ($1, $2, 'email', '`+direction+`', '`+subject+`', '`+body+`', '`+key+`',
-		        '`+stamp+`', '`+stamp+`', 'gmail', 'connector:gmail')`, e.WS)
+	return SeedIDRow(t, OwnerConn(t), `INSERT INTO activity (id, kind, direction, subject, body, thread_key, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'email', '`+direction+`', '`+subject+`', '`+body+`', '`+key+`',
+		        '`+stamp+`', '`+stamp+`', 'gmail', 'connector:gmail')`)
 }
 
 // employeeOf is a contact who works at the account, which is the only way
@@ -293,7 +291,7 @@ func TestAThreadReachesTheAccountThroughItsDealAlone(t *testing.T) {
 	unattached := e.SeedPerson(t, "Unaffiliated Ursula", &e.Rep1)
 	notice := seedMessage(t, e, unattached, "thread-deal", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", extractClock.Add(-48*time.Hour))
-	LinkActivity(t, OwnerConn(t), e.WS, notice, "deal", deal)
+	LinkActivity(t, OwnerConn(t), notice, "deal", deal)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}
@@ -438,8 +436,8 @@ func TestAThreadLinkedStraightToTheAccountIsStillRead(t *testing.T) {
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	notice := seedUnlinkedMessage(t, e, "thread-direct", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", extractClock.Add(-48*time.Hour))
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, notice, org)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
+		VALUES ( $1, 'organization', $2)`, notice, org)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}

--- a/backend/internal/compose/integration/signalscan_integration_test.go
+++ b/backend/internal/compose/integration/signalscan_integration_test.go
@@ -57,7 +57,7 @@ func mailViaEmployee(t *testing.T, e *Env, org ids.UUID, subject, direction stri
 	t.Helper()
 	owner := OwnerConn(t)
 	id := AccountMailDirectedAt(t, owner, e.WS, subject, direction, at)
-	LinkActivity(t, owner, e.WS, id, "person", employeeOf(t, e, org, subject+" contact"))
+	LinkActivity(t, owner, id, "person", employeeOf(t, e, org, subject+" contact"))
 }
 
 func openSignalKinds(t *testing.T, e *Env, org ids.UUID) []string {

--- a/backend/internal/compose/integration/strength_integration_test.go
+++ b/backend/internal/compose/integration/strength_integration_test.go
@@ -43,24 +43,24 @@ func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 			direction = "outbound"
 		}
 		occurred := now.AddDate(0, 0, -(5 + i*3))
-		activity := SeedRow(t, owner, fmt.Sprintf(
-			`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			 VALUES ($1, $2, 'email', 'touch', '%s', '%s', 'manual', 'human:x')`,
+		activity := SeedIDRow(t, owner, fmt.Sprintf(
+			`INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
+			 VALUES ($1, 'email', 'touch', '%s', '%s', 'manual', 'human:x')`,
 			occurred.Format(time.RFC3339), direction,
-		), e.WS)
+		))
 		if _, err := owner.Exec(context.Background(),
-			`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, 'person', $3)`,
-			e.WS, activity, person); err != nil {
+			`INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ( $1, 'person', $2)`,
+			activity, person); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// A lead with its own linked activity: never an input (ADR-0008).
 	lead := SeedRow(t, owner, `INSERT INTO lead (id, workspace_id, full_name, email, source, captured_by) VALUES ($1, $2, 'Cold Lead', 'cold@lead.test', 'import', 'human:x')`, e.WS)
-	leadTouch := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by) VALUES ($1, $2, 'email', 'lead touch', now(), 'inbound', 'manual', 'human:x')`, e.WS)
+	leadTouch := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by) VALUES ($1, 'email', 'lead touch', now(), 'inbound', 'manual', 'human:x')`)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, lead_id) VALUES ($1, $2, 'lead', $3)`,
-		e.WS, leadTouch, lead); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, lead_id) VALUES ( $1, 'lead', $2)`,
+		leadTouch, lead); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/timescan_integration_test.go
+++ b/backend/internal/compose/integration/timescan_integration_test.go
@@ -128,12 +128,12 @@ func seedGenuineTouch(t *testing.T, owner *pgx.Conn, ws, dealID ids.UUID, kind s
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, $2, $3, 'Genuine engagement', $4, 'manual', 'human:x')`,
-		id, ws, kind, at); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, $2, 'Genuine engagement', $3, 'manual', 'human:x')`,
+		id, kind, at); err != nil {
 		t.Fatalf("seeding a genuine %s touch: %v", kind, err)
 	}
-	LinkActivity(t, owner, ws, id, "deal", dealID)
+	LinkActivity(t, owner, id, "deal", dealID)
 }
 
 // seedNoActivityReminder enrolls one enabled, ownerless no_activity_reminder

--- a/backend/internal/compose/offerdraft_integration_test.go
+++ b/backend/internal/compose/offerdraft_integration_test.go
@@ -87,12 +87,12 @@ func seedDraftOfferWithDealActivity(ctx context.Context, t *testing.T, e *integr
 	owner := integration.OwnerConn(t)
 	activityID := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, $2, 'note', $3, '2026-07-01T10:00:00Z', 'manual', 'human:x')`,
-		activityID, e.WS, subjectText); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'note', $2, '2026-07-01T10:00:00Z', 'manual', 'human:x')`,
+		activityID, subjectText); err != nil {
 		t.Fatalf("seed deal activity: %v", err)
 	}
-	integration.LinkActivity(t, owner, e.WS, activityID, "deal", dealID)
+	integration.LinkActivity(t, owner, activityID, "deal", dealID)
 
 	return ids.From[ids.OfferKind](ids.UUID(created.Id)), "activity:" + activityID.String()
 }

--- a/backend/internal/compose/orgconnections_integration_test.go
+++ b/backend/internal/compose/orgconnections_integration_test.go
@@ -72,23 +72,22 @@ func TestConnectorCapturedMailPutsAColleagueOnTheAccount(t *testing.T) {
 	var activityID ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (`+wsClause+`, 'email', 'Angebot', 'inbound', $1, 'gmail:m-1', 'connector:gmail')
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES ( 'email', 'Angebot', 'inbound', $1, 'gmail:m-1', 'connector:gmail')
 			RETURNING id`, now.AddDate(0, 0, -1)).Scan(&activityID); err != nil {
 			return err
 		}
 		// The participant rows capture stamps: the mailbox owner and the
 		// counterparty. This is the fact the old derivation had no access to.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (`+wsClause+`, $1, $2, 'to')`, activityID, owner); err != nil {
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, 'to')`, activityID, owner); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (`+wsClause+`, $1, $2, 'from')`, activityID, contact)
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'from')`, activityID, contact)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding connector-captured mail: %v", err)
@@ -126,21 +125,20 @@ func TestADepartedColleagueIsNotOfferedAsAWayIn(t *testing.T) {
 	var activityID ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-			VALUES (`+wsClause+`, 'email', 'Alt', 'outbound', $1, 'manual', 'human:test')
+			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+			VALUES ( 'email', 'Alt', 'outbound', $1, 'manual', 'human:test')
 			RETURNING id`, now.AddDate(0, 0, -2)).Scan(&activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-			VALUES (`+wsClause+`, $1, $2, 'from')`, activityID, e.Rep2); err != nil {
+			INSERT INTO activity_participant (activity_id, user_id, role)
+			VALUES ( $1, $2, 'from')`, activityID, e.Rep2); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-			VALUES (`+wsClause+`, $1, $2, 'to')`, activityID, contact)
+			INSERT INTO activity_participant (activity_id, person_id, role)
+			VALUES ( $1, $2, 'to')`, activityID, contact)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the interaction: %v", err)

--- a/backend/internal/compose/participantbackfill_integration_test.go
+++ b/backend/internal/compose/participantbackfill_integration_test.go
@@ -40,9 +40,8 @@ func seedLegacyActivity(t *testing.T, e *integration.Env, sourceID, capturedBy, 
 	var id ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at,
-			                      source_system, source_id, source, captured_by, counterparty_email)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (kind, subject, direction, occurred_at, source_system, source_id, source, captured_by, counterparty_email)
+			VALUES (
 			        'email', 'Alt', $1, now(), 'gmail', $2, $3, $4, $5)
 			RETURNING id`,
 			direction, sourceID, "gmail:"+sourceID, capturedBy, counterparty).Scan(&id)
@@ -222,9 +221,8 @@ func seedLegacyActivityOfKind(t *testing.T, e *integration.Env, sourceID, captur
 	var id ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at,
-			                      source_system, source_id, source, captured_by, counterparty_email)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (kind, subject, direction, occurred_at, source_system, source_id, source, captured_by, counterparty_email)
+			VALUES (
 			        $1, 'Alt', 'outbound', now(), 'gmail', $2, $3, $4, 'pat@counterparty.test')
 			RETURNING id`, kind, sourceID, "gmail:"+sourceID, capturedBy).Scan(&id)
 	}); err != nil {

--- a/backend/internal/compose/participantreplay_integration_test.go
+++ b/backend/internal/compose/participantreplay_integration_test.go
@@ -40,10 +40,9 @@ func replayCtx(e *integration.Env) context.Context {
 func seedReplayableMail(t *testing.T, e *integration.Env, sourceID, raw string) ids.UUID {
 	t.Helper()
 	owner := integration.OwnerConn(t)
-	id := integration.SeedRow(t, owner, `INSERT INTO activity
-		(id, workspace_id, kind, subject, occurred_at, direction, source_system, source_id, source, captured_by)
-		VALUES ($1, $2, 'email', 'Q3 terms', '2026-08-01T09:00:00Z', 'inbound',
-		        'gmail', '`+sourceID+`', 'gmail:`+sourceID+`', 'connector:gmail')`, e.WS)
+	id := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source_system, source_id, source, captured_by)
+		VALUES ($1, 'email', 'Q3 terms', '2026-08-01T09:00:00Z', 'inbound',
+		        'gmail', '`+sourceID+`', 'gmail:`+sourceID+`', 'connector:gmail')`)
 	if _, err := owner.Exec(context.Background(), `
 		INSERT INTO raw_capture (source_system, source_id, payload)
 		VALUES ('gmail', $1, to_jsonb($2::text))`, sourceID, raw); err != nil {

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -114,8 +114,8 @@ func seedReplyAnchor(t *testing.T, e *integration.Env) ids.UUID {
 	id := ids.NewV7()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1,
 			        'email', 'Pricing question', now(), 'manual', 'human:x')`, id)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -83,9 +83,9 @@ func (e *reconcileEnv) seedInteraction(t *testing.T, dealID ids.UUID, kind, subj
 	id := ids.NewV7()
 	ctx := context.Background()
 	if _, err := e.owner.Exec(ctx,
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, $2, $3, $4, now() - make_interval(hours => $5), 'manual', 'human:x')`,
-		id, e.WS, kind, subject, occurredHoursAgo); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, $2, $3, now() - make_interval(hours => $4), 'manual', 'human:x')`,
+		id, kind, subject, occurredHoursAgo); err != nil {
 		t.Fatalf("seed %s activity: %v", kind, err)
 	}
 	e.linkActivity(t, id, dealID)
@@ -98,10 +98,10 @@ func (e *reconcileEnv) seedTask(t *testing.T, dealID ids.UUID, done bool) ids.UU
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at, is_done, done_at, source, captured_by)
-		 VALUES ($1, $2, 'task', 'Existing next step', now(), now() + interval '2 days', $3,
-		         CASE WHEN $3 THEN now() ELSE NULL END, 'manual', 'human:x')`,
-		id, e.WS, done); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, due_at, is_done, done_at, source, captured_by)
+		 VALUES ($1, 'task', 'Existing next step', now(), now() + interval '2 days', $2,
+		         CASE WHEN $2 THEN now() ELSE NULL END, 'manual', 'human:x')`,
+		id, done); err != nil {
 		t.Fatalf("seed task: %v", err)
 	}
 	e.linkActivity(t, id, dealID)
@@ -111,8 +111,7 @@ func (e *reconcileEnv) seedTask(t *testing.T, dealID ids.UUID, done bool) ids.UU
 func (e *reconcileEnv) linkActivity(t *testing.T, activityID, dealID ids.UUID) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id) VALUES ($1, $2, 'deal', $3)`,
-		e.WS, activityID, dealID); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, deal_id) VALUES ( $1, 'deal', $2)`, activityID, dealID); err != nil {
 		t.Fatalf("link activity to deal: %v", err)
 	}
 }

--- a/backend/internal/compose/retentiongraph_integration_test.go
+++ b/backend/internal/compose/retentiongraph_integration_test.go
@@ -56,10 +56,9 @@ func TestRetentionCorrectsTheRelationshipGraphInItsOwnTransaction(t *testing.T) 
 		var id ids.UUID
 		if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 			ctx := context.Background()
-			ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 			if err := tx.QueryRow(ctx, `
-				INSERT INTO activity (workspace_id, kind, subject, direction, occurred_at, source, captured_by)
-				VALUES (`+ws+`, 'email', 'Alt', $1, $2, 'manual', 'human:test')
+				INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
+				VALUES ( 'email', 'Alt', $1, $2, 'manual', 'human:test')
 				RETURNING id`, direction, at).Scan(&id); err != nil {
 				return err
 			}
@@ -68,13 +67,13 @@ func TestRetentionCorrectsTheRelationshipGraphInItsOwnTransaction(t *testing.T) 
 				userRole = "to"
 			}
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO activity_participant (workspace_id, activity_id, user_id, role)
-				VALUES (`+ws+`, $1, $2, $3)`, id, e.Rep1, userRole); err != nil {
+				INSERT INTO activity_participant (activity_id, user_id, role)
+				VALUES ( $1, $2, $3)`, id, e.Rep1, userRole); err != nil {
 				return err
 			}
 			_, err := tx.Exec(ctx, `
-				INSERT INTO activity_participant (workspace_id, activity_id, person_id, role)
-				VALUES (`+ws+`, $1, $2, $3)`, id, contact, personRole)
+				INSERT INTO activity_participant (activity_id, person_id, role)
+				VALUES ( $1, $2, $3)`, id, contact, personRole)
 			return err
 		}); err != nil {
 			t.Fatalf("seeding an interaction: %v", err)

--- a/backend/internal/compose/senddeliverability_integration_test.go
+++ b/backend/internal/compose/senddeliverability_integration_test.go
@@ -52,8 +52,8 @@ func TestToolSurfaceSendCarriesTheUnsubscribeSurface(t *testing.T) {
 	anchorID := ids.NewV7()
 	if err := database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1,
 			        'email', 'Pricing question', now(), 'manual', 'human:x')`, anchorID)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/telegramingest_integration_test.go
+++ b/backend/internal/compose/telegramingest_integration_test.go
@@ -118,7 +118,7 @@ func TestIngestWorkerReestablishesWorkspaceContextFromArgs(t *testing.T) {
 	var sourceID string
 	err = database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`SELECT source_id FROM activity WHERE workspace_id = $1 AND source_system = 'telegram'`, e.WS,
+			`SELECT source_id FROM activity WHERE source_system = 'telegram'`,
 		).Scan(&sourceID)
 	})
 	if err != nil {
@@ -210,7 +210,7 @@ func TestIngestWorkerAppliesMembershipWithoutCapturingAnActivity(t *testing.T) {
 		t.Fatalf("Work: %v", err)
 	}
 
-	if n := e.WsCount(t, `SELECT count(*) FROM activity WHERE workspace_id = $1 AND source_system = 'telegram'`, e.WS); n != 0 {
+	if n := e.WsCount(t, `SELECT count(*) FROM activity WHERE source_system = 'telegram'`); n != 0 {
 		t.Errorf("%d activity rows after a my_chat_member update, want 0 — it is a reachability signal, never a message", n)
 	}
 	if n := e.WsCount(t, `
@@ -267,7 +267,7 @@ func TestIngestWorkerCapturesNothingFromAGroupChat(t *testing.T) {
 		t.Fatalf("Work: %v", err)
 	}
 
-	if n := e.WsCount(t, `SELECT count(*) FROM activity WHERE workspace_id = $1 AND source_system = 'telegram'`, e.WS); n != 0 {
+	if n := e.WsCount(t, `SELECT count(*) FROM activity WHERE source_system = 'telegram'`); n != 0 {
 		t.Errorf("%d activity rows after a group-chat message, want 0", n)
 	}
 	if n := e.WsCount(t, `SELECT count(*) FROM person_channel_identity WHERE channel_user_id = '557'`); n != 0 {

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -559,9 +559,9 @@ func seedReplyActivity(t *testing.T, env *voiceBuildEnv) ids.UUID {
 	id := ids.NewV7()
 	err := database.WithWorkspaceTx(env.owner, env.e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO activity (id, workspace_id, kind, subject, body, source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'email', 'the plan', 'Can you confirm the plan?', 'gmail', $3, 'gmail:'||$3, 'connector:gmail')`,
-			id, env.e.WS, "voice-"+id.String())
+			INSERT INTO activity (id, kind, subject, body, source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'the plan', 'Can you confirm the plan?', 'gmail', $2, 'gmail:'||$2, 'connector:gmail')`,
+			id, "voice-"+id.String())
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -123,7 +123,6 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 	if in.OccurredAt != nil {
 		occurredAt = in.OccurredAt.UTC()
 	}
-	wsID := workspaceID(ctx)
 
 	replay, err := replayedActivity(ctx, tx, in)
 	if err != nil {
@@ -135,14 +134,14 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 
 	id := ids.New[ids.ActivityKind]()
 	_, err = tx.Exec(ctx,
-		`INSERT INTO activity (id, workspace_id, kind, channel_provider, subject, body, occurred_at, direction,
+		`INSERT INTO activity (id, kind, channel_provider, subject, body, occurred_at, direction,
 		                       due_at, remind_at, assignee_id, host_user_id, source_system, source_id, source, captured_by,
 		                       thread_key, counterparty_email, counterparty_outbound_attested)
-		 VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, ''),
-		         NULLIF($18, ''), $19)`,
+		 VALUES ($1, $2, NULLIF($3, ''), $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''),
+		         NULLIF($17, ''), $18)`,
 		// NULLIF on channel_provider: the column FKs into channel_provider, and
 		// '' names no provider, so anything without a transport stores NULL.
-		id, wsID, in.Kind, in.ChannelProvider, in.Subject, in.Body, occurredAt, in.Direction,
+		id, in.Kind, in.ChannelProvider, in.Subject, in.Body, occurredAt, in.Direction,
 		in.DueAt, in.RemindAt, in.AssigneeID, in.HostUserID, in.SourceSystem, in.SourceID, in.Source, by,
 		in.ThreadKey, in.CounterpartyEmail, in.CounterpartyOutboundAttested)
 	if err != nil {
@@ -152,7 +151,7 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 		return crmcontracts.Activity{}, false, err
 	}
 
-	if err := insertActivityLinks(ctx, tx, wsID, id, in.Links); err != nil {
+	if err := insertActivityLinks(ctx, tx, id, in.Links); err != nil {
 		return crmcontracts.Activity{}, false, err
 	}
 	// Who was in it (ACT-DDL-3). After the links, because the counterparty is
@@ -191,8 +190,7 @@ func replayedActivity(ctx context.Context, tx pgx.Tx, in LogActivityInput) (*crm
 	var existing ids.ActivityID
 	err := tx.QueryRow(ctx,
 		`SELECT id FROM activity
-		   WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		     AND source_system = $1 AND source_id = $2`,
+		   WHERE source_system = $1 AND source_id = $2`,
 		*in.SourceSystem, *in.SourceID).Scan(&existing)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -319,7 +317,7 @@ func ListActivitiesTx(ctx context.Context, tx pgx.Tx, in ListActivitiesInput) ([
 	return activities, page, nil
 }
 
-const activityColumns = `a.id, a.workspace_id, a.kind, a.channel_provider, a.subject, a.body, a.occurred_at, a.direction,
+const activityColumns = `a.id, a.kind, a.channel_provider, a.subject, a.body, a.occurred_at, a.direction,
 	a.due_at, a.remind_at, a.assignee_id, a.is_done, a.done_at, a.duration_seconds, a.meeting_status,
 	a.source_system, a.source_id, a.source, a.captured_by, a.version, a.created_at, a.updated_at, a.archived_at,
 	a.thread_key, a.capture_label, a.bulk_mail_attested`
@@ -421,14 +419,14 @@ func attachLinks(ctx context.Context, tx pgx.Tx, activities []crmcontracts.Activ
 
 func scanActivity(row pgx.Row) (crmcontracts.Activity, error) {
 	var a crmcontracts.Activity
-	var id, wsID ids.UUID
+	var id ids.UUID
 	var assigneeID *ids.UUID
 	var kind string
 	var channelProvider, direction, meetingStatus, threadKey, captureLabel *string
 	var bulkMailAttested bool
 	var version int64
 
-	err := row.Scan(&id, &wsID, &kind, &channelProvider, &a.Subject, &a.Body, &a.OccurredAt, &direction,
+	err := row.Scan(&id, &kind, &channelProvider, &a.Subject, &a.Body, &a.OccurredAt, &direction,
 		&a.DueAt, &a.RemindAt, &assigneeID, &a.IsDone, &a.DoneAt, &a.DurationSeconds, &meetingStatus,
 		&a.SourceSystem, &a.SourceId, &a.Source, &a.CapturedBy, &version, &a.CreatedAt, &a.UpdatedAt, &a.ArchivedAt,
 		&threadKey, &captureLabel, &bulkMailAttested)

--- a/backend/internal/modules/activities/activitylinks.go
+++ b/backend/internal/modules/activities/activitylinks.go
@@ -85,7 +85,7 @@ func (e *TooManyLinksError) FieldFault() (field, code, message string) {
 // this is the one statement every writer passes through — the timeline's link
 // vocabulary describes what a message or meeting is ABOUT, and a record set
 // larger than this is about nothing.
-func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput) error {
+func insertActivityLinks(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID, links []ActivityLinkInput) error {
 	if len(links) > maxActivityLinks {
 		return &TooManyLinksError{Count: len(links)}
 	}
@@ -103,8 +103,8 @@ func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, a
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			sprintf(`INSERT INTO activity_link (workspace_id, activity_id, entity_type, %s) VALUES ($1, $2, $3, $4)`, column),
-			wsID, activityID, link.EntityType, link.EntityID); err != nil {
+			sprintf(`INSERT INTO activity_link (activity_id, entity_type, %s) VALUES ($1, $2, $3)`, column),
+			activityID, link.EntityType, link.EntityID); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/modules/activities/capturedfiles.go
+++ b/backend/internal/modules/activities/capturedfiles.go
@@ -233,14 +233,12 @@ func accountForCapturedActivity(
 		SELECT organization_id FROM (
 			SELECT link.organization_id, 0 AS rank
 			  FROM activity_link link
-			 WHERE link.workspace_id = current_setting('app.workspace_id')::uuid
-			   AND link.activity_id = $1 AND link.entity_type = 'organization'
+			 WHERE link.activity_id = $1 AND link.entity_type = 'organization'
 			UNION ALL
 			SELECT d.organization_id, 1 AS rank
 			  FROM activity_link link
 			  JOIN deal d ON d.id = link.deal_id
-			 WHERE link.workspace_id = current_setting('app.workspace_id')::uuid
-			   AND link.activity_id = $1 AND link.entity_type = 'deal'
+			 WHERE link.activity_id = $1 AND link.entity_type = 'deal'
 			   AND d.organization_id IS NOT NULL
 		) candidates
 		 ORDER BY rank, organization_id

--- a/backend/internal/modules/activities/capturelabelstats.go
+++ b/backend/internal/modules/activities/capturelabelstats.go
@@ -27,8 +27,7 @@ func (s *Store) LabeledCaptureCountSince(ctx context.Context, since time.Time) (
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT count(*) FROM activity
-			 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			   AND capture_labeled_at >= $1
+			 WHERE capture_labeled_at >= $1
 			   AND `+auth.ActivityAvailableClause("activity"), since,
 		).Scan(&count)
 	})

--- a/backend/internal/modules/activities/capturenoise.go
+++ b/backend/internal/modules/activities/capturenoise.go
@@ -184,8 +184,8 @@ func (s *Store) RedactCapturedNoiseTx(ctx context.Context, tx pgx.Tx, activityID
 // no-op rather than a duplicate.
 func (s *Store) LinkCapturedMailTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID, email string) error {
 	_, err := tx.Exec(ctx, `
-		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		SELECT a.workspace_id, a.id, 'person', $2
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		SELECT a.id, 'person', $2
 		  FROM activity a
 		 WHERE a.counterparty_email = $1
 		   AND a.kind = 'email' AND a.captured_by LIKE 'connector:%'

--- a/backend/internal/modules/activities/channelsend_integration_test.go
+++ b/backend/internal/modules/activities/channelsend_integration_test.go
@@ -95,11 +95,10 @@ func (e *sendEnv) seedAnchorWithTransport(t *testing.T, kind, provider string) i
 	t.Helper()
 	id := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, channel_provider, body, occurred_at, direction,
-		                      source_system, source_id, source, captured_by, thread_key)
-		VALUES ($1, $2, $3, NULLIF($4, ''), 'Is this still available?', now(), 'inbound',
-		        'telegram', $5, 'telegram', 'connector:telegram', $6)`,
-		id, e.ws, kind, provider, "8100:"+testChannelAccount+":"+id.String(), testChannelThreadKey); err != nil {
+		INSERT INTO activity (id, kind, channel_provider, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key)
+		VALUES ($1, $2, NULLIF($3, ''), 'Is this still available?', now(), 'inbound',
+		        'telegram', $4, 'telegram', 'connector:telegram', $5)`,
+		id, kind, provider, "8100:"+testChannelAccount+":"+id.String(), testChannelThreadKey); err != nil {
 		t.Fatalf("seeding the anchor: %v", err)
 	}
 	return id
@@ -116,8 +115,8 @@ func (e *sendEnv) linkPerson(t *testing.T, anchor ids.ActivityID, name string) i
 		t.Fatalf("seeding the linked person: %v", err)
 	}
 	if _, err := e.owner.Exec(ctx,
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		 VALUES ($1, $2, 'person', $3)`, e.ws, anchor, person); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, person_id)
+		 VALUES ( $1, 'person', $2)`, anchor, person); err != nil {
 		t.Fatalf("linking the person: %v", err)
 	}
 	return person
@@ -169,9 +168,9 @@ func TestTheDatabaseRefusesAKindAndTransportThatDisagree(t *testing.T) {
 	// A message that names no transport: unrepliable by construction, so the
 	// column that would have to answer "what carried this" is never empty.
 	_, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, body, occurred_at, source, captured_by)
-		VALUES ($1, $2, $3, 'orphan', now(), 'manual', 'human:test')`,
-		ids.New[ids.ActivityKind](), e.ws, KindMessage)
+		INSERT INTO activity (id, kind, body, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'orphan', now(), 'manual', 'human:test')`,
+		ids.New[ids.ActivityKind](), KindMessage)
 	if err == nil {
 		t.Fatal("a message with no transport was stored; the send path would then have to guess what carried it, which is the derivation this decision removed")
 	}
@@ -183,9 +182,9 @@ func TestTheDatabaseRefusesAKindAndTransportThatDisagree(t *testing.T) {
 	// transport. Asserted because a one-directional CHECK would let an email
 	// carry a provider and quietly become repliable on a channel.
 	_, err = e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, channel_provider, body, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'email', 'telegram', 'orphan', now(), 'manual', 'human:test')`,
-		ids.New[ids.ActivityKind](), e.ws)
+		INSERT INTO activity (id, kind, channel_provider, body, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'telegram', 'orphan', now(), 'manual', 'human:test')`,
+		ids.New[ids.ActivityKind]())
 	if err == nil {
 		t.Fatal("an email acquired a messaging transport; the two axes must disagree in neither direction")
 	}

--- a/backend/internal/modules/activities/commitments_integration_test.go
+++ b/backend/internal/modules/activities/commitments_integration_test.go
@@ -147,14 +147,13 @@ func (e *promiseEnv) seedSplitTask(t *testing.T) (taskID, hiddenDealID ids.UUID)
 		VALUES ($1, $2, $3, $4, $5, $6, 'seed', 'system')`,
 		hiddenDealID, hiddenDealName, orgID, e.other, pipelineID, stageID)
 
-	e.exec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at,
-			assignee_id, is_done, source, captured_by)
-		VALUES ($1, $2, 'task', 'Renew the Zeta contract', now(), now() - interval '2 days',
-			$3, false, 'seed', 'system')`, taskID, e.ws, e.rep)
-	e.exec(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, $3, 'person', $4)`, ids.NewV7(), e.ws, taskID, personID)
-	e.exec(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, deal_id)
-		VALUES ($1, $2, $3, 'deal', $4)`, ids.NewV7(), e.ws, taskID, hiddenDealID)
+	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, assignee_id, is_done, source, captured_by)
+		VALUES ($1, 'task', 'Renew the Zeta contract', now(), now() - interval '2 days',
+			$2, false, 'seed', 'system')`, taskID, e.rep)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), taskID, personID)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, deal_id)
+		VALUES ($1, $2, 'deal', $3)`, ids.NewV7(), taskID, hiddenDealID)
 	return taskID, hiddenDealID
 }
 
@@ -216,12 +215,11 @@ func TestNarrowingToAnUnreadableRecordAnswersNotFound(t *testing.T) {
 		hiddenProjectID, hiddenProjectNam, orgID, e.other)
 	// The task is assigned to the CALLER, so nothing about the task itself is
 	// what hides it — only the project the sweep is narrowed to.
-	e.exec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, due_at,
-			assignee_id, is_done, source, captured_by)
-		VALUES ($1, $2, 'task', 'Ship the Zeta rollout', now(), now(), $3, false, 'seed', 'system')`,
-		taskID, e.ws, e.rep)
-	e.exec(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, project_id)
-		VALUES ($1, $2, $3, 'project', $4)`, ids.NewV7(), e.ws, taskID, hiddenProjectID)
+	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, assignee_id, is_done, source, captured_by)
+		VALUES ($1, 'task', 'Ship the Zeta rollout', now(), now(), $2, false, 'seed', 'system')`,
+		taskID, e.rep)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, project_id)
+		VALUES ($1, $2, 'project', $3)`, ids.NewV7(), taskID, hiddenProjectID)
 
 	projectType := "project"
 	_, _, err := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws))).ListOpenTasks(e.as(), ListOpenTasksInput{

--- a/backend/internal/modules/activities/email_integration_test.go
+++ b/backend/internal/modules/activities/email_integration_test.go
@@ -181,12 +181,11 @@ func (e *sendEnv) seedAnchor(t *testing.T, sourceID, threadKey string) ids.Activ
 	t.Helper()
 	id := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction,
-		                      source_system, source_id, source, captured_by, thread_key)
-		VALUES ($1, $2, 'email', 'Pricing question', now(), 'inbound',
-		        CASE WHEN $3 = '' THEN NULL ELSE 'gmail' END, NULLIF($3, ''),
-		        'gmail', 'human:x', NULLIF($4, ''))`,
-		id, e.ws, sourceID, threadKey); err != nil {
+		INSERT INTO activity (id, kind, subject, occurred_at, direction, source_system, source_id, source, captured_by, thread_key)
+		VALUES ($1, 'email', 'Pricing question', now(), 'inbound',
+		        CASE WHEN $2 = '' THEN NULL ELSE 'gmail' END, NULLIF($2, ''),
+		        'gmail', 'human:x', NULLIF($3, ''))`,
+		id, sourceID, threadKey); err != nil {
 		t.Fatalf("seeding the anchor: %v", err)
 	}
 	return id
@@ -217,10 +216,9 @@ func (e *sendEnv) seedNonMailAnchor(t *testing.T, sourceID string) ids.ActivityI
 	t.Helper()
 	id := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at,
-		                      source_system, source_id, source, captured_by)
-		VALUES ($1, $2, 'meeting', 'Discovery call', now(), 'gcal', $3, 'gcal', 'connector:gcal')`,
-		id, e.ws, sourceID); err != nil {
+		INSERT INTO activity (id, kind, subject, occurred_at, source_system, source_id, source, captured_by)
+		VALUES ($1, 'meeting', 'Discovery call', now(), 'gcal', $2, 'gcal', 'connector:gcal')`,
+		id, sourceID); err != nil {
 		t.Fatalf("seeding the calendar anchor: %v", err)
 	}
 	return id
@@ -238,8 +236,8 @@ func (e *sendEnv) linkToPersonOwnedBy(t *testing.T, anchor ids.ActivityID, owner
 		t.Fatalf("seeding the linked person: %v", err)
 	}
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		 VALUES ($1, $2, 'person', $3)`, e.ws, anchor, person); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, person_id)
+		 VALUES ( $1, 'person', $2)`, anchor, person); err != nil {
 		t.Fatalf("linking the anchor: %v", err)
 	}
 }
@@ -248,8 +246,7 @@ func (e *sendEnv) outboundCount(t *testing.T) int {
 	t.Helper()
 	var n int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM activity WHERE workspace_id = $1 AND direction = 'outbound'`,
-		e.ws).Scan(&n); err != nil {
+		`SELECT count(*) FROM activity WHERE direction = 'outbound'`).Scan(&n); err != nil {
 		t.Fatalf("counting outbound activities: %v", err)
 	}
 	return n

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -213,8 +213,8 @@ func (s *Store) RelinkActivity(ctx context.Context, id ids.ActivityID, in Relink
 		// Idempotent: replaying the same association is a no-op, and a
 		// no-op writes no audit noise.
 		tag, err := tx.Exec(ctx, storekit.SQLf(`
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, %s)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)
+			INSERT INTO activity_link (activity_id, entity_type, %s)
+			VALUES ($1, $2, $3)
 			ON CONFLICT (activity_id, entity_type, `+linkIDCoalesce+`) DO NOTHING`, column),
 			id, in.EntityType, in.EntityID)
 		if err != nil {

--- a/backend/internal/modules/activities/messageidentity.go
+++ b/backend/internal/modules/activities/messageidentity.go
@@ -23,7 +23,7 @@ import (
 )
 
 // uqActivitySource is the natural-key index a captured echo trips the re-key
-// against: (workspace_id, source_system, source_id). It is named because the
+// against: (source_system, source_id). It is named because the
 // absorb below is a legitimate answer to THIS constraint alone — any other
 // uniqueness rule firing on the same statement is a fault, and treating it as
 // the race would take a row off the timeline for a reason nobody established.
@@ -213,13 +213,10 @@ func reKeyActivity(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID, pr
 // but not sufficient: the row must also be shaped like this message's echo.
 func absorbEcho(ctx context.Context, tx pgx.Tx, survivorID ids.ActivityID, stamped string) error {
 	var echoID ids.ActivityID
-	// The violated index keys on (workspace_id, source_system, source_id) and
-	// the re-key changes only the last of the three — that is what makes a row
-	// a CANDIDATE. Each further predicate is what makes it this message's echo:
+	// The violated index keys on (source_system, source_id) and the re-key
+	// changes only the second of the two — that is what makes a row a
+	// CANDIDATE. Each further predicate is what makes it this message's echo:
 	//
-	//   workspace_id — the bound the surrounding statements all state for
-	//     themselves against the GUC; stating it in the join too keeps this
-	//     query as narrow as its siblings.
 	//   kind/direction — a message this mailbox SENT. An inbound mail, a call
 	//     or a meeting sharing the key is a fault, not an echo.
 	//   captured_by — the connector's own provenance, which the sink validates
@@ -267,8 +264,7 @@ func absorbEcho(ctx context.Context, tx pgx.Tx, survivorID ids.ActivityID, stamp
 		SELECT echo.id
 		  FROM activity survivor
 		  JOIN activity echo
-		    ON echo.workspace_id       = survivor.workspace_id
-		   AND echo.id                <> survivor.id
+		    ON echo.id                <> survivor.id
 		   AND echo.source_system      = survivor.source_system
 		   AND echo.source_id          = $2
 		   AND echo.kind               = 'email'
@@ -281,7 +277,7 @@ func absorbEcho(ctx context.Context, tx pgx.Tx, survivorID ids.ActivityID, stamp
 		   AND echo.restricted_at IS NULL
 		 WHERE survivor.id = $1 AND survivor.restricted_at IS NULL`, survivorID, stamped).Scan(&echoID)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return fmt.Errorf("activities: the re-key collided on %s, but no row this workspace holds under that identity is a captured outbound echo of this send",
+		return fmt.Errorf("activities: the re-key collided on %s, but no row under that identity is a captured outbound echo of this send",
 			uqActivitySource)
 	}
 	if err != nil {
@@ -323,8 +319,8 @@ func absorbEcho(ctx context.Context, tx pgx.Tx, survivorID ids.ActivityID, stamp
 func copyEchoLinks(ctx context.Context, tx pgx.Tx, survivorID, echoID ids.ActivityID) error {
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO activity_link
-		  (workspace_id, activity_id, entity_type, person_id, organization_id, deal_id, lead_id, project_id)
-		SELECT echo_link.workspace_id, $1, echo_link.entity_type,
+		  (activity_id, entity_type, person_id, organization_id, deal_id, lead_id, project_id)
+		SELECT $1, echo_link.entity_type,
 		       echo_link.person_id, echo_link.organization_id, echo_link.deal_id,
 		       echo_link.lead_id, echo_link.project_id
 		  FROM activity_link echo_link
@@ -350,7 +346,7 @@ func copyEchoLinks(ctx context.Context, tx pgx.Tx, survivorID, echoID ids.Activi
 // and an ensure-retry cursor, that the survivor does not re-queue: left on the
 // row this absorb archives, the question "who is this stranger?" would be asked
 // about a message the workspace can no longer see, and copied it would be asked
-// twice. Their live-row uniqueness keys on (workspace_id, email), which this
+// twice. Their live-row uniqueness keys on (email), which this
 // write does not touch, so a re-point can collide with nothing.
 func repointEchoReviews(ctx context.Context, tx pgx.Tx, survivorID, echoID ids.ActivityID) error {
 	if _, err := tx.Exec(ctx,

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -33,7 +33,7 @@ import (
 func (e *sendEnv) seedCapturedEcho(t *testing.T) ids.ActivityID {
 	t.Helper()
 	return e.seedEcho(t, echoSeed{
-		workspace: e.ws, direction: "outbound", kind: "email",
+		direction: "outbound", kind: "email",
 		source: "gmail:" + stampedIdentity, capturedBy: "connector:gmail",
 		counterparty: counterparty,
 	})
@@ -43,7 +43,6 @@ func (e *sendEnv) seedCapturedEcho(t *testing.T) ids.ActivityID {
 // exposes is one the absorb's lookup reads, so a case can seed a row that holds
 // the key and is NOT this message's echo.
 type echoSeed struct {
-	workspace    ids.UUID
 	direction    string
 	kind         string
 	source       string
@@ -55,12 +54,10 @@ func (e *sendEnv) seedEcho(t *testing.T, seed echoSeed) ids.ActivityID {
 	t.Helper()
 	id := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction,
-		                      source_system, source_id, source, captured_by, thread_key,
-		                      counterparty_email)
-		VALUES ($1, $2, $3, 'Re: pricing', now(), $4,
-		        'gmail', $5, $6, $7, $5, NULLIF($8, ''))`,
-		id, seed.workspace, seed.kind, seed.direction, stampedIdentity, seed.source, seed.capturedBy,
+		INSERT INTO activity (id, kind, subject, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email)
+		VALUES ($1, $2, 'Re: pricing', now(), $3,
+		        'gmail', $4, $5, $6, $4, NULLIF($7, ''))`,
+		id, seed.kind, seed.direction, stampedIdentity, seed.source, seed.capturedBy,
 		seed.counterparty); err != nil {
 		t.Fatalf("seeding the row on the stamped identity: %v", err)
 	}
@@ -125,11 +122,10 @@ func (e *sendEnv) seedProject(t *testing.T, name string) ids.UUID {
 func (e *sendEnv) link(t *testing.T, activityID ids.ActivityID, entityType string, target ids.UUID) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id, project_id)
-		VALUES ($1, $2, $3,
-		        CASE WHEN $3 = 'person'  THEN $4::uuid END,
-		        CASE WHEN $3 = 'project' THEN $4::uuid END)`,
-		e.ws, activityID, entityType, target); err != nil {
+		INSERT INTO activity_link (activity_id, entity_type, person_id, project_id)
+		VALUES ( $1, $2,
+		        CASE WHEN $2 = 'person'  THEN $3::uuid END,
+		        CASE WHEN $2 = 'project' THEN $3::uuid END)`, activityID, entityType, target); err != nil {
 		t.Fatalf("linking the activity to a %s: %v", entityType, err)
 	}
 }
@@ -161,8 +157,8 @@ func (e *sendEnv) reconcileAbsorbing(t *testing.T, survivor ids.ActivityID) {
 	var holders int
 	if err := e.owner.QueryRow(context.Background(), `
 		SELECT count(*) FROM activity
-		 WHERE workspace_id = $1 AND source_system = 'gmail' AND source_id = $2`,
-		e.ws, stampedIdentity).Scan(&holders); err != nil {
+		 WHERE source_system = 'gmail' AND source_id = $1`,
+		stampedIdentity).Scan(&holders); err != nil {
 		t.Fatalf("counting activities on the stamped identity: %v", err)
 	}
 	if holders != 1 {
@@ -397,7 +393,6 @@ func TestAbsorbRefusesARowThatIsNotThisMessagesEcho(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			e := setupSend(t)
 			survivor := e.seedSentEmail(t, mintedIdentity)
-			tc.seed.workspace = e.ws
 			bystander := e.seedEcho(t, tc.seed)
 
 			if err := e.reconcileExpectingRefusal(t, survivor); err == nil {

--- a/backend/internal/modules/activities/messageidentity_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_integration_test.go
@@ -55,12 +55,10 @@ func (e *sendEnv) seedSentEmail(t *testing.T, threadKey string) ids.ActivityID {
 	t.Helper()
 	id := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction,
-		                      source_system, source_id, source, captured_by, thread_key,
-		                      counterparty_email)
-		VALUES ($1, $2, 'email', 'Re: pricing', now(), 'outbound',
-		        'gmail', $3, 'manual', 'human:x', NULLIF($4, ''), $5)`,
-		id, e.ws, mintedIdentity, threadKey, counterparty); err != nil {
+		INSERT INTO activity (id, kind, subject, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email)
+		VALUES ($1, 'email', 'Re: pricing', now(), 'outbound',
+		        'gmail', $2, 'manual', 'human:x', NULLIF($3, ''), $4)`,
+		id, mintedIdentity, threadKey, counterparty); err != nil {
 		t.Fatalf("seeding the sent email: %v", err)
 	}
 	return id

--- a/backend/internal/modules/activities/participantbackfill.go
+++ b/backend/internal/modules/activities/participantbackfill.go
@@ -140,9 +140,8 @@ func backfillParticipants(ctx context.Context, tx pgx.Tx, limit int) (int, error
 		     ORDER BY a.id
 		     LIMIT $1
 		)
-		INSERT INTO activity_participant (workspace_id, activity_id, user_id, person_id, address, role)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		       c.id, r.user_id, r.person_id, r.address, r.role
+		INSERT INTO activity_participant (activity_id, user_id, person_id, address, role)
+		SELECT c.id, r.user_id, r.person_id, r.address, r.role
 		  FROM candidate c
 		  CROSS JOIN LATERAL (
 		       -- Our side: the role follows the direction, exactly as capture

--- a/backend/internal/modules/activities/participantlog.go
+++ b/backend/internal/modules/activities/participantlog.go
@@ -99,8 +99,8 @@ func insertLoggedParticipant(ctx context.Context, tx pgx.Tx, activityID ids.Acti
 	// operation. Guarding here rather than pre-checking also avoids a race
 	// with a member being archived between the check and the insert.
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO activity_participant (workspace_id, activity_id, user_id, person_id, role)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4
+		INSERT INTO activity_participant (activity_id, user_id, person_id, role)
+		SELECT $1, $2, $3, $4
 		 WHERE $2::uuid IS NULL
 		    OR EXISTS (SELECT 1 FROM app_user u WHERE u.id = $2)
 		ON CONFLICT DO NOTHING`, activityID, userID, personID, role); err != nil {

--- a/backend/internal/modules/activities/pipelinefacts_integration_test.go
+++ b/backend/internal/modules/activities/pipelinefacts_integration_test.go
@@ -110,12 +110,11 @@ func (e *factsEnv) seed(t *testing.T, row capturedRow) ids.UUID {
 	}
 	email := "sender-" + id.String() + "@outside.test"
 	e.exec(t, `
-		INSERT INTO activity (id, workspace_id, kind, occurred_at, source, captured_by,
-		                      counterparty_email, archived_at, channel_provider)
-		VALUES ($1, $2, $3, now(), 'test', $4, $5,
-		        CASE WHEN $6 THEN now() ELSE NULL END,
-		        CASE WHEN $3 = 'message' THEN 'telegram' ELSE NULL END)`,
-		id, e.ws, row.kind, capturedBy, email, row.archived)
+		INSERT INTO activity (id, kind, occurred_at, source, captured_by, counterparty_email, archived_at, channel_provider)
+		VALUES ($1, $2, now(), 'test', $3, $4,
+		        CASE WHEN $5 THEN now() ELSE NULL END,
+		        CASE WHEN $2 = 'message' THEN 'telegram' ELSE NULL END)`,
+		id, row.kind, capturedBy, email, row.archived)
 	if row.undecidedSender {
 		e.exec(t, `
 			INSERT INTO capture_pending_counterparty (id, owner_id, email, status, activity_id)
@@ -125,8 +124,8 @@ func (e *factsEnv) seed(t *testing.T, row capturedRow) ids.UUID {
 		person := ids.NewV7()
 		e.exec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
 			VALUES ($1, $2, 'Linked Person', 'test', 'connector:gmail')`, person, e.ws)
-		e.exec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES ($1, $2, 'person', $3)`, e.ws, id, person)
+		e.exec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, id, person)
 	}
 	return id
 }
@@ -209,8 +208,8 @@ func TestReadingPipelineFactsTakesTheRowScopeNotJustTheGrant(t *testing.T) {
 	person := ids.NewV7()
 	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, owner_id)
 		VALUES ($1, $2, 'Theirs', 'test', 'connector:gmail', $3)`, person, e.ws, other)
-	e.exec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, 'person', $3)`, e.ws, id, person)
+	e.exec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ( $1, 'person', $2)`, id, person)
 
 	// The allow arm over the same seed: unbounded scope reads it. Without this,
 	// a link that failed to land would make the refusal below meaningless.

--- a/backend/internal/modules/activities/timelinescope_integration_test.go
+++ b/backend/internal/modules/activities/timelinescope_integration_test.go
@@ -40,16 +40,16 @@ func TestNarrowingTheTimelineToAnUnreadableLeadAnswersNotFound(t *testing.T) {
 	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Visible Contact', $3, 'seed', 'system')`,
 		visiblePersonID, e.ws, e.rep)
-	e.exec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Called about the rollout', now(), 'seed', 'system')`,
-		activityID, e.ws)
+	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Called about the rollout', now(), 'seed', 'system')`,
+		activityID)
 	// Linked to BOTH: the caller may read this activity through the person, so
 	// the any-link scope admits it. Only the narrowing target is out of reach,
 	// which is precisely the case a scope check alone cannot catch.
-	e.exec(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id)
-		VALUES ($1, $2, $3, 'person', $4)`, ids.NewV7(), e.ws, activityID, visiblePersonID)
-	e.exec(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, lead_id)
-		VALUES ($1, $2, $3, 'lead', $4)`, ids.NewV7(), e.ws, activityID, hiddenLeadID)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), activityID, visiblePersonID)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, lead_id)
+		VALUES ($1, $2, 'lead', $3)`, ids.NewV7(), activityID, hiddenLeadID)
 
 	leadType := "lead"
 	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
@@ -72,11 +72,11 @@ func TestNarrowingTheTimelineToAReadableLeadReturnsIt(t *testing.T) {
 
 	e.exec(t, `INSERT INTO lead (id, workspace_id, full_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'My Prospect', $3, 'seed', 'system')`, ownLeadID, e.ws, e.rep)
-	e.exec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		VALUES ($1, $2, 'note', 'Asked for a Q4 quote', now(), 'seed', 'system')`,
-		activityID, e.ws)
-	e.exec(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, lead_id)
-		VALUES ($1, $2, $3, 'lead', $4)`, ids.NewV7(), e.ws, activityID, ownLeadID)
+	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'Asked for a Q4 quote', now(), 'seed', 'system')`,
+		activityID)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, lead_id)
+		VALUES ($1, $2, 'lead', $3)`, ids.NewV7(), activityID, ownLeadID)
 
 	leadType := "lead"
 	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))

--- a/backend/internal/modules/automation/automationpreview_integration_test.go
+++ b/backend/internal/modules/automation/automationpreview_integration_test.go
@@ -115,7 +115,7 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 	if after := fx.count(t, `SELECT count(*) FROM event_outbox`); after != outboxBefore {
 		t.Fatalf("preview wrote %d outbox rows — a preview is a read", after-outboxBefore)
 	}
-	if n := fx.count(t, `SELECT count(*) FROM activity WHERE workspace_id = $1`, fx.ws); n != 0 {
+	if n := fx.count(t, `SELECT count(*) FROM activity `); n != 0 {
 		t.Fatalf("preview minted %d activities — it must never apply the plan", n)
 	}
 	if n := fx.count(t, `SELECT count(*) FROM workflow_run`); n != 0 {

--- a/backend/internal/modules/capture/channelconnfixture_test.go
+++ b/backend/internal/modules/capture/channelconnfixture_test.go
@@ -376,9 +376,9 @@ func (f *channelFixture) seedActivity(t *testing.T) ids.UUID {
 	owner, _ := setupCaptureDB(t)
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(), `
-		INSERT INTO activity (id, workspace_id, kind, subject, body, direction, source_system, source_id, source, captured_by)
-		VALUES ($1, $2, 'note', 'telegram message', 'hello', 'inbound', 'telegram', $3, 'telegram:seed', 'connector:telegram')`,
-		id, f.ws, id.String()); err != nil {
+		INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id, source, captured_by)
+		VALUES ($1, 'note', 'telegram message', 'hello', 'inbound', 'telegram', $2, 'telegram:seed', 'connector:telegram')`,
+		id, id.String()); err != nil {
 		t.Fatalf("seeding activity: %v", err)
 	}
 	return id

--- a/backend/internal/modules/capture/participant.go
+++ b/backend/internal/modules/capture/participant.go
@@ -153,9 +153,8 @@ func StampFurtherParticipants(
 	// counterparty promotion does — the row records which address was actually
 	// written to, and a person may hold several.
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO activity_participant (workspace_id, activity_id, user_id, person_id, address, role)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		       $1, u.id, pe.person_id, inp.address, inp.role
+		INSERT INTO activity_participant (activity_id, user_id, person_id, address, role)
+		SELECT $1, u.id, pe.person_id, inp.address, inp.role
 		  FROM unnest($2::text[], $3::text[]) AS inp(address, role)
 		  LEFT JOIN app_user u
 		         ON $4 AND lower(u.email) = inp.address
@@ -192,8 +191,8 @@ func insertParticipant(
 	// read off the wire, over a participant row that is a nicety rather than
 	// the point of the write.
 	_, err := tx.Exec(ctx, `
-		INSERT INTO activity_participant (workspace_id, activity_id, user_id, person_id, address, role)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, NULLIF($4, ''), $5
+		INSERT INTO activity_participant (activity_id, user_id, person_id, address, role)
+		SELECT $1, $2, $3, NULLIF($4, ''), $5
 		 WHERE $2::uuid IS NULL
 		    OR EXISTS (SELECT 1 FROM app_user u WHERE u.id = $2)
 		ON CONFLICT DO NOTHING`,

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -356,9 +356,8 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 	occurredAt := fields.OccurredAt
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (workspace_id, kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14)
+		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested)
+		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
@@ -437,8 +436,8 @@ func (s *Sink) linkActivity(ctx context.Context, tx pgx.Tx, activityID ids.Activ
 			return fmt.Errorf("capture: link target %s %s: %w", link.Type, link.ID, err)
 		}
 		if _, err := tx.Exec(ctx, fmt.Sprintf(`
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, %s)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`, column),
+			INSERT INTO activity_link (activity_id, entity_type, %s)
+			VALUES ($1, $2, $3)`, column),
 			activityID, string(link.Type), link.ID); err != nil {
 			return fmt.Errorf("capture: linking activity: %w", err)
 		}

--- a/backend/internal/modules/capture/sinkreply.go
+++ b/backend/internal/modules/capture/sinkreply.go
@@ -91,16 +91,13 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 	// statement serve both: mail compares NULL to NULL and matches, a channel
 	// compares provider to provider.
 	//
-	// Scoped to the WORKSPACE as well, which the medium match alone never was:
-	// thread_key is unique to nobody, so a forged References root could match an
-	// outbound leg belonging to a different workspace and publish that workspace's
-	// activity id as the matched outbound. RLS was retired (core 0217), so no
-	// policy supplies the predicate — this statement has to. It is also what makes
-	// idx_activity_channel_thread usable, since that index leads with workspace_id.
+	// The thread key is the whole bound, which is what makes the forged-root case
+	// worth stating: a References header naming a thread the sender was never on
+	// still has to match an outbound leg of THAT thread, on the same medium, that
+	// this installation itself sent. idx_activity_channel_thread is what serves it.
 	err := tx.QueryRow(ctx, `
 		SELECT id FROM activity
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND thread_key = $1 AND direction = 'outbound' AND kind = $2
+		 WHERE thread_key = $1 AND direction = 'outbound' AND kind = $2
 		  AND channel_provider IS NOT DISTINCT FROM NULLIF($3, '')
 		  AND archived_at IS NULL AND id <> $4
 		ORDER BY occurred_at DESC LIMIT 1`,

--- a/backend/internal/modules/capture/tracelinks_integration_test.go
+++ b/backend/internal/modules/capture/tracelinks_integration_test.go
@@ -45,8 +45,8 @@ func seedTracedActivityOwnedBy(ctx context.Context, t *testing.T, db *database.D
 	activityID, personID := ids.NewV7(), ids.NewV7()
 	if err := db.Tx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, occurred_at, source_system, source_id, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (id, kind, occurred_at, source_system, source_id, source, captured_by)
+			VALUES ($1,
 			        'note', now(), 'gmail', $2, 'gmail', 'connector:gmail')`,
 			activityID, sourceID); err != nil {
 			return err
@@ -74,8 +74,8 @@ func seedTracedActivityOwnedBy(ctx context.Context, t *testing.T, db *database.D
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'person', $2)`,
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`,
 			activityID, personID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/capture/traceresolution_integration_test.go
+++ b/backend/internal/modules/capture/traceresolution_integration_test.go
@@ -101,9 +101,8 @@ func seedRecord(ctx context.Context, t *testing.T, db *database.DB,
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, channel_provider, occurred_at, source_system,
-			                      source_id, source, captured_by, counterparty_email)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO activity (id, kind, channel_provider, occurred_at, source_system, source_id, source, captured_by, counterparty_email)
+			VALUES ($1,
 			        CASE WHEN $4 = '' THEN 'note' ELSE 'message' END, NULLIF($4, ''),
 			        now(), $5, $2, $5, 'connector:' || $5, $3)`,
 			activityID, sourceID, sender, channelProvider, system); err != nil {

--- a/backend/internal/modules/capture/tracerollback_integration_test.go
+++ b/backend/internal/modules/capture/tracerollback_integration_test.go
@@ -83,8 +83,8 @@ func hideIncumbent(ctx context.Context, t *testing.T, db *database.DB, sourceID 
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			SELECT workspace_id, id, 'person', $2 FROM activity WHERE source_id = $1`,
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			SELECT id, 'person', $2 FROM activity WHERE source_id = $1`,
 			sourceID, personID)
 		return err
 	}); err != nil {

--- a/backend/internal/modules/comms/store_channel_integration_test.go
+++ b/backend/internal/modules/comms/store_channel_integration_test.go
@@ -33,9 +33,9 @@ func (e *storeEnv) telegramActivity(t *testing.T) ids.ActivityID {
 	t.Helper()
 	act := ids.New[ids.ActivityKind]()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, channel_provider, source, captured_by)
-		 VALUES ($1, $2, 'message', 'telegram', 'connector:telegram', 'human:x')`,
-		act, e.ws); err != nil {
+		`INSERT INTO activity (id, kind, channel_provider, source, captured_by)
+		 VALUES ($1, 'message', 'telegram', 'connector:telegram', 'human:x')`,
+		act); err != nil {
 		t.Fatal(err)
 	}
 	return act

--- a/backend/internal/modules/comms/store_integration_test.go
+++ b/backend/internal/modules/comms/store_integration_test.go
@@ -110,8 +110,8 @@ func setupStore(t *testing.T) *storeEnv {
 	}
 	for _, act := range []ids.ActivityID{e.activity, e.activity2} {
 		if _, err := owner.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, source, captured_by) VALUES ($1, $2, 'email', 'test', 'human:x')`,
-			act, e.ws); err != nil {
+			`INSERT INTO activity (id, kind, source, captured_by) VALUES ($1, 'email', 'test', 'human:x')`,
+			act); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/modules/comms/store_receiptdurability_integration_test.go
+++ b/backend/internal/modules/comms/store_receiptdurability_integration_test.go
@@ -189,8 +189,8 @@ func TestRecordSentKeepsTheReceiptWhenTheReconcileHitsAUniqueViolation(t *testin
 	// re-key would have succeeded and this case would test nothing.
 	var echoes int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM activity WHERE workspace_id = $1 AND source_system = 'gmail' AND source_id = $2`,
-		e.ws, stampedIdentity).Scan(&echoes); err != nil {
+		`SELECT count(*) FROM activity WHERE source_system = 'gmail' AND source_id = $1`,
+		stampedIdentity).Scan(&echoes); err != nil {
 		t.Fatalf("counting rows on the stamped key: %v", err)
 	}
 	if echoes != 1 {

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -333,11 +333,11 @@ func (s *Store) linkActivityToPerson(ctx context.Context, tx pgx.Tx, activityID 
 	}
 	personID = canonical
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-		SELECT $1, $2, 'person', $3
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		SELECT $1, 'person', $2
 		WHERE NOT EXISTS (
-			SELECT 1 FROM activity_link WHERE activity_id = $2 AND entity_type = 'person' AND person_id = $3)`,
-		workspaceID(ctx), activityID, personID); err != nil {
+			SELECT 1 FROM activity_link WHERE activity_id = $1 AND entity_type = 'person' AND person_id = $2)`,
+		activityID, personID); err != nil {
 		return fmt.Errorf("people: linking activity to person: %w", err)
 	}
 	return namePersonAmongParticipants(ctx, tx, activityID, personID)

--- a/backend/internal/modules/people/ensure_edges_integration_test.go
+++ b/backend/internal/modules/people/ensure_edges_integration_test.go
@@ -28,9 +28,9 @@ func (e *dedupeEnv) ensureInput(ctx context.Context, t *testing.T, email, displa
 	activityID := ids.New[ids.ActivityKind]()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, direction, source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'email', 'hi', 'inbound', 'gmail', $3, 'gmail:seed', 'connector:gmail')`,
-			activityID, e.ws, activityID.String())
+			INSERT INTO activity (id, kind, subject, direction, source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'hi', 'inbound', 'gmail', $2, 'gmail:seed', 'connector:gmail')`,
+			activityID, activityID.String())
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/people/ensurechannel_integration_test.go
+++ b/backend/internal/modules/people/ensurechannel_integration_test.go
@@ -61,9 +61,9 @@ func (e *dedupeEnv) channelEnsureInput(ctx context.Context, t *testing.T, ci con
 	activityID := ids.New[ids.ActivityKind]()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, channel_provider, body, direction, source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'message', 'telegram', 'hello', 'inbound', 'telegram', $3, 'telegram:seed', $4)`,
-			activityID, e.ws, activityID.String(), channelCapturedBy)
+			INSERT INTO activity (id, kind, channel_provider, body, direction, source_system, source_id, source, captured_by)
+			VALUES ($1, 'message', 'telegram', 'hello', 'inbound', 'telegram', $2, 'telegram:seed', $3)`,
+			activityID, activityID.String(), channelCapturedBy)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/people/ensurename_integration_test.go
+++ b/backend/internal/modules/people/ensurename_integration_test.go
@@ -220,10 +220,9 @@ func (e *dedupeEnv) attestOutbound(ctx context.Context, t *testing.T, email stri
 	t.Helper()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, counterparty_email,
-			                      counterparty_outbound_attested, source, captured_by)
-			VALUES ($1, $2, 'email', 'hi', $3, true, 'test', 'human:test')`,
-			ids.NewV7(), e.ws, email)
+			INSERT INTO activity (id, kind, subject, counterparty_email, counterparty_outbound_attested, source, captured_by)
+			VALUES ($1, 'email', 'hi', $2, true, 'test', 'human:test')`,
+			ids.NewV7(), email)
 		return err
 	}); err != nil {
 		t.Fatalf("attesting outbound to %s: %v", email, err)

--- a/backend/internal/modules/people/leaddedupe_integration_test.go
+++ b/backend/internal/modules/people/leaddedupe_integration_test.go
@@ -87,13 +87,13 @@ func TestDedupeLeadMergeArm(t *testing.T) {
 	activity := ids.NewV7()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-			 VALUES ($1, $2, 'note', 'Called', now(), 'manual', 'human:x')`, activity, e.ws); err != nil {
+			`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			 VALUES ($1, 'note', 'Called', now(), 'manual', 'human:x')`, activity); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, lead_id)
-			 VALUES ($1, $2, $3, 'lead', $4)`, ids.NewV7(), e.ws, activity, second.UUID)
+			`INSERT INTO activity_link (id, activity_id, entity_type, lead_id)
+			 VALUES ($1, $2, 'lead', $3)`, ids.NewV7(), activity, second.UUID)
 		return err
 	}); err != nil {
 		t.Fatalf("seed loser activity: %v", err)

--- a/backend/internal/modules/people/promoteactivities_integration_test.go
+++ b/backend/internal/modules/people/promoteactivities_integration_test.go
@@ -33,15 +33,15 @@ func (e *promoteConsentEnv) seedLeadActivity(t *testing.T, lead ids.LeadID, subj
 	t.Helper()
 	activity := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
-		 VALUES ($1, $2, 'note', $3, now(), 'manual', 'human:x')`,
-		activity, e.ws, subject); err != nil {
+		`INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		 VALUES ($1, 'note', $2, now(), 'manual', 'human:x')`,
+		activity, subject); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, lead_id)
-		 VALUES ($1, $2, $3, 'lead', $4)`,
-		ids.NewV7(), e.ws, activity, lead.UUID); err != nil {
+		`INSERT INTO activity_link (id, activity_id, entity_type, lead_id)
+		 VALUES ($1, $2, 'lead', $3)`,
+		ids.NewV7(), activity, lead.UUID); err != nil {
 		t.Fatal(err)
 	}
 	return activity
@@ -121,9 +121,9 @@ func TestPromotionDropsALeadLinkThePersonAlreadyHas(t *testing.T) {
 	lead := e.seedLead(t, shared)
 	activity := e.seedLeadActivity(t, lead, "Replied to our outreach")
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id)
-		 VALUES ($1, $2, $3, 'person', $4)`,
-		ids.NewV7(), e.ws, activity, ids.UUID(existing.Id)); err != nil {
+		`INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		 VALUES ($1, $2, 'person', $3)`,
+		ids.NewV7(), activity, ids.UUID(existing.Id)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/modules/people/strengthasof_integration_test.go
+++ b/backend/internal/modules/people/strengthasof_integration_test.go
@@ -38,15 +38,14 @@ func (e *dedupeEnv) seedInteraction(t *testing.T, personID ids.PersonID, at time
 	ctx := e.as()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity (id, workspace_id, kind, subject, direction, occurred_at,
-			                      source_system, source_id, source, captured_by)
-			VALUES ($1, $2, 'email', 'Hallo', $3, $4, 'gmail', $5, 'gmail:seed', 'connector:gmail')`,
-			id, e.ws, direction, at, id.String()); err != nil {
+			INSERT INTO activity (id, kind, subject, direction, occurred_at, source_system, source_id, source, captured_by)
+			VALUES ($1, 'email', 'Hallo', $2, $3, 'gmail', $4, 'gmail:seed', 'connector:gmail')`,
+			id, direction, at, id.String()); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
-			VALUES ($1, $2, 'person', $3)`, e.ws, id, personID)
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ( $1, 'person', $2)`, id, personID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding an interaction: %v", err)

--- a/backend/internal/modules/privacy/retentionselectors.go
+++ b/backend/internal/modules/privacy/retentionselectors.go
@@ -24,8 +24,7 @@ var retentionSelectors = map[string]string{
 		  AND full_name IS DISTINCT FROM 'Anonymized Lead'
 		  AND created_at < now() - make_interval(days => $1) LIMIT $2`,
 	"activity/": `SELECT a.id FROM activity a
-		WHERE a.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND a.archived_at IS NULL
+		WHERE a.archived_at IS NULL
 		  AND a.occurred_at < now() - make_interval(days => $1)
 		  ` + correspondenceFloorPredicate(3, 4) + `
 		  AND NOT EXISTS (SELECT 1 FROM activity_link l
@@ -36,8 +35,7 @@ var retentionSelectors = map[string]string{
 		          AND (coalesce(p.legal_hold, false) OR coalesce(o.legal_hold, false) OR coalesce(d.legal_hold, false)))
 		LIMIT $2`,
 	"activity/transcript": `SELECT a.id FROM activity a
-		WHERE a.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND a.source_system = 'transcript' AND a.body IS NOT NULL
+		WHERE a.source_system = 'transcript' AND a.body IS NOT NULL
 		  AND a.occurred_at < now() - make_interval(days => $1)
 		  ` + correspondenceFloorPredicate(3, 4) + `
 		  AND NOT EXISTS (SELECT 1 FROM activity_link l

--- a/backend/internal/modules/search/pending.go
+++ b/backend/internal/modules/search/pending.go
@@ -46,7 +46,7 @@ var pendingSources = map[string]pendingSource{
 	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)", tenantScoped: true},
 	entityDeal:         {table: entityDeal, text: "t.name"},
 	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)", tenantScoped: true},
-	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)", tenantScoped: true},
+	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)"},
 	entityProject:      {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},
 }
 

--- a/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
+++ b/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
@@ -94,8 +94,8 @@ func seedChannelDeliveryForRollback(t *testing.T, conn *pgx.Conn, ws string, inF
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO activity (workspace_id, kind, channel_provider, body, direction, occurred_at, source, captured_by)
-			VALUES (`+wsClause+`, 'message', 'telegram', 'Shipping Monday.', 'outbound', now(), 'manual', 'human:test')
+			INSERT INTO activity (kind, channel_provider, body, direction, occurred_at, source, captured_by)
+			VALUES ( 'message', 'telegram', 'Shipping Monday.', 'outbound', now(), 'manual', 'human:test')
 			RETURNING id`).Scan(&activityID); err != nil {
 			return err
 		}

--- a/backend/migrations/core/1787046665_activity_spine_drop_workspace.down.sql
+++ b/backend/migrations/core/1787046665_activity_spine_drop_workspace.down.sql
@@ -1,0 +1,78 @@
+-- Reverse of 1787034854: the activity spine carries the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE activity ADD COLUMN workspace_id uuid;
+ALTER TABLE activity_link ADD COLUMN workspace_id uuid;
+ALTER TABLE activity_participant ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['activity', 'activity_link', 'activity_participant'] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE activity ADD CONSTRAINT activity_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE activity_link ADD CONSTRAINT activity_link_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE activity_participant ADD CONSTRAINT activity_participant_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+-- UNIQUE (id), which is what the migration before this one left: phase B
+-- collapsed it from its composite form and this restores that state.
+ALTER TABLE activity ADD CONSTRAINT uq_activity_ws_id UNIQUE (id);
+
+ALTER TABLE activity DROP CONSTRAINT activity_meeting_no_overlap;
+ALTER TABLE activity ADD CONSTRAINT activity_meeting_no_overlap
+  EXCLUDE USING gist (
+    workspace_id WITH =,
+    host_user_id WITH =,
+    tsrange(timezone('UTC', occurred_at), timezone('UTC', occurred_at) + interval '1 hour') WITH &&
+  ) WHERE (kind = 'meeting' AND host_user_id IS NOT NULL AND archived_at IS NULL);
+
+DROP INDEX idx_activity_channel_thread;
+DROP INDEX idx_activity_counterparty_email;
+DROP INDEX idx_activity_counterparty_outbound_attested;
+DROP INDEX idx_activity_direction;
+DROP INDEX idx_activity_kind;
+DROP INDEX idx_activity_labeled;
+DROP INDEX idx_activity_meeting_host;
+DROP INDEX idx_activity_reminders;
+DROP INDEX idx_activity_tasks;
+DROP INDEX idx_activity_thread;
+DROP INDEX idx_activity_unlabeled;
+DROP INDEX idx_activity_ws_time;
+DROP INDEX idx_aparticipant_address;
+DROP INDEX idx_aparticipant_person;
+DROP INDEX idx_aparticipant_user;
+
+CREATE INDEX idx_activity_channel_thread ON activity (workspace_id, channel_provider, thread_key) WHERE channel_provider IS NOT NULL;
+CREATE INDEX idx_activity_counterparty_email ON activity (workspace_id, counterparty_email) WHERE counterparty_email IS NOT NULL;
+CREATE INDEX idx_activity_counterparty_outbound_attested ON activity (workspace_id, counterparty_email) WHERE counterparty_email IS NOT NULL AND counterparty_outbound_attested;
+CREATE INDEX idx_activity_direction ON activity (workspace_id, direction, occurred_at DESC) WHERE direction IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_activity_kind ON activity (workspace_id, kind, occurred_at DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_activity_labeled ON activity (workspace_id, capture_labeled_at) WHERE capture_labeled_at IS NOT NULL;
+CREATE INDEX idx_activity_meeting_host ON activity (workspace_id, host_user_id, occurred_at) WHERE kind = 'meeting' AND archived_at IS NULL;
+CREATE INDEX idx_activity_reminders ON activity (workspace_id, remind_at) WHERE kind = 'task' AND remind_at IS NOT NULL AND is_done = false AND archived_at IS NULL;
+CREATE INDEX idx_activity_tasks ON activity (workspace_id, assignee_id, due_at) WHERE kind = 'task' AND is_done = false AND archived_at IS NULL;
+CREATE INDEX idx_activity_thread ON activity (workspace_id, thread_key) WHERE thread_key IS NOT NULL;
+CREATE INDEX idx_activity_unlabeled ON activity (workspace_id, occurred_at) WHERE capture_label IS NULL AND captured_by LIKE 'connector:%' AND kind = 'email';
+CREATE INDEX idx_activity_ws_time ON activity (workspace_id, occurred_at DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_aparticipant_address ON activity_participant (workspace_id, lower(address)) WHERE address IS NOT NULL;
+CREATE INDEX idx_aparticipant_person ON activity_participant (workspace_id, person_id, activity_id) WHERE person_id IS NOT NULL;
+CREATE INDEX idx_aparticipant_user ON activity_participant (workspace_id, user_id, activity_id) WHERE user_id IS NOT NULL;

--- a/backend/migrations/core/1787046665_activity_spine_drop_workspace.up.sql
+++ b/backend/migrations/core/1787046665_activity_spine_drop_workspace.up.sql
@@ -1,0 +1,57 @@
+-- 1787034854: the activity spine drops the tenant column (ADR-0091 §8 phase D).
+--
+-- activity and the two tables that hang off every row of it:
+--
+--   activity              the record of what happened
+--   activity_link         what it is about — a person, a company, a deal
+--   activity_participant  who was on it, by seat or by address
+--
+-- activity is the most-referenced table in the schema after person, which is
+-- why it takes a change of its own. Its identity key is already the provider's:
+-- uq_activity_source is (source_system, source_id), which is what makes a
+-- connector replay free.
+--
+-- uq_activity_ws_id is phase B's leftover — a second copy of activity's own
+-- primary key, created as a composite foreign-key target that phase C rewrote
+-- away. It is referenced by no foreign key and indexes nothing activity_pkey
+-- does not.
+
+ALTER TABLE activity_participant DROP CONSTRAINT activity_participant_workspace_id_fkey;
+ALTER TABLE activity_participant DROP COLUMN workspace_id;
+
+ALTER TABLE activity_link DROP CONSTRAINT activity_link_workspace_id_fkey;
+ALTER TABLE activity_link DROP COLUMN workspace_id;
+
+-- The meeting overlap rule is an EXCLUDE constraint, so it names the column in
+-- its own definition and cannot be carried through a DROP COLUMN: it is dropped
+-- and rebuilt on what it was always really about — one host cannot be in two
+-- meetings at once. The tenant was only ever the outer bound around that host.
+ALTER TABLE activity DROP CONSTRAINT activity_meeting_no_overlap;
+ALTER TABLE activity DROP CONSTRAINT uq_activity_ws_id;
+ALTER TABLE activity DROP CONSTRAINT activity_workspace_id_fkey;
+ALTER TABLE activity DROP COLUMN workspace_id;
+
+ALTER TABLE activity ADD CONSTRAINT activity_meeting_no_overlap
+  EXCLUDE USING gist (
+    host_user_id WITH =,
+    tsrange(timezone('UTC', occurred_at), timezone('UTC', occurred_at) + interval '1 hour') WITH &&
+  ) WHERE (kind = 'meeting' AND host_user_id IS NOT NULL AND archived_at IS NULL);
+
+-- The thirteen indexes that led with the column, recreated on what actually
+-- selects rows: a kind, a direction, a thread, a counterparty, a task's
+-- assignee, a reminder's moment, a meeting's host, a participant's person.
+CREATE INDEX idx_activity_channel_thread ON activity (channel_provider, thread_key) WHERE channel_provider IS NOT NULL;
+CREATE INDEX idx_activity_counterparty_email ON activity (counterparty_email) WHERE counterparty_email IS NOT NULL;
+CREATE INDEX idx_activity_counterparty_outbound_attested ON activity (counterparty_email) WHERE counterparty_email IS NOT NULL AND counterparty_outbound_attested;
+CREATE INDEX idx_activity_direction ON activity (direction, occurred_at DESC) WHERE direction IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_activity_kind ON activity (kind, occurred_at DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_activity_labeled ON activity (capture_labeled_at) WHERE capture_labeled_at IS NOT NULL;
+CREATE INDEX idx_activity_meeting_host ON activity (host_user_id, occurred_at) WHERE kind = 'meeting' AND archived_at IS NULL;
+CREATE INDEX idx_activity_reminders ON activity (remind_at) WHERE kind = 'task' AND remind_at IS NOT NULL AND is_done = false AND archived_at IS NULL;
+CREATE INDEX idx_activity_tasks ON activity (assignee_id, due_at) WHERE kind = 'task' AND is_done = false AND archived_at IS NULL;
+CREATE INDEX idx_activity_thread ON activity (thread_key) WHERE thread_key IS NOT NULL;
+CREATE INDEX idx_activity_unlabeled ON activity (occurred_at) WHERE capture_label IS NULL AND captured_by LIKE 'connector:%' AND kind = 'email';
+CREATE INDEX idx_activity_ws_time ON activity (occurred_at DESC) WHERE archived_at IS NULL;
+CREATE INDEX idx_aparticipant_address ON activity_participant (lower(address)) WHERE address IS NOT NULL;
+CREATE INDEX idx_aparticipant_person ON activity_participant (person_id, activity_id) WHERE person_id IS NOT NULL;
+CREATE INDEX idx_aparticipant_user ON activity_participant (user_id, activity_id) WHERE user_id IS NOT NULL;


### PR DESCRIPTION
`activity` and the two tables that hang off every row of it: `activity_link` (what it is about) and `activity_participant` (who was on it). `activity` is the most-referenced table in the schema after `person`, which is why it takes a change of its own — ~220 sites across ~100 files.

Its identity key was already the provider's: `uq_activity_source` is `(source_system, source_id)`, which is what makes a connector replay free. `uq_activity_ws_id` goes with the column — phase B's leftover, a second copy of `activity`'s own primary key, referenced by no foreign key.

## An EXCLUDE constraint cannot be carried through a DROP COLUMN

`activity_meeting_no_overlap` is a gist EXCLUDE naming `workspace_id` in its own definition, so it is dropped and rebuilt on what it was always really about: **one host cannot be in two meetings at once.** The tenant was the outer bound around that host, and there is one installation to bound.

## Three statements templated over mixed tables, again

`search`'s `pendingSources` and `flipreconcile`'s orphan scan both gain `activity` — the same per-source predicate the last two slices introduced, one entry at a time as their tables lose the column. The cutover fixture's estate wipe is the third.

## How the fixture churn was done, and what it caught

~300 statements changed. They were rewritten mechanically and **checked** mechanically: one pass rewrites INSERT column/value lists and renumbers placeholders, a second removes workspace predicates from SELECT/UPDATE/DELETE, and a third compares each SQL literal's highest `$N` against the arguments its call supplies — accounting for the helpers that prepend `id` and `workspace`.

What the static pass could not resolve it **named rather than guessed**, which is how the `INSERT … SELECT` forms, the multi-row `VALUES`, and several env-specific seeders were found. Two things it did *not* catch, and which the lane did:

- a blunt predicate removal stripped `WHERE workspace_id = $1` from `person` and `organization` subqueries sharing a literal with `activity` — those tables keep the column, and the benchmark fixture is restored;
- one fixture seeds against a schema deliberately rolled **back** past this migration (`migrations/schema_integration_test.go`), where the column still exists, so it keeps writing it.

Two helpers gain a sibling that mints an id and binds nothing else — `SeedID` on `SearchEnv` and `SeedIDRow` beside `SeedRow` — which is what each becomes when phase D finishes.

## Verification

- Lane applied to an empty database; the down restores all three columns with their foreign keys, the unique, the exclusion constraint and the fifteen wide indexes.
- `make check-backend` green; `make test-integration` OK, 0 skips, 41 packages.

Phase D: 49 → 46 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the tenant column from the activity spine: `activity`, `activity_link`, and `activity_participant` (ADR‑0091 §8 phase D). Old behavior required `workspace_id` in inserts, joins, and constraints; new behavior removes it, relies on installation‑wide identity `(source_system, source_id)`, and keeps behavior otherwise unchanged except meeting overlap is enforced per host installation‑wide.

- Rebuilds `activity_meeting_no_overlap` to key on host only (no `workspace_id`).
- Removes `uq_activity_ws_id`; keeps `uq_activity_source` on `(source_system, source_id)`.
- Drops workspace predicates and columns across DML/joins; links and participants now join by `activity_id` only; reply threading matches by medium and `thread_key` across the installation.
- Adds `activity` to search pending‑sources; updates `flipreconcile` to stop tenant scoping for activities.
- Updates writers/stores (capture sink/reply, lifecycle, participant log/backfill, message identity) to not supply/expect `workspace_id`; updates fixtures/tests and adds `SeedID`/`SeedIDRow`.

**Required migration actions**
- Remove `workspace_id` from all SQL touching `activity`, `activity_link`, or `activity_participant`.
- Join link/participant rows to activities by `activity_id` only.
- Deduplicate activities by `(source_system, source_id)`; stop relying on workspace‑scoped uniqueness.
- Replace workspace‑aware test/fixture helpers for `activity` with `SeedID`/`SeedIDRow`.

<sup>Written for commit 6eedf480ed3267aa4406f8fe210787f364a07c8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

