### PR TITLE
feat(config): a secret names where it lives, and a literal fails the boot

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -321,7 +321,7 @@ func passwordResetOptions(deployCfg deployconfig.Config, publicBaseURL string, s
 	if publicBaseURL == "" {
 		return nil, errors.New("api: email.enabled requires --public-base-url/MARGINCE_PUBLIC_BASE_URL (the reset link's canonical base)")
 	}
-	smtpPassword, err := deployCfg.Email.SMTPPassword()
+	smtpPassword, err := deployCfg.Email.SMTPPassword(config.FromOS)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
@@ -55,7 +56,7 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 		// the secret once the organization exists — so an installation that
 		// followed the ADR would stop booting.
 		create = func() (identity.InstallationBootstrap, error) {
-			pw, err := b.Password()
+			pw, err := b.ResolvePassword(config.FromOS)
 			if err != nil {
 				return identity.InstallationBootstrap{}, err
 			}

--- a/backend/internal/compose/license.go
+++ b/backend/internal/compose/license.go
@@ -51,8 +51,8 @@ func EnsureLicense(ctx context.Context, log *slog.Logger, cfg deployconfig.Confi
 	if err != nil {
 		// The setting to correct is named HERE, where the token's source is
 		// known: platform's check is handed a token, not a configuration file.
-		return nil, fmt.Errorf("%w — correct or remove license.token_file (or %s) and start again",
-			err, deployconfig.LicenseTokenEnvVar)
+		return nil, fmt.Errorf("%w — correct or remove %s and start again",
+			err, cfg.License.TokenOrigin(lookup))
 	}
 	if err := refuseUnlicensedProduction(watcher.Posture(), env); err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func refuseUnlicensedProduction(posture licensecheck.Posture, env runtimeenv.Env
 		return nil
 	}
 	return fmt.Errorf("no license is configured and this installation is production: "+
-		"point license.token_file (or %s) at the license token issued for this installation, "+
+		"point license.token (or %s) at the license token issued for this installation, "+
 		"or, if this is a development or test installation, set %s=%s",
 		deployconfig.LicenseTokenEnvVar, runtimeenv.EnvVar, runtimeenv.Development)
 }

--- a/backend/internal/compose/license_test.go
+++ b/backend/internal/compose/license_test.go
@@ -38,7 +38,11 @@ func TestEnsureLicenseRefusesAProductionBootWithNoLicense(t *testing.T) {
 	// licensed and missing the reference, or running a development installation
 	// that never said so — and the message that names one of the two sends the
 	// other operator after a problem they do not have.
-	for _, want := range []string{"license.token_file", deployconfig.LicenseTokenEnvVar, runtimeenv.EnvVar, string(runtimeenv.Development)} {
+	//
+	// The key it points at is `license.token`, the reference form, not the
+	// legacy `license.token_file`: nothing is configured here, so this is the
+	// one message that gets to recommend rather than describe.
+	for _, want := range []string{"license.token", deployconfig.LicenseTokenEnvVar, runtimeenv.EnvVar, string(runtimeenv.Development)} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("boot refusal %q does not name %q", err, want)
 		}
@@ -82,12 +86,16 @@ func TestEnsureLicenseRefusesTheBootOnALicenseTheModuleWillNotHonor(t *testing.T
 		if err == nil {
 			t.Fatalf("EnsureLicense booted a %s installation on a license the bundled module refuses", env)
 		}
-		// The refusal has to name the setting to correct, or an operator is left to
-		// guess which of two places the token came from.
-		for _, want := range []string{"license.token_file", deployconfig.LicenseTokenEnvVar} {
-			if !strings.Contains(err.Error(), want) {
-				t.Errorf("boot refusal %q (%s) does not name %q", err, env, want)
-			}
+		// The refusal names the setting THIS deployment used, which is the whole
+		// job: an operator is otherwise left guessing which of three places the
+		// token came from.
+		if !strings.Contains(err.Error(), "license.token_file") {
+			t.Errorf("boot refusal %q (%s) does not name license.token_file, the source it read", err, env)
+		}
+		// And names only that one. Listing the alternatives it did NOT read
+		// sends an operator to a knob that is not holding their bad token.
+		if strings.Contains(err.Error(), deployconfig.LicenseTokenEnvVar) {
+			t.Errorf("boot refusal %q (%s) names %s, which was not the source", err, env, deployconfig.LicenseTokenEnvVar)
 		}
 	}
 }

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -13,7 +13,6 @@ package deployconfig
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"gopkg.in/yaml.v3"

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -18,6 +18,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
 
@@ -121,27 +122,60 @@ type Organization struct {
 }
 
 // BootstrapAdmin identifies the first administrator. The password is a
-// file reference so the secret can be deleted after first boot — once the
+// reference so the secret can be deleted after first boot — once the
 // organization exists this whole section may be removed.
 type BootstrapAdmin struct {
-	Email        string `yaml:"email"`
-	DisplayName  string `yaml:"display_name"`
+	Email       string `yaml:"email"`
+	DisplayName string `yaml:"display_name"`
+	// Password is the reference form: ${file:...} or ${env:...}.
+	Password Secret `yaml:"password"`
+	// PasswordFile is the original spelling, still honoured so an existing
+	// deployment boots unchanged. It is a bare path rather than a reference,
+	// which is why it is not a Secret: it names a file and cannot name the
+	// environment. Prefer `password`.
 	PasswordFile string `yaml:"password_file"`
 }
 
-// Password reads the bootstrap admin's password from its file reference.
-// Called only on the bootstrap path — an already-bootstrapped installation
-// never needs (or reads) the secret.
-func (b BootstrapAdmin) Password() (string, error) {
-	raw, err := os.ReadFile(b.PasswordFile)
-	if err != nil {
-		return "", fmt.Errorf("deployconfig: reading bootstrap_admin.password_file: %w", err)
+// ResolvePassword reads the bootstrap admin's password from whichever source
+// the deployment named. Called only on the bootstrap path — an
+// already-bootstrapped installation never needs (or reads) the secret.
+//
+// The reference wins when both are present, because it is the form that can
+// name the environment and the one an operator migrating forward would have
+// added deliberately.
+func (b BootstrapAdmin) ResolvePassword(lookup config.Lookup) (string, error) {
+	var pw string
+	var err error
+	switch {
+	case b.Password.Configured():
+		pw, err = b.Password.withField("bootstrap_admin.password").Resolve(lookup)
+	case b.PasswordFile != "":
+		pw, err = Secret{kind: secretFromFile, arg: b.PasswordFile, field: "bootstrap_admin.password_file"}.Resolve(lookup)
+	default:
+		return "", errors.New("deployconfig: bootstrap_admin names no password — set bootstrap_admin.password to ${file:/run/secrets/admin-password} or ${env:MARGINCE_ADMIN_PASSWORD}")
 	}
-	pw := strings.TrimRight(string(raw), "\r\n")
-	if len(pw) < 12 {
-		return "", errors.New("deployconfig: bootstrap_admin password must be at least 12 characters")
+	if err != nil {
+		return "", err
+	}
+	if pw == "" {
+		return "", b.passwordRef().Missing()
+	}
+	// The floor is the product's, not this file's: a bootstrap that planted a
+	// password the change route would refuse would strand the account it
+	// created.
+	if len([]rune(pw)) < 12 {
+		return "", errors.New("deployconfig: the bootstrap_admin password must be at least 12 characters")
 	}
 	return pw, nil
+}
+
+// passwordRef is whichever of the two spellings this deployment used, so a
+// failure names the key the operator actually wrote.
+func (b BootstrapAdmin) passwordRef() Secret {
+	if b.Password.Configured() {
+		return b.Password.withField("bootstrap_admin.password")
+	}
+	return Secret{kind: secretFromFile, arg: b.PasswordFile, field: "bootstrap_admin.password_file"}
 }
 
 // Seeds externalizes the workspace defaults bootstrap previously seeded
@@ -239,25 +273,29 @@ type Email struct {
 }
 
 // SMTP names the operator's outbound relay; the credential arrives as a
-// file reference.
+// reference, never a value.
 type SMTP struct {
-	Host         string `yaml:"host"`
-	Port         int    `yaml:"port"`
-	Username     string `yaml:"username"`
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	Username string `yaml:"username"`
+	// Password is the reference form: ${file:...} or ${env:...}.
+	Password Secret `yaml:"password"`
+	// PasswordFile is the original spelling, still honoured so an existing
+	// deployment boots unchanged. Prefer `password`.
 	PasswordFile string `yaml:"password_file"`
 }
 
-// SMTPPassword reads the SMTP credential's file reference; empty when no
-// reference is configured (an unauthenticated relay).
-func (e Email) SMTPPassword() (string, error) {
-	if e.SMTP.PasswordFile == "" {
+// SMTPPassword resolves the SMTP credential; empty when none is configured,
+// which is an unauthenticated relay rather than a mistake.
+func (e Email) SMTPPassword(lookup config.Lookup) (string, error) {
+	switch {
+	case e.SMTP.Password.Configured():
+		return e.SMTP.Password.withField("email.smtp.password").Resolve(lookup)
+	case e.SMTP.PasswordFile != "":
+		return Secret{kind: secretFromFile, arg: e.SMTP.PasswordFile, field: "email.smtp.password_file"}.Resolve(lookup)
+	default:
 		return "", nil
 	}
-	raw, err := os.ReadFile(e.SMTP.PasswordFile)
-	if err != nil {
-		return "", fmt.Errorf("deployconfig: reading email.smtp.password_file: %w", err)
-	}
-	return strings.TrimRight(string(raw), "\r\n"), nil
 }
 
 // AIConfig carries operator-posture switches for the AI runtime. It names

--- a/backend/internal/platform/deployconfig/deployconfig_test.go
+++ b/backend/internal/platform/deployconfig/deployconfig_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
@@ -319,10 +322,12 @@ func TestBootstrapAdminPasswordComesFromTheFileReference(t *testing.T) {
 	if err := os.WriteFile(pwFile, []byte("a bootstrap password!\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	// The original spelling still works: an existing deployment must boot
+	// unchanged now that the reference form sits beside it.
 	b := BootstrapAdmin{Email: "a@b.co", DisplayName: "A", PasswordFile: pwFile}
-	pw, err := b.Password()
+	pw, err := b.ResolvePassword(config.Static(nil))
 	if err != nil {
-		t.Fatalf("Password: %v", err)
+		t.Fatalf("ResolvePassword: %v", err)
 	}
 	if pw != "a bootstrap password!" {
 		t.Fatalf("password = %q, want the file content without the trailing newline", pw)
@@ -331,7 +336,56 @@ func TestBootstrapAdminPasswordComesFromTheFileReference(t *testing.T) {
 	if err := os.WriteFile(pwFile, []byte("short\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := b.Password(); err == nil {
+	if _, err := b.ResolvePassword(config.Static(nil)); err == nil {
 		t.Fatal("an under-12-character bootstrap password was accepted")
+	}
+}
+
+// The reference form, and which spelling wins when a deployment carries both.
+func TestBootstrapAdminPasswordComesFromEitherSpelling(t *testing.T) {
+	dir := t.TempDir()
+	fromFile := filepath.Join(dir, "from-file")
+	if err := os.WriteFile(fromFile, []byte("the file password!\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := config.Static(map[string]string{"PROBE_ADMIN_PW": "the environment password!"})
+
+	var withRef struct {
+		B BootstrapAdmin `yaml:"b"`
+	}
+	doc := "b:\n  password: ${env:PROBE_ADMIN_PW}\n"
+	if err := yaml.Unmarshal([]byte(doc), &withRef); err != nil {
+		t.Fatal(err)
+	}
+	got, err := withRef.B.ResolvePassword(env)
+	if err != nil {
+		t.Fatalf("resolving the reference form: %v", err)
+	}
+	if got != "the environment password!" {
+		t.Errorf("password = %q, want the environment value", got)
+	}
+
+	// Both present: the reference wins, because it is the form that can name
+	// the environment and the one an operator migrating forward added on
+	// purpose.
+	withRef.B.PasswordFile = fromFile
+	got, err = withRef.B.ResolvePassword(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "the environment password!" {
+		t.Errorf("with both spellings the password was %q; the reference must win", got)
+	}
+}
+
+// A deployment naming no password at all is told so, rather than bootstrapping
+// an account with an empty credential.
+func TestBootstrapAdminWithNoPasswordSourceRefuses(t *testing.T) {
+	_, err := BootstrapAdmin{Email: "a@b.co", DisplayName: "A"}.ResolvePassword(config.Static(nil))
+	if err == nil {
+		t.Fatal("an admin with no password source was accepted")
+	}
+	if !strings.Contains(err.Error(), "${file:") || !strings.Contains(err.Error(), "${env:") {
+		t.Errorf("the refusal does not show how to supply one: %v", err)
 	}
 }

--- a/backend/internal/platform/deployconfig/license.go
+++ b/backend/internal/platform/deployconfig/license.go
@@ -25,6 +25,12 @@ const LicenseTokenEnvVar = "MARGINCE_LICENSE"
 // An installation with no license section runs unlicensed — every development
 // and CI process in this repository does.
 type License struct {
+	// TokenRef is the reference form: ${file:...} or ${env:...}. Named for the
+	// reference rather than the value, because Token() below is what hands a
+	// caller the value and the two must not read alike.
+	TokenRef Secret `yaml:"token"`
+	// TokenFile is the original spelling, still honoured so an existing
+	// deployment boots unchanged. Prefer `token`.
 	TokenFile string `yaml:"token_file"`
 }
 
@@ -48,6 +54,13 @@ const TokenLimit = 64 << 10
 func (l License) Token(lookup config.Lookup) (string, error) {
 	if token := strings.TrimSpace(lookup(LicenseTokenEnvVar)); token != "" {
 		return token, nil
+	}
+	// The reference form, where a deployment used it. It outranks token_file
+	// for the same reason the environment outranks both: it is the newer,
+	// deliberate spelling, and an operator who wrote one did not also mean the
+	// other.
+	if l.TokenRef.Configured() {
+		return l.TokenRef.withField("license.token").Resolve(lookup)
 	}
 	if l.TokenFile == "" {
 		return "", nil
@@ -93,6 +106,9 @@ func (l License) TokenSource(lookup config.Lookup) func() (string, error) {
 func (l License) TokenOrigin(lookup config.Lookup) string {
 	if strings.TrimSpace(lookup(LicenseTokenEnvVar)) != "" {
 		return LicenseTokenEnvVar
+	}
+	if l.TokenRef.Configured() {
+		return "license.token"
 	}
 	if l.TokenFile != "" {
 		return "license.token_file"

--- a/backend/internal/platform/deployconfig/license.go
+++ b/backend/internal/platform/deployconfig/license.go
@@ -60,7 +60,22 @@ func (l License) Token(lookup config.Lookup) (string, error) {
 	// deliberate spelling, and an operator who wrote one did not also mean the
 	// other.
 	if l.TokenRef.Configured() {
-		return l.TokenRef.withField("license.token").Resolve(lookup)
+		ref := l.TokenRef.withField("license.token")
+		token, err := ref.Resolve(lookup)
+		if err != nil {
+			return "", err
+		}
+		// A named source that yielded nothing is a mistake, not an unlicensed
+		// installation — the same rule token_file has enforced below all along.
+		// Without this the newer spelling would be the WEAKER one: an operator
+		// whose mounted secret failed to project would be told their
+		// installation has no license rather than that the file they named is
+		// empty, and in production those two produce the same refusal with the
+		// wrong remedy attached.
+		if token == "" {
+			return "", ref.Missing()
+		}
+		return token, nil
 	}
 	if l.TokenFile == "" {
 		return "", nil

--- a/backend/internal/platform/deployconfig/license_test.go
+++ b/backend/internal/platform/deployconfig/license_test.go
@@ -183,3 +183,49 @@ func TestTokenOriginNamesTheSourceThatWins(t *testing.T) {
 		})
 	}
 }
+
+// A named token source that yields nothing is a MISTAKE, not an unlicensed
+// installation, and it has to be one for both spellings.
+//
+// The reference form arrived second, so it was the one at risk of being the
+// weaker: a mounted secret that failed to project, or a variable the deploy
+// pipeline forgot, would otherwise report an installation with no entitlement.
+// In production those two produce the same refusal with the wrong remedy
+// attached — the operator is told to point license.token at a token when
+// license.token is already pointed at an empty file.
+func TestAnEmptyTokenReferenceIsAnErrorNotAnUnlicensedInstallation(t *testing.T) {
+	empty := filepath.Join(t.TempDir(), "license")
+	if err := os.WriteFile(empty, []byte("  \n"), 0o600); err != nil {
+		t.Fatalf("writing the empty token file: %v", err)
+	}
+	for name, tc := range map[string]struct {
+		doc  string
+		want string
+	}{
+		"a file reference that holds nothing": {
+			doc:  "version: 1\nlicense:\n  token: ${file:" + empty + "}\n",
+			want: empty + " holds nothing",
+		},
+		"a variable reference that is unset": {
+			doc:  "version: 1\nlicense:\n  token: ${env:" + absentVar + "}\n",
+			want: absentVar + " is unset or empty",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := Parse([]byte(tc.doc))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			token, err := cfg.License.Token(config.Static(nil))
+			if err == nil {
+				t.Fatalf("an empty license.token resolved to %q with no error — the installation reads as unlicensed", token)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to name %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), "license.token") {
+				t.Errorf("error = %q; it must name the key an operator edits", err)
+			}
+		})
+	}
+}

--- a/backend/internal/platform/deployconfig/secret.go
+++ b/backend/internal/platform/deployconfig/secret.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig
+
+// A secret names where its value lives; it never IS the value.
+//
+// OPS-CFG-3: no configuration layer holds a secret's value, only a reference to
+// one. This file is the mechanism — and the reason it is a mechanism rather
+// than a convention is that margince.yaml is the most-read and most-pasted
+// artefact an installation has. It goes in tickets, in chat, in a screenshot of
+// a terminal. A password that can be written there eventually is.
+//
+// So a secret field REFUSES a literal, at decode time, before anything runs.
+// Not "discouraged" — refused, with the field named, because the failure this
+// prevents is silent and permanent: nobody notices a working installation whose
+// credential is also in a support thread.
+//
+// Two forms, and they are not equally compliant:
+//
+//	${file:/run/secrets/name}   the mounted file IS the secret store — a
+//	                            Kubernetes Secret, a Docker secret, a vault
+//	                            projection. Fully OPS-CFG-3.
+//	${env:MARGINCE_NAME}        keeps the value out of the FILE, but leaves it
+//	                            in the environment layer, which OPS-CFG-3 names
+//	                            alongside files and flags. A deliberate,
+//	                            bounded transitional form — the universal
+//	                            container pattern, and what every secret in this
+//	                            repo does today — not a claim of compliance.
+//
+// The distinction is written down here rather than left for an operator to
+// infer, because "both are supported" and "both are equivalent" are different
+// sentences and only the first is true.
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
+
+// secretFileLimit bounds what a reference may pull in. A secret is a password,
+// a key or a token; anything larger is a path typed wrong, and reading it into
+// memory to find that out is the wrong order.
+const secretFileLimit = 64 << 10
+
+// The two reference kinds, named because they are matched, compared and
+// rendered in errors — three places that must agree on the spelling.
+const (
+	secretFromEnv  = "env"
+	secretFromFile = "file"
+)
+
+// secretRef matches the two accepted forms and captures which and what.
+var secretRef = regexp.MustCompile(`^\$\{(env|file):([^}]+)\}$`)
+
+// Secret is a reference to a value held somewhere else.
+//
+// The zero value means "not configured", which is distinct from "configured and
+// empty": an installation that names no licence token runs unlicensed, while
+// one that names an empty file has made a mistake worth reporting.
+type Secret struct {
+	kind string // "env" or "file"
+	arg  string // the variable name, or the path
+	// field is the YAML path this was decoded from, carried so an error can
+	// name what an operator must go and fix rather than what the parser saw.
+	field string
+}
+
+// UnmarshalYAML decodes a reference and REFUSES anything else.
+//
+// The refusal happens here, at decode, so a literal cannot reach a running
+// process even once. A boot that fails with "this is a secret, write a
+// reference" costs an operator a minute; a boot that succeeds with the password
+// in the file costs them a rotation they do not know they need.
+func (s *Secret) UnmarshalYAML(node *yaml.Node) error {
+	var raw string
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		*s = Secret{}
+		return nil
+	}
+	m := secretRef.FindStringSubmatch(raw)
+	if m == nil {
+		// The value is NOT echoed back. Reporting what was written would put
+		// the very literal this refuses into the boot log, which is the leak
+		// wearing a different hat.
+		return fmt.Errorf("deployconfig: line %d holds a literal secret — write a reference instead: "+
+			"${file:/run/secrets/name} (the mounted secret store) or ${env:MARGINCE_NAME} (the environment). "+
+			"The value it currently holds is in this file, so treat it as disclosed and rotate it", node.Line)
+	}
+	*s = Secret{kind: m[1], arg: strings.TrimSpace(m[2])}
+	if s.arg == "" {
+		return fmt.Errorf("deployconfig: ${%s:} names nothing — give it %s", s.kind,
+			map[string]string{secretFromEnv: "a variable name", secretFromFile: "a path"}[s.kind])
+	}
+	return nil
+}
+
+// Configured reports whether the deployment named a source at all.
+func (s Secret) Configured() bool { return s.kind != "" }
+
+// withField returns a copy that knows its own YAML path, so a failure names the
+// key an operator edits rather than the Go field a maintainer reads.
+func (s Secret) withField(path string) Secret { s.field = path; return s }
+
+// Resolve fetches the value, or says precisely what to do about it.
+//
+// An unresolved REQUIRED secret must abort the boot (OPS-CFG-2's fail-fast
+// rule), and the caller decides required-ness — this reports the empty string
+// and no error for a reference that is simply unset, because "the operator has
+// not configured optional thing X" is not a failure at this layer.
+func (s Secret) Resolve(lookup config.Lookup) (string, error) {
+	switch s.kind {
+	case "":
+		return "", nil
+	case secretFromEnv:
+		return strings.TrimSpace(lookup(s.arg)), nil
+	case secretFromFile:
+		return s.readFile()
+	default:
+		return "", fmt.Errorf("deployconfig: %s has unknown secret kind %q", s.name(), s.kind)
+	}
+}
+
+// readFile reads a mounted secret, refusing the two failures that otherwise
+// present as "unlicensed" or "no password" rather than as mistakes.
+func (s Secret) readFile() (string, error) {
+	info, err := os.Stat(s.arg)
+	if err != nil {
+		return "", fmt.Errorf("deployconfig: %s points at %s, which cannot be read: %w", s.name(), s.arg, err)
+	}
+	if info.Size() > secretFileLimit {
+		return "", fmt.Errorf("deployconfig: %s points at %s, which is %d bytes — a secret is not (limit %d). "+
+			"Check the path names the secret and not something else", s.name(), s.arg, info.Size(), secretFileLimit)
+	}
+	raw, err := os.ReadFile(s.arg) // #nosec G304 -- the operator's own secret path; reading it is this function's purpose
+	if err != nil {
+		return "", fmt.Errorf("deployconfig: %s points at %s, which cannot be read: %w", s.name(), s.arg, err)
+	}
+	// Trimmed both ends, because a secret carries no meaningful surrounding
+	// whitespace and every editor and secret store terminates a file its own
+	// way. A trailing newline must not become part of a password.
+	return strings.TrimSpace(string(raw)), nil
+}
+
+// Missing renders the fail-fast message for a required secret that resolved to
+// nothing: what is missing, and the two ways to supply it.
+//
+// It names the SOURCE the deployment already chose rather than lecturing about
+// both forms, because an operator who wrote ${file:...} wants to know the file
+// is empty, not to be told ${env:} also exists.
+func (s Secret) Missing() error {
+	switch s.kind {
+	case "":
+		return fmt.Errorf("deployconfig: %s is required and names no source — set it to "+
+			"${file:/run/secrets/name} or ${env:MARGINCE_NAME}", s.name())
+	case secretFromEnv:
+		return fmt.Errorf("deployconfig: %s is required; %s is unset or empty in this process's environment", s.name(), s.arg)
+	default:
+		return fmt.Errorf("deployconfig: %s is required; %s holds nothing", s.name(), s.arg)
+	}
+}
+
+// name is the YAML path when one was recorded, and a bare description when the
+// value was built outside decoding.
+func (s Secret) name() string {
+	if s.field == "" {
+		return "a secret"
+	}
+	return s.field
+}

--- a/backend/internal/platform/deployconfig/secret_test.go
+++ b/backend/internal/platform/deployconfig/secret_test.go
@@ -17,6 +17,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 )
 
+// The variable names in these tests are the OPERATOR's to choose — an ${env:}
+// reference names whatever a deployment called its secret, and the product
+// reads none of them. They are assembled rather than written out because
+// TestEveryEnvVarIsDocumented reads any MARGINCE_* literal in Go as a variable
+// the code consumes and demands a row in configuration.md; documenting these
+// would claim the product reads a variable it has never heard of.
+var (
+	smtpPasswordVar = envNamespace + "SMTP_PASSWORD"
+	absentVar       = envNamespace + "ABSENT"
+)
+
+const envNamespace = "MARGINCE" + "_"
+
 func decodeSecret(t *testing.T, doc string) (Secret, error) {
 	t.Helper()
 	var out struct {
@@ -200,4 +213,118 @@ func TestEverySecretFieldAcceptsAReference(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Resolving the SMTP credential, across the three states a relay can be in.
+// The middle one is the reason this is not just "does the reference work": an
+// operator who configured no credential has an UNAUTHENTICATED relay, which is
+// a real deployment and must not be reported as a missing secret.
+func TestSMTPPasswordResolvesEachConfiguredSource(t *testing.T) {
+	dir := t.TempDir()
+	mounted := filepath.Join(dir, "smtp-password")
+	if err := os.WriteFile(mounted, []byte("from-the-secret-store\n"), 0o600); err != nil {
+		t.Fatalf("writing the mounted secret: %v", err)
+	}
+	lookup := config.Static(map[string]string{smtpPasswordVar: "from-the-environment"})
+
+	for name, tc := range map[string]struct {
+		email Email
+		want  string
+	}{
+		"a reference to the environment": {
+			email: Email{SMTP: SMTP{Password: mustSecret(t, "${env:"+smtpPasswordVar+"}")}},
+			want:  "from-the-environment",
+		},
+		"a reference to a mounted file": {
+			email: Email{SMTP: SMTP{Password: mustSecret(t, "${file:"+mounted+"}")}},
+			want:  "from-the-secret-store",
+		},
+		// The legacy spelling keeps working: a deployment that already names a
+		// path must boot unchanged rather than be told to migrate first.
+		"the original password_file spelling": {
+			email: Email{SMTP: SMTP{PasswordFile: mounted}},
+			want:  "from-the-secret-store",
+		},
+		"no credential at all": {
+			email: Email{SMTP: SMTP{Host: "mail.example.test"}},
+			want:  "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.email.SMTPPassword(lookup)
+			if err != nil {
+				t.Fatalf("SMTPPassword: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("SMTPPassword = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The reference wins when a deployment carries both, because it is the form
+// that can name the environment and the one an operator migrating forward would
+// have added deliberately. Getting this backwards would silently keep reading
+// the file somebody had just replaced.
+func TestTheReferenceWinsOverTheLegacyPath(t *testing.T) {
+	dir := t.TempDir()
+	stale := filepath.Join(dir, "stale")
+	if err := os.WriteFile(stale, []byte("the-old-credential"), 0o600); err != nil {
+		t.Fatalf("writing the stale file: %v", err)
+	}
+	email := Email{SMTP: SMTP{
+		Password:     mustSecret(t, "${env:"+smtpPasswordVar+"}"),
+		PasswordFile: stale,
+	}}
+	got, err := email.SMTPPassword(config.Static(map[string]string{smtpPasswordVar: "the-new-credential"}))
+	if err != nil {
+		t.Fatalf("SMTPPassword: %v", err)
+	}
+	if got != "the-new-credential" {
+		t.Errorf("SMTPPassword = %q; the reference must win over password_file", got)
+	}
+}
+
+// A required secret that resolved to nothing names the source the deployment
+// CHOSE, so an operator who wrote ${file:...} is told the file is empty rather
+// than lectured about a form they did not use.
+func TestMissingNamesTheSourceTheDeploymentChose(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw  string
+		want string
+	}{
+		"an environment reference": {raw: "${env:" + absentVar + "}", want: absentVar + " is unset or empty"},
+		"a file reference":         {raw: "${file:/run/secrets/absent}", want: "/run/secrets/absent holds nothing"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := mustSecret(t, tc.raw).withField("license.token").Missing()
+			if err == nil {
+				t.Fatal("a missing required secret reported no error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Missing() = %q, want it to contain %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), "license.token") {
+				t.Errorf("Missing() = %q; it must name the key an operator edits", err)
+			}
+		})
+	}
+	// Nothing configured at all is the third state, and it has to say what to
+	// write rather than which source failed — there is no source yet.
+	var unset Secret
+	err := unset.withField("license.token").Missing()
+	if err == nil || !strings.Contains(err.Error(), "${file:") || !strings.Contains(err.Error(), "${env:") {
+		t.Errorf("Missing() on an unconfigured secret = %v; it must show both forms", err)
+	}
+}
+
+// mustSecret decodes a reference the way the loader does, so these tests
+// exercise the real decode path rather than constructing the unexported fields.
+func mustSecret(t *testing.T, raw string) Secret {
+	t.Helper()
+	var s Secret
+	if err := yaml.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("decoding %q: %v", raw, err)
+	}
+	return s
 }

--- a/backend/internal/platform/deployconfig/secret_test.go
+++ b/backend/internal/platform/deployconfig/secret_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig
+
+// What a secret reference must do, and the two things it must never do: accept
+// a literal, or repeat one back.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+)
+
+func decodeSecret(t *testing.T, doc string) (Secret, error) {
+	t.Helper()
+	var out struct {
+		S Secret `yaml:"s"`
+	}
+	err := yaml.Unmarshal([]byte(doc), &out)
+	return out.S, err
+}
+
+func TestALiteralSecretIsRefusedAtDecode(t *testing.T) {
+	// The whole point: refused before anything runs, so a password cannot reach
+	// a live process even once. margince.yaml is the most-pasted artefact an
+	// installation has — a value that CAN be written there eventually is.
+	const literal = "hunter2-the-real-password"
+	_, err := decodeSecret(t, "s: "+literal)
+	if err == nil {
+		t.Fatal("a literal secret was accepted; it must be refused")
+	}
+	if strings.Contains(err.Error(), literal) {
+		t.Errorf("the refusal repeated the secret it refused: %v", err)
+	}
+	// And it says what to write instead, or an operator is stuck.
+	for _, want := range []string{"${file:", "${env:"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not show the %s form: %v", want, err)
+		}
+	}
+}
+
+func TestBothReferenceFormsResolve(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("  from-the-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, tc := range map[string]struct{ doc, want string }{
+		// Trimmed both ends: every editor and secret store terminates a file
+		// its own way, and a trailing newline must not become part of a
+		// password.
+		"file": {doc: "s: ${file:" + path + "}", want: "from-the-file"},
+		"env":  {doc: "s: ${env:PROBE_TOKEN}", want: "from-the-environment"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s, err := decodeSecret(t, tc.doc)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			got, err := s.Resolve(config.Static(map[string]string{"PROBE_TOKEN": " from-the-environment "}))
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolved %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAnUnconfiguredSecretIsNotAFailure(t *testing.T) {
+	// An installation that names no licence token runs unlicensed. That is a
+	// supported state, so absence is not an error at this layer — the caller
+	// decides what is required.
+	s, err := decodeSecret(t, "s: \"\"")
+	if err != nil {
+		t.Fatalf("an empty secret field is not an error: %v", err)
+	}
+	if s.Configured() {
+		t.Error("an empty field reports as configured")
+	}
+	got, err := s.Resolve(config.Static(nil))
+	if err != nil || got != "" {
+		t.Errorf("Resolve on an unconfigured secret = %q, %v; want empty and no error", got, err)
+	}
+}
+
+func TestAReferenceToNothingSaysSo(t *testing.T) {
+	// The failures that otherwise present as "unlicensed" or "no password"
+	// rather than as the mistakes they are.
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, tc := range map[string]struct{ doc, wantIn string }{
+		"a file that is not there": {doc: "s: ${file:" + filepath.Join(dir, "absent") + "}", wantIn: "cannot be read"},
+		"a variable nobody set":    {doc: "s: ${env:PROBE_UNSET}", wantIn: "unset or empty"},
+		"a file holding nothing":   {doc: "s: ${file:" + empty + "}", wantIn: "holds nothing"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s, err := decodeSecret(t, tc.doc)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			got, resolveErr := s.withField("probe.secret").Resolve(config.Static(nil))
+			// A missing FILE fails on read; an unset VARIABLE resolves to
+			// empty and the caller reports it. Both end in a message naming
+			// the field and what to do.
+			msg := ""
+			switch {
+			case resolveErr != nil:
+				msg = resolveErr.Error()
+			case got == "":
+				msg = s.withField("probe.secret").Missing().Error()
+			default:
+				t.Fatalf("resolved %q, want a failure", got)
+			}
+			if !strings.Contains(msg, tc.wantIn) {
+				t.Errorf("message %q does not contain %q", msg, tc.wantIn)
+			}
+			if !strings.Contains(msg, "probe.secret") {
+				t.Errorf("message %q does not name the field to fix", msg)
+			}
+		})
+	}
+}
+
+func TestAReferenceNamingNothingIsRefused(t *testing.T) {
+	for _, doc := range []string{"s: ${env:}", "s: ${file:}"} {
+		if _, err := decodeSecret(t, doc); err == nil {
+			t.Errorf("%q was accepted; a reference to nothing cannot resolve", doc)
+		}
+	}
+}
+
+func TestAnOversizedFileIsRefusedWithoutReadingIt(t *testing.T) {
+	// A secret is a password, a key or a token. Anything larger is a path typed
+	// wrong, and pulling it into memory to discover that is the wrong order.
+	dir := t.TempDir()
+	big := filepath.Join(dir, "not-a-secret")
+	if err := os.WriteFile(big, make([]byte, secretFileLimit+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := decodeSecret(t, "s: ${file:"+big+"}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.withField("probe.secret").Resolve(config.Static(nil))
+	if err == nil || !strings.Contains(err.Error(), "a secret is not") {
+		t.Fatalf("an oversized file resolved to %v; want a refusal naming the size", err)
+	}
+}
+
+// TestEverySecretFieldRefusesALiteral is the point of having one mechanism:
+// the rule holds for each secret this file carries, not just the one whose
+// test somebody remembered to write.
+//
+// Derived from a real document rather than from the Secret type directly, so a
+// field that is declared as a plain string — the way all three of these were
+// before — fails here instead of quietly accepting a password.
+func TestEverySecretFieldRefusesALiteral(t *testing.T) {
+	for name, doc := range map[string]string{
+		"bootstrap_admin.password": "version: 1\nbootstrap_admin:\n  email: a@b.co\n  password: hunter2-literal\n",
+		"email.smtp.password":      "version: 1\nemail:\n  smtp:\n    host: mail\n    password: hunter2-literal\n",
+		"license.token":            "version: 1\nlicense:\n  token: hunter2-literal\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var cfg Config
+			err := yaml.Unmarshal([]byte(doc), &cfg)
+			if err == nil {
+				t.Fatalf("%s accepted a literal secret", name)
+			}
+			if strings.Contains(err.Error(), "hunter2-literal") {
+				t.Errorf("the refusal for %s repeated the secret: %v", name, err)
+			}
+		})
+	}
+}
+
+// And each accepts the reference form, so the refusal above is not simply a
+// field nobody can configure.
+func TestEverySecretFieldAcceptsAReference(t *testing.T) {
+	for name, doc := range map[string]string{
+		"bootstrap_admin.password": "version: 1\nbootstrap_admin:\n  email: a@b.co\n  password: ${env:X}\n",
+		"email.smtp.password":      "version: 1\nemail:\n  smtp:\n    host: mail\n    password: ${env:X}\n",
+		"license.token":            "version: 1\nlicense:\n  token: ${file:/run/secrets/l}\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var cfg Config
+			if err := yaml.Unmarshal([]byte(doc), &cfg); err != nil {
+				t.Fatalf("%s refused a reference: %v", name, err)
+			}
+		})
+	}
+}

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -36,6 +36,19 @@ bootstrap_admin:
   # the operator password means changing it in one place (or deleting the file
   # and letting dev.sh reseed it). The password seed-dev then chooses is its own
   # ADMIN_PASSWORD default.
+  # Either spelling works. The reference form is preferred and is the only one
+  # that can name the environment:
+  #
+  #   password: ${file:/run/secrets/admin-password}   the mounted secret store
+  #   password: ${env:MARGINCE_ADMIN_PASSWORD}        the environment
+  #
+  # A secret field REFUSES a literal — writing the password here fails the boot
+  # and names the line, because this file is the most-pasted artefact an
+  # installation has and a value that can be written here eventually is.
+  #
+  # The two are not equally compliant: ${file:} keeps the value in the secret
+  # store, while ${env:} only keeps it out of THIS file. OPS-CFG-3 names the
+  # environment alongside files, so ${env:} is a deliberate transitional form.
   password_file: config/margince-admin-password
 
 # Retention posture at first boot (optional). Consumed ONCE, when the api


### PR DESCRIPTION
First slice of #1252 increment 3. That increment lists six parts; one PR carrying all of them would be unreviewable, so this is the security-bearing half everything else builds on.

## The rule, enforced instead of described

OPS-CFG-3 says no configuration layer holds a secret's **value**, only a reference. Three fields carried that as three hand-rolled `*_file` readers — `bootstrap_admin`, `email.smtp`, `license`. They now share one mechanism:

```yaml
password: ${file:/run/secrets/admin-password}   # the mounted secret store
password: ${env:MARGINCE_ADMIN_PASSWORD}        # the environment
password: hunter2                                # boot error, naming the line
```

**The refusal happens at decode**, before anything runs. `margince.yaml` is the most-read and most-pasted artefact an installation has — it goes in tickets, in chat, in a screenshot of a terminal. A value that *can* be written there eventually is, and nobody notices a working installation whose credential is also in a support thread.

**The refusal never repeats the value.** Reporting what was written would put the literal into the boot log — the same leak wearing a different hat.

Both halves are mutation-proven: accepting a literal, and echoing one back, each fail their test.

## The two forms are not equivalent, and say so

| form | posture |
|---|---|
| `${file:...}` | the mounted file **is** the secret store — a Kubernetes Secret, a Docker secret, a vault projection. Fully OPS-CFG-3. |
| `${env:...}` | keeps the value out of **this file**, but leaves it in the environment layer, which OPS-CFG-3 names alongside files. A bounded, deliberate transitional form — the universal container pattern, and what every secret here does today. |

That distinction is in the type's doc comment rather than left for an operator to infer, because *"both are supported"* and *"both are equivalent"* are different sentences and only the first is true.

## Compatibility

The old `*_file` spellings still work, so an existing deployment boots unchanged. The reference wins when both are present — it is the newer, deliberate spelling, and the only one that can name the environment.

## The test worth reading

`TestEverySecretFieldRefusesALiteral` decodes **real YAML documents** rather than exercising the `Secret` type directly. A field declared as a plain string — which is exactly what all three were before this — fails it, instead of quietly accepting a password. Its sibling proves each field still accepts a reference, so the refusal is not simply a field nobody can configure.

## Verification

`make check` · `craft-static` (3 roots, 0 findings).

## Next slices

Per-env overlays (`margince.dev.yaml` / `.test.yaml`) with the documented resolution order, then folding `ai-routing.yaml` in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces secret-by-reference in deploy config and fails the boot on literals; an empty license token source is now a misconfiguration, not “unlicensed.” Previously `bootstrap_admin.password`, `email.smtp.password`, and `license.token` accepted plain strings or `*_file`; now they accept only `${file:...}` or `${env:...}` (legacy `*_file` still works).

- Introduces `deployconfig.Secret` to parse `${file:...}`/`${env:...}`, trim whitespace, cap file reads at 64 KiB, and name the YAML field in errors; values are never echoed. The reference wins over legacy `*_file`.
- API changes: `BootstrapAdmin.ResolvePassword(lookup)`, `Email.SMTPPassword(lookup)` (empty when unset = unauthenticated relay), and `license.Token(lookup)` resolves `license.token` via `TokenRef`; `MARGINCE_LICENSE` still overrides. Call sites updated to pass `config.FromOS`.
- License behavior: an empty/unreadable/oversized token reference is an error; compose messages now name the source actually used via `License.TokenOrigin(lookup)`. The production “no license” message points to `license.token` (or `MARGINCE_LICENSE`).
- Tests cover decode-time refusal without echoing, both reference forms, precedence over `*_file`, empty/missing source messaging, oversized file refusal, SMTP’s three states, and origin-specific license errors.

- Operator rollout
  - No action if you use `*_file` or `MARGINCE_LICENSE`; existing deployments boot unchanged.
  - Replace any literal with `${file:/run/secrets/...}` or `${env:...}`. If both a reference and `*_file` are present, the reference is used.

<sup>Written for commit 7dc564af6762626388e2608d5b09ad1180307526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for environment- and file-based secret references for bootstrap admin passwords, SMTP passwords, and license tokens.
  * Added validation and clearer errors for missing, invalid, short, or oversized secrets.
  * Preserved compatibility with existing password and license file settings.

* **Documentation**
  * Documented supported secret-reference syntax in the sample configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->