### PR TITLE
test(migrations): the lead-merge foreign keys carry their visibility decision

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -214,6 +214,7 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// never accepted from the request body.
 	"lead.promoted_person_id":          "server-derived: stamped by PromoteLead",
 	"person.merged_into_id":            "server-derived: stamped by MergePerson",
+	"lead.merged_into_id":              "server-derived: stamped by MergeLead, the lead-side twin of MergePerson — a caller names the two leads, both of which the merge gates, and the surviving id is written from what that gate resolved",
 	"organization.merged_into_id":      "server-derived: stamped by MergeOrganization",
 	"person.converted_from_lead_id":    "server-derived: stamped by PromoteLead",
 	"deal_stage_history.deal_id":       "server-derived: appended by CreateDeal/AdvanceDeal",
@@ -248,6 +249,8 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
 	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
 	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query, exactly as its person and organization siblings above",
+	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query, exactly as its person and organization siblings above",
 	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own row-scoped connector-activity query (PO-DDL-12), never from a request body",
 	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own row-scoped ListDueOrgs read produced (CAP-PARAM-7), never from a request body",
 	// The signature pass's read cursor (PO-F-2a): both ids come from the


### PR DESCRIPTION
**The FK fitness gate is red on `main` right now**, and every branch cut since inherits it.

#1653 gave `lead` a `merged_into_id` and `dedupe_candidate` its `left_lead_id` / `right_lead_id`. All three point at a row-scoped record, so `TestFK_rowScopedTargetsHaveVisibilityDecision` demands a written decision for each — *"a reference to a row-scoped record is a read of it"* — and none had one.

All three are **server-derived**, and each is the exact twin of an entry already in the list:

- `lead.merged_into_id` is stamped by `MergeLead` the way `person.merged_into_id` is by `MergePerson`;
- the two dedupe columns are stamped by `recordDedupeCandidate` from the sweep's own row-scoped match query, beside its `person` and `organization` siblings.

Classified rather than gated, because there is nothing here a caller supplies: the merge gates both leads it is given and writes the surviving id from what that gate resolved.

## Verification

`TestFK_rowScopedTargetsHaveVisibilityDecision` passes. Confirmed the failure is pre-existing by running it against `origin/main` unmodified — all three reported there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks three lead-related FKs as server-derived so the FK fitness gate passes. Previously, `main` failed because `lead.merged_into_id` and `dedupe_candidate.{left_lead_id,right_lead_id}` referenced row-scoped records without a recorded visibility decision.

- Classifies `lead.merged_into_id` as stamped by `MergeLead`, mirroring `person.merged_into_id`; classifies both `dedupe_candidate` lead IDs as stamped by `recordDedupeCandidate`, mirroring person/org siblings.
- No API/runtime behavior changes; test-only update that unblocks the gate.
- No schema changes or migrations required.

<sup>Written for commit 7049adb15cfaca2e07f84e90b8c54f52fce87990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

