### PR TITLE
test(e2e): the lead surface has specs — list, note, promote

### DIFF
--- a/frontend/e2e/leads.spec.ts
+++ b/frontend/e2e/leads.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { mockApi } from "./seed";
+
+/**
+ * The lead surface end to end (ADR-0118/A169, ADR-0119/A170): the list names
+ * the owner and opens the LEAD's own page (never the person's), the page can
+ * be worked (a note logged against the lead), and promotion says what it will
+ * do before it does it. German chrome, as the app renders it.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("AC-leads-list: a row names its owner and opens the lead's own page", async ({
+  page,
+}) => {
+  await page.goto("/#/leads");
+  const row = page.getByRole("row", { name: /Jonas Petersen/ });
+  await expect(row).toBeVisible();
+  // The owner column answers "whose lead is this" — the same column the
+  // people and company lists carry, never "typed by a person".
+  await expect(row).toContainText("Lena Fischer");
+  await row.getByText("Jonas Petersen").click();
+  await expect(page).toHaveURL(/#\/leads\/l-1$/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Jonas Petersen" }),
+  ).toBeVisible();
+});
+
+test("AC-leaddetail-work: a note is logged against the lead itself", async ({
+  page,
+}) => {
+  const posted = page.waitForRequest(
+    (request) =>
+      request.url().endsWith("/v1/activities") && request.method() === "POST",
+  );
+  await page.goto("/#/leads/l-1");
+  // The composer is inline on the lead page (ADR-0118/A169), not behind a
+  // button: working the lead is the page's job.
+  await page.getByLabel("Betreff *").fill("Rückruf vereinbart");
+  await page.getByRole("button", { name: "Erfassen" }).click();
+  const request = await posted;
+  const body = request.postDataJSON();
+  expect(body.subject).toBe("Rückruf vereinbart");
+  // The link is the LEAD, not a person: this is what activity_link's lead arm
+  // (migration 0038) exists for.
+  expect(body.links).toEqual([{ entity_type: "lead", entity_id: "l-1" }]);
+});
+
+test("AC-leaddetail-promote: the confirm step says what promotion will do, then lands on the contact", async ({
+  page,
+}) => {
+  await page.goto("/#/leads/l-1");
+  await page.getByRole("button", { name: "Zum Kontakt machen" }).click();
+  await expect(
+    page.getByText("Die Übernahme legt einen neuen Kontakt an."),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Übernehmen" }).click();
+  await expect(page).toHaveURL(/#\/contacts\/p-new$/);
+});

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -84,6 +84,25 @@ export const stages = [
   },
 ];
 
+// One working lead for the leads list and page: named, owned by u1, scored,
+// promotable (it has an email), with the identity fields the inline rows edit.
+export const seededLead = {
+  id: "l-1",
+  workspace_id: "w",
+  full_name: "Jonas Petersen",
+  email: "jonas@nordwind.example",
+  title: "Head of Operations",
+  company_name: "Nordwind Logistik",
+  status: "working",
+  score: 46,
+  owner_id: "u1",
+  captured_by: "human:u1",
+  source: "inbound",
+  version: 3,
+  created_at: "2026-07-01T08:00:00Z",
+  updated_at: "2026-07-05T08:00:00Z",
+};
+
 export const anna = {
   id: "p-anna",
   workspace_id: "w",
@@ -1029,7 +1048,45 @@ export async function mockApi(
       return json(brandt);
     }
     if (path === "/leads" && method === "GET") {
-      return json(page([]));
+      return json(page([seededLead]));
+    }
+    if (path === "/leads/l-1" && method === "GET") {
+      return json(seededLead);
+    }
+    if (path === "/leads/l-1" && method === "PATCH") {
+      const body = route.request().postDataJSON();
+      return json({ ...seededLead, ...body, version: seededLead.version + 1 });
+    }
+    if (path === "/leads/l-1/score") {
+      return json({ score: seededLead.score, explained: false });
+    }
+    if (path === "/leads/l-1/promote-preview") {
+      return json({ outcome: "create" });
+    }
+    if (path === "/leads/l-1/promote" && method === "POST") {
+      return json({
+        person: {
+          ...anna,
+          id: "p-new",
+          full_name: "Jonas Petersen",
+          converted_from_lead_id: "l-1",
+        },
+        merged: false,
+        lead_id: "l-1",
+      });
+    }
+    if (path === "/users") {
+      return json(
+        page([
+          {
+            id: "u1",
+            email: "lena@seed.test",
+            display_name: "Lena Fischer",
+            seat_type: "full",
+            status: "active",
+          },
+        ]),
+      );
     }
     if (path === "/pipelines") {
       return json(
@@ -1079,6 +1136,26 @@ export async function mockApi(
     }
     if (path.startsWith("/approvals/") && method === "POST") {
       return json({ ...approval, status: "approved" });
+    }
+    if (path === "/activities" && method === "POST") {
+      const body = route.request().postDataJSON();
+      return json(
+        {
+          id: "act-new",
+          workspace_id: "w",
+          kind: body.kind ?? "note",
+          subject: body.subject ?? "",
+          body: body.body ?? null,
+          occurred_at: "2026-07-06T09:00:00Z",
+          links: body.links ?? [],
+          source: "manual",
+          captured_by: "human:u1",
+          version: 1,
+          created_at: "2026-07-06T09:00:00Z",
+          updated_at: "2026-07-06T09:00:00Z",
+        },
+        201,
+      );
     }
     if (path === "/activities") {
       return json(page([]));

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1082,8 +1082,8 @@ export async function mockApi(
             id: "u1",
             email: "lena@seed.test",
             display_name: "Lena Fischer",
-            seat_type: "full",
             status: "active",
+            is_agent: false,
           },
         ]),
       );


### PR DESCRIPTION
Zero lead e2e specs until now; three named ones against the mocked API. Whole Playwright suite: 92 passed / 14 skipped (the live-stack suites). Codex reviewed: the seed's ids and page() helper predate this change and stay as they are. Batman merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end coverage for the lead surface using the mocked API. Previously we had no lead e2e specs; now we test list navigation, note logging against the lead, and promotion flow.

**Details**
- Adds `frontend/e2e/leads.spec.ts` with three Playwright tests (German UI): list shows owner and opens the lead page; note posts to `/v1/activities` linking the lead; promotion shows a confirm message and navigates to the new contact.
- Extends `seed.ts` with a working lead `l-1` and user `u1`, plus mocks for: `GET /leads`, `GET/PATCH /leads/l-1`, `GET /leads/l-1/score`, `GET /leads/l-1/promote-preview`, `POST /leads/l-1/promote`, `GET /users`, and `POST /activities`.

<sup>Written for commit 7a2f6d64b04becdcd0cbd2b1e052d4d17a77fe16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

