### PR TITLE
fix(migrations): the dedupe FK classification stops claiming a row-scoped detector

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -247,9 +247,10 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"signal_resolution.matched_org_id":           "child row: written only through Resolve's gated attribution — the org already passed auth.EnsureLinkTarget",
 	"person_social.person_id":                    "child row: written only through the person store — CreatePerson mints the parent row itself, UpdatePerson passes auth.EnsureVisible first",
 	// The dedupe review queue (DH-DDL-1): pair ids are server-derived —
-	// recordDedupeCandidate stamps them from the ensure chokepoint's own fuzzy
-	// query, never from a request body; the disposition endpoints address the
-	// candidate row, not the pair ids.
+	// recordDedupeCandidate stamps them from an internal match query, never from a
+	// request body; the disposition endpoints address the candidate row, not the
+	// pair ids. WHICH query differs by entity type, so each entry below names its
+	// own rather than this line naming one for all of them.
 	//
 	// The detector is deliberately NOT row-scoped: it filters on the workspace and
 	// archived_at only, so it does pair a caller's record with one they cannot see

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -247,15 +247,28 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"signal_resolution.matched_org_id":           "child row: written only through Resolve's gated attribution — the org already passed auth.EnsureLinkTarget",
 	"person_social.person_id":                    "child row: written only through the person store — CreatePerson mints the parent row itself, UpdatePerson passes auth.EnsureVisible first",
 	// The dedupe review queue (DH-DDL-1): pair ids are server-derived —
-	// recordDedupeCandidate stamps them from the ensure chokepoint's own
-	// row-scoped fuzzy query, never from a request body; the disposition
-	// endpoints address the candidate row, not the pair ids.
-	"dedupe_candidate.left_person_id":           "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own row-scoped match query",
-	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate — the same writer and the same sweep as the person and organization pairs above, choosing the lead columns",
-	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate — the same writer and the same sweep as the person and organization pairs above, choosing the lead columns",
+	// recordDedupeCandidate stamps them from the ensure chokepoint's own fuzzy
+	// query, never from a request body; the disposition endpoints address the
+	// candidate row, not the pair ids.
+	//
+	// The detector is deliberately NOT row-scoped: it filters on the workspace and
+	// archived_at only, so it does pair a caller's record with one they cannot see
+	// — a duplicate you cannot see is still a duplicate, and scoping the detector
+	// would blind it to exactly the pairs worth catching. What keeps such a pair
+	// from being DISCLOSED is the queue read, which requires BOTH sides to pass
+	// the caller's row scope (dedupeVisibilityClause, and EnsureVisible per side
+	// in GetDedupeCandidate). These six entries rest on that read, so nothing here
+	// is licence to relax it, and TestDedupeQueueHides*PairsOutsideTheCallersRowScope
+	// is what holds it for each entity type.
+	"dedupe_candidate.left_person_id":  "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	"dedupe_candidate.right_person_id": "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	"dedupe_candidate.left_org_id":     "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	"dedupe_candidate.right_org_id":    "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
+	// The lead pair reaches the same writer, but not from a sweep: fuzzyLead runs
+	// inline in the transaction that writes the lead, so the left id is the row
+	// that transaction just created or updated.
+	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query, inline in the transaction that wrote the lead",
+	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
 	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own row-scoped connector-activity query (PO-DDL-12), never from a request body",
 	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own row-scoped ListDueOrgs read produced (CAP-PARAM-7), never from a request body",
 	// The signature pass's read cursor (PO-F-2a): both ids come from the

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -247,8 +247,14 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"signal_resolution.matched_org_id":           "child row: written only through Resolve's gated attribution — the org already passed auth.EnsureLinkTarget",
 	"person_social.person_id":                    "child row: written only through the person store — CreatePerson mints the parent row itself, UpdatePerson passes auth.EnsureVisible first",
 	// The dedupe review queue (DH-DDL-1): pair ids are server-derived —
-	// recordDedupeCandidate stamps them inline in the transaction that writes the
-	// record, from that path's own fuzzy match query, never from a request body.
+	// recordDedupeCandidate is their only writer, and both ids come from the writing
+	// path's own match query, never from a request body. Which query varies more than
+	// a single phrase can carry: the fuzzy tier for a near match, an exact identity
+	// lane at confidence 1.0 for a shared phone or a lane conflict. What every path
+	// shares is that the ids are ones it resolved itself, and that is the invariant
+	// this waiver rests on — not a transaction boundary, which the identity-conflict
+	// writer deliberately does not share with its caller.
+	//
 	// The disposition endpoints accept only a winner_id already equal to one of the
 	// stored pair ids, both of which the read below has just gated.
 	//
@@ -261,23 +267,25 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// GetDedupeCandidate). All six entries rest on that read, held by
 	// TestDedupeQueueHidesPairsOutsideTheCallersRowScope and, per entity type and
 	// per side, TestDedupeQueueHidesAPairTheCallerCanOnlyHalfSee.
-	"dedupe_candidate.left_person_id":           "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
-	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
-	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
-	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
-	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query, inline in the transaction that wrote the lead",
+	"dedupe_candidate.left_person_id":           "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
 	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
-	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own row-scoped connector-activity query (PO-DDL-12), never from a request body",
-	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own row-scoped ListDueOrgs read produced (CAP-PARAM-7), never from a request body",
+	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own connector-activity query (PO-DDL-12), never from a request body — it runs as the system principal, so what holds this is the absence of a caller, not a scope clause",
+	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own ListDueOrgs read produced (CAP-PARAM-7), never from a request body — a background pass with no caller to scope against",
 	// The signature pass's read cursor (PO-F-2a): both ids come from the
 	// pass's own SignatureCandidates query — the person it just read for and
 	// the activity whose body it just read — never from a request body.
-	"person_signature_enrich_state.person_id":   "server-derived: stamped by the enrich pass from its own row-scoped candidate query",
+	"person_signature_enrich_state.person_id":   "server-derived: stamped by the enrich pass from its own candidate query, as the system principal — no caller, so no scope clause to apply",
 	"person_signature_enrich_state.activity_id": "server-derived: stamped by the enrich pass from the activity that candidate query returned",
 	// The interaction participants (ACT-DDL-3): neither id is ever carried on
 	// a request body. Capture mints the activity in the same transaction and
-	// resolves the counterparty through the ensure chokepoint's own row-scoped
-	// lookup; a manual activity takes its person from a link the activities
+	// resolves the counterparty through the ensure chokepoint's own lookup — which
+	// carries no scope clause either, and does not need one: capture runs without a
+	// caller to scope against, and the read side is what gates disclosure. A manual
+	// activity takes its person from a link the activities
 	// store already put through auth.EnsureLinkTarget. Reads inherit the
 	// activity's own visibility (the link walk), so a participant row never
 	// discloses an activity its reader could not already open.

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -247,27 +247,24 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"signal_resolution.matched_org_id":           "child row: written only through Resolve's gated attribution — the org already passed auth.EnsureLinkTarget",
 	"person_social.person_id":                    "child row: written only through the person store — CreatePerson mints the parent row itself, UpdatePerson passes auth.EnsureVisible first",
 	// The dedupe review queue (DH-DDL-1): pair ids are server-derived —
-	// recordDedupeCandidate stamps them from an internal match query, never from a
-	// request body; the disposition endpoints address the candidate row, not the
-	// pair ids. WHICH query differs by entity type, so each entry below names its
-	// own rather than this line naming one for all of them.
+	// recordDedupeCandidate stamps them inline in the transaction that writes the
+	// record, from that path's own fuzzy match query, never from a request body.
+	// The disposition endpoints accept only a winner_id already equal to one of the
+	// stored pair ids, both of which the read below has just gated.
 	//
-	// The detector is deliberately NOT row-scoped: it filters on the workspace and
-	// archived_at only, so it does pair a caller's record with one they cannot see
-	// — a duplicate you cannot see is still a duplicate, and scoping the detector
-	// would blind it to exactly the pairs worth catching. What keeps such a pair
-	// from being DISCLOSED is the queue read, which requires BOTH sides to pass
-	// the caller's row scope (dedupeVisibilityClause, and EnsureVisible per side
-	// in GetDedupeCandidate). These six entries rest on that read, so nothing here
-	// is licence to relax it, and TestDedupeQueueHides*PairsOutsideTheCallersRowScope
-	// is what holds it for each entity type.
-	"dedupe_candidate.left_person_id":  "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
-	"dedupe_candidate.right_person_id": "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
-	"dedupe_candidate.left_org_id":     "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
-	"dedupe_candidate.right_org_id":    "server-derived: stamped by recordDedupeCandidate from the dedupe sweep's own match query",
-	// The lead pair reaches the same writer, but not from a sweep: fuzzyLead runs
-	// inline in the transaction that writes the lead, so the left id is the row
-	// that transaction just created or updated.
+	// The detector applies NO row-scope predicate — no auth.ScopeClauseFor, no owner
+	// term — so it does pair a caller's record with one they cannot see. That is
+	// deliberate: a duplicate you cannot see is still a duplicate, and scoping the
+	// detector would blind it to exactly the pairs worth catching. What keeps such a
+	// pair from being DISCLOSED is the queue read, which requires BOTH sides to pass
+	// the caller's row scope (dedupeVisibilityClause, and EnsureVisible per side in
+	// GetDedupeCandidate). All six entries rest on that read, held by
+	// TestDedupeQueueHidesPairsOutsideTheCallersRowScope and, per entity type and
+	// per side, TestDedupeQueueHidesAPairTheCallerCanOnlyHalfSee.
+	"dedupe_candidate.left_person_id":           "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
+	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
+	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
+	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the writing path's own fuzzy match query",
 	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query, inline in the transaction that wrote the lead",
 	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
 	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own row-scoped connector-activity query (PO-DDL-12), never from a request body",


### PR DESCRIPTION
The follow-up promised on [#1685](https://github.com/gradionhq/margince-poc-v1/pull/1685), now that it has landed. Two test files, no production change.

## The gap

#1685 classified `dedupe_candidate`'s lead pair ids as **server-derived** rather than gating them with `auth.EnsureLinkTarget`. That is the right call — gating the detector would blind it to exactly the duplicates worth catching — but it makes the queue **read** the only thing standing between a pair and disclosure, and that read was proven for `entity_type='person'` alone.

Why the read is load-bearing rather than incidental: **the detector is deliberately not row-scoped.** `fuzzyLead` filters on the workspace and `archived_at` only, so a lead pair can legitimately name a lead the reader cannot see. What keeps it private is `dedupeVisibilityClause` requiring **both** sides plus `EnsureVisible` per side in `GetDedupeCandidate`.

`TestDedupeQueueHidesLeadPairsOutsideTheCallersRowScope` drives it: a stranger sees zero rows and gets `ErrNotFound` by id, and then — the arm that matters — after one side is made visible again they must **still** see nothing, because a clause admitting either side leaks the existence of the one they cannot read.

Mutation-verified: weakening the both-sides `AND` to an `OR` in `dedupeVisibilityClause` fails precisely on that arm and nowhere else.

## The prose correction, including four entries that predate #1685

The person/organization entries claim the ids come "from the dedupe sweep's own **row-scoped** match query". The row-scoped half is not true of any of the three detectors — none of them applies `auth.ScopeClauseFor`. Left standing, it invites a future reader to relax the read that is actually doing the work, so this is a fix-the-invariant change rather than a fix to the two new rows.

The lead entries also said "the same sweep". There is no lead sweep: `fuzzyLead` runs inline in the transaction that writes the lead, so a reader grepping for one finds nothing.

The block comment now states where the gate lives and names the tests that hold it, so the next person adding an entity type to this queue can see what they owe.

## Deliberately not changed

**#1685's `lead.merged_into_id` reason stays as it is.** My closed #1684 cited `MergeLead` having no HTTP surface; #1685 cites `mergePair`'s writability probes on both leads. Theirs is the stronger fact and the one the merge path actually enforces, so it wins.

## Provenance

Both defects came out of an adversarial review round on #1684 (the duplicate of #1685) — the security pass verified all three classifications are true and caught the false "row-scoped" claim; the craft pass caught a non-sequitur in my own reasoning, which is why the `merged_into_id` entry above is theirs and not mine.

Two things from that round are out of scope and tracked separately: [#1690](https://github.com/gradionhq/margince-poc-v1/issues/1690) (the digest's dedupe count is an existence oracle) and [#1687](https://github.com/gradionhq/margince-poc-v1/issues/1687) (why `main` was red long enough for two sessions to fix it independently).

Verified against a real database: both row-scope tests and `TestFK_rowScopedTargetsHaveVisibilityDecision` pass; `craft static --strict` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects FK waiver comments in `schema_fitness_integration_test.go` to stop claiming a row‑scoped dedupe detector and to document the real invariants that gate disclosure. No production behavior changes.

- All six `dedupe_candidate` IDs now cite `recordDedupeCandidate` as the sole writer and state the true source: server‑derived from the writing path’s own queries (fuzzy and exact lanes), never from a request body. The detector is not row‑scoped; disclosure is gated by the queue read requiring both sides visible via `dedupeVisibilityClause` and per‑side `EnsureVisible` in `GetDedupeCandidate`. Disposition only accepts a `winner_id` equal to one of the stored pair IDs. Held by `TestDedupeQueueHidesPairsOutsideTheCallersRowScope` and `TestDedupeQueueHidesAPairTheCallerCanOnlyHalfSee`.
- Fixes sibling waivers that also claimed row scope: `person_profile_field.person_id`, `capture_auto_enrich_state.organization_id`, `person_signature_enrich_state.person_id`, and activity participants now state they run as the system principal (no caller to scope) and that disclosure is gated on reads, not writer-side scoping.

<sup>Written for commit 2938bf163beae1917597c1f9464dd13cb8f4299b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy for duplicate lead detection by hiding deduplication candidates when viewers lack access to either record.
  * Confirmed that both list and detail views enforce visibility checks, while record owners retain access.

* **Tests**
  * Added integration coverage for row-level access controls and deduplication candidate visibility.
  * Expanded schema validation coverage for workspace-wide and transaction-based duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->