### PR TITLE
fix(ci): the reader reports what it cannot read, and is tested itself

### DIFF
--- a/frontend/scripts/test-budget.reader.test.ts
+++ b/frontend/scripts/test-budget.reader.test.ts
@@ -143,6 +143,88 @@ describe("the waiter-budget reader", () => {
     expect(probe?.unresolved).toEqual([]);
   });
 
+  it("resolves the shorthand `{ timeout }`, which is how a named budget is written", () => {
+    // The idiomatic spelling once the value has a name, and the one a reader
+    // that only looks at property ASSIGNMENTS records as the 1000ms default.
+    const [probe] = read(
+      `const timeout = 4000;
+       it("x", async () => { await waitFor(() => {}, { timeout }); });`,
+      "shorthand.test.tsx",
+    );
+    expect(probe?.waiterBudgetMs).toBe(4_000);
+    expect(probe?.unresolved).toEqual([]);
+  });
+
+  it("reports an options object it cannot see inside, rather than defaulting", () => {
+    // A spread and an options object passed by name each hide a budget. Saying
+    // "no timeout stated" about them is the same mistake as folding one wrong:
+    // both end as the smallest number that keeps the gate green.
+    const spread = read(
+      `const opts = { timeout: 4000 };
+       it("x", async () => { await waitFor(() => {}, { ...opts }); });`,
+      "spread.test.tsx",
+    )[0];
+    const byName = read(
+      `const opts = { timeout: 4000 };
+       it("x", async () => { await waitFor(() => {}, opts); });`,
+      "byname.test.tsx",
+    )[0];
+    expect(spread?.unresolved.length).toBe(1);
+    expect(byName?.unresolved.length).toBe(1);
+  });
+
+  it("reads past the `undefined` placeholder to the options behind it", () => {
+    // `findByText(matcher, undefined, { timeout })` is the ordinary spelling
+    // when the middle argument is skipped, and a reader that treats any
+    // identifier as an opaque options object reports it unreadable instead of
+    // folding the budget that is right there.
+    const [probe] = read(
+      `it("x", async () => {
+         await screen.findByText(/a/, undefined, { timeout: 4000 });
+       });`,
+      "placeholder.test.tsx",
+    );
+    expect(probe?.unresolved).toEqual([]);
+    expect(probe?.waiterBudgetMs).toBe(4_000);
+  });
+
+  it("does not read a non-string title as the ceiling", () => {
+    // Scanning the arguments from the start finds the title first, and then
+    // reports a test's own name as a timeout it cannot fold.
+    const [probe] = read(
+      `const TITLE = "x";
+       it(TITLE, async () => { await screen.findByText("a"); });`,
+      "title.test.tsx",
+    );
+    expect(probe?.unresolved).toEqual([]);
+    expect(probe?.ceilingIsStated).toBe(false);
+  });
+
+  it("ignores a test vitest never runs", () => {
+    // A skipped body spends nothing. Counting it lets a test that cannot fail
+    // set the ceiling for the thousands that do.
+    const found = read(
+      `it.skip("skipped", async () => { await waitFor(() => {}, { timeout: 30000 }); });
+       it.todo("todo");`,
+      "skipped.test.tsx",
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("counts a helper declared inside the test body once per call", () => {
+    // Collected as a helper AND visited where it is defined, it was charged
+    // once for the declaration plus once per call.
+    const [probe] = read(
+      `it("x", async () => {
+         const settle = () => waitFor(() => {}, { timeout: 1000 });
+         await settle();
+         await settle();
+       });`,
+      "inbody.test.tsx",
+    );
+    expect(probe?.waiterBudgetMs).toBe(2_000);
+  });
+
   it("reports a timeout it cannot fold instead of assuming the default", () => {
     // The one that matters: an unfoldable budget quietly recorded as 1000 hid a
     // live 11000ms violation from the guard.

--- a/frontend/scripts/test-budget.reader.test.ts
+++ b/frontend/scripts/test-budget.reader.test.ts
@@ -225,6 +225,109 @@ describe("the waiter-budget reader", () => {
     expect(probe?.waiterBudgetMs).toBe(2_000);
   });
 
+  it("takes the EXPORTED constant, not a local one that shares its name", () => {
+    // A module-level export and a function-local of the same name are both
+    // "the last declaration of X" to a reader that walks a file flat. Taking
+    // the wrong one folded a 10000ms budget to 2ms, silently.
+    writeFileSync(
+      join(dir, "shadowed.ts"),
+      `export const POLL_MS = 5000;\nfunction helper() { const POLL_MS = 1; return POLL_MS; }\n`,
+      "utf8",
+    );
+    const [probe] = read(
+      `import { POLL_MS } from "./shadowed";
+       it("x", async () => { await waitFor(() => {}, { timeout: POLL_MS * 2 }); });`,
+      "shadowed.test.tsx",
+    );
+    expect(probe?.waiterBudgetMs).toBe(10_000);
+  });
+
+  it("reports every options shape it cannot see into, not just the two it knows", () => {
+    // A whitelist of readable shapes sends everything else down the same path
+    // as "states no timeout", and that path ends at the smallest number.
+    for (const [name, argument] of [
+      ["access", "OPTS.slow"],
+      ["call", "makeOpts()"],
+      ["ternary", "cond ? { timeout: 30000 } : undefined"],
+    ] as const) {
+      const [probe] = read(
+        `it("x", async () => { await waitFor(() => {}, ${argument}); });`,
+        `opaque-${name}.test.tsx`,
+      );
+      expect([name, probe?.unresolved.length]).toEqual([name, 1]);
+    }
+  });
+
+  it("records a conditionally-run test, which really does run", () => {
+    // `it.runIf(cond)` runs when cond holds. Treating it as skipped left a
+    // live test under no guard at all — the more expensive of the two mistakes.
+    const found = read(
+      `it.runIf(cond)("conditional", async () => { await waitFor(() => {}, { timeout: 30000 }); });`,
+      "runif.test.tsx",
+    );
+    expect(found.map((probe) => probe.waiterBudgetMs)).toEqual([30_000]);
+  });
+
+  it("ignores every test inside a skipped suite", () => {
+    // isSkipped inspecting only the `it` chain reddened the guard naming a
+    // test vitest never runs — the same failure it was added to prevent, one
+    // level up.
+    const found = read(
+      `describe.skip("suite", () => {
+         it("x", async () => { await waitFor(() => {}, { timeout: 30000 }); });
+       });`,
+      "describeskip.test.tsx",
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("does not treat a local variable as a helper just because the name matches", () => {
+    // Skipping a "helper declaration" that is not a function at all dropped
+    // the waiter inside it.
+    const [probe] = read(
+      `const renderAs = () => waitFor(() => {}, { timeout: 1000 });
+       it("x", async () => {
+         const renderAs = await screen.findByText("x", undefined, { timeout: 25000 });
+         expect(renderAs).toBeTruthy();
+       });`,
+      "shadow-local.test.tsx",
+    );
+    expect(probe?.waiterBudgetMs).toBe(25_000);
+  });
+
+  it("reports two same-named helpers only when their budgets disagree", () => {
+    // Same cost either way is not an ambiguity that matters; a different cost
+    // is, and picking one silently under-counted a whole suite.
+    const agree = read(
+      `describe("a", () => { const settle = () => waitFor(() => {}, { timeout: 2000 });
+         it("x", async () => { await settle(); }); });
+       describe("b", () => { const settle = () => waitFor(() => {}, { timeout: 2000 });
+         it("y", async () => { await settle(); }); });`,
+      "agree.test.tsx",
+    );
+    const differ = read(
+      `describe("a", () => { const settle = () => waitFor(() => {}, { timeout: 8000 });
+         it("x", async () => { await settle(); }); });
+       describe("b", () => { const settle = () => waitFor(() => {}, { timeout: 2000 });
+         it("y", async () => { await settle(); }); });`,
+      "differ.test.tsx",
+    );
+    expect(agree.map((probe) => probe.waiterBudgetMs)).toEqual([2_000, 2_000]);
+    expect(differ.every((probe) => probe.unresolved.length === 1)).toBe(true);
+  });
+
+  it("folds a ceiling written as an expression, rather than ignoring it", () => {
+    // Missed AND unreported, so the test silently rejoined the population it
+    // had opted out of.
+    const [probe] = read(
+      `const SETTLE_MS = 5000;
+       it("x", async () => { await screen.findByText("a"); }, SETTLE_MS * 4);`,
+      "exprceiling.test.tsx",
+    );
+    expect(probe?.ceilingMs).toBe(20_000);
+    expect(probe?.ceilingIsStated).toBe(true);
+  });
+
   it("reports a timeout it cannot fold instead of assuming the default", () => {
     // The one that matters: an unfoldable budget quietly recorded as 1000 hid a
     // live 11000ms violation from the guard.

--- a/frontend/scripts/test-budget.reader.test.ts
+++ b/frontend/scripts/test-budget.reader.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { budgetsIn } from "./test-budget";
+
+// The reader's own tests. test-budget.test.ts holds the TREE against the
+// reader; nothing there holds the reader against anything, because it can only
+// see what this tree happens to contain today. Every shape below was a hole
+// this reader actually had — each one made real tests invisible or made their
+// budget read smaller than it is, and a smaller budget is a guard that passes.
+//
+// Synthetic fixtures on purpose: a regression that stops the reader seeing
+// `it.each` cannot be caught by a tree whose `it.each` tests all happen to sit
+// inside their ceiling.
+
+const GLOBAL = 10_000;
+let dir = "";
+
+function read(source: string, name = "probe.test.tsx") {
+  const file = join(dir, name);
+  writeFileSync(file, source, "utf8");
+  return budgetsIn(file, GLOBAL);
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "test-budget-"));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("the waiter-budget reader", () => {
+  it("takes the default budget for a waiter that states none", () => {
+    const [probe] = read(
+      `it("x", async () => { await screen.findByText("a"); });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(1_000);
+    expect(probe?.ceilingMs).toBe(GLOBAL);
+    expect(probe?.ceilingIsStated).toBe(false);
+  });
+
+  it("sums the waiters a test runs in sequence", () => {
+    const [probe] = read(
+      `it("x", async () => {
+         await screen.findByText("a");
+         await waitFor(() => {}, { timeout: 4000 });
+         await screen.findAllByRole("row");
+       });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(6_000);
+  });
+
+  it("sees it.each, it.only and it.concurrent, which are tests like any other", () => {
+    // Matching only the immediate callee dropped 17 call sites in this tree,
+    // silently — and a test the reader never records is a test under no guard.
+    const found = read(
+      `it.each([1, 2])("each %s", async () => { await screen.findByText("a"); });
+       it.only("only", async () => { await screen.findByText("a"); });
+       it.concurrent("concurrent", async () => { await screen.findByText("a"); });
+       test.each\`a\`("tagged", async () => { await screen.findByText("a"); });`,
+    );
+    expect(found.map((probe) => probe.name)).toEqual([
+      "each %s",
+      "only",
+      "concurrent",
+      "tagged",
+    ]);
+    expect(found.every((probe) => probe.waiterBudgetMs === 1_000)).toBe(true);
+  });
+
+  it("reads the ceiling from either form vitest accepts", () => {
+    const [positional] = read(`it("x", async () => {}, 500);`, "a.test.tsx");
+    const [options] = read(
+      `it("x", { timeout: 500 }, async () => {});`,
+      "b.test.tsx",
+    );
+    expect(positional?.ceilingMs).toBe(500);
+    expect(options?.ceilingMs).toBe(500);
+    expect([positional?.ceilingIsStated, options?.ceilingIsStated]).toEqual([
+      true,
+      true,
+    ]);
+  });
+
+  it("counts the waiters inside a helper the test awaits", () => {
+    const [probe] = read(
+      `function settle() { return waitFor(() => {}, { timeout: 9000 }); }
+       it("x", async () => { await settle(); });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(9_000);
+  });
+
+  it("counts a one-line arrow helper, whose body IS the waiter", () => {
+    // The commonest helper shape, and the one a reader that descends past the
+    // node it was handed counts as zero.
+    const [probe] = read(
+      `const settle = () => waitFor(() => {}, { timeout: 9000 });
+       it("x", async () => { await settle(); });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(9_000);
+  });
+
+  it("counts a helper once per call, not once per test", () => {
+    // Recursion protection that also suppressed repeat calls reported 1000 for
+    // a test that really spends 4000.
+    const [probe] = read(
+      `const settle = () => waitFor(() => {}, { timeout: 1000 });
+       it("x", async () => { await settle(); await settle(); await settle(); await settle(); });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(4_000);
+  });
+
+  it("survives a helper that calls itself", () => {
+    const [probe] = read(
+      `function loop() { return loop(); }
+       it("x", async () => { await loop(); await screen.findByText("a"); });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(1_000);
+  });
+
+  it("folds arithmetic over the constants a file declares", () => {
+    const [probe] = read(
+      `const POLL = 800;
+       const ROUNDS = 2;
+       it("x", async () => { await waitFor(() => {}, { timeout: POLL * ROUNDS * 5 }); });`,
+    );
+    expect(probe?.waiterBudgetMs).toBe(8_000);
+  });
+
+  it("folds a constant imported from a sibling module", () => {
+    writeFileSync(
+      join(dir, "cadence.ts"),
+      "export const POLL = 800;\n",
+      "utf8",
+    );
+    const [probe] = read(
+      `import { POLL } from "./cadence";
+       it("x", async () => { await waitFor(() => {}, { timeout: POLL * 10 }); });`,
+      "imports.test.tsx",
+    );
+    expect(probe?.waiterBudgetMs).toBe(8_000);
+    expect(probe?.unresolved).toEqual([]);
+  });
+
+  it("reports a timeout it cannot fold instead of assuming the default", () => {
+    // The one that matters: an unfoldable budget quietly recorded as 1000 hid a
+    // live 11000ms violation from the guard.
+    const [probe] = read(
+      `import { POLL } from "@somewhere/external";
+       it("x", async () => { await waitFor(() => {}, { timeout: POLL * 10 }); });`,
+      "unfoldable.test.tsx",
+    );
+    expect(probe?.unresolved).toEqual(["POLL * 10"]);
+  });
+});

--- a/frontend/scripts/test-budget.reader.test.ts
+++ b/frontend/scripts/test-budget.reader.test.ts
@@ -328,6 +328,46 @@ describe("the waiter-budget reader", () => {
     expect(probe?.ceilingIsStated).toBe(true);
   });
 
+  it("reports a constant this file gives two different values", () => {
+    // No scope information, so two suites each declaring their own SETTLE_MS
+    // collapsed to whichever came last in source order — the same last-wins
+    // defect that crossed the import boundary, one hop closer.
+    const [probe] = read(
+      `const SETTLE_MS = 9000;
+       function helper() { const SETTLE_MS = 1; return SETTLE_MS; }
+       it("x", async () => { await waitFor(() => {}, { timeout: SETTLE_MS }); });`,
+      "shadowed-const.test.tsx",
+    );
+    expect(probe?.unresolved).toEqual(["SETTLE_MS"]);
+  });
+
+  it("does not charge a method call the budget of a same-named helper", () => {
+    // `userEvent.clear(input)` is not the file's `clear` helper. Phantom
+    // budget inflates the very measurement that sets the suite ceiling.
+    const [probe] = read(
+      `const clear = () => waitFor(() => {}, { timeout: 7000 });
+       it("x", async () => { await userEvent.clear(input); });`,
+      "method.test.tsx",
+    );
+    expect(probe?.waiterBudgetMs).toBe(0);
+  });
+
+  it("reads a quoted or computed timeout key", () => {
+    // Comparing source text read these as "states no timeout", which lands on
+    // the default — the silent-smallest-number path again.
+    const quoted = read(
+      `it("x", async () => { await waitFor(() => {}, { "timeout": 5000 }); });`,
+      "quoted.test.tsx",
+    )[0];
+    const computed = read(
+      `it("x", async () => { await waitFor(() => {}, { ["timeout"]: 5000 }); });`,
+      "computed.test.tsx",
+    )[0];
+    expect([quoted?.waiterBudgetMs, computed?.waiterBudgetMs]).toEqual([
+      5_000, 5_000,
+    ]);
+  });
+
   it("reports a timeout it cannot fold instead of assuming the default", () => {
     // The one that matters: an unfoldable budget quietly recorded as 1000 hid a
     // live 11000ms violation from the guard.

--- a/frontend/scripts/test-budget.test.ts
+++ b/frontend/scripts/test-budget.test.ts
@@ -5,7 +5,7 @@ import {
   MAX_DEFAULT_WAITER_BUDGET_MS,
   TEST_TIMEOUT_MS,
 } from "../vitest.budget";
-import { budgetsIn } from "./test-budget";
+import { budgetsIn, type TestBudget } from "./test-budget";
 
 // The budget that governs every other suite here, gated the only way a budget
 // can be: against the thing it has to outlast. Issue 1144 was not a slow test —
@@ -38,9 +38,11 @@ const EXEMPT = new Set([
   "src/screens/company-context.test.tsx::keeps a failed status poll to the catalog sentence",
 ]);
 
-const budgets = globSync("src/**/*.test.ts?(x)")
-  .flatMap((file) => budgetsIn(file, TEST_TIMEOUT_MS))
-  .filter((budget) => !EXEMPT.has(`${budget.file}::${budget.name}`));
+const all = globSync("src/**/*.test.ts?(x)").flatMap((file) =>
+  budgetsIn(file, TEST_TIMEOUT_MS),
+);
+const key = (budget: TestBudget) => `${budget.file}::${budget.name}`;
+const budgets = all.filter((budget) => !EXEMPT.has(key(budget)));
 
 /**
  * The tests this ceiling is FOR: the ones that state no ceiling of their own.
@@ -97,6 +99,18 @@ describe("the frontend suite's time budget", () => {
           `${budget.file}:${budget.line} states a timeout this reader cannot fold: ${budget.unresolved.join(", ")}`,
       );
     expect(unreadable).toEqual([]);
+  });
+
+  it("exempts exactly the two tests it names, and nothing else", () => {
+    // `file::name` is not a unique key in this tree — three pairs already
+    // collide elsewhere — so an exemption could come to cover a second test
+    // added under one of these names, silently. Asserting one budget each is
+    // what keeps the exemption as narrow as its reason.
+    const covered = [...EXEMPT].map(
+      (entry) =>
+        [entry, all.filter((budget) => key(budget) === entry).length] as const,
+    );
+    expect(covered).toEqual([...EXEMPT].map((entry) => [entry, 1]));
   });
 
   it("reads a tree it can actually parse", () => {

--- a/frontend/scripts/test-budget.test.ts
+++ b/frontend/scripts/test-budget.test.ts
@@ -21,7 +21,7 @@ import { budgetsIn } from "./test-budget";
 
 /**
  * The two `clickRefresh` cases in `company-context.test.tsx` spend 30s of waiter
- * budget under a 10437ms ceiling, and they are LEFT that way on purpose. That
+ * budget under this suite's ceiling, and they are LEFT that way on purpose. That
  * file carries issue 613 — a panel that does not render even with a 10s waiter,
  * which is starvation rather than this arithmetic — and giving those two a
  * ceiling that covers their waiters would turn its fast red into a slow one and

--- a/frontend/scripts/test-budget.test.ts
+++ b/frontend/scripts/test-budget.test.ts
@@ -8,52 +8,60 @@ import {
 import { budgetsIn } from "./test-budget";
 
 // The budget that governs every other suite here, gated the only way a budget
-// can be: against the thing it has to outlast. #1144 was not a slow test — it
-// was a per-test ceiling smaller than the sum of the per-waiter budgets the
+// can be: against the thing it has to outlast. Issue 1144 was not a slow test —
+// it was a per-test ceiling smaller than the sum of the per-waiter budgets the
 // test was allowed to spend, so tests failed with every waiter in them still
 // inside its own budget. Nothing in vitest compares those two numbers, which is
 // why one drifted under the other unnoticed for as long as it did.
 //
 // Read from the syntax tree rather than run: a guard that proved the ceiling by
 // actually waiting eleven seconds would cost eleven seconds every run and still
-// only prove it for the machine it ran on. This costs about a third of a second
-// and proves it for every test in the tree.
+// only prove it for the machine it ran on. This costs about half a second and
+// proves it for every test in the tree.
 
 /**
- * `company-context.test.tsx`'s two `clickRefresh` cases spend 30s of waiter
- * budget under a ceiling of 10437ms, and they are LEFT that way on purpose.
- * That file carries #613 — a panel that does not render even with a 10s waiter,
- * which is starvation rather than this arithmetic — and giving those two tests a
+ * The two `clickRefresh` cases in `company-context.test.tsx` spend 30s of waiter
+ * budget under a 10437ms ceiling, and they are LEFT that way on purpose. That
+ * file carries issue 613 — a panel that does not render even with a 10s waiter,
+ * which is starvation rather than this arithmetic — and giving those two a
  * ceiling that covers their waiters would turn its fast red into a slow one and
- * bury the defect being investigated. Named here, with the reason, rather than
- * left to look like an oversight: this is the one place the invariant below does
- * not hold, and it does not hold deliberately.
+ * bury the defect being investigated.
+ *
+ * Keyed by file AND line, not by file: exempting the whole file would cover
+ * forty tests under a reason that describes two, and would silently unguard
+ * every test added there later.
  */
-const EXEMPT = new Map([
-  [
-    "src/screens/company-context.test.tsx",
-    "#613 — starvation, deliberately left fast-red",
-  ],
+const EXEMPT = new Set([
+  "src/screens/company-context.test.tsx:416",
+  "src/screens/company-context.test.tsx:433",
 ]);
 
 const budgets = globSync("src/**/*.test.ts?(x)")
   .flatMap((file) => budgetsIn(file, TEST_TIMEOUT_MS))
-  .filter((budget) => !EXEMPT.has(budget.file));
+  .filter((budget) => !EXEMPT.has(`${budget.file}:${budget.line}`));
+
+/**
+ * The tests this ceiling is FOR: the ones that state no ceiling of their own.
+ * Defined by that rather than by `ceilingMs === TEST_TIMEOUT_MS`, which would
+ * make the set's membership depend on the constant measured over it — re-derive
+ * the constant and a test whose stated ceiling happens to equal the new value
+ * joins the population, moving the measurement again.
+ */
+const defaultPopulation = budgets.filter((budget) => !budget.ceilingIsStated);
 
 describe("the frontend suite's time budget", () => {
   it("is the ceiling vitest actually applies", () => {
     // Everything below reasons about TEST_TIMEOUT_MS. If the config stops
     // reading it, all of it becomes true about a number nothing uses — and
-    // #1144 is back with this suite still green.
+    // issue 1144 is back with this suite still green.
     expect(viteConfig.test?.testTimeout).toBe(TEST_TIMEOUT_MS);
   });
 
   it("covers every waiter budget the tests under it compose", () => {
     // The invariant, per test rather than in aggregate: a test may spend the
     // sum of its waiters' budgets without any one of them failing, so its own
-    // ceiling has to be at least that. A test that needs longer raises its
-    // own — vitest takes it as the third argument to `it` — and several here
-    // already do.
+    // ceiling has to be at least that. A test that needs longer states its own
+    // — vitest takes it as an argument to `it` — and several here do.
     const over = budgets
       .filter((budget) => budget.waiterBudgetMs > budget.ceilingMs)
       .map(
@@ -65,21 +73,36 @@ describe("the frontend suite's time budget", () => {
 
   it("is derived from the widest budget it has to cover, not chosen", () => {
     // The ceiling is only honest if MAX_DEFAULT_WAITER_BUDGET_MS is still the
-    // real maximum. Re-measured here from the same trees, so a suite that
-    // grows a longer chain moves the measurement instead of silently sitting
-    // closer to the edge.
-    const widest = budgets
-      .filter((budget) => budget.ceilingMs === TEST_TIMEOUT_MS)
-      .reduce((max, budget) => Math.max(max, budget.waiterBudgetMs), 0);
+    // real maximum. Re-measured here from the same trees, so a suite that grows
+    // a longer chain moves the measurement instead of silently sitting closer
+    // to the edge.
+    const widest = defaultPopulation.reduce(
+      (max, budget) => Math.max(max, budget.waiterBudgetMs),
+      0,
+    );
     expect(widest).toBe(MAX_DEFAULT_WAITER_BUDGET_MS);
   });
 
+  it("could read every budget it was asked to judge", () => {
+    // A timeout this reader cannot fold is the one that matters: the budget it
+    // hides is the budget nobody checked. An earlier version quietly recorded
+    // an unfoldable `{ timeout: … }` as the smallest possible value and walked
+    // past a live 11000ms violation.
+    const unreadable = budgets
+      .filter((budget) => budget.unresolved.length > 0)
+      .map(
+        (budget) =>
+          `${budget.file}:${budget.line} states a timeout this reader cannot fold: ${budget.unresolved.join(", ")}`,
+      );
+    expect(unreadable).toEqual([]);
+  });
+
   it("reads a tree it can actually parse", () => {
-    // Every assertion above is an absence-assertion over `budgets`, and an
-    // absence-assertion passes for free over an empty list — a glob that
-    // stopped matching, or a parser that returned nothing, would look exactly
-    // like a clean tree.
+    // Three of the assertions above are absence-assertions, and an absence
+    // holds for free over an empty list — a glob that stopped matching, or a
+    // reader that returned nothing, would look exactly like a clean tree.
     expect(budgets.length).toBeGreaterThan(2_000);
+    expect(defaultPopulation.length).toBeGreaterThan(2_000);
     expect(budgets.some((budget) => budget.waiterBudgetMs > 0)).toBe(true);
   });
 });

--- a/frontend/scripts/test-budget.test.ts
+++ b/frontend/scripts/test-budget.test.ts
@@ -27,18 +27,20 @@ import { budgetsIn } from "./test-budget";
  * ceiling that covers their waiters would turn its fast red into a slow one and
  * bury the defect being investigated.
  *
- * Keyed by file AND line, not by file: exempting the whole file would cover
+ * Keyed by file and test NAME, not by file and not by line. By file would cover
  * forty tests under a reason that describes two, and would silently unguard
- * every test added there later.
+ * every test added there later; by line would shift the moment anything is
+ * inserted above them — in the one file most likely to be edited, since it is
+ * the one still under investigation.
  */
 const EXEMPT = new Set([
-  "src/screens/company-context.test.tsx:416",
-  "src/screens/company-context.test.tsx:433",
+  "src/screens/company-context.test.tsx::quotes the server when the start itself was refused",
+  "src/screens/company-context.test.tsx::keeps a failed status poll to the catalog sentence",
 ]);
 
 const budgets = globSync("src/**/*.test.ts?(x)")
   .flatMap((file) => budgetsIn(file, TEST_TIMEOUT_MS))
-  .filter((budget) => !EXEMPT.has(`${budget.file}:${budget.line}`));
+  .filter((budget) => !EXEMPT.has(`${budget.file}::${budget.name}`));
 
 /**
  * The tests this ceiling is FOR: the ones that state no ceiling of their own.

--- a/frontend/scripts/test-budget.ts
+++ b/frontend/scripts/test-budget.ts
@@ -1,23 +1,33 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import ts from "typescript";
 import { ASYNC_UTIL_TIMEOUT_MS } from "../vitest.budget";
 
 // Reads a test file and works out, for every test in it, how long that test is
 // ALLOWED to spend waiting — the sum of the budgets of the waiters it runs in
-// sequence — and how long it is allowed to take. #1144 is what happens when the
-// first number exceeds the second: the test fails while every waiter in it is
-// still inside its own budget, and the failure names the test rather than the
-// waiter that was slow.
+// sequence — and how long it is allowed to take. Issue 1144 is what happens
+// when the first number exceeds the second: the test fails while every waiter
+// in it is still inside its own budget, and the failure names the test rather
+// than the waiter that was slow.
 //
 // Parsed with the TypeScript compiler rather than matched with a regex. A
 // hand-rolled scanner over this tree over-counted a 688-line file as one test
-// with 39 waiters, and a guard that reports a number nobody believes is worse
-// than no guard: it would demand a ceiling ten times larger than anything real.
+// with 39 waiters, and a guard reporting a number nobody believes is worse than
+// no guard: it would demand a ceiling ten times anything real.
+//
+// EVERY UNCERTAINTY IS REPORTED, NEVER ASSUMED AWAY. A waiter whose timeout
+// this cannot fold, or a test shape it does not recognise, is the one case that
+// matters — the budget it hides is exactly the budget nobody checked. An
+// earlier version defaulted an unfoldable `{ timeout: … }` to the smallest
+// possible value and walked straight past a live 11000ms violation.
 
-/** A waiter whose budget is not stated takes Testing Library's default. */
+/** A waiter that states no timeout takes Testing Library's default. */
 const DEFAULT_WAITER_MS = ASYNC_UTIL_TIMEOUT_MS;
 
 const WAITER = /^(findBy|findAllBy|waitFor|waitForElementToBeRemoved)/;
+
+/** `it`, and the forms that wrap it: `it.each(cases)(…)`, `it.only`, `it.for`. */
+const TEST_CALLEE = /^(it|test)$/;
 
 export type TestBudget = {
   file: string;
@@ -27,6 +37,10 @@ export type TestBudget = {
   waiterBudgetMs: number;
   /** The per-test ceiling this test actually runs under, in ms. */
   ceilingMs: number;
+  /** Whether that ceiling is the test's own, rather than the suite default. */
+  ceilingIsStated: boolean;
+  /** Timeouts this reader could not fold, each as written. Must be empty. */
+  unresolved: string[];
 };
 
 /** `X * 4` and `X + 3000`, the two ways a budget here is built from another. */
@@ -43,15 +57,29 @@ function arithmetic(
   return undefined;
 }
 
-/** `const X = 5000` and `const Y = X * 4` anywhere, so a named budget resolves. */
-function numericConsts(source: ts.SourceFile): Map<string, number> {
-  const known = new Map<string, number>();
+/**
+ * A resolver for numbers written in this file: a literal, a name it gave a
+ * number to, or arithmetic over those. A name imported from elsewhere does not
+ * resolve, and that is reported rather than guessed at.
+ */
+function resolver(consts: Map<string, number>) {
   const value = (node: ts.Expression): number | undefined => {
     if (ts.isNumericLiteral(node)) return Number(node.text);
-    if (ts.isIdentifier(node)) return known.get(node.text);
+    if (ts.isIdentifier(node)) return consts.get(node.text);
+    if (ts.isParenthesizedExpression(node)) return value(node.expression);
     if (ts.isBinaryExpression(node)) return arithmetic(node, value);
     return undefined;
   };
+  return value;
+}
+
+/** `const X = 5000` and `const Y = X * 4` anywhere in one file. */
+function declaredConsts(
+  source: ts.SourceFile,
+  seeded: Map<string, number>,
+): Map<string, number> {
+  const known = new Map(seeded);
+  const value = resolver(known);
   const visit = (node: ts.Node): void => {
     if (
       ts.isVariableDeclaration(node) &&
@@ -67,86 +95,191 @@ function numericConsts(source: ts.SourceFile): Map<string, number> {
   return known;
 }
 
-/** A number written as a literal, or as a name this file gave a number to. */
-function asNumber(
-  node: ts.Expression,
-  consts: Map<string, number>,
-): number | undefined {
-  if (ts.isNumericLiteral(node)) return Number(node.text);
-  if (ts.isIdentifier(node)) return consts.get(node.text);
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+}
+
+/** `./use-company-read` next to the importer, with the extension it actually has. */
+function resolveModule(
+  fromFile: string,
+  specifier: string,
+): string | undefined {
+  if (!specifier.startsWith(".")) return undefined;
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}/index.ts`,
+    `${base}/index.tsx`,
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
   return undefined;
 }
 
-/** `timeout:` in one options object, when it resolves to a number. */
-function timeoutProperty(
+/** The numeric constants ONE named import brings in, added to `into`. */
+function takeImport(
+  statement: ts.ImportDeclaration,
+  file: string,
+  into: Map<string, number>,
+): void {
+  if (!ts.isStringLiteral(statement.moduleSpecifier)) return;
+  const bindings = statement.importClause?.namedBindings;
+  if (!bindings || !ts.isNamedImports(bindings)) return;
+  const target = resolveModule(file, statement.moduleSpecifier.text);
+  if (!target) return;
+  const theirs = declaredConsts(parse(target), new Map());
+  for (const element of bindings.elements) {
+    const value = theirs.get((element.propertyName ?? element.name).text);
+    if (value !== undefined) into.set(element.name.text, value);
+  }
+}
+
+/**
+ * A test's numeric constants, including the ones it imports from a sibling
+ * module — `{ timeout: READ_POLL_MS * EXPECTED_READS * 5 }` is a real waiter
+ * budget in this tree and READ_POLL_MS lives in the hook it drives. One hop
+ * only: a budget written two modules away is reported unresolved rather than
+ * chased, and reported is the safe end of that trade.
+ */
+function numericConsts(
+  source: ts.SourceFile,
+  file: string,
+): Map<string, number> {
+  const imported = new Map<string, number>();
+  for (const statement of source.statements) {
+    if (ts.isImportDeclaration(statement))
+      takeImport(statement, file, imported);
+  }
+  return declaredConsts(source, imported);
+}
+
+/** The `timeout:` property of one options object, if it has one. */
+function timeoutExpression(
   options: ts.ObjectLiteralExpression,
-  consts: Map<string, number>,
-): number | undefined {
+): ts.Expression | undefined {
   for (const property of options.properties) {
     if (!ts.isPropertyAssignment(property)) continue;
     if (property.name.getText() !== "timeout") continue;
-    return asNumber(property.initializer, consts);
+    return property.initializer;
   }
   return undefined;
 }
 
-/** `{ timeout: SETTLE_MS }` in a waiter's options, wherever it sits. */
-function statedTimeout(
+/** The `timeout:` a call states, wherever among its options objects it sits. */
+function statedTimeout(call: ts.CallExpression): ts.Expression | undefined {
+  return optionArguments(call)
+    .map(timeoutExpression)
+    .find((expression) => expression !== undefined);
+}
+
+/** Every options object among a call's arguments, in order. */
+function optionArguments(
   call: ts.CallExpression,
-  consts: Map<string, number>,
-): number | undefined {
-  for (const argument of call.arguments) {
-    if (!ts.isObjectLiteralExpression(argument)) continue;
-    const stated = timeoutProperty(argument, consts);
-    if (stated !== undefined) return stated;
-  }
-  return undefined;
+): ts.ObjectLiteralExpression[] {
+  return call.arguments.filter(
+    (argument): argument is ts.ObjectLiteralExpression =>
+      ts.isObjectLiteralExpression(argument),
+  );
 }
 
-function calleeName(call: ts.CallExpression): string {
+/**
+ * The root name a call is made through: `it` for `it`, `it.only`, `it.each(…)`
+ * and `it.each(…)(…)` alike. Walking to the root is what keeps the table-driven
+ * and focused forms visible — matching only the immediate callee dropped 17
+ * call sites in this tree, silently, which is the shape of hole this reader
+ * exists to close.
+ */
+function rootCallee(node: ts.Node): string {
+  let current: ts.Node = node;
+  for (;;) {
+    if (ts.isCallExpression(current)) current = current.expression;
+    else if (ts.isPropertyAccessExpression(current))
+      current = current.expression;
+    else if (ts.isTaggedTemplateExpression(current)) current = current.tag;
+    else break;
+  }
+  return ts.isIdentifier(current) ? current.text : "";
+}
+
+/** The immediate name a call uses, for spotting a waiter or a helper. */
+function directCallee(call: ts.CallExpression): string {
   const expression = call.expression;
   if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
   if (ts.isIdentifier(expression)) return expression.text;
   return "";
 }
 
+type Reading = { ms: number; unresolved: string[] };
+
 /**
- * The waiter budget of one node, following awaited calls into module-level
- * helpers: `renderAs()` runs waiters of its own, and a test that awaits it
- * spends them. A helper that is not module-level, or that this cannot resolve,
- * contributes nothing — the count is then an UNDER-estimate, which is the
- * direction that lets a real violation through rather than inventing one.
+ * The waiter budget of one node, following awaited calls into the helpers that
+ * do the waiting — a suite's render helper is usually where they live, and a
+ * reader that stops at the test body cannot see them.
+ *
+ * `path` guards against recursion only, and is unwound on the way out: a helper
+ * awaited four times costs four times, which is the whole point. Costs are
+ * memoized per helper so that repetition is cheap rather than quadratic.
  */
 function budgetOf(
   node: ts.Node,
   consts: Map<string, number>,
   helpers: Map<string, ts.Node>,
-  seen: Set<string>,
-): number {
-  let total = 0;
+  path: Set<string>,
+  memo: Map<string, Reading>,
+): Reading {
+  const value = resolver(consts);
+  let ms = 0;
+  const unresolved: string[] = [];
+
+  const helperCost = (name: string): Reading => {
+    const cached = memo.get(name);
+    if (cached) return cached;
+    if (path.has(name)) return { ms: 0, unresolved: [] };
+    const body = helpers.get(name);
+    if (!body) return { ms: 0, unresolved: [] };
+    path.add(name);
+    const reading = budgetOf(body, consts, helpers, path, memo);
+    path.delete(name);
+    memo.set(name, reading);
+    return reading;
+  };
+
+  const takeWaiter = (call: ts.CallExpression): void => {
+    const stated = statedTimeout(call);
+    if (!stated) {
+      ms += DEFAULT_WAITER_MS;
+      return;
+    }
+    const folded = value(stated);
+    if (folded === undefined) unresolved.push(stated.getText());
+    else ms += folded;
+  };
+
   const visit = (current: ts.Node): void => {
     if (ts.isCallExpression(current)) {
-      const name = calleeName(current);
-      if (WAITER.test(name)) {
-        total += statedTimeout(current, consts) ?? DEFAULT_WAITER_MS;
-      } else if (helpers.has(name) && !seen.has(name)) {
-        seen.add(name);
-        const body = helpers.get(name);
-        if (body) total += budgetOf(body, consts, helpers, seen);
+      const name = directCallee(current);
+      if (WAITER.test(name)) takeWaiter(current);
+      else if (helpers.has(name)) {
+        const reading = helperCost(name);
+        ms += reading.ms;
+        unresolved.push(...reading.unresolved);
       }
     }
     ts.forEachChild(current, visit);
   };
-  ts.forEachChild(node, visit);
-  return total;
+  // The node itself, not only its children: a one-line arrow helper's body IS
+  // the waiter call, and descending past it counts nothing.
+  visit(node);
+  return { ms, unresolved };
 }
 
-/**
- * Named `function f() {}` and `const f = () => {}` bodies, by name, from
- * ANYWHERE in the file — a suite's render helper usually sits inside its own
- * `describe`, and one collected only from the top level misses exactly the
- * helpers that do the waiting.
- */
+/** Named `function f() {}` and `const f = () => {}` bodies, by name, anywhere. */
 function namedHelpers(source: ts.SourceFile): Map<string, ts.Node> {
   const helpers = new Map<string, ts.Node>();
   const visit = (node: ts.Node): void => {
@@ -168,49 +301,61 @@ function namedHelpers(source: ts.SourceFile): Map<string, ts.Node> {
   return helpers;
 }
 
-/** The per-test ceiling: vitest takes it as the third argument to `it`. */
-function statedCeiling(
-  call: ts.CallExpression,
-  consts: Map<string, number>,
-): number | undefined {
-  const third = call.arguments[2];
-  if (!third) return undefined;
-  if (ts.isObjectLiteralExpression(third))
-    return timeoutProperty(third, consts);
-  return asNumber(third, consts);
-}
-
 export function budgetsIn(file: string, globalCeilingMs: number): TestBudget[] {
-  const source = ts.createSourceFile(
-    file,
-    readFileSync(file, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-  );
-  const consts = numericConsts(source);
+  const source = parse(file);
+  const consts = numericConsts(source, file);
+  const value = resolver(consts);
   const helpers = namedHelpers(source);
   const found: TestBudget[] = [];
 
   const record = (call: ts.CallExpression): void => {
+    // vitest takes the callback anywhere after the name, and the ceiling either
+    // as a bare number or as `{ timeout }` — `it(name, fn, 500)` and
+    // `it(name, { timeout: 500 }, fn)` are both supported, so neither position
+    // may be assumed.
+    const body = call.arguments.find(
+      (argument) =>
+        ts.isArrowFunction(argument) || ts.isFunctionExpression(argument),
+    );
+    if (!body) return;
+
+    const unresolved: string[] = [];
+    let ceilingMs = globalCeilingMs;
+    let ceilingIsStated = false;
+    const stated =
+      call.arguments.find(
+        (argument) =>
+          ts.isNumericLiteral(argument) || ts.isIdentifier(argument),
+      ) ??
+      optionArguments(call)
+        .map(timeoutExpression)
+        .find((expression) => expression !== undefined);
+    if (stated) {
+      const folded = value(stated);
+      if (folded === undefined) unresolved.push(stated.getText());
+      else {
+        ceilingMs = folded;
+        ceilingIsStated = true;
+      }
+    }
+
     const title = call.arguments[0];
-    const body = call.arguments[1];
-    if (!body || !(ts.isArrowFunction(body) || ts.isFunctionExpression(body)))
-      return;
+    const reading = budgetOf(body, consts, helpers, new Set(), new Map());
     found.push({
       file,
       line:
         source.getLineAndCharacterOfPosition(call.getStart(source)).line + 1,
       name: title && ts.isStringLiteralLike(title) ? title.text : "<computed>",
-      waiterBudgetMs: budgetOf(body, consts, helpers, new Set()),
-      ceilingMs: statedCeiling(call, consts) ?? globalCeilingMs,
+      waiterBudgetMs: reading.ms,
+      ceilingMs,
+      ceilingIsStated,
+      unresolved: [...unresolved, ...reading.unresolved],
     });
   };
 
   const visit = (node: ts.Node): void => {
-    if (ts.isCallExpression(node) && node.arguments.length >= 2) {
-      const name = calleeName(node);
-      if (name === "it" || name === "test") record(node);
-    }
+    if (ts.isCallExpression(node) && TEST_CALLEE.test(rootCallee(node)))
+      record(node);
     ts.forEachChild(node, visit);
   };
   visit(source);

--- a/frontend/scripts/test-budget.ts
+++ b/frontend/scripts/test-budget.ts
@@ -34,8 +34,13 @@ const TEST_CALLEE = /^(it|test)$/;
  * nothing, so letting one into the population lets a test that cannot fail set
  * the ceiling for the thousands that do — or redden the guard while naming a
  * test nobody executes.
+ *
+ * `runIf` and `skipIf` are NOT here: they run depending on a condition, so a
+ * test written either way really executes and really owes a budget. Treating
+ * them as skipped left a live test under no guard at all, which is the more
+ * expensive mistake of the two.
  */
-const NOT_RUN = /^(skip|todo|skipIf|runIf)$/;
+const NOT_RUN = /^(skip|todo)$/;
 
 /** Whether any link in the call chain says "do not run this". */
 function isSkipped(node: ts.Node): boolean {
@@ -125,6 +130,32 @@ function parse(file: string): ts.SourceFile {
   );
 }
 
+/**
+ * The numbers a module EXPORTS at its top level. Not `declaredConsts`, which
+ * walks a whole file flat and lets the last declaration of a name win: a
+ * function-local `const POLL_MS = 1` in the imported module then overwrote the
+ * exported `POLL_MS = 5000`, and a 10000ms budget folded to 2ms with nothing
+ * reported.
+ */
+function exportedConsts(source: ts.SourceFile): Map<string, number> {
+  const known = new Map<string, number>();
+  const value = resolver(known);
+  for (const statement of source.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    const exported = statement.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!exported) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer)
+        continue;
+      const resolved = value(declaration.initializer);
+      if (resolved !== undefined) known.set(declaration.name.text, resolved);
+    }
+  }
+  return known;
+}
+
 /** `./use-company-read` next to the importer, with the extension it actually has. */
 function resolveModule(
   fromFile: string,
@@ -154,7 +185,7 @@ function takeImport(
   if (!bindings || !ts.isNamedImports(bindings)) return;
   const target = resolveModule(file, statement.moduleSpecifier.text);
   if (!target) return;
-  const theirs = declaredConsts(parse(target), new Map());
+  const theirs = exportedConsts(parse(target));
   for (const element of bindings.elements) {
     const value = theirs.get((element.propertyName ?? element.name).text);
     if (value !== undefined) into.set(element.name.text, value);
@@ -213,7 +244,7 @@ function statedTimeout(
 ): ts.Expression | typeof OPAQUE | undefined {
   let found: ts.Expression | typeof OPAQUE | undefined;
   for (const argument of call.arguments.slice(1)) {
-    if (!looksLikeOptions(argument)) continue;
+    if (cannotCarryOptions(argument)) continue;
     if (!ts.isObjectLiteralExpression(argument)) return OPAQUE;
     const stated = timeoutExpression(argument);
     if (stated === OPAQUE) return OPAQUE;
@@ -231,15 +262,34 @@ function statedTimeout(
 const OPAQUE = Symbol("an options argument this reader cannot read");
 
 /**
- * Whether an argument could be carrying options. A bare `undefined` or `null`
- * is not: it is the placeholder that skips a positional argument, as in
- * `findByText(matcher, undefined, { timeout })`, and reading it as an options
- * object nobody can see turns a perfectly readable waiter into a reported one.
+ * Shapes that definitively CANNOT be an options object carrying a timeout — a
+ * matcher, a placeholder, a callback. Everything else is treated as possibly
+ * carrying one, because the default has to be "unreadable", not "absent".
+ *
+ * That direction is the whole lesson of this file. A whitelist of shapes the
+ * reader understands sends every other shape down the same path as "states no
+ * timeout", and that path ends at the 1000ms default — the smallest number,
+ * which is the one that keeps the gate green. Property access, a call, a
+ * ternary, an `as` cast and a `!` assertion all reached it that way.
  */
-function looksLikeOptions(argument: ts.Expression): boolean {
-  if (ts.isIdentifier(argument)) return argument.text !== "undefined";
-  if (argument.kind === ts.SyntaxKind.NullKeyword) return false;
-  return ts.isObjectLiteralExpression(argument) || ts.isSpreadElement(argument);
+function cannotCarryOptions(argument: ts.Expression): boolean {
+  if (ts.isIdentifier(argument)) return argument.text === "undefined";
+  switch (argument.kind) {
+    case ts.SyntaxKind.NullKeyword:
+    case ts.SyntaxKind.TrueKeyword:
+    case ts.SyntaxKind.FalseKeyword:
+      return true;
+    default:
+      break;
+  }
+  return (
+    ts.isStringLiteralLike(argument) ||
+    ts.isNumericLiteral(argument) ||
+    ts.isRegularExpressionLiteral(argument) ||
+    ts.isArrayLiteralExpression(argument) ||
+    ts.isArrowFunction(argument) ||
+    ts.isFunctionExpression(argument)
+  );
 }
 
 /**
@@ -271,9 +321,33 @@ function directCallee(call: ts.CallExpression): string {
 
 type Reading = { ms: number; unresolved: string[] };
 
-/** Whether this node is the DEFINITION of a helper, rather than a call to one. */
-function declaresHelper(node: ts.Node, helpers: Map<string, ts.Node>): boolean {
-  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+/**
+ * The helpers one file declares, EVERY declaration of each name. Two suites in
+ * one file commonly declare their own `mount` or `settle`, and this reader has
+ * no scope information to tell a call which one it meant. Keeping only the last
+ * silently reported suite A's 8000ms helper as suite B's 2000ms one.
+ *
+ * Holding all of them lets the disagreement decide: when every declaration of a
+ * name costs the same, which is the ordinary case, the answer is that cost
+ * whichever one was meant. Only when they differ is the call genuinely
+ * unreadable, and only then is it reported.
+ */
+type Helpers = Map<string, ts.Node[]>;
+
+/**
+ * Whether this node is the DEFINITION of a helper, rather than a call to one.
+ * The initializer has to BE a function: a local variable that merely shares a
+ * module-level helper's name — `const renderAs = await screen.findByText(…)` —
+ * is not a definition, and skipping it dropped its waiter entirely.
+ */
+function declaresHelper(node: ts.Node, helpers: Helpers): boolean {
+  if (
+    ts.isVariableDeclaration(node) &&
+    ts.isIdentifier(node.name) &&
+    node.initializer &&
+    (ts.isArrowFunction(node.initializer) ||
+      ts.isFunctionExpression(node.initializer))
+  ) {
     return helpers.has(node.name.text);
   }
   if (ts.isFunctionDeclaration(node) && node.name) {
@@ -294,7 +368,7 @@ function declaresHelper(node: ts.Node, helpers: Map<string, ts.Node>): boolean {
 function budgetOf(
   node: ts.Node,
   consts: Map<string, number>,
-  helpers: Map<string, ts.Node>,
+  helpers: Helpers,
   path: Set<string>,
   memo: Map<string, Reading>,
 ): Reading {
@@ -310,12 +384,27 @@ function budgetOf(
     // cached: memoizing it would hand a later direct call the under-count, so
     // the total would depend on the order the helpers were first reached.
     if (path.has(name)) return { ms: 0, unresolved: [] };
-    const body = helpers.get(name);
-    if (!body) return { ms: 0, unresolved: [] };
+    const bodies = helpers.get(name);
+    if (!bodies || bodies.length === 0) return { ms: 0, unresolved: [] };
     const outermost = path.size === 0;
     path.add(name);
-    const reading = budgetOf(body, consts, helpers, path, memo);
+    const readings = bodies.map((body) =>
+      budgetOf(body, consts, helpers, path, memo),
+    );
     path.delete(name);
+    const costs = new Set(readings.map((reading) => reading.ms));
+    const reading: Reading =
+      costs.size === 1
+        ? {
+            ms: readings[0]?.ms ?? 0,
+            unresolved: readings.flatMap((one) => one.unresolved),
+          }
+        : {
+            ms: 0,
+            unresolved: [
+              `${name}() is declared ${bodies.length} times in this file with different waiter budgets (${[...costs].sort((a, b) => a - b).join("ms, ")}ms)`,
+            ],
+          };
     if (outermost) memo.set(name, reading);
     return reading;
   };
@@ -372,10 +461,16 @@ function statedCeiling(
   call: ts.CallExpression,
   body: ts.Expression,
 ): ts.Expression | typeof OPAQUE | undefined {
+  // Any expression after the callback, not only a literal or a name: a ceiling
+  // written as `SETTLE_MS * 4` was neither folded NOR reported, so the test
+  // silently rejoined the population it had opted out of.
   const positional = call.arguments
     .slice(call.arguments.indexOf(body) + 1)
     .find(
-      (argument) => ts.isNumericLiteral(argument) || ts.isIdentifier(argument),
+      (argument) =>
+        !ts.isObjectLiteralExpression(argument) &&
+        !ts.isArrowFunction(argument) &&
+        !ts.isFunctionExpression(argument),
     );
   if (positional) return positional;
   return call.arguments
@@ -385,11 +480,16 @@ function statedCeiling(
 }
 
 /** Named `function f() {}` and `const f = () => {}` bodies, by name, anywhere. */
-function namedHelpers(source: ts.SourceFile): Map<string, ts.Node> {
-  const helpers = new Map<string, ts.Node>();
+function namedHelpers(source: ts.SourceFile): Helpers {
+  const byName: Helpers = new Map();
+  const remember = (name: string, body: ts.Node): void => {
+    const bodies = byName.get(name);
+    if (bodies) bodies.push(body);
+    else byName.set(name, [body]);
+  };
   const visit = (node: ts.Node): void => {
     if (ts.isFunctionDeclaration(node) && node.name && node.body) {
-      helpers.set(node.name.text, node.body);
+      remember(node.name.text, node.body);
     } else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
       const initializer = node.initializer;
       if (
@@ -397,13 +497,13 @@ function namedHelpers(source: ts.SourceFile): Map<string, ts.Node> {
         (ts.isArrowFunction(initializer) ||
           ts.isFunctionExpression(initializer))
       ) {
-        helpers.set(node.name.text, initializer.body);
+        remember(node.name.text, initializer.body);
       }
     }
     ts.forEachChild(node, visit);
   };
   visit(source);
-  return helpers;
+  return byName;
 }
 
 export function budgetsIn(file: string, globalCeilingMs: number): TestBudget[] {
@@ -456,15 +556,20 @@ export function budgetsIn(file: string, globalCeilingMs: number): TestBudget[] {
     });
   };
 
-  const visit = (node: ts.Node): void => {
-    if (
-      ts.isCallExpression(node) &&
-      TEST_CALLEE.test(rootCallee(node)) &&
-      !isSkipped(node)
-    )
-      record(node);
-    ts.forEachChild(node, visit);
+  // `skipped` is carried DOWN the tree: `describe.skip` suppresses every test
+  // inside it, and a reader that only inspected the `it` chain reddened the
+  // guard naming a test vitest never runs — the same failure isSkipped was
+  // added to prevent, one level up.
+  const visit = (node: ts.Node, skipped: boolean): void => {
+    let inherited = skipped;
+    if (ts.isCallExpression(node)) {
+      const root = rootCallee(node);
+      const here = skipped || isSkipped(node);
+      if (root === "describe") inherited = here;
+      else if (TEST_CALLEE.test(root) && !here) record(node);
+    }
+    ts.forEachChild(node, (child) => visit(child, inherited));
   };
-  visit(source);
+  visit(source, false);
   return found;
 }

--- a/frontend/scripts/test-budget.ts
+++ b/frontend/scripts/test-budget.ts
@@ -104,21 +104,40 @@ function declaredConsts(
   source: ts.SourceFile,
   seeded: Map<string, number>,
 ): Map<string, number> {
-  const known = new Map(seeded);
-  const value = resolver(known);
+  // Every value each name is ever given, not the last one. This reader has no
+  // scope information, so two `describe` blocks that each declare their own
+  // `SETTLE_MS`, or a module-level one shadowed by a function-local, were
+  // collapsed to whichever came last in source order — the same last-wins
+  // defect `exportedConsts` fixes across a module boundary, one hop closer.
+  // A name given two different values resolves to nothing, and a waiter that
+  // needed it is reported rather than folded to the wrong number.
+  const seen = new Map<string, Set<number>>();
+  for (const [name, resolved] of seeded) seen.set(name, new Set([resolved]));
+  const single = (): Map<string, number> => {
+    const settled = new Map<string, number>();
+    for (const [name, values] of seen) {
+      const only = values.size === 1 ? [...values][0] : undefined;
+      if (only !== undefined) settled.set(name, only);
+    }
+    return settled;
+  };
   const visit = (node: ts.Node): void => {
     if (
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
       node.initializer
     ) {
-      const resolved = value(node.initializer);
-      if (resolved !== undefined) known.set(node.name.text, resolved);
+      const resolved = resolver(single())(node.initializer);
+      if (resolved !== undefined) {
+        const values = seen.get(node.name.text);
+        if (values) values.add(resolved);
+        else seen.set(node.name.text, new Set([resolved]));
+      }
     }
     ts.forEachChild(node, visit);
   };
   visit(source);
-  return known;
+  return single();
 }
 
 function parse(file: string): ts.SourceFile {
@@ -212,6 +231,25 @@ function numericConsts(
 }
 
 /**
+ * Whether a property key names the timeout, however it is written. Comparing
+ * source text read `{ "timeout": 5000 }` and `{ ["timeout"]: 5000 }` as "states
+ * no timeout", which is the silent-default path this file exists to close — and
+ * it would have rested on a lint rule the reader knows nothing about.
+ */
+function isTimeoutKey(name: ts.PropertyName): boolean {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) {
+    return name.text === "timeout";
+  }
+  if (
+    ts.isComputedPropertyName(name) &&
+    ts.isStringLiteralLike(name.expression)
+  ) {
+    return name.expression.text === "timeout";
+  }
+  return false;
+}
+
+/**
  * The `timeout:` of one options object — `{ timeout: 4000 }` and the shorthand
  * `{ timeout }` alike, since the shorthand is the idiomatic spelling once the
  * value has a name. A spread carries properties this reader cannot see, so the
@@ -227,7 +265,7 @@ function timeoutExpression(
       continue;
     }
     if (!ts.isPropertyAssignment(property)) continue;
-    if (property.name.getText() !== "timeout") continue;
+    if (!isTimeoutKey(property.name)) continue;
     return property.initializer;
   }
   return undefined;
@@ -311,7 +349,14 @@ function rootCallee(node: ts.Node): string {
   return ts.isIdentifier(current) ? current.text : "";
 }
 
-/** The immediate name a call uses, for spotting a waiter or a helper. */
+/**
+ * The immediate name a call uses. Good enough to spot a waiter, which is always
+ * reached through an object (`screen.findByText`) or bare (`waitFor`) — but a
+ * HELPER is only ever called by its bare name, so the caller checks that too.
+ * Without it `userEvent.clear(input)` was charged the whole budget of a
+ * file-declared `clear` helper, and phantom budget inflates the very
+ * measurement that sets the suite's ceiling.
+ */
 function directCallee(call: ts.CallExpression): string {
   const expression = call.expression;
   if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
@@ -381,8 +426,16 @@ function budgetOf(
     if (cached) return cached;
     // Recursion guard. A helper reached while it is already being computed
     // contributes nothing to THIS reading, and that truncated answer is not
-    // cached: memoizing it would hand a later direct call the under-count, so
-    // the total would depend on the order the helpers were first reached.
+    // cached, which keeps a later DIRECT call from inheriting the under-count.
+    //
+    // It does not make mutual recursion order-independent, and saying so would
+    // be claiming more than the code does: with `a()` calling `b()` and `b()`
+    // calling `a()`, the outermost reading memoized still embeds a truncated
+    // inner one, so `await b(); await a()` and `await a(); await b()` differ.
+    // Both under-count, which is the direction that lets a violation through
+    // rather than inventing one. Mutually recursive helpers do not occur in
+    // this tree; if they arrive, the honest fix is to key the memo on the
+    // path rather than on the name.
     if (path.has(name)) return { ms: 0, unresolved: [] };
     const bodies = helpers.get(name);
     if (!bodies || bodies.length === 0) return { ms: 0, unresolved: [] };
@@ -440,7 +493,8 @@ function budgetOf(
     if (ts.isCallExpression(current)) {
       const name = directCallee(current);
       if (WAITER.test(name)) takeWaiter(current);
-      else if (helpers.has(name)) takeHelper(name);
+      else if (ts.isIdentifier(current.expression) && helpers.has(name))
+        takeHelper(name);
     }
     ts.forEachChild(current, visit);
   };

--- a/frontend/scripts/test-budget.ts
+++ b/frontend/scripts/test-budget.ts
@@ -29,6 +29,27 @@ const WAITER = /^(findBy|findAllBy|waitFor|waitForElementToBeRemoved)/;
 /** `it`, and the forms that wrap it: `it.each(cases)(…)`, `it.only`, `it.for`. */
 const TEST_CALLEE = /^(it|test)$/;
 
+/**
+ * The modifiers that mean vitest never runs the callback. A skipped body spends
+ * nothing, so letting one into the population lets a test that cannot fail set
+ * the ceiling for the thousands that do — or redden the guard while naming a
+ * test nobody executes.
+ */
+const NOT_RUN = /^(skip|todo|skipIf|runIf)$/;
+
+/** Whether any link in the call chain says "do not run this". */
+function isSkipped(node: ts.Node): boolean {
+  let current: ts.Node = node;
+  for (;;) {
+    if (ts.isCallExpression(current)) current = current.expression;
+    else if (ts.isTaggedTemplateExpression(current)) current = current.tag;
+    else if (ts.isPropertyAccessExpression(current)) {
+      if (NOT_RUN.test(current.name.text)) return true;
+      current = current.expression;
+    } else return false;
+  }
+}
+
 export type TestBudget = {
   file: string;
   line: number;
@@ -159,11 +180,21 @@ function numericConsts(
   return declaredConsts(source, imported);
 }
 
-/** The `timeout:` property of one options object, if it has one. */
+/**
+ * The `timeout:` of one options object — `{ timeout: 4000 }` and the shorthand
+ * `{ timeout }` alike, since the shorthand is the idiomatic spelling once the
+ * value has a name. A spread carries properties this reader cannot see, so the
+ * whole object is reported unreadable rather than searched and found wanting.
+ */
 function timeoutExpression(
   options: ts.ObjectLiteralExpression,
-): ts.Expression | undefined {
+): ts.Expression | typeof OPAQUE | undefined {
   for (const property of options.properties) {
+    if (ts.isSpreadAssignment(property)) return OPAQUE;
+    if (ts.isShorthandPropertyAssignment(property)) {
+      if (property.name.text === "timeout") return property.name;
+      continue;
+    }
     if (!ts.isPropertyAssignment(property)) continue;
     if (property.name.getText() !== "timeout") continue;
     return property.initializer;
@@ -171,21 +202,44 @@ function timeoutExpression(
   return undefined;
 }
 
-/** The `timeout:` a call states, wherever among its options objects it sits. */
-function statedTimeout(call: ts.CallExpression): ts.Expression | undefined {
-  return optionArguments(call)
-    .map(timeoutExpression)
-    .find((expression) => expression !== undefined);
+/**
+ * The `timeout:` a waiter states, wherever among its arguments it sits — or
+ * OPAQUE when an argument might carry one this reader cannot read. Only
+ * arguments after the first are considered: a waiter's first argument is its
+ * matcher or callback, and an options object never sits there.
+ */
+function statedTimeout(
+  call: ts.CallExpression,
+): ts.Expression | typeof OPAQUE | undefined {
+  let found: ts.Expression | typeof OPAQUE | undefined;
+  for (const argument of call.arguments.slice(1)) {
+    if (!looksLikeOptions(argument)) continue;
+    if (!ts.isObjectLiteralExpression(argument)) return OPAQUE;
+    const stated = timeoutExpression(argument);
+    if (stated === OPAQUE) return OPAQUE;
+    if (stated !== undefined && found === undefined) found = stated;
+  }
+  return found;
 }
 
-/** Every options object among a call's arguments, in order. */
-function optionArguments(
-  call: ts.CallExpression,
-): ts.ObjectLiteralExpression[] {
-  return call.arguments.filter(
-    (argument): argument is ts.ObjectLiteralExpression =>
-      ts.isObjectLiteralExpression(argument),
-  );
+/**
+ * An options argument this reader cannot see inside — a spread, or an object
+ * handed over by name. Distinguished from "states no timeout" because the two
+ * mean opposite things: one is a default budget, the other is a budget nobody
+ * checked, and collapsing them is what let an 11000ms test read as 4000.
+ */
+const OPAQUE = Symbol("an options argument this reader cannot read");
+
+/**
+ * Whether an argument could be carrying options. A bare `undefined` or `null`
+ * is not: it is the placeholder that skips a positional argument, as in
+ * `findByText(matcher, undefined, { timeout })`, and reading it as an options
+ * object nobody can see turns a perfectly readable waiter into a reported one.
+ */
+function looksLikeOptions(argument: ts.Expression): boolean {
+  if (ts.isIdentifier(argument)) return argument.text !== "undefined";
+  if (argument.kind === ts.SyntaxKind.NullKeyword) return false;
+  return ts.isObjectLiteralExpression(argument) || ts.isSpreadElement(argument);
 }
 
 /**
@@ -217,6 +271,17 @@ function directCallee(call: ts.CallExpression): string {
 
 type Reading = { ms: number; unresolved: string[] };
 
+/** Whether this node is the DEFINITION of a helper, rather than a call to one. */
+function declaresHelper(node: ts.Node, helpers: Map<string, ts.Node>): boolean {
+  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+    return helpers.has(node.name.text);
+  }
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return helpers.has(node.name.text);
+  }
+  return false;
+}
+
 /**
  * The waiter budget of one node, following awaited calls into the helpers that
  * do the waiting — a suite's render helper is usually where they live, and a
@@ -240,20 +305,29 @@ function budgetOf(
   const helperCost = (name: string): Reading => {
     const cached = memo.get(name);
     if (cached) return cached;
+    // Recursion guard. A helper reached while it is already being computed
+    // contributes nothing to THIS reading, and that truncated answer is not
+    // cached: memoizing it would hand a later direct call the under-count, so
+    // the total would depend on the order the helpers were first reached.
     if (path.has(name)) return { ms: 0, unresolved: [] };
     const body = helpers.get(name);
     if (!body) return { ms: 0, unresolved: [] };
+    const outermost = path.size === 0;
     path.add(name);
     const reading = budgetOf(body, consts, helpers, path, memo);
     path.delete(name);
-    memo.set(name, reading);
+    if (outermost) memo.set(name, reading);
     return reading;
   };
 
   const takeWaiter = (call: ts.CallExpression): void => {
     const stated = statedTimeout(call);
-    if (!stated) {
+    if (stated === undefined) {
       ms += DEFAULT_WAITER_MS;
+      return;
+    }
+    if (stated === OPAQUE) {
+      unresolved.push(call.getText().replace(/\s+/g, " ").slice(0, 80));
       return;
     }
     const folded = value(stated);
@@ -261,15 +335,23 @@ function budgetOf(
     else ms += folded;
   };
 
+  const takeHelper = (name: string): void => {
+    const reading = helperCost(name);
+    ms += reading.ms;
+    for (const item of reading.unresolved) {
+      if (!unresolved.includes(item)) unresolved.push(item);
+    }
+  };
+
   const visit = (current: ts.Node): void => {
+    // A helper DECLARED inside the body being read is counted at each call, so
+    // descending into its definition as well would charge the test once more
+    // for a waiter it may never reach.
+    if (declaresHelper(current, helpers)) return;
     if (ts.isCallExpression(current)) {
       const name = directCallee(current);
       if (WAITER.test(name)) takeWaiter(current);
-      else if (helpers.has(name)) {
-        const reading = helperCost(name);
-        ms += reading.ms;
-        unresolved.push(...reading.unresolved);
-      }
+      else if (helpers.has(name)) takeHelper(name);
     }
     ts.forEachChild(current, visit);
   };
@@ -277,6 +359,29 @@ function budgetOf(
   // the waiter call, and descending past it counts nothing.
   visit(node);
   return { ms, unresolved };
+}
+
+/**
+ * The ceiling a test states for itself, in either form vitest accepts:
+ * `it(name, fn, 500)` and `it(name, { timeout: 500 }, fn)`. The bare number is
+ * only ever AFTER the callback — scanning from argument 0 reads a non-string
+ * title as the ceiling, and then reports a test's own name as a timeout the
+ * reader cannot fold.
+ */
+function statedCeiling(
+  call: ts.CallExpression,
+  body: ts.Expression,
+): ts.Expression | typeof OPAQUE | undefined {
+  const positional = call.arguments
+    .slice(call.arguments.indexOf(body) + 1)
+    .find(
+      (argument) => ts.isNumericLiteral(argument) || ts.isIdentifier(argument),
+    );
+  if (positional) return positional;
+  return call.arguments
+    .filter((argument) => ts.isObjectLiteralExpression(argument))
+    .map((argument) => timeoutExpression(argument))
+    .find((expression) => expression !== undefined);
 }
 
 /** Named `function f() {}` and `const f = () => {}` bodies, by name, anywhere. */
@@ -322,15 +427,13 @@ export function budgetsIn(file: string, globalCeilingMs: number): TestBudget[] {
     const unresolved: string[] = [];
     let ceilingMs = globalCeilingMs;
     let ceilingIsStated = false;
-    const stated =
-      call.arguments.find(
-        (argument) =>
-          ts.isNumericLiteral(argument) || ts.isIdentifier(argument),
-      ) ??
-      optionArguments(call)
-        .map(timeoutExpression)
-        .find((expression) => expression !== undefined);
-    if (stated) {
+    // The bare number is only ever AFTER the callback: `it(name, fn, ms)`.
+    // Scanning from argument 0 reads a non-string title as the ceiling, and
+    // then reports a test's own name as a timeout it cannot fold.
+    const stated = statedCeiling(call, body);
+    if (stated === OPAQUE) {
+      unresolved.push("an options object this reader cannot read");
+    } else if (stated) {
       const folded = value(stated);
       if (folded === undefined) unresolved.push(stated.getText());
       else {
@@ -354,7 +457,11 @@ export function budgetsIn(file: string, globalCeilingMs: number): TestBudget[] {
   };
 
   const visit = (node: ts.Node): void => {
-    if (ts.isCallExpression(node) && TEST_CALLEE.test(rootCallee(node)))
+    if (
+      ts.isCallExpression(node) &&
+      TEST_CALLEE.test(rootCallee(node)) &&
+      !isSkipped(node)
+    )
       record(node);
     ts.forEachChild(node, visit);
   };

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SLOWEST_MEASURED_TEST_MS } from "../../vitest.budget";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { ProviderCard } from "./integrations-provider";
@@ -126,10 +127,13 @@ const SETTLE_MS = 10_000;
 // `renderAs` runs one waiter at SETTLE_MS, and each case below awaits it. A
 // test may spend the SUM of its waiters' budgets without any one of them
 // failing, so its own ceiling has to cover that — and the suite's is derived
-// for tests that wait at the default. Stated here rather than borrowed: without
-// it these fail while the settle is still inside its budget, and the failure
-// names the test rather than the round trip that was slow (#1144).
-const RENDER_TEST_MS = SETTLE_MS + 3000;
+// for tests that wait at the default. Stated here rather than borrowed, with
+// the SAME measured allowance for the work between the waits that the suite
+// ceiling uses, so the two rest on one measurement rather than on a round
+// number picked here. Without it these fail while the settle is still inside
+// its budget, and the failure names the test rather than the round trip that
+// was slow (issue 1144).
+const RENDER_TEST_MS = SETTLE_MS + SLOWEST_MEASURED_TEST_MS;
 
 // The card sits on the Settings → Integrations entry, whose predicate opens for
 // all five roles, and the reads behind it are granted to all five. The writes

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -11,6 +11,10 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { useReducer } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ASYNC_UTIL_TIMEOUT_MS,
+  SLOWEST_MEASURED_TEST_MS,
+} from "../../../vitest.budget";
 import type { components } from "../../api/schema";
 import { LocaleProvider } from "../../i18n";
 import type { ConversationState } from "./conversation-machine";
@@ -27,14 +31,18 @@ type IngestStats = components["schemas"]["VoiceIngestStats"];
 
 // The two build cases below narrate a poll, so each raises two of its waiters
 // to 4000ms to outlast it. A test may spend the SUM of its waiters' budgets
-// without any one of them failing, and these spend 12000ms — past the suite's
-// own ceiling, which is derived for tests that wait at the default. So they
-// state their own, the way read-conclusion.test.tsx and onboarding-restore
-// .test.tsx already do: the two raised waiters, the defaults beside them, and
-// room for the render work between. Without it the test fails while every
-// waiter in it is still inside its budget, and the failure names the test
-// rather than the poll that was slow (#1144).
-const BUILD_TEST_MS = 4000 * 2 + 1000 * 4 + 4000;
+// without any one of them failing, and the heavier of the two spends 12000ms —
+// past the suite's own ceiling, which is derived for tests that wait at the
+// default. So they state their own, the way read-conclusion.test.tsx and
+// onboarding-restore.test.tsx already do: the raised waiters, the defaults
+// beside them, and the SAME measured allowance for the work between them that
+// the suite ceiling uses, so the two rest on one measurement rather than on a
+// round number picked here. Without it the test fails while every waiter in it
+// is still inside its budget, and the failure names the test rather than the
+// poll that was slow (issue 1144).
+const POLL_WAITER_MS = 4000;
+const BUILD_TEST_MS =
+  POLL_WAITER_MS * 2 + ASYNC_UTIL_TIMEOUT_MS * 4 + SLOWEST_MEASURED_TEST_MS;
 
 const PROFILE_ID = "018f3a1b-0000-7000-8000-0000000000d1";
 const BUILD_IDS = [

--- a/frontend/src/screens/onboarding.test.tsx
+++ b/frontend/src/screens/onboarding.test.tsx
@@ -10,6 +10,10 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ASYNC_UTIL_TIMEOUT_MS,
+  SLOWEST_MEASURED_TEST_MS,
+} from "../../vitest.budget";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { OnboardingScreen } from "./onboarding";
@@ -366,6 +370,18 @@ beforeEach(() => {
 // clobber what the administrator typed.
 const EXPECTED_READS = 2;
 
+// The dossier case below waits out the whole poll cadence — five rounds of
+// EXPECTED_READS at READ_POLL_MS — and three default waiters beside it. A test
+// may spend the SUM of its waiters' budgets without any one of them failing, so
+// its own ceiling has to cover that; the suite's is derived for tests that wait
+// at the default. Stated here rather than borrowed, with the same measured
+// allowance for the work between the waits that the suite ceiling uses, so both
+// rest on one measurement instead of two guesses (issue 1144).
+const DOSSIER_TEST_MS =
+  READ_POLL_MS * EXPECTED_READS * 5 +
+  ASYNC_UTIL_TIMEOUT_MS * 3 +
+  SLOWEST_MEASURED_TEST_MS;
+
 describe("the conversational company act", () => {
   it("loads the detailed AI profile after the public login profile was cached", async () => {
     const calls = stubApi();
@@ -397,56 +413,60 @@ describe("the conversational company act", () => {
     expect(screen.queryByLabelText(/Company name/)).toBeNull();
   });
 
-  it("preserves administrator typing when a newer streamed dossier arrives", async () => {
-    const completedRead = {
-      ...readyRead,
-      profile_fields: readyRead.profile_fields.map((field) =>
-        field.field === "icp"
-          ? { ...field, value: "Enterprise manufacturers" }
-          : field,
-      ),
-    } as const satisfies CompanySiteRead;
-    const calls = stubApi({ readSequence: [readingRead, completedRead] });
-    render(<OnboardingScreen />);
+  it(
+    "preserves administrator typing when a newer streamed dossier arrives",
+    async () => {
+      const completedRead = {
+        ...readyRead,
+        profile_fields: readyRead.profile_fields.map((field) =>
+          field.field === "icp"
+            ? { ...field, value: "Enterprise manufacturers" }
+            : field,
+        ),
+      } as const satisfies CompanySiteRead;
+      const calls = stubApi({ readSequence: [readingRead, completedRead] });
+      render(<OnboardingScreen />);
 
-    await submitWebsite();
-    // Every field is inline-editable on the review board — there is no
-    // separate edit mode to switch into first, only the collapsed row's own
-    // summary to open, exactly as a human would.
-    await screen.findByRole("heading", {
-      name: /Here is everything I found/,
-    });
-    const icpRow = document.getElementById("ob-triage-row-icp");
-    if (icpRow === null) {
-      throw new Error("expected the icp row to exist");
-    }
-    await userEvent.click(within(icpRow).getByRole("button"));
-    const icp = (await screen.findByLabelText(
-      /Ideal customer/,
-    )) as HTMLTextAreaElement;
-    await userEvent.clear(icp);
-    await userEvent.type(icp, "Owner-led manufacturers");
+      await submitWebsite();
+      // Every field is inline-editable on the review board — there is no
+      // separate edit mode to switch into first, only the collapsed row's own
+      // summary to open, exactly as a human would.
+      await screen.findByRole("heading", {
+        name: /Here is everything I found/,
+      });
+      const icpRow = document.getElementById("ob-triage-row-icp");
+      if (icpRow === null) {
+        throw new Error("expected the icp row to exist");
+      }
+      await userEvent.click(within(icpRow).getByRole("button"));
+      const icp = (await screen.findByLabelText(
+        /Ideal customer/,
+      )) as HTMLTextAreaElement;
+      await userEvent.clear(icp);
+      await userEvent.type(icp, "Owner-led manufacturers");
 
-    // This waits for a COUNT of polls, not for a condition the render reaches,
-    // so it cannot succeed before the cadence has run EXPECTED_READS times
-    // however fast the machine is. The budget is therefore a multiple of that
-    // floor rather than a number of its own: four cadence periods of headroom
-    // over the two it must outlast, which is what a loaded runner spends on
-    // scheduling. A budget written independently of the cadence cannot be seen
-    // to disagree with it.
-    await waitFor(
-      () => {
-        const reads = calls.filter(
-          (request) =>
-            request.method === "GET" &&
-            request.url.includes("/company/site-reads/"),
-        );
-        expect(reads.length).toBeGreaterThanOrEqual(EXPECTED_READS);
-      },
-      { timeout: READ_POLL_MS * EXPECTED_READS * 5 },
-    );
-    expect(icp.value).toBe("Owner-led manufacturers");
-  });
+      // This waits for a COUNT of polls, not for a condition the render reaches,
+      // so it cannot succeed before the cadence has run EXPECTED_READS times
+      // however fast the machine is. The budget is therefore a multiple of that
+      // floor rather than a number of its own: four cadence periods of headroom
+      // over the two it must outlast, which is what a loaded runner spends on
+      // scheduling. A budget written independently of the cadence cannot be seen
+      // to disagree with it.
+      await waitFor(
+        () => {
+          const reads = calls.filter(
+            (request) =>
+              request.method === "GET" &&
+              request.url.includes("/company/site-reads/"),
+          );
+          expect(reads.length).toBeGreaterThanOrEqual(EXPECTED_READS);
+        },
+        { timeout: READ_POLL_MS * EXPECTED_READS * 5 },
+      );
+      expect(icp.value).toBe("Owner-led manufacturers");
+    },
+    DOSSIER_TEST_MS,
+  );
 
   it("caps the fact selection the confirmation sends at the server limit", async () => {
     const calls = stubApi({

--- a/frontend/vitest.budget.ts
+++ b/frontend/vitest.budget.ts
@@ -44,21 +44,27 @@ export const ASYNC_UTIL_TIMEOUT_MS = 1_000;
 
 /**
  * The largest budget any test spends waiting, among the tests that run under
- * THIS ceiling — 7000ms, in `settings.test.tsx`'s "the diagnostics card…" case,
- * seven default-budget waiters in sequence. Measured from the syntax tree by
- * `src/test-budget.ts` rather than counted by hand: a hand count over this tree
- * read one 688-line file as a single test with 39 waiters, and a ceiling built
- * on that would have been ten times anything real.
+ * THIS ceiling — 10000ms, in `company-context.test.tsx`'s two write-posture
+ * cases, whose render helper waits once at that file's own `SETTLE_MS`. They
+ * state no ceiling of their own, so they belong to this population and set its
+ * width; that file's two `clickRefresh` cases are a different matter and are
+ * exempted by name in scripts/test-budget.test.ts.
+ *
+ * Measured from the syntax tree by `scripts/test-budget.ts` rather than counted
+ * by hand: a hand count over this tree read one 688-line file as a single test
+ * with 39 waiters, and a ceiling built on that would have been ten times
+ * anything real.
  *
  * A test that deliberately raises its OWN waiters above the default — a slow
- * settle, a poll it has to outlast — owes its own per-test ceiling and does not
- * bear on this number. `read-conclusion.test.tsx` and `onboarding-restore.test.tsx`
- * already work that way. The guard in src/test-budget.test.ts is what keeps the
+ * settle, a poll it has to outlast — owes its own per-test ceiling and then
+ * leaves this population. `read-conclusion.test.tsx`, `onboarding-restore.test.tsx`,
+ * `voice-act.test.tsx`, `integrations-provider.test.tsx` and `onboarding.test.tsx`
+ * all work that way. The guard in scripts/test-budget.test.ts is what keeps the
  * two populations honest: it holds EVERY test's waiter budget against the
  * ceiling that test actually runs under, so a suite cannot quietly join this one
  * while spending like the other.
  */
-export const MAX_DEFAULT_WAITER_BUDGET_MS = 7_000;
+export const MAX_DEFAULT_WAITER_BUDGET_MS = 10_000;
 
 /**
  * The slowest single test measured under deliberate load, in milliseconds —

--- a/frontend/vitest.budget.ts
+++ b/frontend/vitest.budget.ts
@@ -32,9 +32,21 @@
 // have to remember to copy.
 //
 // That file keeps its own numbers and is deliberately untouched: it overrides
-// the per-wait budget as well as the per-test one, and the defect it is still
-// carrying (#613) is starvation rather than arithmetic. The ceiling below is
-// SMALLER than its 10s-per-waiter budget, so it cannot mask that.
+// the per-waiter budget as well as the per-test one, and the defect it is still
+// carrying (issue 613) is starvation rather than arithmetic. Its two starved
+// cases are exempted by name in scripts/test-budget.test.ts so they stay
+// fast-red.
+//
+// Two of its OTHER cases state no ceiling of their own, so they sit in the
+// population this ceiling is measured over and are what set its width at
+// 10000ms. That is a real cost and it is recorded rather than smoothed over:
+// the whole suite's ceiling is being driven by one file's local waiter
+// override, and until issue 613 is settled and that file can be edited, the
+// right fix — giving those two cases their own ceiling, as
+// integrations-provider.test.tsx does — is not available. Issue 1717 carries
+// it. Do not read the ceiling below as "smaller than anything company-context
+// waits for": it is larger, and what keeps issue 613 fast-red is the exemption,
+// not this number.
 //
 // So the ceiling has to clear the longest chain the suite legitimately composes,
 // plus the render and act work sitting between those waits.


### PR DESCRIPTION
Third round on issue 1144, following #1706 and #1710 — **both of which auto-merged before their `/code-review` finished**, so each round's findings had to land as the next PR. I have not armed auto-merge here; this one waits for review.

Review of #1710 found ten things. Two were HIGH and one of those was a **live violation the guard walked straight past**.

## The reader was assuming the friendliest value

`onboarding.test.tsx:400` waits `{ timeout: READ_POLL_MS * EXPECTED_READS * 5 }` — arithmetic over a constant imported from the hook it drives. The reader could fold neither, so it recorded the *default* 1000 ms where the test spends 8000, and its real 11 000 ms budget read as 4000 and passed under a 10 437 ms ceiling.

That is the same shape as the bug being fixed, one level up: a number nobody could read, quietly replaced by the smallest one that keeps the gate green.

Now the reader folds arithmetic, follows a named import one hop, and — the part that matters — **reports what it still cannot fold**. An unreadable budget fails the guard rather than defaulting:

```
✗ could read every budget it was asked to judge
  → src/screens/integrations-provider.test.tsx:176 states a timeout this reader cannot fold: RENDER_TEST_MS
```

`onboarding.test.tsx`'s dossier case now states its own ceiling, derived from the same terms.

## Four test shapes were invisible

| shape | was | now |
|---|---|---|
| `it.each(cases)(…)`, `it.only`, `it.concurrent` | dropped — callee matched at the immediate name, not the root of the call chain. **17 call sites** under no guard | recorded |
| `it(name, { timeout }, fn)` | dropped entirely, ceiling and body both | recorded |
| `const settle = () => waitFor(cb, { timeout: 9000 })` | counted **0** — the reader descended past the node it was handed, and for a concise arrow that node *is* the waiter | counted 9000 |
| a helper awaited four times | counted **once** — the recursion guard doubled as a de-duplicator | counted four times |

Recovered records: 2919 → 2971.

## The part that was missing rather than wrong

`scripts/test-budget.reader.test.ts` is new. `test-budget.test.ts` holds the **tree** against the reader; nothing held the **reader** against anything — so a regression that blinded it was invisible unless some test in the tree happened to exercise the shape *and* exceed its ceiling. Both reader mutations I tried against #1710's guard passed for exactly that reason.

Eleven cases, each a hole the reader actually had. Mutation-tested:

| Mutant | Result |
|---|---|
| reader stops visiting the node it was handed | **red** — the arrow-helper and repeat-call cases |
| reader matches the immediate callee again | **red** — the `it.each` case |
| the config stops reading the derived value | **red** — `expected 5000 to be 13437` |
| the dossier test drops its stated ceiling | **red** — `expected 11000 to be 10000` |
| reader loses import resolution | **red** — six unfoldable timeouts reported |

## Scope and derivation corrections

- **The exemption is keyed by `file:line`.** Exempting all of `company-context.test.tsx` covered forty tests under a reason describing two, and silently unguarded anything added there later.
- **The default population is "states no ceiling of its own"**, not "ceiling equals the constant". The old spelling made the set's membership depend on the constant measured over it — re-derive one and the other moves, so a developer following the red message could loop.
- **The ceiling is 13 437 ms**, because with the reader seeing what it had been missing the widest budget in that population is 10 000 ms (`company-context`'s two write-posture cases, which state no ceiling and so belong to it). Not 7000; that figure was an artefact of the blind spots.
- **The per-test ceilings added in #1710 used round headroom**, against the rule this change states for the global. They now derive their between-waits allowance from `SLOWEST_MEASURED_TEST_MS`, so local and global rest on one measurement.
- Two stale references fixed: the constant's docstring named a test that does not exist (`grep` finds no "diagnostics card"), and two comments still pointed at `src/test-budget.ts` after the move to `scripts/`.

## Verification

`make check-q` green. `make check-fe` green — **238 files, 3047 tests**.

## Coverage

Test tooling and test config: no new product code, so new-code coverage does not apply. The two mutation batteries above are the substitute proof.

## Review

- `/code-review` (Fable) — three rounds so far, and each one found something real. Running again on this diff; **auto-merge deliberately not armed** until it comes back.
- **Codex has not reviewed this**: `/codex:*` cannot be invoked by an agent.
- CodeRabbit arrives on its own.

Claims worth attacking:
- *"reports what it cannot fold"* — one hop of import resolution is arbitrary; a budget two modules away is still reported rather than chased, which is the safe end but not a complete answer.
- *"the widest is 10 000"* — measured by the same reader it is checking. The reader's own tests are what stop that being circular; they are eleven cases, not a proof.
- *"the exemption covers exactly two tests"* — worth confirming nothing else in that file drifts over the ceiling later, since only those two lines are named.

Refs #1144, follows #1706 and #1710