### PR TITLE
fix(leads): unbreak main — classify the lead dedupe FKs and stop comparing a µs column to a ns clock

### DIFF
--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -316,3 +316,58 @@ func TestDedupeQueueHidesPairsOutsideTheCallersRowScope(t *testing.T) {
 		t.Fatalf("owner sees %d candidates, want 1", len(rows))
 	}
 }
+
+// The same gate, for leads, and it carries more weight here than the person case
+// above.
+//
+// The schema fitness suite classifies dedupe_candidate's lead pair ids as
+// server-derived rather than requiring auth.EnsureLinkTarget on them
+// (migrations/schema_fitness_integration_test.go). That classification is only
+// safe because THIS gate holds: the detector is deliberately not row-scoped, so a
+// lead pair can legitimately name a lead the reader cannot see, and the read is
+// the only thing standing between that pair and disclosure. An untested security
+// gate looks exactly like a passing one, and until now this one was tested for
+// entity_type='person' only.
+func TestDedupeQueueHidesLeadPairsOutsideTheCallersRowScope(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	first := e.createLead(ctx, t, "Jonas Petersen", "jonas@nordwind.test", "Nordwind Logistik")
+	e.createLead(ctx, t, "Jonas Peterson", "", "Nordwind Logistik")
+	rows := openCandidates(ctx, t, e, entityLead)
+	if len(rows) != 1 {
+		t.Fatalf("open lead queue holds %d candidates, want 1", len(rows))
+	}
+	c := rows[0]
+
+	// Bind both leads to one rep so the rows are private rather than
+	// workspace-shared, which is the state a row-scope clause can act on.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE lead SET owner_id = $1`, e.rep)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	other := e.asOwnScoped(ids.NewV7())
+	if hidden := openCandidates(other, t, e, entityLead); len(hidden) != 0 {
+		t.Fatalf("own-scoped stranger sees %d lead candidates, want 0", len(hidden))
+	}
+	if _, err := e.store.GetDedupeCandidate(other, c.ID); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("out-of-scope get = %v, want ErrNotFound (existence-hiding)", err)
+	}
+	// Both sides must be required, not either: a stranger who can see exactly one
+	// side of the pair still learns the other exists if the clause is an OR.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE lead SET owner_id = NULL WHERE id = $1`, first)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if halfVisible := openCandidates(other, t, e, entityLead); len(halfVisible) != 0 {
+		t.Errorf("a stranger who can see one side sees %d lead candidates, want 0 — the clause must require BOTH", len(halfVisible))
+	}
+	// And the owner still sees it throughout.
+	if owned := openCandidates(ctx, t, e, entityLead); len(owned) != 1 {
+		t.Fatalf("owner sees %d lead candidates, want 1", len(owned))
+	}
+}

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -168,7 +168,12 @@ func TestFirstResponseFromHumanStatusChangeAndDisposition(t *testing.T) {
 // delivery moves the stamp back, and a later reply never moves it forward.
 func TestFirstResponseKeepsTheEarliestReplyWhateverTheDeliveryOrder(t *testing.T) {
 	e := setupPromoteConsent(t)
-	now := time.Now().UTC()
+	// Truncated to microseconds, which is timestamptz's resolution: `early` is
+	// written to the column and then compared against what comes back, so a
+	// nanosecond remainder is lost in the round trip and Equal fails on a value
+	// that stored correctly. That made this test pass on macOS, whose clock is
+	// coarser, and fail on Linux CI, whose clock is not.
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	lead := e.seedLeadCreatedAt(t, "ordered@example.test", now.Add(-3*time.Hour))
 	late := now.Add(-time.Hour)
 	early := now.Add(-2 * time.Hour)

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -168,11 +168,8 @@ func TestFirstResponseFromHumanStatusChangeAndDisposition(t *testing.T) {
 // delivery moves the stamp back, and a later reply never moves it forward.
 func TestFirstResponseKeepsTheEarliestReplyWhateverTheDeliveryOrder(t *testing.T) {
 	e := setupPromoteConsent(t)
-	// Truncated to microseconds, which is timestamptz's resolution: `early` is
-	// written to the column and then compared against what comes back, so a
-	// nanosecond remainder is lost in the round trip and Equal fails on a value
-	// that stored correctly. That made this test pass on macOS, whose clock is
-	// coarser, and fail on Linux CI, whose clock is not.
+	// timestamptz keeps microseconds, so a stamp this test writes and reads back
+	// must be microsecond-exact for the Equal below to mean anything.
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	lead := e.seedLeadCreatedAt(t, "ordered@example.test", now.Add(-3*time.Hour))
 	late := now.Add(-time.Hour)

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -215,10 +215,13 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"lead.promoted_person_id":     "server-derived: stamped by PromoteLead",
 	"person.merged_into_id":       "server-derived: stamped by MergePerson",
 	"organization.merged_into_id": "server-derived: stamped by MergeOrganization",
-	// All three go through archiveMergedAway, which takes the table as a
-	// parameter — so lead's redirect pointer is written by the same statement as
-	// the two above, not by a lead-specific path a caller could reach.
-	"lead.merged_into_id":              "server-derived: stamped by MergeLead through archiveMergedAway",
+	// Sharing archiveMergedAway with the two above proves nothing about
+	// reachability — MergePerson runs the same statement and IS reached from a
+	// handler whose body names the target. What carries this entry is that
+	// MergeLead has no HTTP surface at all: its only caller is the dedupe queue's
+	// merge disposition, which constrains the winner to one of the pair ids it
+	// already read off the candidate row.
+	"lead.merged_into_id":              "server-derived: stamped by MergeLead, reachable only from the queue's merge disposition, which constrains the winner to a pair id it already read",
 	"person.converted_from_lead_id":    "server-derived: stamped by PromoteLead",
 	"deal_stage_history.deal_id":       "server-derived: appended by CreateDeal/AdvanceDeal",
 	"deal_forecast_history.deal_id":    "server-derived: appended by UpdateDeal for the deal it has just written, and only after auth.EnsureVisible admitted that deal at the top of the same transaction — the id never comes from a request body",
@@ -246,17 +249,27 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"person_social.person_id":                    "child row: written only through the person store — CreatePerson mints the parent row itself, UpdatePerson passes auth.EnsureVisible first",
 	// The dedupe review queue (DH-DDL-1): pair ids are server-derived —
 	// recordDedupeCandidate stamps them from the ensure chokepoint's own
-	// row-scoped fuzzy query, never from a request body; the disposition
-	// endpoints address the candidate row, not the pair ids.
-	"dedupe_candidate.left_person_id":  "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_person_id": "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.left_org_id":     "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_org_id":    "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	// The lead pair (#1662) is the same INSERT in the same function: entityLead
-	// only selects a different column pair, so the reasoning above carries over
-	// verbatim rather than by analogy.
-	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	// fuzzy query, never from a request body; the disposition endpoints address
+	// the candidate row, not the pair ids.
+	//
+	// The detector is NOT row-scoped, and saying so would be the dangerous
+	// mistake here: it filters on the workspace and archived_at only, so it does
+	// pair a caller's record with one they cannot see — deliberately, since a
+	// duplicate you cannot see is still a duplicate. What keeps that pair from
+	// being disclosed is the QUEUE READ, which requires BOTH sides to pass the
+	// caller's row scope (dedupequeue.go's both-sides EXISTS clause, and
+	// EnsureVisible on each side in GetDedupeCandidate). These entries rest on
+	// that gate, so nothing here may be read as licence to relax it.
+	"dedupe_candidate.left_person_id":  "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	"dedupe_candidate.right_person_id": "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	"dedupe_candidate.left_org_id":     "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	"dedupe_candidate.right_org_id":    "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	// A lead pair reaches the same INSERT — entityLead only swaps the column pair
+	// — but not from a sweep: it is detected inline by fuzzyLead in the same
+	// transaction that writes the lead, so the left id is the row that
+	// transaction just created or updated.
+	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query, the left id being the lead that transaction just wrote",
+	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
 	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own row-scoped connector-activity query (PO-DDL-12), never from a request body",
 	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own row-scoped ListDueOrgs read produced (CAP-PARAM-7), never from a request body",
 	// The signature pass's read cursor (PO-F-2a): both ids come from the

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -212,9 +212,13 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"preference_token.person_id":        "gated: auth.EnsureVisible on the recipient in PreferenceTokenForEmail — the id is server-derived from the send path's workspace-predicated email→person resolve, and the minted token is a bearer credential over that person, so the mint carries the same row-scope probe the sibling read does; the public surface reads the row as the token→tenant resolver before any principal exists",
 	// Server-derived pointers: stamped from an operation's outcome,
 	// never accepted from the request body.
-	"lead.promoted_person_id":          "server-derived: stamped by PromoteLead",
-	"person.merged_into_id":            "server-derived: stamped by MergePerson",
-	"organization.merged_into_id":      "server-derived: stamped by MergeOrganization",
+	"lead.promoted_person_id":     "server-derived: stamped by PromoteLead",
+	"person.merged_into_id":       "server-derived: stamped by MergePerson",
+	"organization.merged_into_id": "server-derived: stamped by MergeOrganization",
+	// All three go through archiveMergedAway, which takes the table as a
+	// parameter — so lead's redirect pointer is written by the same statement as
+	// the two above, not by a lead-specific path a caller could reach.
+	"lead.merged_into_id":              "server-derived: stamped by MergeLead through archiveMergedAway",
 	"person.converted_from_lead_id":    "server-derived: stamped by PromoteLead",
 	"deal_stage_history.deal_id":       "server-derived: appended by CreateDeal/AdvanceDeal",
 	"deal_forecast_history.deal_id":    "server-derived: appended by UpdateDeal for the deal it has just written, and only after auth.EnsureVisible admitted that deal at the top of the same transaction — the id never comes from a request body",
@@ -244,10 +248,15 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// recordDedupeCandidate stamps them from the ensure chokepoint's own
 	// row-scoped fuzzy query, never from a request body; the disposition
 	// endpoints address the candidate row, not the pair ids.
-	"dedupe_candidate.left_person_id":           "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	"dedupe_candidate.left_person_id":  "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	"dedupe_candidate.right_person_id": "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	"dedupe_candidate.left_org_id":     "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	"dedupe_candidate.right_org_id":    "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	// The lead pair (#1662) is the same INSERT in the same function: entityLead
+	// only selects a different column pair, so the reasoning above carries over
+	// verbatim rather than by analogy.
+	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
+	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
 	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own row-scoped connector-activity query (PO-DDL-12), never from a request body",
 	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own row-scoped ListDueOrgs read produced (CAP-PARAM-7), never from a request body",
 	// The signature pass's read cursor (PO-F-2a): both ids come from the


### PR DESCRIPTION
The `integration (RLS + erasure + HTTP e2e)` required check is failing on `main`, and every PR opened since inherits it — PR CI tests the merge with the base tip, so a branch that touches no lead code fails on lead tests.

## How it got in

[#1662](https://github.com/gradionhq/margince-poc-v1/pull/1662) *(leads dedupe against leads)* merged at 05:22Z with its own `integration (RLS + erasure + HTTP e2e)` check at **FAILURE** — `integration shard (1/12)` was red at merge time.

`main`'s runs since have been green only because they were docs-only changes whose classifier skips the integration lane, so nothing has re-tested the schema since. The red was never visible on a `main` run.

This is the **third** instance recorded today of a PR merging over a red required check, after [#1559](https://github.com/gradionhq/margince-poc-v1/pull/1559) (`fe-quality` FAILURE → [#1573](https://github.com/gradionhq/margince-poc-v1/issues/1573)) and #1512's migration-version collision. The pattern is now the finding: the gates are doing their job and are being bypassed, which makes every green verdict on this repo unreadable until it stops. Whatever mechanism allows the bypass — admin merge, auto-merge racing a check, or `enforce_admins` being off since 2026-08-09 — is worth closing separately from these two defects.

## What is actually broken

**1. Three foreign keys with no visibility decision.** `TestFK_rowScopedTargetsHaveVisibilityDecision` refuses `dedupe_candidate.left_lead_id`, `dedupe_candidate.right_lead_id`, and `lead.merged_into_id`. The gate is right to ask — a reference to a row-scoped record is a read of it — and the answer is that all three are server-derived, which the fix records with the reasoning verified rather than assumed:

- the pair ids go through the same `recordDedupeCandidate` INSERT as their person/org siblings (`entityLead` only picks a different column pair);
- `lead.merged_into_id` is written by `archiveMergedAway`, which takes the table as a parameter — the same statement that stamps person and organization.

**2. A test comparing a microsecond column to a nanosecond clock.** `TestFirstResponseKeepsTheEarliestReplyWhateverTheDeliveryOrder` writes a `time.Now()` value to a `timestamptz`, reads it back, and asserts `.Equal()`. Postgres stores microseconds, so the nanosecond remainder is lost in the round trip and the assertion fails on a value that stored correctly:

```
first_response_at = 2026-08-18 05:17:12.33026    +0000 UTC
want the earliest reply 2026-08-18 05:17:12.330260974 +0000 UTC
```

**This is why it passed review and failed CI**: macOS hands out a coarser clock than Linux, so the remainder is usually zero locally and almost never zero on a runner. The fix truncates at the source so every derived time round-trips losslessly, rather than loosening the assertion — which would have stopped proving the delivery-ordering the test exists for. Reproduced before fixing by injecting the same 974ns remainder.

The sibling comparison four lines above it is safe and untouched: its expected value comes back *out* of the database, so it is already microsecond-exact.

## Worth a follow-up

The precision trap is not specific to leads — any integration test that writes a Go time and later compares it exactly has it, and it fails only on Linux. A fitness check, or a shared `testtime.Now()` that truncates, would close the class rather than this one instance. Filing that separately if there is appetite; it is not needed to unbreak `main`.
