### PR TITLE
fix(ci): the spacing gate can see a unit screen, and says how many it saw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,12 @@ icon-lint:
 ## ds-spacing — spacing gate: no NEW raw-px margin/padding/gap, in inline styles
 ## (*.tsx) or in stylesheets (*.css outside the design-system tier, which defines
 ## the scale). Diff-scoped vs origin/main; use the --space-* scale or a layout class.
+## check-ds-spacing.test.sh runs beside it because the gate reports success both
+## when it inspected everything and when its pathspecs reached nothing: the census
+## is the only thing that can tell those two apart.
 ds-spacing:
 	frontend/scripts/check-ds-spacing.sh
+	bash frontend/scripts/check-ds-spacing.test.sh
 
 ## space-tokens — every --space-* token a stylesheet USES is DEFINED. An
 ## undefined custom property resolves to nothing rather than to a smaller
@@ -314,6 +318,7 @@ fe-ds-gates:
 	frontend/scripts/check-font-lock.sh
 	frontend/scripts/check-icon-glyph.sh
 	frontend/scripts/check-ds-spacing.sh
+	bash frontend/scripts/check-ds-spacing.test.sh
 	frontend/scripts/check-space-tokens.sh
 	frontend/scripts/check-native-controls.sh
 	frontend/scripts/check-ext-imports.sh

--- a/frontend/scripts/check-ds-spacing.sh
+++ b/frontend/scripts/check-ds-spacing.sh
@@ -69,17 +69,28 @@ untracked() {
   git -C "$REPO_ROOT" ls-files --others --exclude-standard -- "$@" 2>/dev/null || true
 }
 
-# Read-loop rather than mapfile — the CI/dev host ships bash 3.2 (no mapfile),
-# same portability constraint as check-ds-purity.sh.
 # The unit trees join the pathspecs: a unit's screen is shipped UI in the same
 # bundle, and a spacing gate that stopped at frontend/src would hold the core to
 # a scale the extension tier escapes.
+#
+# A git pathspec `**/` requires an intermediate directory, so `<tree>/**/*.tsx`
+# does NOT match a file sitting directly in <tree> — and every unit screen sits
+# directly at extensions/<unit>/frontend/screen.tsx. Each recursive pattern
+# therefore carries its direct-child sibling. The lists are spelled ONCE and
+# shared by the tracked and untracked collectors below: two copies is how the
+# extensions entry lost its sibling while the frontend/src entry kept one.
+# check-ds-spacing.test.sh holds the census these have to keep collecting.
+TSX_PATHSPEC=('frontend/src/**/*.tsx' 'frontend/src/*.tsx' 'extensions/*/frontend/**/*.tsx' 'extensions/*/frontend/*.tsx')
+CSS_PATHSPEC=('frontend/src/**/*.css' 'frontend/src/*.css' 'extensions/*/frontend/**/*.css' 'extensions/*/frontend/*.css')
+
+# Read-loop rather than mapfile — the CI/dev host ships bash 3.2 (no mapfile),
+# same portability constraint as check-ds-purity.sh.
 CHANGED_TSX=()
 while IFS= read -r f; do
   [[ -n "$f" ]] && CHANGED_TSX+=("$f")
 done < <(
-  git -C "$REPO_ROOT" diff --name-only --diff-filter=d "$BASE" -- 'frontend/src/**/*.tsx' 'frontend/src/*.tsx' 'extensions/*/frontend/**/*.tsx' 2>/dev/null || true
-  untracked 'frontend/src/**/*.tsx' 'frontend/src/*.tsx' 'extensions/*/frontend/**/*.tsx'
+  git -C "$REPO_ROOT" diff --name-only --diff-filter=d "$BASE" -- "${TSX_PATHSPEC[@]}" 2>/dev/null || true
+  untracked "${TSX_PATHSPEC[@]}"
 )
 
 CHANGED_CSS=()
@@ -88,8 +99,8 @@ while IFS= read -r f; do
   [[ "$f" == frontend/src/design-system/* ]] && continue
   CHANGED_CSS+=("$f")
 done < <(
-  git -C "$REPO_ROOT" diff --name-only --diff-filter=d "$BASE" -- 'frontend/src/**/*.css' 'frontend/src/*.css' 'extensions/*/frontend/**/*.css' 2>/dev/null || true
-  untracked 'frontend/src/**/*.css' 'frontend/src/*.css' 'extensions/*/frontend/**/*.css'
+  git -C "$REPO_ROOT" diff --name-only --diff-filter=d "$BASE" -- "${CSS_PATHSPEC[@]}" 2>/dev/null || true
+  untracked "${CSS_PATHSPEC[@]}"
 )
 
 # The added-lines diff for one file, tracked or not. `--no-index` exits non-zero

--- a/frontend/scripts/check-ds-spacing.sh
+++ b/frontend/scripts/check-ds-spacing.sh
@@ -73,15 +73,19 @@ untracked() {
 # bundle, and a spacing gate that stopped at frontend/src would hold the core to
 # a scale the extension tier escapes.
 #
-# A git pathspec `**/` requires an intermediate directory, so `<tree>/**/*.tsx`
-# does NOT match a file sitting directly in <tree> — and every unit screen sits
-# directly at extensions/<unit>/frontend/screen.tsx. Each recursive pattern
-# therefore carries its direct-child sibling. The lists are spelled ONCE and
-# shared by the tracked and untracked collectors below: two copies is how the
-# extensions entry lost its sibling while the frontend/src entry kept one.
+# ONE pattern per tree, and it is the plain one. A git pathspec is not :(glob)
+# magic, so its `*` spans directory separators: 'frontend/src/*.tsx' already
+# matches every depth under frontend/src. It is `**/` that carries the
+# requirement — an intermediate directory — so '<tree>/**/*.tsx' silently misses
+# a file sitting DIRECTLY in <tree>. That is what the extension entry was, on
+# its own, while every unit screen sits at extensions/<unit>/frontend/screen.tsx.
+# Do not add a `**/` sibling back: it can only ever match a subset.
+#
+# Spelled ONCE and shared by the tracked and untracked collectors below — two
+# copies is how these two trees came to disagree in the first place.
 # check-ds-spacing.test.sh holds the census these have to keep collecting.
-TSX_PATHSPEC=('frontend/src/**/*.tsx' 'frontend/src/*.tsx' 'extensions/*/frontend/**/*.tsx' 'extensions/*/frontend/*.tsx')
-CSS_PATHSPEC=('frontend/src/**/*.css' 'frontend/src/*.css' 'extensions/*/frontend/**/*.css' 'extensions/*/frontend/*.css')
+TSX_PATHSPEC=('frontend/src/*.tsx' 'extensions/*/frontend/*.tsx')
+CSS_PATHSPEC=('frontend/src/*.css' 'extensions/*/frontend/*.css')
 
 # Read-loop rather than mapfile — the CI/dev host ships bash 3.2 (no mapfile),
 # same portability constraint as check-ds-purity.sh.

--- a/frontend/scripts/check-ds-spacing.test.sh
+++ b/frontend/scripts/check-ds-spacing.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# The spacing gate's own test — it gates the gate's CENSUS, not its verdict.
+#
+# check-ds-spacing.sh reports success both when it inspected every file it
+# should have and when it inspected none of them, so a pathspec that quietly
+# stops matching is indistinguishable from a clean tree. That is exactly what
+# happened: `extensions/*/frontend/**/*.tsx` was the only pattern for the unit
+# tier, a git pathspec `**/` requires an intermediate directory, and every unit
+# screen sits DIRECTLY at extensions/<unit>/frontend/screen.tsx — so three
+# shipped units were exempt from the rule while the gate said PASS.
+#
+# The pathspec lists are read out of the gate itself rather than restated here.
+# A test that spells its own copy of the thing under test passes against the
+# copy, not against production.
+#
+# Usage: bash frontend/scripts/check-ds-spacing.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GATE="$SCRIPT_DIR/check-ds-spacing.sh"
+ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# The gate's own declarations, evaluated verbatim. Two lines, or the gate has
+# been restructured and this test is reading something else.
+DECLS="$(grep -E '^(TSX|CSS)_PATHSPEC=\(' "$GATE" || true)"
+if [[ "$(printf '%s\n' "$DECLS" | grep -c .)" -ne 2 ]]; then
+  echo "FAIL: could not read TSX_PATHSPEC and CSS_PATHSPEC out of $GATE — the" >&2
+  echo "      gate no longer declares them on one line each, so this test is" >&2
+  echo "      gating nothing. Re-point it at wherever the pathspecs now live." >&2
+  exit 1
+fi
+eval "$DECLS"
+
+# ---------------------------------------------------------------------------
+# 1. The property, on a synthetic tree: every tree a pathspec list names must
+#    be matched at BOTH depths — a file directly in it and a file nested under
+#    it. Synthetic because the real repo ships no unit CSS, so the *.css half
+#    of the defect is unreachable here and a census over real files would prove
+#    nothing about it. `git ls-files` is the pathspec engine `git diff` and
+#    `git ls-files --others` in the gate both match with.
+# ---------------------------------------------------------------------------
+REPO="$TMP/repo"
+SHAPES=(
+  frontend/src/App
+  frontend/src/screens/deals/DealList
+  extensions/probe/frontend/screen
+  extensions/probe/frontend/views/panel
+)
+for shape in "${SHAPES[@]}"; do
+  mkdir -p "$REPO/$(dirname "$shape")"
+  : >"$REPO/$shape.tsx"
+  : >"$REPO/$shape.css"
+done
+git -C "$REPO" init --quiet
+for shape in "${SHAPES[@]}"; do
+  git -C "$REPO" add -- "$shape.tsx" "$shape.css"
+done
+
+check_shape_census() {
+  local kind="$1"
+  shift
+  local want got
+  want="$(printf '%s\n' "${SHAPES[@]/%/.$kind}" | sort)"
+  got="$(git -C "$REPO" ls-files -- "$@" | sort)"
+  if [[ "$got" != "$want" ]]; then
+    fail "the *.$kind pathspecs miss files the gate claims to inspect:"
+    diff <(printf '%s\n' "$want") <(printf '%s\n' "$got") >&2 || true
+  fi
+}
+
+check_shape_census tsx "${TSX_PATHSPEC[@]}"
+check_shape_census css "${CSS_PATHSPEC[@]}"
+
+# ---------------------------------------------------------------------------
+# 2. The census against THIS repo: the pathspecs must collect every file of
+#    that suffix under the two trees the gate says it gates. The expected set
+#    is derived from the trees rather than from the patterns, so the two cannot
+#    agree by both being wrong.
+# ---------------------------------------------------------------------------
+check_repo_census() {
+  local kind="$1"
+  shift
+  local want got
+  want="$(git -C "$ROOT" ls-files -- frontend/src extensions \
+    | grep -E "^(frontend/src/|extensions/[^/]+/frontend/).*\.$kind\$" | sort || true)"
+  got="$(git -C "$ROOT" ls-files -- "$@" | sort)"
+  if [[ "$got" != "$want" ]]; then
+    fail "the *.$kind pathspecs do not collect every tracked *.$kind under frontend/src and extensions/*/frontend:"
+    diff <(printf '%s\n' "$want") <(printf '%s\n' "$got") >&2 || true
+  fi
+}
+
+check_repo_census tsx "${TSX_PATHSPEC[@]}"
+check_repo_census css "${CSS_PATHSPEC[@]}"
+
+# A count, not a verdict: the unit tier ships screens today, so a collection
+# that reaches none of them is a broken pathspec however green the gate reads.
+EXT_TSX="$(git -C "$ROOT" ls-files -- "${TSX_PATHSPEC[@]}" | grep -c '^extensions/' || true)"
+if [[ "$EXT_TSX" -eq 0 ]]; then
+  fail "the *.tsx pathspecs collect 0 files under extensions/*/frontend, and the tier ships screens — the gate is inspecting nothing there"
+fi
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "" >&2
+  echo "check-ds-spacing.sh's collectors are no longer reaching every file it" >&2
+  echo "reports on. Note that a git pathspec '**/' requires an intermediate" >&2
+  echo "directory: a recursive pattern needs its direct-child sibling beside it" >&2
+  echo "('<tree>/**/*.tsx' AND '<tree>/*.tsx')." >&2
+  exit 1
+fi
+
+echo "==> DS spacing census: ${#TSX_PATHSPEC[@]} *.tsx and ${#CSS_PATHSPEC[@]} *.css pathspecs reach both depths of every gated tree ($EXT_TSX unit-tier *.tsx collected)"

--- a/frontend/scripts/check-ds-spacing.test.sh
+++ b/frontend/scripts/check-ds-spacing.test.sh
@@ -4,10 +4,17 @@
 # check-ds-spacing.sh reports success both when it inspected every file it
 # should have and when it inspected none of them, so a pathspec that quietly
 # stops matching is indistinguishable from a clean tree. That is exactly what
-# happened: `extensions/*/frontend/**/*.tsx` was the only pattern for the unit
+# happened: 'extensions/*/frontend/**/*.tsx' was the only pattern for the unit
 # tier, a git pathspec `**/` requires an intermediate directory, and every unit
 # screen sits DIRECTLY at extensions/<unit>/frontend/screen.tsx — so three
 # shipped units were exempt from the rule while the gate said PASS.
+#
+# Three things have to hold, and each is checked separately, because any one of
+# them alone can be true while the gate collects nothing:
+#
+#   1. the pathspecs match every depth of every tree they name;
+#   2. the collectors actually EXPAND those pathspecs, and reach for no others;
+#   3. what they collect in THIS repo is every file of that suffix in it.
 #
 # The pathspec lists are read out of the gate itself rather than restated here.
 # A test that spells its own copy of the thing under test passes against the
@@ -19,7 +26,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GATE="$SCRIPT_DIR/check-ds-spacing.sh"
-ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+
+# The gate is deliberately fail-open outside a git checkout (a source export, a
+# container that refuses a dubious-ownership repo). Its test has to skip on the
+# same terms rather than turn `make fe-ds-gates` red for a reason that has
+# nothing to do with spacing.
+ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$ROOT" ]]; then
+  echo "==> DS spacing census: not a git checkout — skipped"
+  exit 0
+fi
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -43,11 +59,11 @@ fi
 eval "$DECLS"
 
 # ---------------------------------------------------------------------------
-# 1. The property, on a synthetic tree: every tree a pathspec list names must
-#    be matched at BOTH depths — a file directly in it and a file nested under
-#    it. Synthetic because the real repo ships no unit CSS, so the *.css half
-#    of the defect is unreachable here and a census over real files would prove
-#    nothing about it. `git ls-files` is the pathspec engine `git diff` and
+# 1. The property, on a synthetic tree: each list must match every depth of
+#    every tree it names — a file directly in it and a file nested under it.
+#    Synthetic because the real repo ships no unit CSS, so the *.css half of the
+#    defect is unreachable here and a census over real files would prove nothing
+#    about it. `git ls-files` is the pathspec engine `git diff` and
 #    `git ls-files --others` in the gate both match with.
 # ---------------------------------------------------------------------------
 REPO="$TMP/repo"
@@ -83,20 +99,48 @@ check_shape_census tsx "${TSX_PATHSPEC[@]}"
 check_shape_census css "${CSS_PATHSPEC[@]}"
 
 # ---------------------------------------------------------------------------
-# 2. The census against THIS repo: the pathspecs must collect every file of
-#    that suffix under the two trees the gate says it gates. The expected set
-#    is derived from the trees rather than from the patterns, so the two cannot
-#    agree by both being wrong.
+# 2. The collectors reach for those lists and for nothing else. Reading the
+#    arrays proves what they say, not what is used: re-inlining one call site
+#    back to a literal leaves every other assertion here green while new unit
+#    screens go uninspected again. Four call sites — tracked and untracked,
+#    tsx and css — and one authority between them.
+# ---------------------------------------------------------------------------
+for var in TSX_PATHSPEC CSS_PATHSPEC; do
+  uses="$(grep -c -F "\"\${${var}[@]}\"" "$GATE" || true)"
+  if [[ "$uses" -ne 2 ]]; then
+    fail "\$$var is expanded at $uses call site(s) in check-ds-spacing.sh, expected 2 (the tracked diff and the untracked listing)"
+  fi
+done
+
+# A quoted *.tsx / *.css glob on any CODE line but the two declarations is a
+# second authority — the shape this gate already regressed into once. Comment
+# lines are dropped first: the pathspec trap is explained in prose right above
+# the declarations, and prose is not a call site.
+STRAY="$(grep -nE "'[^']*\*\.(tsx|css)'" "$GATE" \
+  | grep -vE '^[0-9]+:[[:space:]]*#' \
+  | grep -vE '^[0-9]+:(TSX|CSS)_PATHSPEC=' || true)"
+if [[ -n "$STRAY" ]]; then
+  fail "check-ds-spacing.sh names a *.tsx/*.css pathspec outside TSX_PATHSPEC/CSS_PATHSPEC:"
+  printf '%s\n' "$STRAY" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The census against THIS repo: the pathspecs must collect every tracked
+#    file of that suffix under the two trees the gate says it gates. The
+#    expected set is derived from the trees rather than from the patterns, so
+#    the two cannot agree by both being wrong — and it is spelled with the same
+#    depth-spanning semantics a git pathspec `*` has, so a unit that vendors a
+#    sub-tree is expected on both sides rather than failing as a surplus.
 # ---------------------------------------------------------------------------
 check_repo_census() {
   local kind="$1"
   shift
   local want got
   want="$(git -C "$ROOT" ls-files -- frontend/src extensions \
-    | grep -E "^(frontend/src/|extensions/[^/]+/frontend/).*\.$kind\$" | sort || true)"
+    | grep -E "^(frontend/src/|extensions/.+/frontend/).*\.$kind\$" | sort || true)"
   got="$(git -C "$ROOT" ls-files -- "$@" | sort)"
   if [[ "$got" != "$want" ]]; then
-    fail "the *.$kind pathspecs do not collect every tracked *.$kind under frontend/src and extensions/*/frontend:"
+    fail "the *.$kind pathspecs do not collect exactly the tracked *.$kind under frontend/src and extensions/*/frontend:"
     diff <(printf '%s\n' "$want") <(printf '%s\n' "$got") >&2 || true
   fi
 }
@@ -104,20 +148,24 @@ check_repo_census() {
 check_repo_census tsx "${TSX_PATHSPEC[@]}"
 check_repo_census css "${CSS_PATHSPEC[@]}"
 
-# A count, not a verdict: the unit tier ships screens today, so a collection
-# that reaches none of them is a broken pathspec however green the gate reads.
+# A count, not a verdict — but only where there is something to count.
+# extensions/ is the fork-owned tier: a downstream shipping only backend units
+# has no unit frontend at all, and "the gate inspects nothing there" is then a
+# true statement about an empty tree rather than a broken pathspec.
 EXT_TSX="$(git -C "$ROOT" ls-files -- "${TSX_PATHSPEC[@]}" | grep -c '^extensions/' || true)"
-if [[ "$EXT_TSX" -eq 0 ]]; then
-  fail "the *.tsx pathspecs collect 0 files under extensions/*/frontend, and the tier ships screens — the gate is inspecting nothing there"
+EXT_SCREENS="$(git -C "$ROOT" ls-files -- 'extensions/*/frontend/*' | grep -c . || true)"
+if [[ "$EXT_SCREENS" -gt 0 && "$EXT_TSX" -eq 0 ]]; then
+  fail "the unit tier ships $EXT_SCREENS frontend file(s) and the *.tsx pathspecs collect 0 of them — the gate is inspecting nothing there"
 fi
 
 if [[ "$FAILURES" -ne 0 ]]; then
   echo "" >&2
   echo "check-ds-spacing.sh's collectors are no longer reaching every file it" >&2
-  echo "reports on. Note that a git pathspec '**/' requires an intermediate" >&2
-  echo "directory: a recursive pattern needs its direct-child sibling beside it" >&2
-  echo "('<tree>/**/*.tsx' AND '<tree>/*.tsx')." >&2
+  echo "reports on. Note that a git pathspec is not :(glob): its '*' spans" >&2
+  echo "directory separators, so ONE '<tree>/*.tsx' covers every depth, while" >&2
+  echo "'<tree>/**/*.tsx' requires an intermediate directory and misses the" >&2
+  echo "files sitting directly in <tree>." >&2
   exit 1
 fi
 
-echo "==> DS spacing census: ${#TSX_PATHSPEC[@]} *.tsx and ${#CSS_PATHSPEC[@]} *.css pathspecs reach both depths of every gated tree ($EXT_TSX unit-tier *.tsx collected)"
+echo "==> DS spacing census: the *.tsx and *.css pathspecs reach every depth of every gated tree, from both collectors ($EXT_TSX unit-tier *.tsx collected)"


### PR DESCRIPTION
## What was wrong

`frontend/scripts/check-ds-spacing.sh` collected the unit tier with
`extensions/*/frontend/**/*.tsx`, and nothing else. A git pathspec `**/` requires
an intermediate directory, and every unit screen sits **directly** at
`extensions/<unit>/frontend/screen.tsx` — so the pattern matched nothing, and it
matched nothing quietly:

```
$ git ls-files -- 'extensions/*/frontend/**/*.tsx'   # 0 files
$ git ls-files -- 'extensions/*/frontend/*.tsx'      # 6, across 3 units
```

Three shipped units have been exempt from a design-system rule the repo believes
it enforces, and the gate reported `PASS` the whole time.

## The pathspec rule, measured

The first version of this PR paired each `**/` pattern with a direct-child
sibling, on the theory that the recursive one carries the depth. Review
challenged that and was right — measured on a scratch repo:

```
$ git ls-files -- 'extensions/*/frontend/*.tsx'
extensions/a/b/frontend/s.tsx      <- '*' spanned two segments
extensions/x/frontend/s.tsx
extensions/x/frontend/views/v.tsx  <- and every depth below

$ git ls-files -- 'extensions/*/frontend/**/*.tsx'
extensions/x/frontend/views/v.tsx  <- only this one
```

A git pathspec is **not** `:(glob)` magic, so its `*` spans directory
separators: `<tree>/*.tsx` already covers every depth. `**/` is the pattern that
carries a requirement, and it can only ever match a subset of its plain sibling.
So the fix is **one pattern per tree**, not two, and the `**/` forms are gone
rather than paired up — keeping them would have left the next author copying the
form that caused this.

## What changed

- `TSX_PATHSPEC` / `CSS_PATHSPEC`: one plain pattern per gated tree, declared
  **once** and shared by all four collectors (tracked/untracked × tsx/css). Four
  copies is how these two trees came to disagree in the first place.
- The comment above them now states the real semantics, so the trap is written
  down where the next tree gets added.
- New `frontend/scripts/check-ds-spacing.test.sh`, wired into `make ds-spacing`
  and `make fe-ds-gates` beside the gate (the shape `ext-imports` already uses).

**Sweep.** `check-ds-spacing.sh` is the only script in `frontend/scripts/` that
selects files by git pathspec — `grep -rn '\*\*/' frontend/scripts/ scripts/`
returns those lines and nothing else. The sibling DS gates collect with `find`,
which has no such trap.

**No backlog imported.** The newly gated screens carry no raw-px spacing today,
so this does not turn a branch red on inherited code.

## The test gates the census, not the verdict

This gate reports success both when it inspected everything and when its
pathspecs reached nothing, so its exit code cannot distinguish the two. Three
things have to hold, and each can be true while the gate still collects nothing:

1. **The pathspecs match every depth** of every tree they name — checked on a
   synthetic repo, which is where the `*.css` half of the defect is reachable at
   all (no unit ships CSS today, so a census over real files would prove nothing
   about it).
2. **The collectors expand those arrays, and reach for no others** — each array
   used at both of its call sites, and no `*.tsx`/`*.css` glob named on any other
   code line.
3. **The repo census** — the pathspecs collect exactly the tracked files of that
   suffix under `frontend/src/` and `extensions/*/frontend/`, with the expected
   set derived from the *trees* rather than from the patterns, so the two cannot
   agree by both being wrong.

Plus a count: the unit tier collects more than zero `*.tsx` — asserted only when
a unit frontend tree exists, since `extensions/` is the fork-owned tier and a
backend-only downstream has nothing there to inspect.

The pathspec arrays are read out of the gate itself rather than restated, so the
test cannot pass against its own copy of production; it refuses loudly if the
gate stops declaring them where it looks, and skips outside a git checkout on the
same terms the gate does.

## Proof — control → red → green, and the guard's own defect test

A pathspec fix verified by "the gate still passes" reproduces the original bug
exactly, so every arm carries the control run on unmodified `origin/main`.

| Arm | `origin/main` gate (control) | this branch | plant removed |
|---|---|---|---|
| tracked `*.tsx` — `screen.tsx` `marginTop: 13` | exit 0, "nothing to gate" | **exit 1**, names `extensions/notes/frontend/screen.tsx:89` | exit 0 |
| untracked `*.css` — `planted-probe.css` `padding: 7px` | exit 0, "nothing to gate" | **exit 1**, names `extensions/notes/frontend/planted-probe.css:2` | exit 0 |

And the census test against three mutants, each **exit 1**:

| Mutant | Caught by |
|---|---|
| the original defect — unit tier reachable only via `**/` | the depth property, the repo census, **and** the unit-tier count |
| one call site re-inlined to a literal (the arrays still read right) | the call-site count and the stray-glob check |
| the css collector wired to the tsx array | both call-site counts |

<details>
<summary>Full recorded session (the script that produced it is in the conversation below)</summary>

```
############ 0. THE DEFECT, MEASURED ON origin/main ############
$ git ls-files -- 'extensions/*/frontend/**/*.tsx'   # what the gate used to ask for
  ^ 0 files
$ git ls-files -- 'extensions/*/frontend/*.tsx'      # where unit screens actually live
extensions/dispact-connector/frontend/screen.test.tsx
extensions/dispact-connector/frontend/screen.tsx
extensions/notes/frontend/screen.test.tsx
extensions/notes/frontend/screen.tsx
extensions/zalo-oa/frontend/screen.test.tsx
extensions/zalo-oa/frontend/screen.tsx

############ 1. TRACKED *.tsx ARM ############
planted:     <div className="wrap narrow" style={{ marginTop: 13 }}>

$ CONTROL — origin/main's gate
==> DS spacing check: no changed frontend *.tsx or *.css — nothing to gate
exit=0

$ RED — this branch's gate
==> DS spacing check (1 changed *.tsx, 0 changed *.css vs ac206c387223)

FAIL: raw-px spacing in inline styles (new code)
  extensions/notes/frontend/screen.tsx:89:     <div className="wrap narrow" style={{ marginTop: 13 }}>

Use the --space-* scale (tokens.css) or a layout class instead of a raw
px margin/padding/gap — e.g. className="filter-tabs", the .card/.form-stack
rhythm, style={{ marginTop: 'var(--space-3)' }}, or gap: var(--space-2).
A genuine one-off is waived in-line, with a reason, on the offending line:
  // ds:ignore <reason>      (.tsx)
  /* ds:ignore <reason> */   (.css)
exit=1

$ GREEN — plant removed
==> DS spacing check: no changed frontend *.tsx or *.css — nothing to gate
exit=0

############ 2. UNTRACKED *.css ARM (the collector the fix also repairs) ############
planted: extensions/notes/frontend/planted-probe.css -> padding: 7px

$ CONTROL — origin/main's gate
==> DS spacing check: no changed frontend *.tsx or *.css — nothing to gate
exit=0

$ RED — this branch's gate
==> DS spacing check (0 changed *.tsx, 1 changed *.css vs ac206c387223)

FAIL: raw-px spacing in stylesheets (new code)
  extensions/notes/frontend/planted-probe.css:2: padding: 7px

Use the --space-* scale (tokens.css) or a layout class instead of a raw
px margin/padding/gap — e.g. className="filter-tabs", the .card/.form-stack
rhythm, style={{ marginTop: 'var(--space-3)' }}, or gap: var(--space-2).
A genuine one-off is waived in-line, with a reason, on the offending line:
  // ds:ignore <reason>      (.tsx)
  /* ds:ignore <reason> */   (.css)
exit=1

$ GREEN — plant removed
==> DS spacing check: no changed frontend *.tsx or *.css — nothing to gate
exit=0

############ 3. THE CENSUS TEST, AGAINST THREE MUTANTS ############

--- mutant: the original defect — unit tier reachable only via **/ ---
FAIL: the *.tsx pathspecs miss files the gate claims to inspect:
1d0
< extensions/probe/frontend/screen.tsx
FAIL: the *.css pathspecs miss files the gate claims to inspect:
1d0
< extensions/probe/frontend/screen.css
FAIL: the *.tsx pathspecs do not collect exactly the tracked *.tsx under frontend/src and extensions/*/frontend:
1,6d0
< extensions/dispact-connector/frontend/screen.test.tsx
< extensions/dispact-connector/frontend/screen.tsx
< extensions/notes/frontend/screen.test.tsx
< extensions/notes/frontend/screen.tsx
< extensions/zalo-oa/frontend/screen.test.tsx
< extensions/zalo-oa/frontend/screen.tsx
FAIL: the unit tier ships 18 frontend file(s) and the *.tsx pathspecs collect 0 of them — the gate is inspecting nothing there

check-ds-spacing.sh's collectors are no longer reaching every file it
reports on. Note that a git pathspec is not :(glob): its '*' spans
directory separators, so ONE '<tree>/*.tsx' covers every depth, while
'<tree>/**/*.tsx' requires an intermediate directory and misses the
files sitting directly in <tree>.
exit=1

--- mutant: one call site re-inlined to a literal (the arrays still read right) ---
FAIL: $TSX_PATHSPEC is expanded at 1 call site(s) in check-ds-spacing.sh, expected 2 (the tracked diff and the untracked listing)
FAIL: check-ds-spacing.sh names a *.tsx/*.css pathspec outside TSX_PATHSPEC/CSS_PATHSPEC:
97:  untracked 'frontend/src/*.tsx' 'extensions/*/frontend/**/*.tsx'

check-ds-spacing.sh's collectors are no longer reaching every file it
reports on. Note that a git pathspec is not :(glob): its '*' spans
directory separators, so ONE '<tree>/*.tsx' covers every depth, while
'<tree>/**/*.tsx' requires an intermediate directory and misses the
files sitting directly in <tree>.
exit=1

--- mutant: the css collector wired to the tsx array ---
FAIL: $TSX_PATHSPEC is expanded at 3 call site(s) in check-ds-spacing.sh, expected 2 (the tracked diff and the untracked listing)
FAIL: $CSS_PATHSPEC is expanded at 1 call site(s) in check-ds-spacing.sh, expected 2 (the tracked diff and the untracked listing)

check-ds-spacing.sh's collectors are no longer reaching every file it
reports on. Note that a git pathspec is not :(glob): its '*' spans
directory separators, so ONE '<tree>/*.tsx' covers every depth, while
'<tree>/**/*.tsx' requires an intermediate directory and misses the
files sitting directly in <tree>.
exit=1

--- GREEN: census test vs the fix ---
==> DS spacing census: the *.tsx and *.css pathspecs reach every depth of every gated tree, from both collectors (6 unit-tier *.tsx collected)
exit=0
```

</details>

## Coverage

Shell + Makefile: **this produces no measured new-code coverage**, and
SonarCloud's new-code measure should not be read as "untested" here. The
substitute proof is the mutation battery above — each guard shown red against the
defect it describes and green against the fix.

## Review

- `/code-review` (Fable) — **run, five findings, all five addressed**; see the
  reply in the conversation. One of them inverted the fix's central claim.
- **Codex has not reviewed this**: `/codex:*` cannot be invoked by an agent, so an
  unattended run cannot complete that step. Two reviewers, not three, unless a
  human types it.
- CodeRabbit arrives on its own.

Follow-up filed as #1691, not fixed here: `check-font-lock.sh` and `check-space-tokens.sh`
still scan `frontend/src` only, so the unit tier is exempt from those two rules —
the same gap as this issue, reached by a different route.

Closes #1637
