### PR TITLE
refactor(frontend): one record list, three record types — the shared columns and views are defined once

### DIFF
--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -41,12 +41,11 @@ import {
   useSorMode,
   useViewerId,
 } from "./common";
-import { RECORD_ZONE } from "./company360";
 import { CreateAction, type CreateField } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { EditAction } from "./edit";
-import { EntityRef, OwnerName, useRoster } from "./entityref";
+import { EntityRef, useRoster } from "./entityref";
 import { RecordHistoryTab, useRecordHistory } from "./history";
 import { LeadManualSignals } from "./leadsignals";
 import {
@@ -58,6 +57,7 @@ import {
   useOwnerChips,
 } from "./listquery";
 import { LogActivity } from "./logactivity";
+import { createdColumn, ownerColumn, standardViews } from "./recordlist";
 import { ShareAction } from "./share";
 
 // Leads (B-EP09.10a/b): visually SEGREGATED from the contact graph — the
@@ -505,6 +505,7 @@ export function LeadsScreen() {
   const ownerChips = useOwnerChips();
   const t = useT();
   const { locale } = useLocale();
+  const viewerId = useViewerId();
   const cf = useObjectCustomFields("lead");
   const state = useListQuery<Lead>({
     key: "leads",
@@ -593,24 +594,8 @@ export function LeadsScreen() {
             header: t("lead.status"),
             cell: (lead: Lead) => <StatusBadge status={lead.status} />,
           },
-          {
-            key: "owner",
-            header: t("list.owner"),
-            cell: (lead: Lead) => (
-              <OwnerName ownerId={lead.owner_id} unowned={t("list.unowned")} />
-            ),
-            sort: "owner_id",
-          },
-          {
-            key: "created",
-            header: t("list.created"),
-            cell: (lead: Lead) => (
-              <span className="t-caption">
-                {formatDateAbbrev(lead.created_at, locale, RECORD_ZONE)}
-              </span>
-            ),
-            sort: "created_at",
-          },
+          ownerColumn<Lead>(t),
+          createdColumn<Lead>(t, locale),
         ]}
         rowKey={(lead) => lead.id}
         rowRoute={(lead) => ({ screen: "leads", id: lead.id })}
@@ -632,7 +617,7 @@ export function LeadsScreen() {
         // mine, my team's, the unowned queue.
         dataChips={ownerChips}
         views={[
-          { label: "list.viewAll", sort: "-created_at" },
+          ...standardViews(viewerId),
           { label: "list.viewHighestScore", sort: "-score" },
           {
             label: "list.viewHot",

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -32,11 +32,7 @@ import {
   ConfidenceMeter,
   EvidenceChip,
 } from "../design-system/trust";
-import {
-  formatDateAbbrev,
-  formatDateTime,
-  formatMoney,
-} from "../format/format";
+import { formatDateTime, formatMoney } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { taskWriteKeys } from "./activitykeys";
@@ -100,7 +96,6 @@ import {
 } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
-import { OwnerName } from "./entityref";
 import {
   EvidenceVerdict,
   factClaim,
@@ -119,6 +114,7 @@ import {
   useOwnerChips,
 } from "./listquery";
 import { PartnerTab } from "./partners";
+import { createdColumn, ownerColumn, standardViews } from "./recordlist";
 import { RelationshipsTab } from "./relationships";
 import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import {
@@ -670,26 +666,8 @@ export function CompaniesScreen() {
                 </span>
               ) : null,
           },
-          {
-            key: "owner",
-            header: t("list.owner"),
-            cell: (org: Organization) => (
-              <OwnerName ownerId={org.owner_id} unowned={t("list.unowned")} />
-            ),
-            sort: "owner_id",
-          },
-          {
-            key: "created",
-            header: t("list.created"),
-            cell: (org: Organization) => (
-              <span className="t-caption">
-                {org.created_at
-                  ? formatDateAbbrev(org.created_at, locale, RECORD_ZONE)
-                  : ""}
-              </span>
-            ),
-            sort: "created_at",
-          },
+          ownerColumn<Organization>(t),
+          createdColumn<Organization>(t, locale),
         ]}
         tools={<SaveViewAction resource="organizations" query={state.query} />}
         rowKey={(org) => org.id}
@@ -716,16 +694,7 @@ export function CompaniesScreen() {
         ]}
         dataViews={savedViews}
         views={[
-          { label: "list.viewAll", sort: "-created_at" },
-          ...(viewerId
-            ? [
-                {
-                  label: "list.viewMine" as const,
-                  sort: "-created_at",
-                  filters: { owner_id: viewerId },
-                },
-              ]
-            : []),
+          ...standardViews(viewerId),
           {
             label: "list.viewCustomers",
             sort: "display_name",

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -9,7 +9,6 @@ import { Badge, SegmentedControl } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import { useRecordTimeline } from "../design-system/recordtimeline";
 import { ProvenanceTag } from "../design-system/trust";
-import { formatDateAbbrev } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
@@ -21,7 +20,6 @@ import {
   useSorMode,
   useViewerId,
 } from "./common";
-import { RECORD_ZONE } from "./company360";
 import { TimelineActions } from "./compose";
 import { ConsentSection } from "./consent";
 import { RecordContextPanel } from "./context";
@@ -29,7 +27,7 @@ import { CreateAction, type CreateField, type FormRows } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { EditAction } from "./edit";
-import { EntityRef, OwnerName } from "./entityref";
+import { EntityRef } from "./entityref";
 import { RecordHistoryTab } from "./history";
 import {
   type ListPage,
@@ -52,6 +50,7 @@ import {
 } from "./person360";
 import { EnrichedFields } from "./personcorrections";
 import { PersonGraphPanel } from "./persongraph";
+import { createdColumn, ownerColumn, standardViews } from "./recordlist";
 import { RelationshipsTab } from "./relationships";
 import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import { ShareAction } from "./share";
@@ -409,29 +408,8 @@ export function ContactsScreen() {
               </span>
             ),
           },
-          {
-            key: "owner",
-            header: t("list.owner"),
-            cell: (person: Person) => (
-              <OwnerName
-                ownerId={person.owner_id}
-                unowned={t("list.unowned")}
-              />
-            ),
-            sort: "owner_id",
-          },
-          {
-            key: "created",
-            header: t("list.created"),
-            cell: (person: Person) => (
-              <span className="t-caption">
-                {person.created_at
-                  ? formatDateAbbrev(person.created_at, locale, RECORD_ZONE)
-                  : ""}
-              </span>
-            ),
-            sort: "created_at",
-          },
+          ownerColumn<Person>(t),
+          createdColumn<Person>(t, locale),
         ]}
         tools={<SaveViewAction resource="people" query={state.query} />}
         rowKey={(person) => person.id}
@@ -439,16 +417,7 @@ export function ContactsScreen() {
         dataChips={ownerChips}
         dataViews={savedViews}
         views={[
-          { label: "list.viewAll", sort: "-created_at" },
-          ...(viewerId
-            ? [
-                {
-                  label: "list.viewMine" as const,
-                  sort: "-created_at",
-                  filters: { owner_id: viewerId },
-                },
-              ]
-            : []),
+          ...standardViews(viewerId),
           { label: "list.viewAZ", sort: "full_name" },
         ]}
       />

--- a/frontend/src/screens/recordlist.test.tsx
+++ b/frontend/src/screens/recordlist.test.tsx
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { createdColumn, ownerColumn, standardViews } from "./recordlist";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// The record lists that share the Owner/Created columns and the standard
+// views. A fourth owner-scoped list joins this array, not the copy-paste.
+const RECORD_LISTS = ["people.tsx", "organizations.tsx", "leads.tsx"];
+
+describe("one record list, three record types", () => {
+  it("every record list takes Owner and Created from recordlist.tsx, never its own copy", () => {
+    // Three lists carried three copies of the Owner column, and a fix on two
+    // of them missed the third. A screen that spells its own
+    // `key: "owner"` reintroduces exactly that.
+    for (const file of RECORD_LISTS) {
+      const source = readFileSync(join(here, file), "utf8");
+      expect(source, `${file} imports the shared columns`).toMatch(
+        /from "\.\/recordlist"/,
+      );
+      expect(source, `${file} defines its own owner column`).not.toMatch(
+        /key:\s*"owner"/,
+      );
+      expect(source, `${file} defines its own created column`).not.toMatch(
+        /key:\s*"created"/,
+      );
+      expect(source, `${file} spells its own Mine view`).not.toMatch(
+        /label:\s*"list\.viewMine"/,
+      );
+    }
+  });
+
+  it("the standard views are All, and Mine only for a signed-in reader", () => {
+    const t = ((key: string) => key) as Parameters<typeof ownerColumn>[0];
+    expect(ownerColumn(t).sort).toBe("owner_id");
+    expect(createdColumn(t, "en").sort).toBe("created_at");
+    expect(standardViews(undefined).map((v) => v.label)).toEqual([
+      "list.viewAll",
+    ]);
+    expect(standardViews("u-1").map((v) => v.label)).toEqual([
+      "list.viewAll",
+      "list.viewMine",
+    ]);
+    expect(standardViews("u-1")[1]?.filters).toEqual({ owner_id: "u-1" });
+  });
+});

--- a/frontend/src/screens/recordlist.tsx
+++ b/frontend/src/screens/recordlist.tsx
@@ -1,0 +1,78 @@
+import type { ListColumn } from "../design-system/listtable";
+import { formatDateAbbrev } from "../format/format";
+import type { useLocale, useT } from "../i18n";
+import { RECORD_ZONE } from "./company360";
+import { OwnerName } from "./entityref";
+import type { ViewSpec } from "./listquery";
+
+/**
+ * The columns and views every owner-scoped record list shares (people,
+ * companies, leads), defined ONCE.
+ *
+ * Three lists carried three copies of the Owner column, and when the column
+ * was fixed on People and Companies (it had rendered "typed by a person" for
+ * every human-captured row) the Leads copy kept the bug. A column that exists
+ * on two lists is defined here; a screen adds only what is specific to its
+ * record.
+ */
+
+/** A row that can be owned and was created at some point. */
+export type OwnedRecord = {
+  owner_id?: string | null;
+  created_at?: string;
+};
+
+type Translate = ReturnType<typeof useT>;
+type Locale = ReturnType<typeof useLocale>["locale"];
+
+/** The Owner column: whose record this is, sortable by owner_id. */
+export function ownerColumn<Row extends OwnedRecord>(
+  t: Translate,
+): ListColumn<Row> {
+  return {
+    key: "owner",
+    header: t("list.owner"),
+    cell: (row) => (
+      <OwnerName ownerId={row.owner_id} unowned={t("list.unowned")} />
+    ),
+    sort: "owner_id",
+  };
+}
+
+/** The Created column, in the record zone, sortable by created_at. */
+export function createdColumn<Row extends OwnedRecord>(
+  t: Translate,
+  locale: Locale,
+): ListColumn<Row> {
+  return {
+    key: "created",
+    header: t("list.created"),
+    cell: (row) => (
+      <span className="t-caption">
+        {row.created_at
+          ? formatDateAbbrev(row.created_at, locale, RECORD_ZONE)
+          : ""}
+      </span>
+    ),
+    sort: "created_at",
+  };
+}
+
+/**
+ * The views every record list opens with: everything newest-first, and —
+ * for a signed-in reader — theirs. A screen appends its own (A–Z on its
+ * name column, lifecycle cuts, score cuts).
+ */
+export function standardViews(
+  viewerId: string | undefined,
+): readonly ViewSpec[] {
+  const views: ViewSpec[] = [{ label: "list.viewAll", sort: "-created_at" }];
+  if (viewerId) {
+    views.push({
+      label: "list.viewMine",
+      sort: "-created_at",
+      filters: { owner_id: viewerId },
+    });
+  }
+  return views;
+}


### PR DESCRIPTION
Three list screens carried three copies of the Owner column, and when #1577
fixed it on People and Companies (it rendered 'typed by a person' for every
human-captured row) the Leads copy kept the bug. recordlist.tsx now defines
the Owner column, the Created column and the standard All/Mine views once;
people, organizations and leads compose them and add only what is specific
to their record. A source-level test holds the three screens to it: none may
spell its own owner/created column or Mine view again. The backend half —
owner_team_id/unassigned on leads through the shared ownership clause —
landed in #1654.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Deliberate behaviour change (Codex flagged it): the leads list now also offers the standard **Mine** view, as People and Companies do — that is the plan's 'Meine Leads' default and the point of one shared standard. Everything else is byte-for-byte the same behaviour (Codex verified per screen). Batman merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Owner and Created columns and the standard All/Mine views across People, Companies, and Leads by defining them once in `recordlist.tsx`. Previously, Leads had no Mine view and a divergent Owner column; now it uses the shared column and shows Mine when signed in. All other behavior is unchanged.

**Review notes**
- `people.tsx`, `organizations.tsx`, and `leads.tsx` now use `ownerColumn`, `createdColumn`, and `standardViews(viewerId)`; sort keys stay `owner_id`/`created_at` and dates use the same formatting.
- Leads now includes the standard Mine view; anonymous users still see only All.
- `recordlist.test.tsx` enforces shared columns/views and verifies labels/filters to prevent regressions.
- No migrations or backend changes; relies on ownership support from #1654.

<sup>Written for commit dff198211d099c8b8e598aca32046e593f791c52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

