### PR TITLE
fix(ci): the breaking-change gate compares against where the branch left, not where main is now

### DIFF
--- a/scripts/check-contract-breaking.sh
+++ b/scripts/check-contract-breaking.sh
@@ -69,6 +69,25 @@ if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
   echo "skip contract-breaking-check: base ref '$BASE_REF' not found (nothing to diff against)"
   exit 0
 fi
+# Narrow the base to where this branch actually diverged. The tip is the wrong
+# baseline for a branch that does not descend from it: a path merged to the base
+# AFTER the branch left is absent from this checkout, and oasdiff reports it as
+# a removal this branch never made. That is every stacked PR — GitHub builds its
+# merge ref against the PR's own base branch, so main's newer paths are simply
+# not there — and rebasing only holds until the next merge lands.
+#
+# Nothing is weakened for a branch that does descend from the base: its merge
+# base IS the tip, so the comparison is byte-identical. A real removal is still
+# a removal against either baseline, because the branch removed it after the
+# point both sides agree on.
+#
+# A shallow clone can have both refs and still no common ancestor; keep the tip
+# in that case rather than failing, since the check above has already decided
+# whether a missing base is fatal.
+if MERGE_BASE="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" && [ -n "$MERGE_BASE" ]; then
+  BASE_REF="$MERGE_BASE"
+fi
+
 if ! git cat-file -e "$BASE_REF:$CRM_YAML" 2>/dev/null; then
   echo "skip contract-breaking-check: contract did not exist at $BASE_REF (nothing to diff)"
   exit 0


### PR DESCRIPTION
Fixes #1730. One script, nineteen lines, all comment but one.

`scripts/check-contract-breaking.sh` diffs `backend/api/crm.yaml` against
**`origin/main`'s tip**. For a branch that descends from main that is correct —
GitHub's merge ref already contains main, so every path on main is in the
checkout. For a branch that does not descend from it, it blames the branch for
somebody else's merge: a path added to main *after* the branch left is absent
from the checkout, and `oasdiff` calls it
`api-path-removed-without-deprecation`.

That is every stacked PR — the merge ref is built against the PR's own base
branch, so main's newer paths are simply not there.

## What it cost today

Three phase-D PRs that do not touch `crm.yaml` at all:

| PR | base | before |
|---|---|---|
| #1701 | `main` | passes |
| #1720 | `refactor/phase-d-people` | fails |
| #1723 | `refactor/phase-d-person` | fails |
| #1727 | `main` | passes |

First on `/filters/vocabulary` (#1665). I rebased the stack, which cleared it —
then #1719 merged `/filters/preview` twenty minutes later and the next PR up
failed on that. **Rebasing only holds until the next merge**, so a stack of
three can never be simultaneously green on a busy day.

## The change

```diff
+if MERGE_BASE="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" && [ -n "$MERGE_BASE" ]; then
+  BASE_REF="$MERGE_BASE"
+fi
```

Placed after the existing ref-exists check, so `CONTRACT_BREAKING_REQUIRE_BASE`
still fires on a missing base; a shallow clone with no common ancestor keeps the
tip rather than failing.

## Verified three ways, against the live tree

1. **Original script, `refactor/phase-d-person`** → fails,
   `in API POST /filters/preview — api path removed without deprecation`.
2. **Fixed script, same branch** → `no breaking API changes`.
3. **Fixed script with `/filters/preview` genuinely deleted from `crm.yaml`** →
   fails with the same finding. The gate is not weakened.

For a branch that descends from main the merge base *is* the tip, so the
comparison is byte-identical — (1) and (3) are the two ends that matter.

## Not changed

`scripts/check-migration-versions.sh` keeps comparing against the tip, and
should: two branches must not claim the same version, and that genuinely is a
question about the tip, not about divergence. The two gates want different
baselines for different reasons, which is worth stating rather than making them
consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops false-positive contract-breaking failures by diffing `backend/api/crm.yaml` against the merge base with the base ref, not the base ref’s tip. Previously, stacked PRs not descending from `main` were flagged for API paths added after they diverged; now only removals introduced by the branch are reported.

- Computes the merge base of `HEAD` and `BASE_REF` and uses it when available; descendant branches behave identically because their merge base equals the tip.
- Keeps existing guardrails: if `BASE_REF` is missing the gate still skips; if there’s no common ancestor (shallow clone), it falls back to the tip.
- Not changed: `scripts/check-migration-versions.sh` continues to compare against the tip to prevent duplicate version claims.

<sup>Written for commit 916f6d3ebec21243994f6188919088f410c356f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

