### PR TITLE
fix(ci): every allowlist owes a plant, derived from the policy itself

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,14 +10,28 @@
 # a scoped allowlist (a path AND a pattern) over a bare path exclusion: a whole
 # file waved through stops being scanned for the real thing.
 #
-# Scoping REQUIRES `targetRules`. A global `[[allowlists]]` carrying `paths`
-# makes gitleaks skip the whole file before it reads a line, so `condition =
-# "AND"` never gets the chance to narrow it — the exemption silently widens to
-# the entire file. Binding the allowlist to the rule it excuses keeps it out of
-# that path (config.go: allowlists with targetRules are not added to the global
-# list), so the file stays scanned for everything else. This is covered by the
-# mutation tests in scripts/test-secret-scan.sh — a planted token in one of the
-# files named below must still fail the gate.
+# A scoped exemption takes THREE elements, and dropping any ONE of them widens
+# it to the whole file. Measured against the pinned scanner, by planting a token
+# of the excused rule on a line the allowlist regex does not match:
+#
+#   targetRules       Without it the entry is GLOBAL: gitleaks skips the file
+#                     before it reads a line, so `condition` never gets the
+#                     chance to narrow anything and the exemption covers every
+#                     rule (config.go: allowlists with targetRules are not added
+#                     to the global list). Both scoped entries below were written
+#                     this way first.
+#   regexes           Without it the entry excuses the whole path for its rule —
+#                     `paths` alone is a file exclusion wearing a rule's name.
+#   condition = "AND" Without it the condition defaults to OR, and matching the
+#                     PATH alone is then enough. Same result as no regexes at
+#                     all, from an omission that looks like formatting.
+#
+# With all three, the file stays scanned — for the other rules AND for the
+# excused rule on every line the regex does not name. That is the property
+# scripts/test-secret-scan.sh holds: it derives its plants from the entries
+# below, so every allowlist here owes one token of each rule it targets, in a
+# file its own paths cover, and one of a rule it does not target. An allowlist
+# nobody planted against is exactly the one that is over-broad.
 
 [extend]
 useDefault = true

--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ check-craft-doc:
 ## secret-scan — no hardcoded credential reaches main: gitleaks over a clean
 ## `git archive HEAD` export, policy in .gitleaks.toml. Scans the COMMITTED
 ## tree, not the working tree, so a sibling worktree or a local .env.local
-## cannot change the verdict (gitleaks does not honour .gitignore). Needs
+## cannot change the verdict (gitleaks does not honour .gitignore).
 ## Needs nothing installed: scripts/gitleaks-pin.sh fetches and checksum-verifies
 ## the one pinned binary, so CI's secret-scan job and a laptop run the same
 ## scanner and therefore reach the same verdict.

--- a/Makefile
+++ b/Makefile
@@ -497,15 +497,19 @@ check-craft-doc:
 ## `git archive HEAD` export, policy in .gitleaks.toml. Scans the COMMITTED
 ## tree, not the working tree, so a sibling worktree or a local .env.local
 ## cannot change the verdict (gitleaks does not honour .gitignore). Needs
-## gitleaks on PATH (`brew install gitleaks`); CI's secret-scan job runs this
-## same target against a version- and checksum-pinned binary.
+## Needs nothing installed: scripts/gitleaks-pin.sh fetches and checksum-verifies
+## the one pinned binary, so CI's secret-scan job and a laptop run the same
+## scanner and therefore reach the same verdict.
 secret-scan:
 	@./scripts/secret-scan.sh
 
-## test-secret-scan — prove the secret gate still catches: plant a token in
-## each file .gitleaks.toml exempts and require the scan to fail anyway. An
-## over-broad allowlist reports "no leaks found" exactly like a clean tree, so
-## the policy is only trustworthy with this beside it.
+## test-secret-scan — prove the secret gate still catches. The plants are
+## DERIVED from .gitleaks.toml: every allowlist owes one token of each rule it
+## targets, in a file its own paths cover, plus one of a rule it does not — so
+## it proves the exemption covers the line it names rather than the file, and
+## an allowlist added tomorrow is gated without anyone remembering to add a
+## case. An over-broad allowlist reports "no leaks found" exactly like a clean
+## tree, so the policy is only trustworthy with this beside it.
 test-secret-scan:
 	@./scripts/test-secret-scan.sh
 

--- a/scripts/test-secret-scan.sh
+++ b/scripts/test-secret-scan.sh
@@ -3,44 +3,40 @@
 #
 # A scan policy can only fail by being too permissive, and an over-broad
 # allowlist is invisible: it reports the same "no leaks found" as a clean tree.
-# So every allowlist in .gitleaks.toml that names a file is re-checked here —
-# plant a credential-shaped token in that file, and the scan must still fail.
+# So every allowlist in .gitleaks.toml is re-checked here — plant a credential
+# in a file it covers, and the scan must still fail.
 #
 # TWO properties, and the second is the one a single plant cannot reach:
 #
 #   (a) an allowlist does not hide ANOTHER rule's finding. A global
 #       `[[allowlists]]` carrying `paths` makes gitleaks skip the whole file
-#       before it reads a line, so `condition = "AND"` never narrows it and the
+#       before it reads a line, so `condition` never narrows it and the
 #       exemption widens to everything in the file. `targetRules` is what keeps
-#       the file scanned. Both scoped entries were written the wrong way first;
-#       only this caught it.
+#       the file scanned. Both scoped entries were written the wrong way first.
 #
-#   (b) an allowlist does not hide ITS OWN rule's finding on a line the
-#       allowlist regex does not match. Nothing about (a) implies this, and it
-#       is the property the policy file's "the file stays scanned for
-#       everything else" is read as promising. Measured against the pinned
-#       scanner, three separate one-line omissions each widen a scoped
-#       exemption to the whole file for its own rule: dropping
-#       `condition = "AND"` (which then defaults to OR), dropping `regexes`,
-#       and dropping `targetRules`.
+#   (b) an allowlist does not hide ITS OWN rule's finding on a line its regex
+#       does not match. Nothing about (a) implies this, and it is the property
+#       "the file stays scanned for everything else" is read as promising.
+#       Measured: dropping `targetRules`, `regexes`, or `condition = "AND"`
+#       each widens a scoped exemption to the whole file for its own rule.
 #
-# So the plants are DERIVED from the policy rather than listed here: every
-# allowlist that names `targetRules` owes one plant per rule it targets, in a
-# file its own `paths` cover, plus a foreign-rule plant for (a). A hand-kept
-# list goes stale the first time somebody adds an allowlist — and an allowlist
-# nobody planted against is exactly the one that is over-broad.
+# The plants are DERIVED from the policy rather than listed. A hand-kept list
+# goes stale the first time somebody adds an allowlist, and an allowlist nobody
+# planted against is exactly the one that is over-broad.
 #
-# The suite FAILS CLOSED. An allowlist that targets a rule with no plant recipe
-# below, or names a path no tracked file matches, is an UNGATED allowlist and
-# is reported as a failure rather than skipped.
+# THE SHAPE GATE IS THE LOAD-BEARING PART. Deriving from a file this script
+# hand-parses is only safe if anything it cannot fully read is REFUSED, so the
+# policy is held to a narrow committed form: no indentation, no tables besides
+# [extend] and [[allowlists]], one quoting style per key, and a `paths` on every
+# entry. Each rejected shape below was demonstrated to hide a real credential
+# while this suite printed ok, so every one of them is a fixed bug rather than
+# fastidiousness. A coverage ledger backs the gate up: an allowlist that reaches
+# the end of the run with no plant against it fails, whatever went wrong.
 #
-# Every recipe is proved on a file no allowlist covers before it is trusted
-# anywhere else: an assertion that a plant is still caught passes for free if
-# the plant never tripped its rule at all.
-#
-# The tokens are generated per run rather than written down: a literal here
-# would be a credential-shaped string in the repo, which the gate would rightly
-# flag.
+# The tokens are generated per run rather than written down — a literal here
+# would be a credential-shaped string in the repo — and each is PROVED to trip
+# its rule before it is trusted: a random high-entropy string lands under the
+# generic-api-key floor often enough to redden roughly one run in fifty.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -54,7 +50,8 @@ gitleaks="$(gitleaks_bin)"
 
 work="$(mktemp -d)"
 backups="$(mktemp -d)"
-trap 'rm -rf "$work" "$backups"' EXIT
+probe="$(mktemp -d)"
+trap 'rm -rf "$work" "$backups" "$probe"' EXIT
 git archive HEAD | tar -x -C "$work"
 
 failures=0
@@ -63,85 +60,96 @@ fail() {
 	failures=$((failures + 1))
 }
 
-# `od` is bounded by -N, so `tr` reads to EOF — piping into a `head` that exits
-# early would SIGPIPE the producer, and `pipefail` would end the run at 141.
-hex() { od -An -tx1 -N"$1" /dev/urandom | tr -d ' \n'; }
+# The separator between a parsed field and its value. A unit separator, not a
+# pipe: `|` is ordinary inside a path regex — '''(^|/)vendor/''' — and a
+# delimiter that can occur in the data truncates it into a different, usually
+# invalid, pattern.
+SEP=$(printf '\037')
 
-# plant_line <rule-id> — a line that trips EXACTLY that rule, or exit 1 for a
-# rule this suite does not know how to plant for. Each shape was measured
-# against the pinned scanner; the sanity pass below re-measures it every run,
-# so a rule set that moves under us is a failure here rather than a silent
-# weakening of every assertion that follows.
-plant_line() {
-	case "$1" in
-	generic-api-key) printf 'const plantedApiKey = "%s"\n' "$(hex 24)" ;;
-	linkedin-client-id) printf 'const planted_linkedin_client_id = "%s"\n' "$(hex 7)" ;;
-	github-pat) printf 'const plantedToken = "ghp_%s"\n' "$(hex 18)" ;;
-	*) return 1 ;;
-	esac
+# --- 0. the policy is in the form this script can actually read ---------------
+# Refuse first, parse second.
+shape_gate() {
+	local policy="$root/.gitleaks.toml" line n bad=0
+	note() {
+		fail "$1"
+		bad=1
+	}
+
+	# TOML tolerates leading whitespace on a table header and on a key; the
+	# parser below anchors at column 0. An indented `[[allowlists]]` was
+	# demonstrated to exempt a whole directory while this suite printed ok.
+	if grep -nE '^[ \t]+(\[|(description|targetRules|paths|regexes|condition|regexTarget|stopwords)[ \t]*=)' "$policy"; then
+		note "the lines above are indented. Every table header and key in .gitleaks.toml sits at column 0 — an indented one is valid TOML this suite cannot see."
+	fi
+
+	# Only two table kinds. A `[[rules]]` block carries a nested allowlist of
+	# its own, which is an exemption channel nothing here reads.
+	while IFS= read -r line; do
+		case "$line" in
+		"[extend]" | "[[allowlists]]") ;;
+		*) note "unsupported table '$line' in .gitleaks.toml. This suite gates [[allowlists]] only; a [[rules]] block carries exemptions of its own that nothing here would plant against." ;;
+		esac
+	done < <(grep -E '^\[' "$policy")
+
+	# [extend] turns rules ON. `disabledRules` turns whole detectors OFF, which
+	# is an exemption with no allowlist to plant against.
+	n="$(grep -cE '^useDefault[ \t]*=[ \t]*true$' "$policy" || true)"
+	if [[ "$n" -ne 1 ]]; then
+		note ".gitleaks.toml must carry exactly one 'useDefault = true'; found $n."
+	fi
+	if grep -nE '^(disabledRules|stopwords)[ \t]*=' "$policy"; then
+		note "the keys above disable detection outside any allowlist, so nothing here plants against them."
+	fi
+
+	# One quoting style per key, because the array reader splits on ONE
+	# delimiter: a mixed-quote array silently drops the entries in the other
+	# style, and a dropped path owes no plant.
+	if grep -nE "^(description|targetRules)[ \t]*=.*'''" "$policy"; then
+		note "description and targetRules use \"basic strings\"; the lines above mix in ''' literals."
+	fi
+	if grep -nE '^(paths|regexes)[ \t]*=.*"' "$policy"; then
+		note "paths and regexes use '''literal strings'''; the lines above mix in \" basic strings."
+	fi
+
+	# gitleaks honours a repo-root .gitleaksignore: a fingerprint exemption list
+	# outside this policy entirely, and one the scan of the export would read.
+	if git ls-tree -r --name-only HEAD | grep -qx '\.gitleaksignore'; then
+		note "a tracked .gitleaksignore exempts findings outside .gitleaks.toml, and nothing here reads it."
+	fi
+
+	return "$bad"
 }
 
-# The rule every allowlist here is foreign to, so it carries property (a) for
-# each of them: no allowlist in the policy targets it.
-FOREIGN_RULE="github-pat"
+if ! shape_gate; then
+	echo "" >&2
+	echo "test-secret-scan: .gitleaks.toml is in a form this suite cannot fully read," >&2
+	echo "  so it cannot promise every allowlist was planted against. Fix the shape, or" >&2
+	echo "  teach scripts/test-secret-scan.sh the new one — do not leave it unread." >&2
+	exit 1
+fi
 
-# expect <caught|missed> <path> <rule-id> <why> — plant a token of <rule-id> in
-# the export copy of <path>, scan, then restore the file so each case is judged
-# alone.
-expect() {
-	local want="$1" target="$2" rule="$3" why="$4" file="$work/$2" got line
-	if [[ ! -f "$file" ]]; then
-		fail "$target does not exist in the committed tree"
-		return
-	fi
-	if ! line="$(plant_line "$rule")"; then
-		fail "no plant recipe for rule '$rule' — $target is ungated. Add one to plant_line()."
-		return
-	fi
-	# The backup lives OUTSIDE the scanned tree. Left beside the original it
-	# would be scanned too, under a name no allowlist path matches — its own
-	# findings would then turn every case green and the suite would pass
-	# without testing anything.
-	cp "$file" "$backups/orig"
-	printf '\n%s' "$line" >>"$file"
-	if "$gitleaks" dir "$work" --config "$root/.gitleaks.toml" --redact --no-banner >/dev/null 2>&1; then
-		got="missed"
-	else
-		got="caught"
-	fi
-	cp "$backups/orig" "$file"
-
-	if [[ "$got" == "$want" ]]; then
-		printf '  ok    %-6s  %-18s  %s\n' "$got" "$rule" "$target"
-	else
-		fail "want $want, got $got — $target vs $rule: $why"
-	fi
-}
-
-# --- the policy, read rather than restated -----------------------------------
-# One record per allowlist field: <index>|desc|<text>, <index>|rule|<rule id>,
-# <index>|path|<path regex>. A global allowlist (no targetRules) emits no rule
-# record, which is how the loops below tell the two kinds apart.
+# --- 1. the policy, read rather than restated --------------------------------
+# One record per field: <index><SEP><kind><SEP><value>, kind in desc|rule|path|
+# regex. The index is MONOTONIC across the whole file and never resets, so no
+# two allowlists can merge into one record set.
 read_policy() {
-	awk '
-		# Values are TOML basic strings ("...") or literal strings (\x27\x27\x27...\x27\x27\x27),
-		# and an array may span lines, so a value is buffered until its bracket
-		# closes and then split on its own delimiter — exactly, rather than
-		# matched with a regex a quote inside a pattern would break.
-		function flush(   n, i, parts, sep, kind) {
+	awk -v sep="$SEP" '
+		function flush(   n, i, parts, q, kind) {
 			if (key == "") return
-			sep = (index(buf, "\x27\x27\x27") > 0) ? "\x27\x27\x27" : "\""
-			kind = (key == "targetRules") ? "rule" : (key == "paths" ? "path" : "desc")
-			n = split(buf, parts, sep)
-			for (i = 2; i <= n; i += 2) print idx "|" kind "|" parts[i]
+			q = (key == "paths" || key == "regexes") ? "\x27\x27\x27" : "\""
+			kind = (key == "targetRules") ? "rule" : \
+			       (key == "paths") ? "path" : \
+			       (key == "regexes") ? "regex" : "desc"
+			n = split(buf, parts, q)
+			for (i = 2; i <= n; i += 2) print idx sep kind sep parts[i]
 			key = ""; buf = ""
 		}
-		/^\[\[allowlists\]\]/ { flush(); idx++; next }
-		/^\[/                 { flush(); idx = 0; next }
-		idx == 0              { next }
+		/^\[\[allowlists\]\]/ { flush(); idx++; inside = 1; next }
+		/^\[/                 { flush(); inside = 0; next }
+		!inside               { next }
 		{
 			if (key == "") {
-				if ($0 !~ /^(description|targetRules|paths)[ \t]*=/) next
+				if ($0 !~ /^(description|targetRules|paths|regexes)[ \t]*=/) next
 				key = $0; sub(/[ \t]*=.*/, "", key)
 				buf = $0; sub(/^[^=]*=[ \t]*/, "", buf)
 			} else {
@@ -159,26 +167,180 @@ if [[ -z "$POLICY" ]]; then
 	exit 1
 fi
 
-field() { printf '%s\n' "$POLICY" | awk -F'|' -v i="$1" -v k="$2" '$1 == i && $2 == k { print $3 }'; }
-indices() { printf '%s\n' "$POLICY" | awk -F'|' '{ print $1 }' | sort -un; }
+field() { printf '%s\n' "$POLICY" | awk -F"$SEP" -v i="$1" -v k="$2" '$1 == i && $2 == k { print $3 }'; }
+indices() { printf '%s\n' "$POLICY" | awk -F"$SEP" '{ print $1 }' | sort -un; }
 
-# A global allowlist — one with no `targetRules` — waves its files through for
-# EVERY rule, which is the anti-pattern .gitleaks.toml opens by warning against.
-# That makes it a CLOSED set, and a closed set has to be enumerated rather than
-# derived: deriving it from the policy would mean the policy grants itself the
-# exemption, and dropping `targetRules` from a scoped allowlist would widen it to
-# a whole file with nothing here to notice. Measured: that omission alone hides a
-# planted token of the allowlist's own rule.
-SANCTIONED_GLOBAL="Fabricated fixtures in tests and Storybook stories"
+# Every allowlist must end the run having been planted against. This ledger is
+# the backstop for a shape the gate above did not anticipate: whatever the
+# reason an entry escaped the loops, it is reported rather than skipped.
+planted_against=""
+mark_planted() { planted_against="${planted_against} $1"; }
+
+# The first line of a list, without an early-exiting consumer: an `awk … exit`
+# closes the pipe and SIGPIPEs its producer, which `pipefail` then reports as
+# 141 — the same trap the bounded `od` read below avoids.
+first_of() { awk 'NF && !done { print; done = 1 }'; }
+
+# --- 2. the plants ------------------------------------------------------------
+# distinct_token <n> — n DISTINCT characters from a 62-symbol alphabet, so the
+# value's Shannon entropy is log2(n) by construction rather than by luck. `od`
+# is bounded by -N, so nothing downstream can SIGPIPE the producer.
+distinct_token() {
+	local want="$1" out
+	out="$(od -An -tu1 -N512 /dev/urandom | awk -v want="$want" '
+		BEGIN {
+			ALPHA = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+			n = length(ALPHA)
+			for (i = 1; i <= n; i++) A[i] = substr(ALPHA, i, 1)
+		}
+		{ for (i = 1; i <= NF; i++) { ch = A[($i % n) + 1]; if (!(ch in seen)) { seen[ch] = 1; out = out ch } } }
+		END { print substr(out, 1, want) }')"
+	[[ "${#out}" -eq "$want" ]] || return 1
+	printf '%s' "$out"
+}
+
+# candidate_line <rule-id> — one line shaped like that rule's secret, or exit 1
+# for a rule this suite does not know how to plant for.
+candidate_line() {
+	case "$1" in
+	generic-api-key) printf 'const plantedApiKey = "%s"\n' "$(distinct_token 40)" ;;
+	linkedin-client-id) printf 'const planted_linkedin_client_id = "%s"\n' "$(distinct_token 14)" ;;
+	github-pat) printf 'const plantedToken = "ghp_%s"\n' "$(distinct_token 36)" ;;
+	*) return 1 ;;
+	esac
+}
+
+# plant_line <rule-id> — a line PROVED to trip that rule against the default
+# rule set, alone in its own directory. A candidate is only SHAPED like the
+# secret; the entropy floor and the rule's stopwords decide the rest, and an
+# assertion that a plant is "still caught" is worthless if the plant never
+# tripped anything. Bounded retries, then a hard failure — never a skip.
+plant_line() {
+	local rule="$1" line attempt
+	printf '[extend]\nuseDefault = true\n' >"$probe/config.toml"
+	for attempt in 1 2 3 4 5 6 7 8; do
+		line="$(candidate_line "$rule")" || return 1
+		rm -rf "${probe:?}/tree"
+		mkdir -p "$probe/tree"
+		printf '%s' "$line" >"$probe/tree/candidate.go"
+		if ! "$gitleaks" dir "$probe/tree" --config "$probe/config.toml" --redact --no-banner >/dev/null 2>&1; then
+			printf '%s' "$line"
+			return 0
+		fi
+	done
+	return 2
+}
+
+# The rule every allowlist here is foreign to, so it carries property (a) for
+# each of them. Asserted below rather than assumed: if an allowlist ever targets
+# it, the loop would plant the same rule twice and (a) would silently stop being
+# tested for that entry.
+FOREIGN_RULE="github-pat"
+
+# expect <caught|missed> <path> <rule-id> <why> — plant a token of <rule-id> in
+# the export copy of <path>, scan, then restore the file so each case is judged
+# alone.
+expect() {
+	local want="$1" target="$2" rule="$3" why="$4" file="$work/$2" got line status=0
+	if [[ ! -f "$file" ]]; then
+		fail "$target does not exist in the committed tree"
+		return
+	fi
+	line="$(plant_line "$rule")" || status=$?
+	if [[ "$status" -eq 1 ]]; then
+		fail "no plant recipe for rule '$rule' — $target is ungated. Add one to candidate_line()."
+		return
+	elif [[ "$status" -ne 0 ]]; then
+		fail "could not generate a token that trips '$rule' in 8 attempts — $target is ungated, and the recipe in candidate_line() no longer matches the pinned rule set."
+		return
+	fi
+	# The backup lives OUTSIDE the scanned tree. Left beside the original it
+	# would be scanned too, under a name no allowlist path matches — its own
+	# findings would then turn every case green and the suite would pass
+	# without testing anything.
+	cp "$file" "$backups/orig"
+	# The trailing newline is load-bearing. An unterminated final line is read
+	# differently under `regexTarget = "line"`, and a plant landing as one is
+	# reported missed in any file that carries an exempted line elsewhere — an
+	# accusation against the policy caused entirely by the plant's shape.
+	printf '\n%s\n' "$line" >>"$file"
+	if "$gitleaks" dir "$work" --config "$root/.gitleaks.toml" --redact --no-banner >/dev/null 2>&1; then
+		got="missed"
+	else
+		got="caught"
+	fi
+	cp "$backups/orig" "$file"
+
+	if [[ "$got" == "$want" ]]; then
+		printf '  ok    %-6s  %-18s  %s\n' "$got" "$rule" "$target"
+	else
+		fail "want $want, got $got — $target vs $rule: $why"
+	fi
+}
+
+echo "test-secret-scan: planting a token the allowlists must not hide"
+
+# --- 3. the baseline the whole suite rests on ---------------------------------
+# `expect` judges a scan of the WHOLE tree, so ANY finding anywhere makes it
+# report "caught". If the committed tree does not scan clean, every "caught"
+# case below passes without the plant having done anything, and the suite reads
+# green while gating nothing.
+if ! "$gitleaks" dir "$work" --config "$root/.gitleaks.toml" --redact --no-banner >/dev/null 2>&1; then
+	echo "test-secret-scan: the committed tree does not scan clean, so a planted" >&2
+	echo "  token cannot be told from what is already there — every 'caught' case" >&2
+	echo "  below would pass for free. Run 'make secret-scan' and resolve that first." >&2
+	exit 1
+fi
+
+# --- 4. the sanctioned wholesale exemption, as a closed set -------------------
+# A global allowlist — no `targetRules` — waves its files through for EVERY
+# rule, the anti-pattern .gitleaks.toml opens by warning against. That makes it
+# a CLOSED set, enumerated rather than derived: deriving it from the policy
+# would let the policy grant itself the exemption. It is keyed on the paths as
+# well as the description, because widening the sanctioned entry's own `paths`
+# in place, and adding a second entry that reuses its description, each hide a
+# real credential otherwise. LC_ALL=C so the comparison does not depend on the
+# caller's collation.
+SANCTIONED_GLOBAL_DESC="Fabricated fixtures in tests and Storybook stories"
+SANCTIONED_GLOBAL_PATHS='\.stories\.tsx$
+\.test\.tsx?$
+_test\.go$'
 
 for i in $(indices); do
 	[[ -n "$(field "$i" rule)" ]] && continue
 	desc="$(field "$i" desc)"
-	if [[ "$desc" != "$SANCTIONED_GLOBAL" ]]; then
-		fail "allowlist '$desc' names no targetRules, so it exempts its files from EVERY rule. Scope it with targetRules, or add it to SANCTIONED_GLOBAL here and argue for it in the pull request."
+	paths="$(field "$i" path | LC_ALL=C sort)"
+	if [[ "$desc" != "$SANCTIONED_GLOBAL_DESC" ]]; then
+		fail "allowlist '$desc' names no targetRules, so it exempts its files from EVERY rule. Scope it with targetRules, or sanction it here and argue for it in the pull request."
+		mark_planted "$i"
+	elif [[ "$paths" != "$SANCTIONED_GLOBAL_PATHS" ]]; then
+		fail "the sanctioned wholesale exemption's paths have moved. It may exempt fixtures and nothing else; sanctioning is keyed on the paths, not on the description alone."
+		mark_planted "$i"
 	fi
 done
 
+# A description may not be reused: the sanctioning above is a string comparison,
+# and a second entry wearing the sanctioned string would inherit its blessing.
+DUPES="$(printf '%s\n' "$POLICY" | awk -F"$SEP" '$2 == "desc" { print $3 }' | LC_ALL=C sort | uniq -d)"
+if [[ -n "$DUPES" ]]; then
+	fail "two allowlists share a description, and the wholesale-exemption check keys on it: $DUPES"
+fi
+
+# --- 5. the plant recipes themselves ------------------------------------------
+# A control file no allowlist covers. Every rule any allowlist targets must be
+# plantable and caught HERE first: without it, "still caught" below could be
+# reporting a plant that never tripped anything.
+CONTROL="backend/internal/modules/people/person.go"
+TARGETED="$(for i in $(indices); do field "$i" rule; done | LC_ALL=C sort -u)"
+if printf '%s\n' "$TARGETED" | grep -qx "$FOREIGN_RULE"; then
+	fail "an allowlist now targets $FOREIGN_RULE, which this suite uses as the rule every allowlist is foreign to. Property (a) would stop being tested for it. Pick a different FOREIGN_RULE."
+fi
+for rule in $(printf '%s\n%s\n' "$FOREIGN_RULE" "$TARGETED" | LC_ALL=C sort -u); do
+	[[ -z "$rule" ]] && continue
+	expect caught "$CONTROL" "$rule" "no allowlist covers this file, so every rule must fire here"
+done
+
+# --- 6. every scoped allowlist, against its own rule and a foreign one --------
 # The paths of every GLOBAL allowlist, as one alternation. A file matching one
 # of these is exempt wholesale, so it can never carry a "still caught" plant —
 # picking one as a subject would assert the opposite of what it proves.
@@ -191,76 +353,100 @@ for i in $(indices); do
 	done < <(field "$i" path)
 done
 
-# subject_for <path regex> — a tracked file the regex covers and no global
-# allowlist exempts. gitleaks matches `paths` with Go's RE2 against the path
-# relative to the scan root; grep -E is the closest thing a POSIX shell has, so
-# a pattern the two read differently shows up as "no tracked file matches",
-# which is a loud failure and not a silent skip.
-subject_for() {
+# The files a pattern covers, minus anything exempt wholesale, read from the
+# tree the scan actually reads rather than from the index — a file staged but
+# not committed is absent from the export and would fail as "does not exist".
+#
+# gitleaks matches `paths` with Go's RE2 against the ABSOLUTE path, while this
+# matches `grep -E` against a repo-relative one, so a `^`-anchored pattern is
+# inert there and live here. That disagreement cannot pass silently: the
+# subjects below include a file whose CONTENT the allowlist regex matches, and
+# an inert allowlist and a live one differ there.
+subjects_for() {
 	local matched
-	matched="$(git ls-files | { grep -E -- "$1" || true; })"
-	[[ -n "$global_paths" ]] && matched="$(printf '%s\n' "$matched" | { grep -E -v -- "$global_paths" || true; })"
-	printf '%s\n' "$matched" | awk 'NF { print; exit }'
+	matched="$(git ls-tree -r --name-only HEAD | { grep -E -- "$1" || true; })"
+	if [[ -n "$global_paths" ]]; then
+		matched="$(printf '%s\n' "$matched" | { grep -E -v -- "$global_paths" || true; })"
+	fi
+	printf '%s\n' "$matched"
 }
 
-echo "test-secret-scan: planting a token the allowlists must not hide"
-
-# --- the baseline the whole suite rests on ------------------------------------
-# `expect` judges a scan of the WHOLE tree, so ANY finding anywhere makes it
-# report "caught". If the committed tree does not scan clean, every "caught"
-# assertion below passes without the plant having done anything, and the suite
-# reads green while gating nothing.
-if ! "$gitleaks" dir "$work" --config "$root/.gitleaks.toml" --redact --no-banner >/dev/null 2>&1; then
-	echo "test-secret-scan: the committed tree does not scan clean, so a planted" >&2
-	echo "  token cannot be told from what is already there — every 'caught' case" >&2
-	echo "  below would pass for free. Run 'make secret-scan' and resolve that first." >&2
-	exit 1
-fi
-
-
-# --- 0. the recipes themselves ------------------------------------------------
-# A control file no allowlist covers. Every rule any allowlist targets must be
-# plantable and caught HERE first: without this, "still caught" below could be
-# reporting a plant that never tripped anything.
-CONTROL="backend/internal/modules/people/person.go"
-RULES="$(
-	{
-		printf '%s\n' "$FOREIGN_RULE"
-		for i in $(indices); do field "$i" rule; done
-	} | sort -u
-)"
-for rule in $RULES; do
-	expect caught "$CONTROL" "$rule" "no allowlist covers this file, so every rule must fire here"
-done
-
-# --- 1. every scoped allowlist, against its own rule and a foreign one --------
-# (b) is the own-rule plant: the line does not match the allowlist's regex, so
-# the exemption must not reach it. (a) is the foreign-rule plant: the file must
-# stay scanned for every rule the allowlist does not name.
 for i in $(indices); do
 	rules="$(field "$i" rule)"
 	[[ -z "$rules" ]] && continue
 	desc="$(field "$i" desc)"
+	patterns="$(field "$i" path)"
+	if [[ -z "$patterns" ]]; then
+		fail "allowlist '$desc' names no paths, so it applies repo-wide for its rules — strictly broader than any path-scoped entry, and nothing here can plant against it. Give it paths."
+		mark_planted "$i"
+		continue
+	fi
+	regexes="$(field "$i" regex)"
 	while IFS= read -r pattern; do
 		[[ -z "$pattern" ]] && continue
-		subject="$(subject_for "$pattern")"
-		if [[ -z "$subject" ]]; then
-			fail "allowlist '$desc' names a path no tracked file matches: $pattern — nothing gates it"
+		covered="$(subjects_for "$pattern")"
+		if [[ -z "$(printf '%s' "$covered" | tr -d '[:space:]')" ]]; then
+			fail "allowlist '$desc' names a path no committed file matches: $pattern — nothing gates it"
+			mark_planted "$i"
 			continue
 		fi
-		for rule in $rules $FOREIGN_RULE; do
-			expect caught "$subject" "$rule" \
-				"the '$desc' exemption must cover the line it names, not the file"
+		# Two subjects, because they exercise different halves. The first file
+		# the pattern covers proves the path scope; a file whose CONTENT the
+		# allowlist's own regex matches is where the exemption is actually
+		# live, and it is the one where an over-broad entry hides the plant.
+		subject="$(printf '%s\n' "$covered" | first_of)"
+		live=""
+		while IFS= read -r rx; do
+			[[ -z "$rx" ]] && continue
+			while IFS= read -r f; do
+				[[ -n "$f" ]] || continue
+				[[ -f "$work/$f" ]] || continue
+				if grep -qE -- "$rx" "$work/$f"; then
+					live="$f"
+					break
+				fi
+			done < <(printf '%s\n' "$covered")
+			[[ -n "$live" ]] && break
+		done < <(printf '%s\n' "$regexes")
+		for target in $subject $live; do
+			for rule in $rules $FOREIGN_RULE; do
+				expect caught "$target" "$rule" \
+					"the '$desc' exemption must cover the line it names, not the file"
+			done
 		done
+		mark_planted "$i"
+	done < <(printf '%s\n' "$patterns")
+done
+
+# --- 7. the wholesale exemptions, asserted rather than assumed ----------------
+# Fixtures are exempt in full, and deliberately so: a test asserting that a
+# credentialed URL is refused has to contain one. Asserted rather than assumed,
+# so the trade-off is on the record instead of being something nobody noticed —
+# and derived from the entry itself, so the day its paths change the assertion
+# follows them instead of naming a file that is no longer the example.
+for i in $(indices); do
+	[[ -n "$(field "$i" rule)" ]] && continue
+	desc="$(field "$i" desc)"
+	while IFS= read -r pattern; do
+		[[ -z "$pattern" ]] && continue
+		exempt="$(git ls-tree -r --name-only HEAD | { grep -E -- "$pattern" || true; } | first_of)"
+		if [[ -z "$exempt" ]]; then
+			fail "wholesale exemption '$desc' names a path no committed file matches: $pattern"
+			mark_planted "$i"
+			continue
+		fi
+		expect missed "$exempt" "$FOREIGN_RULE" "'$desc' exempts this path in full, by design"
+		mark_planted "$i"
 	done < <(field "$i" path)
 done
 
-# --- 2. the wholesale exemptions, asserted rather than assumed ----------------
-# Fixtures are exempt in full, and deliberately so: a test asserting that a
-# credentialed URL is refused has to contain one. Stated here so the trade-off
-# is on the record instead of being something nobody noticed.
-expect missed "backend/internal/shared/ports/websearch/sourcepolicy_test.go" "$FOREIGN_RULE" \
-	"test fixtures are exempt by design"
+# --- 8. the ledger ------------------------------------------------------------
+for i in $(indices); do
+	case " $planted_against " in
+	*" $i "*) ;;
+	*) fail "allowlist $i ('$(field "$i" desc)') finished the run with no plant against it — this suite cannot say whether it is over-broad." ;;
+	esac
+done
 
 if [[ "$failures" -ne 0 ]]; then
 	echo "test-secret-scan: FAIL ($failures)" >&2

--- a/scripts/test-secret-scan.sh
+++ b/scripts/test-secret-scan.sh
@@ -134,6 +134,21 @@ fi
 # two allowlists can merge into one record set.
 read_policy() {
 	awk -v sep="$SEP" '
+		# The text of a line with its quoted entries removed. The `]` that ends
+		# an array is the one OUTSIDE a quoted entry: a path like
+		# \x27\x27\x27\\.(test|spec)\\.[jt]sx?$\x27\x27\x27 carries one inside a character class, and
+		# treating it as the terminator ended the array early — the entries
+		# after it were dropped, owed no plant, and the ledger still reported
+		# full coverage, which is the fail-open this suite exists to prevent.
+		function unquoted(text,   out, parts, n, i, q) {
+			for (q = 1; q <= 2; q++) {
+				out = ""
+				n = split(text, parts, (q == 1) ? "\x27\x27\x27" : "\"")
+				for (i = 1; i <= n; i += 2) out = out parts[i]
+				text = out
+			}
+			return text
+		}
 		function flush(   n, i, parts, q, kind) {
 			if (key == "") return
 			q = (key == "paths" || key == "regexes") ? "\x27\x27\x27" : "\""
@@ -155,7 +170,7 @@ read_policy() {
 			} else {
 				buf = buf "\n" $0
 			}
-			if (buf !~ /^\[/ || buf ~ /\]/) flush()
+			if (buf !~ /^\[/ || unquoted(buf) ~ /\]/) flush()
 		}
 		END { flush() }
 	' "$root/.gitleaks.toml"
@@ -164,6 +179,21 @@ read_policy() {
 POLICY="$(read_policy)"
 if [[ -z "$POLICY" ]]; then
 	echo "test-secret-scan: .gitleaks.toml declares no allowlists this suite can read — it is gating nothing" >&2
+	exit 1
+fi
+
+# The parser read every entry the file declares. `paths` and `regexes` are the
+# triple-quoted keys, so the number of \x27\x27\x27 delimiters in the policy fixes how many
+# entries there are, independently of how the parser walked them. An entry the
+# parser drops owes no plant and the ledger still reports full coverage — the
+# exact fail-open the shape gate exists to prevent, and the one a `]` inside a
+# character class caused by ending its array early.
+QUOTED="$(grep -o "'''" "$root/.gitleaks.toml" | grep -c . || true)"
+READ_ENTRIES="$(printf '%s\n' "$POLICY" | awk -F"$SEP" '$2 == "path" || $2 == "regex"' | grep -c . || true)"
+if [[ $((QUOTED / 2)) -ne "$READ_ENTRIES" ]]; then
+	echo "test-secret-scan: .gitleaks.toml declares $((QUOTED / 2)) quoted path/regex entries" >&2
+	echo "  and this suite read $READ_ENTRIES of them. An entry it cannot see owes no plant," >&2
+	echo "  and the coverage ledger cannot tell that apart from full coverage." >&2
 	exit 1
 fi
 
@@ -216,14 +246,22 @@ candidate_line() {
 # assertion that a plant is "still caught" is worthless if the plant never
 # tripped anything. Bounded retries, then a hard failure — never a skip.
 plant_line() {
-	local rule="$1" line attempt
+	local rule="$1" line
 	printf '[extend]\nuseDefault = true\n' >"$probe/config.toml"
-	for attempt in 1 2 3 4 5 6 7 8; do
+	for _ in 1 2 3 4 5 6 7 8; do
 		line="$(candidate_line "$rule")" || return 1
 		rm -rf "${probe:?}/tree"
 		mkdir -p "$probe/tree"
 		printf '%s' "$line" >"$probe/tree/candidate.go"
-		if ! "$gitleaks" dir "$probe/tree" --config "$probe/config.toml" --redact --no-banner >/dev/null 2>&1; then
+		rm -f "$probe/report.json"
+		"$gitleaks" dir "$probe/tree" --config "$probe/config.toml" --redact --no-banner \
+			--report-format json --report-path "$probe/report.json" >/dev/null 2>&1 || true
+		# The REQUESTED rule, not merely some rule. A candidate shaped for one
+		# detector can trip a different one — the linkedin plant carries a
+		# high-entropy value beside the word `client_id`, so generic-api-key
+		# fires on it too. Accepting that would let a "still caught" assertion
+		# pass on a finding the allowlist under test never governed.
+		if grep -q "\"RuleID\": *\"$rule\"" "$probe/report.json" 2>/dev/null; then
 			printf '%s' "$line"
 			return 0
 		fi

--- a/scripts/test-secret-scan.sh
+++ b/scripts/test-secret-scan.sh
@@ -6,14 +6,41 @@
 # So every allowlist in .gitleaks.toml that names a file is re-checked here —
 # plant a credential-shaped token in that file, and the scan must still fail.
 #
-# The trap this exists for: a GLOBAL `[[allowlists]]` carrying `paths` makes
-# gitleaks skip the whole file before it reads a line, so `condition = "AND"`
-# never narrows it and the exemption quietly widens to everything in the file.
-# Binding the allowlist to its rule with `targetRules` keeps the file scanned.
-# Both scoped entries were written the wrong way first; only this caught it.
+# TWO properties, and the second is the one a single plant cannot reach:
 #
-# The token is generated per run rather than written down: a literal here would
-# be a credential-shaped string in the repo, which the gate would rightly flag.
+#   (a) an allowlist does not hide ANOTHER rule's finding. A global
+#       `[[allowlists]]` carrying `paths` makes gitleaks skip the whole file
+#       before it reads a line, so `condition = "AND"` never narrows it and the
+#       exemption widens to everything in the file. `targetRules` is what keeps
+#       the file scanned. Both scoped entries were written the wrong way first;
+#       only this caught it.
+#
+#   (b) an allowlist does not hide ITS OWN rule's finding on a line the
+#       allowlist regex does not match. Nothing about (a) implies this, and it
+#       is the property the policy file's "the file stays scanned for
+#       everything else" is read as promising. Measured against the pinned
+#       scanner, three separate one-line omissions each widen a scoped
+#       exemption to the whole file for its own rule: dropping
+#       `condition = "AND"` (which then defaults to OR), dropping `regexes`,
+#       and dropping `targetRules`.
+#
+# So the plants are DERIVED from the policy rather than listed here: every
+# allowlist that names `targetRules` owes one plant per rule it targets, in a
+# file its own `paths` cover, plus a foreign-rule plant for (a). A hand-kept
+# list goes stale the first time somebody adds an allowlist — and an allowlist
+# nobody planted against is exactly the one that is over-broad.
+#
+# The suite FAILS CLOSED. An allowlist that targets a rule with no plant recipe
+# below, or names a path no tracked file matches, is an UNGATED allowlist and
+# is reported as a failure rather than skipped.
+#
+# Every recipe is proved on a file no allowlist covers before it is trusted
+# anywhere else: an assertion that a plant is still caught passes for free if
+# the plant never tripped its rule at all.
+#
+# The tokens are generated per run rather than written down: a literal here
+# would be a credential-shaped string in the repo, which the gate would rightly
+# flag.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -30,19 +57,45 @@ backups="$(mktemp -d)"
 trap 'rm -rf "$work" "$backups"' EXIT
 git archive HEAD | tar -x -C "$work"
 
-# 18 random bytes as 36 hex characters, matching the shape of a GitHub PAT.
+failures=0
+fail() {
+	printf '  FAIL  %s\n' "$1"
+	failures=$((failures + 1))
+}
+
 # `od` is bounded by -N, so `tr` reads to EOF — piping into a `head` that exits
 # early would SIGPIPE the producer, and `pipefail` would end the run at 141.
-token="ghp_$(od -An -tx1 -N18 /dev/urandom | tr -d ' \n')"
-failures=0
+hex() { od -An -tx1 -N"$1" /dev/urandom | tr -d ' \n'; }
 
-# expect <caught|missed> <path> <why> — plant the token in the export copy of
-# <path>, scan, then restore the file so each case is judged alone.
+# plant_line <rule-id> — a line that trips EXACTLY that rule, or exit 1 for a
+# rule this suite does not know how to plant for. Each shape was measured
+# against the pinned scanner; the sanity pass below re-measures it every run,
+# so a rule set that moves under us is a failure here rather than a silent
+# weakening of every assertion that follows.
+plant_line() {
+	case "$1" in
+	generic-api-key) printf 'const plantedApiKey = "%s"\n' "$(hex 24)" ;;
+	linkedin-client-id) printf 'const planted_linkedin_client_id = "%s"\n' "$(hex 7)" ;;
+	github-pat) printf 'const plantedToken = "ghp_%s"\n' "$(hex 18)" ;;
+	*) return 1 ;;
+	esac
+}
+
+# The rule every allowlist here is foreign to, so it carries property (a) for
+# each of them: no allowlist in the policy targets it.
+FOREIGN_RULE="github-pat"
+
+# expect <caught|missed> <path> <rule-id> <why> — plant a token of <rule-id> in
+# the export copy of <path>, scan, then restore the file so each case is judged
+# alone.
 expect() {
-	local want="$1" target="$2" why="$3" file="$work/$2" got
+	local want="$1" target="$2" rule="$3" why="$4" file="$work/$2" got line
 	if [[ ! -f "$file" ]]; then
-		printf '  FAIL  %s does not exist in the committed tree\n' "$target"
-		failures=$((failures + 1))
+		fail "$target does not exist in the committed tree"
+		return
+	fi
+	if ! line="$(plant_line "$rule")"; then
+		fail "no plant recipe for rule '$rule' — $target is ungated. Add one to plant_line()."
 		return
 	fi
 	# The backup lives OUTSIDE the scanned tree. Left beside the original it
@@ -50,7 +103,7 @@ expect() {
 	# findings would then turn every case green and the suite would pass
 	# without testing anything.
 	cp "$file" "$backups/orig"
-	printf '\nconst plantedToken = "%s"\n' "$token" >>"$file"
+	printf '\n%s' "$line" >>"$file"
 	if "$gitleaks" dir "$work" --config "$root/.gitleaks.toml" --redact --no-banner >/dev/null 2>&1; then
 		got="missed"
 	else
@@ -59,37 +112,154 @@ expect() {
 	cp "$backups/orig" "$file"
 
 	if [[ "$got" == "$want" ]]; then
-		printf '  ok    %-6s  %s\n' "$got" "$target"
+		printf '  ok    %-6s  %-18s  %s\n' "$got" "$rule" "$target"
 	else
-		printf '  FAIL  want %s, got %s — %s: %s\n' "$want" "$got" "$target" "$why"
-		failures=$((failures + 1))
+		fail "want $want, got $got — $target vs $rule: $why"
 	fi
+}
+
+# --- the policy, read rather than restated -----------------------------------
+# One record per allowlist field: <index>|desc|<text>, <index>|rule|<rule id>,
+# <index>|path|<path regex>. A global allowlist (no targetRules) emits no rule
+# record, which is how the loops below tell the two kinds apart.
+read_policy() {
+	awk '
+		# Values are TOML basic strings ("...") or literal strings (\x27\x27\x27...\x27\x27\x27),
+		# and an array may span lines, so a value is buffered until its bracket
+		# closes and then split on its own delimiter — exactly, rather than
+		# matched with a regex a quote inside a pattern would break.
+		function flush(   n, i, parts, sep, kind) {
+			if (key == "") return
+			sep = (index(buf, "\x27\x27\x27") > 0) ? "\x27\x27\x27" : "\""
+			kind = (key == "targetRules") ? "rule" : (key == "paths" ? "path" : "desc")
+			n = split(buf, parts, sep)
+			for (i = 2; i <= n; i += 2) print idx "|" kind "|" parts[i]
+			key = ""; buf = ""
+		}
+		/^\[\[allowlists\]\]/ { flush(); idx++; next }
+		/^\[/                 { flush(); idx = 0; next }
+		idx == 0              { next }
+		{
+			if (key == "") {
+				if ($0 !~ /^(description|targetRules|paths)[ \t]*=/) next
+				key = $0; sub(/[ \t]*=.*/, "", key)
+				buf = $0; sub(/^[^=]*=[ \t]*/, "", buf)
+			} else {
+				buf = buf "\n" $0
+			}
+			if (buf !~ /^\[/ || buf ~ /\]/) flush()
+		}
+		END { flush() }
+	' "$root/.gitleaks.toml"
+}
+
+POLICY="$(read_policy)"
+if [[ -z "$POLICY" ]]; then
+	echo "test-secret-scan: .gitleaks.toml declares no allowlists this suite can read — it is gating nothing" >&2
+	exit 1
+fi
+
+field() { printf '%s\n' "$POLICY" | awk -F'|' -v i="$1" -v k="$2" '$1 == i && $2 == k { print $3 }'; }
+indices() { printf '%s\n' "$POLICY" | awk -F'|' '{ print $1 }' | sort -un; }
+
+# A global allowlist — one with no `targetRules` — waves its files through for
+# EVERY rule, which is the anti-pattern .gitleaks.toml opens by warning against.
+# That makes it a CLOSED set, and a closed set has to be enumerated rather than
+# derived: deriving it from the policy would mean the policy grants itself the
+# exemption, and dropping `targetRules` from a scoped allowlist would widen it to
+# a whole file with nothing here to notice. Measured: that omission alone hides a
+# planted token of the allowlist's own rule.
+SANCTIONED_GLOBAL="Fabricated fixtures in tests and Storybook stories"
+
+for i in $(indices); do
+	[[ -n "$(field "$i" rule)" ]] && continue
+	desc="$(field "$i" desc)"
+	if [[ "$desc" != "$SANCTIONED_GLOBAL" ]]; then
+		fail "allowlist '$desc' names no targetRules, so it exempts its files from EVERY rule. Scope it with targetRules, or add it to SANCTIONED_GLOBAL here and argue for it in the pull request."
+	fi
+done
+
+# The paths of every GLOBAL allowlist, as one alternation. A file matching one
+# of these is exempt wholesale, so it can never carry a "still caught" plant —
+# picking one as a subject would assert the opposite of what it proves.
+global_paths=""
+for i in $(indices); do
+	[[ -n "$(field "$i" rule)" ]] && continue
+	while IFS= read -r p; do
+		[[ -z "$p" ]] && continue
+		global_paths="${global_paths:+$global_paths|}$p"
+	done < <(field "$i" path)
+done
+
+# subject_for <path regex> — a tracked file the regex covers and no global
+# allowlist exempts. gitleaks matches `paths` with Go's RE2 against the path
+# relative to the scan root; grep -E is the closest thing a POSIX shell has, so
+# a pattern the two read differently shows up as "no tracked file matches",
+# which is a loud failure and not a silent skip.
+subject_for() {
+	local matched
+	matched="$(git ls-files | { grep -E -- "$1" || true; })"
+	[[ -n "$global_paths" ]] && matched="$(printf '%s\n' "$matched" | { grep -E -v -- "$global_paths" || true; })"
+	printf '%s\n' "$matched" | awk 'NF { print; exit }'
 }
 
 echo "test-secret-scan: planting a token the allowlists must not hide"
 
-# The scanner runs at all: an ordinary product file carries no exemption.
-expect caught "backend/internal/modules/people/person.go" \
-	"no allowlist covers this file"
+# --- the baseline the whole suite rests on ------------------------------------
+# `expect` judges a scan of the WHOLE tree, so ANY finding anywhere makes it
+# report "caught". If the committed tree does not scan clean, every "caught"
+# assertion below passes without the plant having done anything, and the suite
+# reads green while gating nothing.
+if ! "$gitleaks" dir "$work" --config "$root/.gitleaks.toml" --redact --no-banner >/dev/null 2>&1; then
+	echo "test-secret-scan: the committed tree does not scan clean, so a planted" >&2
+	echo "  token cannot be told from what is already there — every 'caught' case" >&2
+	echo "  below would pass for free. Run 'make secret-scan' and resolve that first." >&2
+	exit 1
+fi
 
-# Every file a scoped allowlist names stays scanned for everything else. These
-# are the cases that regress silently when an exemption is written globally.
-expect caught "backend/internal/modules/agents/tools_intents.go" \
-	"the OpenAPIOp exemption must cover that line only"
-expect caught "backend/internal/modules/agents/tools_confirm.go" \
-	"the OpenAPIOp exemption must cover that line only"
-# The OpenAPIOp exemption is scoped to the whole agents module, so a file that
-# carries no exempted line at all must still be scanned — otherwise widening
-# the path to the module would have quietly widened the exemption to it.
-expect caught "backend/internal/modules/agents/registry.go" \
-	"a module-scoped exemption must not exempt the module"
-expect caught "frontend/src/screens/onboarding-conversation/connect-scene.tsx" \
-	"the LinkedinStatus exemption must cover that secret only"
 
-# Fixtures are exempt wholesale, and deliberately so: a test asserting that a
-# credentialed URL is refused has to contain one. Asserted rather than assumed,
-# so the trade-off is on the record instead of being something nobody noticed.
-expect missed "backend/internal/shared/ports/websearch/sourcepolicy_test.go" \
+# --- 0. the recipes themselves ------------------------------------------------
+# A control file no allowlist covers. Every rule any allowlist targets must be
+# plantable and caught HERE first: without this, "still caught" below could be
+# reporting a plant that never tripped anything.
+CONTROL="backend/internal/modules/people/person.go"
+RULES="$(
+	{
+		printf '%s\n' "$FOREIGN_RULE"
+		for i in $(indices); do field "$i" rule; done
+	} | sort -u
+)"
+for rule in $RULES; do
+	expect caught "$CONTROL" "$rule" "no allowlist covers this file, so every rule must fire here"
+done
+
+# --- 1. every scoped allowlist, against its own rule and a foreign one --------
+# (b) is the own-rule plant: the line does not match the allowlist's regex, so
+# the exemption must not reach it. (a) is the foreign-rule plant: the file must
+# stay scanned for every rule the allowlist does not name.
+for i in $(indices); do
+	rules="$(field "$i" rule)"
+	[[ -z "$rules" ]] && continue
+	desc="$(field "$i" desc)"
+	while IFS= read -r pattern; do
+		[[ -z "$pattern" ]] && continue
+		subject="$(subject_for "$pattern")"
+		if [[ -z "$subject" ]]; then
+			fail "allowlist '$desc' names a path no tracked file matches: $pattern — nothing gates it"
+			continue
+		fi
+		for rule in $rules $FOREIGN_RULE; do
+			expect caught "$subject" "$rule" \
+				"the '$desc' exemption must cover the line it names, not the file"
+		done
+	done < <(field "$i" path)
+done
+
+# --- 2. the wholesale exemptions, asserted rather than assumed ----------------
+# Fixtures are exempt in full, and deliberately so: a test asserting that a
+# credentialed URL is refused has to contain one. Stated here so the trade-off
+# is on the record instead of being something nobody noticed.
+expect missed "backend/internal/shared/ports/websearch/sourcepolicy_test.go" "$FOREIGN_RULE" \
 	"test fixtures are exempt by design"
 
 if [[ "$failures" -ne 0 ]]; then


### PR DESCRIPTION
## First, the correction: #1659's headline claim does not reproduce

The issue reports that a `targetRules`-scoped allowlist hides its **own** rule's
findings anywhere in the file. Measured against the pinned scanner (8.30.1) and
the committed policy, planting into `backend/internal/modules/agents/registry.go`
— the file the "OpenAPI operation ids" allowlist covers, on a line its
`OpenAPIOp:\s` regex does not match:

| plant | committed policy | that allowlist removed (control) |
|---|---|---|
| the issue's exact token, `AKIAIOSFODNN7EXAMPLE9Q…` | 0 findings | **0 findings** |
| a random `generic-api-key` token | **1 finding** | 1 finding |

The issue's token yields nothing **with or without** the allowlist — gitleaks
drops it on its own (`EXAMPLE`), so the control that was supposed to show the
allowlist doing the hiding does not hold. A real token of that rule **is**
caught. So the scoped allowlists narrow correctly within their own rule, and
`.gitleaks.toml`'s prose is true rather than false.

The issue's *other* half is exactly right, and it is the actual defect:

> `scripts/test-secret-scan.sh` plants `ghp_<36 hex>`, which trips `github-pat`.
> Every current allowlist targets `generic-api-key` or `linkedin-client-id`, so
> none of them **could** hide the planted token.

One plant shape, and no allowlist could ever have hidden it. The suite proved
"these exemptions do not hide *another* rule's finding" while being read as
proving the property the policy file actually promises. **A gate reading green
over the inverse defect** — the same class as #1637.

## Impact — unchanged from the issue, and it should not be inflated

Defence in depth, **not** a live exposure. Nothing is or was exposed: the
allowlists in the tree are correctly scoped, which is what the measurement above
establishes. What was missing is the gate that would notice if one stopped being.

## What the exemption mechanics actually are, measured

Three elements, and dropping **any one** widens the exemption to the whole file
for that rule. Each measured by planting a token of the excused rule on a line
the allowlist regex does not match:

| omission | planted token |
|---|---|
| as committed (`targetRules` + `regexes` + `condition = "AND"`) | **caught** |
| `condition = "AND"` dropped (defaults to OR — path alone suffices) | missed |
| `regexes` dropped (a file exclusion wearing a rule's name) | missed |
| `targetRules` dropped (global: skips the file for *every* rule) | missed |

`.gitleaks.toml`'s header now states this, replacing a paragraph that named only
the `targetRules` case.

## What changed in the gate

The plants are **derived from the policy** instead of listed. Every allowlist
naming `targetRules` owes one token of each rule it targets, in a file its own
`paths` cover, plus a foreign-rule token for the older property. A hand-kept list
goes stale the first time somebody adds an allowlist — and an allowlist nobody
planted against is exactly the one that is over-broad.

Three things make it hard to pass for the wrong reason:

- **It fails closed.** An allowlist targeting a rule with no plant recipe, or
  naming a path no tracked file matches, is reported as *ungated* rather than
  skipped.
- **Every recipe is proved first** on a file no allowlist covers. An assertion
  that a plant is "still caught" passes for free if the plant never tripped its
  rule at all.
- **The tree must scan clean before any plant.** `expect` judges a whole-tree
  scan, so one pre-existing finding would make every `caught` case pass without
  the plant doing anything.

**Global allowlists are enumerated, not derived.** One with no `targetRules`
waves its files through for every rule. Deriving that set from the policy would
let the policy grant itself the exemption — and it is exactly how the
`no-targetrules` mutant slipped through the first version of this test: the
allowlist simply stopped being visible to the loop. It is now a closed set of one
(the deliberate fixtures exemption), and anything else fails with instructions.

## Proof — red against five mutants, green against the tree

<details>
<summary>Full recorded session (script in the conversation below)</summary>

```
############ 0. THE PREMISE IN #1659, RE-MEASURED ############
The issue reports that a scoped allowlist hides its OWN rule's finding anywhere
in the file. Planting the issue's exact token, and a random one of the same rule,
with and without the allowlist that is supposed to be hiding it:
  the issue's token                          committed policy           -> 0 finding(s)
  the issue's token                          allowlist REMOVED (control) -> 0 finding(s)
  a random generic-api-key token             committed policy           -> 1 finding(s)
  a random generic-api-key token             allowlist REMOVED (control) -> 1 finding(s)

############ 1. THE REAL GAP: THE OLD SUITE COULD NOT SEE ANY OF IT ############
$ git show origin/main:scripts/test-secret-scan.sh | grep -n 'token=' 
36:token="ghp_$(od -An -tx1 -N18 /dev/urandom | tr -d ' \n')"
  ^ one shape, tripping github-pat. No allowlist in the policy targets that rule,
    so no allowlist could ever have hidden the planted token.

############ 2. THE NEW SUITE, AGAINST THREE WIDENING MUTANTS ############

--- mutant: no-condition ---
test-secret-scan: planting a token the allowlists must not hide
  ok    caught  generic-api-key     backend/internal/modules/people/person.go
  ok    caught  github-pat          backend/internal/modules/people/person.go
  ok    caught  linkedin-client-id  backend/internal/modules/people/person.go
  FAIL  want caught, got missed — backend/internal/modules/agents/approvals.go vs generic-api-key: the 'OpenAPI operation ids in the agent tool registry' exemption must cover the line it names, not the file
  ok    caught  github-pat          backend/internal/modules/agents/approvals.go
  ok    caught  linkedin-client-id  frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    caught  github-pat          frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    missed  github-pat          backend/internal/shared/ports/websearch/sourcepolicy_test.go
test-secret-scan: FAIL (1)
exit=1

--- mutant: no-regexes ---
test-secret-scan: planting a token the allowlists must not hide
  ok    caught  generic-api-key     backend/internal/modules/people/person.go
  ok    caught  github-pat          backend/internal/modules/people/person.go
  ok    caught  linkedin-client-id  backend/internal/modules/people/person.go
  FAIL  want caught, got missed — backend/internal/modules/agents/approvals.go vs generic-api-key: the 'OpenAPI operation ids in the agent tool registry' exemption must cover the line it names, not the file
  ok    caught  github-pat          backend/internal/modules/agents/approvals.go
  ok    caught  linkedin-client-id  frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    caught  github-pat          frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    missed  github-pat          backend/internal/shared/ports/websearch/sourcepolicy_test.go
test-secret-scan: FAIL (1)
exit=1

--- mutant: no-targetrules ---
  FAIL  allowlist 'OpenAPI operation ids in the agent tool registry' names no targetRules, so it exempts its files from EVERY rule. Scope it with targetRules, or add it to SANCTIONED_GLOBAL here and argue for it in the pull request.
test-secret-scan: planting a token the allowlists must not hide
  ok    caught  github-pat          backend/internal/modules/people/person.go
  ok    caught  linkedin-client-id  backend/internal/modules/people/person.go
  ok    caught  linkedin-client-id  frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    caught  github-pat          frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    missed  github-pat          backend/internal/shared/ports/websearch/sourcepolicy_test.go
test-secret-scan: FAIL (1)
exit=1

--- mutant: a new allowlist for a rule with no plant recipe ---
test-secret-scan: planting a token the allowlists must not hide
  FAIL  no plant recipe for rule 'aws-access-token' — backend/internal/modules/people/person.go is ungated. Add one to plant_line().
  ok    caught  generic-api-key     backend/internal/modules/people/person.go
  ok    caught  github-pat          backend/internal/modules/people/person.go
  ok    caught  linkedin-client-id  backend/internal/modules/people/person.go
  ok    caught  generic-api-key     backend/internal/modules/agents/approvals.go
  ok    caught  github-pat          backend/internal/modules/agents/approvals.go
  ok    caught  linkedin-client-id  frontend/src/screens/onboarding-conversation/connect-scene.tsx
  ok    caught  github-pat          frontend/src/screens/onboarding-conversation/connect-scene.tsx
  FAIL  no plant recipe for rule 'aws-access-token' — backend/internal/modules/deals/basecurrencyfreeze.go is ungated. Add one to plant_line().
  ok    caught  github-pat          backend/internal/modules/deals/basecurrencyfreeze.go
  ok    missed  github-pat          backend/internal/shared/ports/websearch/sourcepolicy_test.go
test-secret-scan: FAIL (2)
exit=1

--- GREEN: the committed policy ---
test-secret-scan: planting a token the allowlists must not hide
```

</details>

| Mutant | Result |
|---|---|
| `condition = "AND"` dropped | **exit 1** — "must cover the line it names, not the file" |
| `regexes` dropped | **exit 1** — same assertion |
| `targetRules` dropped | **exit 1** — "names no targetRules, so it exempts its files from EVERY rule" |
| a new allowlist for a rule with no plant recipe | **exit 1** — "is ungated. Add one to plant_line()." |
| an allowlist naming a path no tracked file matches | **exit 1** — caught by the clean-tree baseline |
| the committed policy | exit 0 |

Each probed **one at a time**: a combined probe would only show that *some*
assertion fired.

## Interaction with the two open PRs that touch this file

#1656 and #1120 each add a `[[allowlists]]` entry. Both are covered
automatically — the derivation reads whatever the file declares — and I checked
the parser against both entries verbatim, including #1656's apostrophe in its
description. Textual rebase conflicts in the appended blocks are possible; the
logic is not in conflict.

One thing for #1656's author: that PR's new comment says *"a second
`generic-api-key` match elsewhere in this file would also be excused"*. Measured
above, that is not what happens with all three elements present — and #1656's
entry has all three. Flagged on that PR rather than edited here.

## Coverage

Shell + TOML + Makefile comments: **no measured new-code coverage**, and
SonarCloud's new-code measure should not be read as "untested". The mutation
battery above is the substitute proof, each guard shown red against the defect it
describes.

## Review

- `/code-review` (Fable) and `/security-review` — the issue carries the `security`
  label, so both are run before merge.
- **Codex has not reviewed this**: `/codex:*` cannot be invoked by an agent. Two
  reviewers, not three, unless a human types it.
- CodeRabbit arrives on its own.

Claims worth attacking:
- *"the scoped allowlists narrow correctly"* — the measurement is one rule in one
  file; is there a shape where it does not?
- *"global allowlists are a closed set"* — `SANCTIONED_GLOBAL` is a hand-kept
  string, deliberately. Is that the right place for the one thing not derived?
- *"the plant recipes trip exactly their rule"* — they are re-measured each run on
  a control file, but the recipes themselves are hand-written.

Closes #1659

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives secret-scan plants directly from `.gitleaks.toml` and refuses policy shapes the gate cannot read, so each allowlist proves it doesn’t hide its own rule or any other rule. Previously the test planted only a `github-pat` and allowed unreadable shapes to pass, missing over-broad or invisible exemptions.

- `scripts/test-secret-scan.sh`: plants one token per `targetRules` rule plus a foreign `github-pat`; chooses both a first path match and a file whose content matches the allowlist regex; reads subjects from the committed export; verifies each plant in an isolated probe and requires the requested rule to fire; enforces a clean-tree baseline; appends with a trailing newline; builds distinct-character tokens; parses with a unit separator; counts triple-quote delimiters to detect partial reads; keeps a coverage ledger so every allowlist is planted.
- Shape gate: rejects indented keys/headers, any table beyond `[extend]` and `[[allowlists]]` (e.g., `[[rules]]`), `[extend].disabledRules`/`stopwords`, mixed‑quote arrays, tracked `.gitleaksignore`, and anything but exactly one `useDefault = true`.
- Global allowlists: treated as a closed, sanctioned set keyed on description and paths; duplicate descriptions fail; allowlists with `targetRules` but no `paths`, or with `paths` matching no committed files, fail closed.
- Makefile: `secret-scan` and `test-secret-scan` use the pinned, checksum-verified scanner via `scripts/gitleaks-pin.sh`.
- `.gitleaks.toml` docs: scoped exemptions require `targetRules`, `regexes`, and `condition = "AND"`; dropping any one widens the exemption to the entire file for that rule.

**Required actions**
- For every allowlist, include `targetRules`, `regexes`, `condition = "AND"`, and `paths` that match at least one committed file; keep descriptions unique.
- Do not add or widen global allowlists; to sanction one, add its description and paths to the sanctioned set in `scripts/test-secret-scan.sh` and justify it in the PR.
- Use only supported shapes: top-level `[[allowlists]]` and `[extend] useDefault = true`; no `[[rules]]`, `disabledRules`/`stopwords`, mixed-quote arrays, indented keys/headers, or a tracked `.gitleaksignore`.
- When targeting a new rule, add a plant recipe in `candidate_line()` and run `make test-secret-scan` locally.

<sup>Written for commit 3dafac126d36e414e21c68f60686f2b1d2b213de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret-scanning validation to detect uncovered, overly broad, duplicate, or incorrectly scoped allowlist exemptions.
  * Added checks confirming approved exemptions remain valid while unrelated secrets continue to be detected.

* **Documentation**
  * Clarified the requirements for narrowly scoped secret-scan exemptions.
  * Documented that secret scanning uses a pinned, checksum-verified scanner, without requiring a system-installed tool.
  * Expanded guidance on policy coverage and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->