### PR TITLE
chore(renovate): js-yaml stays on the 4.x line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,11 @@
   },
   "packageRules": [
     {
+      "description": "js-yaml stays on the 4.x line, and this is the only place that can say so. The override in pnpm-workspace.yaml exists solely to lift @redocly/openapi-core's EXACT 4.3.0 pin to 4.3.1 for GHSA-5p4m-2wfm-xmqj; Renovate reads that override as an ordinary range and offers the major like any other range it manages. Taking the major breaks the build instead of the advisory: openapi-typescript 7.x — latest — depends on @redocly/openapi-core ^1.34.6, which reads `js-yaml`'s `types.merge`, removed in 5.x, so `openapi-typescript` dies on require and fe-typecheck-composed fails with no schema to check against. @redocly/openapi-core 2.x is written against js-yaml ^5.2.2, so this rule and the override both go away together, once openapi-typescript adopts that line.",
+      "matchPackageNames": ["js-yaml"],
+      "allowedVersions": "<5"
+    },
+    {
       "description": "A major needs a human to read the changelog, so it can never satisfy automerge on its own and its branch would otherwise sit open indefinitely — the one shape that pays the rebase cost forever while having no path to merge. `conflicted` above still rebases a lockfile major on every main merge that touches the lockfile (24 of the last 100 did), so majors are pinned to `never`: the branch goes stale, which is the correct state for a change waiting on a person. Whoever picks it up rebases it by ticking the PR's own checkbox.",
       "matchUpdateTypes": ["major"],
       "automerge": false,


### PR DESCRIPTION
Closes the CI failure on https://github.com/gradionhq/margince-poc-v1/pull/1389 by making the bump un-proposable instead of merging it.

## What is wrong

`js-yaml` in `pnpm-workspace.yaml` is an **override**, not a dependency. It exists for one reason: `@redocly/openapi-core` pins the EXACT version `4.3.0`, which carries GHSA-5p4m-2wfm-xmqj, and an override is the only way to lift it to `4.3.1`. Renovate cannot see that — it reads the override as an ordinary range and offered `^5.0.0` like any other major.

Taking the major breaks the build rather than the advisory. `openapi-typescript@7.13.0` (latest) depends on `@redocly/openapi-core ^1.34.6`, whose YAML shim reads `js-yaml`'s `types.merge` — removed in 5.x — so the generator dies on require:

```
node_modules/@redocly/openapi-core/lib/js-yaml/index.js:9
    implicit: [js_yaml_1.types.merge],
                               ^
TypeError: Cannot read properties of undefined (reading 'merge')
```

`fe-typecheck-composed` then has no `schema.d.ts` to check against, `fe-quality` fails, and the `frontend` lane fails with it. The comment above the override already states that the 4.x line is deliberate; a bot cannot read a comment.

## What this does

One `packageRules` entry: `js-yaml` is capped at `<5`, with the reason and the condition for removal written next to it. Renovate closes https://github.com/gradionhq/margince-poc-v1/pull/1389 itself on its next run — the update is no longer allowed — so nothing needs closing by hand.

## When it goes away

`@redocly/openapi-core` 2.x is written against `js-yaml ^5.2.2`. Once `openapi-typescript` adopts that line, the `4.3.0` pin is gone, and the rule and the override both come out together.

## Verification

- `renovate-config-validator --strict` → `Config validated successfully`
- Registry-checked: `openapi-typescript@7.13.0` → `@redocly/openapi-core ^1.34.6` (js-yaml `4.3.0`); `@redocly/openapi-core@2.46.1` → `js-yaml ^5.2.2`
- Failure quoted above is from https://github.com/gradionhq/margince-poc-v1/actions/runs/32026930270/job/95379089679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Renovate from proposing `js-yaml` 5.x by capping it to `<5`, keeping builds green. Previously, Renovate treated the workspace override as a normal range and suggested 5.x, which broke the OpenAPI generator and downstream CI; now it will only allow 4.x.

- Adds a `packageRules` entry in `renovate.json` for `js-yaml` with `allowedVersions: "<5"`.
- Reason: `openapi-typescript` 7.x depends on `@redocly/openapi-core ^1.34.6`, which relies on `js-yaml`’s `types.merge` removed in 5.x; the workspace override exists only to lift the exact `4.3.0` pin to `4.3.1` for GHSA-5p4m-2wfm-xmqj.
- Rollout: No manual action; Renovate will auto-close any open 5.x bump PRs on its next run.
- Removal: Delete this rule and the override when `openapi-typescript` adopts `@redocly/openapi-core` 2.x (uses `js-yaml ^5.2.2`).

<sup>Written for commit 6363a9d61d21125fb722586e3577363e96881b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management rules to keep `js-yaml` on compatible versions below 5.
* **Documentation**
  * Documented the compatibility and security considerations behind this version restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->