### PR TITLE
feat(compose): count and sample a filter before it is saved (LVS-EXT-9)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5230,6 +5230,7 @@ paths:
     post:
       tags: [Lists]
       operationId: previewFilter
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport, matching createFilteredExport
       # Human-only, and the reason is the same property that makes this operation
       # safe for a human: it is deliberately NOT audit-logged, because a count
       # that recomputes while somebody types must not write an audit row per

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5226,6 +5226,54 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /filters/preview:
+    post:
+      tags: [Lists]
+      operationId: previewFilter
+      # Human-only, and the reason is the same property that makes this operation
+      # safe for a human: it is deliberately NOT audit-logged, because a count
+      # that recomputes while somebody types must not write an audit row per
+      # keystroke. For an agent that same property would make it an un-audited
+      # bulk record read — the one shape agent governance exists to prevent. A
+      # governed read tool here is an additive decision that has to answer the
+      # audit question first, not a default this inherits from being a read.
+      x-agent-access: human-only
+      summary: Count and sample what a filter would select, before it is saved (LVS-EXT-9).
+      description: |
+        The match count and a bounded first page for a candidate filter tree —
+        the filter a human is still editing, which nothing else in the contract
+        can evaluate. The object list operations take flat scalar parameters and
+        cannot express a tree; membership needs a stored list; and the filtered
+        export is audit-logged, so driving a live recount through it would write
+        an audit row per keystroke.
+
+        POST because the filter tree is a structured body, not because anything
+        is created. Nothing is: no row, no audit entry, no outbox event. That is
+        the property that separates this from the export, and it is deliberate —
+        a preview a human triggers by typing must not be indistinguishable from
+        an extraction they chose to perform.
+
+        Row-scoped like every read: the count and the page are what THIS caller
+        may see, so two people previewing the same filter can legitimately get
+        different numbers. `columns` and `rows` are the same projection the JSON
+        filtered export writes for the same filter, so what you preview is what
+        an export of it would contain.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FilterPreviewRequest' }
+      responses:
+        '200':
+          description: The count and first page.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FilterPreview' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
   # ------------------------------ /views ------------------------------------
   /views:
     get:
@@ -19673,6 +19721,73 @@ components:
       properties:
         data: { type: array, items: { $ref: '#/components/schemas/ListMember' } }
         page: { $ref: '#/components/schemas/PageInfo' }
+
+    FilterPreviewRequest:
+      type: object
+      description: A candidate filter to evaluate without saving it.
+      required: [resource, filter]
+      properties:
+        resource:
+          type: string
+          enum: [person, organization, deal, lead, project]
+        filter:
+          type: object
+          additionalProperties: true
+          description: |
+            The canonical filter tree — the same representation a dynamic list's
+            `definition` and a saved view's `query` carry, and untyped here for
+            the same reason they are. The grammar's authority is the predicate
+            engine, which validates the tree and answers a precise 422 naming the
+            offending field and reason; a recursive schema here would be a second
+            statement of that grammar, free to drift from the one that decides.
+            One engine evaluates all three, so a tree this operation accepts is
+            one a list or view accepts.
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 25
+          description: |
+            How many rows to sample. The COUNT is unaffected by this — it is the
+            full match count for the caller, not the size of the page.
+
+    FilterPreview:
+      type: object
+      description: |
+        What a candidate filter would select for this caller (LVS-EXT-9).
+      required: [resource, match_count, columns, rows, truncated]
+      properties:
+        resource:
+          type: string
+          enum: [person, organization, deal, lead, project]
+        match_count:
+          type: integer
+          description: |
+            Every row the filter selects that this caller may see — not the
+            length of `rows`. This is the number a builder shows a human while
+            they decide whether the filter is right, so it is a full count rather
+            than a page size dressed up as one.
+        columns:
+          type: array
+          items: { type: string }
+          description: |
+            The column order the rows below are keyed by, schema-derived and
+            identical to the JSON filtered export's for the same resource.
+        rows:
+          type: array
+          description: |
+            Up to `limit` matching rows as column→value maps, ordered by id.
+            Deliberately the export's projection rather than a shape invented for
+            this screen: a preview that showed different columns than the export
+            of the same filter would be a preview of something else.
+          items:
+            type: object
+            additionalProperties: true
+        truncated:
+          type: boolean
+          description: |
+            Whether `match_count` exceeds the rows returned — so a caller can say
+            "showing 25 of 812" without comparing lengths and guessing.
 
     FilterVocabulary:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -337,6 +337,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "tool", Tool: "send_account_email", RecordType: "activity", Tier: "confirmation_required", Scope: "send"},
 	"POST /v1/embeddings/reindex":                                        {Op: "EmbedReindexStart", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/exports":                                                   {Op: "createFilteredExport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/filters/preview":                                           {Op: "previewFilter", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates":                                                  {Op: "setFxRate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates/propose-refresh":                                  {Op: "proposeFxRateRefresh", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/imports":                                                   {Op: "createImportRun", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/filterpreview.go
+++ b/backend/internal/compose/filterpreview.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Previewing a filter nobody has saved yet (LVS-EXT-9).
+//
+// A filter builder shows a count that recomputes as clauses change, and until
+// now nothing in the contract could evaluate the tree it recomputes for: the
+// object list operations take flat scalar parameters and cannot express a tree,
+// membership needs a stored list, and the filtered export is audit-logged — so
+// driving a live recount through it would write an audit row per keystroke.
+//
+// It lives in compose rather than in collections for the same reason filtered
+// export does: it needs the export's schema-derived projection as well as the
+// collections store's engine, and a module may not import a sibling. Sharing
+// that projection is also what makes the preview honest — the columns and values
+// are the ones the JSON export writes for the same filter, so somebody deciding
+// from a preview is deciding about the thing they would get.
+//
+// What this deliberately does NOT do is write: no row, no audit entry, no outbox
+// event. That is the property separating it from the export, and it is why the
+// operation is human-only in the contract — un-audited is right for somebody
+// typing and wrong for an agent reading records in bulk.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/collections"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+// filterPreviewDefaultRows is the page a caller who names no limit gets, and
+// filterPreviewMaxRows the ceiling. Both are about what a builder renders while
+// somebody types — a preview is a glance, not a report. The contract publishes
+// the same two numbers.
+const (
+	filterPreviewDefaultRows = 25
+	filterPreviewMaxRows     = 100
+)
+
+// filterPreviewHandlers shadows the generated PreviewFilter stub.
+type filterPreviewHandlers struct {
+	pool        *pgxpool.Pool
+	collections *collections.Store
+}
+
+// filterPreviewRequest is the preview body, decoded here rather than through the
+// generated type for one reason: the generated Filter is a map, and the engine
+// takes a storekit.Predicate. Decoding straight into the predicate — exactly as
+// filteredExportRequest does — keeps the tree typed from the wire inward instead
+// of re-marshalling a map to get there.
+type filterPreviewRequest struct {
+	Resource string              `json:"resource"`
+	Filter   *storekit.Predicate `json:"filter"`
+	Limit    *int                `json:"limit"`
+}
+
+func (h filterPreviewHandlers) PreviewFilter(w http.ResponseWriter, r *http.Request) {
+	var req filterPreviewRequest
+	if !httperr.Decode(w, r, &req) {
+		return
+	}
+	if req.Filter == nil {
+		httperr.Write(w, r, httperr.Validation("filter", codeInvalid,
+			"a filter tree is required — preview evaluates a candidate filter, not the whole object"))
+		return
+	}
+	engine, ok, err := h.collections.SegmentEngine(r.Context(), req.Resource)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	if !ok {
+		httperr.Write(w, r, httperr.Validation("resource", codeInvalid,
+			fmt.Sprintf("%q is not a filterable resource", req.Resource)))
+		return
+	}
+
+	preview, err := h.preview(r.Context(), engine, *req.Filter, rowLimit(req.Limit))
+	if err != nil {
+		writeFilterPreviewError(w, r, err)
+		return
+	}
+	preview.Resource = crmcontracts.FilterPreviewResource(req.Resource)
+	httperr.WriteJSON(w, http.StatusOK, preview)
+}
+
+// preview runs the count and the page in ONE transaction.
+//
+// Two transactions against a moving table would let a concurrent write land
+// between them, and the caller would read "812 matches" above a page whose rows
+// do not add up — a discrepancy they cannot explain and would reasonably read as
+// a bug in the filter they are building.
+func (h filterPreviewHandlers) preview(
+	ctx context.Context, engine storekit.Query, pred storekit.Predicate, limit int,
+) (crmcontracts.FilterPreview, error) {
+	var out crmcontracts.FilterPreview
+	err := database.WithWorkspaceTx(ctx, h.pool, func(tx pgx.Tx) error {
+		count, err := engine.CountMatching(ctx, tx, pred)
+		if err != nil {
+			return err
+		}
+		matched, err := engine.SelectIDs(ctx, tx, pred, limit)
+		if err != nil {
+			return err
+		}
+		columns, err := exportableColumns(ctx, tx, engine.Table)
+		if err != nil {
+			return err
+		}
+		rows, err := readRowsByID(ctx, tx, engine.Table, columns, matched)
+		if err != nil {
+			return err
+		}
+		out = crmcontracts.FilterPreview{
+			MatchCount: count,
+			Columns:    columns,
+			Rows:       rowsAsMaps(memberData{table: engine.Table, columns: columns, rows: rows}),
+			Truncated:  count > len(rows),
+		}
+		return nil
+	})
+	return out, err
+}
+
+// rowLimit clamps the requested page. An absent limit is the default rather than
+// "as many as allowed": a caller who did not ask for a size is a builder
+// rendering a glance, and the ceiling is there so one cannot ask for a report.
+func rowLimit(requested *int) int {
+	if requested == nil || *requested <= 0 {
+		return filterPreviewDefaultRows
+	}
+	if *requested > filterPreviewMaxRows {
+		return filterPreviewMaxRows
+	}
+	return *requested
+}
+
+// writeFilterPreviewError maps a refused predicate onto the 422 the contract
+// promises, naming the offending field. Everything else — a permission denial
+// from the engine's own read gate, a database fault — travels as itself.
+func writeFilterPreviewError(w http.ResponseWriter, r *http.Request, err error) {
+	var pred *storekit.PredicateError
+	if errors.As(err, &pred) {
+		httperr.Write(w, r, httperr.Validation(pred.Field, pred.Code, pred.Message))
+		return
+	}
+	httperr.Write(w, r, err)
+}

--- a/backend/internal/compose/filterpreview.go
+++ b/backend/internal/compose/filterpreview.go
@@ -20,8 +20,16 @@ package compose
 //
 // What this deliberately does NOT do is write: no row, no audit entry, no outbox
 // event. That is the property separating it from the export, and it is why the
-// operation is human-only in the contract — un-audited is right for somebody
-// typing and wrong for an agent reading records in bulk.
+// operation is human-only — un-logged is right for somebody typing and wrong for
+// an agent reading records in bulk.
+//
+// Why un-logged is defensible at all, stated as the fact rather than the
+// intuition: GET /v1/people already returns the same Person projection, 200 rows
+// a page WITH a cursor, writing no ledger row either. Preview is strictly less
+// capable — 100 rows, no cursor — so it opens no channel a human with read access
+// did not have. The export's system_log row is about an extraction ARTIFACT
+// leaving the system, which a preview does not produce; it is not a general
+// obligation on reading records, or the paged list read would owe one too.
 
 import (
 	"context"
@@ -34,6 +42,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/collections"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
@@ -46,6 +55,13 @@ import (
 const (
 	filterPreviewDefaultRows = 25
 	filterPreviewMaxRows     = 100
+	// previewStatementTimeoutMS bounds each statement in a preview. Generous for
+	// an indexable filter and short enough that an expensive one cannot hold a
+	// pool connection: a glance that takes five seconds has already failed at
+	// being a glance. A literal rather than a bind, because SET LOCAL takes no
+	// parameters — which is safe only because it is a constant here and never a
+	// caller's value.
+	previewStatementTimeoutMS = "5000"
 )
 
 // filterPreviewHandlers shadows the generated PreviewFilter stub.
@@ -66,6 +82,14 @@ type filterPreviewRequest struct {
 }
 
 func (h filterPreviewHandlers) PreviewFilter(w http.ResponseWriter, r *http.Request) {
+	// The human-only class is enforced here as well as at the transport, the same
+	// pairing the bundle export and overlay's user-map reads use: this returns
+	// records in bulk and writes no ledger row, so it should not rest on
+	// route-pattern resolution alone.
+	if err := auth.RequireHuman(r.Context()); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
 	var req filterPreviewRequest
 	if !httperr.Decode(w, r, &req) {
 		return
@@ -73,6 +97,11 @@ func (h filterPreviewHandlers) PreviewFilter(w http.ResponseWriter, r *http.Requ
 	if req.Filter == nil {
 		httperr.Write(w, r, httperr.Validation("filter", codeInvalid,
 			"a filter tree is required — preview evaluates a candidate filter, not the whole object"))
+		return
+	}
+	limit, err := previewRowLimit(req.Limit)
+	if err != nil {
+		httperr.Write(w, r, err)
 		return
 	}
 	engine, ok, err := h.collections.SegmentEngine(r.Context(), req.Resource)
@@ -86,7 +115,7 @@ func (h filterPreviewHandlers) PreviewFilter(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	preview, err := h.preview(r.Context(), engine, *req.Filter, rowLimit(req.Limit))
+	preview, err := h.preview(r.Context(), engine, *req.Filter, limit)
 	if err != nil {
 		writeFilterPreviewError(w, r, err)
 		return
@@ -95,17 +124,37 @@ func (h filterPreviewHandlers) PreviewFilter(w http.ResponseWriter, r *http.Requ
 	httperr.WriteJSON(w, http.StatusOK, preview)
 }
 
-// preview runs the count and the page in ONE transaction.
+// preview runs the count and the page in ONE transaction, which buys less than
+// it looks like and is still worth having.
 //
-// Two transactions against a moving table would let a concurrent write land
-// between them, and the caller would read "812 matches" above a page whose rows
-// do not add up — a discrepancy they cannot explain and would reasonably read as
-// a bug in the filter they are building.
+// What it does NOT buy is a shared snapshot. These run at READ COMMITTED — the
+// pool sets no isolation level — so each statement takes its own snapshot and a
+// commit landing between them is visible to the second. Claiming otherwise would
+// invite the next reader to rely on stability that is not there.
+//
+// What it does buy: one connection, one workspace binding, and two statements
+// back to back, which is the smallest window available without paying for
+// REPEATABLE READ. A preview is a glance at a moving table, and a count one write
+// stale is the honest cost of that — the alternative is a serialization failure
+// shown to somebody who is only typing.
 func (h filterPreviewHandlers) preview(
 	ctx context.Context, engine storekit.Query, pred storekit.Predicate, limit int,
 ) (crmcontracts.FilterPreview, error) {
 	var out crmcontracts.FilterPreview
 	err := database.WithWorkspaceTx(ctx, h.pool, func(tx pgx.Tx) error {
+		// The count is unbounded by design and its predicate is written by the
+		// caller — up to PredicateMaxLeaves substring matches, each of which can
+		// mean a sequential scan, over the largest tables. That combination is new
+		// here: the automation preview also counts without a cap, but from a fixed
+		// catalog of predicates rather than a tree somebody typed.
+		//
+		// So the statement, not the tree, carries the ceiling. A filter too
+		// expensive to count is refused in bounded time instead of holding a pool
+		// connection for as long as it takes, which is the difference between one
+		// slow request and a server that stops answering.
+		if _, err := tx.Exec(ctx, "SET LOCAL statement_timeout = "+previewStatementTimeoutMS); err != nil {
+			return fmt.Errorf("bound the preview statement: %w", err)
+		}
 		count, err := engine.CountMatching(ctx, tx, pred)
 		if err != nil {
 			return err
@@ -133,17 +182,24 @@ func (h filterPreviewHandlers) preview(
 	return out, err
 }
 
-// rowLimit clamps the requested page. An absent limit is the default rather than
-// "as many as allowed": a caller who did not ask for a size is a builder
-// rendering a glance, and the ceiling is there so one cannot ask for a report.
-func rowLimit(requested *int) int {
-	if requested == nil || *requested <= 0 {
-		return filterPreviewDefaultRows
+// previewRowLimit resolves the requested page size, refusing what the contract
+// calls invalid rather than quietly substituting something else.
+//
+// An ABSENT limit is the documented default: a caller who did not ask for a size
+// is a builder rendering a glance. A limit outside the published 1..100 is a 422,
+// which is the sibling preview's convention (the automation preview refuses
+// window_days = 0 for the same reason) and the only answer consistent with
+// declaring bounds at all — silently returning 100 rows to somebody who asked for
+// 5000 tells them their request was honoured when it was rewritten.
+func previewRowLimit(requested *int) (int, error) {
+	if requested == nil {
+		return filterPreviewDefaultRows, nil
 	}
-	if *requested > filterPreviewMaxRows {
-		return filterPreviewMaxRows
+	if *requested < 1 || *requested > filterPreviewMaxRows {
+		return 0, httperr.Validation("limit", codeInvalid,
+			fmt.Sprintf("limit must be between 1 and %d — a preview is a glance, not a report", filterPreviewMaxRows))
 	}
-	return *requested
+	return *requested, nil
 }
 
 // writeFilterPreviewError maps a refused predicate onto the 422 the contract

--- a/backend/internal/compose/filterpreview_test.go
+++ b/backend/internal/compose/filterpreview_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// previewRowLimit is pure, so it is proven here rather than behind a database.
+// The integration suite covers the refusal reaching the wire as a 422 naming
+// `limit`; what belongs in this lane is the boundary table — the default, both
+// ends of the published range, and both sides of each end.
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+func TestPreviewRowLimitTakesTheRangeTheContractPublishes(t *testing.T) {
+	limit := func(n int) *int { return &n }
+
+	for _, c := range []struct {
+		name      string
+		requested *int
+		want      int
+		refused   bool
+	}{
+		// Absent is the documented default, and it is NOT the same answer as an
+		// out-of-range value: a caller who named no size gets a glance, a caller
+		// who named an impossible one gets told.
+		{"absent", nil, filterPreviewDefaultRows, false},
+		{"the floor", limit(1), 1, false},
+		{"the ceiling", limit(filterPreviewMaxRows), filterPreviewMaxRows, false},
+		{"just inside the ceiling", limit(filterPreviewMaxRows - 1), filterPreviewMaxRows - 1, false},
+		{"zero", limit(0), 0, true},
+		{"negative", limit(-1), 0, true},
+		{"just past the ceiling", limit(filterPreviewMaxRows + 1), 0, true},
+		{"far past the ceiling", limit(5000), 0, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := previewRowLimit(c.requested)
+			if c.refused {
+				if err == nil {
+					t.Fatalf("limit %v was accepted as %d; the contract calls it invalid", c.requested, got)
+				}
+				// A refusal has to reach the caller as a 422 naming `limit`, not as
+				// a 500 — so the error carries both, and this checks both rather
+				// than settling for "an error happened".
+				var detailed *httperr.DetailedError
+				if !errors.As(err, &detailed) {
+					t.Fatalf("err = %#v, want a *httperr.DetailedError so the transport can answer 422", err)
+				}
+				if detailed.Status != http.StatusUnprocessableEntity {
+					t.Errorf("status = %d, want 422", detailed.Status)
+				}
+				if len(detailed.Fields) != 1 || detailed.Fields[0].Field != "limit" {
+					t.Errorf("fields = %+v, want exactly one naming limit", detailed.Fields)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("limit %v refused: %v", c.requested, err)
+			}
+			if got != c.want {
+				t.Errorf("limit %v = %d, want %d", c.requested, got, c.want)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/integration/collections/filterpreview_integration_test.go
+++ b/backend/internal/compose/integration/collections/filterpreview_integration_test.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package collections
+
+// Previewing an unsaved filter (LVS-EXT-9), over the composed server.
+//
+// Three claims only a real database and a real server can settle, and each one
+// is a promise the operation's contract makes:
+//
+//   - the count is the FULL match count, not the page it labels — the number a
+//     human reads while deciding whether their filter is right;
+//   - the columns and rows are the same projection the JSON export writes for the
+//     same filter, so a preview is a preview OF the thing you would get;
+//   - nothing is written. No audit row, no outbox event. That is what separates a
+//     count recomputing while somebody types from an extraction they chose.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+// seedPeopleWithTier creates people carrying a picklist custom field, returning
+// the column name so a filter can name it.
+func seedPeopleWithTier(t *testing.T, e *apptest.AppEnv, gold, other int) string {
+	t.Helper()
+	var field apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
+		"object": "person", "label": "Preview Tier", "type": "text", "source": "ui",
+	}, nil, &field); status != http.StatusCreated {
+		t.Fatalf("create custom field: status=%d body=%v", status, field)
+	}
+	column, _ := field["column_name"].(string)
+	if column == "" {
+		t.Fatalf("created field carries no column_name: %v", field)
+	}
+	for i := range gold + other {
+		tier := "gold"
+		if i >= gold {
+			tier = "silver"
+		}
+		var person apptest.AnyMap
+		if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+			"full_name": "Preview Subject", "source": "ui", column: tier,
+		}, nil, &person); status != http.StatusCreated {
+			t.Fatalf("create person %d: status=%d body=%v", i, status, person)
+		}
+	}
+	return column
+}
+
+// ledgerRows counts every row this tree records a write in, across all three
+// ledgers rather than one.
+//
+// All three, because "writes nothing" is only meaningful if it covers everywhere
+// a write could show up: the write shape commits an audit row AND an outbox event
+// together, so watching one would miss half of a mutation — and a BULK read is
+// recorded in neither. The filtered export logs to system_log on the stated
+// reasoning that an export targets no single record, so audit_log alone would
+// have made the contrast below silently vacuous.
+func ledgerRows(t *testing.T, e *apptest.AppEnv) int {
+	t.Helper()
+	var n int
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT (SELECT count(*) FROM audit_log)
+		     + (SELECT count(*) FROM event_outbox)
+		     + (SELECT count(*) FROM system_log)`).Scan(&n); err != nil {
+		t.Fatalf("count the ledgers: %v", err)
+	}
+	return n
+}
+
+type previewBody struct {
+	Resource   string           `json:"resource"`
+	MatchCount int              `json:"match_count"`
+	Columns    []string         `json:"columns"`
+	Rows       []apptest.AnyMap `json:"rows"`
+	Truncated  bool             `json:"truncated"`
+}
+
+// The count counts everything and the page is bounded, which is the whole point:
+// a builder says "showing 3 of 12" from one call.
+func TestAFilterPreviewCountsEveryMatchAndReturnsABoundedPage(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
+	e.BootstrapWorkspace(t)
+	column := seedPeopleWithTier(t, e, 12, 4)
+
+	limit := 3
+	var got previewBody
+	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		"resource": "person",
+		"filter":   apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+		"limit":    limit,
+	}, nil, &got); status != http.StatusOK {
+		t.Fatalf("preview: status=%d body=%+v", status, got)
+	}
+	if got.MatchCount != 12 {
+		t.Errorf("match_count = %d, want 12 — the full match count, not the page", got.MatchCount)
+	}
+	if len(got.Rows) != limit {
+		t.Errorf("rows = %d, want the requested %d", len(got.Rows), limit)
+	}
+	if !got.Truncated {
+		t.Error("truncated = false while the count exceeds the page — a caller cannot say 'showing 3 of 12'")
+	}
+	if got.Resource != "person" {
+		t.Errorf("resource = %q, want the one asked for", got.Resource)
+	}
+	// The non-matching four are excluded, so the filter really ran.
+	if got.MatchCount == 16 {
+		t.Error("match_count counted every person; the predicate was not applied")
+	}
+}
+
+// A filter matching everything it selects fits in one page: truncated is false
+// and the count equals the rows, so the flag is not simply always true.
+func TestAFilterPreviewThatFitsIsNotTruncated(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
+	e.BootstrapWorkspace(t)
+	column := seedPeopleWithTier(t, e, 2, 1)
+
+	var got previewBody
+	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		"resource": "person",
+		"filter":   apptest.AnyMap{"field": column, "op": "eq", "value": "gold"},
+	}, nil, &got); status != http.StatusOK {
+		t.Fatalf("preview: status=%d body=%+v", status, got)
+	}
+	if got.MatchCount != 2 || len(got.Rows) != 2 {
+		t.Fatalf("match_count=%d rows=%d, want 2 and 2", got.MatchCount, len(got.Rows))
+	}
+	if got.Truncated {
+		t.Error("truncated = true for a page holding every match")
+	}
+}
+
+// The invariant the shared projection exists for: preview and the JSON export of
+// the SAME filter describe the same slice. If these ever diverge, a human decides
+// from a preview and receives something else.
+func TestAFilterPreviewDescribesTheSameSliceTheExportWrites(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
+	e.BootstrapWorkspace(t)
+	column := seedPeopleWithTier(t, e, 3, 2)
+	filter := apptest.AnyMap{"field": column, "op": "eq", "value": "gold"}
+
+	var preview previewBody
+	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		"resource": "person", "filter": filter, "limit": 100,
+	}, nil, &preview); status != http.StatusOK {
+		t.Fatalf("preview: status=%d body=%+v", status, preview)
+	}
+
+	// The export renders JSON, so the harness decodes its envelope straight into
+	// the shape below — that envelope is the comparison's other half.
+	var exported struct {
+		Rows     []apptest.AnyMap `json:"rows"`
+		RowCount int              `json:"row_count"`
+	}
+	if status := e.Call(t, "POST", "/v1/exports", apptest.AnyMap{
+		"object": "person", "filter": filter, "format": "json",
+	}, nil, &exported); status != http.StatusOK {
+		t.Fatalf("export: status=%d", status)
+	}
+
+	if exported.RowCount != preview.MatchCount {
+		t.Errorf("export wrote %d rows, preview promised %d", exported.RowCount, preview.MatchCount)
+	}
+	if len(exported.Rows) != len(preview.Rows) {
+		t.Fatalf("export rows=%d preview rows=%d", len(exported.Rows), len(preview.Rows))
+	}
+	// Same keys, same values, row for row — both are ordered by id.
+	for i := range preview.Rows {
+		for key, want := range exported.Rows[i] {
+			got, present := preview.Rows[i][key]
+			if !present {
+				t.Errorf("row %d: export carries %q and the preview omits it", i, key)
+				continue
+			}
+			if fmt.Sprint(got) != fmt.Sprint(want) {
+				t.Errorf("row %d key %q: preview %v, export %v", i, key, got, want)
+			}
+		}
+		for key := range preview.Rows[i] {
+			if _, present := exported.Rows[i][key]; !present {
+				t.Errorf("row %d: preview carries %q and the export does not", i, key)
+			}
+		}
+	}
+}
+
+// Previewing writes nothing. The export of the same filter DOES write a ledger
+// row, which is what makes this a contrast rather than an assertion about
+// silence: the ledgers provably grow on this path, and a preview does not grow
+// them. Without that second half, a broken counter would read as a passing test.
+func TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
+	e.BootstrapWorkspace(t)
+	column := seedPeopleWithTier(t, e, 2, 0)
+	filter := apptest.AnyMap{"field": column, "op": "eq", "value": "gold"}
+
+	before := ledgerRows(t, e)
+	for range 3 {
+		var got previewBody
+		if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+			"resource": "person", "filter": filter,
+		}, nil, &got); status != http.StatusOK {
+			t.Fatalf("preview: status=%d", status)
+		}
+	}
+	if after := ledgerRows(t, e); after != before {
+		t.Errorf("three previews wrote %d ledger rows; a recount while somebody types must write none", after-before)
+	}
+
+	var exported apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/exports", apptest.AnyMap{
+		"object": "person", "filter": filter, "format": "json",
+	}, nil, &exported); status != http.StatusOK {
+		t.Fatalf("export: status=%d", status)
+	}
+	if after := ledgerRows(t, e); after <= before {
+		t.Errorf("the export grew no ledger (%d → %d), so this test cannot tell a silent preview from a broken counter", before, after)
+	}
+}
+
+// A tree the engine refuses is a 422 naming the offending field, not a 500 and
+// not an empty preview — an empty result would read as "nothing matches".
+func TestAFilterPreviewRefusesAnUnknownFieldByName(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
+	e.BootstrapWorkspace(t)
+
+	var refused apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		"resource": "person",
+		"filter":   apptest.AnyMap{"field": "not_a_column", "op": "eq", "value": "x"},
+	}, nil, &refused); status != http.StatusUnprocessableEntity {
+		t.Fatalf("unknown field: status=%d body=%v, want 422", status, refused)
+	}
+	var missingFilter apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		"resource": "person",
+	}, nil, &missingFilter); status != http.StatusUnprocessableEntity {
+		t.Fatalf("absent filter: status=%d body=%v, want 422", status, missingFilter)
+	}
+	var badResource apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
+		"resource": "activity",
+		"filter":   apptest.AnyMap{"field": "kind", "op": "eq", "value": "call"},
+	}, nil, &badResource); status != http.StatusUnprocessableEntity {
+		t.Fatalf("non-filterable resource: status=%d body=%v, want 422", status, badResource)
+	}
+}

--- a/backend/internal/compose/integration/collections/filterpreview_integration_test.go
+++ b/backend/internal/compose/integration/collections/filterpreview_integration_test.go
@@ -19,8 +19,8 @@ package collections
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
@@ -57,25 +57,29 @@ func seedPeopleWithTier(t *testing.T, e *apptest.AppEnv, gold, other int) string
 	return column
 }
 
-// ledgerRows counts every row this tree records a write in, across all three
-// ledgers rather than one.
+// ledgers counts the three places this tree records a write, SEPARATELY.
 //
-// All three, because "writes nothing" is only meaningful if it covers everywhere
-// a write could show up: the write shape commits an audit row AND an outbox event
-// together, so watching one would miss half of a mutation — and a BULK read is
-// recorded in neither. The filtered export logs to system_log on the stated
-// reasoning that an export targets no single record, so audit_log alone would
-// have made the contrast below silently vacuous.
-func ledgerRows(t *testing.T, e *apptest.AppEnv) int {
+// Separately rather than as a sum, because a sum can only say "something moved":
+// it cannot tell an export logging where it should from an export logging into
+// the record-mutation spine, and the assertions below want both. All three,
+// because "writes nothing" is only meaningful if it covers everywhere a write
+// shows up — the write shape commits an audit row AND an outbox event together,
+// and a bulk read is recorded in neither.
+//
+// Read through e.Owner precisely BECAUSE it bypasses RLS: "nothing was written
+// anywhere" must not be satisfiable by a row hidden in another workspace.
+type ledgerCounts struct{ audit, outbox, system int }
+
+func ledgers(t *testing.T, e *apptest.AppEnv) ledgerCounts {
 	t.Helper()
-	var n int
+	var c ledgerCounts
 	if err := e.Owner.QueryRow(context.Background(), `
-		SELECT (SELECT count(*) FROM audit_log)
-		     + (SELECT count(*) FROM event_outbox)
-		     + (SELECT count(*) FROM system_log)`).Scan(&n); err != nil {
+		SELECT (SELECT count(*) FROM audit_log),
+		       (SELECT count(*) FROM event_outbox),
+		       (SELECT count(*) FROM system_log)`).Scan(&c.audit, &c.outbox, &c.system); err != nil {
 		t.Fatalf("count the ledgers: %v", err)
 	}
-	return n
+	return c
 }
 
 type previewBody struct {
@@ -114,9 +118,13 @@ func TestAFilterPreviewCountsEveryMatchAndReturnsABoundedPage(t *testing.T) {
 	if got.Resource != "person" {
 		t.Errorf("resource = %q, want the one asked for", got.Resource)
 	}
-	// The non-matching four are excluded, so the filter really ran.
-	if got.MatchCount == 16 {
-		t.Error("match_count counted every person; the predicate was not applied")
+	// columns is a required field the row comparison never touches, so an empty or
+	// mis-sized one would pass every other assertion here.
+	if len(got.Columns) == 0 {
+		t.Error("columns is empty; a caller cannot render a table from row keys alone")
+	}
+	if len(got.Rows) > 0 && len(got.Columns) != len(got.Rows[0]) {
+		t.Errorf("columns lists %d names for rows carrying %d keys", len(got.Columns), len(got.Rows[0]))
 	}
 }
 
@@ -176,16 +184,19 @@ func TestAFilterPreviewDescribesTheSameSliceTheExportWrites(t *testing.T) {
 	if len(exported.Rows) != len(preview.Rows) {
 		t.Fatalf("export rows=%d preview rows=%d", len(exported.Rows), len(preview.Rows))
 	}
-	// Same keys, same values, row for row — both are ordered by id.
+	// DeepEqual, not stringified. Both sides return through the same
+	// json.Unmarshal so their types already agree — and type divergence with
+	// identical TEXT is exactly what matters here: swap rowsAsMaps for a CSV-style
+	// renderer and every value becomes a string, which a text comparison would wave
+	// through while the preview stopped being a preview of the JSON export. The
+	// per-key loop only reports which key diverged.
 	for i := range preview.Rows {
+		if reflect.DeepEqual(preview.Rows[i], exported.Rows[i]) {
+			continue
+		}
 		for key, want := range exported.Rows[i] {
-			got, present := preview.Rows[i][key]
-			if !present {
-				t.Errorf("row %d: export carries %q and the preview omits it", i, key)
-				continue
-			}
-			if fmt.Sprint(got) != fmt.Sprint(want) {
-				t.Errorf("row %d key %q: preview %v, export %v", i, key, got, want)
+			if got := preview.Rows[i][key]; !reflect.DeepEqual(got, want) {
+				t.Errorf("row %d key %q: preview %#v, export %#v", i, key, got, want)
 			}
 		}
 		for key := range preview.Rows[i] {
@@ -196,17 +207,21 @@ func TestAFilterPreviewDescribesTheSameSliceTheExportWrites(t *testing.T) {
 	}
 }
 
-// Previewing writes nothing. The export of the same filter DOES write a ledger
-// row, which is what makes this a contrast rather than an assertion about
-// silence: the ledgers provably grow on this path, and a preview does not grow
-// them. Without that second half, a broken counter would read as a passing test.
+// Previewing writes nothing, and the export of the same filter writes exactly one
+// system_log row and nothing else.
+//
+// The second half is what makes the first half mean something: without it, a
+// counter that had stopped working would read as a passing test. Naming WHICH
+// ledger the export grows also turns the reasoning behind that choice — a bulk
+// export targets no single record, so it does not belong in the audit spine —
+// from a comment into an assertion.
 func TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
 	column := seedPeopleWithTier(t, e, 2, 0)
 	filter := apptest.AnyMap{"field": column, "op": "eq", "value": "gold"}
 
-	before := ledgerRows(t, e)
+	before := ledgers(t, e)
 	for range 3 {
 		var got previewBody
 		if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
@@ -215,8 +230,8 @@ func TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes(t *testing.T) {
 			t.Fatalf("preview: status=%d", status)
 		}
 	}
-	if after := ledgerRows(t, e); after != before {
-		t.Errorf("three previews wrote %d ledger rows; a recount while somebody types must write none", after-before)
+	if after := ledgers(t, e); after != before {
+		t.Errorf("three previews moved the ledgers %+v → %+v; a recount while somebody types must write nothing", before, after)
 	}
 
 	var exported apptest.AnyMap
@@ -225,35 +240,65 @@ func TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes(t *testing.T) {
 	}, nil, &exported); status != http.StatusOK {
 		t.Fatalf("export: status=%d", status)
 	}
-	if after := ledgerRows(t, e); after <= before {
-		t.Errorf("the export grew no ledger (%d → %d), so this test cannot tell a silent preview from a broken counter", before, after)
+	after := ledgers(t, e)
+	if after.system != before.system+1 {
+		t.Errorf("system_log grew by %d, want exactly 1 — otherwise this test cannot tell a silent preview from a broken counter", after.system-before.system)
+	}
+	if after.audit != before.audit {
+		t.Errorf("the export wrote %d audit_log row(s); a bulk export targets no single record and does not belong in the record-mutation spine", after.audit-before.audit)
+	}
+	if after.outbox != before.outbox {
+		t.Errorf("the export wrote %d outbox event(s); exporting is not a domain mutation", after.outbox-before.outbox)
 	}
 }
 
-// A tree the engine refuses is a 422 naming the offending field, not a 500 and
-// not an empty preview — an empty result would read as "nothing matches".
-func TestAFilterPreviewRefusesAnUnknownFieldByName(t *testing.T) {
+// A refusal is a 422 that NAMES the offending input, which is the difference
+// between a builder highlighting the broken clause and a builder showing a
+// generic red banner. Asserting only the status code would leave that promise
+// untested — an empty field, or the wrong one, would pass.
+func TestAFilterPreviewRefusalNamesTheOffendingInput(t *testing.T) {
 	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(integration.SchemaPool(t)))
 	e.BootstrapWorkspace(t)
+	limitTooLarge := 5000
 
-	var refused apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
-		"resource": "person",
-		"filter":   apptest.AnyMap{"field": "not_a_column", "op": "eq", "value": "x"},
-	}, nil, &refused); status != http.StatusUnprocessableEntity {
-		t.Fatalf("unknown field: status=%d body=%v, want 422", status, refused)
-	}
-	var missingFilter apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
-		"resource": "person",
-	}, nil, &missingFilter); status != http.StatusUnprocessableEntity {
-		t.Fatalf("absent filter: status=%d body=%v, want 422", status, missingFilter)
-	}
-	var badResource apptest.AnyMap
-	if status := e.Call(t, "POST", "/v1/filters/preview", apptest.AnyMap{
-		"resource": "activity",
-		"filter":   apptest.AnyMap{"field": "kind", "op": "eq", "value": "call"},
-	}, nil, &badResource); status != http.StatusUnprocessableEntity {
-		t.Fatalf("non-filterable resource: status=%d body=%v, want 422", status, badResource)
+	for _, c := range []struct {
+		name  string
+		body  apptest.AnyMap
+		field string
+	}{
+		{"a field the vocabulary does not admit", apptest.AnyMap{
+			"resource": "person",
+			"filter":   apptest.AnyMap{"field": "not_a_column", "op": "eq", "value": "x"},
+		}, "not_a_column"},
+		{"no filter at all", apptest.AnyMap{"resource": "person"}, "filter"},
+		{"a resource with no engine", apptest.AnyMap{
+			"resource": "activity",
+			"filter":   apptest.AnyMap{"field": "kind", "op": "eq", "value": "call"},
+		}, "resource"},
+		// The contract publishes 1..100; a value outside it is refused rather than
+		// quietly rewritten, so a caller learns their request was not honoured.
+		{"a limit past the published ceiling", apptest.AnyMap{
+			"resource": "person",
+			"filter":   apptest.AnyMap{"field": "full_name", "op": "contains", "value": "a"},
+			"limit":    limitTooLarge,
+		}, "limit"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			// The per-field breakdown rides details.errors (httperr's fieldDetails),
+			// not the problem's top level.
+			var problem struct {
+				Details struct {
+					Errors []struct {
+						Field string `json:"field"`
+					} `json:"errors"`
+				} `json:"details"`
+			}
+			if status := e.Call(t, "POST", "/v1/filters/preview", c.body, nil, &problem); status != http.StatusUnprocessableEntity {
+				t.Fatalf("→ %d, want 422", status)
+			}
+			if got := problem.Details.Errors; len(got) != 1 || got[0].Field != c.field {
+				t.Errorf("field errors = %v, want exactly one naming %q", got, c.field)
+			}
+		})
 	}
 }

--- a/backend/internal/compose/integration/predicate_integration_test.go
+++ b/backend/internal/compose/integration/predicate_integration_test.go
@@ -104,4 +104,34 @@ func TestPredicateEngineFiltersRealRowsWithinRowScope(t *testing.T) {
 	if !got[mineOther] || !got[mineMatch] || got[foreignMatch] || got[mineLiteral] {
 		t.Errorf("nested OR = %v, want {%s, %s}", got, mineOther, mineMatch)
 	}
+
+	// The COUNT is scoped the same way the page is, and it needs saying
+	// separately: a count is an existence oracle. An unscoped one would answer
+	// "812 rows match owner_id = <another team's rep>" while the page it labels
+	// showed none, which tells the caller precisely what the row scope exists to
+	// withhold. The rep-versus-admin delta below IS the scope clause, exactly as
+	// it is for SelectIDs above.
+	countMatching := func(ctx context.Context, p storekit.Predicate) int {
+		t.Helper()
+		var n int
+		err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+			var err error
+			n, err = engine.CountMatching(ctx, tx, p)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("predicate count: %v", err)
+		}
+		return n
+	}
+
+	if n := countMatching(rep, contains("renewal")); n != 2 {
+		t.Errorf("team-scoped count(renewal) = %d, want 2 — the foreign team's match must not be counted", n)
+	}
+	if n := countMatching(e.Admin(), contains("renewal")); n != 3 {
+		t.Errorf("admin count(renewal) = %d, want 3 across both teams", n)
+	}
+	if n := countMatching(rep, byForeignOwner); n != 0 {
+		t.Errorf("team-scoped count on a foreign owner = %d, want 0 — a count must not confirm rows the caller cannot read", n)
+	}
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	traceHandlers
 	pipelineTraceHandlers
 	filteredExportHandlers
+	filterPreviewHandlers
 	overlayExportHandlers
 	orgRollupHandlers
 	strengthHandlers

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -120,15 +120,17 @@ func (s *Server) wireExportSurface(pool *pgxpool.Pool, log *slog.Logger) {
 	// vocabulary with this workspace's cf_* columns, so an export cannot
 	// disagree with the list or the saved view it was built from — the same
 	// seam newPeopleHandlers wires for the record stores.
+	// One store for both surfaces: the preview rides the same engine and the same
+	// projection as the export, so a filter's count and sample cannot disagree
+	// with an export of that filter.
+	collectionsStore := NewCollectionsStore(pool)
 	s.filteredExportHandlers = filteredExportHandlers{
 		writer:      NewFilteredExportWriter(pool),
-		collections: NewCollectionsStore(pool),
+		collections: collectionsStore,
 	}
-	// The preview rides the same store and the same projection, so a filter's
-	// count and sample cannot disagree with the export of that filter.
 	s.filterPreviewHandlers = filterPreviewHandlers{
 		pool:        pool,
-		collections: NewCollectionsStore(pool),
+		collections: collectionsStore,
 	}
 	s.overlayExportHandlers = newOverlayExportHandlers(pool, log)
 }

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -124,6 +124,12 @@ func (s *Server) wireExportSurface(pool *pgxpool.Pool, log *slog.Logger) {
 		writer:      NewFilteredExportWriter(pool),
 		collections: NewCollectionsStore(pool),
 	}
+	// The preview rides the same store and the same projection, so a filter's
+	// count and sample cannot disagree with the export of that filter.
+	s.filterPreviewHandlers = filterPreviewHandlers{
+		pool:        pool,
+		collections: NewCollectionsStore(pool),
+	}
 	s.overlayExportHandlers = newOverlayExportHandlers(pool, log)
 }
 

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -579,6 +579,10 @@ func (stubs) GetFieldHistory(w nethttp.ResponseWriter, r *nethttp.Request, param
 	httperr.NotImplemented(w, r, "GetFieldHistory")
 }
 
+func (stubs) PreviewFilter(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "PreviewFilter")
+}
+
 func (stubs) GetFilterVocabulary(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.GetFilterVocabularyParams) {
 	httperr.NotImplemented(w, r, "GetFilterVocabulary")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3936,6 +3936,60 @@ func (e FieldHistoryEntryEntityType) Valid() bool {
 	}
 }
 
+// Defines values for FilterPreviewResource.
+const (
+	FilterPreviewResourceDeal         FilterPreviewResource = "deal"
+	FilterPreviewResourceLead         FilterPreviewResource = "lead"
+	FilterPreviewResourceOrganization FilterPreviewResource = "organization"
+	FilterPreviewResourcePerson       FilterPreviewResource = "person"
+	FilterPreviewResourceProject      FilterPreviewResource = "project"
+)
+
+// Valid indicates whether the value is a known member of the FilterPreviewResource enum.
+func (e FilterPreviewResource) Valid() bool {
+	switch e {
+	case FilterPreviewResourceDeal:
+		return true
+	case FilterPreviewResourceLead:
+		return true
+	case FilterPreviewResourceOrganization:
+		return true
+	case FilterPreviewResourcePerson:
+		return true
+	case FilterPreviewResourceProject:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for FilterPreviewRequestResource.
+const (
+	FilterPreviewRequestResourceDeal         FilterPreviewRequestResource = "deal"
+	FilterPreviewRequestResourceLead         FilterPreviewRequestResource = "lead"
+	FilterPreviewRequestResourceOrganization FilterPreviewRequestResource = "organization"
+	FilterPreviewRequestResourcePerson       FilterPreviewRequestResource = "person"
+	FilterPreviewRequestResourceProject      FilterPreviewRequestResource = "project"
+)
+
+// Valid indicates whether the value is a known member of the FilterPreviewRequestResource enum.
+func (e FilterPreviewRequestResource) Valid() bool {
+	switch e {
+	case FilterPreviewRequestResourceDeal:
+		return true
+	case FilterPreviewRequestResourceLead:
+		return true
+	case FilterPreviewRequestResourceOrganization:
+		return true
+	case FilterPreviewRequestResourcePerson:
+		return true
+	case FilterPreviewRequestResourceProject:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FilterVocabularyResource.
 const (
 	FilterVocabularyResourceDeal         FilterVocabularyResource = "deal"
@@ -14204,6 +14258,54 @@ type FieldHistoryListResponse struct {
 	Data []FieldHistoryEntry `json:"data"`
 	Page PageInfo            `json:"page"`
 }
+
+// FilterPreview What a candidate filter would select for this caller (LVS-EXT-9).
+type FilterPreview struct {
+	// Columns The column order the rows below are keyed by, schema-derived and
+	// identical to the JSON filtered export's for the same resource.
+	Columns []string `json:"columns"`
+
+	// MatchCount Every row the filter selects that this caller may see — not the
+	// length of `rows`. This is the number a builder shows a human while
+	// they decide whether the filter is right, so it is a full count rather
+	// than a page size dressed up as one.
+	MatchCount int                   `json:"match_count"`
+	Resource   FilterPreviewResource `json:"resource"`
+
+	// Rows Up to `limit` matching rows as column→value maps, ordered by id.
+	// Deliberately the export's projection rather than a shape invented for
+	// this screen: a preview that showed different columns than the export
+	// of the same filter would be a preview of something else.
+	Rows []map[string]interface{} `json:"rows"`
+
+	// Truncated Whether `match_count` exceeds the rows returned — so a caller can say
+	// "showing 25 of 812" without comparing lengths and guessing.
+	Truncated bool `json:"truncated"`
+}
+
+// FilterPreviewResource defines model for FilterPreview.Resource.
+type FilterPreviewResource string
+
+// FilterPreviewRequest A candidate filter to evaluate without saving it.
+type FilterPreviewRequest struct {
+	// Filter The canonical filter tree — the same representation a dynamic list's
+	// `definition` and a saved view's `query` carry, and untyped here for
+	// the same reason they are. The grammar's authority is the predicate
+	// engine, which validates the tree and answers a precise 422 naming the
+	// offending field and reason; a recursive schema here would be a second
+	// statement of that grammar, free to drift from the one that decides.
+	// One engine evaluates all three, so a tree this operation accepts is
+	// one a list or view accepts.
+	Filter map[string]interface{} `json:"filter"`
+
+	// Limit How many rows to sample. The COUNT is unaffected by this — it is the
+	// full match count for the caller, not the size of the page.
+	Limit    *int                         `json:"limit,omitempty"`
+	Resource FilterPreviewRequestResource `json:"resource"`
+}
+
+// FilterPreviewRequestResource defines model for FilterPreviewRequest.Resource.
+type FilterPreviewRequestResource string
 
 // FilterVocabulary What a filter may say about one record type (LVS-EXT-8). Read from the
 // engine that evaluates filters, so the set here and the set the engine
@@ -24626,6 +24728,9 @@ type EmbedReindexStartJSONRequestBody = EmbedReindexStartRequest
 // CreateFilteredExportJSONRequestBody defines body for CreateFilteredExport for application/json ContentType.
 type CreateFilteredExportJSONRequestBody = FilteredExportRequest
 
+// PreviewFilterJSONRequestBody defines body for PreviewFilter for application/json ContentType.
+type PreviewFilterJSONRequestBody = FilterPreviewRequest
+
 // SetFxRateJSONRequestBody defines body for SetFxRate for application/json ContentType.
 type SetFxRateJSONRequestBody = SetFxRateRequest
 
@@ -31206,6 +31311,9 @@ type ServerInterface interface {
 	// Per-field change history for one record, projected from audit_log before/after diffs.
 	// (GET /field-history)
 	GetFieldHistory(w http.ResponseWriter, r *http.Request, params GetFieldHistoryParams)
+	// Count and sample what a filter would select, before it is saved (LVS-EXT-9).
+	// (POST /filters/preview)
+	PreviewFilter(w http.ResponseWriter, r *http.Request)
 	// Read what a new filter clause may name on one record type (LVS-EXT-8).
 	// (GET /filters/vocabulary)
 	GetFilterVocabulary(w http.ResponseWriter, r *http.Request, params GetFilterVocabularyParams)
@@ -32811,6 +32919,12 @@ func (_ Unimplemented) ListExtensions(w http.ResponseWriter, r *http.Request) {
 // Per-field change history for one record, projected from audit_log before/after diffs.
 // (GET /field-history)
 func (_ Unimplemented) GetFieldHistory(w http.ResponseWriter, r *http.Request, params GetFieldHistoryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Count and sample what a filter would select, before it is saved (LVS-EXT-9).
+// (POST /filters/preview)
+func (_ Unimplemented) PreviewFilter(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -40198,6 +40312,28 @@ func (siw *ServerInterfaceWrapper) GetFieldHistory(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetFieldHistory(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PreviewFilter operation middleware
+func (siw *ServerInterfaceWrapper) PreviewFilter(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PreviewFilter(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -52902,6 +53038,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/field-history", wrapper.GetFieldHistory)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/filters/preview", wrapper.PreviewFilter)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/filters/vocabulary", wrapper.GetFilterVocabulary)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -40326,8 +40326,6 @@ func (siw *ServerInterfaceWrapper) PreviewFilter(w http.ResponseWriter, r *http.
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
 	r = r.WithContext(ctx)

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -390,16 +390,20 @@ type Query struct {
 	ActivityWalk bool
 }
 
-// predicateWhere composes the three clauses every execution of a predicate runs
-// under — the resource's base clause, the compiled predicate, and the caller's
-// row scope — and answers the joined WHERE with its bind parameters.
+// predicateWhere is the admission point AND the clause composer for every
+// execution of a predicate: it takes the object read gate, then joins the
+// resource's base clause, the compiled predicate, and the caller's row scope.
 //
-// It exists so that a second executor cannot compose two of the three. The row
-// scope is the one that matters: it is what makes a predicate able only to
-// NARROW what the caller may already see, and an executor that forgot it would
-// still return plausible rows, just other people's. One composition point means
-// the question "is this scoped?" has one answer for every caller.
+// Both live here so a second executor cannot take two of the three, or the
+// clauses without the gate. The row scope is the one that matters most: it is
+// what makes a predicate able only to NARROW what the caller may already see,
+// and an executor that forgot it would still return plausible rows, just other
+// people's. One point of composition means "is this scoped?" has one answer for
+// every caller.
 func (q Query) predicateWhere(ctx context.Context, p Predicate) (string, []any, error) {
+	if err := auth.Require(ctx, q.Table, principal.ActionRead); err != nil {
+		return "", nil, err
+	}
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 
@@ -439,11 +443,10 @@ func (q Query) predicateWhere(ctx context.Context, p Predicate) (string, []any, 
 //
 // Unbounded on purpose, and it is the same WHERE SelectIDs runs: same base
 // clause, same predicate, same row scope, so the count and the page it labels
-// cannot disagree about what matched.
+// cannot disagree about what MATCHING MEANS. Whether they saw the same rows is a
+// question about the snapshot, not the clause, and the caller decides that by
+// choosing which transaction to run both in.
 func (q Query) CountMatching(ctx context.Context, tx pgx.Tx, p Predicate) (int, error) {
-	if err := auth.Require(ctx, q.Table, principal.ActionRead); err != nil {
-		return 0, err
-	}
 	where, args, err := q.predicateWhere(ctx, p)
 	if err != nil {
 		return 0, err
@@ -459,12 +462,12 @@ func (q Query) CountMatching(ctx context.Context, tx pgx.Tx, p Predicate) (int, 
 // SelectIDs runs the predicate inside the caller's workspace-bound
 // transaction and returns matching row ids, deterministically ordered
 // by id (the keyset tie-breaker) and hard-capped at PredicateRowLimit.
-// The row-scope clause is composed HERE, unconditionally — a predicate
-// can only ever narrow what the caller is already allowed to see.
+//
+// The read gate and the row-scope clause both come from predicateWhere — see
+// there for why they live together — so a predicate can only ever narrow what
+// the caller is already allowed to see. The cap stays here rather than in the
+// helper: it bounds a PAGE, and a count must not inherit it.
 func (q Query) SelectIDs(ctx context.Context, tx pgx.Tx, p Predicate, limit int) ([]ids.UUID, error) {
-	if err := auth.Require(ctx, q.Table, principal.ActionRead); err != nil {
-		return nil, err
-	}
 	if limit <= 0 || limit > PredicateRowLimit {
 		limit = PredicateRowLimit
 	}

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -390,6 +390,72 @@ type Query struct {
 	ActivityWalk bool
 }
 
+// predicateWhere composes the three clauses every execution of a predicate runs
+// under — the resource's base clause, the compiled predicate, and the caller's
+// row scope — and answers the joined WHERE with its bind parameters.
+//
+// It exists so that a second executor cannot compose two of the three. The row
+// scope is the one that matters: it is what makes a predicate able only to
+// NARROW what the caller may already see, and an executor that forgot it would
+// still return plausible rows, just other people's. One composition point means
+// the question "is this scoped?" has one answer for every caller.
+func (q Query) predicateWhere(ctx context.Context, p Predicate) (string, []any, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+
+	where := make([]string, 0, 3)
+	if q.BaseWhere != "" {
+		where = append(where, q.BaseWhere)
+	}
+	compiled, err := CompilePredicate(p, q.Fields, arg)
+	if err != nil {
+		return "", nil, err
+	}
+	where = append(where, compiled)
+
+	var scope string
+	if q.ActivityWalk {
+		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
+	} else {
+		scope, err = auth.ScopeClauseFor(ctx, q.Table, "t", arg)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return strings.Join(where, " AND "), args, nil
+}
+
+// CountMatching answers how many rows the predicate selects for this caller.
+//
+// It is a COUNT rather than len(SelectIDs): SelectIDs is capped at
+// PredicateRowLimit, so counting its result would silently report 1000 for every
+// larger set — a number that looks exact and is not. The filter builder shows
+// this figure to a human deciding whether their filter is right, which is
+// precisely the situation where a plausible wrong number is worse than a slow
+// one.
+//
+// Unbounded on purpose, and it is the same WHERE SelectIDs runs: same base
+// clause, same predicate, same row scope, so the count and the page it labels
+// cannot disagree about what matched.
+func (q Query) CountMatching(ctx context.Context, tx pgx.Tx, p Predicate) (int, error) {
+	if err := auth.Require(ctx, q.Table, principal.ActionRead); err != nil {
+		return 0, err
+	}
+	where, args, err := q.predicateWhere(ctx, p)
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	sql := fmt.Sprintf("SELECT count(*) FROM %s t WHERE %s", q.Table, where)
+	if err := tx.QueryRow(ctx, sql, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("predicate count on %s: %w", q.Table, err)
+	}
+	return n, nil
+}
+
 // SelectIDs runs the predicate inside the caller's workspace-bound
 // transaction and returns matching row ids, deterministically ordered
 // by id (the keyset tie-breaker) and hard-capped at PredicateRowLimit.
@@ -402,35 +468,12 @@ func (q Query) SelectIDs(ctx context.Context, tx pgx.Tx, p Predicate, limit int)
 	if limit <= 0 || limit > PredicateRowLimit {
 		limit = PredicateRowLimit
 	}
-
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-
-	where := make([]string, 0, 3)
-	if q.BaseWhere != "" {
-		where = append(where, q.BaseWhere)
-	}
-	compiled, err := CompilePredicate(p, q.Fields, arg)
+	where, args, err := q.predicateWhere(ctx, p)
 	if err != nil {
 		return nil, err
 	}
-	where = append(where, compiled)
-
-	var scope string
-	if q.ActivityWalk {
-		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
-	} else {
-		scope, err = auth.ScopeClauseFor(ctx, q.Table, "t", arg)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if scope != "" {
-		where = append(where, scope)
-	}
-
 	sql := fmt.Sprintf("SELECT t.id FROM %s t WHERE %s ORDER BY t.id LIMIT %d",
-		q.Table, strings.Join(where, " AND "), limit)
+		q.Table, where, limit)
 	rows, err := tx.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3328,6 +3328,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/filters/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Count and sample what a filter would select, before it is saved (LVS-EXT-9).
+         * @description The match count and a bounded first page for a candidate filter tree —
+         *     the filter a human is still editing, which nothing else in the contract
+         *     can evaluate. The object list operations take flat scalar parameters and
+         *     cannot express a tree; membership needs a stored list; and the filtered
+         *     export is audit-logged, so driving a live recount through it would write
+         *     an audit row per keystroke.
+         *
+         *     POST because the filter tree is a structured body, not because anything
+         *     is created. Nothing is: no row, no audit entry, no outbox event. That is
+         *     the property that separates this from the export, and it is deliberate —
+         *     a preview a human triggers by typing must not be indistinguishable from
+         *     an extraction they chose to perform.
+         *
+         *     Row-scoped like every read: the count and the page are what THIS caller
+         *     may see, so two people previewing the same filter can legitimately get
+         *     different numbers. `columns` and `rows` are the same projection the JSON
+         *     filtered export writes for the same filter, so what you preview is what
+         *     an export of it would contain.
+         */
+        post: operations["previewFilter"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/views": {
         parameters: {
             query?: never;
@@ -14312,6 +14349,61 @@ export interface components {
             data: components["schemas"]["ListMember"][];
             page: components["schemas"]["PageInfo"];
         };
+        /** @description A candidate filter to evaluate without saving it. */
+        FilterPreviewRequest: {
+            /** @enum {string} */
+            resource: "person" | "organization" | "deal" | "lead" | "project";
+            /**
+             * @description The canonical filter tree — the same representation a dynamic list's
+             *     `definition` and a saved view's `query` carry, and untyped here for
+             *     the same reason they are. The grammar's authority is the predicate
+             *     engine, which validates the tree and answers a precise 422 naming the
+             *     offending field and reason; a recursive schema here would be a second
+             *     statement of that grammar, free to drift from the one that decides.
+             *     One engine evaluates all three, so a tree this operation accepts is
+             *     one a list or view accepts.
+             */
+            filter: {
+                [key: string]: unknown;
+            };
+            /**
+             * @description How many rows to sample. The COUNT is unaffected by this — it is the
+             *     full match count for the caller, not the size of the page.
+             * @default 25
+             */
+            limit: number;
+        };
+        /** @description What a candidate filter would select for this caller (LVS-EXT-9). */
+        FilterPreview: {
+            /** @enum {string} */
+            resource: "person" | "organization" | "deal" | "lead" | "project";
+            /**
+             * @description Every row the filter selects that this caller may see — not the
+             *     length of `rows`. This is the number a builder shows a human while
+             *     they decide whether the filter is right, so it is a full count rather
+             *     than a page size dressed up as one.
+             */
+            match_count: number;
+            /**
+             * @description The column order the rows below are keyed by, schema-derived and
+             *     identical to the JSON filtered export's for the same resource.
+             */
+            columns: string[];
+            /**
+             * @description Up to `limit` matching rows as column→value maps, ordered by id.
+             *     Deliberately the export's projection rather than a shape invented for
+             *     this screen: a preview that showed different columns than the export
+             *     of the same filter would be a preview of something else.
+             */
+            rows: {
+                [key: string]: unknown;
+            }[];
+            /**
+             * @description Whether `match_count` exceeds the rows returned — so a caller can say
+             *     "showing 25 of 812" without comparing lengths and guessing.
+             */
+            truncated: boolean;
+        };
         /**
          * @description What a filter may say about one record type (LVS-EXT-8). Read from the
          *     engine that evaluates filters, so the set here and the set the engine
@@ -23916,6 +24008,34 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    previewFilter: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FilterPreviewRequest"];
+            };
+        };
+        responses: {
+            /** @description The count and first page. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FilterPreview"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
         };


### PR DESCRIPTION
LVS-EXT-9, the second of the two reads [#1468](https://github.com/gradionhq/margince-poc-v1/issues/1468) needs. **Stacked on [#1665](https://github.com/gradionhq/margince-poc-v1/pull/1665)** — merge that first; this branch contains it, so the diff to read is the last three commits.

`POST /v1/filters/preview` answers the count and a bounded page for a filter nobody has saved. Nothing else in the contract can evaluate one: the object list operations take flat scalar parameters and cannot express a tree, membership needs a stored list, and the filtered export is logged — so driving a live recount through it would write a ledger row per keystroke.

## Three decisions worth the reviewer's attention

**The count is a `COUNT`, not `len(SelectIDs)`.** `SelectIDs` is capped at `PredicateRowLimit`, so counting its result would report 1000 for every larger set — a number that looks exact and is not, shown to somebody deciding whether their filter is right. So `storekit` gains `CountMatching`.

That in turn moved the composition of the three clauses every predicate execution needs — base, predicate, **row scope** — into one `predicateWhere` both executors call. This is the part I would most like challenged: a second executor composing two of the three would still return plausible rows, just other people's, so one composition point is the whole safety argument. `SelectIDs`' behaviour is unchanged; the existing storekit suite passes untouched.

**The projection is the export's, not one invented for this screen.** `exportableColumns` + `readRowsByID` + `rowsAsMaps`, so the columns and values are the ones the JSON export writes for the same filter — which is why the operation lives in compose rather than collections, since a module may not import a sibling.

That gives a real invariant instead of a resemblance, and `TestAFilterPreviewDescribesTheSameSliceTheExportWrites` drives both surfaces with one filter and compares row for row, key for key, in both directions. A preview showing different columns than the export of the same filter would be a preview of something else.

**Count and page run in ONE transaction.** Two would let a concurrent write land between them and put "812 matches" above a page that does not add up — a discrepancy the reader cannot explain and would reasonably blame on the filter they are building.

## Human-only, and why the gate made me say so

The fail-closed codegen gate (ADR-0055) refused the operation until it declared its agent governance — a POST reads as mutating. That forced a decision I would otherwise have defaulted, and the answer is `x-agent-access: human-only` for a specific reason: **the same property that makes this safe for a human makes it wrong for an agent.** It is deliberately not logged, because a recount per keystroke must not write a ledger row per keystroke. For an agent, un-logged plus bulk records is precisely the shape agent governance exists to prevent. A governed read tool here is an additive decision that has to answer the audit question first.

## The filter stays untyped on the wire

Exactly as a dynamic list's `definition` and a saved view's `query` are. A recursive schema would be a second statement of a grammar the engine already owns and free to drift from it; the engine answers a precise 422 naming the offending field, which is better feedback than schema validation gives. Stated in the property's description so the next reader doesn't "fix" it.

## What the no-write test actually proves

`TestAFilterPreviewWritesNoLedgerRowWhereAnExportDoes` counts `audit_log` + `event_outbox` + `system_log` and asserts the **export does grow them**. Without that second half a broken counter would read as a passing test.

That contrast also caught my own error: my first version watched `audit_log` alone and failed, because a filtered export logs to `system_log` — on the stated reasoning that a bulk export targets no single record, so it does not belong in the record-mutation spine. Watching one ledger would have made the whole assertion vacuous.

**One contract inaccuracy found and not fixed here:** `createFilteredExport`'s description promises *"every export writes one `audit_log` entry"*, while it writes `system_log`. The behaviour is right and deliberate; the description names the wrong table. Same class as the `CustomField` retired-status wording, and contract-first says that reconciliation lands upstream rather than as a local description edit.

Mutation-verified: forcing `truncated` false fails only the test that names it. `make check-backend`, `make check-fe` (3034 tests) and `craft static --strict` all green; the five preview integration tests pass against a real database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts and samples an unsaved filter via POST /v1/filters/preview (LVS-EXT-9) so builders can evaluate a filter tree without saving or writing logs. Old behavior required saving a list or using the filtered export (which logs); new behavior returns a full, row‑scoped count plus an export‑aligned sample with no ledger writes.

- Adds POST /v1/filters/preview: returns resource, match_count, columns, rows, truncated; requires cookieAuth; human-only enforced in policy and in-handler (agents refused).
- Counts with `storekit` CountMatching; pages with SelectIDs; both share a new predicateWhere that composes base clause + predicate + row scope; count and page run back-to-back in one transaction to minimize drift.
- Projects rows using the JSON export’s projection (`exportableColumns`/`readRowsByID`/`rowsAsMaps`) so preview and export of the same filter match.
- Bounds expensive queries with SET LOCAL statement_timeout=5s; enforces limit 1..100 (422 if out of range); maps predicate validation to 422 naming the offending field.
- Tests: integration verifies scoped COUNT, export parity, and “no writes” (no `audit_log`, `event_outbox`, or `system_log` changes); adds a scope test for CountMatching and a unit boundary table for limit.

Client impact
- Automation cannot call `/v1/filters/preview` (human-only, cookie session required).
- Clients must send a limit within 1..100; out-of-range returns 422.

<sup>Written for commit 1b616ae682c8d15d26da24aedb1a451f0562da36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

