### PR TITLE
feat(config): a posture states its differences in a file review can see

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/licensecheck"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // bindInstallation settles what this installation IS before anything serves:
@@ -41,7 +40,7 @@ import (
 // Returns the loaded deployment config every later boot phase reads, and the
 // license watcher whose posture baseComposeOptions reports.
 func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger) (deployconfig.Config, *licensecheck.Watcher, error) {
-	deployCfg, err := deployconfig.Load(cfg.configPath)
+	deployCfg, err := deployconfig.Load(cfg.configPath, cfg.posture)
 	if err != nil {
 		return deployconfig.Config{}, nil, err
 	}
@@ -66,7 +65,7 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, lo
 	// The deployment posture decides which license authorities are honored: a
 	// production installation accepts one, and only a non-production one also
 	// runs on a license minted for a test.
-	license, err := compose.EnsureLicense(ctx, logger, deployCfg, runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar)), config.FromOS)
+	license, err := compose.EnsureLicense(ctx, logger, deployCfg, cfg.posture, config.FromOS)
 	if err != nil {
 		return deployconfig.Config{}, nil, err
 	}
@@ -101,7 +100,6 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 	// about whether the reset is live. It is stated by the deployment rather
 	// than inferred from MARGINCE_ENV, which is still read here for the posture
 	// itself — a different question, and no longer a destructive one.
-	env := runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar))
 	allowDataReset := deployCfg.Operations.AllowDataReset
 	// Said out loud at boot because each role reads its own --config: an api
 	// armed beside a worker that was not given the file purges the workspace and
@@ -129,7 +127,7 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 	opts = append(opts, reset.opts...)
 	// /me carries both facts, from two options, because they are two facts: the
 	// deployment posture, and whether the reset exists here at all.
-	opts = append(opts, compose.WithNonProduction(env), compose.WithDataResetAvailable(allowDataReset))
+	opts = append(opts, compose.WithNonProduction(cfg.posture), compose.WithDataResetAvailable(allowDataReset))
 	// Gate 1: the connector's whole route group — /mcp, the authorization
 	// server and both discovery documents — exists only when the deployment
 	// declared it. The boot check in bindInstallation already proved the

--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // apiConfig is the parsed boot configuration of the api process.
@@ -43,6 +44,11 @@ type apiConfig struct {
 	webhookKey          string
 	metricsToken        string
 	oauthAccessTokenTTL time.Duration
+	// posture is what MARGINCE_ENV says this deployment is, read ONCE here
+	// (OPS-CFG-2) rather than at each of the three places that used to ask.
+	// It selects the configuration overlay and which license authorities are
+	// honoured; it decides nothing destructive — see shared/runtimeenv.
+	posture runtimeenv.Environment
 	// unknownVars are the MARGINCE_* variables found in the environment that
 	// this role does not read. Computed during parsing, where the surface is
 	// assembled, and REPORTED once the logger exists — an operator has to see
@@ -127,6 +133,7 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	// After Apply, so the report describes the environment the role actually
 	// consulted.
 	cfg.unknownVars = registry.Undeclared(config.Environ())
+	cfg.posture = runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar))
 	if cfg.dsn == "" {
 		return apiConfig{}, errors.New("api: --dsn or MARGINCE_DSN required")
 	}

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -62,7 +62,7 @@ func runDebugSubcommand(ctx context.Context, args []string, stdout io.Writer) (b
 // is a boot error (a typo must not silently drop the blocklist or flip the
 // payload posture).
 func loadDeployment(cfg *workerConfig) (deployconfig.Config, error) {
-	deployCfg, err := deployconfig.Load(cfg.configPath)
+	deployCfg, err := deployconfig.Load(cfg.configPath, cfg.posture)
 	if err != nil {
 		return deployconfig.Config{}, err
 	}

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/cliflags"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // workerConfig is the parsed boot configuration of the worker process.
@@ -63,6 +64,11 @@ type workerConfig struct {
 	logLevel             string
 	logFormat            string
 	observeAddr          string
+	// posture is what MARGINCE_ENV says this deployment is, read ONCE here
+	// (OPS-CFG-2). It selects the configuration overlay and which license
+	// authorities are honoured; it decides nothing destructive — see
+	// shared/runtimeenv.
+	posture runtimeenv.Environment
 	// unknownVars are the MARGINCE_* variables found in the environment that
 	// this role does not read; reported once the logger exists. See the api's
 	// copy for why the reporting is deferred.
@@ -154,6 +160,7 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	env.Apply(fs, config.FromOS)
 	// After Apply, so the report describes the environment the role consulted.
 	cfg.unknownVars = registry.Undeclared(config.Environ())
+	cfg.posture = runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar))
 	if cfg.dsn == "" {
 		return workerConfig{}, errors.New("worker: --dsn or MARGINCE_DSN required")
 	}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
-	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 	"github.com/gradionhq/margince/backend/pkg/extension"
 )
 
@@ -71,7 +70,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// refuses to boot on. The RUNNING posture is the api's to watch: it is the
 	// role that serves it, and two roles re-resolving one calendar answer would
 	// report the same lapse twice.
-	if _, err := compose.EnsureLicense(ctx, logger, deployCfg, runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar)), config.FromOS); err != nil {
+	if _, err := compose.EnsureLicense(ctx, logger, deployCfg, cfg.posture, config.FromOS); err != nil {
 		return err
 	}
 

--- a/backend/internal/platform/deployconfig/capture_test.go
+++ b/backend/internal/platform/deployconfig/capture_test.go
@@ -6,13 +6,15 @@ package deployconfig
 import (
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 // The yaml tag is the contract, not the field name: the loader runs with
 // KnownFields(true), so a misspelled key is a refusal to boot rather than a
 // setting that quietly does nothing.
 func TestTracePayloadsIsReadFromTheFile(t *testing.T) {
-	cfg, err := Load(writeTemp(t, "version: 1\ncapture:\n  trace_payloads: true\n"))
+	cfg, err := Load(writeTemp(t, "version: 1\ncapture:\n  trace_payloads: true\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -277,26 +277,14 @@ type MCP struct {
 	ConnectorEnabled bool `yaml:"connector_enabled"`
 }
 
-// Load reads and strictly validates the configuration file. A missing
-// file is not an error: it returns the zero configuration (version 1,
-// all defaults), which boots an existing installation but cannot
-// bootstrap an empty database.
-func Load(path string) (Config, error) {
-	raw, err := os.ReadFile(path) // #nosec G304 -- the operator's own --config path; reading it is the function's purpose
-	if errors.Is(err, os.ErrNotExist) {
-		return Config{Version: 1}, nil
-	}
-	if err != nil {
-		return Config{}, fmt.Errorf("deployconfig: reading %s: %w", path, err)
-	}
-	return Parse(raw)
-}
-
-// Parse strictly decodes and validates configuration bytes. Unknown
-// fields, invalid values, and incompatible combinations are errors — a
+// Parse strictly decodes and validates a single configuration document.
+// Unknown fields, invalid values, and incompatible combinations are errors — a
 // typo must never silently disable authentication.
+//
+// One document: what a running process reads is the base file plus its
+// posture's overlay, which is Load in layers.go.
 func Parse(raw []byte) (Config, error) {
-	var cfg Config
+	cfg := Config{Version: 1}
 	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {

--- a/backend/internal/platform/deployconfig/deployconfig_test.go
+++ b/backend/internal/platform/deployconfig/deployconfig_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
 const fullConfig = `
@@ -141,7 +143,7 @@ func TestCompanyContextRolloutDefaultsToOnboarding(t *testing.T) {
 }
 
 func TestLoadMissingFileBootsExistingInstallation(t *testing.T) {
-	cfg, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	cfg, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"), runtimeenv.Production)
 	if err != nil {
 		t.Fatalf("missing file must not be an error (it cannot bootstrap, only bind): %v", err)
 	}
@@ -195,7 +197,7 @@ func TestParseRatesFxCurrencies(t *testing.T) {
 // new deployment (and every `make dev`, which copies it) a config that fails at
 // boot. It also guards the now-active rates block against a typo.
 func TestShippedExampleConfigParses(t *testing.T) {
-	cfg, err := Load("../../../../config/margince.example.yaml")
+	cfg, err := Load("../../../../config/margince.example.yaml", runtimeenv.Production)
 	if err != nil {
 		t.Fatalf("config/margince.example.yaml no longer parses: %v", err)
 	}
@@ -242,14 +244,14 @@ func writeTemp(t *testing.T, doc string) string {
 }
 
 func TestMCPConnectorGateDefaultsOff(t *testing.T) {
-	cfg, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\n"))
+	cfg, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cfg.MCP.ConnectorEnabled {
 		t.Fatal("the connector gate must default OFF — an unset flag must never expose /mcp")
 	}
-	on, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\nmcp:\n  connector_enabled: true\n"))
+	on, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\nmcp:\n  connector_enabled: true\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/platform/deployconfig/layers.go
+++ b/backend/internal/platform/deployconfig/layers.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig
+
+// The file layer of OPS-CFG-1 is two files, not one.
+//
+// A deployment posture changes a handful of keys and shares the rest. Before
+// this, the two ways to express that were both bad: keep a whole second copy of
+// the configuration per posture and let them drift, or have a script append
+// text to the file at boot — which is what `make dev` did to arm the data
+// reset, so the dev stack's most destructive capability was turned on by a
+// shell heredoc that no review ever saw as a diff.
+//
+// So the base file states what the installation IS, and an overlay beside it
+// states what THIS POSTURE changes:
+//
+//	config/margince.yaml       every installation
+//	config/margince.dev.yaml   what a dev stack does differently
+//
+// Within the file layer the overlay wins; the whole file layer still sits
+// between compiled defaults and the environment, exactly where OPS-CFG-1 puts
+// it. The full order, unchanged by this file:
+//
+//	compiled defaults -> margince.yaml -> margince.<posture>.yaml -> env -> flags
+//
+// How a key merges is legible from the YAML in front of the operator, which is
+// the property that makes a two-file layer safe to reason about:
+//
+//	a scalar   the overlay's value replaces the base's
+//	a mapping  merges key by key, so an overlay adds a provider without
+//	           restating the ones the base already names
+//	a list     replaces entirely, because half a list is not a list — an
+//	           overlay naming [SEK] means SEK, not "USD, GBP, CHF and SEK"
+//
+// The consequence worth knowing: an overlay can add a mapping key and can
+// change one, but cannot REMOVE one. A posture that must not have a key removes
+// it from the base and adds it to the postures that want it.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
+)
+
+// Load reads the deployment configuration for a posture: the base file, then
+// the overlay that posture names, validated once over the merged result.
+//
+// Neither file has to exist. A missing base is how an already-bootstrapped
+// installation runs on defaults alone; a missing overlay is the ordinary case
+// for every posture that needs no changes. What is NOT tolerated is a file that
+// exists and is wrong — an unreadable path, a typo'd key, a value out of range
+// — because a configuration file that half-applied is worse than one that
+// stopped the boot.
+func Load(path string, env runtimeenv.Environment) (Config, error) {
+	// Version is the compiled-defaults layer, so the layering has no
+	// special case for "no file at all" — an installation with neither
+	// file and one with an empty base reach validate() the same way.
+	cfg := Config{Version: 1}
+	for _, layer := range []string{path, OverlayPath(path, env)} {
+		if err := applyLayer(layer, &cfg); err != nil {
+			return Config{}, err
+		}
+	}
+	if err := cfg.validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// applyLayer decodes one file over what the earlier layers left, naming the
+// file in any failure. With two candidate files an unqualified "unknown field
+// mcp_enabled" would send an operator to the wrong one.
+func applyLayer(path string, cfg *Config) error {
+	raw, err := os.ReadFile(path) // #nosec G304 -- the operator's own --config path, and the overlay derived from it
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("deployconfig: reading %s: %w", path, err)
+	}
+	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+	dec.KnownFields(true)
+	// A file holding only comments decodes to EOF rather than to nothing,
+	// and that is a real file an operator writes: an overlay committed as a
+	// placeholder for the posture, with the keys still commented out.
+	if err := dec.Decode(cfg); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("deployconfig: %s: %w", path, err)
+	}
+	return nil
+}
+
+// OverlayPath names the posture's overlay: the base path with the posture
+// inserted before its extension, so `config/margince.yaml` under MARGINCE_ENV=dev
+// names `config/margince.dev.yaml`.
+//
+// Derived rather than configured, and derived for EVERY posture including
+// production. A second flag for the overlay path would let the two disagree,
+// and a production installation that wants the split gets it by the same rule
+// the dev stack does instead of by an exception it has to discover.
+func OverlayPath(path string, env runtimeenv.Environment) string {
+	ext := filepath.Ext(path)
+	return strings.TrimSuffix(path, ext) + "." + string(env) + ext
+}

--- a/backend/internal/platform/deployconfig/layers_test.go
+++ b/backend/internal/platform/deployconfig/layers_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
+)
+
+// layered writes a base and (when non-empty) an overlay for the posture, and
+// loads them the way a boot does.
+func layered(t *testing.T, env runtimeenv.Environment, base, overlay string) (Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "margince.yaml")
+	if err := os.WriteFile(path, []byte(base), 0o600); err != nil {
+		t.Fatalf("writing the base: %v", err)
+	}
+	if overlay != "" {
+		if err := os.WriteFile(OverlayPath(path, env), []byte(overlay), 0o600); err != nil {
+			t.Fatalf("writing the overlay: %v", err)
+		}
+	}
+	return Load(path, env)
+}
+
+func TestTheOverlayForThisPostureWinsKeyByKey(t *testing.T) {
+	cfg, err := layered(t, runtimeenv.Development,
+		"version: 1\norganization:\n  name: Acme\n  timezone: Europe/Berlin\nmcp:\n  connector_enabled: false\n",
+		"mcp:\n  connector_enabled: true\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.MCP.ConnectorEnabled {
+		t.Error("the overlay set mcp.connector_enabled: true and the base's false survived")
+	}
+	// The keys the overlay is silent about are the reason for having a base at
+	// all: an overlay states a difference, not a whole configuration.
+	if cfg.Organization.Name != "Acme" || cfg.Organization.Timezone != "Europe/Berlin" {
+		t.Errorf("the base's organization did not survive the overlay: %+v", cfg.Organization)
+	}
+}
+
+// A posture that arms nothing must not inherit another posture's arming — the
+// file is selected by name, so only the running posture's overlay is read.
+func TestOnlyTheRunningPosturesOverlayIsRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "margince.yaml")
+	if err := os.WriteFile(path, []byte("version: 1\n"), 0o600); err != nil {
+		t.Fatalf("writing the base: %v", err)
+	}
+	if err := os.WriteFile(OverlayPath(path, runtimeenv.Development),
+		[]byte("operations:\n  allow_data_reset: true\n"), 0o600); err != nil {
+		t.Fatalf("writing the dev overlay: %v", err)
+	}
+	prod, err := Load(path, runtimeenv.Production)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if prod.Operations.AllowDataReset {
+		t.Fatal("production read the dev overlay and armed the tenant-data purge")
+	}
+	dev, err := Load(path, runtimeenv.Development)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !dev.Operations.AllowDataReset {
+		t.Error("the dev overlay did not arm the reset for the posture it names")
+	}
+}
+
+// The merge rule an operator reads off the YAML in front of them: a mapping
+// merges, a list replaces. Both halves matter — a list that merged would make
+// "which currencies does this installation propose" unanswerable without
+// reading two files and knowing which way each key goes.
+func TestAMappingMergesAndAListReplaces(t *testing.T) {
+	cfg, err := layered(t, runtimeenv.Test,
+		"version: 1\nrates:\n  fx_currencies: [USD, GBP, CHF]\n  model_pricing:\n    gemini: https://base.test/gemini\n    openai: https://base.test/openai\n",
+		"rates:\n  fx_currencies: [SEK]\n  model_pricing:\n    openai: https://overlay.test/openai\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Rates.FxCurrencies; len(got) != 1 || got[0] != "SEK" {
+		t.Errorf("fx_currencies = %v; a list the overlay names replaces the base's entirely", got)
+	}
+	want := map[string]string{"gemini": "https://base.test/gemini", "openai": "https://overlay.test/openai"}
+	for k, v := range want {
+		if cfg.Rates.ModelPricing[k] != v {
+			t.Errorf("model_pricing[%s] = %q, want %q", k, cfg.Rates.ModelPricing[k], v)
+		}
+	}
+	if len(cfg.Rates.ModelPricing) != len(want) {
+		t.Errorf("model_pricing = %v; a mapping merges, so the base's untouched keys stay", cfg.Rates.ModelPricing)
+	}
+}
+
+// An overlay committed as a placeholder — the posture exists, its keys are
+// still commented out — is a file a boot must read and shrug at.
+func TestACommentOnlyOverlayIsNotAFailure(t *testing.T) {
+	cfg, err := layered(t, runtimeenv.Development,
+		"version: 1\norganization:\n  name: Acme\n",
+		"# nothing to change for dev yet\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Organization.Name != "Acme" {
+		t.Errorf("organization.name = %q, want Acme", cfg.Organization.Name)
+	}
+}
+
+// Strictness is per layer, not just for the base: an overlay is where a typo is
+// LIKELIER, because it is the file edited per posture and the one with no
+// example to copy from.
+func TestATypoInTheOverlayFailsTheBootAndNamesTheFile(t *testing.T) {
+	_, err := layered(t, runtimeenv.Development,
+		"version: 1\n",
+		"mcp:\n  conector_enabled: true\n")
+	if err == nil {
+		t.Fatal("a misspelled key in the overlay booted; a typo must never silently do nothing")
+	}
+	if !strings.Contains(err.Error(), "margince.dev.yaml") {
+		t.Errorf("error = %q; it must name which of the two files holds the typo", err)
+	}
+}
+
+// Validation runs over the MERGED result, never per file. An overlay that
+// completes what the base only starts is the ordinary way a posture supplies
+// its own admin, and validating the base alone would refuse it.
+func TestValidationRunsOverTheMergedResult(t *testing.T) {
+	cfg, err := layered(t, runtimeenv.Test,
+		"version: 1\norganization:\n  name: Acme\nbootstrap_admin:\n  email: admin@acme.test\n  display_name: Admin\n  password_file: /run/secrets/base-admin\n",
+		"bootstrap_admin:\n  password_file: /run/secrets/test-admin\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.BootstrapAdmin == nil {
+		t.Fatal("bootstrap_admin vanished across the merge")
+	}
+	if cfg.BootstrapAdmin.Email != "admin@acme.test" {
+		t.Errorf("email = %q; the base's value survived an overlay that only replaced the password reference", cfg.BootstrapAdmin.Email)
+	}
+}
+
+func TestOverlayPathInsertsThePostureBeforeTheExtension(t *testing.T) {
+	for _, tc := range []struct {
+		base string
+		env  runtimeenv.Environment
+		want string
+	}{
+		{"config/margince.yaml", runtimeenv.Development, "config/margince.dev.yaml"},
+		{"config/margince.yaml", runtimeenv.Test, "config/margince.test.yaml"},
+		{"config/margince.yaml", runtimeenv.Production, "config/margince.production.yaml"},
+		{"/etc/margince/deploy.yml", runtimeenv.Production, "/etc/margince/deploy.production.yml"},
+	} {
+		if got := OverlayPath(tc.base, tc.env); got != tc.want {
+			t.Errorf("OverlayPath(%q, %q) = %q, want %q", tc.base, tc.env, got, tc.want)
+		}
+	}
+}
+
+// Neither file is required. This is how an already-bootstrapped installation
+// runs: the ADR permits deleting the file once the organization exists.
+func TestNeitherLayerHasToExist(t *testing.T) {
+	cfg, err := Load(filepath.Join(t.TempDir(), "absent.yaml"), runtimeenv.Development)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("version = %d; the compiled default is the first layer", cfg.Version)
+	}
+}
+
+// The dev overlay is tracked and every `make dev` reads it, so a typo in it
+// breaks every engineer's stack at once — and it has no example beside it to
+// diff against, unlike the base.
+//
+// Staged under the names the dev stack uses, because that is what the overlay
+// derivation keys off: `make dev` copies the example to config/margince.yaml,
+// which is what makes config/margince.dev.yaml its overlay. Loading the example
+// under its own name would silently test nothing.
+func TestShippedDevOverlayArmsTheResetForDevOnly(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "margince.yaml")
+	copyRepoFile(t, "../../../../config/margince.example.yaml", base)
+	copyRepoFile(t, "../../../../config/margince.dev.yaml", OverlayPath(base, runtimeenv.Development))
+
+	dev, err := Load(base, runtimeenv.Development)
+	if err != nil {
+		t.Fatalf("config/margince.dev.yaml no longer parses over the base: %v", err)
+	}
+	if !dev.Operations.AllowDataReset {
+		t.Error("the dev overlay must arm operations.allow_data_reset — a dev stack without the Reset data button is a silent regression")
+	}
+	// The same base at any other posture arms nothing. This is the property the
+	// heredoc that used to append the switch could not have: it wrote into the
+	// base, so the arming was not posture-scoped at all.
+	prod, err := Load(base, runtimeenv.Production)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if prod.Operations.AllowDataReset {
+		t.Fatal("the shipped example arms the tenant-data purge in production")
+	}
+}
+
+func copyRepoFile(t *testing.T, from, to string) {
+	t.Helper()
+	raw, err := os.ReadFile(from)
+	if err != nil {
+		t.Fatalf("reading %s: %v", from, err)
+	}
+	if err := os.WriteFile(to, raw, 0o600); err != nil {
+		t.Fatalf("writing %s: %v", to, err)
+	}
+}

--- a/config/margince.dev.yaml
+++ b/config/margince.dev.yaml
@@ -1,0 +1,26 @@
+# config/margince.dev.yaml — what a DEV stack does differently.
+#
+# Read only when MARGINCE_ENV=dev, on top of config/margince.yaml, later layer
+# winning per key. `make dev` exports that variable for both the api and the
+# worker, so this file is the dev stack's posture and nothing else's.
+#
+# It is tracked, and config/margince.yaml is not. That is the point: what arms a
+# destructive capability on every engineer's machine belongs in a file review
+# can see, not in text a shell script appends to a generated one — which is how
+# the reset used to be turned on, invisibly, at first boot.
+#
+# A base key this file does not name keeps the base's value. To try something
+# without committing it, edit config/margince.yaml instead; it is yours.
+version: 1
+
+operations:
+  # Arms POST /v1/admin/reset-data, the api and worker lanes behind it, and the
+  # "Reset data" action /me offers. It PURGES this installation's tenant data
+  # back to its first-boot state.
+  #
+  # Safe HERE and nowhere else, because a dev database holds seed data an engineer
+  # can recreate with `make seed-dev`. Deliberately not derived from MARGINCE_ENV
+  # by the code: a deployment being CALLED dev is not consent to erase what is in
+  # it, so the arming is stated in the posture's own file and every other posture
+  # gets the compiled default, which is off.
+  allow_data_reset: true

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -7,6 +7,12 @@
 #
 # The api bootstraps the demo organization + admin from this file the first time
 # it boots against an empty database; an existing installation just reads it.
+#
+# This is the BASE. MARGINCE_ENV selects an overlay beside it —
+# config/margince.dev.yaml for a dev stack — and its keys win over this file's.
+# Within a key: a scalar replaces, a mapping merges, a list replaces entirely.
+# The whole file layer still sits between compiled defaults and the environment
+# (OPS-CFG-1): defaults -> this file -> the overlay -> env vars -> flags.
 version: 1
 
 organization:
@@ -193,9 +199,9 @@ company_context:
 # COMMENTED OUT, and that is the shipped posture — every switch is off unless an
 # operator writes it, so a deployment that mounts this file as-is arms nothing.
 #
-# `make dev` appends the dev arming to its own copy (config/margince.yaml) when
-# it seeds it, which is why a dev stack has the Reset data button and this file
-# still does not.
+# A dev stack gets the Reset data button from config/margince.dev.yaml, the
+# tracked overlay MARGINCE_ENV=dev selects on top of this file — which is why a
+# dev stack has the button and this file still does not.
 #
 # operations:
 #   # Arms POST /v1/admin/reset-data, the lanes behind it, and the "Reset data"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -708,6 +708,44 @@ seeded alongside on first run; both are gitignored. `--config` reaches
 **both** the api and worker, so a posture like `ai.capture_payloads` applies
 to every role. Delete `config/margince.yaml` and re-run `make dev` to reset.
 
+#### The file layer is two files: a base and the posture's overlay
+
+`MARGINCE_ENV` selects an overlay read on top of the base, named by inserting
+the posture before the extension — so `--config config/margince.yaml` under
+`MARGINCE_ENV=dev` also reads
+[`config/margince.dev.yaml`](../../config/margince.dev.yaml). Neither file has
+to exist. The derivation is the same for every posture, production included, so
+a deployment that wants the split gets it by the same rule rather than by an
+exception.
+
+The full order, which is OPS-CFG-1 with the file layer split in two:
+
+```
+compiled defaults → margince.yaml → margince.<posture>.yaml → env vars → flags
+```
+
+Later wins. Within the file layer, how a key merges is legible from the YAML
+itself:
+
+| The base key is | The overlay | Why |
+|---|---|---|
+| a scalar (`connector_enabled: false`) | replaces it | one value, one answer |
+| a mapping (`model_pricing:`) | merges key by key | an overlay adds a provider without restating the others |
+| a list (`fx_currencies: [USD, GBP]`) | replaces it entirely | half a list is not a list — `[SEK]` means SEK |
+
+The consequence worth knowing: an overlay can add a mapping key and change one,
+but cannot **remove** one. A posture that must not have a key takes it out of
+the base and puts it in the postures that want it.
+
+Both files decode strictly. An unknown key in either is a boot error naming the
+file that holds it, and validation runs once over the merged result — so an
+overlay may complete a section the base only starts.
+
+`MARGINCE_ENV` is a **configuration selector, not a trust boundary**. Nothing
+destructive keys off it: the data reset is armed by `operations.allow_data_reset`
+below, which is why the dev arming lives in the tracked
+`config/margince.dev.yaml` and every other posture gets the compiled default.
+
 `capture.trace_payloads` (default `false`) turns on payload capture in the
 24-hour Capture activity trace every member sees under Settings. With it off,
 the trace records what the pipeline decided about each message and nothing about

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -128,6 +128,26 @@ state="${rundir}/env"
 log_colour=0
 [[ "${MARGINCE_LOG_LEVEL:-info}" == "debug" ]] && log_colour=1
 
+# effective_flag KEY — what the api will see for a boolean key, printed as
+# "true", "false", or "" when neither file names it (the compiled default).
+#
+# The overlay is consulted first because MARGINCE_ENV=dev makes it the winning
+# layer, and a key it names decides even when it names `false`. Both files are
+# grepped rather than parsed: this is a status line, and a shell YAML parser
+# would be a second implementation of the loader that could disagree with it.
+effective_flag() { # key
+  local key=$1 f value
+  for f in "$dev_cfg" "$deploy_cfg"; do
+    [[ -f "$f" ]] || continue
+    value=$(grep -E "^[[:space:]]+${key}:[[:space:]]*(true|false)[[:space:]]*$" "$f" \
+      | tail -1 | sed -E 's/.*:[[:space:]]*//; s/[[:space:]]*$//')
+    if [[ -n "$value" ]]; then
+      printf '%s' "$value"
+      return
+    fi
+  done
+}
+
 log_as() { # role — tag each line of stdin and append to $log
   awk -v mode=tag -v role="$1" -v colour="$log_colour" \
     -f "${repo_root}/scripts/lib/devlog.awk" >>"$log"
@@ -451,6 +471,7 @@ up)
   # posture (e.g. ai.capture_payloads for Layer-3 capture) and it persists across
   # restarts (it lives in config/, not the scratch rundir dev-stop clears).
   deploy_cfg="config/margince.yaml"
+  dev_cfg="config/margince.dev.yaml"
   admin_pw_file="config/margince-admin-password"
   # The OPERATOR's password, which is deliberately not the one anybody signs in
   # with. A configured bootstrap requires the admin to replace it before the
@@ -464,32 +485,29 @@ up)
   fi
   if [[ ! -f "$deploy_cfg" ]]; then
     cp config/margince.example.yaml "$deploy_cfg"
-    # The destructive switch is armed HERE, not in the example, because the
-    # example is the file a deployment is told to mount. A production
-    # installation that copied it verbatim must not thereby arm a purge of its
-    # own tenant data — which is the same "inferred consent" this switch exists
-    # to end, and it would be worse in a file than in an env var operators are
-    # warned about.
-    cat >>"$deploy_cfg" <<'DEVOPS'
-
-# Added by `make dev` — a dev stack wants the Reset data button. Delete this to
-# take it away; a real deployment never has it.
-operations:
-  allow_data_reset: true
-DEVOPS
-    echo "dev: seeded $deploy_cfg from config/margince.example.yaml (+ operations.allow_data_reset for dev) — edit it to change org/admin or AI posture (e.g. ai.capture_payloads)"
+    echo "dev: seeded $deploy_cfg from config/margince.example.yaml — edit it to change org/admin or AI posture (e.g. ai.capture_payloads)"
   fi
+  # The dev posture's own differences — the Reset data button among them — live
+  # in the TRACKED config/margince.dev.yaml, which MARGINCE_ENV=dev selects on
+  # top of the file above. They used to be appended here, which meant the most
+  # destructive capability a dev stack has was armed by a heredoc no review ever
+  # saw as a diff, in a file git does not track.
   # Report which deployment config the api + worker are using, and its AI
   # posture — mirrors the ai-routing line above so both configs are visible.
-  if grep -Eq '^[[:space:]]*capture_payloads:[[:space:]]*true' "$deploy_cfg"; then
+  #
+  # Both keys are read the way the api reads them: the dev overlay first,
+  # because it wins, and the base only for a key the overlay is silent about. A
+  # status line that reported the base alone would contradict the running
+  # process the moment anyone used the overlay for what it is for.
+  if [[ "$(effective_flag capture_payloads)" == "true" ]]; then
     capture_note="ai.capture_payloads ON"
   else
     capture_note="ai.capture_payloads off"
   fi
-  echo "dev: using $deploy_cfg for the deployment config ($capture_note)"
+  echo "dev: using $deploy_cfg (+ $dev_cfg) for the deployment config ($capture_note)"
   # An operator flipping mcp.connector_enabled needs to see that it took
   # effect — the gate is otherwise silent until a client actually tries it.
-  if grep -Eq '^[[:space:]]*connector_enabled:[[:space:]]*true' "$deploy_cfg"; then
+  if [[ "$(effective_flag connector_enabled)" == "true" ]]; then
     echo "dev: mcp.connector_enabled ON — connect a client at http://localhost:${fe_port}/mcp"
   else
     echo "dev: mcp.connector_enabled off"


### PR DESCRIPTION
Increment 3, slice 2 of #1252.

## The problem

The dev stack's most destructive capability was armed by a shell heredoc. `make dev` appended `operations.allow_data_reset: true` to `config/margince.yaml` on first boot — a file git does not track, written by a script — so the switch that purges an installation's tenant data never appeared in a diff and no review ever saw it.

## The change

The file layer of OPS-CFG-1 becomes two files instead of one. `MARGINCE_ENV` selects an overlay beside the base, named by inserting the posture before the extension, and its keys win:

```
compiled defaults → margince.yaml → margince.<posture>.yaml → env vars → flags
```

`config/margince.dev.yaml` is now **tracked** and carries the dev arming. Every other posture gets the compiled default, which is off — the property the heredoc could not give, because it wrote into the base where the arming was not posture-scoped at all.

Derivation is uniform across postures, production included, so a deployment that wants the split gets it by the same rule rather than by an exception it has to discover.

### Merge semantics are legible from the YAML, not the Go type

| The base key is | The overlay | Why |
|---|---|---|
| a scalar | replaces it | one value, one answer |
| a mapping | merges key by key | an overlay adds a provider without restating the others |
| a list | replaces entirely | half a list is not a list — `[SEK]` means SEK |

The consequence is documented where it will be read: an overlay can add a mapping key and change one, but cannot **remove** one.

### Other properties

- Both layers decode strictly, and a failure **names which file** holds the typo. With two candidate files an unqualified "unknown field" sends an operator to the wrong one.
- Validation runs once over the **merged** result, so an overlay may complete a section the base only starts.
- A comment-only overlay (a committed placeholder) is not a boot failure.
- `MARGINCE_ENV` is read **once per role** into the config the role already carries, replacing three separate reads of the environment (OPS-CFG-2).

## Tests

Mutation-proven — each of these fails the test that claims the behaviour:

| Mutation | Caught by |
|---|---|
| overlay always resolves to `dev` | `TestOnlyTheRunningPosturesOverlayIsRead` — *"production read the dev overlay and armed the tenant-data purge"* |
| the overlay layer is never read | four tests, including the shipped-file pair |
| `KnownFields(false)` on a layer | `TestATypoInTheOverlayFailsTheBootAndNamesTheFile` |

`TestShippedDevOverlayArmsTheResetForDevOnly` stages the two real files under the names the dev stack uses — loading the example under its own name would silently test nothing, since the overlay derivation keys off the base's filename.

## Also fixed

`dev.sh`'s two status lines (`ai.capture_payloads`, `mcp.connector_enabled`) read the base alone, which was correct only while no overlay existed. They now report the effective value across both layers, so the report cannot contradict the running process.

## Gates

`make -C backend check` exit 0 · `make craft-static` PASS, 0 findings.

Refs #1252

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits deployment config into a base file and a posture-specific overlay selected by MARGINCE_ENV, and tracks config/margince.dev.yaml to arm dev-only data reset. This replaces the heredoc that silently edited the untracked base, making the destructive switch reviewable and scoped to dev.

- `deployconfig.Load` now takes `(path, posture)` and reads base → overlay, then validates merged config; `runtimeenv` is parsed once per role and passed through (also to license checks).
- Overlay path is `margince.<posture>.yaml`; precedence is compiled defaults → base → overlay → env vars → flags. Merge rules: scalar replaces; mapping merges by key; list replaces. Overlays can’t remove mapping keys. Both files decode strictly and errors name the file; comment-only overlays are allowed.
- New tracked `config/margince.dev.yaml` sets `operations.allow_data_reset: true`; all other postures keep the compiled default (off).
- `scripts/dev.sh` stops appending the reset flag to the base and now reports effective values across base + overlay.
- Docs and tests updated to cover overlay selection, merge semantics, and dev-only arming. No deployment changes required; overlays are optional.

<sup>Written for commit 9b692ebf2decc7703234ef3bc0f9cd4307366aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

