### PR TITLE
feat(records): a person and an account remember when something last happened, and the lists sort by it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14921,6 +14921,15 @@ components:
         captured_by: { type: string, readOnly: true, description: 'Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied.' }
         raw: { type: [object, 'null'], additionalProperties: true }
         version: { $ref: '#/components/schemas/RowVersion' }
+        last_activity_at:
+          type: [string, 'null']
+          format: date-time
+          readOnly: true
+          description: >-
+            When something last happened with this person — the newest `occurred_at` of an activity
+            linked to it, maintained on the activity write exactly as `deal.last_activity_at` is
+            (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must
+            reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-1).
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }
@@ -15161,6 +15170,15 @@ components:
         raw: { type: [object, 'null'], additionalProperties: true }
         partner: { $ref: '#/components/schemas/Partner' }
         version: { $ref: '#/components/schemas/RowVersion' }
+        last_activity_at:
+          type: [string, 'null']
+          format: date-time
+          readOnly: true
+          description: >-
+            When something last happened with this account — the newest `occurred_at` of an activity
+            linked to it, maintained on the activity write exactly as `deal.last_activity_at` is
+            (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must
+            reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -309,6 +309,13 @@ var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	// deleting, or the sweep aborts on the first held activity. This entry is
 	// that obligation, not a record of one already met.
 	"activity": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
+	// Not guards at all: migration 1787030814's last_activity_at maintenance
+	// recomputes the person/deal/organization clocks a deleted link or
+	// employment used to count toward, and refuses nothing. The sweep deletes
+	// those records too, so the recompute's work is discarded with them; it
+	// costs the reset time on a large timeline, never a refusal.
+	"activity_link": "a clock-maintenance trigger (last_activity_at recompute on the rows the link reached), not a guard: it refuses no delete",
+	"relationship":  "a clock-maintenance trigger (the employer's last_activity_at recompute), not a guard: it refuses no delete",
 })
 
 func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {

--- a/backend/internal/compose/integration/lastactivity_integration_test.go
+++ b/backend/internal/compose/integration/lastactivity_integration_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// last_activity_at on person and organization (PO-DDL-1/-4 as amended
+// 2026-08-18): kept on the writes themselves by migration 1787030814's
+// triggers, over a real migrated Postgres. A note on a contact moves the
+// contact's clock and the clock of every account currently employing them; a
+// note on a deal moves the deal's account; a back-dated capture never moves a
+// clock backwards; an employment that starts later brings the contact's
+// history to the account; archiving the newest activity moves a clock back;
+// a clock move is not an edit (no version bump); and the two lists sort by it.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestLastActivity_MovesThePersonAndEveryAccountItReaches(t *testing.T) {
+	e := Setup(t)
+	acme := e.SeedOrg(t, "Acme Clock", nil)
+	other := e.SeedOrg(t, "Other Clock", nil)
+	quiet := e.SeedOrg(t, "Quiet Clock", nil)
+	late := e.SeedOrg(t, "Late Employer Clock", nil)
+	staff := e.SeedPerson(t, "Works At Acme", nil)
+	personID := ids.From[ids.PersonKind](staff)
+	orgID := ids.From[ids.OrganizationKind](acme)
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID, IsCurrentPrimary: true, Source: "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	deal, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Other's deal", AmountMinor: int64Ptr(100), Currency: strPtr("EUR"),
+		PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(other)), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log := func(when time.Time, links ...activities.ActivityLinkInput) ids.UUID {
+		t.Helper()
+		subject := "touch"
+		logged, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+			Kind: "note", Subject: &subject, OccurredAt: &when, Source: "manual", Links: links,
+		})
+		if err != nil {
+			t.Fatalf("logging: %v", err)
+		}
+		return ids.UUID(logged.Id)
+	}
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	older := newest.Add(-72 * time.Hour)
+	newestNote := log(newest, activities.ActivityLinkInput{EntityType: "person", EntityID: staff})
+	// A back-dated capture arriving later must not move a clock backwards.
+	log(older, activities.ActivityLinkInput{EntityType: "person", EntityID: staff})
+	log(older, activities.ActivityLinkInput{EntityType: "deal", EntityID: ids.UUID(deal.Id)})
+
+	person, err := e.People.GetPerson(e.Admin(), personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if person.LastActivityAt == nil || !person.LastActivityAt.Equal(newest) {
+		t.Fatalf("person.last_activity_at = %v, want %v (the newest, not the last written)", person.LastActivityAt, newest)
+	}
+	clock := func(org ids.UUID) *time.Time {
+		t.Helper()
+		o, err := e.People.GetOrganization(e.Admin(), orgIDOf(org), storekit.LiveOnly)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return o.LastActivityAt
+	}
+	if got := clock(acme); got == nil || !got.Equal(newest) {
+		t.Fatalf("employer's last_activity_at = %v, want %v via the live employment", got, newest)
+	}
+	if got := clock(other); got == nil || !got.Equal(older) {
+		t.Fatalf("deal account's last_activity_at = %v, want %v via the deal", got, older)
+	}
+	if got := clock(quiet); got != nil {
+		t.Fatalf("an account nothing reached has last_activity_at = %v, want NULL", got)
+	}
+
+	// A clock move is the timeline's, not an edit of the record: the person's
+	// version is still what creation stamped, so an editor's If-Match holds.
+	if person.Version == nil || *person.Version != 1 {
+		t.Fatalf("person.version = %d after two notes, want 1 — a clock move must not bump the version", *person.Version)
+	}
+
+	// An employment that starts AFTER the notes brings the contact's history to
+	// the new account: the reach set moved without any activity being written.
+	lateID := ids.From[ids.OrganizationKind](late)
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &personID, OrganizationID: &lateID, IsCurrentPrimary: false, Source: "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := clock(late); got == nil || !got.Equal(newest) {
+		t.Fatalf("new employer's last_activity_at = %v, want %v — the reach set moved", got, newest)
+	}
+
+	// Archiving the newest note moves the clocks BACK to the next-newest: the
+	// column is a recompute from the live timeline, never a monotone high-water
+	// mark that outlives what it counted.
+	if _, err := e.Activities.ArchiveActivity(e.Admin(), ids.From[ids.ActivityKind](newestNote)); err != nil {
+		t.Fatal(err)
+	}
+	person, err = e.People.GetPerson(e.Admin(), personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if person.LastActivityAt == nil || !person.LastActivityAt.Equal(older) {
+		t.Fatalf("person.last_activity_at after archiving the newest = %v, want %v", person.LastActivityAt, older)
+	}
+	if got := clock(acme); got == nil || !got.Equal(older) {
+		t.Fatalf("employer's last_activity_at after the archive = %v, want %v", got, older)
+	}
+	// Re-log the newest so the sort below has three distinct clocks again.
+	log(newest, activities.ActivityLinkInput{EntityType: "person", EntityID: staff})
+
+	// The list sorts by it, newest first: acme, other, then the untouched one.
+	sort := "-last_activity_at"
+	page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{Sort: &sort})
+	if err != nil {
+		t.Fatalf("sorting organizations by last activity: %v", err)
+	}
+	var order []ids.UUID
+	for _, o := range page {
+		id := ids.UUID(o.Id)
+		if id == acme || id == other || id == quiet {
+			order = append(order, id)
+		}
+	}
+	if len(order) != 3 || order[0] != acme || order[1] != other || order[2] != quiet {
+		t.Fatalf("sort=-last_activity_at ordered %v, want acme, other, quiet (NULLS LAST)", order)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15525,8 +15525,11 @@ type Organization struct {
 	// It is one ordinary organization, reachable by id everywhere, but the surfaces that answer
 	// *which companies are we selling to* exclude it unless `include_anchor` is set, and it
 	// cannot be archived or merged. A caller that offers company actions should tell it apart.
-	IsAnchor  *bool   `json:"is_anchor,omitempty"`
-	LegalName *string `json:"legal_name,omitempty"`
+	IsAnchor *bool `json:"is_anchor,omitempty"`
+
+	// LastActivityAt When something last happened with this account — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
+	LegalName      *string    `json:"legal_name,omitempty"`
 
 	// Lifecycle WHERE THE ACCOUNT STANDS with us (PO-DDL-4, ADR-0079/A124). Single-valued: an account is at one point in a sales motion at a time. `unknown` is the default and means it — the retired `classification` defaulted to `prospect` and, having no writer, rendered that default on every unassessed account as though someone had judged it.
 	Lifecycle *OrganizationLifecycle `json:"lifecycle,omitempty"`
@@ -17126,7 +17129,10 @@ type Person struct {
 	// FullName Always present (display name).
 	FullName string             `json:"full_name"`
 	Id       openapi_types.UUID `json:"id"`
-	LastName *string            `json:"last_name,omitempty"`
+
+	// LastActivityAt When something last happened with this person — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-1).
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
+	LastName       *string    `json:"last_name,omitempty"`
 
 	// MergedIntoId Set when this row was merged away.
 	MergedIntoId *openapi_types.UUID     `json:"merged_into_id,omitempty"`
@@ -27614,6 +27620,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "is_anchor")
 	}
 
+	if raw, found := object["last_activity_at"]; found {
+		err = json.Unmarshal(raw, &a.LastActivityAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'last_activity_at': %w", err)
+		}
+		delete(object, "last_activity_at")
+	}
+
 	if raw, found := object["legal_name"]; found {
 		err = json.Unmarshal(raw, &a.LegalName)
 		if err != nil {
@@ -27852,6 +27866,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.LastActivityAt != nil {
+		object["last_activity_at"], err = json.Marshal(a.LastActivityAt)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'last_activity_at': %w", err)
+		}
+	}
+
 	if a.LegalName != nil {
 		object["legal_name"], err = json.Marshal(a.LegalName)
 		if err != nil {
@@ -28081,6 +28102,14 @@ func (a *Person) UnmarshalJSON(b []byte) error {
 		delete(object, "id")
 	}
 
+	if raw, found := object["last_activity_at"]; found {
+		err = json.Unmarshal(raw, &a.LastActivityAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'last_activity_at': %w", err)
+		}
+		delete(object, "last_activity_at")
+	}
+
 	if raw, found := object["last_name"]; found {
 		err = json.Unmarshal(raw, &a.LastName)
 		if err != nil {
@@ -28256,6 +28285,13 @@ func (a Person) MarshalJSON() ([]byte, error) {
 	object["id"], err = json.Marshal(a.Id)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'id': %w", err)
+	}
+
+	if a.LastActivityAt != nil {
+		object["last_activity_at"], err = json.Marshal(a.LastActivityAt)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'last_activity_at': %w", err)
+		}
 	}
 
 	if a.LastName != nil {

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -79,9 +79,10 @@ type LogActivityInput struct {
 	Source                       string
 }
 
-// LogActivity writes the activity + links and maintains
-// deal.last_activity_at (data-model §7: kept current on write, driving
-// the stalled flag). Idempotent on (source_system, source_id): replaying
+// LogActivity writes the activity + links; the last_activity_at clocks on
+// deal, person and organization (data-model §7: kept current on write, the
+// deal's driving the stalled flag) move on the link row itself, by
+// migration 1787030814's triggers. Idempotent on (source_system, source_id): replaying
 // a capture returns the existing activity.
 func (s *Store) LogActivity(ctx context.Context, in LogActivityInput) (crmcontracts.Activity, bool, error) {
 	if err := auth.Require(ctx, "activity", principal.ActionCreate); err != nil {
@@ -152,7 +153,7 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 		return crmcontracts.Activity{}, false, err
 	}
 
-	if err := insertActivityLinks(ctx, tx, wsID, id, in.Links, occurredAt); err != nil {
+	if err := insertActivityLinks(ctx, tx, wsID, id, in.Links); err != nil {
 		return crmcontracts.Activity{}, false, err
 	}
 	// Who was in it (ACT-DDL-3). After the links, because the counterparty is

--- a/backend/internal/modules/activities/activitylinks.go
+++ b/backend/internal/modules/activities/activitylinks.go
@@ -12,7 +12,6 @@ package activities
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -61,8 +60,12 @@ func (e *TooManyLinksError) FieldFault() (field, code, message string) {
 	return fieldLinks, "too_many_links", e.Error()
 }
 
-// insertActivityLinks writes the polymorphic link rows and maintains
-// deal.last_activity_at on deal links. The FK alone is not enough: it is
+// insertActivityLinks writes the polymorphic link rows. The last_activity_at
+// clocks on deal, person and organization move with them, but not from here:
+// migration 1787030814 keeps them on the activity_link row itself (a trigger
+// recomputing from the timeline), because this is not the only writer of that
+// row — capture files links too, and the reach set moves without any link
+// being written. A clock kept at a call site was stale everywhere else. The FK alone is not enough: it is
 // checked as the table owner, bypassing RLS, so it would accept a
 // guessed cross-tenant or out-of-scope UUID as a link target — every
 // target passes the row-scope link check first.
@@ -79,7 +82,7 @@ func (e *TooManyLinksError) FieldFault() (field, code, message string) {
 // this is the one statement every writer passes through — the timeline's link
 // vocabulary describes what a message or meeting is ABOUT, and a record set
 // larger than this is about nothing.
-func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput, occurredAt time.Time) error {
+func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, activityID ids.ActivityID, links []ActivityLinkInput) error {
 	if len(links) > maxActivityLinks {
 		return &TooManyLinksError{Count: len(links)}
 	}
@@ -100,13 +103,6 @@ func insertActivityLinks(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, a
 			sprintf(`INSERT INTO activity_link (workspace_id, activity_id, entity_type, %s) VALUES ($1, $2, $3, $4)`, column),
 			wsID, activityID, link.EntityType, link.EntityID); err != nil {
 			return err
-		}
-		if link.EntityType == "deal" {
-			if _, err := tx.Exec(ctx,
-				`UPDATE deal SET last_activity_at = greatest(coalesce(last_activity_at, $2), $2) WHERE id = $1`,
-				link.EntityID, occurredAt); err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -131,6 +131,10 @@ func mirrorStructuralBindings() []FieldBinding {
 			Reason: "Derived from captured interactions; the mirror holds no interaction history.",
 		},
 		{
+			WireSlot: "last_activity_at", Disposition: DispositionNativeOnly,
+			Reason: "Maintained from this installation's own timeline on the activity write; the mirror holds no interaction history.",
+		},
+		{
 			WireSlot: "merged_into_id", Disposition: DispositionNativeOnly,
 			Reason: "Merge is a native operation over native rows; a mirrored record is never merged away.",
 		},

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -36,6 +36,9 @@ const (
 	leadSourceColumn  = "source"
 	createdAtColumn   = "created_at"
 	updatedAtColumn   = "updated_at"
+	// lastActivityColumn is the timeline clock person and organization carry
+	// (DM-VOCAB-1/2), maintained by activities on the link write.
+	lastActivityColumn = "last_activity_at"
 )
 
 // leadListFields is the lead list's core sortable vocabulary. Every column

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -72,10 +72,11 @@ type ListOrganizationsInput struct {
 // vocabulary — exactly the data-model §13.5 DM-VOCAB-2 set; active cf_
 // columns join it per request.
 var organizationListFields = map[string]string{
-	createdAtColumn: storekit.KindTimestamp,
-	updatedAtColumn: storekit.KindTimestamp,
-	orgNameColumn:   fieldcatalog.TypeText,
-	ownerIDColumn:   storekit.KindUUID,
+	createdAtColumn:    storekit.KindTimestamp,
+	updatedAtColumn:    storekit.KindTimestamp,
+	orgNameColumn:      fieldcatalog.TypeText,
+	ownerIDColumn:      storekit.KindUUID,
+	lastActivityColumn: storekit.KindTimestamp,
 }
 
 // organizationDomainClause narrows the page to the account that lists one

--- a/backend/internal/modules/people/organization_read.go
+++ b/backend/internal/modules/people/organization_read.go
@@ -141,6 +141,7 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&classification, &lifecycle, &relevance, &parentID, &mergedInto, &logoObjectKey, &linkedinURL, &o.Source, &o.CapturedBy,
 		&version, &o.CreatedAt, &o.UpdatedAt, &o.ArchivedAt, &o.IsAnchor,
+		&o.LastActivityAt,
 	}
 	cf := storekit.ScanDests(active)
 	if err := row.Scan(append(append(dests, cf...), extra...)...); err != nil {

--- a/backend/internal/modules/people/organizationarchive.go
+++ b/backend/internal/modules/people/organizationarchive.go
@@ -95,7 +95,7 @@ func (s *Store) ArchiveOrganization(ctx context.Context, id ids.OrganizationID) 
 const orgColumns = `id, workspace_id, display_name, legal_name, description, industry, size_band, owner_id,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	classification, lifecycle, relevance, parent_org_id, merged_into_id, logo_object_key, linkedin_url, source, captured_by,
-	version, created_at, updated_at, archived_at, is_anchor`
+	version, created_at, updated_at, archived_at, is_anchor, last_activity_at`
 
 // readOrganization resolves one organization row; active names the
 // custom-field columns to carry alongside the core ones — nil for

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -162,7 +162,7 @@ func ensurePersonEmailsUnclaimed(ctx context.Context, tx pgx.Tx, emails []Person
 const personColumns = `id, workspace_id, full_name, first_name, last_name, title, owner_id,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	merged_into_id, converted_from_lead_id, source, captured_by,
-	version, created_at, updated_at, archived_at`
+	version, created_at, updated_at, archived_at, last_activity_at`
 
 // readPerson resolves one person row; active names the custom-field
 // columns to carry alongside the core ones — nil for internal decision
@@ -202,7 +202,7 @@ func scanPerson(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcon
 		&id, &wsID, &p.FullName, &p.FirstName, &p.LastName, &p.Title, &ownerID,
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&mergedInto, &fromLead, &p.Source, &p.CapturedBy,
-		&version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt,
+		&version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt, &p.LastActivityAt,
 	}
 	cf := storekit.ScanDests(active)
 	if err := row.Scan(append(append(dests, cf...), extra...)...); err != nil {

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -63,10 +63,11 @@ type ListPeopleInput struct {
 // exactly the data-model §13.5 DM-VOCAB-1 set; active cf_ columns join
 // it per request.
 var personListFields = map[string]string{
-	createdAtColumn:  storekit.KindTimestamp,
-	updatedAtColumn:  storekit.KindTimestamp,
-	personNameColumn: fieldcatalog.TypeText,
-	ownerIDColumn:    storekit.KindUUID,
+	createdAtColumn:    storekit.KindTimestamp,
+	updatedAtColumn:    storekit.KindTimestamp,
+	personNameColumn:   fieldcatalog.TypeText,
+	ownerIDColumn:      storekit.KindUUID,
+	lastActivityColumn: storekit.KindTimestamp,
 }
 
 // personTagClause narrows the page to the people carrying one tag, or ""

--- a/backend/migrations/core/1787030814_person_org_last_activity.down.sql
+++ b/backend/migrations/core/1787030814_person_org_last_activity.down.sql
@@ -1,0 +1,28 @@
+-- Reverse: the clocks stop being maintained and the two columns go; the
+-- timeline they were derived from is untouched. deal.last_activity_at stays
+-- (0006) and goes back to being unmaintained, as it was.
+DROP TRIGGER IF EXISTS deal_last_activity ON deal;
+DROP TRIGGER IF EXISTS relationship_last_activity ON relationship;
+DROP TRIGGER IF EXISTS activity_last_activity ON activity;
+DROP TRIGGER IF EXISTS activity_link_last_activity ON activity_link;
+DROP FUNCTION IF EXISTS trg_deal_last_activity();
+DROP FUNCTION IF EXISTS trg_relationship_last_activity();
+DROP FUNCTION IF EXISTS trg_activity_last_activity();
+DROP FUNCTION IF EXISTS trg_activity_link_last_activity();
+DROP FUNCTION IF EXISTS refresh_last_activity_for_link(uuid, uuid, uuid);
+DROP FUNCTION IF EXISTS move_last_activity(regclass, uuid);
+DROP FUNCTION IF EXISTS last_activity_of_organization(uuid);
+DROP FUNCTION IF EXISTS last_activity_of_deal(uuid);
+DROP FUNCTION IF EXISTS last_activity_of_person(uuid);
+DROP INDEX IF EXISTS idx_org_last_activity_keyset;
+DROP INDEX IF EXISTS idx_person_last_activity_keyset;
+ALTER TABLE organization DROP COLUMN IF EXISTS last_activity_at;
+ALTER TABLE person       DROP COLUMN IF EXISTS last_activity_at;
+
+CREATE OR REPLACE FUNCTION set_updated_at_bump_version() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  NEW.version = OLD.version + 1;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/migrations/core/1787030814_person_org_last_activity.up.sql
+++ b/backend/migrations/core/1787030814_person_org_last_activity.up.sql
@@ -1,0 +1,201 @@
+-- last_activity_at on person and organization (PO-DDL-1/-4 as amended
+-- 2026-08-18): when something last happened with the record, kept current on
+-- the write exactly as deal.last_activity_at is meant to be — a read
+-- accelerator the timeline can always rebuild, never a second truth. It backs
+-- the "Last activity" sort on both lists (DM-VOCAB-1/2).
+--
+-- A person's clock is the newest occurred_at of a live activity linked to
+-- them. An account's clock is the newest occurred_at of a live activity that
+-- REACHES it — filed against it, against one of its deals, or against a
+-- contact it currently employs — the same three arms activities.OrgReachSet
+-- walks for the account timeline, so the column and the timeline agree.
+--
+-- The clocks are maintained HERE, by triggers on the writes that move them,
+-- rather than at a call site in Go. The activity_link row is written by more
+-- than one module (activities logs, capture files, relink moves), and the
+-- reach set changes without any activity being written at all — an employment
+-- starts or ends, a deal moves account, an activity is archived or re-dated.
+-- A clock kept at one call site is stale on every other path; a clock kept on
+-- the row is right for every writer, present and future. Each maintenance is
+-- a recompute from the timeline (max over live linked activities), never an
+-- increment, so it is idempotent and converges under concurrent writers.
+--
+-- The deal clock joins the same mechanism: activities.insertActivityLinks used
+-- to advance it in Go, on the logging path only, and capture never did.
+--
+-- Moving a clock is NOT an edit of the record: set_updated_at_bump_version
+-- skips an UPDATE whose only change is last_activity_at, so an arriving mail
+-- neither rewrites updated_at nor invalidates an editor's If-Match version.
+
+ALTER TABLE person       ADD COLUMN IF NOT EXISTS last_activity_at timestamptz NULL;
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS last_activity_at timestamptz NULL;
+
+-- The clock refresh below runs its UPDATEs under a transaction-local flag; the
+-- bump trigger sees it and leaves updated_at and version alone. A flag rather
+-- than a row comparison because a BEFORE trigger's NEW does not yet carry the
+-- STORED generated columns (search_tsv), so OLD and NEW never compare equal.
+CREATE OR REPLACE FUNCTION set_updated_at_bump_version() RETURNS trigger AS $$
+BEGIN
+  IF current_setting('margince.last_activity_move', true) = 'on' THEN
+    RETURN NEW;
+  END IF;
+  NEW.updated_at = now();
+  NEW.version = OLD.version + 1;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Every clock UPDATE goes through this, so the flag is set and cleared in one
+-- place. Cleared explicitly rather than left to transaction end: the same
+-- transaction usually goes on to write real edits that MUST bump.
+CREATE OR REPLACE FUNCTION move_last_activity(tbl regclass, rid uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF rid IS NULL THEN RETURN; END IF;
+  PERFORM set_config('margince.last_activity_move', 'on', true);
+  CASE tbl
+    WHEN 'person'::regclass THEN
+      UPDATE person SET last_activity_at = last_activity_of_person(rid) WHERE id = rid;
+    WHEN 'deal'::regclass THEN
+      UPDATE deal SET last_activity_at = last_activity_of_deal(rid) WHERE id = rid;
+    WHEN 'organization'::regclass THEN
+      UPDATE organization SET last_activity_at = last_activity_of_organization(rid) WHERE id = rid;
+  END CASE;
+  PERFORM set_config('margince.last_activity_move', 'off', true);
+END;
+$$;
+
+-- The three clock derivations, from the timeline's own tables.
+CREATE OR REPLACE FUNCTION last_activity_of_person(pid uuid) RETURNS timestamptz
+LANGUAGE sql STABLE AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE l.person_id = pid
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_deal(did uuid) RETURNS timestamptz
+LANGUAGE sql STABLE AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE l.deal_id = did
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_organization(oid uuid) RETURNS timestamptz
+LANGUAGE sql STABLE AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    LEFT JOIN deal d ON d.id = l.deal_id
+    LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
+      AND r.ended_at IS NULL AND r.archived_at IS NULL
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE oid IN (l.organization_id, d.organization_id, r.organization_id)
+$$;
+
+-- Recompute the clocks a link touches: its person, its deal, and every account
+-- it reaches (directly, through the deal, through the person's live employers).
+CREATE OR REPLACE FUNCTION refresh_last_activity_for_link(pid uuid, did uuid, oid uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  reached uuid;
+BEGIN
+  PERFORM move_last_activity('person', pid);
+  PERFORM move_last_activity('deal', did);
+  FOR reached IN
+     SELECT oid WHERE oid IS NOT NULL
+     UNION SELECT d.organization_id FROM deal d WHERE d.id = did AND d.organization_id IS NOT NULL
+     UNION SELECT r.organization_id FROM relationship r
+            WHERE r.person_id = pid AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
+  LOOP
+    PERFORM move_last_activity('organization', reached);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION trg_activity_link_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP IN ('DELETE', 'UPDATE') THEN
+    PERFORM refresh_last_activity_for_link(OLD.person_id, OLD.deal_id, OLD.organization_id);
+  END IF;
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    PERFORM refresh_last_activity_for_link(NEW.person_id, NEW.deal_id, NEW.organization_id);
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER activity_link_last_activity
+  AFTER INSERT OR UPDATE OR DELETE ON activity_link
+  FOR EACH ROW EXECUTE FUNCTION trg_activity_link_last_activity();
+
+-- Re-dating or archiving an activity moves every clock it counted toward.
+CREATE OR REPLACE FUNCTION trg_activity_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM refresh_last_activity_for_link(l.person_id, l.deal_id, l.organization_id)
+     FROM activity_link l WHERE l.activity_id = NEW.id;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER activity_last_activity
+  AFTER UPDATE OF occurred_at, archived_at ON activity
+  FOR EACH ROW
+  WHEN (OLD.occurred_at IS DISTINCT FROM NEW.occurred_at OR OLD.archived_at IS DISTINCT FROM NEW.archived_at)
+  EXECUTE FUNCTION trg_activity_last_activity();
+
+-- An employment starting, ending, moving or being archived changes which
+-- account a contact's activities reach.
+CREATE OR REPLACE FUNCTION trg_relationship_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP IN ('DELETE', 'UPDATE') AND OLD.kind = 'employment' THEN
+    PERFORM move_last_activity('organization', OLD.organization_id);
+  END IF;
+  IF TG_OP IN ('INSERT', 'UPDATE') AND NEW.kind = 'employment' THEN
+    PERFORM move_last_activity('organization', NEW.organization_id);
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER relationship_last_activity
+  AFTER INSERT OR UPDATE OR DELETE ON relationship
+  FOR EACH ROW EXECUTE FUNCTION trg_relationship_last_activity();
+
+-- A deal moving to another account takes its activities' reach with it.
+CREATE OR REPLACE FUNCTION trg_deal_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM move_last_activity('organization', OLD.organization_id);
+  PERFORM move_last_activity('organization', NEW.organization_id);
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER deal_last_activity
+  AFTER UPDATE OF organization_id ON deal
+  FOR EACH ROW
+  WHEN (OLD.organization_id IS DISTINCT FROM NEW.organization_id)
+  EXECUTE FUNCTION trg_deal_last_activity();
+
+-- Backfill: every clock from the timeline as it stands. Deal included, since
+-- capture never advanced it.
+SELECT set_config('margince.last_activity_move', 'on', true);
+UPDATE person       SET last_activity_at = last_activity_of_person(id);
+UPDATE deal         SET last_activity_at = last_activity_of_deal(id);
+UPDATE organization SET last_activity_at = last_activity_of_organization(id);
+SELECT set_config('margince.last_activity_move', 'off', true);
+
+-- Sort indexes in the ORDER BY's own shape (see 0292): the sort column, then
+-- the keyset tie-breakers, partial on the live rows, descending only — recency
+-- is asked for newest-first.
+CREATE INDEX IF NOT EXISTS idx_person_last_activity_keyset
+  ON person (last_activity_at DESC NULLS LAST, created_at DESC, id DESC)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_org_last_activity_keyset
+  ON organization (last_activity_at DESC NULLS LAST, created_at DESC, id DESC)
+  WHERE archived_at IS NULL;

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -364,11 +364,6 @@ var crossStoreWrites = gatekit.Waive(map[string]string{
 	"internal/modules/people:person_consent":       "merge carries the survivor's consent state in the single transaction",
 	"internal/modules/people:consent_event":        "merge re-points the append-only consent proof log in the single transaction",
 
-	// activities maintains the deal-timeline denormalization where the
-	// activity lands: deal.last_activity_at moves in the same transaction
-	// as the activity insert or the two drift.
-	"internal/modules/activities:deal": "deal.last_activity_at is denormalized from the timeline; it must move in the activity's own transaction",
-
 	// The outbound-send reconcile folds the provider's own captured echo of a
 	// message this workspace sent into the send's own row. That fold is one
 	// indivisible act — links copied, review moved, key released, row archived

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -131,7 +131,6 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	"internal/modules/ai:persistBuildVersion":         "runs only inside CompleteBuild's transaction, under its voice_profile row lock (storekit.LockRow before the pre-read)",
 
 	// Writes that are race-free by their own shape.
-	"internal/modules/activities:insertActivityLinks":     "deal.last_activity_at is a single-statement monotone max (greatest of stored and new) — the value is computed inside the UPDATE, never from a pre-read, so concurrent writers converge on the maximum",
 	"internal/modules/capture:AdvanceChannelPollOffsetTx": "single-statement monotone cursor: the `poll_offset < $2` predicate IS the CAS, so a writer holding a lower offset than the row already carries matches zero rows and its advance is correctly dropped. A version guard would be wrong here — the poll cursor is not optimistically concurrent state an operator edits, and bumping version on it would fire the send path's binding fence on every inbound message (0151's trigger comment)",
 	"internal/modules/privacy:anonymizeSubjectRows":       "terminal absolute write: the erasure overwrites the PII columns regardless of concurrent state, by design",
 	"internal/modules/privacy:anonymizeLeadTwins":         "terminal absolute write: the same erasure statement as anonymizeSubjectRows, extracted for length — it overwrites the lead twin's PII columns regardless of concurrent state, by design",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10037,6 +10037,11 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             version?: components["schemas"]["RowVersion"];
+            /**
+             * Format: date-time
+             * @description When something last happened with this person — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-1).
+             */
+            readonly last_activity_at?: string | null;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -10225,6 +10230,11 @@ export interface components {
             } | null;
             partner?: components["schemas"]["Partner"];
             version?: components["schemas"]["RowVersion"];
+            /**
+             * Format: date-time
+             * @description When something last happened with this account — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+             */
+            readonly last_activity_at?: string | null;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -562,6 +562,7 @@ export const de = {
   "list.unowned": "Nicht zugewiesen",
   "list.created": "Erstellt",
   "list.updated": "Geändert",
+  "list.lastActivity": "Letzte Aktivität",
   "list.filterOwnerMe": "Meine Datensätze",
   "list.filterOwnerAll": "Alle Zuständigen",
   "list.filterOwnerUnassigned": "Nicht zugewiesen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -574,6 +574,7 @@ export const en = {
   "list.unowned": "Unassigned",
   "list.created": "Created",
   "list.updated": "Updated",
+  "list.lastActivity": "Last activity",
   "list.filterOwnerMe": "My records",
   "list.filterOwnerAll": "Any owner",
   "list.filterOwnerUnassigned": "Unassigned",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -555,6 +555,7 @@ export const vi = {
   "list.unowned": "Chưa phân công",
   "list.created": "Ngày tạo",
   "list.updated": "Cập nhật",
+  "list.lastActivity": "Hoạt động gần nhất",
   "list.filterOwnerMe": "Bản ghi của tôi",
   "list.filterOwnerAll": "Mọi người phụ trách",
   "list.filterOwnerUnassigned": "Chưa phân công",

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -764,6 +764,33 @@ describe("CompaniesScreen — list dials reach the server (P-14)", () => {
     );
   });
 
+  it("sorts by last activity on the server, not over the rows it holds", async () => {
+    const user = userEvent.setup();
+    const { urls } = stubFetch(async () =>
+      jsonResponse({
+        data: [{ ...org, last_activity_at: "2026-08-10T12:00:00Z" }],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(<CompaniesScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Sort by Last activity" }),
+    );
+    // The server owns the order: a fresh keyset walk under the new sort.
+    await waitFor(() =>
+      expect(
+        urls.some(
+          (url) =>
+            url.includes("sort=last_activity_at") && !url.includes("cursor="),
+        ),
+      ).toBe(true),
+    );
+  });
+
   it("narrows to one lifecycle stage through the server", async () => {
     const user = userEvent.setup();
     const { urls } = stubFetch(async () => emptyPage());

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -679,6 +679,21 @@ export function CompaniesScreen() {
             sort: "owner_id",
           },
           {
+            // When something last happened with this record — the timeline's
+            // clock, kept by the activity write, so it can be sorted on the
+            // server. Empty when nothing has, which is a fact, not a gap.
+            key: "lastActivity",
+            header: t("list.lastActivity"),
+            cell: (org: Organization) => (
+              <span className="t-caption">
+                {org.last_activity_at
+                  ? formatDateAbbrev(org.last_activity_at, locale, RECORD_ZONE)
+                  : ""}
+              </span>
+            ),
+            sort: "last_activity_at",
+          },
+          {
             key: "created",
             header: t("list.created"),
             cell: (org: Organization) => (

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -421,6 +421,25 @@ export function ContactsScreen() {
             sort: "owner_id",
           },
           {
+            // When something last happened with this record — the timeline's
+            // clock, kept by the activity write, so it can be sorted on the
+            // server. Empty when nothing has, which is a fact, not a gap.
+            key: "lastActivity",
+            header: t("list.lastActivity"),
+            cell: (person: Person) => (
+              <span className="t-caption">
+                {person.last_activity_at
+                  ? formatDateAbbrev(
+                      person.last_activity_at,
+                      locale,
+                      RECORD_ZONE,
+                    )
+                  : ""}
+              </span>
+            ),
+            sort: "last_activity_at",
+          },
+          {
             key: "created",
             header: t("list.created"),
             cell: (person: Person) => (


### PR DESCRIPTION
PO-DDL-1/-4 as amended (foundation#1349): last_activity_at is STORED on
person and organization and sortable on both lists (DM-VOCAB-1/2).

It is kept on the writes themselves. Review of the first cut showed a clock
advanced at one Go call site (activities.insertActivityLinks) is stale on
every other path — capture files activity_link rows without it, relink moves
them, and the reach set changes with no link written at all when an
employment starts or ends, a deal moves account, or an activity is archived
or re-dated. So migration 1787028748 keeps all three clocks (deal too, which
capture had never advanced) with triggers on activity_link, activity,
relationship and deal.organization_id, each a recompute from the live
timeline (max over linked activities; an account through the same three
arms OrgReachSet walks), never an increment — idempotent, and it moves BACK
when the newest activity is archived. A clock move is not an edit:
set_updated_at_bump_version skips it under a transaction-local flag, so an
arriving mail neither rewrites updated_at nor breaks an editor's If-Match.
The Go deal writer is removed; the backfill covers all three columns.

Proven against Postgres: a note on an employed contact moves the contact and
the employer; a note on a deal moves its account; a back-dated capture never
moves a clock backwards; an employment that starts later brings the history
to the new account; archiving the newest note moves the clocks back; the
person's version is still 1 after two notes; an untouched account sorts last.
Full integration lane green (41 packages).

Spec: gradionhq/margince-foundation#1349 (PO-DDL-1/-4, DM-VOCAB-1/2). Closes #1131. Supersedes #1660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only last_activity_at clock to people and organizations and makes both lists sortable by it. Previously only deals tried to advance their clock in Go on log, which missed capture, relinks, and reach changes; now database triggers recompute clocks from the live timeline so they stay correct and can move back when the newest activity is archived.

- Triggers and functions: migration `1787030814` adds `last_activity_at` to `person` and `organization`, recompute helpers, and AFTER triggers on `activity_link`, `activity` (`occurred_at`, `archived_at`), `relationship` (employment), and `deal.organization_id`. All three clocks (`person`, `deal`, `organization`) are derived as a max over unarchived linked activities; idempotent, convergent, and include reach via deals and current employments.
- Version semantics: updates that only change `last_activity_at` no longer bump `updated_at` or `version` (`set_updated_at_bump_version` skips under a transaction-local flag).
- Go path changes: removed the `deal.last_activity_at` advance from `insertActivityLinks`; `LogActivity` no longer passes `occurredAt` to link insert.
- Backfill and indexes: migration backfills `person`, `deal`, and `organization` clocks and adds DESC NULLS LAST keyset indexes to support server-side sort.
- API and UI: adds read-only `last_activity_at` to Person and Organization schemas; People and Companies screens show a “Last activity” column and request `sort=last_activity_at` for server-side ordering; i18n strings and tests included.
- Resets: clock-maintenance triggers on `activity_link` and `relationship` do not block deletes; data reset notes updated.

- Rollout: apply migration `1787030814` (includes backfill and new write triggers). No client write changes required; to use the sort, pass `sort=last_activity_at` on People/Organizations list APIs.

<sup>Written for commit 2c8793c6909ba39bdd451f37a3c4754511725de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

