### PR TITLE
refactor(people): the person cluster drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/capturedbykind_integration_test.go
+++ b/backend/internal/compose/capturedbykind_integration_test.go
@@ -31,8 +31,8 @@ func seatPersonCapturedBy(t *testing.T, e *integration.Env, fullName, capturedBy
 	t.Helper()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, $4, 'test', $5)`, ids.NewV7(), e.WS, e.Rep1, fullName, capturedBy)
+			INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, $3, 'test', $4)`, ids.NewV7(), e.Rep1, fullName, capturedBy)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding %s: %v", fullName, err)
@@ -124,9 +124,8 @@ func TestCapturedByKindNarrowsRowScopeAndNeverWidensIt(t *testing.T) {
 	// An AI-created person owned by Rep3, who sits in the other team.
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'Other Team AI Record', 'test', 'agent:capture_counterparty_verdict')`,
-			ids.NewV7(), e.WS, e.Rep3)
+			INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, 'Other Team AI Record', 'test', 'agent:capture_counterparty_verdict')`, ids.NewV7(), e.Rep3)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding: %v", err)

--- a/backend/internal/compose/captureenrich_integration_test.go
+++ b/backend/internal/compose/captureenrich_integration_test.go
@@ -50,13 +50,13 @@ func seedEnrichPerson(t *testing.T, e *integration.Env, email, body string) ids.
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			VALUES ($1, $2, 'Bob Person', 'gmail:seed', 'connector:gmail')`, person, e.WS); err != nil {
+			INSERT INTO person (id, full_name, source, captured_by)
+			VALUES ($1, 'Bob Person', 'gmail:seed', 'connector:gmail')`, person); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, source, captured_by)
-			VALUES ($1, $2, $3, 'work', true, 'gmail:seed', 'connector:gmail')`, e.WS, person, email); err != nil {
+			INSERT INTO person_email (person_id, email, email_type, is_primary, source, captured_by)
+			VALUES ( $1, $2, 'work', true, 'gmail:seed', 'connector:gmail')`, person, email); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `

--- a/backend/internal/compose/captureofflinedemo_integration_test.go
+++ b/backend/internal/compose/captureofflinedemo_integration_test.go
@@ -108,14 +108,14 @@ func seedOfflineDemoAccount(t *testing.T, e *integration.Env, owner ids.UUID, sl
 	}
 	var personID ids.UUID
 	err = e.Pool.QueryRow(ctx, `
-		INSERT INTO person (workspace_id, full_name, source, captured_by)
-		VALUES ($1, $2, 'test', 'human:test') RETURNING id`, e.WS, "Petra "+slug).Scan(&personID)
+		INSERT INTO person (full_name, source, captured_by)
+		VALUES ( $1, 'test', 'human:test') RETURNING id`, "Petra "+slug).Scan(&personID)
 	if err != nil {
 		t.Fatalf("seeding a person: %v", err)
 	}
 	if _, err := e.Pool.Exec(ctx, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, $3, true, 'test', 'human:test')`, e.WS, personID, "petra@"+slug+".example"); err != nil {
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, $2, true, 'test', 'human:test')`, personID, "petra@"+slug+".example"); err != nil {
 		t.Fatalf("seeding an address: %v", err)
 	}
 	if _, err := e.Pool.Exec(ctx, `

--- a/backend/internal/compose/captureparticipant_integration_test.go
+++ b/backend/internal/compose/captureparticipant_integration_test.go
@@ -217,8 +217,8 @@ func TestDeletingAPersonOrAUserIsNotBlockedByGraphRows(t *testing.T) {
 	var doomed ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO person (workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (`+ws+`, 'Departing Contact', $1, 'manual', 'human:test', 'workspace')
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES ( 'Departing Contact', $1, 'manual', 'human:test', 'workspace')
 			RETURNING id`, e.Rep1).Scan(&contact); err != nil {
 			return err
 		}

--- a/backend/internal/compose/erasureapprovals_integration_test.go
+++ b/backend/internal/compose/erasureapprovals_integration_test.go
@@ -38,8 +38,8 @@ func erasureSubject(t *testing.T, e *integration.Env) (ids.PersonID, ids.Approva
 	person := e.SeedPerson(t, "Anna Weber", nil)
 	const addr = "anna.erasure@example.com"
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, $3, true, 'test', 'human:seed')`, e.WS, person, addr)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, $2, true, 'test', 'human:seed')`, person, addr)
 
 	id, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind: "held_draft",
@@ -198,8 +198,8 @@ func TestErasureLeavesALookalikeAddressAlone(t *testing.T) {
 	e := integration.Setup(t)
 	subject := e.SeedPerson(t, "Pattern Subject", nil)
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, 't_m@example.com', true, 'test', 'human:seed')`, e.WS, subject)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, 't_m@example.com', true, 'test', 'human:seed')`, subject)
 
 	bystander, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind:           "held_draft",
@@ -238,8 +238,8 @@ func TestErasureLeavesAnAddressThatMerelyContainsTheSubjectsAlone(t *testing.T) 
 	e := integration.Setup(t)
 	subject := e.SeedPerson(t, "Suffix Subject", nil)
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, 'm@example.com', true, 'test', 'human:seed')`, e.WS, subject)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, 'm@example.com', true, 'test', 'human:seed')`, subject)
 
 	bystander, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind:           "held_draft",

--- a/backend/internal/compose/erasuregraph_integration_test.go
+++ b/backend/internal/compose/erasuregraph_integration_test.go
@@ -54,16 +54,15 @@ func TestErasureRemovesTheSubjectFromTheRelationshipGraph(t *testing.T) {
 	var activityID ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO person (workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (`+ws+`, 'Erase Me', $1, 'manual', 'human:test', 'workspace')
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES ( 'Erase Me', $1, 'manual', 'human:test', 'workspace')
 			RETURNING id`, e.Rep1).Scan(&person); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-			VALUES (`+ws+`, $1, $2, true, 'manual', 'human:test')`, person, subjectEmail); err != nil {
+			INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+			VALUES ( $1, $2, true, 'manual', 'human:test')`, person, subjectEmail); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `

--- a/backend/internal/compose/erasurequotations_integration_test.go
+++ b/backend/internal/compose/erasurequotations_integration_test.go
@@ -55,8 +55,8 @@ func transcriptSubject(t *testing.T, e *integration.Env) (ids.PersonID, ids.UUID
 	t.Helper()
 	person := e.SeedPerson(t, "Mara Kessler", nil)
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, 'mara.kessler@example.com', true, 'test', 'human:seed')`, e.WS, person)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, 'mara.kessler@example.com', true, 'test', 'human:seed')`, person)
 
 	activityID := seedTranscript(t, e, "1: Tom: Where did we land on pricing?\n2: "+quotedTranscriptLine)
 	e.WsExec(t, `
@@ -191,8 +191,8 @@ func TestErasureLeavesTheQuotationOfAMeetingItMayNotDestroy(t *testing.T) {
 	subject := e.SeedPerson(t, "Mara Kessler", nil)
 	const addr = "mara.kessler@example.com"
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, $3, true, 'test', 'human:seed')`, e.WS, subject, addr)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, $2, true, 'test', 'human:seed')`, subject, addr)
 	colleague := e.SeedPerson(t, "Bob Ferrer", nil)
 
 	quote := "Tom: loop in " + addr + " on the renewal."
@@ -292,8 +292,8 @@ func TestSubjectAccessWithholdsAQuotationFromARecordTheSubjectHasNoPartIn(t *tes
 	subject := e.SeedPerson(t, "Mara Kessler", nil)
 	const addr = "mara.kessler@example.com"
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, $3, true, 'test', 'human:seed')`, e.WS, subject, addr)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, $2, true, 'test', 'human:seed')`, subject, addr)
 
 	const theirsAlone = "Tom: Bob, hold the line at list price - Contoso got thirty percent and nobody is to know."
 	elsewhere := seedTranscript(t, e, "1: "+theirsAlone)

--- a/backend/internal/compose/flipreconcile.go
+++ b/backend/internal/compose/flipreconcile.go
@@ -79,14 +79,14 @@ func (w *flipWriters) ReconcileIdentities(ctx context.Context) error {
 // exactly what this is meant to adopt.
 // flipTenantScope is the workspace predicate for the ONE query this file
 // templates over five native tables, and it is per-object because ADR-0091 §8
-// phase D removes the column from them at different times — deal already, the
-// rest still to come. A predicate spelled for all five fails the statement
-// outright for whichever has lost it; spelled for none, a reconstruction adopts
-// the EXPORTING installation's records as its own. Each entry drops out as its
-// slice lands, and the function goes with the last one.
+// phase D removes the column from them at different times — only lead still
+// carries it. A predicate spelled for all five fails the statement outright for
+// whichever has lost it; spelled for none, a reconstruction adopts the
+// EXPORTING installation's records as its own. The last entry drops out with
+// the lead slice, and the function goes with it.
 func flipTenantScope(object string) string {
 	switch object {
-	case flipObjectPerson, flipObjectLead:
+	case flipObjectLead:
 		return "\n\t\t\t  AND n.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid"
 	default:
 		return ""

--- a/backend/internal/compose/graphedge_integration_test.go
+++ b/backend/internal/compose/graphedge_integration_test.go
@@ -79,8 +79,8 @@ func (v edgeEnv) person(t *testing.T, name string) ids.PersonID {
 	id := ids.New[ids.PersonKind]()
 	if err := database.WithWorkspaceTx(v.e.Admin(), v.e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person (workspace_id, id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 'manual', 'human:test', 'workspace')`,
+			INSERT INTO person (id, full_name, owner_id, source, captured_by, visibility)
+			VALUES ( $1, $2, $3, 'manual', 'human:test', 'workspace')`,
 			id, name, v.e.Rep1)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/graphjobs_integration_test.go
+++ b/backend/internal/compose/graphjobs_integration_test.go
@@ -54,8 +54,8 @@ func seedGraphPerson(t *testing.T, e *integration.Env, name string) ids.UUID {
 	var id ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO person (workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2,
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES ( $1, $2,
 			        'manual', 'human:test', 'workspace')
 			RETURNING id`, name, e.Rep1).Scan(&id)
 	}); err != nil {

--- a/backend/internal/compose/heldrelease_integration_test.go
+++ b/backend/internal/compose/heldrelease_integration_test.go
@@ -91,8 +91,8 @@ func seedHeldDraft(t *testing.T, e *integration.Env, svc *approvals.Service) hel
 	// refuses — correctly, and for a reason that has nothing to do with the
 	// release under test.
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, $3, true, 'test', 'human:seed')`, e.WS, person, to)
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, $2, true, 'test', 'human:seed')`, person, to)
 
 	// The counterparty on the thread, carrying the address a reply answers.
 	e.WsExec(t, `

--- a/backend/internal/compose/integration/activitycontext_integration_test.go
+++ b/backend/internal/compose/integration/activitycontext_integration_test.go
@@ -106,10 +106,10 @@ func seedMeetingFixture(t *testing.T, e *SearchEnv) meetingFixture {
 	f.rep1Deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, source, captured_by)
 		VALUES ($1, $2, 'Turbinenbau Renewal', $3, $4, $5, 'manual', 'human:x')`,
 		e.Rep1, f.pipeline, f.stage, f.rep1Org)
-	f.organizer = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Annegret Weiss', 'manual', 'human:x')`, e.Rep1)
-	f.otherPerson = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Bernhard Klein', 'manual', 'human:x')`, e.Rep1)
+	f.organizer = e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Annegret Weiss', 'manual', 'human:x')`, e.Rep1)
+	f.otherPerson = e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Bernhard Klein', 'manual', 'human:x')`, e.Rep1)
 	return f
 }
 
@@ -308,8 +308,8 @@ func TestAMeetingNeverDisclosesTheRecordBehindALinkTheCallerCannotSee(t *testing
 func TestAMeetingNeverDisclosesAnAttendeeTheCallerCannotSee(t *testing.T) {
 	e := SetupSearch(t)
 	f := seedMeetingFixture(t, e)
-	hidden := e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Dieter Fremd', 'manual', 'human:x')`, e.Rep3)
+	hidden := e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Dieter Fremd', 'manual', 'human:x')`, e.Rep3)
 	meeting := seedMeeting(t, e, "Joint review")
 	linkMeeting(t, e, meeting, "deal", "deal_id", f.rep1Deal)
 	addParty(t, e, meeting, "organizer", &hidden, "dieter@othertteam.example")
@@ -354,16 +354,16 @@ func TestTheOrganizerSurvivesAnOversizedInvitation(t *testing.T) {
 	// seeded FIRST, so every one of them holds a lower id than the organizer.
 	if _, err := e.Owner.Exec(context.Background(), `
 		WITH room AS (
-		    INSERT INTO person (workspace_id, owner_id, full_name, source, captured_by)
-		    SELECT $1, $2, 'Attendee ' || n, 'manual', 'human:x' FROM generate_series(1, 60) n
+		    INSERT INTO person (owner_id, full_name, source, captured_by)
+		    SELECT $1, 'Attendee ' || n, 'manual', 'human:x' FROM generate_series(1, 60) n
 		    RETURNING id
 		)
 		INSERT INTO activity_participant (activity_id, role, person_id)
-		SELECT $3, 'attendee', id FROM room`, e.WS, e.Rep1, meeting); err != nil {
+		SELECT $2, 'attendee', id FROM room`, e.Rep1, meeting); err != nil {
 		t.Fatalf("seeding the oversized invitation: %v", err)
 	}
-	organizer := e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Zoe Organizer', 'manual', 'human:x')`, e.Rep1)
+	organizer := e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Zoe Organizer', 'manual', 'human:x')`, e.Rep1)
 	addParty(t, e, meeting, "organizer", &organizer, "zoe@turbinenbau.example")
 
 	assembled, err := prepFor(e.Admin(), t, e, meeting)

--- a/backend/internal/compose/integration/binding_integration_test.go
+++ b/backend/internal/compose/integration/binding_integration_test.go
@@ -60,7 +60,7 @@ func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stale Row Person', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Stale Row Person', 'manual', 'human:x')`)
 	// A row stamped under a DIFFERENT identity than currentIdentity — the
 	// entity has an embedding row, just not a current one, so it must
 	// still count as pending (the swap case, distinct from "no row at all").
@@ -321,13 +321,13 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	const nameOrg = "Pending Org"
 	const nameTwo = "Pending Two"
 
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, '`+nameOne+`', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, '`+nameOne+`', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, '`+nameOrg+`', 'manual', 'human:x')`)
 	// A lead with every text-bearing column NULL: concat_ws collapses to
 	// '', so it must NOT count as pending — the non-empty qualifier.
 	e.Seed(t, `INSERT INTO lead (id, workspace_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`)
 	// Already covered at the current identity: must not count as pending.
-	coveredID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Already Covered', 'manual', 'human:x')`)
+	coveredID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Already Covered', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'covered-hash', $3, '[1,2,3]'::vector)`,
@@ -335,11 +335,7 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 		t.Fatalf("seeding the already-covered row: %v", err)
 	}
 
-	ws2PersonID := ids.NewV7()
-	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
-		ws2PersonID, ws2, nameTwo); err != nil {
-		t.Fatalf("seeding the sibling workspace's person: %v", err)
-	}
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, '`+nameTwo+`', 'manual', 'human:x')`)
 
 	counts, err := e.Store.PendingByWorkspace(ctx, identity)
 	if err != nil {
@@ -357,16 +353,20 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	wsKey := ids.From[ids.WorkspaceKind](e.WS)
 	ws2Key := ids.From[ids.WorkspaceKind](ws2)
 
-	// The organization counts under BOTH workspaces, and that is the honest
-	// answer rather than a leak: ADR-0091 §8 phase D took the tenant column off
-	// organization, so it belongs to the installation and every workspace this
-	// rollup enumerates sees it. The two numbers converge on one when the
-	// re-embed fan-out itself collapses and there is a single pass to report.
-	if counts[wsKey] != 2 {
-		t.Fatalf("counts[e.WS] = %d, want 2 (its person + the installation's organization; the null lead and the already-covered person must be excluded)", counts[wsKey])
+	// Both people and the organization count under BOTH workspaces, and that is
+	// the honest answer rather than a leak: ADR-0091 §8 phase D took the tenant
+	// column off person and organization alike, so they belong to the
+	// installation and every workspace this rollup enumerates sees them. The
+	// covered person is excluded from both for the same reason — one embedding
+	// at this identity covers an installation-wide row wherever it is counted.
+	// The two numbers converge on one when the re-embed fan-out itself collapses
+	// and there is a single pass to report.
+	const wantPerWorkspace = 3 // two people + the organization
+	if counts[wsKey] != wantPerWorkspace {
+		t.Fatalf("counts[e.WS] = %d, want %d (both people + the organization; the null lead and the already-covered person must be excluded)", counts[wsKey], wantPerWorkspace)
 	}
-	if counts[ws2Key] != 2 {
-		t.Fatalf("counts[ws2] = %d, want 2 (its own person + the same installation-wide organization)", counts[ws2Key])
+	if counts[ws2Key] != wantPerWorkspace {
+		t.Fatalf("counts[ws2] = %d, want %d (the same installation-wide rows)", counts[ws2Key], wantPerWorkspace)
 	}
 
 	sum := 0
@@ -376,20 +376,19 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	if sum != total {
 		t.Fatalf("sum of PendingByWorkspace = %d, EntitiesPending = %d — must agree", sum, total)
 	}
-	// 4, not 3: the installation-wide organization is counted once per
-	// enumerated workspace, and EntitiesPending is the sum of that rollup.
-	if total != 4 {
-		t.Fatalf("EntitiesPending = %d, want 4", total)
+	// Every pending row is installation-wide, so each is counted once per
+	// enumerated workspace and EntitiesPending is the sum of that rollup.
+	if total != 2*wantPerWorkspace {
+		t.Fatalf("EntitiesPending = %d, want %d", total, 2*wantPerWorkspace)
 	}
 
-	wantWSTokens := int64((len(nameOne) + len(nameOrg)) / 4)
-	if tokens[wsKey] != wantWSTokens {
-		t.Fatalf("tokens[e.WS] = %d, want %d (SUM(length)/4 over the pending set)", tokens[wsKey], wantWSTokens)
+	// The same text is in both sums, for the same reason the same rows are in
+	// both counts: they belong to the installation, not to either workspace.
+	wantTokens := int64((len(nameOne) + len(nameTwo) + len(nameOrg)) / 4)
+	if tokens[wsKey] != wantTokens {
+		t.Fatalf("tokens[e.WS] = %d, want %d (SUM(length)/4 over the pending set)", tokens[wsKey], wantTokens)
 	}
-	// The organization's text is in both sums, for the same reason its row is in
-	// both counts: it belongs to the installation.
-	wantWS2Tokens := int64((len(nameTwo) + len(nameOrg)) / 4)
-	if tokens[ws2Key] != wantWS2Tokens {
-		t.Fatalf("tokens[ws2] = %d, want %d", tokens[ws2Key], wantWS2Tokens)
+	if tokens[ws2Key] != wantTokens {
+		t.Fatalf("tokens[ws2] = %d, want %d", tokens[ws2Key], wantTokens)
 	}
 }

--- a/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
@@ -235,14 +235,14 @@ func seedForeignCounterparties(t *testing.T, e *integration.SearchEnv) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		for _, q := range []string{
-			`INSERT INTO person (workspace_id, full_name, source, captured_by)
-			   VALUES (current_setting('app.workspace_id')::uuid, 'Other Connection One', 'capture', 'connector:gmail'),
-			          (current_setting('app.workspace_id')::uuid, 'Other Connection Two', 'capture', 'connector:gmail'),
-			          (current_setting('app.workspace_id')::uuid, 'Other Connection Three', 'capture', 'connector:gmail')`,
-			`INSERT INTO person (workspace_id, full_name, source, captured_by)
-			   VALUES (current_setting('app.workspace_id')::uuid, 'Manually Typed', 'manual', 'human:someone')`,
+			`INSERT INTO person (full_name, source, captured_by)
+			   VALUES ('Other Connection One', 'capture', 'connector:gmail'),
+			          ('Other Connection Two', 'capture', 'connector:gmail'),
+			          ('Other Connection Three', 'capture', 'connector:gmail')`,
+			`INSERT INTO person (full_name, source, captured_by)
+			   VALUES ('Manually Typed', 'manual', 'human:someone')`,
 			`INSERT INTO organization (display_name, source, captured_by)
-			   VALUES ( 'Other Connection Co', 'capture', 'connector:gmail')`,
+			   VALUES ('Other Connection Co', 'capture', 'connector:gmail')`,
 		} {
 			if _, execErr := tx.Exec(e.Admin(), q); execErr != nil {
 				return execErr

--- a/backend/internal/compose/integration/capture/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_integration_test.go
@@ -129,7 +129,7 @@ func readCaptureCounts(t *testing.T, e *integration.SearchEnv) captureCounts {
 
 func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	e := integration.SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Inbox Sender', 'manual', 'human:x')`)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: personID}
@@ -266,7 +266,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
 	e := integration.SetupSearch(t)
 	// A person owned by team2 — invisible to the team1 granting human.
-	foreignPerson := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Foreign Target', $3, 'manual', 'human:x')`, e.Rep3)
+	foreignPerson := e.SeedID(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by) VALUES ($1, 'Foreign Target', $2, 'manual', 'human:x')`, e.Rep3)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: foreignPerson}

--- a/backend/internal/compose/integration/capture/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_scope_integration_test.go
@@ -120,8 +120,8 @@ func TestCaptureSkipsALeadCollidingWithAnInvisibleIncumbent(t *testing.T) {
 
 func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t *testing.T) {
 	e := integration.SetupSearch(t)
-	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		VALUES ($1, $2, 'Foreign Counterparty', $3, 'manual', 'human:x')`, e.Rep3)
+	foreign := e.SeedID(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Foreign Counterparty', $2, 'manual', 'human:x')`, e.Rep3)
 
 	fake := &scopeFake{records: []connector.NormalizedRecord{{
 		EntityType: datasource.EntityActivity,

--- a/backend/internal/compose/integration/capture/fieldprovenance_integration_test.go
+++ b/backend/internal/compose/integration/capture/fieldprovenance_integration_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
 	e := integration.SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Inbox Sender', 'manual', 'human:x')`)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: personID}

--- a/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
@@ -45,9 +45,8 @@ const telegramProvider = "telegram"
 func seedChannelIdentity(t *testing.T, e *integration.Env, person ids.UUID, channelUserID, username string) {
 	t.Helper()
 	e.WsExec(t, `
-		INSERT INTO person_channel_identity
-		  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+		INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+		VALUES (
 		        $1, 'telegram', $2, $3, 'telegram', 'connector:telegram')`,
 		person, channelUserID, username)
 }
@@ -366,8 +365,8 @@ func TestSARIncludesAChannelOnlySubjectsRawCapture(t *testing.T) {
 func seedPersonEmail(t *testing.T, e *integration.Env, person ids.UUID, email string) {
 	t.Helper()
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 'manual', 'user:test')`,
+		INSERT INTO person_email (person_id, email, source, captured_by)
+		VALUES ( $1, $2, 'manual', 'user:test')`,
 		person, email)
 }
 

--- a/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
@@ -224,10 +224,9 @@ func (c *telegramEnv) bindChannelIdentity(t *testing.T, person string, identity 
 	t.Helper()
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person_channel_identity
-			  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, 'telegram', 'connector:telegram')`,
-			c.ws, person, identity.Provider, identity.ChannelUserID, identity.Username)
+			INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+			VALUES ( $1, $2, $3, $4, 'telegram', 'connector:telegram')`,
+			person, identity.Provider, identity.ChannelUserID, identity.Username)
 		return err
 	}); err != nil {
 		t.Fatalf("binding the channel identity: %v", err)

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -102,10 +102,9 @@ func (c *channelSendEnv) bindIdentity(t *testing.T) {
 	t.Helper()
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person_channel_identity
-				(workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-			VALUES ($1, $2, 'telegram', $3, 'buyer', 'telegram', 'connector:telegram')`,
-			c.ws, c.personID, channelSendAccountID)
+			INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+			VALUES ( $1, 'telegram', $2, 'buyer', 'telegram', 'connector:telegram')`,
+			c.personID, channelSendAccountID)
 		return err
 	}); err != nil {
 		t.Fatalf("binding the channel identity: %v", err)

--- a/backend/internal/compose/integration/embedding_integration_test.go
+++ b/backend/internal/compose/integration/embedding_integration_test.go
@@ -93,7 +93,7 @@ func TestEmbeddingUpsertReusesUnchangedText(t *testing.T) {
 	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Vector Person', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Vector Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person", embedder)
 	if err != nil || !fresh {
@@ -117,8 +117,8 @@ func TestSimilarityRankingAndRowScope(t *testing.T) {
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 
-	shared := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Anke Schulz', 'manual', 'human:x')`)
-	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Bernd Kruse', $3, 'manual', 'human:x')`, e.Rep3)
+	shared := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Anke Schulz', 'manual', 'human:x')`)
+	foreign := e.SeedID(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by) VALUES ($1, 'Bernd Kruse', $2, 'manual', 'human:x')`, e.Rep3)
 	for id, text := range map[ids.UUID]string{shared: "Anke Schulz", foreign: "Bernd Kruse"} {
 		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, text, embedder); err != nil {
 			t.Fatal(err)
@@ -160,9 +160,9 @@ func TestHybridRRFAgreementWins(t *testing.T) {
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 
-	agree := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Solar Grid', 'manual', 'human:x')`)
-	lexOnly := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Solar Panels', 'manual', 'human:x')`)
-	vecOnly := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Photovoltaik Cluster', 'manual', 'human:x')`)
+	agree := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Solar Grid', 'manual', 'human:x')`)
+	lexOnly := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Solar Panels', 'manual', 'human:x')`)
+	vecOnly := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Photovoltaik Cluster', 'manual', 'human:x')`)
 
 	// Embeddings: the agreeing row and the vector-only row both embed
 	// the QUERY text (identical vector); the lexical-only row embeds
@@ -204,7 +204,7 @@ func TestEmbedGenMaintainsRowsFromEvents(t *testing.T) {
 	fake := ai.NewFakeClient()
 	gen := search.NewEmbedGen(e.Store, fakeEmbedder(t, fake))
 
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Event Driven', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Event Driven', 'manual', 'human:x')`)
 	env := kevents.Envelope{
 		EventID: ids.NewV7(),
 		Type:    "person.created",
@@ -243,8 +243,8 @@ func (e *SearchEnv) storedEmbeddingModel(t *testing.T, entityID ids.UUID) string
 	t.Helper()
 	var model string
 	err := e.Owner.QueryRow(context.Background(),
-		`SELECT model FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2 AND chunk_ix = 0`,
-		e.WS, entityID).Scan(&model)
+		`SELECT model FROM embedding WHERE entity_type = 'person' AND entity_id = $1 AND chunk_ix = 0`,
+		entityID).Scan(&model)
 	if err != nil {
 		t.Fatalf("reading stored embedding: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestUpsertReembedsOnIdentityChange(t *testing.T) {
 	fake := ai.NewFakeClient()
 	embedderA := fakeEmbedderNamed(t, fake, "model-a")
 	embedderB := fakeEmbedderNamed(t, fake, "model-b")
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Identity Person', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Identity Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Same Text", embedderA)
 	if err != nil || !fresh {
@@ -293,7 +293,7 @@ func TestUpsertSkipsUnchangedUnderSameIdentity(t *testing.T) {
 	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-c")
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stable Person', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Stable Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Stable Text", embedder)
 	if err != nil || !fresh {
@@ -314,7 +314,7 @@ func TestUpsertSkipsUnchangedUnderSameIdentity(t *testing.T) {
 // vector into a column other rows expect at a fixed width.
 func TestUpsertRejectsWidthMismatch(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Width Mismatch', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Width Mismatch', 'manual', 'human:x')`)
 	// dims (999) deliberately differs from resDims (1024): the declared
 	// identity and the actual response disagree, which the width guard
 	// must catch by comparing against the IDENTITY's width, not a fixed
@@ -339,7 +339,7 @@ func TestUpsertRejectsWidthMismatch(t *testing.T) {
 // it ever reaches storage.
 func TestUpsertRejectsZeroVector(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Zero Vector', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Zero Vector', 'manual', 'human:x')`)
 	// Width matches (1024/1024) so only the zero-vector guard can be what
 	// rejects this — a decoy width mismatch would leave the test proving
 	// the wrong guard fired.
@@ -370,8 +370,8 @@ func TestSimilarEntitiesFiltersIdentityAndDoesNotCrossDimCrash(t *testing.T) {
 	e := SetupSearch(t)
 	ctx := context.Background()
 
-	threeDim := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Three Dim Person', 'manual', 'human:x')`)
-	twoDim := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Two Dim Person', 'manual', 'human:x')`)
+	threeDim := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Three Dim Person', 'manual', 'human:x')`)
+	twoDim := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Two Dim Person', 'manual', 'human:x')`)
 
 	// Seed the unbounded embedding column directly at two different
 	// widths under two different identities — the mixed-width store
@@ -450,7 +450,7 @@ func (embedIdentityNeverCalled) EmbedIdentity() (string, int) { return "", 0 }
 // acking (platform/events' at-least-once bus then redelivers forever).
 func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unbound Person', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Unbound Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Unbound Person", embedIdentityNeverCalled{})
 	if err != nil {
@@ -462,8 +462,8 @@ func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 
 	var count int
 	if err := e.Owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2`,
-		e.WS, personID).Scan(&count); err != nil {
+		`SELECT count(*) FROM embedding WHERE entity_type = 'person' AND entity_id = $1`,
+		personID).Scan(&count); err != nil {
 		t.Fatalf("counting embedding rows: %v", err)
 	}
 	if count != 0 {
@@ -478,7 +478,7 @@ func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 // no live width or model.
 func TestHybridSearchDegradesToLexicalOnUnboundLane(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lexical Only Grid', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Lexical Only Grid', 'manual', 'human:x')`)
 
 	hits, semantic, err := e.Store.HybridSearch(e.Admin(), "Lexical Only Grid", embedIdentityNeverCalled{}, 10)
 	if err != nil {
@@ -525,7 +525,7 @@ func (embedCallFails) EmbedIdentity() (string, int) { return "fake/embed@8", 8 }
 // a lane that was never bound, because both are one fact to the caller.
 func TestHybridSearchDegradesToLexicalWhenTheEmbedCallFails(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Provider Down Grid', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Provider Down Grid', 'manual', 'human:x')`)
 
 	hits, semantic, err := e.Store.HybridSearch(e.Admin(), "Provider Down Grid", embedCallFails{}, 10)
 	if err != nil {

--- a/backend/internal/compose/integration/embeddriftsweep_integration_test.go
+++ b/backend/internal/compose/integration/embeddriftsweep_integration_test.go
@@ -40,11 +40,11 @@ func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	embeddedID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Embedded Person', 'manual', 'human:x')`)
+	embeddedID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Embedded Person', 'manual', 'human:x')`)
 	if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", embeddedID, "Embedded Person", embedder); err != nil {
 		t.Fatalf("seeding the already-embedded baseline: %v", err)
 	}
-	lostID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lost Event Person', 'manual', 'human:x')`)
+	lostID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Lost Event Person', 'manual', 'human:x')`)
 	baselineCalls := len(fake.Calls())
 
 	healed, err := e.Store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
@@ -102,7 +102,7 @@ func TestSweepWorkspaceEmbeddingDriftRefusesTheBindingChangeCase(t *testing.T) {
 	if err := e.Store.SeedBinding(ctx, "provider/model-old@1024"); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unswept Person', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Unswept Person', 'manual', 'human:x')`)
 
 	// The refusal only proves anything if there was real pending work to
 	// refuse — healed==0 over an empty pending set is vacuous.
@@ -144,7 +144,7 @@ func TestSweepWorkspaceEmbeddingDriftWaitsOutARunningReindex(t *testing.T) {
 	if err := e.Store.ClaimAndEnqueueReembedding(ctx, search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("ClaimAndEnqueueReembedding: %v", err)
 	}
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Mid Reindex Person', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Mid Reindex Person', 'manual', 'human:x')`)
 
 	// The wait-out only proves anything if the sweep had real pending work
 	// it chose not to touch — healed==0 over an empty set is vacuous.

--- a/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
@@ -70,13 +70,18 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	archived := SeedExtraWorkspace(t, re.Owner, "reindex-archived", true)
 
 	// Both live tenants get an entity to embed, so each child has real work and
-	// the victim's write actually reaches the fault.
-	re.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Fanout Person', 'manual', 'human:x')`)
-	healthyPersonID := ids.NewV7()
+	// the victim's write actually reaches the fault. A LEAD, not a person:
+	// ADR-0091 §8 phase D took the tenant column off person, so a person belongs
+	// to the installation and the first child to embed one covers it for every
+	// other — which would leave the second child nothing to do and the fault
+	// nothing to fire on. A lead still carries its tenant, so each child has
+	// work that is its own.
+	re.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Fanout Lead', 'manual', 'human:x')`)
+	healthyLeadID := ids.NewV7()
 	if _, err := re.Owner.Exec(context.Background(),
-		`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Fanout Person', 'manual', 'human:x')`,
-		healthyPersonID, healthy); err != nil {
-		t.Fatalf("seeding the healthy tenant's person: %v", err)
+		`INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Fanout Lead', 'manual', 'human:x')`,
+		healthyLeadID, healthy); err != nil {
+		t.Fatalf("seeding the healthy tenant's lead: %v", err)
 	}
 	// Permanent, not transient: a fault that healed would let the tenant
 	// complete on a later attempt and read as green — the outcome this denies.
@@ -109,12 +114,12 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	// The pass is only worth a row if it did the work.
 	var model string
 	if err := re.Owner.QueryRow(context.Background(),
-		`SELECT model FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2 AND chunk_ix = 0`,
-		healthy, healthyPersonID).Scan(&model); err != nil {
+		`SELECT model FROM embedding WHERE entity_type = 'lead' AND entity_id = $1 AND chunk_ix = 0`,
+		healthyLeadID).Scan(&model); err != nil {
 		t.Fatalf("reading the healthy tenant's embedding: %v", err)
 	}
 	if model != re.identity {
-		t.Errorf("the healthy tenant's person is embedded under %q, want %q", model, re.identity)
+		t.Errorf("the healthy tenant's lead is embedded under %q, want %q", model, re.identity)
 	}
 
 	// The archived tenant must have no row at all. This count is fenced on the

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -161,8 +161,7 @@ func seedStaleEmbeddingRow(t *testing.T, e *apptest.AppEnv, wsID string) {
 	ctx := context.Background()
 	var personID string
 	if err := e.Owner.QueryRow(ctx,
-		`INSERT INTO person (workspace_id, full_name, source, captured_by) VALUES ($1, 'Stale Row Person', 'manual', 'human:x') RETURNING id`,
-		wsID).Scan(&personID); err != nil {
+		`INSERT INTO person (full_name, source, captured_by) VALUES ( 'Stale Row Person', 'manual', 'human:x') RETURNING id`).Scan(&personID); err != nil {
 		t.Fatalf("seeding the stale-row person: %v", err)
 	}
 	if _, err := e.Owner.Exec(ctx, `

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -50,13 +50,13 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 		ctx := context.Background()
 		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, first_name, title, source, captured_by)
-			 VALUES ($1, `+wsClause+`, 'Selma Subject', 'Selma', 'CFO', 'manual', 'human:x')`, personID); err != nil {
+			`INSERT INTO person (id, full_name, first_name, title, source, captured_by)
+			 VALUES ($1, 'Selma Subject', 'Selma', 'CFO', 'manual', 'human:x')`, personID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-			 VALUES (`+wsClause+`, $1, $2, 'manual', 'human:x')`, personID, subjectEmail); err != nil {
+			`INSERT INTO person_email (person_id, email, source, captured_by)
+			 VALUES ( $1, $2, 'manual', 'human:x')`, personID, subjectEmail); err != nil {
 			return err
 		}
 		activityID := ids.NewV7()
@@ -273,10 +273,9 @@ func TestErasurePreservesActivityUnderTransitiveHold(t *testing.T) {
 
 	err := database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, first_name, source, captured_by)
-			 VALUES ($1, `+ws+`, 'Held Subject', 'Held', 'manual', 'human:x')`, personID); err != nil {
+			`INSERT INTO person (id, full_name, first_name, source, captured_by)
+			 VALUES ($1, 'Held Subject', 'Held', 'manual', 'human:x')`, personID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
@@ -380,10 +379,9 @@ func TestErasePersonHonoursCommercialCorrespondenceFloor(t *testing.T) {
 
 	err := database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, first_name, source, captured_by)
-			 VALUES ($1, `+ws+`, 'Floored Subject', 'Floored', 'manual', 'human:x')`, personID); err != nil {
+			`INSERT INTO person (id, full_name, first_name, source, captured_by)
+			 VALUES ($1, 'Floored Subject', 'Floored', 'manual', 'human:x')`, personID); err != nil {
 			return err
 		}
 		// A recent external email — commercial correspondence within the floor.

--- a/backend/internal/compose/integration/erasure_restriction_integration_test.go
+++ b/backend/internal/compose/integration/erasure_restriction_integration_test.go
@@ -47,15 +47,14 @@ func seedRestrictionFixture(t *testing.T, e *Env) restrictionFixture {
 	f := restrictionFixture{person: ids.NewV7(), email: ids.NewV7(), note: ids.NewV7(), delivery: ids.NewV7()}
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, first_name, source, captured_by)
-			 VALUES ($1, `+ws+`, 'Held Subject', 'Held', 'manual', 'human:x')`, f.person); err != nil {
+			`INSERT INTO person (id, full_name, first_name, source, captured_by)
+			 VALUES ($1, 'Held Subject', 'Held', 'manual', 'human:x')`, f.person); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-			 VALUES (`+ws+`, $1, 'held@example.test', 'manual', 'human:x')`, f.person); err != nil {
+			`INSERT INTO person_email (person_id, email, source, captured_by)
+			 VALUES ( $1, 'held@example.test', 'manual', 'human:x')`, f.person); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -72,12 +72,12 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 	var f exportFixture
 	// rep1 (team1) carries a social row to prove the child relation
 	// travels with its parent.
-	f.rep1Person = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Rep1 Person', 'manual', 'human:x')`, e.Rep1)
-	e.Seed(t, `INSERT INTO person_social (id, workspace_id, person_id, platform, handle)
-		VALUES ($1, $2, $3, 'linkedin', 'in/rep1')`, f.rep1Person)
-	f.rep3Person = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Rep3 Person', 'manual', 'human:x')`, e.Rep3)
+	f.rep1Person = e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Rep1 Person', 'manual', 'human:x')`, e.Rep1)
+	e.SeedID(t, `INSERT INTO person_social (id, person_id, platform, handle)
+		VALUES ($1, $2, 'linkedin', 'in/rep1')`, f.rep1Person)
+	f.rep3Person = e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Rep3 Person', 'manual', 'human:x')`, e.Rep3)
 	f.rep1Org = e.SeedID(t, `INSERT INTO organization (id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, 'Rep1 Org', 'manual', 'human:x')`, e.Rep1)
 	f.rep3Org = e.SeedID(t, `INSERT INTO organization (id, owner_id, display_name, source, captured_by)

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -369,8 +369,8 @@ func TestFieldHistoryErasureBoundsCollateralScrubs(t *testing.T) {
 	const twinEmail = "selma.twin@example.test"
 	// The subject's address is what ties the twin to the person: the
 	// eraser wipes any lead carrying one of the subject's emails.
-	e.WsExec(t, `INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-		 VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 'manual', 'human:x')`,
+	e.WsExec(t, `INSERT INTO person_email (person_id, email, source, captured_by)
+		 VALUES ( $1, $2, 'manual', 'human:x')`,
 		personID, twinEmail)
 	leadID := seedLead(t, e, "Selma Subject", twinEmail, nil)
 

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -34,7 +34,7 @@ import (
 // the store layer where scoped principals are cheap to mint.
 func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	e := SetupSearch(t)
-	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Shared Secret', $3, 'manual', 'human:x')`, e.Rep3)
+	foreign := e.SeedID(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by) VALUES ($1, 'Shared Secret', $2, 'manual', 'human:x')`, e.Rep3)
 
 	repCtx := e.AsTeamRep(e.Rep1, e.Team1)
 	peopleStore := people.NewStore(e.DB())
@@ -99,7 +99,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 func TestAReadShareCanBePassedOnButNotWidened(t *testing.T) {
 	e := SetupSearch(t)
 	// Owned by rep3 in team2, so rep1 in team1 has no path to it but a share.
-	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Out Of Scope', $3, 'manual', 'human:x')`, e.Rep3)
+	foreign := e.SeedID(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by) VALUES ($1, 'Out Of Scope', $2, 'manual', 'human:x')`, e.Rep3)
 	colleague := e.Seed(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'colleague@search.test', 'Colleague')`)
 	svc := identity.NewService(e.Pool)
 

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -141,8 +141,8 @@ func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
 		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
-	e.WsExec(t, `INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		VALUES ($1, $2, 'dana@acme.test', true, 'manual', 'human:x')`, e.WS, contact)
+	e.WsExec(t, `INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ( $1, 'dana@acme.test', true, 'manual', 'human:x')`, contact)
 
 	// Two qualifying interactions inside the §4 window, one each way, so
 	// the score is non-zero and reciprocity is balanced.

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -120,9 +120,8 @@ func seedRollupDealLinkedActivity(t *testing.T, e *Env, st rollupStages, org ids
 func seedRollupPersonLinkedActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.Time) {
 	t.Helper()
 	personID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		VALUES ($1, $2, 'Rollup Contact', 'manual', 'human:test')`,
-		personID, e.WS)
+	e.WsExec(t, `INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Rollup Contact', 'manual', 'human:test')`, personID)
 	e.WsExec(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
 		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:test')`,
 		ids.NewV7(), e.WS, personID, org)

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -179,7 +179,7 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 			t.Errorf("%s = %d, want %d", name, n, want)
 		}
 	}
-	assertCount("reconstructed persons", `SELECT count(*) FROM person WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source LIKE 'mirror:hubspot:%'`, 3)
+	assertCount("reconstructed persons", `SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%'`, 3)
 	assertCount("reconstructed organizations", `SELECT count(*) FROM organization WHERE source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed leads", `SELECT count(*) FROM lead WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source_system = 'mirror:hubspot'`, 1)
@@ -188,9 +188,8 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id
 		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`, 1)
 	assertCount("reconstructed employment", `
-		SELECT count(*) FROM relationship r JOIN person p ON p.id = r.person_id AND p.workspace_id = r.workspace_id
-		WHERE r.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND r.kind = 'employment' AND p.source = 'mirror:hubspot:person:p-1'`, 1)
+		SELECT count(*) FROM relationship r JOIN person p ON p.id = r.person_id
+		WHERE r.kind = 'employment' AND p.source = 'mirror:hubspot:person:p-1'`, 1)
 	// The bundle's owner map named the SOURCE workspace's admin, who does
 	// not exist in this clean instance — so ownership falls to the
 	// rebuild's own operator rather than landing ownerless (an ownerless
@@ -249,7 +248,7 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 	// The order is the foreign keys' — a deal points at its stage, its pipeline
 	// and its organization — and the predicate is per table because ADR-0091 §8
 	// phase D has reached some of these and not others. A `workspace_id = $1`
-	// spelled for all seven fails outright on the three that no longer have it.
+	// spelled for all seven fails outright on the six that no longer have it.
 	for _, t2 := range []struct {
 		table        string
 		tenantScoped bool
@@ -258,7 +257,7 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 		{"stage", false},
 		{"pipeline", false},
 		{"organization", false},
-		{"person", true},
+		{"person", false},
 		{"lead", true},
 		{"activity", false},
 	} {

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -500,7 +500,7 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`)
 	assertOne("primary employment relationship", `
 		SELECT count(*) FROM relationship r
-		JOIN person p ON p.id = r.person_id AND p.workspace_id = r.workspace_id
+		JOIN person p ON p.id = r.person_id
 		WHERE r.kind = 'employment' AND r.is_current_primary AND p.source = 'mirror:hubspot:person:p-1'`)
 	assertOne("activity link", `
 		SELECT count(*) FROM activity_link al
@@ -514,7 +514,7 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 	// are pinned per-record rather than by count.
 	assertOne("imported person's email", `
 		SELECT count(*) FROM person_email pe
-		JOIN person p ON p.id = pe.person_id AND p.workspace_id = pe.workspace_id
+		JOIN person p ON p.id = pe.person_id
 		WHERE p.source = 'mirror:hubspot:person:p-1' AND pe.email = 'mor@baer-pharma.test'`)
 	assertOne("imported organization's domain", `
 		SELECT count(*) FROM organization_domain od

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -218,7 +218,7 @@ func TestOverlayArchivePersonWritesBack(t *testing.T) {
 
 // The verbs the provider declares unsupported still answer 422, and never
 // reach the native handler — proven by the native table holding nothing
-// for the workspace afterward, not just by the status code.
+// afterward, not just by the status code.
 func TestOverlayUnsupportedWritesStillRefused(t *testing.T) {
 	e := setupOverlayWrite(t)
 	placeholder := ids.NewV7().String()
@@ -247,7 +247,7 @@ func TestOverlayUnsupportedWritesStillRefused(t *testing.T) {
 	var personCount int
 	if err := e.Owner.QueryRow(
 		context.Background(),
-		`SELECT count(*) FROM person WHERE workspace_id = (SELECT id FROM workspace WHERE slug = $1)`, e.Slug,
+		`SELECT count(*) FROM person`,
 	).Scan(&personCount); err != nil {
 		t.Fatalf("counting native person rows: %v", err)
 	}

--- a/backend/internal/compose/integration/participants_integration_test.go
+++ b/backend/internal/compose/integration/participants_integration_test.go
@@ -121,8 +121,8 @@ func TestAKnownContactResolvesFromAnUntrustedHeaderToo(t *testing.T) {
 	owner := OwnerConn(t)
 	activity := seedInteraction(t, e)
 	person := e.SeedPerson(t, "Sam Second", &e.Rep1)
-	SeedRow(t, owner, `INSERT INTO person_email (id, workspace_id, person_id, email, source, captured_by)
-		VALUES ($1, $2, '`+person.String()+`', 'sam@target.example', 'manual', 'human:x')`, e.WS)
+	SeedIDRow(t, owner, `INSERT INTO person_email (id, person_id, email, source, captured_by)
+		VALUES ($1, '`+person.String()+`', 'sam@target.example', 'manual', 'human:x')`)
 
 	stampParties(t, e, activity, false,
 		connector.MessageParticipant{Email: "sam@target.example", Role: connector.ParticipantRoleCC})

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -299,9 +299,9 @@ func seedBenchTier(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierSpe
 	// Every ~97th person carries the FTS token the canonical search
 	// query hits, so the query does real ranking work over a real
 	// selectivity, not a table scan of universal matches.
-	exec(`INSERT INTO person (workspace_id, full_name, source, captured_by)
-	      SELECT $1, 'Person ' || i || CASE WHEN i % 97 = 0 THEN ' Hamburg' ELSE '' END, 'manual', 'human:bench'
-	      FROM generate_series(1, $2) AS i`, ws, spec.persons)
+	exec(`INSERT INTO person (full_name, source, captured_by)
+	      SELECT 'Person ' || i || CASE WHEN i % 97 = 0 THEN ' Hamburg' ELSE '' END, 'manual', 'human:bench'
+	      FROM generate_series(1, $1) AS i`, spec.persons)
 	exec(`INSERT INTO organization (display_name, source, captured_by)
 	      SELECT 'Org ' || i || CASE WHEN i % 89 = 0 THEN ' Hamburg GmbH' ELSE '' END, 'manual', 'human:bench'
 	      FROM generate_series(1, $1) AS i`, spec.organizations)
@@ -320,25 +320,25 @@ func seedBenchTier(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierSpe
 	               'Body ' || i,
 	               now() - (i % 720 || ' hours')::interval,
 	               'manual', 'human:bench'
-	        FROM generate_series(1, $2) AS i
+	        FROM generate_series(1, $1) AS i
 	        RETURNING id
 	      ), total AS (
-	        SELECT count(*) AS n FROM person WHERE workspace_id = $1
+	        SELECT count(*) AS n FROM person
 	      ), numbered AS (
 	        SELECT id, (row_number() OVER () - 1) % (SELECT n FROM total) + 1 AS target_rn FROM act
 	      ), people AS (
-	        SELECT id, row_number() OVER () AS rn FROM person WHERE workspace_id = $1
+	        SELECT id, row_number() OVER () AS rn FROM person
 	      )
 	      INSERT INTO activity_link (activity_id, entity_type, person_id)
 	      SELECT n.id, 'person', p.id
-	      FROM numbered n JOIN people p ON p.rn = n.target_rn`, ws, spec.bulkActivities)
+	      FROM numbered n JOIN people p ON p.rn = n.target_rn`, spec.bulkActivities)
 
 	// Employment edges for the ADR-0021 edge-count evidence.
 	exec(`WITH total AS (
 	        SELECT count(*) AS n FROM organization
 	      ), people AS (
 	        SELECT id, (row_number() OVER () - 1) % (SELECT n FROM total) + 1 AS target_rn
-	        FROM person WHERE workspace_id = $1 LIMIT $2
+	        FROM person LIMIT $2
 	      ), orgs AS (
 	        SELECT id, row_number() OVER () AS rn FROM organization
 	      )
@@ -359,8 +359,8 @@ func seedBenchAnchor(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierS
 	t.Helper()
 	var anchor ids.UUID
 	if err := owner.QueryRow(context.Background(),
-		`INSERT INTO person (workspace_id, full_name, source, captured_by)
-		 VALUES ($1, 'Anchor Hamburg', 'manual', 'human:bench') RETURNING id`, ws).Scan(&anchor); err != nil {
+		`INSERT INTO person (full_name, source, captured_by)
+		 VALUES ( 'Anchor Hamburg', 'manual', 'human:bench') RETURNING id`).Scan(&anchor); err != nil {
 		t.Fatalf("seeding anchor: %v", err)
 	}
 	benchExec(t, owner, spec.tier, `WITH act AS (

--- a/backend/internal/compose/integration/perfrecord_bench_test.go
+++ b/backend/internal/compose/integration/perfrecord_bench_test.go
@@ -209,9 +209,9 @@ func recordBenchSeeds(workspace string) []struct {
 		sql  string
 		args []any
 	}{
-		{"persons", `INSERT INTO person (workspace_id, full_name, source, captured_by)
-		   SELECT $1, 'Bench Person ' || i, 'manual', 'human:bench'
-		   FROM generate_series(1, $2) AS i`, []any{workspace, recordBenchPersons}},
+		{"persons", `INSERT INTO person (full_name, source, captured_by)
+		   SELECT 'Bench Person ' || i, 'manual', 'human:bench'
+		   FROM generate_series(1, $1) AS i`, []any{recordBenchPersons}},
 		{"organizations", `INSERT INTO organization (display_name, source, captured_by)
 		   SELECT 'Bench Org ' || i, 'manual', 'human:bench'
 		   FROM generate_series(1, $1) AS i`, []any{recordBenchOrganizations}},

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -135,10 +135,9 @@ func TestCorrectionLedgerSurvivesRederivation(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
-	SeedRow(t, owner, `INSERT INTO person_profile_field
-		(id, workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-		VALUES ($1, $2, '`+mine.String()+`', 'title', 'Business Development Manager',
-		        'Anna Weber, Business Development Manager', 'site_read:https://example.test/team', 'site_read', 'agent:enrich')`, e.WS)
+	SeedIDRow(t, owner, `INSERT INTO person_profile_field (id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+		VALUES ($1, '`+mine.String()+`', 'title', 'Business Development Manager',
+		        'Anna Weber, Business Development Manager', 'site_read:https://example.test/team', 'site_read', 'agent:enrich')`)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 	svc := personRoomService(e)
@@ -279,10 +278,9 @@ func TestErasureReachesTheEnrichmentSidecarAndTheLedger(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
-	SeedRow(t, owner, `INSERT INTO person_profile_field
-		(id, workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-		VALUES ($1, $2, '`+mine.String()+`', 'title', 'Head of Procurement',
-		        'Anna Weber — Head of Procurement at ScaleCommerce', 'site_read:https://example.test/team', 'site_read', 'agent:enrich')`, e.WS)
+	SeedIDRow(t, owner, `INSERT INTO person_profile_field (id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+		VALUES ($1, '`+mine.String()+`', 'title', 'Head of Procurement',
+		        'Anna Weber — Head of Procurement at ScaleCommerce', 'site_read:https://example.test/team', 'site_read', 'agent:enrich')`)
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
 	if err := ai.NewFeedbackStore(e.DB()).Record(rep, ai.RecordInput{
@@ -531,11 +529,10 @@ func TestMergeCarriesTheEnrichmentSidecarToTheSurvivor(t *testing.T) {
 	duplicate := e.SeedPerson(t, "A. Weber", &e.Rep1)
 
 	// The duplicate carries a field the survivor does not.
-	SeedRow(t, owner, `INSERT INTO person_profile_field
-		(id, workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-		VALUES ($1, $2, '`+duplicate.String()+`', 'title', 'Head of Procurement',
+	SeedIDRow(t, owner, `INSERT INTO person_profile_field (id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+		VALUES ($1, '`+duplicate.String()+`', 'title', 'Head of Procurement',
 		        'Anna Weber — Head of Procurement', 'site_read:https://example.test/team',
-		        'site_read', 'agent:enrich')`, e.WS)
+		        'site_read', 'agent:enrich')`)
 	// And one they BOTH carry, with different values.
 	for _, p := range []struct {
 		id    ids.UUID
@@ -543,10 +540,9 @@ func TestMergeCarriesTheEnrichmentSidecarToTheSurvivor(t *testing.T) {
 	}{
 		{survivor, "+49 111"}, {duplicate, "+49 222"},
 	} {
-		SeedRow(t, owner, `INSERT INTO person_profile_field
-			(id, workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			VALUES ($1, $2, '`+p.id.String()+`', 'phone', '`+p.value+`', 'sig',
-			        'activity:x', 'capture_enrich', 'agent:enrich')`, e.WS)
+		SeedIDRow(t, owner, `INSERT INTO person_profile_field (id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+			VALUES ($1, '`+p.id.String()+`', 'phone', '`+p.value+`', 'sig',
+			        'activity:x', 'capture_enrich', 'agent:enrich')`)
 	}
 
 	if _, err := e.People.MergePerson(e.Admin(),

--- a/backend/internal/compose/integration/personautoenrich_integration_test.go
+++ b/backend/internal/compose/integration/personautoenrich_integration_test.go
@@ -61,9 +61,9 @@ func seedEmployedPerson(t *testing.T, e *Env, name string) (ids.PersonID, ids.Or
 			return err
 		}
 		if _, err := tx.Exec(context.Background(), `
-			INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, $4, 'manual', 'user:seed')`,
-			personID, e.WS, e.Rep1, name); err != nil {
+			INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, $3, 'manual', 'user:seed')`,
+			personID, e.Rep1, name); err != nil {
 			return err
 		}
 		_, err := tx.Exec(context.Background(), `
@@ -245,8 +245,8 @@ func TestPersonAutoEnrichStopsAtAContactWithNoEmployer(t *testing.T) {
 	personID := ids.From[ids.PersonKind](ids.NewV7())
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'Anna Muster', 'manual', 'user:seed')`, personID, e.WS, e.Rep1)
+			INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, 'Anna Muster', 'manual', 'user:seed')`, personID, e.Rep1)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the unemployed contact: %v", err)
@@ -271,8 +271,8 @@ func TestPersonAutoEnrichFollowsAMergeToTheSurvivor(t *testing.T) {
 	mergedAway := ids.From[ids.PersonKind](ids.NewV7())
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by, archived_at)
-			VALUES ($1, $2, $3, 'A. Muster', 'manual', 'user:seed', now())`, mergedAway, e.WS, e.Rep1)
+			INSERT INTO person (id, owner_id, full_name, source, captured_by, archived_at)
+			VALUES ($1, $2, 'A. Muster', 'manual', 'user:seed', now())`, mergedAway, e.Rep1)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the merged-away contact: %v", err)

--- a/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
+++ b/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
@@ -49,17 +49,15 @@ func seedChannelSubject(t *testing.T, e *Env) ids.UUID {
 	personID := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			 VALUES ($1, `+wsClause+`, 'Tilda Telegram', 'connector:telegram', 'connector:telegram')`,
+			`INSERT INTO person (id, full_name, source, captured_by)
+			 VALUES ($1, 'Tilda Telegram', 'connector:telegram', 'connector:telegram')`,
 			personID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_channel_identity
-			  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-			VALUES (`+wsClause+`, $1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`,
+			INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+			VALUES ( $1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`,
 			personID, channelSubjectAccount)
 		return err
 	})

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -64,15 +64,14 @@ func seedMailRecipient(t *testing.T, e *Env) ids.UUID {
 	personID := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			 VALUES ($1, `+wsClause+`, 'Erika Recipient', 'manual', 'human:x')`, personID); err != nil {
+			`INSERT INTO person (id, full_name, source, captured_by)
+			 VALUES ($1, 'Erika Recipient', 'manual', 'human:x')`, personID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-			 VALUES (`+wsClause+`, $1, $2, 'manual', 'human:x')`, personID, mailRecipientEmail)
+			`INSERT INTO person_email (person_id, email, source, captured_by)
+			 VALUES ( $1, $2, 'manual', 'human:x')`, personID, mailRecipientEmail)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/providerclaims_integration_test.go
+++ b/backend/internal/compose/integration/providerclaims_integration_test.go
@@ -106,15 +106,14 @@ func seedMergeSubject(t *testing.T, e *Env, name string) ids.UUID {
 	personID := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			 VALUES ($1, `+wsClause+`, $2, 'manual', 'human:x')`, personID, name); err != nil {
+			`INSERT INTO person (id, full_name, source, captured_by)
+			 VALUES ($1, $2, 'manual', 'human:x')`, personID, name); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-			 VALUES (`+wsClause+`, $1, $2, 'manual', 'human:x')`,
+			`INSERT INTO person_email (person_id, email, source, captured_by)
+			 VALUES ( $1, $2, 'manual', 'human:x')`,
 			personID, personID.String()+"@example.com")
 		return err
 	})
@@ -197,15 +196,14 @@ func TestErasureReachesAnArchivedDuplicatesPurchasedClaims(t *testing.T) {
 	archived := ids.NewV7()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person (id, workspace_id, full_name, source, captured_by, archived_at)
-			 VALUES ($1, `+wsClause+`, 'Selma Subject', 'manual', 'human:x', now())`, archived); err != nil {
+			`INSERT INTO person (id, full_name, source, captured_by, archived_at)
+			 VALUES ($1, 'Selma Subject', 'manual', 'human:x', now())`, archived); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, source, captured_by, archived_at)
-			 VALUES (`+wsClause+`, $1, $2, 'manual', 'human:x', now())`, archived, subjectEmail)
+			`INSERT INTO person_email (person_id, email, source, captured_by, archived_at)
+			 VALUES ( $1, $2, 'manual', 'human:x', now())`, archived, subjectEmail)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -333,8 +333,8 @@ func TestRecordHistoryErasureBoundsCollateralScrubs(t *testing.T) {
 	const twinEmail = "selma.twin@example.test"
 	// The subject's address is what ties the twin to the person: the
 	// eraser wipes any lead carrying one of the subject's emails.
-	e.WsExec(t, `INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-		 VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 'manual', 'human:x')`,
+	e.WsExec(t, `INSERT INTO person_email (person_id, email, source, captured_by)
+		 VALUES ( $1, $2, 'manual', 'human:x')`,
 		personID, twinEmail)
 	leadID := seedLead(t, e, "Selma Subject", twinEmail, nil)
 

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -52,7 +52,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 	names := []string{"Reembed One", "Reembed Two", "Reembed Three"}
 	personIDs := make([]ids.UUID, len(names))
 	for i, name := range names {
-		id := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
+		id := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`, name)
 		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, name, staleEmbedder); err != nil {
 			t.Fatalf("seeding the stale-identity baseline for %s: %v", name, err)
 		}
@@ -155,10 +155,10 @@ func TestReembedWorkspaceCostsOnlyTheWorkspaceThatCannotWrite(t *testing.T) {
 	}
 
 	healthy := SeedExtraWorkspace(t, e.Owner, "reembed-healthy", false)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Tenant Person', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Faulted Tenant Person', 'manual', 'human:x')`)
 	healthyPersonID := ids.NewV7()
-	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Tenant Person', 'manual', 'human:x')`,
-		healthyPersonID, healthy); err != nil {
+	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Healthy Tenant Person', 'manual', 'human:x')`,
+		healthyPersonID); err != nil {
 		t.Fatalf("seeding the healthy tenant's person: %v", err)
 	}
 	failEmbeddingWritesFor(t, e.Owner, e.WS)
@@ -171,13 +171,10 @@ func TestReembedWorkspaceCostsOnlyTheWorkspaceThatCannotWrite(t *testing.T) {
 	if err := e.Store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity}, ids.From[ids.WorkspaceKind](healthy), embedder); err != nil {
 		t.Fatalf("the healthy tenant's pass, while the victim's is faulted: %v", err)
 	}
-	// Read outside e.WS: SearchEnv.storedEmbeddingModel is pinned to the
-	// harness's own workspace, and a cross-tenant claim has to read the tenant
-	// it is making the claim about.
 	var model string
 	if err := e.Owner.QueryRow(ctx,
-		`SELECT model FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2 AND chunk_ix = 0`,
-		healthy, healthyPersonID).Scan(&model); err != nil {
+		`SELECT model FROM embedding WHERE entity_type = 'person' AND entity_id = $1 AND chunk_ix = 0`,
+		healthyPersonID).Scan(&model); err != nil {
 		t.Fatalf("reading the healthy tenant's embedding: %v", err)
 	}
 	if model != identity {
@@ -203,7 +200,7 @@ func TestReembedWorkspaceIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
 	if err := e.Store.SeedBinding(ctx, markerIdentity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Drift Person', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Drift Person', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'stale-hash', $3, '[1,2,3]'::vector)`,

--- a/backend/internal/compose/integration/reembedrun_integration_test.go
+++ b/backend/internal/compose/integration/reembedrun_integration_test.go
@@ -203,7 +203,7 @@ func TestAHealthyRunIsNotStealableHoweverLongItTakes(t *testing.T) {
 	}
 
 	for i := range 4 {
-		e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
+		e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`,
 			fmt.Sprintf("Slow Corpus Person %d", i))
 	}
 
@@ -281,7 +281,7 @@ func TestReembedReportsProgressBeforeItsScanAndItsFirstEmbed(t *testing.T) {
 		t.Fatalf("seeding the run: %v", err)
 	}
 	for i := range 2 {
-		e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
+		e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`,
 			fmt.Sprintf("Slow First Entity Person %d", i))
 	}
 	ageMarkerPastTheStealWindow(t, e)

--- a/backend/internal/compose/integration/replyaddress_integration_test.go
+++ b/backend/internal/compose/integration/replyaddress_integration_test.go
@@ -100,11 +100,11 @@ func TestAParticipantWithNoAddressFallsBackToThePrimaryEmail(t *testing.T) {
 	// Inserted with the NON-primary first, so a query that ignores the flag
 	// returns this one on insertion order and the test fails loudly.
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, position, source, captured_by)
-		VALUES ($1, $2, 'anna.private@example.com', false, 0, 'test', 'human:seed')`, e.WS, person)
+		INSERT INTO person_email (person_id, email, is_primary, position, source, captured_by)
+		VALUES ( $1, 'anna.private@example.com', false, 0, 'test', 'human:seed')`, person)
 	e.WsExec(t, `
-		INSERT INTO person_email (workspace_id, person_id, email, is_primary, position, source, captured_by)
-		VALUES ($1, $2, 'anna@work.example.com', true, 1, 'test', 'human:seed')`, e.WS, person)
+		INSERT INTO person_email (person_id, email, is_primary, position, source, captured_by)
+		VALUES ( $1, 'anna@work.example.com', true, 1, 'test', 'human:seed')`, person)
 
 	anchor := seedReplyThread(t, e, "inbound",
 		replyParty{role: "from", person: &person},

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -196,7 +196,7 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
 		t.Fatal(err)
 	}
-	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Graph Contact', 'manual', 'human:x')`)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Graph Contact', 'manual', 'human:x')`)
 	noteID := e.SeedID(t, `INSERT INTO activity (id, kind, subject, source, captured_by) VALUES ($1, 'note', 'Kickoff call', 'manual', 'human:x')`)
 	taskID := e.SeedID(t, `INSERT INTO activity (id, kind, subject, is_done, source, captured_by) VALUES ($1, 'task', 'Send offer', false, 'manual', 'human:x')`)
 	for _, activityID := range []ids.UUID{noteID, taskID} {

--- a/backend/internal/compose/integration/resolveentities_integration_test.go
+++ b/backend/internal/compose/integration/resolveentities_integration_test.go
@@ -35,10 +35,10 @@ type resolveFixture struct {
 func seedResolveFixture(t *testing.T, e *queryEnv) resolveFixture {
 	t.Helper()
 	var f resolveFixture
-	f.rep1Person = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Anna Weber', 'manual', 'human:x')`, e.Rep1)
-	f.rep3Person = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Bernd Kruse', 'manual', 'human:x')`, e.Rep3)
+	f.rep1Person = e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Anna Weber', 'manual', 'human:x')`, e.Rep1)
+	f.rep3Person = e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Bernd Kruse', 'manual', 'human:x')`, e.Rep3)
 	seedEmail(t, e, f.rep1Person, "anna@acme.example")
 	seedEmail(t, e, f.rep3Person, "bernd@logistik.example")
 	return f
@@ -47,9 +47,9 @@ func seedResolveFixture(t *testing.T, e *queryEnv) resolveFixture {
 func seedEmail(t *testing.T, e *queryEnv, person ids.UUID, address string) {
 	t.Helper()
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO person_email (id, workspace_id, person_id, email, email_type, is_primary, source, captured_by)
-		 VALUES ($1, $2, $3, $4, 'work', true, 'manual', 'human:x')`,
-		ids.NewV7(), e.WS, person, address); err != nil {
+		`INSERT INTO person_email (id, person_id, email, email_type, is_primary, source, captured_by)
+		 VALUES ($1, $2, $3, 'work', true, 'manual', 'human:x')`,
+		ids.NewV7(), person, address); err != nil {
 		t.Fatalf("seeding %s: %v", address, err)
 	}
 }

--- a/backend/internal/compose/integration/retention_authoring_integration_test.go
+++ b/backend/internal/compose/integration/retention_authoring_integration_test.go
@@ -556,14 +556,13 @@ func TestRetentionAnonymizesAnUnattachedPersonAndArchivesAnAgedNote(t *testing.T
 	SeedRetentionPolicies(t, e)
 
 	personID, noteID := ids.NewV7(), ids.NewV7()
-	wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 	// A person past the 730-day window with no granted consent and no deal
 	// stakeholder role — the selector's whole definition of unattached.
-	e.WsExec(t, `INSERT INTO person (id, workspace_id, full_name, first_name, last_name, title, source, captured_by, created_at)
-		VALUES ($1, `+wsClause+`, 'Old Contact', 'Old', 'Contact', 'Buyer', 'manual', 'human:x', now() - interval '800 days')`,
+	e.WsExec(t, `INSERT INTO person (id, full_name, first_name, last_name, title, source, captured_by, created_at)
+		VALUES ($1, 'Old Contact', 'Old', 'Contact', 'Buyer', 'manual', 'human:x', now() - interval '800 days')`,
 		personID)
-	e.WsExec(t, `INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-		VALUES (`+wsClause+`, $1, 'old.contact@example.test', 'manual', 'human:x')`, personID)
+	e.WsExec(t, `INSERT INTO person_email (person_id, email, source, captured_by)
+		VALUES ( $1, 'old.contact@example.test', 'manual', 'human:x')`, personID)
 	// A NOTE, deliberately: an internal note is not commercial correspondence, so
 	// it carries no statutory floor and the 1095-day archive reaches it. An email
 	// of the same age would be shielded, which is the boundary

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -26,7 +26,7 @@ import (
 // out-see the entity lists (object RBAC before row scope).
 func TestSearchHonorsObjectRBAC(t *testing.T) {
 	e := SetupSearch(t)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Rostock Person', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Rostock Person', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Rostock Werft', 'manual', 'human:x')`)
 
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
@@ -54,11 +54,11 @@ func TestSearchHonorsObjectRBAC(t *testing.T) {
 
 func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 	e := SetupSearch(t)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Heike Hamburg', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Heike Hamburg', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Hamburg Logistics GmbH', 'manual', 'human:x')`)
 	e.Seed(t, `INSERT INTO lead (id, workspace_id, company_name, email, source, captured_by) VALUES ($1, $2, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO activity (id, kind, subject, body, source, captured_by) VALUES ($1, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unrelated Munich', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Unrelated Munich', 'manual', 'human:x')`)
 
 	page, err := e.Store.Search(e.Admin(), search.Input{Query: "hamburg"})
 	if err != nil {
@@ -88,8 +88,8 @@ func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 
 func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
 	e := SetupSearch(t)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Scoped Bremen', $3, 'manual', 'human:x')`, e.Rep3)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Shared Bremen', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by) VALUES ($1, 'Scoped Bremen', $2, 'manual', 'human:x')`, e.Rep3)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Shared Bremen', 'manual', 'human:x')`)
 
 	// rep1 (team1, row_scope=team) must not see rep3's (team2) record —
 	// but the ownerless row is workspace-shared.
@@ -112,7 +112,7 @@ func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
 
 func TestSearchExcludesArchivedRows(t *testing.T) {
 	e := SetupSearch(t)
-	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, archived_at) VALUES ($1, $2, 'Archived Kiel', 'manual', 'human:x', now())`)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by, archived_at) VALUES ($1, 'Archived Kiel', 'manual', 'human:x', now())`)
 	page, err := e.Store.Search(e.Admin(), search.Input{Query: "kiel"})
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +143,7 @@ func TestSearchRankedCursorWalksAllHitsOnce(t *testing.T) {
 	e := SetupSearch(t)
 	want := map[string]bool{}
 	for i := 0; i < 5; i++ {
-		id := e.Seed(t, fmt.Sprintf(`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Dresden Contact %d', 'manual', 'human:x')`, i))
+		id := e.SeedID(t, fmt.Sprintf(`INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Dresden Contact %d', 'manual', 'human:x')`, i))
 		want[id.String()] = false
 	}
 	got := 0

--- a/backend/internal/compose/integration/searchcontext_integration_test.go
+++ b/backend/internal/compose/integration/searchcontext_integration_test.go
@@ -31,10 +31,10 @@ type contextFixture struct {
 func seedContextFixture(t *testing.T, e *queryEnv) contextFixture {
 	t.Helper()
 	return contextFixture{
-		rep1Person: e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'Annegret Turbinenbau', 'manual', 'human:x')`, e.Rep1),
-		rep3Person: e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'Bernhard Turbinenbau', 'manual', 'human:x')`, e.Rep3),
+		rep1Person: e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, 'Annegret Turbinenbau', 'manual', 'human:x')`, e.Rep1),
+		rep3Person: e.SeedID(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, 'Bernhard Turbinenbau', 'manual', 'human:x')`, e.Rep3),
 	}
 }
 

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -58,8 +58,8 @@ var stakeholderTouchedAt = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 // stakeholderTouchedAt.
 func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, directions ...string) ids.UUID {
 	t.Helper()
-	person := SeedRow(t, owner, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		VALUES ($1, $2, 'Stakeholder', 'manual', 'human:x')`, e.WS)
+	person := SeedIDRow(t, owner, `INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Stakeholder', 'manual', 'human:x')`)
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, source, captured_by)
 		 VALUES ($1, 'deal_stakeholder', $2, $3, 'manual', 'human:x')`, e.WS, person, deal); err != nil {

--- a/backend/internal/compose/integration/signals_integration_test.go
+++ b/backend/internal/compose/integration/signals_integration_test.go
@@ -73,7 +73,7 @@ func personCount(t *testing.T, e *SearchEnv) int {
 	t.Helper()
 	var n int
 	if err := e.Owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM person WHERE workspace_id = $1`, e.WS).Scan(&n); err != nil {
+		`SELECT count(*) FROM person`).Scan(&n); err != nil {
 		t.Fatal(err)
 	}
 	return n
@@ -99,12 +99,12 @@ func (e *SearchEnv) seedOrgWithDomain(t *testing.T, name, domain string) ids.UUI
 // match and the warm/cold join both read.
 func (e *SearchEnv) seedEmployedContact(t *testing.T, orgID ids.UUID, name, email string) ids.UUID {
 	t.Helper()
-	personID := e.Seed(t,
-		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, name, e.Rep1)
+	personID := e.SeedID(t,
+		`INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, $2, $3, 'manual', 'human:x')`, name, e.Rep1)
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO person_email (id, workspace_id, person_id, email, is_primary, source, captured_by)
-		 VALUES ($1, $2, $3, $4, true, 'manual', 'human:x')`, ids.NewV7(), e.WS, personID, email); err != nil {
+		`INSERT INTO person_email (id, person_id, email, is_primary, source, captured_by)
+		 VALUES ($1, $2, $3, true, 'manual', 'human:x')`, ids.NewV7(), personID, email); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.Owner.Exec(context.Background(),
@@ -152,9 +152,9 @@ func TestSignalRowScopeFollowsSubjectEntity(t *testing.T) {
 	e := SetupSearch(t)
 	store := signalStore(e)
 
-	foreignPerson := e.Seed(t,
-		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, 'Foreign Contact', $3, 'manual', 'human:x')`, e.Rep3)
+	foreignPerson := e.SeedID(t,
+		`INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, 'Foreign Contact', $2, 'manual', 'human:x')`, e.Rep3)
 	personType := "person"
 	pid := ids.UUID(foreignPerson)
 	sig, err := store.CreateSignal(e.adminSignals(), signals.CreateSignalInput{

--- a/backend/internal/compose/integration/strength_integration_test.go
+++ b/backend/internal/compose/integration/strength_integration_test.go
@@ -27,7 +27,7 @@ func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
 
-	person := SeedRow(t, owner, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Warm Contact', 'manual', 'human:x')`, e.WS)
+	person := SeedIDRow(t, owner, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Warm Contact', 'manual', 'human:x')`)
 	org := SeedIDRow(t, owner, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Warm GmbH', 'manual', 'human:x')`)
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by) VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`,

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -645,8 +645,7 @@ func (we *webhookEnv) seedPerson(t *testing.T, name string) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	we.execInWorkspace(t,
-		`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
-		id, we.wsID, name)
+		`INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`, id, name)
 	return id
 }
 

--- a/backend/internal/compose/integration/writeauthority_integration_test.go
+++ b/backend/internal/compose/integration/writeauthority_integration_test.go
@@ -49,9 +49,9 @@ type sharedPersonFixture struct {
 func seedSharedPerson(t *testing.T, name string) sharedPersonFixture {
 	t.Helper()
 	e := SetupSearch(t)
-	person := e.Seed(t,
-		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, $4, $3, 'manual', 'human:x')`, e.Rep3, name)
+	person := e.SeedID(t,
+		`INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, $3, $2, 'manual', 'human:x')`, e.Rep3, name)
 	return sharedPersonFixture{
 		env:    e,
 		person: person,
@@ -235,9 +235,9 @@ func leadActor(e *SearchEnv, user ids.UUID, scope principal.RowScope, teams []id
 func TestAMergeNeedsWriteAuthorityOnBothEnds(t *testing.T) {
 	f := seedSharedPerson(t, "Merge Source")
 	e := f.env
-	survivor := e.Seed(t,
-		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, 'Merge Survivor', $3, 'manual', 'human:x')`, e.Rep3)
+	survivor := e.SeedID(t,
+		`INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, 'Merge Survivor', $2, 'manual', 'human:x')`, e.Rep3)
 	store := people.NewStore(e.DB())
 
 	// Read on the source, write on the survivor: the caller may change what the

--- a/backend/internal/compose/integration/writeauthorityreview_integration_test.go
+++ b/backend/internal/compose/integration/writeauthorityreview_integration_test.go
@@ -142,8 +142,8 @@ func TestAReadShareOfARecordCannotDecideAChangeStagedAgainstIt(t *testing.T) {
 	holder := e.As(e.Rep1, []ids.UUID{e.Team1}, grantsAtTeamScope("person", "approval"))
 
 	person := ids.NewV7()
-	e.WsExec(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Staged Subject', 'manual', 'human:x')`, person, e.WS, e.Rep3)
+	e.WsExec(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Staged Subject', 'manual', 'human:x')`, person, e.Rep3)
 
 	staged, err := svc.Stage(e.AgentCtx(), approvals.StageInput{
 		Kind: "archive_record", ProposedChange: json.RawMessage(`{}`),
@@ -181,8 +181,8 @@ func TestAReadShareCannotRevokeSomebodyElsesShare(t *testing.T) {
 	holder := e.As(e.Rep1, []ids.UUID{e.Team1}, grantsAtTeamScope("person"))
 
 	person := ids.NewV7()
-	e.WsExec(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Twice Shared', 'manual', 'human:x')`, person, e.WS, e.Rep3)
+	e.WsExec(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Twice Shared', 'manual', 'human:x')`, person, e.Rep3)
 	shareRecord(owner, t, e, "person", person, e.Rep2, "write")
 	shareRecord(owner, t, e, "person", person, e.Rep1, "read")
 	colleagues := grantIDsFor(t, e, person, e.Rep2)
@@ -219,8 +219,8 @@ func TestAReadOnlySeatCanStillDeclineItsOwnShare(t *testing.T) {
 	})
 
 	person := ids.NewV7()
-	e.WsExec(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Unwanted Share', 'manual', 'human:x')`, person, e.WS, e.Rep3)
+	e.WsExec(t, `INSERT INTO person (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Unwanted Share', 'manual', 'human:x')`, person, e.Rep3)
 	shareRecord(owner, t, e, "person", person, e.Rep1, "read")
 
 	if err := svc.RevokeRecordGrant(readOnly, grantIDsFor(t, e, person, e.Rep1)); err != nil {

--- a/backend/internal/compose/orgconnections_integration_test.go
+++ b/backend/internal/compose/orgconnections_integration_test.go
@@ -61,8 +61,8 @@ func TestConnectorCapturedMailPutsAColleagueOnTheAccount(t *testing.T) {
 	var contact ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO person (workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES (
 			        'Pat Counterparty', $1, 'gmail:seed', 'connector:gmail', 'workspace')
 			RETURNING id`, owner).Scan(&contact)
 	}); err != nil {
@@ -114,8 +114,8 @@ func TestADepartedColleagueIsNotOfferedAsAWayIn(t *testing.T) {
 	var contact ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO person (workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES (
 			        'Known Contact', $1, 'manual', 'human:test', 'workspace')
 			RETURNING id`, e.Rep1).Scan(&contact)
 	}); err != nil {

--- a/backend/internal/compose/orgnamepromotion_integration_test.go
+++ b/backend/internal/compose/orgnamepromotion_integration_test.go
@@ -48,8 +48,8 @@ func seedSigningEmployee(t *testing.T, e *integration.Env, org ids.UUID, fullNam
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'gmail:seed', 'connector:gmail')`, person, e.WS, fullName); err != nil {
+			INSERT INTO person (id, full_name, source, captured_by)
+			VALUES ($1, $2, 'gmail:seed', 'connector:gmail')`, person, fullName); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
@@ -59,9 +59,8 @@ func seedSigningEmployee(t *testing.T, e *integration.Env, org ids.UUID, fullNam
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_profile_field (workspace_id, person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
-			VALUES ($1, $2, 'org_name', $3, $3, 'activity:seed', 0.9, 'capture_enrich', 'agent:enrich')`,
-			e.WS, person, signedName)
+			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
+			VALUES ( $1, 'org_name', $2, $2, 'activity:seed', 0.9, 'capture_enrich', 'agent:enrich')`, person, signedName)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/person360/momentdismissal.go
+++ b/backend/internal/compose/person360/momentdismissal.go
@@ -26,7 +26,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -82,13 +81,12 @@ func (s *Service) DismissMoment(ctx context.Context, personID ids.PersonID, in c
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_moment_dismissal
-				(workspace_id, user_id, person_id, claim_key, evidence_fingerprint)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO person_moment_dismissal (user_id, person_id, claim_key, evidence_fingerprint)
+			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (user_id, person_id, claim_key)
 			DO UPDATE SET evidence_fingerprint = EXCLUDED.evidence_fingerprint,
 			              dismissed_at = now()`,
-			storekit.MustWorkspace(ctx), userID, personID, in.ClaimKey, in.EvidenceFingerprint)
+			userID, personID, in.ClaimKey, in.EvidenceFingerprint)
 		if err != nil {
 			// Wrapped: a bare pgx error carries the table and column it failed
 			// on, and this one reaches a client through httperr.

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -46,7 +46,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -115,15 +114,14 @@ func (s *Service) momentDismissed(ctx context.Context, tx pgx.Tx, personID ids.P
 		return false, nil
 	}
 	var stored string
-	// The workspace is named rather than left to row-level security alone. RLS
-	// does not apply to a superuser or a BYPASSRLS role — which is what every
-	// migration and CI run uses — and without the predicate this QueryRow would
-	// silently take the first of several rows across workspaces.
+	// (user_id, person_id, claim_key) is the table's primary key, so the three
+	// keys name at most one row and QueryRow cannot be reading the first of
+	// several.
 	err := tx.QueryRow(ctx, `
 		SELECT evidence_fingerprint
 		FROM person_moment_dismissal
-		WHERE workspace_id = $1 AND user_id = $2 AND person_id = $3 AND claim_key = $4`,
-		storekit.MustWorkspace(ctx), viewer.UserID, personID, moment.ClaimKey).Scan(&stored)
+		WHERE user_id = $1 AND person_id = $2 AND claim_key = $3`,
+		viewer.UserID, personID, moment.ClaimKey).Scan(&stored)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false, nil
 	}

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -130,8 +130,8 @@ func addPersonEmail(t *testing.T, e *integration.Env, personID ids.UUID, email s
 	t.Helper()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, source, captured_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 'work', true, 'manual', 'human:x')`,
+			INSERT INTO person_email (person_id, email, email_type, is_primary, source, captured_by)
+			VALUES ( $1, $2, 'work', true, 'manual', 'human:x')`,
 			personID, email)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -350,7 +350,7 @@ func TestForecastByOwnerCountsAMultiStakeholderDealOnce(t *testing.T) {
 	e := setupForecast(t)
 	dealID := e.seedOpenDeal(t, "Two champions", 60, &e.Rep1, int64p(50000), stringp("commit"))
 	for _, role := range []string{"champion", "economic_buyer"} {
-		personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`, "Stakeholder "+role)
+		personID := e.seedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`, "Stakeholder "+role)
 		e.seed(t, `INSERT INTO relationship (id, workspace_id, kind, deal_id, person_id, role, source, captured_by)
 			VALUES ($1, $2, 'deal_stakeholder', $3, $4, $5, 'manual', 'human:x')`, dealID, personID, role)
 	}

--- a/backend/internal/compose/retentiongraph_integration_test.go
+++ b/backend/internal/compose/retentiongraph_integration_test.go
@@ -41,8 +41,8 @@ func TestRetentionCorrectsTheRelationshipGraphInItsOwnTransaction(t *testing.T) 
 	var contact ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
-			INSERT INTO person (workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES (
 			        'Long Thread', $1, 'manual', 'human:test', 'workspace')
 			RETURNING id`, e.Rep1).Scan(&contact)
 	}); err != nil {

--- a/backend/internal/compose/sitepersonfields_integration_test.go
+++ b/backend/internal/compose/sitepersonfields_integration_test.go
@@ -28,15 +28,14 @@ func seatEmployee(t *testing.T, e *integration.Env, org ids.UUID, fullName, emai
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'gmail:seed', 'connector:gmail')`, person, e.WS, fullName); err != nil {
+			INSERT INTO person (id, full_name, source, captured_by)
+			VALUES ($1, $2, 'gmail:seed', 'connector:gmail')`, person, fullName); err != nil {
 			return err
 		}
 		if email != "" {
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, source, captured_by)
-				VALUES ($1, $2, $3, 'work', true, 'gmail:seed', 'connector:gmail')`,
-				e.WS, person, email); err != nil {
+				INSERT INTO person_email (person_id, email, email_type, is_primary, source, captured_by)
+				VALUES ( $1, $2, 'work', true, 'gmail:seed', 'connector:gmail')`, person, email); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/telegramingest_integration_test.go
+++ b/backend/internal/compose/telegramingest_integration_test.go
@@ -184,9 +184,8 @@ func TestIngestWorkerAppliesMembershipWithoutCapturingAnActivity(t *testing.T) {
 	// my_chat_member update below reports THAT account blocking the bot.
 	person := e.SeedPerson(t, "Blocks The Bot", nil)
 	e.WsExec(t, `
-		INSERT INTO person_channel_identity
-		  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+		INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+		VALUES (
 		        $1, 'telegram', '556', 'blockeduser', 'telegram', 'connector:telegram')`,
 		person)
 

--- a/backend/internal/modules/activities/channelsend_integration_test.go
+++ b/backend/internal/modules/activities/channelsend_integration_test.go
@@ -110,8 +110,8 @@ func (e *sendEnv) linkPerson(t *testing.T, anchor ids.ActivityID, name string) i
 	person := ids.NewV7()
 	ctx := context.Background()
 	if _, err := e.owner.Exec(ctx,
-		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, person, e.ws, name, e.rep); err != nil {
+		`INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, $2, $3, 'manual', 'human:x')`, person, name, e.rep); err != nil {
 		t.Fatalf("seeding the linked person: %v", err)
 	}
 	if _, err := e.owner.Exec(ctx,

--- a/backend/internal/modules/activities/commitments_integration_test.go
+++ b/backend/internal/modules/activities/commitments_integration_test.go
@@ -140,8 +140,8 @@ func (e *promiseEnv) seedSplitTask(t *testing.T) (taskID, hiddenDealID ids.UUID)
 		VALUES ($1, 'Default', true, 1)`, pipelineID)
 	e.exec(t, `INSERT INTO stage (id, pipeline_id, name, position, win_probability)
 		VALUES ($1, $2, 'Qualified', 1, 20)`, stageID, pipelineID)
-	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		VALUES ($1, $2, $3, $4, 'seed', 'system')`, personID, e.ws, visiblePersonNam, e.rep)
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, $2, $3, 'seed', 'system')`, personID, visiblePersonNam, e.rep)
 	// Owned by the OTHER rep, so an own-scoped caller cannot read it.
 	e.exec(t, `INSERT INTO deal (id, name, organization_id, owner_id, pipeline_id, stage_id, source, captured_by)
 		VALUES ($1, $2, $3, $4, $5, $6, 'seed', 'system')`,

--- a/backend/internal/modules/activities/email_integration_test.go
+++ b/backend/internal/modules/activities/email_integration_test.go
@@ -231,8 +231,8 @@ func (e *sendEnv) linkToPersonOwnedBy(t *testing.T, anchor ids.ActivityID, owner
 	t.Helper()
 	person := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, 'Buyer', $3, 'manual', 'human:x')`, person, e.ws, owner); err != nil {
+		`INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, 'Buyer', $2, 'manual', 'human:x')`, person, owner); err != nil {
 		t.Fatalf("seeding the linked person: %v", err)
 	}
 	if _, err := e.owner.Exec(context.Background(),

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -89,8 +89,8 @@ func (e *sendEnv) seedPerson(t *testing.T, name string) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, id, e.ws, name, e.rep); err != nil {
+		INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, $2, $3, 'manual', 'human:x')`, id, name, e.rep); err != nil {
 		t.Fatalf("seeding the person: %v", err)
 	}
 	return id

--- a/backend/internal/modules/activities/pipelinefacts_integration_test.go
+++ b/backend/internal/modules/activities/pipelinefacts_integration_test.go
@@ -122,10 +122,10 @@ func (e *factsEnv) seed(t *testing.T, row capturedRow) ids.UUID {
 	}
 	if row.withPerson {
 		person := ids.NewV7()
-		e.exec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			VALUES ($1, $2, 'Linked Person', 'test', 'connector:gmail')`, person, e.ws)
+		e.exec(t, `INSERT INTO person (id, full_name, source, captured_by)
+			VALUES ($1, 'Linked Person', 'test', 'connector:gmail')`, person)
 		e.exec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, id, person)
+			VALUES ($1, 'person', $2)`, id, person)
 	}
 	return id
 }
@@ -206,10 +206,10 @@ func TestReadingPipelineFactsTakesTheRowScopeNotJustTheGrant(t *testing.T) {
 	e.exec(t, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Other')`,
 		other, e.ws, "other-"+other.String()+"@facts.test")
 	person := ids.NewV7()
-	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, owner_id)
-		VALUES ($1, $2, 'Theirs', 'test', 'connector:gmail', $3)`, person, e.ws, other)
+	e.exec(t, `INSERT INTO person (id, full_name, source, captured_by, owner_id)
+		VALUES ($1, 'Theirs', 'test', 'connector:gmail', $2)`, person, other)
 	e.exec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id)
-		VALUES ( $1, 'person', $2)`, id, person)
+		VALUES ($1, 'person', $2)`, id, person)
 
 	// The allow arm over the same seed: unbounded scope reads it. Without this,
 	// a link that failed to land would make the refusal below meaningless.

--- a/backend/internal/modules/activities/timelinescope_integration_test.go
+++ b/backend/internal/modules/activities/timelinescope_integration_test.go
@@ -37,9 +37,9 @@ func TestNarrowingTheTimelineToAnUnreadableLeadAnswersNotFound(t *testing.T) {
 	e.exec(t, `INSERT INTO lead (id, workspace_id, full_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Hidden Prospect', $3, 'seed', 'system')`,
 		hiddenLeadID, e.ws, e.other)
-	e.exec(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-		VALUES ($1, $2, 'Visible Contact', $3, 'seed', 'system')`,
-		visiblePersonID, e.ws, e.rep)
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Visible Contact', $2, 'seed', 'system')`,
+		visiblePersonID, e.rep)
 	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, 'note', 'Called about the rollout', now(), 'seed', 'system')`,
 		activityID)

--- a/backend/internal/modules/capture/tracelinks_integration_test.go
+++ b/backend/internal/modules/capture/tracelinks_integration_test.go
@@ -67,8 +67,8 @@ func seedTracedActivityOwnedBy(ctx context.Context, t *testing.T, db *database.D
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			INSERT INTO person (id, full_name, owner_id, source, captured_by)
+			VALUES ($1,
 			        'Linked Person', $2, 'manual', 'human:test')`,
 			personID, personHolder); err != nil {
 			return err

--- a/backend/internal/modules/capture/tracerollback_integration_test.go
+++ b/backend/internal/modules/capture/tracerollback_integration_test.go
@@ -77,8 +77,8 @@ func hideIncumbent(ctx context.Context, t *testing.T, db *database.DB, sourceID 
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'Stranger', $2, 'manual', 'human:test')`,
+			INSERT INTO person (id, full_name, owner_id, source, captured_by)
+			VALUES ($1, 'Stranger', $2, 'manual', 'human:test')`,
 			personID, stranger); err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/channelconsent_integration_test.go
+++ b/backend/internal/modules/consent/channelconsent_integration_test.go
@@ -93,16 +93,14 @@ func setupChannelConsent(t *testing.T) *channelConsentEnv {
 	// A Telegram-only subject: no person_email row at all, which is exactly the
 	// person the address-shaped gate could never answer about.
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		 VALUES ($1, $2, 'Tilda Telegram', 'connector:telegram', 'connector:telegram')`,
-		e.person, e.ws); err != nil {
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, 'Tilda Telegram', 'connector:telegram', 'connector:telegram')`,
+		e.person); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO person_channel_identity
-		  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-		VALUES ($1, $2, 'telegram', $3, 'tilda', 'connector:telegram', 'connector:telegram')`,
-		e.ws, e.person, e.account); err != nil {
+		INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+		VALUES ( $1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`, e.person, e.account); err != nil {
 		t.Fatal(err)
 	}
 
@@ -226,9 +224,8 @@ func TestRequireGrantedForEmailsStillAnswersThroughTheSharedRule(t *testing.T) {
 	gate := NewGate(e.store)
 	address := "tilda-" + e.person.String() + "@example.test"
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-		 VALUES ($1, $2, lower($3), true, 'test', 'human:x')`,
-		e.ws, e.person, address); err != nil {
+		`INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		 VALUES ( $1, lower($2), true, 'test', 'human:x')`, e.person, address); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/modules/consent/preference.go
+++ b/backend/internal/modules/consent/preference.go
@@ -124,7 +124,7 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 			FROM person_email pe
 			JOIN person p ON p.id = pe.person_id AND p.archived_at IS NULL
 			WHERE lower(pe.email) = $1
-			  AND p.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			  
 			LIMIT 1`, email).Scan(&personID)
 		if errors.Is(lookup, pgx.ErrNoRows) {
 			return nil // not a known recipient in this workspace: no token, no header

--- a/backend/internal/modules/integrations/runs_integration_test.go
+++ b/backend/internal/modules/integrations/runs_integration_test.go
@@ -96,9 +96,9 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 		owner *ids.UUID
 	}{{e.mine, &actor}, {e.theirs, &stranger}} {
 		if _, err := owner.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, 'Anna Muster', 'manual', 'human:test')`,
-			p.id, e.ws, p.owner); err != nil {
+			INSERT INTO person (id, owner_id, full_name, source, captured_by)
+			VALUES ($1, $2, 'Anna Muster', 'manual', 'human:test')`,
+			p.id, p.owner); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/modules/people/captureprivacy_integration_test.go
+++ b/backend/internal/modules/people/captureprivacy_integration_test.go
@@ -145,9 +145,9 @@ func (e *privacyEnv) capturePerson(t *testing.T, visibility string) ids.PersonID
 	ctx := e.as(e.owner, principal.RowScopeOwn)
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES ($1, $2, 'Captured Contact', $3, 'gmail:seed', 'connector:gmail', $4)`,
-			id, e.ws, e.owner, visibility)
+			INSERT INTO person (id, full_name, owner_id, source, captured_by, visibility)
+			VALUES ($1, 'Captured Contact', $2, 'gmail:seed', 'connector:gmail', $3)`,
+			id, e.owner, visibility)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding a %s person: %v", visibility, err)

--- a/backend/internal/modules/people/channelidentity.go
+++ b/backend/internal/modules/people/channelidentity.go
@@ -58,12 +58,11 @@ func ResolveOrCreateChannelIdentity(ctx context.Context, tx pgx.Tx, personID ids
 	// channel, and unlike a mail message there is no per-record id worth
 	// stamping — the binding outlives every message that refreshed it.
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO person_channel_identity
-			(workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
-		VALUES ($1, $2, $3, $4, NULLIF($5, ''), $3, $6)
+		INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
+		VALUES ( $1, $2, $3, NULLIF($4, ''), $2, $5)
 		ON CONFLICT (provider, channel_user_id) WHERE archived_at IS NULL
 		DO NOTHING`,
-		workspaceID(ctx), personID, ci.Provider, ci.ChannelUserID, ci.Username, by)
+		personID, ci.Provider, ci.ChannelUserID, ci.Username, by)
 	if err != nil {
 		return ids.PersonID{}, fmt.Errorf("people: binding channel identity: %w", err)
 	}

--- a/backend/internal/modules/people/channelidentity_integration_test.go
+++ b/backend/internal/modules/people/channelidentity_integration_test.go
@@ -47,9 +47,9 @@ func (e *dedupeEnv) resolveOrCreatePersonForIdentity(ctx context.Context, name s
 		}
 		candidate := ids.New[ids.PersonKind]()
 		if _, err := speculative.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5)`,
-			candidate, workspaceID(ctx), name, ci.Provider, "connector:"+ci.Provider); err != nil {
+			INSERT INTO person (id, full_name, source, captured_by)
+			VALUES ($1, $2, $3, $4)`,
+			candidate, name, ci.Provider, "connector:"+ci.Provider); err != nil {
 			return err
 		}
 		owner, err := ResolveOrCreateChannelIdentity(ctx, speculative, candidate, ci)

--- a/backend/internal/modules/people/creatededupe_contention_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_contention_integration_test.go
@@ -68,8 +68,8 @@ func (e *dedupeEnv) beginHeldPhoneCreate(ctx context.Context, t *testing.T, name
 	}
 	id := ids.New[ids.PersonKind]()
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', $4)`,
-		id, e.ws, name, by); err != nil {
+		`INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', $3)`,
+		id, name, by); err != nil {
 		t.Fatalf("inserting the in-flight person: %v", err)
 	}
 	if err := insertPersonPhones(ctx, tx, workspaceID(ctx), id, "manual", by,

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -211,8 +211,7 @@ func exactPersonByEmail(ctx context.Context, tx pgx.Tx, emails []string) (ids.Pe
 	var id ids.PersonID
 	err := tx.QueryRow(ctx, `
 		SELECT person_id FROM person_email
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND email = ANY($1) AND archived_at IS NULL
+		WHERE email = ANY($1) AND archived_at IS NULL
 		ORDER BY person_id
 		LIMIT 1`, lowered).Scan(&id)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -259,8 +258,7 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 		   AND r.is_current_primary AND r.archived_at IS NULL
 		  LEFT JOIN organization_domain od
 		    ON od.organization_id = r.organization_id AND od.archived_at IS NULL
-		 WHERE p.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND p.archived_at IS NULL
+		 WHERE p.archived_at IS NULL
 		   AND (f_fold_apostrophes(lower(p.full_name)) % f_fold_apostrophes(lower($1))
 		        OR ($2::uuid IS NOT NULL AND r.organization_id = $2))`,
 		c.FullName, c.CurrentPrimaryOrgID)

--- a/backend/internal/modules/people/enrichsignature.go
+++ b/backend/internal/modules/people/enrichsignature.go
@@ -94,15 +94,14 @@ func (s *Store) applySignatureField(ctx context.Context, tx pgx.Tx, personID ids
 	if value == "" {
 		return false, nil
 	}
-	wsID := workspaceID(ctx)
 
 	// The evidence row is the admission ticket: one row per (person, field),
 	// first verdict wins — a later pass can never overwrite it.
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO person_profile_field (workspace_id, person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
+		VALUES ( $1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (person_id, field) DO NOTHING`,
-		wsID, personID, f.Name, value, f.Evidence, sourceRef, f.Confidence, enrichSource, enrichCapturedBy)
+		personID, f.Name, value, f.Evidence, sourceRef, f.Confidence, enrichSource, enrichCapturedBy)
 	if err != nil {
 		return false, fmt.Errorf("people: signature evidence row (%s): %w", f.Name, err)
 	}
@@ -128,11 +127,11 @@ func (s *Store) applySignatureField(ctx context.Context, tx pgx.Tx, personID ids
 	case "phone":
 		// A first phone only — a person with any live phone row keeps it.
 		tag, err := tx.Exec(ctx, `
-			INSERT INTO person_phone (workspace_id, person_id, phone, phone_type, is_primary, position, source, captured_by)
-			SELECT $1, $2, $3, 'work', true, 0, $4, $5
+			INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by)
+			SELECT $1, $2, 'work', true, 0, $3, $4
 			WHERE NOT EXISTS (
-				SELECT 1 FROM person_phone WHERE person_id = $2 AND archived_at IS NULL)`,
-			wsID, personID, value, enrichSource, enrichCapturedBy)
+				SELECT 1 FROM person_phone WHERE person_id = $1 AND archived_at IS NULL)`,
+			personID, value, enrichSource, enrichCapturedBy)
 		if err != nil {
 			return false, fmt.Errorf("people: signature phone fill: %w", err)
 		}
@@ -183,15 +182,15 @@ func (s *Store) MarkSignatureRead(ctx context.Context, personID ids.PersonID, ac
 		// caller: the watermark and the candidate query must compare the same
 		// number, and only one of them can be the row itself.
 		tag, err := tx.Exec(ctx, `
-			INSERT INTO person_signature_enrich_state (workspace_id, person_id, activity_id, last_activity_at)
-			SELECT $1, $2, a.id, a.occurred_at FROM activity a
-			 WHERE a.id = $3 AND a.restricted_at IS NULL
+			INSERT INTO person_signature_enrich_state (person_id, activity_id, last_activity_at)
+			SELECT $1, a.id, a.occurred_at FROM activity a
+			 WHERE a.id = $2 AND a.restricted_at IS NULL
 			ON CONFLICT (person_id) DO UPDATE
 			SET activity_id = EXCLUDED.activity_id,
 			    last_activity_at = GREATEST(person_signature_enrich_state.last_activity_at,
 			                                EXCLUDED.last_activity_at),
 			    attempted_at = now()`,
-			workspaceID(ctx), personID, activityID)
+			personID, activityID)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/people/ensure_edges_integration_test.go
+++ b/backend/internal/modules/people/ensure_edges_integration_test.go
@@ -228,8 +228,8 @@ func TestApplySignatureFieldsWithdrawsEvidenceWhenTheFillLosesItsRace(t *testing
 	// the evidence is withdrawn.
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_phone (workspace_id, person_id, phone, phone_type, is_primary, position, source, captured_by)
-			VALUES ($1, $2, '+49 30 9999999', 'work', true, 0, 'manual', 'human:test')`, e.ws, personID)
+			INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by)
+			VALUES ( $1, '+49 30 9999999', 'work', true, 0, 'manual', 'human:test')`, personID)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/people/linkedin_integration_test.go
+++ b/backend/internal/modules/people/linkedin_integration_test.go
@@ -204,8 +204,8 @@ func (e *dedupeEnv) seedEmail(t *testing.T, person ids.PersonID, email string) {
 	ctx := e.as()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_email (workspace_id, person_id, email, is_primary, source, captured_by)
-			VALUES ($1, $2, $3, true, 'manual', 'human:test')`, e.ws, person, email)
+			INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+			VALUES ( $1, $2, true, 'manual', 'human:test')`, person, email)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding email for %s: %v", person, err)

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -241,8 +241,8 @@ func writeLinkedInHandle(ctx context.Context, tx pgx.Tx, connectionID, personID 
 		return false, nil
 	}
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO person_social (workspace_id, person_id, platform, handle)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $3, $2)
+		INSERT INTO person_social (person_id, platform, handle)
+		VALUES ( $1, $3, $2)
 		ON CONFLICT (person_id, platform) DO NOTHING`, personID, *handle, socialLinkedIn)
 	if err != nil {
 		return false, fmt.Errorf("people: writing a confirmed contact's LinkedIn handle: %w", err)

--- a/backend/internal/modules/people/linkedinreview_integration_test.go
+++ b/backend/internal/modules/people/linkedinreview_integration_test.go
@@ -123,8 +123,8 @@ func TestApplyingAMatchNeverOverwritesAHandleTheContactAlreadyHad(t *testing.T) 
 	ctx := e.as()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_social (workspace_id, person_id, platform, handle)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'linkedin', $2)`,
+			INSERT INTO person_social (person_id, platform, handle)
+			VALUES ( $1, 'linkedin', $2)`,
 			andreas.UUID, existing)
 		return err
 	}); err != nil {

--- a/backend/internal/modules/people/mergerelink.go
+++ b/backend/internal/modules/people/mergerelink.go
@@ -62,8 +62,8 @@ func relinkPersonReferences(ctx context.Context, tx pgx.Tx, sourceID, targetID i
 	// overwrite it.
 	if _, err = tx.Exec(ctx, `
 		INSERT INTO person_profile_field
-		  (workspace_id, person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
-		SELECT workspace_id, $2, field, value, evidence_snippet, source_ref, confidence, source, captured_by
+		  (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
+		SELECT $2, field, value, evidence_snippet, source_ref, confidence, source, captured_by
 		  FROM person_profile_field WHERE person_id = $1
 		ON CONFLICT DO NOTHING`, sourceID.UUID, targetID.UUID); err != nil {
 		return counts, fmt.Errorf("relink enrichment fields: %w", err)

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -59,8 +59,8 @@ func replacePersonSocial(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, p
 			continue
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_social (workspace_id, person_id, platform, handle) VALUES ($1, $2, $3, $4)`,
-			wsID, personID, platform, text); err != nil {
+			`INSERT INTO person_social (person_id, platform, handle) VALUES ( $1, $2, $3)`,
+			personID, platform, text); err != nil {
 			return fmt.Errorf("insert person social row: %w", err)
 		}
 	}
@@ -98,9 +98,9 @@ func parsePersonContacts(emails []PersonEmailInput, phones []PersonPhoneInput) e
 func insertPersonEmails(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, personID ids.PersonID, source, by string, emails []PersonEmailInput) error {
 	for _, e := range emails {
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, position, source, captured_by, from_correspondence)
-			 VALUES ($1, $2, lower($3), $4, $5, $6, $7, $8, $9)`,
-			wsID, personID, e.Email, e.EmailType, e.IsPrimary, e.Position, source, by,
+			`INSERT INTO person_email (person_id, email, email_type, is_primary, position, source, captured_by, from_correspondence)
+			 VALUES ( $1, lower($2), $3, $4, $5, $6, $7, $8)`,
+			personID, e.Email, e.EmailType, e.IsPrimary, e.Position, source, by,
 			!e.VouchedNotCorresponded); err != nil {
 			if name, ok := storekit.UniqueViolation(err); ok {
 				if name == "uq_person_email_dedupe" {
@@ -118,9 +118,9 @@ func insertPersonEmails(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, pe
 func insertPersonPhones(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, personID ids.PersonID, source, by string, phones []PersonPhoneInput) error {
 	for _, p := range phones {
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_phone (workspace_id, person_id, phone, phone_type, is_primary, position, source, captured_by)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			wsID, personID, p.Phone, p.PhoneType, p.IsPrimary, p.Position, source, by); err != nil {
+			`INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by)
+			 VALUES ( $1, $2, $3, $4, $5, $6, $7)`,
+			personID, p.Phone, p.PhoneType, p.IsPrimary, p.Position, source, by); err != nil {
 			return fmt.Errorf("insert person phone: %w", err)
 		}
 	}
@@ -137,8 +137,7 @@ func ensurePersonEmailsUnclaimed(ctx context.Context, tx pgx.Tx, emails []Person
 		var existing ids.PersonID
 		err := tx.QueryRow(ctx,
 			`SELECT person_id FROM person_email
-			  WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			    AND email = lower($1) AND archived_at IS NULL`,
+			  WHERE email = lower($1) AND archived_at IS NULL`,
 			e.Email).Scan(&existing)
 		if errors.Is(err, pgx.ErrNoRows) {
 			continue
@@ -159,7 +158,7 @@ func ensurePersonEmailsUnclaimed(ctx context.Context, tx pgx.Tx, emails []Person
 	return nil
 }
 
-const personColumns = `id, workspace_id, full_name, first_name, last_name, title, owner_id,
+const personColumns = `id, full_name, first_name, last_name, title, owner_id,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	merged_into_id, converted_from_lead_id, source, captured_by,
 	version, created_at, updated_at, archived_at, last_activity_at`
@@ -193,13 +192,13 @@ func readPerson(ctx context.Context, tx pgx.Tx, id ids.PersonID, archived storek
 // cursor key).
 func scanPerson(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontracts.Person, error) {
 	var p crmcontracts.Person
-	var id, wsID ids.UUID
+	var id ids.UUID
 	var ownerID, mergedInto, fromLead *ids.UUID
 	var addr crmcontracts.Address
 	var version int64
 
 	dests := []any{
-		&id, &wsID, &p.FullName, &p.FirstName, &p.LastName, &p.Title, &ownerID,
+		&id, &p.FullName, &p.FirstName, &p.LastName, &p.Title, &ownerID,
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&mergedInto, &fromLead, &p.Source, &p.CapturedBy,
 		&version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt, &p.LastActivityAt,

--- a/backend/internal/modules/people/promoteconsent_integration_test.go
+++ b/backend/internal/modules/people/promoteconsent_integration_test.go
@@ -212,13 +212,13 @@ func TestPromotionMergeAppliesWithdrawalWinsAndStateStands(t *testing.T) {
 	// already has newsletter granted.
 	personID := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		 VALUES ($1, $2, 'Lena Person', 'manual', 'human:x')`, personID, e.ws); err != nil {
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, 'Lena Person', 'manual', 'human:x')`, personID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, position, source, captured_by)
-		 VALUES ($1, $2, lower($3), 'work', true, 1, 'manual', 'human:x')`, e.ws, personID, email); err != nil {
+		`INSERT INTO person_email (person_id, email, email_type, is_primary, position, source, captured_by)
+		 VALUES ($1, lower($2), 'work', true, 1, 'manual', 'human:x')`, personID, email); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := e.owner.Exec(context.Background(),

--- a/backend/internal/modules/people/researchclaim.go
+++ b/backend/internal/modules/people/researchclaim.go
@@ -115,9 +115,8 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 			// accepting a newer claim about the same field REPLACES what was
 			// there, which is what a reader who just chose it expects.
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO person_profile_field
-					(workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-				VALUES ($1, $2, $3, $4, $5, $6, $8, $7)
+				INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+				VALUES ( $1, $1, $2, $3, $4, $6, $5)
 				ON CONFLICT (person_id, field) DO UPDATE
 				SET value = EXCLUDED.value,
 				    evidence_snippet = EXCLUDED.evidence_snippet,
@@ -129,7 +128,7 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 				-- itself. Person ids are unique across the fleet, but an
 				-- executor that bypasses row-level security would otherwise be
 				-- one id collision away from updating another tenant's row.
-				WHERE person_profile_field.workspace_id = $1`,
+				`,
 				storekit.MustWorkspace(ctx), personID, claim.Field, claim.Value,
 				claim.Quote, claim.SourceURL, by, researchSource); err != nil {
 				return fmt.Errorf("save the research claim %q: %w", claim.Field, err)

--- a/backend/internal/modules/people/resolvecreate.go
+++ b/backend/internal/modules/people/resolvecreate.go
@@ -107,17 +107,15 @@ func createPerson(ctx context.Context, tx pgx.Tx, match PersonResolution, spec P
 	id := ids.New[ids.PersonKind]()
 	addr := addressColumns(spec.Address)
 	cfCols, cfHolders, args := storekit.InsertFragments(spec.Active, spec.CustomFields, []any{
-		id, wsID, spec.FullName, spec.FirstName, spec.LastName, spec.Title, spec.OwnerID,
+		id, spec.FullName, spec.FirstName, spec.LastName, spec.Title, spec.OwnerID,
 		addr.Line1, addr.Line2, addr.City, addr.Region, addr.PostalCode, addr.Country,
 		spec.Source, spec.CapturedBy, spec.Visibility, spec.Quarantined, spec.ConvertedFromLeadID,
 	})
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO person (id, workspace_id, full_name, first_name, last_name, title, owner_id,
-		                     address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
-		                     source, captured_by, visibility, quarantined_at, converted_from_lead_id`+cfCols+`)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-		         coalesce(NULLIF($16, ''), 'workspace'),
-		         CASE WHEN $17 THEN now() ELSE NULL END, $18`+cfHolders+`)`,
+		`INSERT INTO person (id, full_name, first_name, last_name, title, owner_id, address_line1, address_line2, address_city, address_region, address_postal_code, address_country, source, captured_by, visibility, quarantined_at, converted_from_lead_id`+cfCols+`)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+		         coalesce(NULLIF($15, ''), 'workspace'),
+		         CASE WHEN $16 THEN now() ELSE NULL END, $17`+cfHolders+`)`,
 		args...); err != nil {
 		return ids.PersonID{}, fmt.Errorf("insert person: %w", err)
 	}

--- a/backend/internal/modules/people/searchpersonfields.go
+++ b/backend/internal/modules/people/searchpersonfields.go
@@ -88,7 +88,6 @@ func (s *Store) ApplyDiscoveredFields(ctx context.Context, personID ids.PersonID
 // result can never overwrite what a signature, a site read or a human
 // already answered.
 func fillDiscoveredFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID, by string, fields []DiscoveredField) ([]string, error) {
-	wsID := workspaceID(ctx)
 	var applied []string
 	// Keyed by FIELD and carrying the value actually written: this becomes the
 	// audit after-image, and field history projects per field from it. A list
@@ -105,10 +104,10 @@ func fillDiscoveredFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 			continue
 		}
 		tag, err := tx.Exec(ctx, `
-			INSERT INTO person_profile_field (workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+			VALUES ( $1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (person_id, field) DO NOTHING`,
-			wsID, personID, f.Field, value, snippet, f.SourceRef, searchFieldSource, by)
+			personID, f.Field, value, snippet, f.SourceRef, searchFieldSource, by)
 		if err != nil {
 			return nil, fmt.Errorf("people: discovered field evidence row (%s): %w", f.Field, err)
 		}

--- a/backend/internal/modules/people/sitepersonfields.go
+++ b/backend/internal/modules/people/sitepersonfields.go
@@ -187,7 +187,6 @@ func matchSitePerson(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, i
 // not a fill: adding an address to an existing person changes who that record
 // is reachable as, and the site is not authority for that.
 func fillSitePersonFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID, sourceRef, by string, in SitePersonFields) ([]string, error) {
-	wsID := workspaceID(ctx)
 	var applied []string
 	write := func(field, value string) error {
 		value = strings.TrimSpace(value)
@@ -198,10 +197,10 @@ func fillSitePersonFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		// same rule the signature pass writes under, so a site read can never
 		// overwrite what a signature (or a human) already answered.
 		tag, err := tx.Exec(ctx, `
-			INSERT INTO person_profile_field (workspace_id, person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+			VALUES ( $1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (person_id, field) DO NOTHING`,
-			wsID, personID, field, value, in.EvidenceSnippet, sourceRef, siteFieldSource, by)
+			personID, field, value, in.EvidenceSnippet, sourceRef, siteFieldSource, by)
 		if err != nil {
 			return fmt.Errorf("people: site person evidence row (%s): %w", field, err)
 		}

--- a/backend/internal/modules/people/strengthasof_integration_test.go
+++ b/backend/internal/modules/people/strengthasof_integration_test.go
@@ -59,9 +59,9 @@ func (e *dedupeEnv) seedContact(t *testing.T, name string) ids.PersonID {
 	ctx := e.as()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by, visibility)
-			VALUES ($1, $2, $3, $4, 'manual', 'human:test', 'workspace')`,
-			id, e.ws, name, e.rep)
+			INSERT INTO person (id, full_name, owner_id, source, captured_by, visibility)
+			VALUES ($1, $2, $3, 'manual', 'human:test', 'workspace')`,
+			id, name, e.rep)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding contact %s: %v", name, err)

--- a/backend/internal/modules/people/visibleaddresses_integration_test.go
+++ b/backend/internal/modules/people/visibleaddresses_integration_test.go
@@ -31,9 +31,9 @@ func (e *privacyEnv) seedAddress(t *testing.T, person ids.PersonID, email string
 	ctx := e.as(e.owner, principal.RowScopeAll)
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
-			VALUES ($1, $2, $3, 'gmail:seed', 'connector:gmail')`,
-			e.ws, person, email)
+			INSERT INTO person_email (person_id, email, source, captured_by)
+			VALUES ( $1, $2, 'gmail:seed', 'connector:gmail')`,
+			person, email)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the address: %v", err)

--- a/backend/internal/modules/privacy/retentionselectors.go
+++ b/backend/internal/modules/privacy/retentionselectors.go
@@ -46,8 +46,7 @@ var retentionSelectors = map[string]string{
 		          AND (coalesce(p.legal_hold, false) OR coalesce(o.legal_hold, false) OR coalesce(d.legal_hold, false)))
 		LIMIT $2`,
 	"person/no_consent_no_deal": `SELECT p.id FROM person p
-		WHERE p.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND p.archived_at IS NULL AND NOT p.legal_hold
+		WHERE p.archived_at IS NULL AND NOT p.legal_hold
 		  AND p.full_name IS DISTINCT FROM 'Erased Subject'
 		  AND p.created_at < now() - make_interval(days => $1)
 		  AND NOT EXISTS (SELECT 1 FROM person_consent pc WHERE pc.person_id = p.id AND pc.state = 'granted')

--- a/backend/internal/modules/privacy/sar_integration_test.go
+++ b/backend/internal/modules/privacy/sar_integration_test.go
@@ -76,12 +76,12 @@ func setupSARIdentifiers(t *testing.T) *sarIdentifierEnv {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		 VALUES ($1, $2, 'Sara Subject', 'manual', 'user:'||$3::text)`,
-		person, ws, user); err != nil {
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, 'Sara Subject', 'manual', 'user:'||$2::text)`,
+		person, user); err != nil {
 		t.Fatal(err)
 	}
-	seedIdentifierPairs(ctx, t, owner, ws, person)
+	seedIdentifierPairs(ctx, t, owner, person)
 
 	pool, err := database.NewPool(ctx, appDSN)
 	if err != nil {
@@ -100,31 +100,30 @@ func setupSARIdentifiers(t *testing.T) *sarIdentifierEnv {
 // kind. The two values in a pair differ because the live-row uniqueness indexes
 // are partial on archived_at IS NULL — reusing one value would leave the export
 // unable to say which row it named.
-func seedIdentifierPairs(ctx context.Context, t *testing.T, owner *pgx.Conn, ws ids.UUID, person ids.PersonID) {
+func seedIdentifierPairs(ctx context.Context, t *testing.T, owner *pgx.Conn, person ids.PersonID) {
 	t.Helper()
 	for _, insert := range []struct {
 		statement     string
 		live, retired string
 	}{
 		{
-			`INSERT INTO person_email (workspace_id, person_id, email, source, captured_by, archived_at)
-		  VALUES ($1, $2, $3, 'manual', 'user:test', NULL), ($1, $2, $4, 'manual', 'user:test', $5)`,
+			`INSERT INTO person_email (person_id, email, source, captured_by, archived_at)
+		  VALUES ($1, $2, 'manual', 'user:test', NULL), ($1, $3, 'manual', 'user:test', $4)`,
 			liveEmail, retiredEmail,
 		},
 		{
-			`INSERT INTO person_phone (workspace_id, person_id, phone, source, captured_by, archived_at)
-		  VALUES ($1, $2, $3, 'manual', 'user:test', NULL), ($1, $2, $4, 'manual', 'user:test', $5)`,
+			`INSERT INTO person_phone (person_id, phone, source, captured_by, archived_at)
+		  VALUES ($1, $2, 'manual', 'user:test', NULL), ($1, $3, 'manual', 'user:test', $4)`,
 			livePhone, retiredPhone,
 		},
 		{
-			`INSERT INTO person_channel_identity
-		    (workspace_id, person_id, provider, channel_user_id, username, source, captured_by, archived_at)
-		  VALUES ($1, $2, 'telegram', $3, 'sara', 'connector:telegram', 'connector:telegram', NULL),
-		         ($1, $2, 'telegram', $4, 'sara_old', 'connector:telegram', 'connector:telegram', $5)`,
+			`INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by, archived_at)
+		  VALUES ($1, 'telegram', $2, 'sara', 'connector:telegram', 'connector:telegram', NULL),
+		         ($1, 'telegram', $3, 'sara_old', 'connector:telegram', 'connector:telegram', $4)`,
 			liveAccount, retiredAccount,
 		},
 	} {
-		if _, err := owner.Exec(ctx, insert.statement, ws, person, insert.live, insert.retired, retiredAt); err != nil {
+		if _, err := owner.Exec(ctx, insert.statement, person, insert.live, insert.retired, retiredAt); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/modules/search/pending.go
+++ b/backend/internal/modules/search/pending.go
@@ -42,7 +42,7 @@ type pendingSource struct {
 // to BOTH maps; they must never diverge, since the pending count and the
 // live indexer must agree on what "this entity's text" means.
 var pendingSources = map[string]pendingSource{
-	entityPerson:       {table: entityPerson, text: "t.full_name", tenantScoped: true},
+	entityPerson:       {table: entityPerson, text: "t.full_name"},
 	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)"},
 	entityDeal:         {table: entityDeal, text: "t.name"},
 	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)", tenantScoped: true},

--- a/backend/migrations/core/1787048271_person_cluster_drop_workspace.down.sql
+++ b/backend/migrations/core/1787048271_person_cluster_drop_workspace.down.sql
@@ -1,0 +1,68 @@
+-- Reverse of 1787048271: the person cluster carries the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE person ADD COLUMN workspace_id uuid;
+ALTER TABLE person_email ADD COLUMN workspace_id uuid;
+ALTER TABLE person_phone ADD COLUMN workspace_id uuid;
+ALTER TABLE person_social ADD COLUMN workspace_id uuid;
+ALTER TABLE person_profile_field ADD COLUMN workspace_id uuid;
+ALTER TABLE person_channel_identity ADD COLUMN workspace_id uuid;
+ALTER TABLE person_signature_enrich_state ADD COLUMN workspace_id uuid;
+ALTER TABLE person_moment_dismissal ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'person', 'person_email', 'person_phone', 'person_social',
+    'person_profile_field', 'person_channel_identity',
+    'person_signature_enrich_state', 'person_moment_dismissal'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE person ADD CONSTRAINT person_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_email ADD CONSTRAINT person_email_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_phone ADD CONSTRAINT person_phone_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_social ADD CONSTRAINT person_social_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_profile_field ADD CONSTRAINT person_profile_field_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_channel_identity ADD CONSTRAINT person_channel_identity_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_signature_enrich_state ADD CONSTRAINT person_signature_enrich_state_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE person_moment_dismissal ADD CONSTRAINT person_moment_dismissal_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+-- UNIQUE (id), which is what the migration before this one left: phase B
+-- collapsed it from its composite form and this restores that state.
+ALTER TABLE person ADD CONSTRAINT uq_person_ws_id UNIQUE (id);
+
+DROP INDEX idx_person_owner;
+DROP INDEX idx_person_profile_field;
+DROP INDEX idx_person_channel_identity_person;
+DROP INDEX person_moment_dismissal_person_ix;
+
+CREATE INDEX idx_person_owner ON person (workspace_id, owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_person_ws_live ON person (workspace_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_person_profile_field ON person_profile_field (workspace_id, person_id);
+CREATE INDEX idx_person_channel_identity_person ON person_channel_identity (workspace_id, person_id);
+CREATE INDEX person_moment_dismissal_person_ix ON person_moment_dismissal (workspace_id, person_id);

--- a/backend/migrations/core/1787048271_person_cluster_drop_workspace.up.sql
+++ b/backend/migrations/core/1787048271_person_cluster_drop_workspace.up.sql
@@ -1,0 +1,54 @@
+-- 1787048271: the person cluster drops the tenant column (ADR-0091 §8 phase D).
+--
+-- The contact record and the seven tables that describe one:
+--
+--   person                         the contact itself
+--   person_email, person_phone     how to reach them
+--   person_social                  where else they are
+--   person_profile_field           a claimed field with its evidence
+--   person_channel_identity        who they are on a chat provider
+--   person_signature_enrich_state  how far the signature reader has got
+--   person_moment_dismissal        a suggestion this reader has waved away
+--
+-- person is the most-referenced table in the schema, which is why it takes a
+-- change of its own. Its keys already name something narrower than the tenant,
+-- and phase B put them there: an address is unique installation-wide, a channel
+-- identity is unique by (provider, channel_user_id).
+--
+-- uq_person_ws_id goes with the column — phase B's leftover, a second copy of
+-- person's own primary key, referenced by no foreign key.
+
+ALTER TABLE person_moment_dismissal DROP CONSTRAINT person_moment_dismissal_workspace_id_fkey;
+ALTER TABLE person_moment_dismissal DROP COLUMN workspace_id;
+
+ALTER TABLE person_signature_enrich_state DROP CONSTRAINT person_signature_enrich_state_workspace_id_fkey;
+ALTER TABLE person_signature_enrich_state DROP COLUMN workspace_id;
+
+ALTER TABLE person_channel_identity DROP CONSTRAINT person_channel_identity_workspace_id_fkey;
+ALTER TABLE person_channel_identity DROP COLUMN workspace_id;
+
+ALTER TABLE person_profile_field DROP CONSTRAINT person_profile_field_workspace_id_fkey;
+ALTER TABLE person_profile_field DROP COLUMN workspace_id;
+
+ALTER TABLE person_social DROP CONSTRAINT person_social_workspace_id_fkey;
+ALTER TABLE person_social DROP COLUMN workspace_id;
+
+ALTER TABLE person_phone DROP CONSTRAINT person_phone_workspace_id_fkey;
+ALTER TABLE person_phone DROP COLUMN workspace_id;
+
+ALTER TABLE person_email DROP CONSTRAINT person_email_workspace_id_fkey;
+ALTER TABLE person_email DROP COLUMN workspace_id;
+
+ALTER TABLE person DROP CONSTRAINT uq_person_ws_id;
+ALTER TABLE person DROP CONSTRAINT person_workspace_id_fkey;
+ALTER TABLE person DROP COLUMN workspace_id;
+
+-- The indexes that led with the column, recreated on what actually selects
+-- rows: an owner, a person's fields, their channel identities, their dismissals.
+--
+-- idx_person_ws_live is NOT recreated: it was (workspace_id) WHERE archived_at
+-- IS NULL, and an index on the tenant alone has no narrowed form.
+CREATE INDEX idx_person_owner ON person (owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_person_profile_field ON person_profile_field (person_id);
+CREATE INDEX idx_person_channel_identity_person ON person_channel_identity (person_id);
+CREATE INDEX person_moment_dismissal_person_ix ON person_moment_dismissal (person_id);

--- a/backend/migrations/person_channel_identity_index_integration_test.go
+++ b/backend/migrations/person_channel_identity_index_integration_test.go
@@ -45,7 +45,7 @@ func TestPersonChannelIdentityCascadeIndexIsUnconditional(t *testing.T) {
 	if predicate != nil {
 		t.Errorf("the index the person cascade relies on is partial (%s); the cascade cannot use it", *predicate)
 	}
-	if len(columns) < 2 || columns[0] != "workspace_id" || columns[1] != "person_id" {
-		t.Errorf("index columns = %v, want (workspace_id, person_id) — the cascade's own key", columns)
+	if len(columns) < 1 || columns[0] != "person_id" {
+		t.Errorf("index columns = %v, want person_id leading — the cascade's own key", columns)
 	}
 }

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -197,8 +197,8 @@ func TestVersionBumpAndSkewSemantics(t *testing.T) {
 	var version int64
 	if err := withGUC(t, app, ws, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`INSERT INTO person (workspace_id, full_name, source, captured_by) VALUES ($1, 'Vera', 'test', 'human:test') RETURNING id, version`,
-			ws).Scan(&id, &version)
+			`INSERT INTO person (full_name, source, captured_by) VALUES ('Vera', 'test', 'human:test') RETURNING id, version`,
+		).Scan(&id, &version)
 	}); err != nil {
 		t.Fatalf("inserting person: %v", err)
 	}

--- a/backend/tools/extmigrategate/gate_integration_test.go
+++ b/backend/tools/extmigrategate/gate_integration_test.go
@@ -316,8 +316,8 @@ func TestGateRejectsDMLOnCoreRelations(t *testing.T) {
 	unit := unitName(t, "dml")
 	ns := namespaceOf(t, unit)
 	up := scaffoldUp(ns) + `
-INSERT INTO person (workspace_id, full_name, source, captured_by)
-SELECT id, 'smuggled', 'gate', 'gate' FROM workspace;
+INSERT INTO person (full_name, source, captured_by)
+VALUES ('smuggled', 'gate', 'gate');
 `
 	err := runGate(t, unit, migrationDir(t, up, scaffoldDown(ns)))
 	requireRefusal(t, err, "permission denied for table person", "0001_gate.up.sql")

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -112,7 +112,7 @@ BEGIN
   -- anything else. A seed that creates users with a published password was
   -- never safe to point at real data; the tenant predicate narrowed the damage
   -- but was never what made it safe.
-  UPDATE person       SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;
+  UPDATE person       SET owner_id = admin_id WHERE owner_id IS NULL;
   UPDATE organization SET owner_id = admin_id WHERE owner_id IS NULL;
   UPDATE deal         SET owner_id = admin_id WHERE owner_id IS NULL;
   UPDATE lead         SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;


### PR DESCRIPTION
Stacked on #1701 (the organization cluster) — review that first; this PR's
diff against `main` will collapse to its own commit once #1701 merges.

Eight tables lose `workspace_id` — `person`, `person_email`, `person_phone`,
`person_social`, `person_profile_field`, `person_channel_identity`,
`person_signature_enrich_state`, `person_moment_dismissal` — and the indexes
that led with it are narrowed to what they were actually seeking.
`uq_person_ws_id` goes with them: `0225_collapse_composite_keys` already left
it as `UNIQUE (id)`, a second copy of the table's own primary key kept alive
only as a composite FK target that phase C rewrote away.

## Three gates went quiet rather than red

This is the failure mode phase D keeps producing — a check whose subject is
derived from `workspace_id` stops testing anything instead of failing. Each is
repaired here:

- **`mergerelink`** carried `workspace_id` across a person merge, so the
  enrichment sidecar would have failed to follow the survivor.
- **The search pending rollup and the overlay flip reconciler** each template
  ONE statement over several entity tables. `person` drops out of both
  per-source predicates now that it has no tenant to name.
- **`person_channel_identity`'s cascade index** asserted `(workspace_id,
  person_id)`. It now asserts `person_id` leads — the foreign key's own key,
  which is the invariant the test was always about.

## Two tests changed premise, not syntax

Because the premise is what phase D moved:

- **The cross-workspace pending rollup**: a person is installation-wide now, so
  both people count under every enumerated workspace, and one embedding covers
  the row wherever it is counted. The numbers converge on one when the re-embed
  fan-out itself collapses.
- **The re-embed fan-out** seeds a LEAD per tenant instead of a person. With
  `person` installation-wide the first child embedded both rows, left the second
  nothing to do, and the injected write fault had nothing to fire on — the test
  was passing for the wrong reason.

## Verification

- `make check-backend` — green
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor across `backend/`,
  `extensions/`, `fixtures/`

Remaining phase-D tables after this lands: the lead/relationship cluster,
identity, search's own tables, and `audit_log`/`system_log` last.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes people installation‑wide by removing the tenant (`workspace_id`) column from the `person*` cluster. Previously people were tenant‑scoped; now they are global, so search, overlay reconciliation, and dedupe no longer predicate on a workspace for people.

- Schema/indexes: drop `workspace_id` from `person`, `person_email`, `person_phone`, `person_social`, `person_profile_field`, `person_channel_identity`, `person_signature_enrich_state`, `person_moment_dismissal`; tighten affected indexes; drop redundant `uq_person_ws_id`. `person_channel_identity`’s cascade index now leads with `person_id`.
- Gates/code paths: `mergerelink` no longer carries `workspace_id`; search pending treats `person` as not tenant‑scoped; the overlay flip reconciler predicates only for tables still carrying `workspace_id` (currently `lead`), others drop out. Preference tokens, retention selectors, and dedupe lookups remove workspace predicates for people.
- Semantics/tests: a person now counts across all workspaces; cross‑workspace pending converges on one embedding per person; re‑embed fan‑out seeds a `lead` per tenant to keep work isolated. Queries and selectors stop adding workspace predicates for `person*`.
- Rollback: adds a down migration that restores `workspace_id` to the person cluster and attributes rows to the live workspace; it fails if rows exist and no live workspace can be determined.

**Required changes for consumers**
- Do not read, write, or predicate on `workspace_id` in `person*` tables.
- Only include tenant filters for tables that still carry `workspace_id` (for now, `lead`).

<sup>Written for commit 765f33a7eaff031f2ee13cca3d77bbd52628fec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

