### PR TITLE
feat(records): a person and an account remember when something last happened, and the lists sort by it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14921,6 +14921,15 @@ components:
         captured_by: { type: string, readOnly: true, description: 'Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied.' }
         raw: { type: [object, 'null'], additionalProperties: true }
         version: { $ref: '#/components/schemas/RowVersion' }
+        last_activity_at:
+          type: [string, 'null']
+          format: date-time
+          readOnly: true
+          description: >-
+            When something last happened with this person — the newest `occurred_at` of an activity
+            linked to it, maintained on the activity write exactly as `deal.last_activity_at` is
+            (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must
+            reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-1).
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }
@@ -15161,6 +15170,15 @@ components:
         raw: { type: [object, 'null'], additionalProperties: true }
         partner: { $ref: '#/components/schemas/Partner' }
         version: { $ref: '#/components/schemas/RowVersion' }
+        last_activity_at:
+          type: [string, 'null']
+          format: date-time
+          readOnly: true
+          description: >-
+            When something last happened with this account — the newest `occurred_at` of an activity
+            linked to it, maintained on the activity write exactly as `deal.last_activity_at` is
+            (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must
+            reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }

--- a/backend/internal/compose/integration/lastactivity_integration_test.go
+++ b/backend/internal/compose/integration/lastactivity_integration_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// last_activity_at on person and organization (PO-DDL-1/-4 as amended
+// 2026-08-18): maintained by the activity write exactly as deal's is, over a
+// real migrated Postgres. A note on a contact moves the contact's clock and
+// the clock of every account currently employing them; a note on a deal
+// moves the deal's account; a back-dated capture never moves a clock
+// backwards; and the two lists sort by it.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestLastActivity_MovesThePersonAndEveryAccountItReaches(t *testing.T) {
+	e := Setup(t)
+	acme := e.SeedOrg(t, "Acme Clock", nil)
+	other := e.SeedOrg(t, "Other Clock", nil)
+	quiet := e.SeedOrg(t, "Quiet Clock", nil)
+	staff := e.SeedPerson(t, "Works At Acme", nil)
+	personID := ids.From[ids.PersonKind](staff)
+	orgID := ids.From[ids.OrganizationKind](acme)
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID, IsCurrentPrimary: true, Source: "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	deal, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Other's deal", AmountMinor: int64Ptr(100), Currency: strPtr("EUR"),
+		PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(other)), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log := func(when time.Time, links ...activities.ActivityLinkInput) {
+		t.Helper()
+		subject := "touch"
+		if _, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+			Kind: "note", Subject: &subject, OccurredAt: &when, Source: "manual", Links: links,
+		}); err != nil {
+			t.Fatalf("logging: %v", err)
+		}
+	}
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	older := newest.Add(-72 * time.Hour)
+	log(newest, activities.ActivityLinkInput{EntityType: "person", EntityID: staff})
+	// A back-dated capture arriving later must not move a clock backwards.
+	log(older, activities.ActivityLinkInput{EntityType: "person", EntityID: staff})
+	log(older, activities.ActivityLinkInput{EntityType: "deal", EntityID: ids.UUID(deal.Id)})
+
+	person, err := e.People.GetPerson(e.Admin(), personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if person.LastActivityAt == nil || !person.LastActivityAt.Equal(newest) {
+		t.Fatalf("person.last_activity_at = %v, want %v (the newest, not the last written)", person.LastActivityAt, newest)
+	}
+	clock := func(org ids.UUID) *time.Time {
+		t.Helper()
+		o, err := e.People.GetOrganization(e.Admin(), orgIDOf(org), storekit.LiveOnly)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return o.LastActivityAt
+	}
+	if got := clock(acme); got == nil || !got.Equal(newest) {
+		t.Fatalf("employer's last_activity_at = %v, want %v via the live employment", got, newest)
+	}
+	if got := clock(other); got == nil || !got.Equal(older) {
+		t.Fatalf("deal account's last_activity_at = %v, want %v via the deal", got, older)
+	}
+	if got := clock(quiet); got != nil {
+		t.Fatalf("an account nothing reached has last_activity_at = %v, want NULL", got)
+	}
+
+	// The list sorts by it, newest first: acme, other, then the untouched one.
+	sort := "-last_activity_at"
+	page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Sort: &sort})
+	if err != nil {
+		t.Fatalf("sorting organizations by last activity: %v", err)
+	}
+	var order []ids.UUID
+	for _, o := range page {
+		id := ids.UUID(o.Id)
+		if id == acme || id == other || id == quiet {
+			order = append(order, id)
+		}
+	}
+	if len(order) != 3 || order[0] != acme || order[1] != other || order[2] != quiet {
+		t.Fatalf("sort=-last_activity_at ordered %v, want acme, other, quiet (NULLS LAST)", order)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15517,8 +15517,11 @@ type Organization struct {
 	// It is one ordinary organization, reachable by id everywhere, but the surfaces that answer
 	// *which companies are we selling to* exclude it unless `include_anchor` is set, and it
 	// cannot be archived or merged. A caller that offers company actions should tell it apart.
-	IsAnchor  *bool   `json:"is_anchor,omitempty"`
-	LegalName *string `json:"legal_name,omitempty"`
+	IsAnchor *bool `json:"is_anchor,omitempty"`
+
+	// LastActivityAt When something last happened with this account — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
+	LegalName      *string    `json:"legal_name,omitempty"`
 
 	// Lifecycle WHERE THE ACCOUNT STANDS with us (PO-DDL-4, ADR-0079/A124). Single-valued: an account is at one point in a sales motion at a time. `unknown` is the default and means it — the retired `classification` defaulted to `prospect` and, having no writer, rendered that default on every unassessed account as though someone had judged it.
 	Lifecycle *OrganizationLifecycle `json:"lifecycle,omitempty"`
@@ -17118,7 +17121,10 @@ type Person struct {
 	// FullName Always present (display name).
 	FullName string             `json:"full_name"`
 	Id       openapi_types.UUID `json:"id"`
-	LastName *string            `json:"last_name,omitempty"`
+
+	// LastActivityAt When something last happened with this person — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-1).
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
+	LastName       *string    `json:"last_name,omitempty"`
 
 	// MergedIntoId Set when this row was merged away.
 	MergedIntoId *openapi_types.UUID     `json:"merged_into_id,omitempty"`
@@ -27606,6 +27612,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "is_anchor")
 	}
 
+	if raw, found := object["last_activity_at"]; found {
+		err = json.Unmarshal(raw, &a.LastActivityAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'last_activity_at': %w", err)
+		}
+		delete(object, "last_activity_at")
+	}
+
 	if raw, found := object["legal_name"]; found {
 		err = json.Unmarshal(raw, &a.LegalName)
 		if err != nil {
@@ -27844,6 +27858,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.LastActivityAt != nil {
+		object["last_activity_at"], err = json.Marshal(a.LastActivityAt)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'last_activity_at': %w", err)
+		}
+	}
+
 	if a.LegalName != nil {
 		object["legal_name"], err = json.Marshal(a.LegalName)
 		if err != nil {
@@ -28073,6 +28094,14 @@ func (a *Person) UnmarshalJSON(b []byte) error {
 		delete(object, "id")
 	}
 
+	if raw, found := object["last_activity_at"]; found {
+		err = json.Unmarshal(raw, &a.LastActivityAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'last_activity_at': %w", err)
+		}
+		delete(object, "last_activity_at")
+	}
+
 	if raw, found := object["last_name"]; found {
 		err = json.Unmarshal(raw, &a.LastName)
 		if err != nil {
@@ -28248,6 +28277,13 @@ func (a Person) MarshalJSON() ([]byte, error) {
 	object["id"], err = json.Marshal(a.Id)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'id': %w", err)
+	}
+
+	if a.LastActivityAt != nil {
+		object["last_activity_at"], err = json.Marshal(a.LastActivityAt)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'last_activity_at': %w", err)
+		}
 	}
 
 	if a.LastName != nil {

--- a/backend/internal/modules/activities/activitylinks.go
+++ b/backend/internal/modules/activities/activitylinks.go
@@ -61,8 +61,9 @@ func (e *TooManyLinksError) FieldFault() (field, code, message string) {
 	return fieldLinks, "too_many_links", e.Error()
 }
 
-// insertActivityLinks writes the polymorphic link rows and maintains
-// deal.last_activity_at on deal links. The FK alone is not enough: it is
+// insertActivityLinks writes the polymorphic link rows and maintains the
+// last_activity_at clocks (deal, person, organization — see
+// advanceLastActivity) on every link. The FK alone is not enough: it is
 // checked as the table owner, bypassing RLS, so it would accept a
 // guessed cross-tenant or out-of-scope UUID as a link target — every
 // target passes the row-scope link check first.
@@ -101,15 +102,44 @@ func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, a
 			wsID, activityID, link.EntityType, link.EntityID); err != nil {
 			return err
 		}
-		if link.EntityType == "deal" {
-			if _, err := tx.Exec(ctx,
-				`UPDATE deal SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
-				link.EntityID, occurredAt); err != nil {
-				return err
-			}
+		if err := advanceLastActivity(ctx, tx, link, occurredAt); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// advanceLastActivity moves the linked record's last_activity_at clock —
+// deal, person and organization alike — plus every ACCOUNT the link reaches
+// through the deal or a live employment, the same three arms OrgReachSet
+// walks for the account timeline, so the column and the timeline agree.
+//
+// Each statement is a single-statement monotone max: greatest(stored, new)
+// computed inside the UPDATE, never from a pre-read, so concurrent writers
+// and a back-dated capture both converge on the newest occurred_at.
+func advanceLastActivity(ctx context.Context, tx pgx.Tx, link ActivityLinkInput, occurredAt time.Time) error {
+	direct := map[string]string{
+		linkEntityDeal:         `UPDATE deal SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
+		linkEntityPerson:       `UPDATE person SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
+		linkEntityOrganization: `UPDATE organization SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
+	}
+	if stmt, ok := direct[link.EntityType]; ok {
+		if _, err := tx.Exec(ctx, stmt, link.EntityID, occurredAt); err != nil {
+			return err
+		}
+	}
+	reached := map[string]string{
+		linkEntityDeal:   `SELECT organization_id FROM deal WHERE id = $1 AND organization_id IS NOT NULL`,
+		linkEntityPerson: `SELECT organization_id FROM relationship WHERE person_id = $1 AND kind = 'employment' AND ended_at IS NULL AND archived_at IS NULL`,
+	}
+	via, ok := reached[link.EntityType]
+	if !ok {
+		return nil
+	}
+	_, err := tx.Exec(ctx,
+		`UPDATE organization SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2)
+		 WHERE id IN (`+via+`)`, link.EntityID, occurredAt)
+	return err
 }
 
 // InvalidLinkTypeError maps to 422.

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -131,6 +131,10 @@ func mirrorStructuralBindings() []FieldBinding {
 			Reason: "Derived from captured interactions; the mirror holds no interaction history.",
 		},
 		{
+			WireSlot: "last_activity_at", Disposition: DispositionNativeOnly,
+			Reason: "Maintained from this installation's own timeline on the activity write; the mirror holds no interaction history.",
+		},
+		{
 			WireSlot: "merged_into_id", Disposition: DispositionNativeOnly,
 			Reason: "Merge is a native operation over native rows; a mirrored record is never merged away.",
 		},

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -36,6 +36,9 @@ const (
 	leadSourceColumn  = "source"
 	createdAtColumn   = "created_at"
 	updatedAtColumn   = "updated_at"
+	// lastActivityColumn is the timeline clock person and organization carry
+	// (DM-VOCAB-1/2), maintained by activities on the link write.
+	lastActivityColumn = "last_activity_at"
 )
 
 // leadListFields is the lead list's core sortable vocabulary. Every column

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -72,10 +72,11 @@ type ListOrganizationsInput struct {
 // vocabulary — exactly the data-model §13.5 DM-VOCAB-2 set; active cf_
 // columns join it per request.
 var organizationListFields = map[string]string{
-	createdAtColumn: storekit.KindTimestamp,
-	updatedAtColumn: storekit.KindTimestamp,
-	orgNameColumn:   fieldcatalog.TypeText,
-	ownerIDColumn:   storekit.KindUUID,
+	createdAtColumn:    storekit.KindTimestamp,
+	updatedAtColumn:    storekit.KindTimestamp,
+	orgNameColumn:      fieldcatalog.TypeText,
+	ownerIDColumn:      storekit.KindUUID,
+	lastActivityColumn: storekit.KindTimestamp,
 }
 
 // organizationDomainClause narrows the page to the account that lists one

--- a/backend/internal/modules/people/organization_read.go
+++ b/backend/internal/modules/people/organization_read.go
@@ -141,6 +141,7 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&classification, &lifecycle, &relevance, &parentID, &mergedInto, &logoObjectKey, &linkedinURL, &o.Source, &o.CapturedBy,
 		&version, &o.CreatedAt, &o.UpdatedAt, &o.ArchivedAt, &o.IsAnchor,
+		&o.LastActivityAt,
 	}
 	cf := storekit.ScanDests(active)
 	if err := row.Scan(append(append(dests, cf...), extra...)...); err != nil {

--- a/backend/internal/modules/people/organizationarchive.go
+++ b/backend/internal/modules/people/organizationarchive.go
@@ -95,7 +95,7 @@ func (s *Store) ArchiveOrganization(ctx context.Context, id ids.OrganizationID) 
 const orgColumns = `id, workspace_id, display_name, legal_name, description, industry, size_band, owner_id,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	classification, lifecycle, relevance, parent_org_id, merged_into_id, logo_object_key, linkedin_url, source, captured_by,
-	version, created_at, updated_at, archived_at, is_anchor`
+	version, created_at, updated_at, archived_at, is_anchor, last_activity_at`
 
 // readOrganization resolves one organization row; active names the
 // custom-field columns to carry alongside the core ones — nil for

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -162,7 +162,7 @@ func ensurePersonEmailsUnclaimed(ctx context.Context, tx pgx.Tx, emails []Person
 const personColumns = `id, workspace_id, full_name, first_name, last_name, title, owner_id,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	merged_into_id, converted_from_lead_id, source, captured_by,
-	version, created_at, updated_at, archived_at`
+	version, created_at, updated_at, archived_at, last_activity_at`
 
 // readPerson resolves one person row; active names the custom-field
 // columns to carry alongside the core ones — nil for internal decision
@@ -202,7 +202,7 @@ func scanPerson(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcon
 		&id, &wsID, &p.FullName, &p.FirstName, &p.LastName, &p.Title, &ownerID,
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&mergedInto, &fromLead, &p.Source, &p.CapturedBy,
-		&version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt,
+		&version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt, &p.LastActivityAt,
 	}
 	cf := storekit.ScanDests(active)
 	if err := row.Scan(append(append(dests, cf...), extra...)...); err != nil {

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -63,10 +63,11 @@ type ListPeopleInput struct {
 // exactly the data-model §13.5 DM-VOCAB-1 set; active cf_ columns join
 // it per request.
 var personListFields = map[string]string{
-	createdAtColumn:  storekit.KindTimestamp,
-	updatedAtColumn:  storekit.KindTimestamp,
-	personNameColumn: fieldcatalog.TypeText,
-	ownerIDColumn:    storekit.KindUUID,
+	createdAtColumn:    storekit.KindTimestamp,
+	updatedAtColumn:    storekit.KindTimestamp,
+	personNameColumn:   fieldcatalog.TypeText,
+	ownerIDColumn:      storekit.KindUUID,
+	lastActivityColumn: storekit.KindTimestamp,
 }
 
 // personTagClause narrows the page to the people carrying one tag, or ""

--- a/backend/migrations/core/1787028748_person_org_last_activity.down.sql
+++ b/backend/migrations/core/1787028748_person_org_last_activity.down.sql
@@ -1,0 +1,6 @@
+-- Reverse: the two accelerator columns and their sort indexes go; the
+-- timeline they were derived from is untouched.
+DROP INDEX IF EXISTS idx_org_last_activity_keyset;
+DROP INDEX IF EXISTS idx_person_last_activity_keyset;
+ALTER TABLE organization DROP COLUMN IF EXISTS last_activity_at;
+ALTER TABLE person       DROP COLUMN IF EXISTS last_activity_at;

--- a/backend/migrations/core/1787028748_person_org_last_activity.up.sql
+++ b/backend/migrations/core/1787028748_person_org_last_activity.up.sql
@@ -1,0 +1,49 @@
+-- last_activity_at on person and organization (PO-DDL-1/-4 as amended
+-- 2026-08-18): when something last happened with the record, maintained on
+-- the activity write exactly as deal.last_activity_at is — a read accelerator
+-- the timeline can always rebuild, never a second truth. It backs the
+-- "Last activity" sort on both lists (DM-VOCAB-1/2).
+--
+-- A person's clock is the newest occurred_at of an activity linked to them.
+-- An account's clock is the newest occurred_at of an activity that REACHES
+-- it — filed against it, against one of its deals, or against a contact it
+-- currently employs — the same three arms activities.OrgReachSet walks for
+-- the account timeline, so the column and the timeline cannot disagree.
+--
+-- The indexes are in the ORDER BY's own shape (see 0292): the sort column,
+-- then the keyset tie-breakers, partial on the live rows, descending only —
+-- recency is asked for newest-first.
+
+ALTER TABLE person       ADD COLUMN IF NOT EXISTS last_activity_at timestamptz NULL;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS last_activity_at timestamptz NULL;
+
+UPDATE person p
+   SET last_activity_at = t.newest
+  FROM (SELECT l.person_id, max(a.occurred_at) AS newest
+          FROM activity_link l
+          JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+         WHERE l.person_id IS NOT NULL
+         GROUP BY l.person_id) t
+ WHERE p.id = t.person_id;
+
+UPDATE organization o
+   SET last_activity_at = t.newest
+  FROM (SELECT reach.organization_id, max(a.occurred_at) AS newest
+          FROM (SELECT l.activity_id, x.org_id AS organization_id
+                  FROM activity_link l
+                  LEFT JOIN deal d ON d.id = l.deal_id
+                  LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
+                    AND r.ended_at IS NULL AND r.archived_at IS NULL
+                  CROSS JOIN LATERAL (VALUES (l.organization_id), (d.organization_id), (r.organization_id)) AS x(org_id)
+                 WHERE x.org_id IS NOT NULL) reach
+          JOIN activity a ON a.id = reach.activity_id AND a.archived_at IS NULL
+         GROUP BY reach.organization_id) t
+ WHERE o.id = t.organization_id;
+
+CREATE INDEX IF NOT EXISTS idx_person_last_activity_keyset
+  ON person (last_activity_at DESC NULLS LAST, created_at DESC, id DESC)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_org_last_activity_keyset
+  ON organization (last_activity_at DESC NULLS LAST, created_at DESC, id DESC)
+  WHERE archived_at IS NULL;

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -367,7 +367,9 @@ var crossStoreWrites = gatekit.Waive(map[string]string{
 	// activities maintains the deal-timeline denormalization where the
 	// activity lands: deal.last_activity_at moves in the same transaction
 	// as the activity insert or the two drift.
-	"internal/modules/activities:deal": "deal.last_activity_at is denormalized from the timeline; it must move in the activity's own transaction",
+	"internal/modules/activities:deal":         "deal.last_activity_at is denormalized from the timeline; it must move in the activity's own transaction",
+	"internal/modules/activities:person":       "person.last_activity_at is denormalized from the timeline exactly as deal's is; same transaction, same reason",
+	"internal/modules/activities:organization": "organization.last_activity_at is denormalized from the timeline (direct link, deal, live employment — the OrgReachSet arms); same transaction, same reason",
 
 	// The outbound-send reconcile folds the provider's own captured echo of a
 	// message this workspace sent into the send's own row. That fold is one

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -131,7 +131,7 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	"internal/modules/ai:persistBuildVersion":         "runs only inside CompleteBuild's transaction, under its voice_profile row lock (storekit.LockRow before the pre-read)",
 
 	// Writes that are race-free by their own shape.
-	"internal/modules/activities:insertActivityLinks":     "deal.last_activity_at is a single-statement monotone max (greatest of stored and new) — the value is computed inside the UPDATE, never from a pre-read, so concurrent writers converge on the maximum",
+	"internal/modules/activities:advanceLastActivity":     "every last_activity_at clock (deal, person, organization) is a single-statement monotone max (greatest of stored and new) — the value is computed inside the UPDATE, never from a pre-read, so concurrent writers converge on the maximum",
 	"internal/modules/capture:AdvanceChannelPollOffsetTx": "single-statement monotone cursor: the `poll_offset < $2` predicate IS the CAS, so a writer holding a lower offset than the row already carries matches zero rows and its advance is correctly dropped. A version guard would be wrong here — the poll cursor is not optimistically concurrent state an operator edits, and bumping version on it would fire the send path's binding fence on every inbound message (0151's trigger comment)",
 	"internal/modules/privacy:anonymizeSubjectRows":       "terminal absolute write: the erasure overwrites the PII columns regardless of concurrent state, by design",
 	"internal/modules/privacy:anonymizeLeadTwins":         "terminal absolute write: the same erasure statement as anonymizeSubjectRows, extracted for length — it overwrites the lead twin's PII columns regardless of concurrent state, by design",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10034,6 +10034,11 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             version?: components["schemas"]["RowVersion"];
+            /**
+             * Format: date-time
+             * @description When something last happened with this person — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-1).
+             */
+            readonly last_activity_at?: string | null;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -10222,6 +10227,11 @@ export interface components {
             } | null;
             partner?: components["schemas"]["Partner"];
             version?: components["schemas"]["RowVersion"];
+            /**
+             * Format: date-time
+             * @description When something last happened with this account — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+             */
+            readonly last_activity_at?: string | null;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -562,6 +562,7 @@ export const de = {
   "list.unowned": "Nicht zugewiesen",
   "list.created": "Erstellt",
   "list.updated": "Geändert",
+  "list.lastActivity": "Letzte Aktivität",
   "list.filterOwnerMe": "Meine Datensätze",
   "list.filterOwnerAll": "Alle Zuständigen",
   "list.filterOwnerUnassigned": "Nicht zugewiesen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -574,6 +574,7 @@ export const en = {
   "list.unowned": "Unassigned",
   "list.created": "Created",
   "list.updated": "Updated",
+  "list.lastActivity": "Last activity",
   "list.filterOwnerMe": "My records",
   "list.filterOwnerAll": "Any owner",
   "list.filterOwnerUnassigned": "Unassigned",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -555,6 +555,7 @@ export const vi = {
   "list.unowned": "Chưa phân công",
   "list.created": "Ngày tạo",
   "list.updated": "Cập nhật",
+  "list.lastActivity": "Hoạt động gần nhất",
   "list.filterOwnerMe": "Bản ghi của tôi",
   "list.filterOwnerAll": "Mọi người phụ trách",
   "list.filterOwnerUnassigned": "Chưa phân công",

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -764,6 +764,33 @@ describe("CompaniesScreen — list dials reach the server (P-14)", () => {
     );
   });
 
+  it("sorts by last activity on the server, not over the rows it holds", async () => {
+    const user = userEvent.setup();
+    const { urls } = stubFetch(async () =>
+      jsonResponse({
+        data: [{ ...org, last_activity_at: "2026-08-10T12:00:00Z" }],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(<CompaniesScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Sort by Last activity" }),
+    );
+    // The server owns the order: a fresh keyset walk under the new sort.
+    await waitFor(() =>
+      expect(
+        urls.some(
+          (url) =>
+            url.includes("sort=last_activity_at") && !url.includes("cursor="),
+        ),
+      ).toBe(true),
+    );
+  });
+
   it("narrows to one lifecycle stage through the server", async () => {
     const user = userEvent.setup();
     const { urls } = stubFetch(async () => emptyPage());

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -679,6 +679,21 @@ export function CompaniesScreen() {
             sort: "owner_id",
           },
           {
+            // When something last happened with this record — the timeline's
+            // clock, kept by the activity write, so it can be sorted on the
+            // server. Empty when nothing has, which is a fact, not a gap.
+            key: "lastActivity",
+            header: t("list.lastActivity"),
+            cell: (org: Organization) => (
+              <span className="t-caption">
+                {org.last_activity_at
+                  ? formatDateAbbrev(org.last_activity_at, locale, RECORD_ZONE)
+                  : ""}
+              </span>
+            ),
+            sort: "last_activity_at",
+          },
+          {
             key: "created",
             header: t("list.created"),
             cell: (org: Organization) => (

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -421,6 +421,25 @@ export function ContactsScreen() {
             sort: "owner_id",
           },
           {
+            // When something last happened with this record — the timeline's
+            // clock, kept by the activity write, so it can be sorted on the
+            // server. Empty when nothing has, which is a fact, not a gap.
+            key: "lastActivity",
+            header: t("list.lastActivity"),
+            cell: (person: Person) => (
+              <span className="t-caption">
+                {person.last_activity_at
+                  ? formatDateAbbrev(
+                      person.last_activity_at,
+                      locale,
+                      RECORD_ZONE,
+                    )
+                  : ""}
+              </span>
+            ),
+            sort: "last_activity_at",
+          },
+          {
             key: "created",
             header: t("list.created"),
             cell: (person: Person) => (


### PR DESCRIPTION
PO-DDL-1/-4 as amended (foundation#1349): last_activity_at is STORED on
person and organization, maintained by the activity write exactly as
deal.last_activity_at is — advanceLastActivity in activities moves the
linked record's clock and every account the link reaches (its deal's
account, a live employer), the same three arms OrgReachSet walks for the
account timeline, each as a single-statement monotone max so a back-dated
capture never moves a clock backwards. The migration backfills both from the
timeline and adds the sort indexes in the ORDER BY's own shape.

DM-VOCAB-1/2 gain the sort; both lists show a Last activity column that
sorts on the server. Proven against Postgres: a note on an employed contact
moves the contact and the employer, a note on a deal moves its account, an
untouched account stays NULL and sorts last, and the test fails with the
reach update removed.

Spec: gradionhq/margince-foundation#1349 (PO-DDL-1/-4, DM-VOCAB-1/2). Closes #1131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only last activity clock to `person` and `organization` and enables server‑side sorting by it in Contacts and Companies. Before, only deals tracked last activity and lists could not sort by it; now both records store `last_activity_at` (NULL until the first linked activity), and activities advance these clocks on write. Back‑dated captures never move clocks backwards, and reachable accounts update via deals and live employments.

- Reviewer notes:
  - Migration adds `last_activity_at` to `person` and `organization`, backfills from the timeline, and creates partial keyset indexes: `(last_activity_at DESC NULLS LAST, created_at DESC, id DESC) WHERE archived_at IS NULL`.
  - The activity write path now calls `advanceLastActivity`: updates the directly linked record and any reached organizations (deal’s account, current employer) using a single‑statement GREATEST to ensure monotone max under concurrency.
  - API surfaces read‑only `last_activity_at` for both models; overlay marks it native‑only. Frontend shows a “Last activity” column on People and Companies and requests `sort=last_activity_at`, triggering a fresh keyset walk.
  - New integration test proves propagation and ordering against Postgres.

- Rollout:
  - Run the DB migration.
  - Deploy backend before the frontend so `sort=last_activity_at` and the new fields are available.
  - No client input changes required; mirrors do not write this field.

<sup>Written for commit 17cbed971247431a674dfd1ebe8aef01228062a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

