### PR TITLE
fix(frontend): the leads AC clicks the lead's link, not any text naming it

### DIFF
--- a/frontend/e2e/leads.spec.ts
+++ b/frontend/e2e/leads.spec.ts
@@ -21,7 +21,9 @@ test("AC-leads-list: a row names its owner and opens the lead's own page", async
   // The owner column answers "whose lead is this" — the same column the
   // people and company lists carry, never "typed by a person".
   await expect(row).toContainText("Lena Fischer");
-  await row.getByText("Jonas Petersen").click();
+  // The lead's own link, not any text bearing the name: the row also carries
+  // the bulk-select checkbox's screen-reader label, which names the lead too.
+  await row.getByRole("link", { name: /Jonas Petersen/ }).click();
   await expect(page).toHaveURL(/#\/leads\/l-1$/);
   await expect(
     page.getByRole("heading", { level: 1, name: "Jonas Petersen" }),


### PR DESCRIPTION
`main`'s `uat` lane has been red since #1678, and it is still red now — including on the commit that merged an hour ago.

## What broke

#1678 gave every leads row a bulk-select checkbox. Its accessible label is `lead.bulkSelectRow` — *"{name} auswählen"* — rendered as screen-reader-only text **inside the row**. So the row now names the lead twice, and a locator that was unambiguous when it was written no longer is:

```
Error: locator.click: strict mode violation:
  getByRole('row', { name: /Jonas Petersen/ }).getByText('Jonas Petersen')
  resolved to 2 elements:
    1) <span class="sr-only">Jonas Petersen auswählen</span>
    2) <strong>Jonas Petersen</strong>  aka getByRole('link', { name: 'Jonas Petersen · Nordwind' })
```

Playwright is right to refuse: the two elements do different things, and nothing in the call says which one the test meant.

## The fix

Ask for the link by role. The AC's subject is *"a row … opens the lead's own page"*, so the link is what it was always about — and asking by role is what keeps it stable, since a further accessible name added inside the row is no longer indistinguishable from the element the assertion is about.

I checked whether the same shape sits elsewhere before fixing this one site: `row.getByText(...)` appears exactly once across `frontend/e2e/`, so there is no sibling copy to fix with it.

## Why it outlived three other fixes today

This is the fourth distinct reason `main` has been red today, and the only one still standing after #1685. It survived because of the gap #1687 describes, which is worth stating plainly:

- the change that **broke** it is frontend (#1678);
- the change that **merged over** it is backend-only (#1685);
- the `uat` lane is **skipped** for a backend-only diff.

So `main`'s CI reports success on `f296bed2c` with `uat`, `fe-quality`, `fe-unit` and `fe-bundle` all skipped, while the break is still there. A green tick on `main` currently does not mean the frontend was tested — it often means it was not looked at.

## Verification

`pnpm exec playwright test` — **92 passed, 14 skipped, 0 failed** (CI's last run on `main`: 91 passed, 1 failed) · `make check-fe` exit 0.

## Noticed, not touched

`frontend/e2e/tmp-debug.spec.ts` — *"debug overlay person crash"* — has been in the suite since #865 on 2026-08-11. The name and subject read as session debris that CLAUDE.md says should never have been committed, but deleting somebody's test is not this PR's business. Filed as #1711.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicks the lead’s link by role in the leads list E2E to fix `uat` failures after the bulk‑select checkbox added a screen‑reader label that duplicates the lead’s name. Old: clicked any text named “Jonas Petersen” in the row; New: clicks the link via role; Side effect: stabilizes the test without product changes.

- Change is limited to `frontend/e2e/leads.spec.ts`: replace `row.getByText(...)` with `row.getByRole('link', { name: /.../ })`. No other instances of `row.getByText(...)` found in `frontend/e2e/`.
- Verified: `pnpm exec playwright test` — 92 passed, 14 skipped, 0 failed.

<sup>Written for commit 0ec9a2d4b8010cbf8786f1a66b666296a8c4d536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

