### PR TITLE
fix(ci): the per-test ceiling clears the waits a test is allowed to spend

### DIFF
--- a/frontend/src/test-budget.test.ts
+++ b/frontend/src/test-budget.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASYNC_UTIL_TIMEOUT_MS,
+  LONGEST_WAIT_CHAIN,
+  SLOWEST_MEASURED_TEST_MS,
+  TEST_TIMEOUT_MS,
+} from "../vitest.budget";
+
+// The budget that governs every other suite here, gated the only way a budget
+// can be: against the thing it has to outlast. #1144 was not a slow test — it
+// was a per-test ceiling smaller than the sum of the per-wait ceilings the test
+// was allowed to spend, so tests failed with every assertion in them passing.
+// Nothing in vitest compares those two numbers, which is why one drifted under
+// the other unnoticed for as long as it did.
+//
+// This is arithmetic on constants rather than a timed run on purpose: a guard
+// that proves a timeout by actually waiting six seconds costs six seconds on
+// every run and still only proves it for the machine it ran on.
+describe("the frontend suite's time budget", () => {
+  it("clears the longest chain of waits a single test may legitimately compose", () => {
+    // Below this the failure mode is not a slow test but a wrong verdict: the
+    // waits are each inside their own budget and the test is outside its own.
+    const chainBudget = LONGEST_WAIT_CHAIN * ASYNC_UTIL_TIMEOUT_MS;
+    expect(TEST_TIMEOUT_MS).toBeGreaterThan(chainBudget);
+    // The default this replaced could not, which is the bug in one line.
+    expect(chainBudget).toBeGreaterThan(5_000);
+  });
+
+  it("leaves room for the work between those waits, not only the waiting", () => {
+    // A ceiling that cleared the chain by a millisecond would fail the moment a
+    // render between two waits cost anything at all.
+    const headroom =
+      TEST_TIMEOUT_MS - LONGEST_WAIT_CHAIN * ASYNC_UTIL_TIMEOUT_MS;
+    expect(headroom).toBeGreaterThanOrEqual(SLOWEST_MEASURED_TEST_MS);
+  });
+
+  it("is the sum of its two measurements and nothing else", () => {
+    // The value carries its derivation or it is a number somebody liked. If a
+    // longer chain or a slower test is measured, the ceiling moves with it
+    // rather than being re-guessed.
+    expect(TEST_TIMEOUT_MS).toBe(
+      LONGEST_WAIT_CHAIN * ASYNC_UTIL_TIMEOUT_MS + SLOWEST_MEASURED_TEST_MS,
+    );
+  });
+});

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -29,7 +29,17 @@
       "@composition/copy": ["./src/composition/extlocales.gen"]
     }
   },
-  "include": ["vite.config.ts", "vite.mcp-apps.config.ts", "scripts/**/*.ts", "src"],
+  // vitest.budget.ts sits beside the vite configs because it is config: the
+  // per-test time ceiling, derived from measurements it carries. vite.config.ts
+  // reads it and so does src/test-budget.test.ts, so it has to be in the same
+  // program as both.
+  "include": [
+    "vite.config.ts",
+    "vite.mcp-apps.config.ts",
+    "vitest.budget.ts",
+    "scripts/**/*.ts",
+    "src"
+  ],
   // src/screens/ext/ is the COMPOSED lane's program — its screens call routes
   // that are in `paths` only under the merged contract — so it cannot be typed
   // here any more than it can in the app project, and `@composition/screens`

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 import { serveMcpApps } from "./scripts/vite-inline-views";
+import { TEST_TIMEOUT_MS } from "./vitest.budget";
 
 // The composition alias — the runtime half of the two-lane type story whose
 // compile-time half is tsconfig.app.json / tsconfig.composed.json.
@@ -149,6 +150,11 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Derived in vitest.budget.ts, which carries the measurement and the
+    // arithmetic. The short version: a test of N sequential waits may spend N
+    // seconds without a single wait failing, and the longest chain here is six —
+    // so a five-second ceiling failed tests whose every assertion passed.
+    testTimeout: TEST_TIMEOUT_MS,
     // Rebinds jsdom's Web Storage over the Node ≥23 global stub — see the file.
     setupFiles: ["./vitest.setup.ts"],
     // Playwright owns e2e/ — vitest must not collect its specs

--- a/frontend/vitest.budget.ts
+++ b/frontend/vitest.budget.ts
@@ -1,0 +1,71 @@
+// The frontend suite's time budget, derived rather than picked.
+//
+// Six screen suites failed intermittently with `Test timed out in 5000ms` —
+// vitest's default `testTimeout`, which nothing overrode. They passed in
+// isolation and failed when the machine was busy, so the same commit produced a
+// different verdict run to run (#1144).
+//
+// It is NOT starvation, and it is not vague slowness either. Measured under
+// deliberate load (8 spin loops on 10 cores) with the timeout lifted, the two
+// tests observed failing completed in 609ms and 910ms, and the slowest test in
+// the whole suite took 3437ms. Nothing is stuck, and nothing is close to five
+// seconds of work.
+//
+// What is actually wrong is arithmetic between two budgets that were never
+// compared. Testing Library's `asyncUtilTimeout` and `vi.waitFor`'s timeout both
+// default to one second, and this repo overrides neither — so a test built from
+// N sequential waits may legitimately spend N seconds waiting without any single
+// wait failing. `company-act.test.tsx`'s "re-arms Continue once a skew refetch
+// actually lands a NEW hash" chains six of them. Against a five-second ceiling
+// that test can fail while every assertion in it is passing, and the failure
+// names the test rather than the wait that was slow.
+//
+// The repo had already found this once and written it down, in the one file that
+// hit it hardest — src/screens/company-context.test.tsx pins its own
+// `TEST_MS = SETTLE_MS * 4` with the reason spelled out: "it must cover EVERY
+// waiter in there: four run in sequence, each bounded by SETTLE_MS. A test whose
+// own limit is smaller than the sum lets vitest fire while a waiter still has
+// budget, and what surfaces then is an opaque timeout rather than the assertion
+// the test was written to make." That is this defect exactly, fixed for one
+// file. #1144 is the same arithmetic everywhere it was not fixed, so the ceiling
+// belongs here, once, rather than as a per-file constant six more suites would
+// have to remember to copy.
+//
+// That file keeps its own numbers and is deliberately untouched: it overrides
+// the per-wait budget as well as the per-test one, and the defect it is still
+// carrying (#613) is starvation rather than arithmetic. The ceiling below is
+// SMALLER than its 10s-per-waiter budget, so it cannot mask that.
+//
+// So the ceiling has to clear the longest chain the suite legitimately composes,
+// plus the render and act work sitting between those waits.
+
+/** Testing Library's `asyncUtilTimeout` and `vi.waitFor`'s default, neither overridden. */
+export const ASYNC_UTIL_TIMEOUT_MS = 1_000;
+
+/**
+ * The longest chain of sequential awaited waits in one test. Six, in
+ * `src/screens/onboarding-conversation/company-act.test.tsx` — both the
+ * "re-arms Continue once a skew refetch actually lands a NEW hash" case and the
+ * "re-arms Continue only once a re-check finds the read confirmable" one, with
+ * `voice-act.test.tsx` matching them.
+ */
+export const LONGEST_WAIT_CHAIN = 6;
+
+/**
+ * The slowest single test measured under deliberate load, in milliseconds —
+ * `read-conclusion.test.tsx`'s "a long multi-snapshot run converges on the
+ * review". Used whole as the allowance for the work BETWEEN the waits, which
+ * deliberately over-counts: that figure already contains its own waits. An
+ * over-estimate here is the safe direction, since the cost of a ceiling that is
+ * too high is a slower red, and the cost of one too low is this bug.
+ */
+export const SLOWEST_MEASURED_TEST_MS = 3_437;
+
+/**
+ * The per-test ceiling. Not a round number on purpose: a round one silently
+ * disagrees with the bound it has to outlast, and there is no reading of 10s or
+ * 15s that explains itself. This one is the sum of the two measurements above,
+ * so it moves when they do.
+ */
+export const TEST_TIMEOUT_MS =
+  LONGEST_WAIT_CHAIN * ASYNC_UTIL_TIMEOUT_MS + SLOWEST_MEASURED_TEST_MS;


### PR DESCRIPTION
## The judgement call, made on measurement

#1144's own ⚠️ says not to raise a timeout before establishing whether the tests
are **slow** or **starved**, because sibling #613 looks identical from outside and
is starvation. Measured under deliberate load (8 spin loops on 10 cores) with the
timeout lifted to 120s:

| test | duration under load |
|---|---|
| `company-act.test.tsx` "re-arms Continue once a skew refetch actually lands a NEW hash" | **609 ms** |
| `onboarding-conversation.test.tsx` "folds poll-delta narration into an activity group" | **910 ms** |
| slowest test in the entire suite (`read-conclusion.test.tsx`) | **3437 ms** |

Both tests I watched fail at a 5000 ms ceiling finish in well under a second.
Nothing is stuck, so it is **not starved**. Nothing is near five seconds of work
either, so "legitimately slow under load" does not describe it — there is no
smooth degradation for a bigger number to absorb.

## It is arithmetic between two budgets nobody compared

Testing Library's `asyncUtilTimeout` and `vi.waitFor`'s timeout both default to
**1000 ms**, and this repo overrides neither (no `configure()` anywhere). So a
test built from N sequential awaited waits may legitimately spend **N seconds**
without any single wait failing. `company-act.test.tsx:845` chains **six**.

Against a 5000 ms per-test ceiling, that test fails while every assertion in it
is passing — and the failure names the test rather than the wait that was slow.
25 tests in the suite carry a chain of ≥5. This is the "total that contradicts
its parts" shape.

## The repo had already found this, in one file

`src/screens/company-context.test.tsx` pins its own `TEST_MS = SETTLE_MS * 4`
and spells out the invariant:

> it must cover EVERY waiter in there: four run in sequence, each bounded by
> SETTLE_MS. A test whose own limit is smaller than the sum lets vitest fire
> while a waiter still has budget, and what surfaces then is an opaque timeout
> rather than the assertion the test was written to make. Vitest's per-test
> default is 5s, which is less than one of these waiters alone.

That is this defect, already diagnosed, fixed for exactly one file. #1144 is the
same arithmetic everywhere nobody applied the override — which is why this is
**one config-level authority** rather than six more per-file constants that drift.

## The value, and why it is not round

```
TEST_TIMEOUT_MS = LONGEST_WAIT_CHAIN × ASYNC_UTIL_TIMEOUT_MS + SLOWEST_MEASURED_TEST_MS
                = 6 × 1000 + 3437
                = 9437
```

Each term is a measurement carried in `frontend/vitest.budget.ts` with how it was
taken, so the ceiling moves when they do instead of being re-guessed. The second
term uses the slowest measured *whole test* as the allowance for the work
*between* the waits, which deliberately over-counts — that figure already contains
its own waits — because a ceiling too high costs a slower red and one too low
costs this bug.

**It cannot mask #613.** 9437 ms is deliberately *below* `company-context.test.tsx`'s
own 10 000 ms-per-waiter budget, and that file keeps its own numbers and is
untouched here, exactly as the issue asks.

## The guard

Nothing in vitest compares the per-test ceiling with the per-wait one — which is
how one drifted under the other and stayed there. `src/test-budget.test.ts` gates
the relationship. Against the 5000 ms default it goes red on all three
assertions:

```
× clears the longest chain of waits a single test may legitimately compose
  → expected 5000 to be greater than 6000
× leaves room for the work between those waits, not only the waiting
  → expected -1000 to be greater than or equal to 3437
× is the sum of its two measurements and nothing else
  → expected 5000 to be 9437
```

Arithmetic on constants rather than a timed run, on purpose: a guard that proves
a timeout by actually waiting six seconds costs six seconds on every run and
still only proves it for the machine it ran on.

**What it does not catch, stated rather than implied:** it gates the *relationship*
between the constants, so someone could still fudge a measurement and land on a
round number. That is a review matter; no test can tell a real measurement from
an invented one.

## Reproduction — the honest version

I **observed** the flake twice today, organically, both in this session's transcript:

- one run: `company-act` + `onboarding-conversation`, both `Test timed out in 5000ms`
- the next run of the same commit: a different file failed
- the third: fully green

Disjoint failure sets on one commit — the #1144 signature, and what rules out a
regression.

But I could **not** reproduce it on demand. Twelve deliberately loaded runs were
all green: 8 spinners, 20 spinners on 10 cores, a continuous `go build`/`go vet`
co-tenant, and two full vitest suites concurrently. **So the before/after
repetition counts cannot carry this argument and I am not claiming they do.**
Post-fix, four full runs under the same 20-spinner load are green (3034/3034
each), which shows no regression — not that the flake is gone.

What carries the argument is the structural proof above, which is deterministic
and does not depend on catching the machine in the right mood.

## Coverage

Test-config change plus one test of the config: **no new product code**, so
new-code coverage does not apply. `frontend/tsconfig.node.json` gains
`vitest.budget.ts` because `vite.config.ts` and the new test both read it and
they must share a program.

## Review

- `/code-review` (Fable) — run before merge.
- **Codex has not reviewed this**: `/codex:*` cannot be invoked by an agent. Two
  reviewers, not three, unless a human types it.
- CodeRabbit arrives on its own.

Claims worth attacking:
- *"the longest chain is 6"* — counted with a brace-matching script that
  over-counts on long files; the six-chain cases were hand-verified, the 29/39
  figures it also produced were not, and are not relied on. If a real chain is
  longer than 6, the ceiling is too low and the guard will not say so.
- *"it cannot mask #613"* — rests on that file keeping its own overrides.
- *"not starved"* — established from two tests, not all six.

Closes #1144


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents flaky “Test timed out in 5000ms” by setting a measured per-test timeout in `vitest` and guarding it. Old: suite used the 5000ms default, which could be lower than the sum of sequential waits; New: `testTimeout` is 9437ms (= 6 × 1000ms wait chain + 3437ms slowest test), with a guard test enforcing this. Per-wait timeouts are unchanged, and `company-context.test.tsx` keeps its overrides so this cannot mask #613.

**Changes and review focus**
- Add `frontend/vitest.budget.ts` exporting `ASYNC_UTIL_TIMEOUT_MS`, `LONGEST_WAIT_CHAIN`, `SLOWEST_MEASURED_TEST_MS`, and `TEST_TIMEOUT_MS`; import in `frontend/vite.config.ts` to set `testTimeout`.
- Add `frontend/src/test-budget.test.ts` to assert the timeout clears the longest wait chain, leaves headroom, and equals the documented sum; it fails under the old 5000ms.
- Update `frontend/tsconfig.node.json` to include `vitest.budget.ts`.
- Reviewer: sanity-check `LONGEST_WAIT_CHAIN = 6` and `SLOWEST_MEASURED_TEST_MS = 3437`; confirm `src/screens/company-context.test.tsx` remains untouched. No migrations required.

<sup>Written for commit 3faf238dfb8349feb6a1934b3db36442441e4b03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

