### PR TITLE
fix(platform): the demo seed stops writing a tenant column the finance tables lost

### DIFF
--- a/scripts/seed-demo-company.sh
+++ b/scripts/seed-demo-company.sh
@@ -202,12 +202,11 @@ ensure_activity demo-gf-task "$(jq -n --arg o "$org_id" '{
 # them, at the real write shape, and a hand-inserted ledger would drift from
 # the writer the moment the mirror changes.
 echo "== the accounting source =="
-ws_id="$(psql_one "SELECT workspace_id FROM organization WHERE id = '$org_id'")"
 conn_id="$(psql_one "SELECT id FROM finance_connection WHERE archived_at IS NULL AND status <> 'disconnected' LIMIT 1")"
 if [ -z "$conn_id" ]; then
   conn_id="$(psql_one "INSERT INTO finance_connection
-      (workspace_id, provider, status, credential_ref, source, captured_by)
-    VALUES ('$ws_id', 'offline_demo', 'active', 'offline://demo', 'system', 'system:seed')
+      (provider, status, credential_ref, source, captured_by)
+    VALUES ('offline_demo', 'active', 'offline://demo', 'system', 'system:seed')
     RETURNING id")"
   echo "  OK: connected the offline demo source"
 else
@@ -216,9 +215,9 @@ fi
 
 if [ -z "$(psql_one "SELECT 1 FROM finance_customer_link WHERE organization_id = '$org_id' AND archived_at IS NULL")" ]; then
   psql_one "INSERT INTO finance_customer_link
-      (workspace_id, connection_id, organization_id, external_customer_id,
+      (connection_id, organization_id, external_customer_id,
        sync_hash, source, captured_by)
-    VALUES ('$ws_id', '$conn_id', '$org_id', 'GLAZED-FROG', 'seed', 'system', 'system:seed')" >/dev/null
+    VALUES ('$conn_id', '$org_id', 'GLAZED-FROG', 'seed', 'system', 'system:seed')" >/dev/null
   echo "  OK: matched $COMPANY to a customer in the source"
 else
   echo "  OK: $COMPANY is already matched"


### PR DESCRIPTION
Fixes #1724. One script, no schema change, no Go.

`scripts/seed-demo-company.sh` named `workspace_id` on `finance_connection` and
`finance_customer_link`, and read the value off `organization` to supply it.
Neither finance table has had the column since its ADR-0091 §8 phase D slice, so
`make seed-demo-company` fails on `main` today — and the `organization` read was
about to break too, as soon as #1701 lands.

```diff
-ws_id="$(psql_one "SELECT workspace_id FROM organization WHERE id = '$org_id'")"
 conn_id="$(psql_one "SELECT id FROM finance_connection WHERE archived_at IS NULL ...")"
   conn_id="$(psql_one "INSERT INTO finance_connection
-      (workspace_id, provider, status, credential_ref, source, captured_by)
-    VALUES ('$ws_id', 'offline_demo', ...)
+      (provider, status, credential_ref, source, captured_by)
+    VALUES ('offline_demo', ...)
```

The `ws_id` lookup goes with the two INSERTs — it had no other reader.

**Why it drifted:** nothing runs this script. `live-boot` runs `make seed-dev`
(`scripts/seed-dev.sql`), never `make seed-demo`, so the first person to meet the
breakage is a human setting up a demo. The general gap — no gate catches a
script naming a column the schema does not have — is #1725.

**Verified** against the migrated schema: `bash -n` clean, and both statements'
column lists checked against `pg_attribute` for the two tables.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demo seeding by removing writes to the deleted `workspace_id` column in finance tables. Old: the script read `organization.workspace_id` and inserted it into `finance_connection` and `finance_customer_link`, causing `make seed-demo-company` to fail. New: no `workspace_id` lookup or writes; seeding now succeeds on the current schema.

**Review notes**
- Remove `ws_id` query; drop `workspace_id` from both INSERT column lists.
- No schema or service changes; scope is demo seeding only.
- Column lists validated against current `finance_connection` and `finance_customer_link` definitions.

<sup>Written for commit 16ba9d689cc687d12f8e55e9279e57327655d078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

