### PR TITLE
refactor(people): the lead, relationship and partner cluster drops the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/captureofflinedemo_integration_test.go
+++ b/backend/internal/compose/captureofflinedemo_integration_test.go
@@ -101,7 +101,7 @@ func seedOfflineDemoAccount(t *testing.T, e *integration.Env, owner ids.UUID, sl
 	var orgID ids.UUID
 	err := e.Pool.QueryRow(ctx, `
 		INSERT INTO organization (display_name, lifecycle, owner_id, source, captured_by)
-		VALUES ( $2, 'customer', $1, 'test', 'human:test')
+		VALUES ($2, 'customer', $1, 'test', 'human:test')
 		RETURNING id`, owner, slug+" GmbH").Scan(&orgID)
 	if err != nil {
 		t.Fatalf("seeding an organization: %v", err)
@@ -109,19 +109,18 @@ func seedOfflineDemoAccount(t *testing.T, e *integration.Env, owner ids.UUID, sl
 	var personID ids.UUID
 	err = e.Pool.QueryRow(ctx, `
 		INSERT INTO person (full_name, source, captured_by)
-		VALUES ( $1, 'test', 'human:test') RETURNING id`, "Petra "+slug).Scan(&personID)
+		VALUES ($1, 'test', 'human:test') RETURNING id`, "Petra "+slug).Scan(&personID)
 	if err != nil {
 		t.Fatalf("seeding a person: %v", err)
 	}
 	if _, err := e.Pool.Exec(ctx, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, $2, true, 'test', 'human:test')`, personID, "petra@"+slug+".example"); err != nil {
+		VALUES ($1, $2, true, 'test', 'human:test')`, personID, "petra@"+slug+".example"); err != nil {
 		t.Fatalf("seeding an address: %v", err)
 	}
 	if _, err := e.Pool.Exec(ctx, `
-		INSERT INTO relationship (workspace_id, kind, person_id, organization_id, role, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, 'Head of IT', 'test', 'human:test')`,
-		e.WS, personID, orgID); err != nil {
+		INSERT INTO relationship (kind, person_id, organization_id, role, source, captured_by)
+		VALUES ('employment', $1, $2, 'Head of IT', 'test', 'human:test')`, personID, orgID); err != nil {
 		t.Fatalf("seeding an employment: %v", err)
 	}
 	return orgID

--- a/backend/internal/compose/flipreconcile.go
+++ b/backend/internal/compose/flipreconcile.go
@@ -77,22 +77,6 @@ func (w *flipWriters) ReconcileIdentities(ctx context.Context) error {
 // identity map does not yet know about. The prefix is scoped to
 // incumbent and class, not to a run: another attempt's orphan is
 // exactly what this is meant to adopt.
-// flipTenantScope is the workspace predicate for the ONE query this file
-// templates over five native tables, and it is per-object because ADR-0091 §8
-// phase D removes the column from them at different times — only lead still
-// carries it. A predicate spelled for all five fails the statement outright for
-// whichever has lost it; spelled for none, a reconstruction adopts the
-// EXPORTING installation's records as its own. The last entry drops out with
-// the lead slice, and the function goes with it.
-func flipTenantScope(object string) string {
-	switch object {
-	case flipObjectLead:
-		return "\n\t\t\t  AND n.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid"
-	default:
-		return ""
-	}
-}
-
 func (w *flipWriters) orphanedIdentities(ctx context.Context, object string) ([]migration.IdentityPair, error) {
 	if !flipImportable(object) {
 		// The allowlist is what keeps the class out of the format string
@@ -115,8 +99,8 @@ func (w *flipWriters) orphanedIdentities(ctx context.Context, object string) ([]
 			  ON m.source_system = $2
 			 AND m.object = $3
 			 AND m.external_id = right(n.source, -length($1::text))
-			WHERE starts_with(n.source, $1) AND m.native_id IS NULL%s
-			  AND %s`, object, flipTenantScope(object), liveClause(object)),
+			WHERE starts_with(n.source, $1) AND m.native_id IS NULL
+			  AND %s`, object, liveClause(object)),
 			prefix, w.incumbent, object)
 		if err != nil {
 			return err

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -49,18 +49,18 @@ func seedExchange(t *testing.T, e *integration.Env, person ids.UUID) ids.UUID {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-			VALUES ( 'email', 'Alt', 'inbound', now() - interval '1 day', 'manual', 'human:test')
+			VALUES ('email', 'Alt', 'inbound', now() - interval '1 day', 'manual', 'human:test')
 			RETURNING id`).Scan(&id); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, 'to')`, id, e.Rep1); err != nil {
+			VALUES ($1, $2, 'to')`, id, e.Rep1); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'from')`, id, person)
+			VALUES ($1, $2, 'from')`, id, person)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding an exchange: %v", err)
@@ -196,28 +196,27 @@ func TestCoverageNamesItsColleaguesForTheAgent(t *testing.T) {
 	var dealID ids.UUID
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		ws := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		// The harness seeds no pipeline, so this test brings its own.
 		var pipelineID, stageID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO pipeline (name) VALUES ( 'Coverage Test')
+			INSERT INTO pipeline (name) VALUES ('Coverage Test')
 			RETURNING id`).Scan(&pipelineID); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO stage (pipeline_id, name, position)
-			VALUES ( $1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
+			VALUES ($1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO deal (name, stage_id, pipeline_id, owner_id, source, captured_by)
-			VALUES ( 'Covered', $1, $2, $3, 'manual', 'human:test')
+			VALUES ('Covered', $1, $2, $3, 'manual', 'human:test')
 			RETURNING id`, stageID, pipelineID, e.Rep1).Scan(&dealID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
-			VALUES (`+ws+`, 'deal_stakeholder', $1, $2, 'champion', 'manual', 'human:test')`,
+			INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+			VALUES ('deal_stakeholder', $1, $2, 'champion', 'manual', 'human:test')`,
 			person, dealID)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/integration/activitycontext_integration_test.go
+++ b/backend/internal/compose/integration/activitycontext_integration_test.go
@@ -214,8 +214,8 @@ func TestAMeetingWithOnlyAttendeesPrepsAgainstTheOrganizer(t *testing.T) {
 func TestAMeetingLinkedOnlyToALeadPrepsAgainstTheLead(t *testing.T) {
 	e := SetupSearch(t)
 	seedMeetingFixture(t, e)
-	lead := e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Clara Vogt', 'manual', 'human:x')`, e.Rep1)
+	lead := e.SeedID(t, `INSERT INTO lead (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Clara Vogt', 'manual', 'human:x')`, e.Rep1)
 	meeting := seedMeeting(t, e, "Discovery call")
 	linkMeeting(t, e, meeting, "lead", "lead_id", lead)
 

--- a/backend/internal/compose/integration/binding_integration_test.go
+++ b/backend/internal/compose/integration/binding_integration_test.go
@@ -325,7 +325,7 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	e.SeedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, '`+nameOrg+`', 'manual', 'human:x')`)
 	// A lead with every text-bearing column NULL: concat_ws collapses to
 	// '', so it must NOT count as pending — the non-empty qualifier.
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, source, captured_by) VALUES ($1, 'manual', 'human:x')`)
 	// Already covered at the current identity: must not count as pending.
 	coveredID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Already Covered', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
@@ -369,17 +369,21 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 		t.Fatalf("counts[ws2] = %d, want %d (the same installation-wide rows)", counts[ws2Key], wantPerWorkspace)
 	}
 
+	// EntitiesPending is the installation's backlog, NOT the sum of the rollup.
+	// Every pending row is installation-wide, so each workspace's entry is the
+	// same set of rows; summing would report an installation with two of them as
+	// having twice the work, and that figure prices the re-embed. Asserting the
+	// sum here rather than only the total is the point — it is the arithmetic
+	// that must NOT hold.
 	sum := 0
 	for _, c := range counts {
 		sum += c
 	}
-	if sum != total {
-		t.Fatalf("sum of PendingByWorkspace = %d, EntitiesPending = %d — must agree", sum, total)
+	if total != wantPerWorkspace {
+		t.Fatalf("EntitiesPending = %d, want %d (the installation's backlog, counted once)", total, wantPerWorkspace)
 	}
-	// Every pending row is installation-wide, so each is counted once per
-	// enumerated workspace and EntitiesPending is the sum of that rollup.
-	if total != 2*wantPerWorkspace {
-		t.Fatalf("EntitiesPending = %d, want %d", total, 2*wantPerWorkspace)
+	if sum == total {
+		t.Fatalf("sum of PendingByWorkspace = EntitiesPending = %d across %d workspaces — the total is summing a rollup whose entries are the same rows", total, len(counts))
 	}
 
 	// The same text is in both sums, for the same reason the same rows are in

--- a/backend/internal/compose/integration/capture/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_scope_integration_test.go
@@ -82,8 +82,8 @@ func newScopeCaptureRegistry(t *testing.T, e *integration.SearchEnv, fake *scope
 func TestCaptureSkipsALeadCollidingWithAnInvisibleIncumbent(t *testing.T) {
 	e := integration.SetupSearch(t)
 	// A lead owned by team2's rep — outside the team1 granting human's scope.
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, email, owner_id, source, captured_by)
-		VALUES ($1, $2, 'Hidden Prospect', 'collide@scope.test', $3, 'manual', 'human:x')`, e.Rep3)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, email, owner_id, source, captured_by)
+		VALUES ($1, 'Hidden Prospect', 'collide@scope.test', $2, 'manual', 'human:x')`, e.Rep3)
 
 	fake := &scopeFake{records: []connector.NormalizedRecord{{
 		EntityType: datasource.EntityLead,
@@ -148,7 +148,7 @@ func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t 
 	}
 	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO activity_link (activity_id, entity_type, person_id)
-		VALUES ( $1, 'person', $2)`, activityID, foreign); err != nil {
+		VALUES ($1, 'person', $2)`, activityID, foreign); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
@@ -57,35 +57,31 @@ func setupReembedFleet(t *testing.T) *reembedFleetEnv {
 	return &reembedFleetEnv{SearchEnv: e, embedder: embedder, identity: identity, run: run}
 }
 
-// TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant is
-// the converted shape: the dispatcher enqueues one row per LIVE workspace —
-// archived ones excluded, because an archived tenant's records are not searched
-// and re-embedding them spends model budget building an index nobody queries —
-// each row names its own tenant on the wire, and the tenant whose writes fail is
-// the only row that fails. The marker is still handed back, because the run has
-// reached every workspace it is ever going to.
-func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
+// TestEmbedReindexFansOutOneJobPerLiveWorkspace is the converted shape: the
+// dispatcher enqueues one row per LIVE workspace — archived ones excluded,
+// because an archived tenant's records are not searched and re-embedding them
+// spends model budget building an index nobody queries — each row names its own
+// tenant on the wire, and the corpus is rebuilt at the run's identity.
+//
+// It does NOT assert that a tenant whose writes fail is the only child to fail,
+// which is what this test used to be named for. That property no longer holds
+// and cannot be made to: an embedding row is keyed on
+// (entity_type, entity_id, chunk_ix) alone (phase B) over records that carry no
+// tenant at all (phase D), so the corpus is the installation's and whichever
+// child runs first rebuilds ALL of it. The second child finds every row already
+// fresh at the run's identity, writes nothing, and therefore cannot meet a
+// write fault however permanently it is armed. The fan-out itself is what has
+// gone redundant; collapsing it is ADR-0091's own next step, and the isolation
+// question disappears with it rather than being answered.
+func TestEmbedReindexFansOutOneJobPerLiveWorkspace(t *testing.T) {
 	re := setupReembedFleet(t)
 	healthy := SeedExtraWorkspace(t, re.Owner, "reindex-healthy", false)
 	archived := SeedExtraWorkspace(t, re.Owner, "reindex-archived", true)
 
-	// Both live tenants get an entity to embed, so each child has real work and
-	// the victim's write actually reaches the fault. A LEAD, not a person:
-	// ADR-0091 §8 phase D took the tenant column off person, so a person belongs
-	// to the installation and the first child to embed one covers it for every
-	// other — which would leave the second child nothing to do and the fault
-	// nothing to fire on. A lead still carries its tenant, so each child has
-	// work that is its own.
-	re.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Fanout Lead', 'manual', 'human:x')`)
-	healthyLeadID := ids.NewV7()
-	if _, err := re.Owner.Exec(context.Background(),
-		`INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Fanout Lead', 'manual', 'human:x')`,
-		healthyLeadID, healthy); err != nil {
-		t.Fatalf("seeding the healthy tenant's lead: %v", err)
-	}
-	// Permanent, not transient: a fault that healed would let the tenant
-	// complete on a later attempt and read as green — the outcome this denies.
-	failEmbeddingWritesFor(t, re.Owner, re.WS)
+	// ONE entity, and it belongs to the installation rather than to either
+	// tenant: seeding a row "per tenant" would be seeding the same corpus twice
+	// under two names.
+	leadID := re.SeedID(t, `INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Fanout Lead', 'manual', 'human:x')`)
 
 	runner, completed, failed := jobtest.StartTestJobRunner(t, re.Pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
@@ -102,24 +98,25 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	kind := compose.EmbedReindexWorkspaceArgs{}.Kind()
 	outcomes := jobtest.AwaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
 
-	if _, fannedOut := outcomes[healthy.String()]; !fannedOut {
-		t.Errorf("no re-embed ran for workspace %s — a tenant the fan-out skipped keeps a stale index, and no row records that it did not", healthy)
+	for _, ws := range []ids.UUID{re.WS, healthy} {
+		ran, fannedOut := outcomes[ws.String()]
+		if !fannedOut {
+			t.Errorf("no re-embed ran for workspace %s — a tenant the fan-out skipped keeps a stale index, and no row records that it did not", ws)
+			continue
+		}
+		if !ran {
+			t.Errorf("the re-embed for workspace %s failed", ws)
+		}
 	}
-	if !outcomes[healthy.String()] {
-		t.Error("the healthy tenant's re-embed failed")
-	}
-	if outcomes[re.WS.String()] {
-		t.Error("the tenant whose embedding writes could not land reported a completed job — the failure the per-workspace row exists to record was swallowed")
-	}
-	// The pass is only worth a row if it did the work.
+	// The fan-out is only worth its rows if the corpus actually got rebuilt.
 	var model string
 	if err := re.Owner.QueryRow(context.Background(),
 		`SELECT model FROM embedding WHERE entity_type = 'lead' AND entity_id = $1 AND chunk_ix = 0`,
-		healthyLeadID).Scan(&model); err != nil {
-		t.Fatalf("reading the healthy tenant's embedding: %v", err)
+		leadID).Scan(&model); err != nil {
+		t.Fatalf("reading the rebuilt embedding: %v", err)
 	}
 	if model != re.identity {
-		t.Errorf("the healthy tenant's lead is embedded under %q, want %q", model, re.identity)
+		t.Errorf("the lead is embedded under %q, want %q", model, re.identity)
 	}
 
 	// The archived tenant must have no row at all. This count is fenced on the

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -86,17 +86,17 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 		VALUES ($1, $2, 'Rep1 Deal', $3, $4, $5, 100000, 'EUR', 'manual', 'human:x')`, e.Rep1, pipelineID, stageID, f.rep1Org)
 	f.rep3Deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
 		VALUES ($1, $2, 'Rep3 Deal', $3, $4, $5, 200000, 'EUR', 'manual', 'human:x')`, e.Rep3, pipelineID, stageID, f.rep3Org)
-	f.rep1Lead = e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Rep1 Lead', 'manual', 'human:x')`, e.Rep1)
-	f.rep3Lead = e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
-		VALUES ($1, $2, $3, 'Rep3 Lead', 'manual', 'human:x')`, e.Rep3)
+	f.rep1Lead = e.SeedID(t, `INSERT INTO lead (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Rep1 Lead', 'manual', 'human:x')`, e.Rep1)
+	f.rep3Lead = e.SeedID(t, `INSERT INTO lead (id, owner_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Rep3 Lead', 'manual', 'human:x')`, e.Rep3)
 
 	// Employment edges: each connects a rep's person to that rep's org, so
 	// the whole edge is visible only to that rep (both endpoints owned).
-	e.Seed(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`, f.rep1Person, f.rep1Org)
-	e.Seed(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`, f.rep3Person, f.rep3Org)
+	e.SeedID(t, `INSERT INTO relationship (id, kind, person_id, organization_id, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, f.rep1Person, f.rep1Org)
+	e.SeedID(t, `INSERT INTO relationship (id, kind, person_id, organization_id, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, f.rep3Person, f.rep3Org)
 
 	// Activities scope through their links.
 	f.rep1Activity = e.SeedID(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)

--- a/backend/internal/compose/integration/jobfanout/privacyretention_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/privacyretention_integration_test.go
@@ -49,9 +49,9 @@ func seedRetentionPolicy(t *testing.T, owner *pgx.Conn, ws ids.UUID) {
 // seedOverageLead gives one tenant a lead old enough for the policy to reach.
 func seedOverageLead(t *testing.T, owner *pgx.Conn, ws ids.UUID) ids.UUID {
 	t.Helper()
-	return integration.SeedRow(t, owner, `
-		INSERT INTO lead (id, workspace_id, full_name, status, source, captured_by, created_at)
-		VALUES ($1, $2, 'Over-age Lead', 'new', 'manual', 'human:x', now() - interval '400 days')`, ws)
+	return integration.SeedIDRow(t, owner, `
+		INSERT INTO lead (id, full_name, status, source, captured_by, created_at)
+		VALUES ($1, 'Over-age Lead', 'new', 'manual', 'human:x', now() - interval '400 days')`)
 }
 
 // failLeadWrites makes every lead write raise.

--- a/backend/internal/compose/integration/lastactivity_integration_test.go
+++ b/backend/internal/compose/integration/lastactivity_integration_test.go
@@ -280,7 +280,7 @@ func TestLastActivity_TheAccountClockSeeksInsteadOfScanningTheTimeline(t *testin
 	}); err != nil {
 		t.Fatal(err)
 	}
-	seedTimelineVolume(ctx, t, owner, e.WS, 5000)
+	seedTimelineVolume(ctx, t, owner, 5000)
 
 	const calls = 20
 	before := sequentialScansOf(ctx, t, owner, "activity_link")
@@ -307,11 +307,11 @@ func TestLastActivity_TheAccountClockSeeksInsteadOfScanningTheTimeline(t *testin
 // organization, so the maintenance trigger still fires on every row and finds
 // nothing to move — real rows through the real write path, with none of the
 // recompute cost that would make seeding the volume the slow part of the test.
-func seedTimelineVolume(ctx context.Context, t *testing.T, owner *pgx.Conn, ws ids.UUID, rows int) {
+func seedTimelineVolume(ctx context.Context, t *testing.T, owner *pgx.Conn, rows int) {
 	t.Helper()
 	var lead ids.UUID
-	if err := owner.QueryRow(ctx, `INSERT INTO lead (workspace_id, full_name, source, captured_by)
-		VALUES ($1, 'Timeline Volume', 'manual', 'human:x') RETURNING id`, ws).Scan(&lead); err != nil {
+	if err := owner.QueryRow(ctx, `INSERT INTO lead (full_name, source, captured_by)
+		VALUES ('Timeline Volume', 'manual', 'human:x') RETURNING id`).Scan(&lead); err != nil {
 		t.Fatalf("seeding the volume lead: %v", err)
 	}
 	if _, err := owner.Exec(ctx, `WITH act AS (

--- a/backend/internal/compose/integration/leadlistsort_integration_test.go
+++ b/backend/internal/compose/integration/leadlistsort_integration_test.go
@@ -33,12 +33,12 @@ func TestLeadListSortsByScoreAndPagesUnderIt(t *testing.T) {
 
 	// Seeded out of score order, so a list that ignored the sort would
 	// return them in the creation order below and fail the first check.
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-	           VALUES ($1, $2, 'Middle', 'working', 'inbound', 50, 'human:x')`)
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-	           VALUES ($1, $2, 'Warmest', 'working', 'inbound', 90, 'human:x')`)
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-	           VALUES ($1, $2, 'Coldest', 'working', 'inbound', 10, 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, status, source, score, captured_by)
+	           VALUES ($1, 'Middle', 'working', 'inbound', 50, 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, status, source, score, captured_by)
+	           VALUES ($1, 'Warmest', 'working', 'inbound', 90, 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, status, source, score, captured_by)
+	           VALUES ($1, 'Coldest', 'working', 'inbound', 10, 'human:x')`)
 
 	store := people.NewStore(e.DB())
 	sortField := "-score"
@@ -80,12 +80,12 @@ func TestLeadListNarrowsToTheRequestedMinimumScore(t *testing.T) {
 	e := SetupSearch(t)
 	ctx := e.AsFullUser()
 
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-	           VALUES ($1, $2, 'Warmest', 'working', 'inbound', 90, 'human:x')`)
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-	           VALUES ($1, $2, 'AtTheFloor', 'working', 'inbound', 50, 'human:x')`)
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, status, source, score, captured_by)
-	           VALUES ($1, $2, 'Coldest', 'working', 'inbound', 10, 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, status, source, score, captured_by)
+	           VALUES ($1, 'Warmest', 'working', 'inbound', 90, 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, status, source, score, captured_by)
+	           VALUES ($1, 'AtTheFloor', 'working', 'inbound', 50, 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, full_name, status, source, score, captured_by)
+	           VALUES ($1, 'Coldest', 'working', 'inbound', 10, 'human:x')`)
 
 	store := people.NewStore(e.DB())
 	sortField := "-score"

--- a/backend/internal/compose/integration/leadrouting_integration_test.go
+++ b/backend/internal/compose/integration/leadrouting_integration_test.go
@@ -51,8 +51,8 @@ func setupRouting(t *testing.T) *routingEnv {
 // through the engine, returning the resulting owner (nil = unassigned).
 func (e *routingEnv) routeNewLead(t *testing.T, source string) (ids.UUID, *ids.UUID) {
 	t.Helper()
-	leadID := e.Seed(t,
-		`INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Routed Lead', $3, 'human:x')`,
+	leadID := e.SeedID(t,
+		`INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Routed Lead', $2, 'human:x')`,
 		source)
 	if err := e.engine.HandleEvent(context.Background(), kevents.Envelope{
 		EventID: ids.NewV7(), Type: "lead.created",
@@ -161,8 +161,8 @@ func TestLeadRoutingLeavesHumanAssignmentsAlone(t *testing.T) {
 		"owners": []string{e.Rep1.String()},
 	})
 
-	leadID := e.Seed(t,
-		`INSERT INTO lead (id, workspace_id, full_name, source, owner_id, captured_by) VALUES ($1, $2, 'Claimed Lead', 'manual', $3, 'human:x')`,
+	leadID := e.SeedID(t,
+		`INSERT INTO lead (id, full_name, source, owner_id, captured_by) VALUES ($1, 'Claimed Lead', 'manual', $2, 'human:x')`,
 		e.Rep3)
 	if err := e.engine.HandleEvent(context.Background(), kevents.Envelope{
 		EventID: ids.NewV7(), Type: "lead.created",

--- a/backend/internal/compose/integration/leadscore_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_integration_test.go
@@ -34,8 +34,8 @@ func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
 	// A working lead with a decision-maker title from a high-intent
 	// source: fit = 15 + 8 = 23 (§3.1). Inserted with score 0 so the
 	// recompute demonstrably rebuilds fit AND behavior.
-	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, title, status, source, score, captured_by)
-	                     VALUES ($1, $2, 'Vera VP', 'VP Sales', 'working', 'inbound', 0, 'human:x')`)
+	leadID := e.SeedID(t, `INSERT INTO lead (id, full_name, title, status, source, score, captured_by)
+	                     VALUES ($1, 'Vera VP', 'VP Sales', 'working', 'inbound', 0, 'human:x')`)
 
 	// An inbound email linked to the lead = one fresh reply (+25).
 	subject := "Re: your offer"

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -40,8 +40,8 @@ func TestLeadScoreOverrideIsSticky(t *testing.T) {
 	// A working lead: decision-maker title (+15) from a high-intent source
 	// (+8) → machine fit is 23. Seeded at score 0 so a resumed recompute
 	// demonstrably rebuilds it.
-	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, title, status, source, score, captured_by)
-	                     VALUES ($1, $2, 'Vera VP', 'VP Sales', 'working', 'inbound', 0, 'human:x')`)
+	leadID := e.SeedID(t, `INSERT INTO lead (id, full_name, title, status, source, score, captured_by)
+	                     VALUES ($1, 'Vera VP', 'VP Sales', 'working', 'inbound', 0, 'human:x')`)
 
 	// (1) A human score with no reason is rejected (AC-S1).
 	if _, err := store.UpdateLead(ctx, leadIDOf(leadID), people.UpdateLeadInput{Score: intp(90)}); err == nil {

--- a/backend/internal/compose/integration/merge_integration_test.go
+++ b/backend/internal/compose/integration/merge_integration_test.go
@@ -179,9 +179,9 @@ func TestMergeOrganization_partnerExtensionMovesIntoVacancy(t *testing.T) {
 	}
 	srcID, tgtID := orgIDOf(ids.UUID(source.Id)), orgIDOf(ids.UUID(target.Id))
 	// The source carries the partner program; the target has none.
-	e.WsExec(t, `INSERT INTO partner (workspace_id, organization_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:test')`, e.WS, srcID)
+	e.WsExec(t, `INSERT INTO partner (organization_id, source, captured_by) VALUES ($1, 'manual', 'human:test')`, srcID)
 	e.WsExec(t, `INSERT INTO organization_relationship_type (organization_id, relationship_type, source, captured_by)
-		VALUES ( $1, 'partner', 'manual', 'human:test')`, srcID)
+		VALUES ($1, 'partner', 'manual', 'human:test')`, srcID)
 
 	if _, err := e.People.MergeOrganization(admin, srcID, tgtID); err != nil {
 		t.Fatalf("merge: %v", err)

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -103,7 +103,7 @@ func TestTwoRecordsSharingOneLastTouchInstantEachGetTheirOwnReminder(t *testing.
 	deal := e.SeedDeal(t, "Shared Anchor Deal", pipeline, open, nil)
 	attachDealToOrg(t, owner, deal, org)
 	person := e.SeedPerson(t, "Champion", nil)
-	seedStakeholderSeat(t, owner, e.WS, person, deal)
+	seedStakeholderSeat(t, owner, person, deal)
 	for _, row := range []struct {
 		table string
 		id    ids.UUID
@@ -163,12 +163,12 @@ func TestOnlyAStakeholderSeatMakesAPersonACandidate(t *testing.T) {
 	deal := e.SeedDeal(t, "Busy Account Deal", pipeline, open, nil)
 	attachDealToOrg(t, owner, deal, org)
 	stakeholder := e.SeedPerson(t, "Champion", nil)
-	seedStakeholderSeat(t, owner, e.WS, stakeholder, deal)
+	seedStakeholderSeat(t, owner, stakeholder, deal)
 	// An employee of the same busy account with no seat on the deal. If
 	// employment alone made a candidate, every colleague would earn a
 	// reminder duplicating the account's own.
 	colleague := e.SeedPerson(t, "Colleague", nil)
-	seedEmployment(t, owner, e.WS, colleague, org)
+	seedEmployment(t, owner, colleague, org)
 	for _, row := range []struct {
 		table string
 		id    ids.UUID
@@ -193,8 +193,8 @@ func TestOnlyALeadStillInPlayIsACandidate(t *testing.T) {
 	e := Setup(t)
 	owner := OwnerConn(t)
 
-	working := seedLeadInStatus(t, owner, e.WS, "working")
-	disqualified := seedLeadInStatus(t, owner, e.WS, "disqualified")
+	working := seedLeadInStatus(t, owner, "working")
+	disqualified := seedLeadInStatus(t, owner, "disqualified")
 	for _, id := range []ids.UUID{working, disqualified} {
 		backdateCreatedAt(t, owner, "lead", id, longEstablished)
 		linkQuietTouch(t, owner, e.WS, "lead", id)
@@ -254,7 +254,7 @@ func linkTouch(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityType 
 		t.Fatalf("no activity_link column for entity type %q", entityType)
 	}
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_link (activity_id, entity_type, `+column+`) VALUES ( $1, $2, $3)`, activity, entityType, entity); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, `+column+`) VALUES ($1, $2, $3)`, activity, entityType, entity); err != nil {
 		t.Fatalf("linking the touch to %s %s: %v", entityType, entity, err)
 	}
 }
@@ -297,36 +297,39 @@ func attachDealToOrg(t *testing.T, owner *pgx.Conn, deal, org ids.UUID) {
 }
 
 // seedStakeholderSeat gives a person a live seat on a deal.
-func seedStakeholderSeat(t *testing.T, owner *pgx.Conn, ws, person, deal ids.UUID) {
+func seedStakeholderSeat(t *testing.T, owner *pgx.Conn, person, deal ids.UUID) {
 	t.Helper()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
-		 VALUES ($1, 'deal_stakeholder', $2, $3, 'champion', 'manual', 'human:x')`,
-		ws, person, deal); err != nil {
+		`INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+		 VALUES ('deal_stakeholder', $1, $2, 'champion', 'manual', 'human:x')`, person, deal); err != nil {
 		t.Fatalf("seeding the stakeholder seat: %v", err)
 	}
 }
 
 // seedEmployment employs a person at an organization — a relationship the
 // candidate query deliberately does NOT treat as live work.
-func seedEmployment(t *testing.T, owner *pgx.Conn, ws, person, org ids.UUID) {
+func seedEmployment(t *testing.T, owner *pgx.Conn, person, org ids.UUID) {
 	t.Helper()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-		 VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`,
-		ws, person, org); err != nil {
+		`INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		 VALUES ('employment', $1, $2, 'manual', 'human:x')`,
+		person, org); err != nil {
 		t.Fatalf("seeding the employment edge: %v", err)
 	}
 }
 
-// seedLeadInStatus inserts one lead in the given lifecycle status.
-func seedLeadInStatus(t *testing.T, owner *pgx.Conn, ws ids.UUID, status string) ids.UUID {
+// seedLeadInStatus plants a lead in one named lifecycle status, so a suite can
+// put two leads either side of the in-play boundary and assert that only the
+// one still in play is a candidate. The status is the whole variable — every
+// other column is held constant so a difference in the result can only come
+// from it.
+func seedLeadInStatus(t *testing.T, owner *pgx.Conn, status string) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO lead (id, workspace_id, full_name, status, source, captured_by)
-		 VALUES ($1, $2, 'Inbound Lead', $3, 'manual', 'human:x')`,
-		id, ws, status); err != nil {
+		`INSERT INTO lead (id, full_name, status, source, captured_by)
+		 VALUES ($1, 'Inbound Lead', $2, 'manual', 'human:x')`,
+		id, status); err != nil {
 		t.Fatalf("seeding a %s lead: %v", status, err)
 	}
 	return id

--- a/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
@@ -48,8 +48,8 @@ func accountMailAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject string, a
 // the graph draws them in.
 func employ(t *testing.T, e *integration.Env, person, org ids.UUID, title string) {
 	t.Helper()
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, role, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, $4, 'manual', 'human:x')`, e.WS, person, org, title)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, role, source, captured_by)
+		VALUES ('employment', $1, $2, $3, 'manual', 'human:x')`, person, org, title)
 }
 
 // employAt ties a person to an organization. endedOn nil is a live employment;
@@ -57,9 +57,8 @@ func employ(t *testing.T, e *integration.Env, person, org ids.UUID, title string
 func employAt(t *testing.T, e *integration.Env, person, org ids.UUID, endedOn *time.Time) {
 	t.Helper()
 	e.WsExec(t, `INSERT INTO relationship
-		(workspace_id, kind, person_id, organization_id, started_at, ended_at, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, DATE '2026-01-01', $4::date, 'manual', 'human:x')`,
-		e.WS, person, org, endedOn)
+		(kind, person_id, organization_id, started_at, ended_at, source, captured_by)
+		VALUES ('employment', $1, $2, DATE '2026-01-01', $3::date, 'manual', 'human:x')`, person, org, endedOn)
 }
 
 // accountTimeline lists the account's timeline the way GET /activities does.

--- a/backend/internal/compose/integration/org360/org360_graph_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graph_integration_test.go
@@ -134,16 +134,16 @@ func seedOneHop(t *testing.T, e *integration.Env) oneHopFixture {
 		reseller: e.SeedOrg(t, "Reseller", &e.Rep1),
 	}
 	e.WsExec(t, `UPDATE organization SET parent_org_id = $2 WHERE id = $1`, f.org, f.parent)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, organization_id, counterparty_org_id, source, captured_by)
-		VALUES ($1, 'partner_of', $2, $3, 'manual', 'human:x')`, e.WS, f.org, f.reseller)
+	e.WsExec(t, `INSERT INTO relationship (kind, organization_id, counterparty_org_id, source, captured_by)
+		VALUES ('partner_of', $1, $2, 'manual', 'human:x')`, f.org, f.reseller)
 
 	f.employee = e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 	employ(t, e, f.employee, f.org, "cto")
 	f.deal = e.SeedDeal(t, "Renewal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, f.deal, f.org)
 	f.stakeholder = e.SeedPerson(t, "Outside Counsel", &e.Rep1)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
-		VALUES ($1, 'deal_stakeholder', $2, $3, 'champion', 'manual', 'human:x')`, e.WS, f.stakeholder, f.deal)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+		VALUES ('deal_stakeholder', $1, $2, 'champion', 'manual', 'human:x')`, f.stakeholder, f.deal)
 
 	// Two hops out: the parent's OWN parent, and a company that employs our
 	// contact elsewhere.
@@ -258,16 +258,16 @@ func TestOrganizationGraphRelatedCapCountsCompaniesNotEdges(t *testing.T) {
 	greedy := e.SeedOrg(t, "AAA Greedy Partner", &e.Rep1)
 	for range 30 {
 		for _, kind := range []string{"partner_of", "referred_by", "co_sell_with"} {
-			e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, organization_id, counterparty_org_id, source, captured_by)
-				VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, e.WS, kind, org, greedy)
+			e.WsExec(t, `INSERT INTO relationship (kind, organization_id, counterparty_org_id, source, captured_by)
+				VALUES ($1, $2, $3, 'manual', 'human:x')`, kind, org, greedy)
 		}
 	}
 	// Plus twelve companies attached one plain way each — more than the display
 	// cap, so the drop count has something to report.
 	for i := range 12 {
 		partner := e.SeedOrg(t, fmt.Sprintf("Partner %02d", i), &e.Rep1)
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, organization_id, counterparty_org_id, source, captured_by)
-			VALUES ($1, 'partner_of', $2, $3, 'manual', 'human:x')`, e.WS, org, partner)
+		e.WsExec(t, `INSERT INTO relationship (kind, organization_id, counterparty_org_id, source, captured_by)
+			VALUES ('partner_of', $1, $2, 'manual', 'human:x')`, org, partner)
 	}
 
 	graph, err := svc.Graph(e.As(e.Rep1, nil, graphAdminPerms), ids.From[ids.OrganizationKind](org))

--- a/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
@@ -95,8 +95,8 @@ func TestOrganizationGraphOmitsAGroupTheCallerMayNotRead(t *testing.T) {
 	employ(t, e, employee, org, "cto")
 	deal := e.SeedDeal(t, "Renewal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
-		VALUES ($1, 'deal_stakeholder', $2, $3, 'champion', 'manual', 'human:x')`, e.WS, employee, deal)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+		VALUES ('deal_stakeholder', $1, $2, 'champion', 'manual', 'human:x')`, employee, deal)
 
 	full, err := svc.Graph(e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -179,14 +179,14 @@ func TestOrganizationGraphPrunesNodesToTheCallersRowScope(t *testing.T) {
 	myPartner := e.SeedOrg(t, "My Partner", &e.Rep1)
 	theirPartner := e.SeedOrg(t, "Their Partner", &e.Rep3)
 	for _, partner := range []ids.UUID{myPartner, theirPartner} {
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, organization_id, counterparty_org_id, source, captured_by)
-			VALUES ($1, 'referred_by', $2, $3, 'manual', 'human:x')`, e.WS, partner, org)
+		e.WsExec(t, `INSERT INTO relationship (kind, organization_id, counterparty_org_id, source, captured_by)
+			VALUES ('referred_by', $1, $2, 'manual', 'human:x')`, partner, org)
 	}
 
 	// A seat on the caller's own deal held by a person they cannot read: the
 	// deal is visible, the person is not, so the edge must not appear.
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
-		VALUES ($1, 'deal_stakeholder', $2, $3, 'blocker', 'manual', 'human:x')`, e.WS, theirs, myDeal)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+		VALUES ('deal_stakeholder', $1, $2, 'blocker', 'manual', 'human:x')`, theirs, myDeal)
 
 	graph, err := svc.Graph(e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -139,10 +139,10 @@ func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		VALUES ('employment', $1, $2, 'manual', 'human:x')`, contact, org)
 	e.WsExec(t, `INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, 'dana@acme.test', true, 'manual', 'human:x')`, contact)
+		VALUES ($1, 'dana@acme.test', true, 'manual', 'human:x')`, contact)
 
 	// Two qualifying interactions inside the §4 window, one each way, so
 	// the score is non-zero and reciprocity is balanced.
@@ -204,8 +204,8 @@ func TestOrganization360ConsentReportsEveryPurposeEvenWithoutARow(t *testing.T) 
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Silent Contact", &e.Rep1)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		VALUES ('employment', $1, $2, 'manual', 'human:x')`, contact, org)
 	seedConsentPurpose(t, owner, "product_updates", "Product updates")
 
 	view, err := svc.Assemble(e.Admin(), ids.From[ids.OrganizationKind](org))
@@ -234,8 +234,8 @@ func TestOrganization360ContactsHonorTheCallersRowScope(t *testing.T) {
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
 	for _, person := range []ids.UUID{mine, theirs} {
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, person, org)
+		e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+			VALUES ('employment', $1, $2, 'manual', 'human:x')`, person, org)
 	}
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
@@ -309,8 +309,8 @@ func TestOrganization360NextStepsHideALinkedDealOutOfRowScope(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, mine, org)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		VALUES ('employment', $1, $2, 'manual', 'human:x')`, mine, org)
 	theirDeal := e.SeedDeal(t, "Other team deal", pipeline, stage, &e.Rep3)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, theirDeal, org)
 
@@ -410,15 +410,15 @@ func TestOrganization360NextMeetingParticipantsHonorRowScope(t *testing.T) {
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirs := e.SeedPerson(t, "Another Team's Contact", &e.Rep3)
 	for _, person := range []ids.UUID{mine, theirs} {
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, person, org)
+		e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+			VALUES ('employment', $1, $2, 'manual', 'human:x')`, person, org)
 	}
 
 	meeting := seedMeeting(t, owner, e.WS, "Renewal review", org360Clock.Add(24*time.Hour))
 	integration.LinkActivity(t, owner, meeting, "person", mine)
 	for _, person := range []ids.UUID{mine, theirs} {
 		e.WsExec(t, `INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'attendee')`, meeting, person)
+			VALUES ($1, $2, 'attendee')`, meeting, person)
 	}
 	// The visible contact ALSO holds a second role. uq_activity_participant is
 	// unique on (activity, role, person), so one person legitimately has several
@@ -426,7 +426,7 @@ func TestOrganization360NextMeetingParticipantsHonorRowScope(t *testing.T) {
 	// `attendee`. Without this the fixture has one row per person and cannot
 	// tell a correct answer from one that lists somebody once per role.
 	e.WsExec(t, `INSERT INTO activity_participant (activity_id, person_id, role)
-		VALUES ( $1, $2, 'from')`, meeting, mine)
+		VALUES ($1, $2, 'from')`, meeting, mine)
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -469,8 +469,8 @@ func TestOrganization360ContactRoutesSeparateUntriedFromCold(t *testing.T) {
 	reached := e.SeedPerson(t, "Reached Contact", &e.Rep1)
 	untried := e.SeedPerson(t, "Untried Contact", &e.Rep1)
 	for _, person := range []ids.UUID{reached, untried} {
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, person, org)
+		e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+			VALUES ('employment', $1, $2, 'manual', 'human:x')`, person, org)
 	}
 	// One colleague has a real two-way exchange with the first contact. The
 	// second has none at all, which is the state under test.
@@ -516,8 +516,8 @@ func TestOrganization360ContactRoutesNameThreeAndCountTheRest(t *testing.T) {
 	svc := org360Service(e)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Popular Contact", &e.Rep1)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		VALUES ('employment', $1, $2, 'manual', 'human:x')`, contact, org)
 
 	// Eight colleagues, each stronger than the last, so the ordering is not the
 	// insert order and a scan that returned "the first three" would be caught.
@@ -575,8 +575,8 @@ func TestOrganization360OmitsRoutesWithoutTheActivityGrant(t *testing.T) {
 	svc := org360Service(e)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	person := e.SeedPerson(t, "Reached Contact", &e.Rep1)
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, person, org)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		VALUES ('employment', $1, $2, 'manual', 'human:x')`, person, org)
 	e.WsExec(t, `INSERT INTO graph_interaction_edge
 			(workspace_id, user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
 		VALUES ($1, $2, $3, $4, 20, 10, 10)`,

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -186,16 +186,16 @@ func seedAccount(t *testing.T, e *integration.Env, owner *pgx.Conn, name string,
 	org := e.SeedOrg(t, name, &e.Rep1)
 	for range n {
 		contact := e.SeedPerson(t, name+" contact", &e.Rep1)
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
+		e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+			VALUES ('employment', $1, $2, 'manual', 'human:x')`, contact, org)
 		activity := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by)
 			VALUES ($1, 'email', 'touch', '2026-05-28T09:00:00Z', 'inbound', 'manual', 'human:x')`)
 		integration.LinkActivity(t, owner, activity, "person", contact)
 
 		deal := e.SeedDeal(t, name+" deal", pipeline, stage, &e.Rep1)
 		e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)
-		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
-			VALUES ($1, 'deal_stakeholder', $2, $3, 'champion', 'manual', 'human:x')`, e.WS, contact, deal)
+		e.WsExec(t, `INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+			VALUES ('deal_stakeholder', $1, $2, 'champion', 'manual', 'human:x')`, contact, deal)
 	}
 	return ids.From[ids.OrganizationKind](org)
 }

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -92,7 +92,7 @@ func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.T
 		VALUES ($1, 'note', 'rollup touch', $2, 'manual', 'human:test')`,
 		activityID, occurredAt)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, activityID, org)
+		VALUES ($1, 'organization', $2)`, activityID, org)
 }
 
 // seedRollupDealLinkedActivity files one activity against a DEAL of the
@@ -109,7 +109,7 @@ func seedRollupDealLinkedActivity(t *testing.T, e *Env, st rollupStages, org ids
 		VALUES ($1, 'email', 'deal thread', $2, 'manual', 'human:test')`,
 		activityID, occurredAt)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
-		VALUES ( $1, 'deal', $2)`, activityID, dealID)
+		VALUES ($1, 'deal', $2)`, activityID, dealID)
 }
 
 // seedRollupPersonLinkedActivity files one activity against a PERSON
@@ -122,15 +122,15 @@ func seedRollupPersonLinkedActivity(t *testing.T, e *Env, org ids.UUID, occurred
 	personID := ids.NewV7()
 	e.WsExec(t, `INSERT INTO person (id, full_name, source, captured_by)
 		VALUES ($1, 'Rollup Contact', 'manual', 'human:test')`, personID)
-	e.WsExec(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
-		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:test')`,
-		ids.NewV7(), e.WS, personID, org)
+	e.WsExec(t, `INSERT INTO relationship (id, kind, person_id, organization_id, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, 'manual', 'human:test')`,
+		ids.NewV7(), personID, org)
 	activityID := ids.NewV7()
 	e.WsExec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, 'email', 'contact thread', $2, 'connector:gmail', 'connector:gmail')`,
 		activityID, occurredAt)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id)
-		VALUES ( $1, 'person', $2)`, activityID, personID)
+		VALUES ($1, 'person', $2)`, activityID, personID)
 }
 
 // rollupOrgReadPerms is the minimal caller the rollup admits: read on
@@ -510,9 +510,9 @@ func TestOrgRollupCountsAnActivityReachingTheTreeTwiceOnlyOnce(t *testing.T) {
 		VALUES ($1, 'email', 'filed twice', $2, 'manual', 'human:test')`,
 		activityID, now.Add(-24*time.Hour))
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, activityID, org)
+		VALUES ($1, 'organization', $2)`, activityID, org)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
-		VALUES ( $1, 'deal', $2)`, activityID, dealID)
+		VALUES ($1, 'deal', $2)`, activityID, dealID)
 
 	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, org, "self", fixedClock(now))
 	if err != nil {

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -182,7 +182,7 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 	assertCount("reconstructed persons", `SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%'`, 3)
 	assertCount("reconstructed organizations", `SELECT count(*) FROM organization WHERE source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE source LIKE 'mirror:hubspot:%'`, 2)
-	assertCount("reconstructed leads", `SELECT count(*) FROM lead WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid AND source_system = 'mirror:hubspot'`, 1)
+	assertCount("reconstructed leads", `SELECT count(*) FROM lead WHERE source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed activities", `SELECT count(*) FROM activity WHERE source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed deal→org FK", `
 		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id
@@ -246,28 +246,14 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 	// cascade from it, and this fixture only has to clear what now collides
 	// installation-wide.
 	// The order is the foreign keys' — a deal points at its stage, its pipeline
-	// and its organization — and the predicate is per table because ADR-0091 §8
-	// phase D has reached some of these and not others. A `workspace_id = $1`
-	// spelled for all seven fails outright on the six that no longer have it.
-	for _, t2 := range []struct {
-		table        string
-		tenantScoped bool
-	}{
-		{"deal", false},
-		{"stage", false},
-		{"pipeline", false},
-		{"organization", false},
-		{"person", false},
-		{"lead", true},
-		{"activity", false},
+	// and its organization. No workspace predicate on any of them: ADR-0091 §8
+	// phase D has now taken the column off all seven, so the estate IS every
+	// row of these tables.
+	for _, table := range []string{
+		"deal", "stage", "pipeline", "organization", "person", "lead", "activity",
 	} {
-		sql, args := "DELETE FROM "+t2.table, []any(nil)
-		if t2.tenantScoped {
-			sql += " WHERE workspace_id = $1"
-			args = []any{f.wsID}
-		}
-		if _, err := f.e.Owner.Exec(ctx, sql, args...); err != nil {
-			t.Fatalf("retiring the source estate's %s rows before the rebuild: %v", t2.table, err)
+		if _, err := f.e.Owner.Exec(ctx, "DELETE FROM "+table); err != nil {
+			t.Fatalf("retiring the source estate's %s rows before the rebuild: %v", table, err)
 		}
 	}
 	// The identity ledger goes with the estate, for the same reason and by the

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -338,13 +338,13 @@ func seedBenchTier(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierSpe
 	        SELECT count(*) AS n FROM organization
 	      ), people AS (
 	        SELECT id, (row_number() OVER () - 1) % (SELECT n FROM total) + 1 AS target_rn
-	        FROM person LIMIT $2
+	        FROM person LIMIT $1
 	      ), orgs AS (
 	        SELECT id, row_number() OVER () AS rn FROM organization
 	      )
-	      INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-	      SELECT $1, 'employment', p.id, o.id, 'manual', 'human:bench'
-	      FROM people p JOIN orgs o ON o.rn = p.target_rn`, ws, spec.relationships)
+	      INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+	      SELECT 'employment', p.id, o.id, 'manual', 'human:bench'
+	      FROM people p JOIN orgs o ON o.rn = p.target_rn`, spec.relationships)
 
 	anchor := seedBenchAnchor(t, owner, ws, spec)
 
@@ -360,7 +360,7 @@ func seedBenchAnchor(t *testing.T, owner *pgx.Conn, ws ids.UUID, spec benchTierS
 	var anchor ids.UUID
 	if err := owner.QueryRow(context.Background(),
 		`INSERT INTO person (full_name, source, captured_by)
-		 VALUES ( 'Anchor Hamburg', 'manual', 'human:bench') RETURNING id`).Scan(&anchor); err != nil {
+		 VALUES ('Anchor Hamburg', 'manual', 'human:bench') RETURNING id`).Scan(&anchor); err != nil {
 		t.Fatalf("seeding anchor: %v", err)
 	}
 	benchExec(t, owner, spec.tier, `WITH act AS (

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -318,10 +318,10 @@ func TestPerson360AssemblesEverySectionFromRealRows(t *testing.T) {
 	org := e.SeedOrg(t, "ScaleCommerce", &e.Rep1)
 	mine := e.SeedPerson(t, "Anna Weber", &e.Rep1)
 
-	SeedRow(t, owner, `INSERT INTO relationship
-		(id, workspace_id, kind, person_id, organization_id, role, is_current_primary, source, captured_by)
-		VALUES ($1, $2, 'employment', '`+mine.String()+`', '`+org.String()+`',
-		        'Head of Procurement', true, 'manual', 'human:x')`, e.WS)
+	SeedIDRow(t, owner, `INSERT INTO relationship
+		(id, kind, person_id, organization_id, role, is_current_primary, source, captured_by)
+		VALUES ($1, 'employment', '`+mine.String()+`', '`+org.String()+`',
+		        'Head of Procurement', true, 'manual', 'human:x')`)
 
 	// One inbound message and one open task: the timeline, the last-touch
 	// pair and the next-steps section each read a different slice of these.

--- a/backend/internal/compose/integration/personautoenrich_integration_test.go
+++ b/backend/internal/compose/integration/personautoenrich_integration_test.go
@@ -67,10 +67,10 @@ func seedEmployedPerson(t *testing.T, e *Env, name string) (ids.PersonID, ids.Or
 			return err
 		}
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO relationship (id, workspace_id, person_id, organization_id, kind,
+			INSERT INTO relationship (id, person_id, organization_id, kind,
 			                          is_current_primary, source, captured_by)
-			VALUES ($1, $2, $3, $4, 'employment', true, 'manual', 'user:seed')`,
-			ids.NewV7(), e.WS, personID, orgID)
+			VALUES ($1, $2, $3, 'employment', true, 'manual', 'user:seed')`,
+			ids.NewV7(), personID, orgID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the employed contact: %v", err)

--- a/backend/internal/compose/integration/persongraph_integration_test.go
+++ b/backend/internal/compose/integration/persongraph_integration_test.go
@@ -78,12 +78,12 @@ func seedExchange(t *testing.T, e *Env, colleague, person ids.UUID, subject stri
 	LinkActivity(t, owner, id, "person", person)
 	if _, err := owner.Exec(ctx, `
 		INSERT INTO activity_participant (activity_id, user_id, role)
-		VALUES ( $1, $2, 'from')`, id, colleague); err != nil {
+		VALUES ($1, $2, 'from')`, id, colleague); err != nil {
 		t.Fatalf("seeding our side: %v", err)
 	}
 	if _, err := owner.Exec(ctx, `
 		INSERT INTO activity_participant (activity_id, person_id, role)
-		VALUES ( $1, $2, 'to')`, id, person); err != nil {
+		VALUES ($1, $2, 'to')`, id, person); err != nil {
 		t.Fatalf("seeding their side: %v", err)
 	}
 	wsCtx := principal.WithWorkspaceID(ctx, e.WS)
@@ -187,9 +187,9 @@ func TestPersonGraphHidesCoworkersOutsideRowScope(t *testing.T) {
 	hidden := e.SeedPerson(t, "Hidden Coworker", &e.Rep3)
 
 	for _, p := range []ids.UUID{mine, visible, hidden} {
-		SeedRow(t, owner, `INSERT INTO relationship
-			(id, workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, $2, 'employment', '`+p.String()+`', '`+org.String()+`', 'manual', 'human:x')`, e.WS)
+		SeedIDRow(t, owner, `INSERT INTO relationship
+			(id, kind, person_id, organization_id, source, captured_by)
+			VALUES ($1, 'employment', '`+p.String()+`', '`+org.String()+`', 'manual', 'human:x')`)
 	}
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, graphPerms)
@@ -285,9 +285,9 @@ func TestPersonGraphGivesAColleagueOneNodeAcrossBothArms(t *testing.T) {
 	coworker := e.SeedPerson(t, "Their Colleague", &e.Rep1)
 
 	for _, p := range []ids.UUID{mine, coworker} {
-		SeedRow(t, owner, `INSERT INTO relationship
-			(id, workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, $2, 'employment', '`+p.String()+`', '`+org.String()+`', 'manual', 'human:x')`, e.WS)
+		SeedIDRow(t, owner, `INSERT INTO relationship
+			(id, kind, person_id, organization_id, source, captured_by)
+			VALUES ($1, 'employment', '`+p.String()+`', '`+org.String()+`', 'manual', 'human:x')`)
 	}
 	// The SAME colleague corresponds with both.
 	seedExchange(t, e, e.Rep1, mine, "with Anna")
@@ -341,9 +341,9 @@ func TestPersonGraphAccountEdgesCarryCountsAndNoMessages(t *testing.T) {
 	coworker := e.SeedPerson(t, "Their Colleague", &e.Rep1)
 
 	for _, p := range []ids.UUID{mine, coworker} {
-		SeedRow(t, owner, `INSERT INTO relationship
-			(id, workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, $2, 'employment', '`+p.String()+`', '`+org.String()+`', 'manual', 'human:x')`, e.WS)
+		SeedIDRow(t, owner, `INSERT INTO relationship
+			(id, kind, person_id, organization_id, source, captured_by)
+			VALUES ($1, 'employment', '`+p.String()+`', '`+org.String()+`', 'manual', 'human:x')`)
 	}
 	// Nobody knows Anna; somebody knows her coworker. That is exactly the case
 	// the account arm exists for.

--- a/backend/internal/compose/integration/privacy_customfields_integration_test.go
+++ b/backend/internal/compose/integration/privacy_customfields_integration_test.go
@@ -127,8 +127,8 @@ func TestErasureScrubsCustomFieldColumns(t *testing.T) {
 	leadID := ids.NewV7()
 	err := database.WithWorkspaceTx(f.e.Admin(), f.e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), fmt.Sprintf(
-			`INSERT INTO lead (id, workspace_id, full_name, email, source, captured_by, %s)
-			 VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			`INSERT INTO lead (id, full_name, email, source, captured_by, %s)
+			 VALUES ($1,
 			         'Selma Subject', $2, 'manual', 'human:x', 'about the subject')`,
 			quoted(leadCol),
 		), leadID, subjectEmail)

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -123,12 +123,20 @@ func failEmbeddingWritesFor(t *testing.T, owner *pgx.Conn, ws ids.UUID) {
 			t.Errorf("dropping the fault-injection function: %v", err)
 		}
 	})
+	// The condition names the tenant the WRITE IS RUNNING AS, not the tenant on
+	// the row. Phase B keyed embedding on (entity_type, entity_id, chunk_ix)
+	// alone, so a row belongs to the installation and carries whichever tenant
+	// happened to write it first — a NEW.workspace_id test would then fire or
+	// not depending on which pass won the race, which is not what "this
+	// tenant's writes cannot land" means. The GUC is set by the pass's own
+	// WithWorkspaceTx, so this fires for every write that tenant attempts.
+	//
 	// CREATE TRIGGER takes no bind parameters, so the tenant is interpolated;
 	// it is a UUID rendered by ids.UUID.String(), never caller text.
 	if _, err := owner.Exec(ctx, `
 		CREATE TRIGGER embedding_write_fault_trigger
 		BEFORE INSERT OR UPDATE ON embedding
-		FOR EACH ROW WHEN (NEW.workspace_id = '`+ws.String()+`'::uuid)
+		FOR EACH ROW WHEN (current_setting('app.workspace_id', true) = '`+ws.String()+`')
 		EXECUTE FUNCTION embedding_write_fault()`); err != nil {
 		t.Fatalf("arming the fault-injection trigger: %v", err)
 	}

--- a/backend/internal/compose/integration/retention_integration_test.go
+++ b/backend/internal/compose/integration/retention_integration_test.go
@@ -34,19 +34,18 @@ func seedOverAgeRecords(t *testing.T, e *Env) (staleLead, heldLead, staleDeal, t
 	staleDeal = ids.NewV7()
 	transcript = ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		for _, stmt := range []struct {
 			sql  string
 			args []any
 		}{
 			{
-				`INSERT INTO lead (id, workspace_id, full_name, email, status, source, captured_by, created_at)
-			  VALUES ($1, ` + wsClause + `, 'Old Cold Lead', 'cold@old.example', 'new', 'manual', 'human:x', now() - interval '400 days')`,
+				`INSERT INTO lead (id, full_name, email, status, source, captured_by, created_at)
+			  VALUES ($1, 'Old Cold Lead', 'cold@old.example', 'new', 'manual', 'human:x', now() - interval '400 days')`,
 				[]any{staleLead},
 			},
 			{
-				`INSERT INTO lead (id, workspace_id, full_name, status, legal_hold, source, captured_by, created_at)
-			  VALUES ($1, ` + wsClause + `, 'Held Lead', 'new', true, 'manual', 'human:x', now() - interval '400 days')`,
+				`INSERT INTO lead (id, full_name, status, legal_hold, source, captured_by, created_at)
+			  VALUES ($1, 'Held Lead', 'new', true, 'manual', 'human:x', now() - interval '400 days')`,
 				[]any{heldLead},
 			},
 			{

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -56,7 +56,7 @@ func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 	e := SetupSearch(t)
 	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Heike Hamburg', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Hamburg Logistics GmbH', 'manual', 'human:x')`)
-	e.Seed(t, `INSERT INTO lead (id, workspace_id, company_name, email, source, captured_by) VALUES ($1, $2, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
+	e.SeedID(t, `INSERT INTO lead (id, company_name, email, source, captured_by) VALUES ($1, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO activity (id, kind, subject, body, source, captured_by) VALUES ($1, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
 	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Unrelated Munich', 'manual', 'human:x')`)
 

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -61,8 +61,8 @@ func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, direc
 	person := SeedIDRow(t, owner, `INSERT INTO person (id, full_name, source, captured_by)
 		VALUES ($1, 'Stakeholder', 'manual', 'human:x')`)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, source, captured_by)
-		 VALUES ($1, 'deal_stakeholder', $2, $3, 'manual', 'human:x')`, e.WS, person, deal); err != nil {
+		`INSERT INTO relationship (kind, person_id, deal_id, source, captured_by)
+		 VALUES ('deal_stakeholder', $1, $2, 'manual', 'human:x')`, person, deal); err != nil {
 		t.Fatal(err)
 	}
 	for _, direction := range directions {

--- a/backend/internal/compose/integration/signalextract_integration_test.go
+++ b/backend/internal/compose/integration/signalextract_integration_test.go
@@ -80,7 +80,7 @@ func seedUnlinkedMessage(t *testing.T, e *Env, key, subject, body, direction str
 func employeeOf(t *testing.T, e *Env, org ids.UUID, name string) ids.UUID {
 	t.Helper()
 	person := e.SeedPerson(t, name, &e.Rep1)
-	seedEmployment(t, OwnerConn(t), e.WS, person, org)
+	seedEmployment(t, OwnerConn(t), person, org)
 	return person
 }
 
@@ -264,8 +264,8 @@ func TestAThreadWithATwoEmployerContactIsNotFiledAgainstEither(t *testing.T) {
 	contoso := e.SeedOrg(t, "Contoso", &e.Rep1)
 	moonlighter := e.SeedPerson(t, "Mo Moonlighter", &e.Rep1)
 	owner := OwnerConn(t)
-	seedEmployment(t, owner, e.WS, moonlighter, acme)
-	seedEmployment(t, owner, e.WS, moonlighter, contoso)
+	seedEmployment(t, owner, moonlighter, acme)
+	seedEmployment(t, owner, moonlighter, contoso)
 	seedMessage(t, e, moonlighter, "thread-two-hats", "Renewal",
 		"We have decided not to renew.", "inbound", extractClock.Add(-48*time.Hour))
 
@@ -366,7 +366,7 @@ func TestAConversationIsOwedAFreshReadingWhenItsAccountChanges(t *testing.T) {
 	e.WsExec(t, `UPDATE relationship SET ended_at = $1
 		 WHERE person_id = $2 AND organization_id = $3 AND kind = 'employment'`,
 		extractClock.Add(-time.Hour), mover, acme)
-	seedEmployment(t, owner, e.WS, mover, contoso)
+	seedEmployment(t, owner, mover, contoso)
 
 	// Same thread, same messages, same count — a watermark that knew only the
 	// thread would call this read and never look at it again.

--- a/backend/internal/compose/integration/signals_integration_test.go
+++ b/backend/internal/compose/integration/signals_integration_test.go
@@ -108,9 +108,9 @@ func (e *SearchEnv) seedEmployedContact(t *testing.T, orgID ids.UUID, name, emai
 		t.Fatal(err)
 	}
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
-		 VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`,
-		ids.NewV7(), e.WS, personID, orgID); err != nil {
+		`INSERT INTO relationship (id, kind, person_id, organization_id, source, captured_by)
+		 VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`,
+		ids.NewV7(), personID, orgID); err != nil {
 		t.Fatal(err)
 	}
 	return personID

--- a/backend/internal/compose/integration/strength_integration_test.go
+++ b/backend/internal/compose/integration/strength_integration_test.go
@@ -30,8 +30,7 @@ func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 	person := SeedIDRow(t, owner, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Warm Contact', 'manual', 'human:x')`)
 	org := SeedIDRow(t, owner, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Warm GmbH', 'manual', 'human:x')`)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by) VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`,
-		e.WS, person, org); err != nil {
+		`INSERT INTO relationship (kind, person_id, organization_id, source, captured_by) VALUES ('employment', $1, $2, 'manual', 'human:x')`, person, org); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,17 +48,17 @@ func TestRelationshipStrengthOverSeededRows(t *testing.T) {
 			occurred.Format(time.RFC3339), direction,
 		))
 		if _, err := owner.Exec(context.Background(),
-			`INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ( $1, 'person', $2)`,
+			`INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`,
 			activity, person); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// A lead with its own linked activity: never an input (ADR-0008).
-	lead := SeedRow(t, owner, `INSERT INTO lead (id, workspace_id, full_name, email, source, captured_by) VALUES ($1, $2, 'Cold Lead', 'cold@lead.test', 'import', 'human:x')`, e.WS)
+	lead := SeedIDRow(t, owner, `INSERT INTO lead (id, full_name, email, source, captured_by) VALUES ($1, 'Cold Lead', 'cold@lead.test', 'import', 'human:x')`)
 	leadTouch := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, direction, source, captured_by) VALUES ($1, 'email', 'lead touch', now(), 'inbound', 'manual', 'human:x')`)
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_link (activity_id, entity_type, lead_id) VALUES ( $1, 'lead', $2)`,
+		`INSERT INTO activity_link (activity_id, entity_type, lead_id) VALUES ($1, 'lead', $2)`,
 		leadTouch, lead); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/workflow_integration_test.go
+++ b/backend/internal/compose/integration/workflow_integration_test.go
@@ -81,7 +81,7 @@ func enableLeadRouting(t *testing.T, e *SearchEnv, params map[string]any) {
 func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 	e := SetupSearch(t)
 	enableLeadRouting(t, e, map[string]any{"owners": []string{e.Rep1.String()}})
-	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Fresh Lead', 'manual', 'human:x')`)
+	leadID := e.SeedID(t, `INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Fresh Lead', 'manual', 'human:x')`)
 	engine := compose.NewWorkflowEngine(e.DB())
 
 	env := kevents.Envelope{
@@ -176,7 +176,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	}
 
 	// No automation rows at all: the registered handler stays silent.
-	first := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Ungated Lead', 'manual', 'human:x')`)
+	first := e.SeedID(t, `INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Ungated Lead', 'manual', 'human:x')`)
 	dispatch(first)
 	if got := ownerOf(first); got != nil {
 		t.Fatalf("unconfigured workspace assigned owner %v, want none", got)
@@ -194,7 +194,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	second := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Paused Lead', 'manual', 'human:x')`)
+	second := e.SeedID(t, `INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Paused Lead', 'manual', 'human:x')`)
 	dispatch(second)
 	if got := ownerOf(second); got != nil {
 		t.Fatalf("paused instance assigned owner %v, want none", got)
@@ -209,7 +209,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	third := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Live Lead', 'manual', 'human:x')`)
+	third := e.SeedID(t, `INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Live Lead', 'manual', 'human:x')`)
 	dispatch(third)
 	dispatch(third) // redelivery still applies exactly once
 	if got := ownerOf(third); got == nil || *got != e.Rep3 {

--- a/backend/internal/compose/integration/writeauthority_integration_test.go
+++ b/backend/internal/compose/integration/writeauthority_integration_test.go
@@ -172,9 +172,9 @@ func TestAReadShareCannotArchiveOrEraseThePersonItOpens(t *testing.T) {
 // and it changes what the pipeline says a lead is worth.
 func TestAReadShareOfALeadCannotScoreIt(t *testing.T) {
 	e := SetupSearch(t)
-	lead := e.Seed(t,
-		`INSERT INTO lead (id, workspace_id, full_name, owner_id, source, captured_by)
-		 VALUES ($1, $2, 'Shared Lead', $3, 'manual', 'human:x')`, e.Rep3)
+	lead := e.SeedID(t,
+		`INSERT INTO lead (id, full_name, owner_id, source, captured_by)
+		 VALUES ($1, 'Shared Lead', $2, 'manual', 'human:x')`, e.Rep3)
 	owner := leadActor(e, e.Rep3, principal.RowScopeOwn, nil)
 	holder := leadActor(e, e.Rep1, principal.RowScopeTeam, []ids.UUID{e.Team1})
 	store := people.NewStore(e.DB())

--- a/backend/internal/compose/leadsla_integration_test.go
+++ b/backend/internal/compose/leadsla_integration_test.go
@@ -32,8 +32,8 @@ func TestLeadSLAEscalationLogsOneTaskOnTheLead(t *testing.T) {
 	owner := integration.OwnerConn(t)
 	lead := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO lead (id, workspace_id, full_name, status, source, captured_by, owner_id)
-		 VALUES ($1, $2, 'Overdue Lead', 'new', 'inbound', 'human:x', $3)`, lead, e.WS, e.Rep1); err != nil {
+		`INSERT INTO lead (id, full_name, status, source, captured_by, owner_id)
+		 VALUES ($1, 'Overdue Lead', 'new', 'inbound', 'human:x', $2)`, lead, e.Rep1); err != nil {
 		t.Fatal(err)
 	}
 	deadline := time.Date(2026, 8, 18, 9, 0, 0, 0, time.UTC)

--- a/backend/internal/compose/networktools_integration_test.go
+++ b/backend/internal/compose/networktools_integration_test.go
@@ -34,8 +34,8 @@ func employAt(t *testing.T, e *integration.Env, person, org ids.UUID) {
 	t.Helper()
 	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES (`+wsGUC+`, 'employment', $1, $2, 'manual', 'human:test')`, person, org)
+			INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+			VALUES ('employment', $1, $2, 'manual', 'human:test')`, person, org)
 		return err
 	}, "recording employment")
 }
@@ -64,7 +64,7 @@ func TestIntroPathNamesBothEndsOfTheRouteAndSaysWhenItWasCapped(t *testing.T) {
 	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
 			INSERT INTO organization (display_name, source, captured_by)
-			VALUES ( 'Acme GmbH', 'manual', 'human:test') RETURNING id`).Scan(&orgID)
+			VALUES ('Acme GmbH', 'manual', 'human:test') RETURNING id`).Scan(&orgID)
 	}, "seeding the account")
 	person, err := e.People.CreatePerson(ctx, people.CreatePersonInput{
 		FullName: "Jonas Bach", Source: "manual",
@@ -187,18 +187,18 @@ func seedOpenDeal(t *testing.T, e *integration.Env) ids.UUID {
 	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
 		var pipelineID, stageID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO pipeline (name) VALUES ( 'At-risk test')
+			INSERT INTO pipeline (name) VALUES ('At-risk test')
 			RETURNING id`).Scan(&pipelineID); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO stage (pipeline_id, name, position)
-			VALUES ( $1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
+			VALUES ($1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
 			return err
 		}
 		return tx.QueryRow(ctx, `
 			INSERT INTO deal (name, stage_id, pipeline_id, owner_id, source, captured_by)
-			VALUES ( 'Threadless', $1, $2, $3, 'manual', 'human:test')
+			VALUES ('Threadless', $1, $2, $3, 'manual', 'human:test')
 			RETURNING id`, stageID, pipelineID, e.Rep1).Scan(&dealID)
 	}, "seeding the deal")
 	return dealID

--- a/backend/internal/compose/orgnamepromotion_integration_test.go
+++ b/backend/internal/compose/orgnamepromotion_integration_test.go
@@ -53,14 +53,13 @@ func seedSigningEmployee(t *testing.T, e *integration.Env, org ids.UUID, fullNam
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO relationship (workspace_id, kind, person_id, organization_id, is_current_primary, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, true, 'gmail:seed', 'connector:gmail')`,
-			e.WS, person, org); err != nil {
+			INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
+			VALUES ('employment', $1, $2, true, 'gmail:seed', 'connector:gmail')`, person, org); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
-			VALUES ( $1, 'org_name', $2, $2, 'activity:seed', 0.9, 'capture_enrich', 'agent:enrich')`, person, signedName)
+			VALUES ($1, 'org_name', $2, $2, 'activity:seed', 0.9, 'capture_enrich', 'agent:enrich')`, person, signedName)
 		return err
 	})
 	if err != nil {
@@ -75,7 +74,7 @@ func seedDossierName(t *testing.T, e *integration.Env, org ids.UUID, legalName s
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO organization_profile_field (organization_id, field, value, evidence_snippet, source_url, confidence, source, captured_by)
-		VALUES ( $1, 'legal_name', $2, $2, 'https://gitex.example', 0.9, 'site_read', 'agent:siteread')`,
+		VALUES ($1, 'legal_name', $2, $2, 'https://gitex.example', 0.9, 'site_read', 'agent:siteread')`,
 		org, legalName)
 }
 

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -125,21 +125,10 @@ func setupForecast(t *testing.T) *forecastEnv {
 	return e
 }
 
-// seed writes rows through the owner connection: these suites test READ
-// semantics; the write shape has its own suites.
-func (e *forecastEnv) seed(t *testing.T, sql string, args ...any) ids.UUID {
-	t.Helper()
-	id := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(), sql, append([]any{id, e.WS}, args...)...); err != nil {
-		t.Fatalf("seeding: %v", err)
-	}
-	return id
-}
-
-// seedID is seed for a table that no longer has a workspace to bind — it mints
-// the id and nothing else. ADR-0091 §8 phase D removes the column table by
-// table, so this env seeds some of its fixtures one way and some the other
-// until the last one goes.
+// seedID writes rows through the owner connection, minting the id and nothing
+// else: these suites test READ semantics, and the write shape has its own
+// suites. No workspace is bound because none of the tables these fixtures reach
+// still carries one (ADR-0091 §8 phase D).
 func (e *forecastEnv) seedID(t *testing.T, sql string, args ...any) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
@@ -351,8 +340,8 @@ func TestForecastByOwnerCountsAMultiStakeholderDealOnce(t *testing.T) {
 	dealID := e.seedOpenDeal(t, "Two champions", 60, &e.Rep1, int64p(50000), stringp("commit"))
 	for _, role := range []string{"champion", "economic_buyer"} {
 		personID := e.seedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`, "Stakeholder "+role)
-		e.seed(t, `INSERT INTO relationship (id, workspace_id, kind, deal_id, person_id, role, source, captured_by)
-			VALUES ($1, $2, 'deal_stakeholder', $3, $4, $5, 'manual', 'human:x')`, dealID, personID, role)
+		e.seedID(t, `INSERT INTO relationship (id, kind, deal_id, person_id, role, source, captured_by)
+			VALUES ($1, 'deal_stakeholder', $2, $3, $4, 'manual', 'human:x')`, dealID, personID, role)
 	}
 
 	result := e.runReport(e.Admin(), t, "forecast", `{"group_by":["owner_id"]}`)

--- a/backend/internal/compose/sitepersonfields_integration_test.go
+++ b/backend/internal/compose/sitepersonfields_integration_test.go
@@ -35,14 +35,13 @@ func seatEmployee(t *testing.T, e *integration.Env, org ids.UUID, fullName, emai
 		if email != "" {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO person_email (person_id, email, email_type, is_primary, source, captured_by)
-				VALUES ( $1, $2, 'work', true, 'gmail:seed', 'connector:gmail')`, person, email); err != nil {
+				VALUES ($1, $2, 'work', true, 'gmail:seed', 'connector:gmail')`, person, email); err != nil {
 				return err
 			}
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO relationship (workspace_id, kind, person_id, organization_id, is_current_primary, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, true, 'gmail:seed', 'connector:gmail')`,
-			e.WS, person, org)
+			INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
+			VALUES ('employment', $1, $2, true, 'gmail:seed', 'connector:gmail')`, person, org)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/activities/timelinescope_integration_test.go
+++ b/backend/internal/modules/activities/timelinescope_integration_test.go
@@ -34,9 +34,9 @@ func TestNarrowingTheTimelineToAnUnreadableLeadAnswersNotFound(t *testing.T) {
 	e := setupPromises(t)
 	hiddenLeadID, visiblePersonID, activityID := ids.NewV7(), ids.NewV7(), ids.NewV7()
 
-	e.exec(t, `INSERT INTO lead (id, workspace_id, full_name, owner_id, source, captured_by)
-		VALUES ($1, $2, 'Hidden Prospect', $3, 'seed', 'system')`,
-		hiddenLeadID, e.ws, e.other)
+	e.exec(t, `INSERT INTO lead (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Hidden Prospect', $2, 'seed', 'system')`,
+		hiddenLeadID, e.other)
 	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
 		VALUES ($1, 'Visible Contact', $2, 'seed', 'system')`,
 		visiblePersonID, e.rep)
@@ -70,8 +70,8 @@ func TestNarrowingTheTimelineToAReadableLeadReturnsIt(t *testing.T) {
 	e := setupPromises(t)
 	ownLeadID, activityID := ids.NewV7(), ids.NewV7()
 
-	e.exec(t, `INSERT INTO lead (id, workspace_id, full_name, owner_id, source, captured_by)
-		VALUES ($1, $2, 'My Prospect', $3, 'seed', 'system')`, ownLeadID, e.ws, e.rep)
+	e.exec(t, `INSERT INTO lead (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'My Prospect', $2, 'seed', 'system')`, ownLeadID, e.rep)
 	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, 'note', 'Asked for a Q4 quote', now(), 'seed', 'system')`,
 		activityID)

--- a/backend/internal/modules/automation/automationpreview_integration_test.go
+++ b/backend/internal/modules/automation/automationpreview_integration_test.go
@@ -76,7 +76,7 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 	moveAt := func(stage ids.UUID, at time.Time) {
 		fx.exec(t, `
 			INSERT INTO deal_stage_history (deal_id, to_stage_id, changed_by, changed_at)
-			VALUES ( $1, $2, 'human:test', $3)`, board.ownDeal, stage, at)
+			VALUES ($1, $2, 'human:test', $3)`, board.ownDeal, stage, at)
 	}
 	moveAt(board.openStage, now.AddDate(0, 0, -1))
 	moveAt(board.openStage, now.AddDate(0, 0, -5))
@@ -129,10 +129,10 @@ func TestPreviewDraftOverrideAndValidation(t *testing.T) {
 	autoID := fx.seedAutomation(t, "stage_change_create_task")
 	ctx := fx.humanCtx(fx.rep1, principal.RowScopeOwn)
 
-	fx.exec(t, `INSERT INTO lead (workspace_id, full_name, source, captured_by) VALUES ($1, 'Unrouted A', 'manual', 'human:test')`, fx.ws)
-	fx.exec(t, `INSERT INTO lead (workspace_id, full_name, source, captured_by) VALUES ($1, 'Unrouted B', 'manual', 'human:test')`, fx.ws)
-	fx.exec(t, `INSERT INTO lead (workspace_id, full_name, owner_id, status, source, captured_by) VALUES ($1, 'Routed', $2, 'working', 'manual', 'human:test')`, fx.ws, fx.rep2)
-	fx.exec(t, `INSERT INTO lead (workspace_id, full_name, status, source, captured_by) VALUES ($1, 'Dead', 'disqualified', 'manual', 'human:test')`, fx.ws)
+	fx.exec(t, `INSERT INTO lead (full_name, source, captured_by) VALUES ('Unrouted A', 'manual', 'human:test')`)
+	fx.exec(t, `INSERT INTO lead (full_name, source, captured_by) VALUES ('Unrouted B', 'manual', 'human:test')`)
+	fx.exec(t, `INSERT INTO lead (full_name, owner_id, status, source, captured_by) VALUES ('Routed', $1, 'working', 'manual', 'human:test')`, fx.rep2)
+	fx.exec(t, `INSERT INTO lead (full_name, status, source, captured_by) VALUES ('Dead', 'disqualified', 'manual', 'human:test')`)
 
 	// A draft override previews another recipe under the same stored
 	// instance's RBAC/404 anchor (the editor's preview-before-save).

--- a/backend/internal/modules/capture/sinklead.go
+++ b/backend/internal/modules/capture/sinklead.go
@@ -101,9 +101,8 @@ func (s *Sink) upsertLead(ctx context.Context, tx pgx.Tx, rec connector.Normaliz
 	}
 	var id ids.LeadID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO lead (workspace_id, full_name, email, company_name, title, source_system, source_id, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        NULLIF($1, ''), NULLIF(lower($2), ''), NULLIF($3, ''), NULLIF($4, ''), $5, $6, $7, $8)
+		INSERT INTO lead (full_name, email, company_name, title, source_system, source_id, source, captured_by)
+		VALUES (NULLIF($1, ''), NULLIF(lower($2), ''), NULLIF($3, ''), NULLIF($4, ''), $5, $6, $7, $8)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -87,9 +87,9 @@ func setupLeadConsent(t *testing.T) *leadConsentEnv {
 		t.Fatal(err)
 	}
 	if _, err := owner.Exec(ctx,
-		`INSERT INTO lead (id, workspace_id, full_name, email, status, source, captured_by)
-		 VALUES ($1, $2, 'Lena Lead', lower($3), 'working', 'inbound', 'human:x')`,
-		e.lead, e.ws, e.leadEmail); err != nil {
+		`INSERT INTO lead (id, full_name, email, status, source, captured_by)
+		 VALUES ($1, 'Lena Lead', lower($2), 'working', 'inbound', 'human:x')`,
+		e.lead, e.leadEmail); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/modules/customfields/candidates_integration_test.go
+++ b/backend/internal/modules/customfields/candidates_integration_test.go
@@ -134,9 +134,9 @@ func setupCandidates(t *testing.T) *candidatesFixture {
 func (f *candidatesFixture) seedLead(t *testing.T, value time.Time) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	query := `INSERT INTO lead (id, workspace_id, source, captured_by, ` + quoteIdentifier(f.dateCol) + `)
-		VALUES ($1, $2, 'ui', 'human:test', $3)`
-	if _, err := f.owner.Exec(context.Background(), query, id, f.ws, value); err != nil {
+	query := `INSERT INTO lead (id, source, captured_by, ` + quoteIdentifier(f.dateCol) + `)
+		VALUES ($1, 'ui', 'human:test', $2)`
+	if _, err := f.owner.Exec(context.Background(), query, id, value); err != nil {
 		t.Fatalf("seeding lead: %v", err)
 	}
 	return id

--- a/backend/internal/modules/people/conversationclaim.go
+++ b/backend/internal/modules/people/conversationclaim.go
@@ -105,11 +105,11 @@ func (s *Store) RecordConversationClaim(ctx context.Context, in ClaimInput) (crm
 		var id ids.UUID
 		err := tx.QueryRow(ctx, `
 			INSERT INTO conversation_claim
-				(workspace_id, person_id, kind, body, source_activity_id, source_quote,
+				(person_id, kind, body, source_activity_id, source_quote,
 				 due_at, evidence_fingerprint, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 			RETURNING id`,
-			storekit.MustWorkspace(ctx), in.PersonID, in.Kind, in.Body,
+			in.PersonID, in.Kind, in.Body,
 			in.ActivityID, in.Quote, in.DueAt,
 			claimFingerprint(in), in.Source, by).Scan(&id)
 		if err != nil {

--- a/backend/internal/modules/people/demote_integration_test.go
+++ b/backend/internal/modules/people/demote_integration_test.go
@@ -156,7 +156,7 @@ func TestDemoteRefusesWhenThePersonIsOnALiveDeal(t *testing.T) {
 		{`INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`, []any{pipeline}},
 		{`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, []any{stage, pipeline}},
 		{`INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, source, captured_by) VALUES ($1, $2, 'Rollout', $3, $4, 'manual', 'human:x')`, []any{deal, e.user, pipeline, stage}},
-		{`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, source, captured_by) VALUES ($1, 'deal_stakeholder', $2, $3, 'manual', 'human:x')`, []any{e.ws, ids.UUID(person.Id), deal}},
+		{`INSERT INTO relationship (kind, person_id, deal_id, source, captured_by) VALUES ('deal_stakeholder', $1, $2, 'manual', 'human:x')`, []any{ids.UUID(person.Id), deal}},
 	} {
 		if _, err := e.owner.Exec(ctx, q.sql, q.args...); err != nil {
 			t.Fatalf("seed deal graph: %v", err)

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -276,8 +276,8 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 		return 0, err
 	}
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO relationship (workspace_id, kind, person_id, organization_id, is_current_primary, source, captured_by)
-		SELECT $1, 'employment', p.id, $2, true, $3, $4
+		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
+		SELECT 'employment', p.id, $1, true, $2, $3
 		FROM person p
 		WHERE p.archived_at IS NULL
 		  AND p.merged_into_id IS NULL
@@ -288,15 +288,15 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 			  -- new employer: a former colleague would be re-hired by a domain
 			  -- they left.
 			  AND pe.archived_at IS NULL
-			  AND (split_part(pe.email, '@', 2) = $5
+			  AND (split_part(pe.email, '@', 2) = $4
 			       -- A literal suffix compare, never LIKE — see PersonsOnDomain.
-			       OR right(split_part(pe.email, '@', 2), length($5) + 1) = '.' || $5))
+			       OR right(split_part(pe.email, '@', 2), length($4) + 1) = '.' || $4))
 		  AND NOT EXISTS (
 			SELECT 1 FROM relationship r
 			WHERE r.kind = 'employment' AND r.person_id = p.id
 			  AND r.is_current_primary AND r.archived_at IS NULL)
 		ON CONFLICT DO NOTHING`,
-		workspaceID(ctx), orgID, domainTriageSource(domain), by, domain)
+		orgID, domainTriageSource(domain), by, domain)
 	if err != nil {
 		return 0, fmt.Errorf("people: planting the employment edges for %s: %w", domain, err)
 	}

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -66,13 +66,13 @@ func organizationIsLive(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 // guard; the NOT EXISTS keeps a concurrent race from surfacing as a 500.
 func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyInput, personID ids.PersonID, orgID ids.OrganizationID) error {
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO relationship (workspace_id, kind, person_id, organization_id, is_current_primary, source, captured_by)
-		SELECT $1, 'employment', $2, $3, true, $4, $5
+		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
+		SELECT 'employment', $1, $2, true, $3, $4
 		WHERE NOT EXISTS (
 			SELECT 1 FROM relationship
-			WHERE kind = 'employment' AND person_id = $2 AND is_current_primary AND archived_at IS NULL)
+			WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL)
 		ON CONFLICT DO NOTHING`,
-		workspaceID(ctx), personID, orgID, in.Source, in.CapturedBy); err != nil {
+		personID, orgID, in.Source, in.CapturedBy); err != nil {
 		return fmt.Errorf("people: insert employment edge: %w", err)
 	}
 	return nil

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -363,10 +363,10 @@ func recordDedupeCandidate(ctx context.Context, tx pgx.Tx, entityType string, a,
 		leftCol, rightCol = "left_lead_id", "right_lead_id"
 	}
 	tag, err := tx.Exec(ctx, fmt.Sprintf(`
-		INSERT INTO dedupe_candidate (workspace_id, entity_type, %s, %s, confidence, evidence, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO dedupe_candidate (entity_type, %s, %s, confidence, evidence, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT DO NOTHING`, leftCol, rightCol),
-		workspaceID(ctx), entityType, left, right, confidence, payload, source, by)
+		entityType, left, right, confidence, payload, source, by)
 	if err != nil {
 		return false, fmt.Errorf("people: recording dedupe candidate: %w", err)
 	}

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -171,13 +171,13 @@ func insertLeadRow(ctx context.Context, tx pgx.Tx, in CreateLeadInput, active []
 	// behavioral history yet; signal recompute moves it later.
 	fit := ScoreLeadDetail(deref(in.Title), in.Source, nil, time.Now().UTC())
 	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
-		id, workspaceID(ctx), in.FullName, in.Email, in.Title, in.CompanyName, in.CandidateOrgKey,
+		id, in.FullName, in.Email, in.Title, in.CompanyName, in.CandidateOrgKey,
 		in.LinkedInURL, in.Status, fit.Score, in.OwnerID, in.ProjectID, in.SourceSystem, in.SourceID, in.Source, by,
 	})
 	_, err := tx.Exec(ctx,
-		`INSERT INTO lead (id, workspace_id, full_name, email, title, company_name, candidate_org_key,
+		`INSERT INTO lead (id, full_name, email, title, company_name, candidate_org_key,
 		                   linkedin_url, status, score, owner_id, project_id, source_system, source_id, source, captured_by`+cfCols+`)
-		 VALUES ($1, $2, $3, lower($4), $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16`+cfHolders+`)`,
+		 VALUES ($1, $2, lower($3), $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15`+cfHolders+`)`,
 		args...)
 	if err != nil {
 		// Race behind the pre-checks: the constraint name tells an
@@ -240,8 +240,7 @@ func replayedLead(ctx context.Context, tx pgx.Tx, in CreateLeadInput, active []f
 	var existing ids.LeadID
 	err := tx.QueryRow(ctx,
 		`SELECT id FROM lead
-			  WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-			    AND source_system = $1 AND source_id = $2`,
+			  WHERE source_system = $1 AND source_id = $2`,
 		*in.SourceSystem, *in.SourceID).Scan(&existing)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil

--- a/backend/internal/modules/people/lead_read.go
+++ b/backend/internal/modules/people/lead_read.go
@@ -28,7 +28,7 @@ const liveOnlyClause = ` AND archived_at IS NULL`
 // from activity_link rather than storing them on the lead: the last touch,
 // and how many tasks are still open against it. Every lead read is FROM the
 // unaliased table, which is what lets them name lead.id.
-const leadColumns = `id, workspace_id, full_name, email, title, company_name, candidate_org_key,
+const leadColumns = `id, full_name, email, title, company_name, candidate_org_key,
 	linkedin_url, status, score, score_override_reason, score_computed, owner_id, project_id, source_system, source_id,
 	promoted_person_id, promoted_at, source, captured_by, version, created_at, updated_at, archived_at,
 	routed_at, first_response_at,
@@ -57,7 +57,7 @@ func readLead(ctx context.Context, tx pgx.Tx, id ids.LeadID, archived storekit.A
 // __cursor_key there, exactly as scanPerson does.
 func scanLead(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontracts.Lead, error) {
 	var l crmcontracts.Lead
-	var id, wsID ids.UUID
+	var id ids.UUID
 	var ownerID, projectID, promotedPerson *ids.UUID
 	var email *string
 	var status string
@@ -65,7 +65,7 @@ func scanLead(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontr
 	var openTasks int
 
 	dests := []any{
-		&id, &wsID, &l.FullName, &email, &l.Title, &l.CompanyName, &l.CandidateOrgKey,
+		&id, &l.FullName, &email, &l.Title, &l.CompanyName, &l.CandidateOrgKey,
 		&l.LinkedinUrl, &status, &l.Score, &l.ScoreOverrideReason, &l.ScoreComputed, &ownerID, &projectID, &l.SourceSystem, &l.SourceId,
 		&promotedPerson, &l.PromotedAt, &l.Source, &l.CapturedBy, &version, &l.CreatedAt, &l.UpdatedAt, &l.ArchivedAt,
 		&l.RoutedAt, &l.FirstResponseAt, &l.LastActivityAt, &openTasks,

--- a/backend/internal/modules/people/leaddedupe.go
+++ b/backend/internal/modules/people/leaddedupe.go
@@ -97,8 +97,7 @@ func (s *Store) fuzzyLead(ctx context.Context, tx pgx.Tx, lead crmcontracts.Lead
 	rows, err := tx.Query(ctx, `
 		SELECT id, full_name, company_name, coalesce(split_part(email, '@', 2), '')
 		  FROM lead
-		 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND archived_at IS NULL AND id <> $1
+		 WHERE archived_at IS NULL AND id <> $1
 		   AND (f_fold_apostrophes(lower(coalesce(full_name, ''))) % f_fold_apostrophes(lower($2))
 		        OR ($3 <> '' AND lower(company_name) = lower($3))
 		        OR ($4 <> '' AND lower(split_part(email, '@', 2)) = $4))`,

--- a/backend/internal/modules/people/leadlinkedin_integration_test.go
+++ b/backend/internal/modules/people/leadlinkedin_integration_test.go
@@ -158,7 +158,7 @@ func TestLeadLinkedInRefusesNonURLsAsTheCallersFault(t *testing.T) {
 	}); !errors.As(err, &parseErr) {
 		t.Fatalf("create with a non-http URL → %v, want a values.ParseError (422)", err)
 	}
-	if n := e.count(t, `SELECT count(*) FROM lead WHERE workspace_id = $1`, e.ws); n != 0 {
+	if n := e.count(t, `SELECT count(*) FROM lead`); n != 0 {
 		t.Fatalf("a refused create left %d lead rows", n)
 	}
 	if _, err := e.store.FindLeadByLinkedInURL(ctx, "://nope"); !errors.As(err, &parseErr) {

--- a/backend/internal/modules/people/leadrouting.go
+++ b/backend/internal/modules/people/leadrouting.go
@@ -259,7 +259,7 @@ func ownerCapacity(ctx context.Context, tx pgx.Tx, candidates []ids.UserID) (act
 	rows, err := tx.Query(ctx, `
 		SELECT u.id, count(l.id)
 		  FROM app_user u
-		  LEFT JOIN lead l ON l.workspace_id = u.workspace_id AND l.owner_id = u.id
+		  LEFT JOIN lead l ON l.owner_id = u.id
 		       AND l.status IN ('new','working') AND l.archived_at IS NULL
 		 WHERE u.id = ANY($1) AND u.status = 'active' AND u.archived_at IS NULL
 		 GROUP BY u.id`, candidates)

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -27,9 +27,9 @@ func (e *promoteConsentEnv) seedLeadCreatedAt(t *testing.T, email string, create
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO lead (id, workspace_id, full_name, email, status, source, captured_by, owner_id, created_at)
-		 VALUES ($1, $2, 'Lena Lead', lower($3), 'new', 'inbound', 'human:x', $4, $5)`,
-		id, e.ws, email, e.user, createdAt); err != nil {
+		`INSERT INTO lead (id, full_name, email, status, source, captured_by, owner_id, created_at)
+		 VALUES ($1, 'Lena Lead', lower($2), 'new', 'inbound', 'human:x', $3, $4)`,
+		id, email, e.user, createdAt); err != nil {
 		t.Fatal(err)
 	}
 	return ids.From[ids.LeadKind](id)

--- a/backend/internal/modules/people/linkedin_integration_test.go
+++ b/backend/internal/modules/people/linkedin_integration_test.go
@@ -205,7 +205,7 @@ func (e *dedupeEnv) seedEmail(t *testing.T, person ids.PersonID, email string) {
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-			VALUES ( $1, $2, true, 'manual', 'human:test')`, person, email)
+			VALUES ($1, $2, true, 'manual', 'human:test')`, person, email)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding email for %s: %v", person, err)
@@ -218,8 +218,8 @@ func (e *dedupeEnv) employ(t *testing.T, person ids.PersonID, org ids.Organizati
 	ctx := e.as()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
-			VALUES ($1, 'employment', $2, $3, 'manual', 'human:test')`, e.ws, person, org)
+			INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+			VALUES ('employment', $1, $2, 'manual', 'human:test')`, person, org)
 		return err
 	}); err != nil {
 		t.Fatalf("employing %s: %v", person, err)

--- a/backend/internal/modules/people/partner.go
+++ b/backend/internal/modules/people/partner.go
@@ -255,12 +255,11 @@ func upsertPartnerRow(ctx context.Context, tx pgx.Tx, in UpsertPartnerInput, fit
 		segments = *in.ServedSegments
 	}
 	row := tx.QueryRow(ctx, `
-		INSERT INTO partner (workspace_id, organization_id, partner_role, cert_status, margin_tier,
+		INSERT INTO partner (organization_id, partner_role, cert_status, margin_tier,
 		                     certified_staff, retention_rate, relationship_stage, next_step,
 		                     next_step_due_at, served_segments, partner_fit_score,
 		                     partner_fit_score_computed, partner_fit_override_reason, source, captured_by)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, coalesce($3, 'applied'), $4, coalesce($5, 0), $6,
+		VALUES ($1, $2, coalesce($3, 'applied'), $4, coalesce($5, 0), $6,
 		        coalesce($8, 'research'), $9, $10, $11, $12, $13, $14, 'manual', $7)
 		ON CONFLICT (organization_id) DO UPDATE SET
 		  partner_role = EXCLUDED.partner_role,

--- a/backend/internal/modules/people/promoteconsent_integration_test.go
+++ b/backend/internal/modules/people/promoteconsent_integration_test.go
@@ -114,9 +114,9 @@ func (e *promoteConsentEnv) seedLead(t *testing.T, email string) ids.LeadID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO lead (id, workspace_id, full_name, email, status, source, captured_by)
-		 VALUES ($1, $2, 'Lena Lead', lower($3), 'working', 'inbound', 'human:x')`,
-		id, e.ws, email); err != nil {
+		`INSERT INTO lead (id, full_name, email, status, source, captured_by)
+		 VALUES ($1, 'Lena Lead', lower($2), 'working', 'inbound', 'human:x')`,
+		id, email); err != nil {
 		t.Fatal(err)
 	}
 	return ids.From[ids.LeadKind](id)

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -49,12 +49,11 @@ var relationshipKinds = map[string]bool{
 	"partner_of": true, "referred_by": true, "co_sell_with": true,
 }
 
-const relationshipColumns = `id, workspace_id, kind, person_id, organization_id, counterparty_org_id, deal_id, project_id,
+const relationshipColumns = `id, kind, person_id, organization_id, counterparty_org_id, deal_id, project_id,
 	role, is_current_primary, started_at, ended_at, source, captured_by, version, created_at, updated_at, archived_at`
 
 type relationshipRow struct {
 	ID                ids.UUID // no RelationshipKind in the kernel vocabulary: edges stay untyped
-	WorkspaceID       ids.WorkspaceID
 	Kind              string
 	PersonID          *ids.PersonID
 	OrganizationID    *ids.OrganizationID
@@ -75,7 +74,7 @@ type relationshipRow struct {
 
 func scanRelationship(r pgx.Row) (relationshipRow, error) {
 	var out relationshipRow
-	err := r.Scan(&out.ID, &out.WorkspaceID, &out.Kind, &out.PersonID, &out.OrganizationID, &out.CounterpartyOrgID,
+	err := r.Scan(&out.ID, &out.Kind, &out.PersonID, &out.OrganizationID, &out.CounterpartyOrgID,
 		&out.DealID, &out.ProjectID, &out.Role, &out.IsCurrentPrimary, &out.StartedAt, &out.EndedAt,
 		&out.Source, &out.CapturedBy, &out.Version, &out.CreatedAt, &out.UpdatedAt, &out.ArchivedAt)
 	return out, err
@@ -137,10 +136,9 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 			}
 		}
 		row := tx.QueryRow(ctx, `
-			INSERT INTO relationship (workspace_id, kind, person_id, organization_id, counterparty_org_id,
+			INSERT INTO relationship (kind, person_id, organization_id, counterparty_org_id,
 			                          deal_id, project_id, role, is_current_primary, started_at, ended_at, source, captured_by)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 			RETURNING `+relationshipColumns,
 			in.Kind, in.PersonID, in.OrganizationID, in.CounterpartyOrgID, in.DealID, in.ProjectID,
 			in.Role, in.IsCurrentPrimary, in.StartedAt, in.EndedAt, in.Source, capturedBy)

--- a/backend/internal/modules/people/siteread.go
+++ b/backend/internal/modules/people/siteread.go
@@ -206,11 +206,11 @@ func (s *Store) createOrJoinSiteRead(ctx context.Context, orgID *ids.Organizatio
 		// transaction alive, so the join SELECT below sees the winning row
 		// in the same tx — no second-transaction gap for it to finish in.
 		inserted := tx.QueryRow(ctx, `
-			INSERT INTO site_read (id, workspace_id, organization_id, target_kind, seed_url, requested_by)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO site_read (id, organization_id, target_kind, seed_url, requested_by)
+			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT DO NOTHING
 			RETURNING `+siteReadColumns,
-			readID, workspaceID(ctx), orgID, targetKind, seedURL, requestedBy)
+			readID, orgID, targetKind, seedURL, requestedBy)
 		var err error
 		out, err = scanSiteRead(inserted)
 		if err == nil {

--- a/backend/internal/modules/privacy/retentionselectors.go
+++ b/backend/internal/modules/privacy/retentionselectors.go
@@ -19,8 +19,7 @@ package privacy
 // activities, the holds of every linked record plus the statutory floor.
 var retentionSelectors = map[string]string{
 	"lead/unconverted": `SELECT id FROM lead
-		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		  AND status IN ('new','working') AND archived_at IS NULL AND NOT legal_hold
+		WHERE status IN ('new','working') AND archived_at IS NULL AND NOT legal_hold
 		  AND full_name IS DISTINCT FROM 'Anonymized Lead'
 		  AND created_at < now() - make_interval(days => $1) LIMIT $2`,
 	"activity/": `SELECT a.id FROM activity a

--- a/backend/internal/modules/search/pending.go
+++ b/backend/internal/modules/search/pending.go
@@ -27,13 +27,6 @@ import (
 type pendingSource struct {
 	table string
 	text  string // expression over the aliased table t
-	// tenantScoped says whether this table still carries workspace_id.
-	// ADR-0091 §8 phase D removes it table by table, and this query is ONE
-	// statement templated over all six — so the predicate has to be per-source
-	// while they disagree, or it fails outright for whichever has already lost
-	// the column. Every entry goes false as its slice lands, and the field goes
-	// with the last one.
-	tenantScoped bool
 }
 
 // pendingSources is the set-form counterpart to embedgen.go's embedText —
@@ -45,17 +38,20 @@ var pendingSources = map[string]pendingSource{
 	entityPerson:       {table: entityPerson, text: "t.full_name"},
 	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)"},
 	entityDeal:         {table: entityDeal, text: "t.name"},
-	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)", tenantScoped: true},
+	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)"},
 	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)"},
 	entityProject:      {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},
 }
 
-// PendingByWorkspace is the per-workspace count of live, non-empty-text
-// embeddable entities that lack a current-identity embedding row — the
-// same set EntitiesPending totals and TokenSumByWorkspace prices. system-
-// principal enumeration (mirrors embedgen.go:51-56): this is an index-
-// maintenance rollup, not a user-facing read, so it must see every live
-// entity regardless of any one caller's row scope.
+// PendingByWorkspace is what a re-embed pass for each enumerated workspace will
+// rebuild: live, non-empty-text embeddable entities lacking a current-identity
+// embedding row. Since phase D every entry holds the SAME number — no entity
+// table carries a tenant, so every pass rebuilds the installation's one corpus
+// — and the map collapses to a single figure when the fan-out does. Do not sum
+// it for a total; EntitiesPending says why. system-principal enumeration
+// (mirrors embedgen.go:51-56): this is an index-maintenance rollup, not a
+// user-facing read, so it must see every live entity regardless of any one
+// caller's row scope.
 func (s *Store) PendingByWorkspace(ctx context.Context, currentIdentity string) (map[ids.WorkspaceID]int, error) {
 	counts, _, err := s.pendingStats(ctx, currentIdentity)
 	return counts, err
@@ -73,18 +69,36 @@ func (s *Store) TokenSumByWorkspace(ctx context.Context, currentIdentity string)
 	return tokens, err
 }
 
-// EntitiesPending is the fleet-wide total — the sum of PendingByWorkspace,
-// and the second operand of ReindexNeeded's OR.
+// EntitiesPending is the installation's backlog, and it is deliberately NOT the
+// sum of PendingByWorkspace. Since ADR-0091 §8 phase D no embeddable entity
+// carries a tenant, so every workspace's rollup is the SAME set of rows;
+// summing would multiply the backlog by the number of workspaces enumerated and
+// report an installation with two of them as having twice the work. That number
+// reaches an operator as `entities_pending` and prices the re-embed's token
+// estimate, so the exaggeration would be a bill, not just a display.
+//
+// One pass, therefore, over the same query the per-workspace rollup runs. It is
+// the second operand of ReindexNeeded's OR, which only asks whether the count
+// is above zero — but the status read shows the figure itself.
 func (s *Store) EntitiesPending(ctx context.Context, currentIdentity string) (int, error) {
-	counts, err := s.PendingByWorkspace(ctx, currentIdentity)
+	count, _, err := s.installationPending(ctx, currentIdentity)
+	return count, err
+}
+
+// installationPending counts the backlog once, as the system principal and
+// bound to no particular tenant — which is what every entity table now is.
+func (s *Store) installationPending(ctx context.Context, currentIdentity string) (int, int64, error) {
+	workspaces, err := s.fleetWorkspaceIDs(ctx)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	total := 0
-	for _, c := range counts {
-		total += c
+	if len(workspaces) == 0 {
+		return 0, 0, nil
 	}
-	return total, nil
+	// Any workspace answers for the installation, because the query names none;
+	// the binding exists only so the read has a store handle to run through.
+	return s.forWorkspace(workspaces[0]).workspacePending(
+		systemWorkspaceContext(ctx, workspaces[0].UUID), currentIdentity)
 }
 
 // pendingStats enumerates the fleet and, per workspace, counts and sums
@@ -128,32 +142,21 @@ func (s *Store) pendingStats(ctx context.Context, currentIdentity string) (map[i
 func (s *Store) workspacePending(ctx context.Context, currentIdentity string) (count int, length int64, err error) {
 	txErr := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		for entityType, src := range pendingSources {
-			// The workspace predicates are the query's own — tenant isolation
-			// used to supply them, so this counted one tenant's backlog without
-			// saying so, and an unscoped count reports the whole installation's
-			// under every workspace the caller enumerates. They are conditional
-			// only because phase D has reached some of these tables and not
-			// others; see pendingSource.tenantScoped.
-			// Two fragments, not one: the entity predicate belongs in the OUTER
-			// where, and the embedding leg inside the NOT EXISTS. Folding the
-			// entity predicate into the subquery would invert it — a row of
-			// another workspace would match nothing there, so NOT EXISTS would
-			// be true and the row would be counted rather than excluded.
-			entityScope, embeddingScope := "", ""
-			if src.tenantScoped {
-				entityScope = `
-				  AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-				embeddingScope = ` AND e.workspace_id = t.workspace_id`
-			}
+			// Every embeddable entity is installation-wide since ADR-0091 §8
+			// phase D, so the backlog has no tenant to narrow to: one embedding
+			// at the current identity covers a row wherever this rollup counts
+			// it. The per-workspace shape survives only because the re-embed
+			// fan-out still enqueues one pass per workspace; the two collapse
+			// together.
 			sql := fmt.Sprintf(`
 				SELECT count(*), coalesce(sum(octet_length(btrim(%s))), 0)
 				FROM %s t
 				WHERE t.archived_at IS NULL
-				  AND btrim(%s) <> ''%s
+				  AND btrim(%s) <> ''
 				  AND NOT EXISTS (
 				        SELECT 1 FROM embedding e
-				        WHERE e.entity_type = '%s' AND e.entity_id = t.id AND e.model = $1%s)`,
-				src.text, src.table, src.text, entityScope, entityType, embeddingScope)
+				        WHERE e.entity_type = '%s' AND e.entity_id = t.id AND e.model = $1)`,
+				src.text, src.table, src.text, entityType)
 			var c int
 			var l int64
 			if err := tx.QueryRow(ctx, sql, currentIdentity).Scan(&c, &l); err != nil {

--- a/backend/internal/modules/search/reembed.go
+++ b/backend/internal/modules/search/reembed.go
@@ -149,20 +149,13 @@ type liveEntity struct {
 func (s *Store) liveEntitiesOf(ctx context.Context, entityType string, src pendingSource) ([]liveEntity, error) {
 	var items []liveEntity
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// Scoped by the query itself, and conditionally: tenant isolation used
-		// to bound this scan, so a re-embed pass has to say so or it rebuilds
-		// the whole installation's index under every workspace it is given.
-		// The condition is pendingSource.tenantScoped's — phase D has reached
-		// some of these tables and not others, and one templated statement
-		// cannot spell a predicate for a column half of them no longer have.
-		scope := ""
-		if src.tenantScoped {
-			scope = `
-			   AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-		}
+		// Unscoped, because since ADR-0091 §8 phase D every embeddable entity
+		// is installation-wide: there is no narrower set for a pass to rebuild.
+		// A pass given a workspace therefore rebuilds the same rows as a pass
+		// given any other, which is what makes the fan-out collapsible.
 		sql := fmt.Sprintf(`SELECT t.id, %s FROM %s t
-			 WHERE t.archived_at IS NULL%s`,
-			src.text, src.table, scope)
+			 WHERE t.archived_at IS NULL`,
+			src.text, src.table)
 		rows, err := tx.Query(ctx, sql)
 		if err != nil {
 			return fmt.Errorf("search: selecting live %s rows: %w", entityType, err)

--- a/backend/internal/platform/database/storekit/leadidentity.go
+++ b/backend/internal/platform/database/storekit/leadidentity.go
@@ -73,12 +73,7 @@ func liveLeadBy(ctx context.Context, tx pgx.Tx, predicate, value string, exclude
 	var id ids.LeadID
 	err := tx.QueryRow(ctx, `
 		SELECT id FROM lead
-		 -- The workspace predicate is the probe's own. Tenant isolation used to
-		 -- bound it, so "the live lead holding this address" meant this
-		 -- workspace's; without it a create is refused as a duplicate because
-		 -- ANOTHER workspace holds the address (ADR-0091 §8 phase A).
-		 WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND `+predicate+` AND archived_at IS NULL
+		 WHERE `+predicate+` AND archived_at IS NULL
 		   AND ($2::text IS NULL
 		        OR source_system IS DISTINCT FROM $2
 		        OR source_id IS DISTINCT FROM $3)

--- a/backend/migrations/core/1787050735_records_drop_workspace.down.sql
+++ b/backend/migrations/core/1787050735_records_drop_workspace.down.sql
@@ -1,0 +1,103 @@
+-- Reverse of 1787050735: the lead, relationship and partner cluster carries the
+-- tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE lead ADD COLUMN workspace_id uuid;
+ALTER TABLE relationship ADD COLUMN workspace_id uuid;
+ALTER TABLE partner ADD COLUMN workspace_id uuid;
+ALTER TABLE dedupe_candidate ADD COLUMN workspace_id uuid;
+ALTER TABLE site_read ADD COLUMN workspace_id uuid;
+ALTER TABLE conversation_claim ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'lead', 'relationship', 'partner',
+    'dedupe_candidate', 'site_read', 'conversation_claim'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE lead ADD CONSTRAINT lead_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE relationship ADD CONSTRAINT relationship_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE partner ADD CONSTRAINT partner_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE dedupe_candidate ADD CONSTRAINT dedupe_candidate_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE site_read ADD CONSTRAINT site_read_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE conversation_claim ADD CONSTRAINT conversation_claim_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_lead_ws_live;
+DROP INDEX idx_lead_owner;
+DROP INDEX idx_lead_score;
+DROP INDEX idx_lead_cand_org;
+DROP INDEX idx_lead_linkedin;
+DROP INDEX idx_lead_project;
+DROP INDEX idx_rel_org_people;
+DROP INDEX idx_rel_deal_stakeholders;
+DROP INDEX idx_rel_partner_counterparty;
+DROP INDEX idx_rel_partner_org;
+DROP INDEX idx_rel_project_stakeholders;
+DROP INDEX idx_partner_tier;
+DROP INDEX idx_partner_stage;
+DROP INDEX idx_dedupe_candidate_open;
+DROP INDEX idx_site_read_org;
+DROP INDEX idx_site_read_retry_due;
+DROP INDEX conversation_claim_person_ix;
+DROP INDEX conversation_claim_activity_ix;
+
+CREATE INDEX idx_lead_ws_live ON lead (workspace_id, status) WHERE archived_at IS NULL;
+CREATE INDEX idx_lead_owner ON lead (workspace_id, owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_lead_score ON lead (workspace_id, score DESC)
+  WHERE archived_at IS NULL AND status = ANY (ARRAY['new', 'working']);
+CREATE INDEX idx_lead_cand_org ON lead (workspace_id, candidate_org_key)
+  WHERE candidate_org_key IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_lead_linkedin ON lead (workspace_id, linkedin_url) WHERE linkedin_url IS NOT NULL;
+CREATE INDEX idx_lead_project ON lead (workspace_id, project_id)
+  WHERE project_id IS NOT NULL AND archived_at IS NULL;
+
+CREATE INDEX idx_rel_org_people ON relationship (workspace_id, organization_id)
+  WHERE kind = 'employment' AND archived_at IS NULL;
+CREATE INDEX idx_rel_deal_stakeholders ON relationship (workspace_id, deal_id)
+  WHERE kind = 'deal_stakeholder' AND archived_at IS NULL;
+CREATE INDEX idx_rel_partner_counterparty ON relationship (workspace_id, counterparty_org_id)
+  WHERE kind = ANY (ARRAY['partner_of', 'referred_by', 'co_sell_with']) AND archived_at IS NULL;
+CREATE INDEX idx_rel_partner_org ON relationship (workspace_id, organization_id)
+  WHERE kind = ANY (ARRAY['partner_of', 'referred_by', 'co_sell_with']) AND archived_at IS NULL;
+CREATE INDEX idx_rel_project_stakeholders ON relationship (workspace_id, project_id)
+  WHERE kind = 'project_stakeholder' AND archived_at IS NULL;
+
+CREATE INDEX idx_partner_ws_live ON partner (workspace_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_partner_tier ON partner (workspace_id, margin_tier) WHERE archived_at IS NULL;
+CREATE INDEX idx_partner_stage ON partner (workspace_id, relationship_stage) WHERE archived_at IS NULL;
+
+CREATE INDEX idx_dedupe_candidate_open ON dedupe_candidate (workspace_id, confidence DESC)
+  WHERE disposition = 'open' AND archived_at IS NULL;
+
+CREATE INDEX idx_site_read_org ON site_read (workspace_id, organization_id, created_at DESC);
+CREATE INDEX idx_site_read_retry_due ON site_read (workspace_id, next_attempt_at, id)
+  WHERE status = ANY (ARRAY['deferred', 'failed']) AND next_attempt_at IS NOT NULL;
+
+CREATE INDEX conversation_claim_person_ix ON conversation_claim (workspace_id, person_id, kind)
+  WHERE archived_at IS NULL;
+CREATE INDEX conversation_claim_activity_ix ON conversation_claim (workspace_id, source_activity_id)
+  WHERE archived_at IS NULL;

--- a/backend/migrations/core/1787050735_records_drop_workspace.up.sql
+++ b/backend/migrations/core/1787050735_records_drop_workspace.up.sql
@@ -1,0 +1,78 @@
+-- 1787050735: the lead, relationship and partner cluster drops the tenant column
+-- (ADR-0091 §8 phase D).
+--
+-- Six tables, all of them about a party the installation is dealing with or
+-- the edge between two of them:
+--
+--   lead                the unqualified prospect, before it is a contact
+--   relationship        the edge: employment, deal stakeholder, partner_of
+--   partner             the partner programme's own facts about an account
+--   dedupe_candidate    a proposed merge of two records, awaiting a verdict
+--   site_read           what the site reader fetched about an account
+--   conversation_claim  a claim a message made, filed against a contact
+--
+-- None of the six carries a phase-B leftover constraint: their keys already
+-- name something narrower than the tenant, and the only thing the column still
+-- held was its foreign key to workspace.
+
+ALTER TABLE conversation_claim DROP CONSTRAINT conversation_claim_workspace_id_fkey;
+ALTER TABLE conversation_claim DROP COLUMN workspace_id;
+
+ALTER TABLE site_read DROP CONSTRAINT site_read_workspace_id_fkey;
+ALTER TABLE site_read DROP COLUMN workspace_id;
+
+ALTER TABLE dedupe_candidate DROP CONSTRAINT dedupe_candidate_workspace_id_fkey;
+ALTER TABLE dedupe_candidate DROP COLUMN workspace_id;
+
+ALTER TABLE partner DROP CONSTRAINT partner_workspace_id_fkey;
+ALTER TABLE partner DROP COLUMN workspace_id;
+
+ALTER TABLE relationship DROP CONSTRAINT relationship_workspace_id_fkey;
+ALTER TABLE relationship DROP COLUMN workspace_id;
+
+ALTER TABLE lead DROP CONSTRAINT lead_workspace_id_fkey;
+ALTER TABLE lead DROP COLUMN workspace_id;
+
+-- The indexes that led with the column, recreated on what actually selects
+-- rows. Every predicate is carried over unchanged: what these serve did not
+-- change, only what they have to seek past to get there.
+--
+-- idx_lead_ws_live and idx_partner_ws_live are NOT recreated on the tenant —
+-- the first becomes an index on status alone, the second was (workspace_id)
+-- WHERE archived_at IS NULL and an index on the tenant alone has no narrowed
+-- form at all.
+CREATE INDEX idx_lead_ws_live ON lead (status) WHERE archived_at IS NULL;
+CREATE INDEX idx_lead_owner ON lead (owner_id) WHERE archived_at IS NULL;
+CREATE INDEX idx_lead_score ON lead (score DESC)
+  WHERE archived_at IS NULL AND status = ANY (ARRAY['new', 'working']);
+CREATE INDEX idx_lead_cand_org ON lead (candidate_org_key)
+  WHERE candidate_org_key IS NOT NULL AND archived_at IS NULL;
+CREATE INDEX idx_lead_linkedin ON lead (linkedin_url) WHERE linkedin_url IS NOT NULL;
+CREATE INDEX idx_lead_project ON lead (project_id)
+  WHERE project_id IS NOT NULL AND archived_at IS NULL;
+
+CREATE INDEX idx_rel_org_people ON relationship (organization_id)
+  WHERE kind = 'employment' AND archived_at IS NULL;
+CREATE INDEX idx_rel_deal_stakeholders ON relationship (deal_id)
+  WHERE kind = 'deal_stakeholder' AND archived_at IS NULL;
+CREATE INDEX idx_rel_partner_counterparty ON relationship (counterparty_org_id)
+  WHERE kind = ANY (ARRAY['partner_of', 'referred_by', 'co_sell_with']) AND archived_at IS NULL;
+CREATE INDEX idx_rel_partner_org ON relationship (organization_id)
+  WHERE kind = ANY (ARRAY['partner_of', 'referred_by', 'co_sell_with']) AND archived_at IS NULL;
+CREATE INDEX idx_rel_project_stakeholders ON relationship (project_id)
+  WHERE kind = 'project_stakeholder' AND archived_at IS NULL;
+
+CREATE INDEX idx_partner_tier ON partner (margin_tier) WHERE archived_at IS NULL;
+CREATE INDEX idx_partner_stage ON partner (relationship_stage) WHERE archived_at IS NULL;
+
+CREATE INDEX idx_dedupe_candidate_open ON dedupe_candidate (confidence DESC)
+  WHERE disposition = 'open' AND archived_at IS NULL;
+
+CREATE INDEX idx_site_read_org ON site_read (organization_id, created_at DESC);
+CREATE INDEX idx_site_read_retry_due ON site_read (next_attempt_at, id)
+  WHERE status = ANY (ARRAY['deferred', 'failed']) AND next_attempt_at IS NOT NULL;
+
+CREATE INDEX conversation_claim_person_ix ON conversation_claim (person_id, kind)
+  WHERE archived_at IS NULL;
+CREATE INDEX conversation_claim_activity_ix ON conversation_claim (source_activity_id)
+  WHERE archived_at IS NULL;

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -115,7 +115,7 @@ BEGIN
   UPDATE person       SET owner_id = admin_id WHERE owner_id IS NULL;
   UPDATE organization SET owner_id = admin_id WHERE owner_id IS NULL;
   UPDATE deal         SET owner_id = admin_id WHERE owner_id IS NULL;
-  UPDATE lead         SET owner_id = admin_id WHERE workspace_id = ws AND owner_id IS NULL;
+  UPDATE lead         SET owner_id = admin_id WHERE owner_id IS NULL;
 
   -- 2nd full-seat user so the Share picker / "who has access" have a real
   -- subject beyond the lone admin.


### PR DESCRIPTION
Stacked on #1720 (the person cluster), which is stacked on #1701. Review in
that order; this PR's diff against `main` collapses to its own commit once the
two below it merge.

Six tables lose `workspace_id` — `lead`, `relationship`, `partner`,
`dedupe_candidate`, `site_read`, `conversation_claim` — and the indexes that led
with it are narrowed to what they were actually seeking. None of the six carried
a phase-B leftover constraint: the only thing the column still held was its
foreign key to `workspace`.

## `lead` was the last tenant-scoped embeddable entity

Three per-source predicates that existed only to survive a half-migrated schema
become constant and go away entirely:

- search's `workspacePending` no longer templates a conditional scope,
- search's `liveEntitiesOf` scan is unscoped,
- compose's `flipTenantScope` is gone, and the flip reconciler's query is one
  statement again.

That is a real change in what a re-embed pass *means*, not just a
simplification: the corpus is the installation's, so a pass given one workspace
rebuilds the same rows as a pass given any other. **The per-workspace fan-out is
now redundant machinery over a single corpus** — collapsing it is ADR-0091's own
next step.

## One test assertion is removed, with the reason stated

`TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant` is
renamed and narrowed to what it can still prove. Its second half — that a tenant
whose embedding writes fail is the only child to fail — has no mechanism left:
an embedding row is keyed on `(entity_type, entity_id, chunk_ix)` alone since
phase B, so whichever child runs first rebuilds everything and the second finds
every row fresh, writes nothing, and cannot meet a write fault however
permanently it is armed. The assertion is removed with the reason written into
the test, not weakened in place so it keeps reading green.

`failEmbeddingWritesFor` is retargeted while it is here: its trigger keyed on the
ROW's `workspace_id`, which since phase B is whichever tenant happened to write
first. It now keys on the tenant the write is *running as*, which is what "this
tenant's writes cannot land" was always meant to say — and it makes the sibling
per-tenant-cost test deterministic rather than order-lucky.

## `scripts/seed-dev.sql`

Fixed here and on both PRs below: it is not Go, so the Go-literal sweeps every
slice has used never saw it, and `live-boot` is the only gate that runs it.
Three slices in a row shipped past it. Filed separately as a gate gap.

## Verification

- `make check-backend` — green
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor
- `scripts/seed-dev.sql` run end to end against this branch's schema, with an
  admin seeded so the owner-backfill block actually executes

Remaining phase-D tables after this lands: identity (`app_user`, `session`,
`role`, `team`, `passport`, `oauth_*`, …), search's own two, a handful of
singletons, and `audit_log`/`system_log` last.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops workspace_id from `lead`, `relationship`, `partner`, `dedupe_candidate`, `site_read`, and `conversation_claim`, making these records installation‑scoped. Re‑embed and pending are now installation‑wide (were per‑workspace), so fan‑out and per‑workspace sums are removed to prevent double counting.

**Impact and review notes**
- Removes tenant predicates and conditional templating: `search` pending and live scans are unscoped; `compose`’s tenant flip is deleted; owner capacity joins on `lead.owner_id` only; indexes narrowed to non‑tenant keys.
- Embedding: the corpus is installation‑wide; per‑workspace fan‑out dropped; the write‑fault trigger keys on the running tenant GUC; fan‑out test narrowed to one job per live workspace.
- Privacy/dedupe/probes: drops workspace filters from privacy retention selectors, `storekit` lead identity probes, and fuzzy lead matches.
- Operator metric: `EntitiesPending` rollup runs once (no per‑workspace sum) to avoid double‑counting token estimates.
- Seeds/tests: stop writing workspace_id across fixtures; `scripts/seed-dev.sql` assigns lead owners without a workspace filter.

**Rollout/migration**
- Apply migration 1787050735 up; no data copy required. The down migration restores workspace_id by attributing rows to the single live workspace and fails if none exists on a non‑empty DB.
- Update any direct SQL seeds or ops scripts: stop writing workspace_id and remove workspace predicates for `lead`, `relationship`, `partner`, `dedupe_candidate`, `site_read`, and `conversation_claim`.

<sup>Written for commit 7d2214367b06762523e03e1cf2fc9a21154324b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation-wide handling for leads, relationships, deduplication, site reads, and conversation claims.
  * Updated search embedding counts and re-embedding to cover all live records.
  * Re-embedding now creates jobs for each live workspace while excluding archived workspaces.
* **Bug Fixes**
  * Improved duplicate detection, ownership capacity checks, orphan reconciliation, retention selection, and embedding failure targeting.
* **Database**
  * Updated schema and indexes to support installation-wide records, with rollback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->