### PR TITLE
test(people): the lock ordering is read from the lock manager, not from a clock

### DIFF
--- a/backend/contentionprobe_test.go
+++ b/backend/contentionprobe_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A contention probe that cannot see the backend it is waiting for.
+//
+// pg_stat_activity is not a live view. Its row set is materialized once per
+// TRANSACTION and cached until that transaction ends, so a probe issued inside
+// one is answering from a snapshot taken before the racer it is watching for
+// existed. A racer whose pooled connection is dialled mid-race is then invisible
+// FOREVER — at any budget, on any machine. That is #970, and it cost two issues
+// (#548, #516) that read as timeouts and were not.
+//
+// The trap is that this is a property of the CALL SITE, never of the probe's own
+// code, and the obvious reading of a call site is wrong. In approvals,
+// waitForRowLockWaiter looked exempt because e.owner is a bare *pgx.Conn — but
+// competingTx opens a transaction ON THAT SAME CONNECTION, so pgx ran every
+// probe inside it. Nothing in the probe's file says so.
+//
+// So the obligation is derived rather than remembered: pg_stat_clear_snapshot()
+// drops the cache, and any function that asks pg_blocking_pids must call it. It
+// is cheap, it is a no-op where the snapshot was already fresh, and making it
+// unconditional is what removes the question a reviewer would otherwise have to
+// re-answer at every new call site. A test added next month that passes a
+// transaction-bound connection reintroduces #970 silently; this is what stops it.
+//
+// Scoped to pg_blocking_pids and not to pg_stat_activity generally: counting
+// sessions by role or database (extmigrategate) is a census, not a race, and a
+// stale answer there is not a blind one.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	// blockingPidsProbe is what makes a query a contention probe: it asks who is
+	// waiting on whom, which is the question the stale snapshot answers wrongly.
+	blockingPidsProbe = "pg_blocking_pids"
+
+	// snapshotClear is the call that makes the next read live.
+	snapshotClear = "pg_stat_clear_snapshot"
+)
+
+// TestEveryContentionProbeClearsTheStatsSnapshot walks every Go tree in this
+// module and fails on a function that asks pg_blocking_pids without first
+// dropping the transaction's cached view of who is connected.
+func TestEveryContentionProbeClearsTheStatsSnapshot(t *testing.T) {
+	var offenders []string
+	fset := token.NewFileSet()
+
+	walkErr := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			// Vendored and generated trees are nobody's call site.
+			if name := entry.Name(); name == "vendor" || name == "node_modules" || name == "build" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			// Not skipped. A file this gate cannot read is a file it cannot
+			// clear, and a census that quietly drops its unreadable members
+			// reports "no offenders" for a tree it never saw.
+			return fmt.Errorf("parsing %s: %w", path, parseErr)
+		}
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil {
+				continue
+			}
+			probes, clears := scanForProbe(fn)
+			if probes && !clears {
+				offenders = append(offenders, path+": "+fn.Name.Name)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking the module for contention probes: %v", walkErr)
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf(`%d contention probe(s) ask %s without calling %s() first:
+
+  %s
+
+pg_stat_activity's row set is materialized once per transaction and cached until
+it ends, so a probe issued inside one cannot see a backend that dialled after the
+snapshot was taken — at any budget, on any machine (#970). Whether the connection
+is inside a transaction is a property of the CALL SITE and not of the probe: in
+approvals it looked exempt because the field is a bare *pgx.Conn, and competingTx
+opens a transaction on that same connection.
+
+Add `+"`"+`SELECT `+snapshotClear+`()`+"`"+` immediately before the probe. It is cheap, and where
+the snapshot was already fresh it does nothing.`,
+			len(offenders), blockingPidsProbe, snapshotClear, strings.Join(offenders, "\n  "))
+	}
+}
+
+// scanForProbe reports whether a function's string literals contain a
+// contention probe and whether they contain the snapshot clear.
+//
+// Read from the literals rather than from the call graph on purpose: the query
+// text is where both facts actually live, and a probe assembled from a helper
+// this gate could not follow would read as absent — a census that passes by
+// seeing nothing.
+func scanForProbe(fn *ast.FuncDecl) (probes, clears bool) {
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.BasicLit)
+		if !isLit || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			value = lit.Value
+		}
+		if strings.Contains(value, blockingPidsProbe) {
+			probes = true
+		}
+		if strings.Contains(value, snapshotClear) {
+			clears = true
+		}
+		return true
+	})
+	return probes, clears
+}

--- a/backend/contentionprobe_test.go
+++ b/backend/contentionprobe_test.go
@@ -133,7 +133,7 @@ func scanTree(root string, fset *token.FileSet) ([]string, error) {
 			return err
 		}
 		if entry.IsDir() {
-			if name := entry.Name(); name == "vendor" || name == "node_modules" || name == "build" {
+			if skipDir(entry.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -160,6 +160,24 @@ func scanTree(root string, fset *token.FileSet) ([]string, error) {
 		return nil
 	})
 	return offenders, err
+}
+
+// skipDir reports whether a directory holds no compiled call site.
+//
+// `testdata` and the `_`/`.` prefixes are the GO TOOLCHAIN's own exclusions: it
+// never builds them, so nothing in one can be a probe this gate is responsible
+// for — and a deliberately unparsable fixture in there would otherwise take the
+// whole gate red for a file that is not code. That is a scoping rule, not the
+// "skip what you cannot read" hole this file refuses elsewhere: a parse failure
+// inside a COMPILED tree still fails, because that is a member of the census.
+//
+// vendor and node_modules are dependency trees; build is generated.
+func skipDir(name string) bool {
+	switch name {
+	case "vendor", "node_modules", "build", "testdata":
+		return true
+	}
+	return strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".")
 }
 
 // unprotectedProbes reports, for each probe in fn, why it is not protected —

--- a/backend/contentionprobe_test.go
+++ b/backend/contentionprobe_test.go
@@ -19,23 +19,39 @@ package backendarch
 // probe inside it. Nothing in the probe's file says so.
 //
 // So the obligation is derived rather than remembered: pg_stat_clear_snapshot()
-// drops the cache, and any function that asks pg_blocking_pids must call it. It
-// is cheap, it is a no-op where the snapshot was already fresh, and making it
-// unconditional is what removes the question a reviewer would otherwise have to
-// re-answer at every new call site. A test added next month that passes a
-// transaction-bound connection reintroduces #970 silently; this is what stops it.
+// drops the cache, and any function that asks pg_blocking_pids must call it.
 //
-// Scoped to pg_blocking_pids and not to pg_stat_activity generally: counting
-// sessions by role or database (extmigrategate) is a census, not a race, and a
-// stale answer there is not a blind one.
+// THREE things are required, not one, because co-occurrence is not the
+// invariant. The clear must run BEFORE the probe, on the SAME receiver, and that
+// receiver must not be a pool:
+//
+//   - a clear issued after the probe, or in a branch the run never takes, leaves
+//     the probe reading the snapshot it was meant to drop;
+//   - a clear on a different connection drops a different connection's snapshot;
+//   - a POOL is the case that looks right and is not. pool.Exec(clear) acquires a
+//     connection, runs, and releases it, so the pool.QueryRow(probe) that follows
+//     may be handed another one entirely and the clear provably cannot bind.
+//     Acquire once and issue both on that connection.
+//
+// The first version of this gate required only that both strings appear
+// somewhere in the same function, and it certified a pool call site as
+// protected. A gate that reads green over the defect it names is the thing this
+// file exists to prevent.
+//
+// Scoped to pg_blocking_pids rather than to pg_stat_activity generally: counting
+// sessions by role or database is a census, not a race, and a stale answer there
+// is not a blind one.
 
 import (
 	"fmt"
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -43,26 +59,80 @@ import (
 
 const (
 	// blockingPidsProbe is what makes a query a contention probe: it asks who is
-	// waiting on whom, which is the question the stale snapshot answers wrongly.
+	// waiting on whom, which is the question a stale snapshot answers wrongly.
 	blockingPidsProbe = "pg_blocking_pids"
 
-	// snapshotClear is the call that makes the next read live.
+	// snapshotClear is the call that makes the next read on that connection live.
 	snapshotClear = "pg_stat_clear_snapshot"
+
+	// pooledReceiver marks a handle that hands out a connection per call. Matched
+	// case-insensitively on the receiver's source text, which is conservative by
+	// construction: it can only ever demand that a call site be more explicit
+	// about which connection it is on.
+	pooledReceiver = "pool"
 )
 
-// TestEveryContentionProbeClearsTheStatsSnapshot walks every Go tree in this
-// module and fails on a function that asks pg_blocking_pids without first
-// dropping the transaction's cached view of who is connected.
+// probeTrees are the hand-written Go trees this repo ships. Each is its own
+// module, which is why the list is not `./...`: a suite added under extensions/
+// opens the same database and must inherit this obligation the day it is
+// written, exactly as the license header gate enumerates the same three.
+var probeTrees = []string{".", "../extensions", "../fixtures"}
+
+// sqlCall is one database call in a function: what it executes, where, and on
+// which receiver.
+type sqlCall struct {
+	receiver string
+	pos      token.Pos
+}
+
+// TestEveryContentionProbeClearsTheStatsSnapshot fails on a function that asks
+// pg_blocking_pids without a snapshot clear that can actually reach it.
 func TestEveryContentionProbeClearsTheStatsSnapshot(t *testing.T) {
 	var offenders []string
 	fset := token.NewFileSet()
 
-	walkErr := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+	for _, tree := range probeTrees {
+		if _, err := os.Stat(tree); err != nil {
+			// A tree the vanilla checkout does not ship is not an exemption for
+			// anything, because nothing in it can hold a probe.
+			continue
+		}
+		found, err := scanTree(tree, fset)
+		if err != nil {
+			t.Fatalf("scanning %s for contention probes: %v", tree, err)
+		}
+		offenders = append(offenders, found...)
+	}
+	sort.Strings(offenders)
+
+	if len(offenders) > 0 {
+		t.Fatalf(`%d contention probe(s) are not protected by a %s() the probe can see:
+
+  %s
+
+pg_stat_activity's row set is materialized once per transaction and cached until
+it ends, so a probe issued inside one cannot see a backend that dialled after the
+snapshot was taken — at any budget, on any machine (#970). Whether a connection
+is inside a transaction is a property of the CALL SITE and not of the probe: in
+approvals it looked exempt because the field is a bare *pgx.Conn, and competingTx
+opens a transaction on that same connection.
+
+The clear must run BEFORE the probe, on the SAME receiver, and that receiver must
+not be a pool — a pool hands out a connection per call, so a clear issued through
+one cannot bind the connection the probe is then given. Acquire a connection and
+issue both statements on it.`,
+			len(offenders), snapshotClear, strings.Join(offenders, "\n  "))
+	}
+}
+
+// scanTree parses every Go file under root and reports each unprotected probe.
+func scanTree(root string, fset *token.FileSet) ([]string, error) {
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if entry.IsDir() {
-			// Vendored and generated trees are nobody's call site.
 			if name := entry.Name(); name == "vendor" || name == "node_modules" || name == "build" {
 				return filepath.SkipDir
 			}
@@ -83,59 +153,104 @@ func TestEveryContentionProbeClearsTheStatsSnapshot(t *testing.T) {
 			if !isFunc || fn.Body == nil {
 				continue
 			}
-			probes, clears := scanForProbe(fn)
-			if probes && !clears {
-				offenders = append(offenders, path+": "+fn.Name.Name)
+			for _, reason := range unprotectedProbes(fset, fn) {
+				offenders = append(offenders, fmt.Sprintf("%s: %s — %s", path, fn.Name.Name, reason))
 			}
 		}
 		return nil
 	})
-	if walkErr != nil {
-		t.Fatalf("walking the module for contention probes: %v", walkErr)
-	}
-
-	if len(offenders) > 0 {
-		t.Fatalf(`%d contention probe(s) ask %s without calling %s() first:
-
-  %s
-
-pg_stat_activity's row set is materialized once per transaction and cached until
-it ends, so a probe issued inside one cannot see a backend that dialled after the
-snapshot was taken — at any budget, on any machine (#970). Whether the connection
-is inside a transaction is a property of the CALL SITE and not of the probe: in
-approvals it looked exempt because the field is a bare *pgx.Conn, and competingTx
-opens a transaction on that same connection.
-
-Add `+"`"+`SELECT `+snapshotClear+`()`+"`"+` immediately before the probe. It is cheap, and where
-the snapshot was already fresh it does nothing.`,
-			len(offenders), blockingPidsProbe, snapshotClear, strings.Join(offenders, "\n  "))
-	}
+	return offenders, err
 }
 
-// scanForProbe reports whether a function's string literals contain a
-// contention probe and whether they contain the snapshot clear.
-//
-// Read from the literals rather than from the call graph on purpose: the query
-// text is where both facts actually live, and a probe assembled from a helper
-// this gate could not follow would read as absent — a census that passes by
-// seeing nothing.
-func scanForProbe(fn *ast.FuncDecl) (probes, clears bool) {
-	ast.Inspect(fn.Body, func(node ast.Node) bool {
-		lit, isLit := node.(*ast.BasicLit)
-		if !isLit || lit.Kind != token.STRING {
+// unprotectedProbes reports, for each probe in fn, why it is not protected —
+// naming the failure rather than returning a boolean, because "no clear at all",
+// "cleared afterwards" and "cleared through a pool" need different fixes.
+func unprotectedProbes(fset *token.FileSet, fn *ast.FuncDecl) []string {
+	probes, clears := collectSQLCalls(fset, fn)
+	var reasons []string
+	for _, probe := range probes {
+		switch {
+		case len(clears) == 0:
+			reasons = append(reasons, "asks "+blockingPidsProbe+" and never calls "+snapshotClear+"()")
+		case strings.Contains(strings.ToLower(probe.receiver), pooledReceiver):
+			reasons = append(reasons, "probes through `"+probe.receiver+"`, a pool: each call may be handed a different connection, so no clear can bind this probe")
+		case !clearedBefore(clears, probe):
+			reasons = append(reasons, "asks "+blockingPidsProbe+" on `"+probe.receiver+"` with no "+snapshotClear+"() on that receiver before it")
+		}
+	}
+	return reasons
+}
+
+// clearedBefore reports whether some clear runs earlier than the probe on the
+// same receiver.
+func clearedBefore(clears []sqlCall, probe sqlCall) bool {
+	for _, clear := range clears {
+		if clear.receiver == probe.receiver && clear.pos < probe.pos {
 			return true
 		}
-		value, err := strconv.Unquote(lit.Value)
-		if err != nil {
-			value = lit.Value
+	}
+	return false
+}
+
+// collectSQLCalls finds the calls in fn whose arguments carry the probe or the
+// clear, and records the receiver each is issued on.
+//
+// Read from the argument literals rather than from the call graph: the query
+// text is where both facts live, and a probe assembled through a helper this
+// gate could not follow would read as absent — a census that passes by seeing
+// nothing.
+func collectSQLCalls(fset *token.FileSet, fn *ast.FuncDecl) (probes, clears []sqlCall) {
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
 		}
-		if strings.Contains(value, blockingPidsProbe) {
-			probes = true
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
 		}
-		if strings.Contains(value, snapshotClear) {
-			clears = true
+		found := sqlCall{receiver: exprText(fset, selector.X), pos: call.Pos()}
+		for _, arg := range call.Args {
+			text, ok := literalText(arg)
+			if !ok {
+				continue
+			}
+			if strings.Contains(text, blockingPidsProbe) {
+				probes = append(probes, found)
+			}
+			if strings.Contains(text, snapshotClear) {
+				clears = append(clears, found)
+			}
 		}
 		return true
 	})
 	return probes, clears
+}
+
+// literalText returns a string literal's value.
+func literalText(node ast.Expr) (string, bool) {
+	lit, isLit := node.(*ast.BasicLit)
+	if !isLit || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		// A literal Go itself accepts and strconv does not is not a thing this
+		// gate should decide about; the raw form still matches either name.
+		return lit.Value, true
+	}
+	return value, true
+}
+
+// exprText renders a receiver expression back to source, so `e.Pool` and
+// `conn` are compared as a reader compares them.
+func exprText(fset *token.FileSet, expr ast.Expr) string {
+	var out strings.Builder
+	if err := printer.Fprint(&out, fset, expr); err != nil {
+		// Unprintable receivers are not silently treated as matching anything:
+		// a unique marker can equal no other receiver, so the probe reads as
+		// uncleared rather than as cleared.
+		return fmt.Sprintf("<unprintable receiver at %d>", expr.Pos())
+	}
+	return out.String()
 }

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -320,23 +320,28 @@ func waitForBlockedOn(t *testing.T, e *voiceSendEnv, holder int32) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	// ONE connection for the whole poll, held rather than borrowed per statement.
+	// pg_stat_activity's row set is materialized once per transaction and cached
+	// until it ends, so the probe needs a snapshot clear it can actually see —
+	// and a clear issued through the POOL cannot be that: pool.Exec acquires a
+	// connection, runs, and releases it, and the pool.QueryRow that follows may
+	// be handed a different one. The pair has to share a connection or the clear
+	// is decoration (#970).
+	conn, err := e.Pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquiring the probe's connection: %v", err)
+	}
+	defer conn.Release()
+
 	for {
 		if ctx.Err() != nil {
 			t.Fatal("no backend ever blocked on the first send's row lock — the second send did not contend for it, so this case proves nothing")
 		}
-		// Unconditionally, and not because this call site is known to need it:
-		// pg_stat_activity's row set is materialized once per transaction and
-		// cached until it ends, and whether a given connection is inside one is
-		// a property of the CALL SITE that the probe's own code cannot show
-		// (#970). A pool hands out a fresh implicit transaction per statement
-		// today; a caller that wraps this loop in one would make the probe blind
-		// with nothing here changing. The clear costs a round trip and removes
-		// the question.
-		if _, err := e.Pool.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+		if _, err := conn.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
 			t.Fatalf("clearing the stats snapshot before probing for a backend blocked by %d: %v", holder, err)
 		}
 		var blocked int
-		if err := e.Pool.QueryRow(ctx,
+		if err := conn.QueryRow(ctx,
 			`SELECT count(*)::int FROM pg_stat_activity WHERE $1 = ANY(pg_blocking_pids(pid))`,
 			holder).Scan(&blocked); err != nil {
 			t.Fatalf("probing for a backend blocked by %d: %v", holder, err)

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -324,6 +324,17 @@ func waitForBlockedOn(t *testing.T, e *voiceSendEnv, holder int32) {
 		if ctx.Err() != nil {
 			t.Fatal("no backend ever blocked on the first send's row lock — the second send did not contend for it, so this case proves nothing")
 		}
+		// Unconditionally, and not because this call site is known to need it:
+		// pg_stat_activity's row set is materialized once per transaction and
+		// cached until it ends, and whether a given connection is inside one is
+		// a property of the CALL SITE that the probe's own code cannot show
+		// (#970). A pool hands out a fresh implicit transaction per statement
+		// today; a caller that wraps this loop in one would make the probe blind
+		// with nothing here changing. The clear costs a round trip and removes
+		// the question.
+		if _, err := e.Pool.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+			t.Fatalf("clearing the stats snapshot before probing for a backend blocked by %d: %v", holder, err)
+		}
 		var blocked int
 		if err := e.Pool.QueryRow(ctx,
 			`SELECT count(*)::int FROM pg_stat_activity WHERE $1 = ANY(pg_blocking_pids(pid))`,

--- a/backend/internal/modules/approvals/lockprobe_integration_test.go
+++ b/backend/internal/modules/approvals/lockprobe_integration_test.go
@@ -136,6 +136,19 @@ func TestTheRowLockProbeSeesABackendThatDialsAfterItsFirstLook(t *testing.T) {
 	}
 
 	// The look that used to freeze this connection's view of who is connected.
+	//
+	// The clear is not optional here, and the reason is the trap itself:
+	// e.owner is a bare *pgx.Conn, which reads as "not a transaction" — but
+	// competingTx above opened one ON THIS CONNECTION, so pgx runs this probe
+	// inside it and the snapshot it answers from is the one taken then. Without
+	// the clear, this test — whose entire subject is a probe that cannot see a
+	// backend dialled after its first look — was itself blind in exactly that
+	// way. It is a call-site property, never a property of the probe's own code
+	// (#970), which is why TestEveryContentionProbeClearsTheStatsSnapshot in the
+	// backend suite now requires it of every call site rather than of this one.
+	if _, err := e.owner.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+		t.Fatalf("clearing the stats snapshot before the probe's first look: %v", err)
+	}
 	var queued bool
 	if err := e.owner.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM pg_stat_activity a

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -206,16 +206,35 @@ func assertParkedBeforeTheOrganizationRow(ctx context.Context, t *testing.T, hol
 	// The waiter, found through the lock manager rather than through
 	// pg_blocking_pids: every backend queued on an advisory lock this holder
 	// has been granted. The holder's own row is excluded by `granted`.
+	// The database predicate is not decoration: pg_locks is CLUSTER-wide, an
+	// advisory lock's identity includes the database it was taken in, and the
+	// parallel lane runs a clone per package on one server. Without it a backend
+	// queued on the same key in a neighbouring clone can be selected — and the
+	// organization lookup below resolves an OID local to THIS database, so it
+	// would find nothing and the assertion would pass having examined the wrong
+	// backend. A false green on the exact ordering this exists to catch.
 	var waiter int
 	err := holder.QueryRow(ctx, `
 		SELECT w.pid
 		  FROM pg_locks w
 		  JOIN pg_locks h
-		    ON h.locktype = 'advisory' AND h.granted
+		    ON h.locktype = 'advisory' AND h.granted AND h.database = w.database
 		   AND h.classid = w.classid AND h.objid = w.objid AND h.objsubid = w.objsubid
-		 WHERE w.locktype = 'advisory' AND NOT w.granted AND h.pid = $1
+		 WHERE w.locktype = 'advisory' AND NOT w.granted
+		   AND w.database = (SELECT oid FROM pg_database WHERE datname = current_database())
+		   AND h.pid = $1
 		 LIMIT 1`, holderPID).Scan(&waiter)
-	if err != nil {
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// Distinguished from a read failure on purpose. The caller has already
+		// established that SOMETHING is waiting on this holder; if nothing is
+		// queued on the ADVISORY lock, the apply is blocked somewhere else —
+		// which is the ordering defect showing up one statement earlier, not an
+		// infrastructure fault. Reporting both as "reading the lock manager
+		// failed" is the misattribution this whole change is removing.
+		t.Fatalf("the apply is waiting, but on no advisory lock this holder holds — " +
+			"it reached a different lock first, so it is not parked on the name lock at all")
+	case err != nil:
 		t.Fatalf("reading the lock manager for a backend queued on the name lock: %v", err)
 	}
 

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -112,19 +112,8 @@ func TestAnEvidenceApplyClearingANameWaitsOnTheNameLock(t *testing.T) {
 
 	// WHERE it is blocked is the whole question, and "it waited" cannot answer
 	// it: an apply that takes the row lock first also ends up waiting, just one
-	// statement too late. So the holder — which owns the name lock a human
-	// rename would hold — reaches for the row that rename would edit. If the
-	// apply is parked before touching the row, this succeeds at once. If it is
-	// parked while holding the row, the two are in the cycle that deadlocks and
-	// this blocks until the timeout.
-	if _, err := holder.Exec(ctx, `SET LOCAL lock_timeout = '5s'`); err != nil {
-		t.Fatalf("arming the lock timeout: %v", err)
-	}
-	if _, err := holder.Exec(ctx,
-		`SELECT id FROM organization WHERE id = $1 FOR UPDATE`, orgID); err != nil {
-		t.Fatalf("the rename could not take the organization row while the apply waited (%v) — "+
-			"the apply is holding that row and waiting for the name lock, the ordering that deadlocks", err)
-	}
+	// statement too late.
+	assertParkedBeforeTheOrganizationRow(ctx, t, holder, pid)
 
 	// Releasing the holder must let it through, or the wait was on something
 	// else entirely.
@@ -183,5 +172,82 @@ func TestAnEvidenceApplyWithoutANameDoesNotWaitOnTheNameLock(t *testing.T) {
 	}
 	if finished != nil {
 		t.Fatalf("the apply failed: %v", finished)
+	}
+}
+
+// assertParkedBeforeTheOrganizationRow states the invariant DIRECTLY, by asking
+// Postgres's lock manager where the waiter is — and it contains no clock.
+//
+// It replaces a `SET LOCAL lock_timeout = '5s'` and a `SELECT … FOR UPDATE` from
+// the holder, which inferred the answer from whether that statement returned
+// within five seconds. That inference had the timeout doing two jobs at once —
+// bounding the test AND being the assertion — so a busy cluster produced a red
+// run whose message said the lock ordering had regressed. The observed failure
+// took 4.67s, right at the boundary, under a lane running 29 packages against
+// one server. A flake that cries wolf about a deadlock ordering is worse than a
+// plain flake: the next person either burns a day on a live bug that is not
+// there, or learns to disbelieve the one message that must never be disbelieved.
+//
+// pg_locks is exempt from the frozen-snapshot trap that #970 fixed in this
+// package's other probes: it reads the lock manager directly and is NOT the
+// pg_stat_activity statistics snapshot, which is materialized once per
+// transaction and cached until it ends. That is why this is the honest fix
+// rather than merely a different poll, and the next author will otherwise
+// assume the two views behave alike.
+//
+// Two facts are asserted, and both are needed. That the waiter is parked on the
+// advisory lock says it reached the name lock at all; that it holds no write
+// lock on `organization` says it had not touched the row first. Either alone
+// passes over the defect: an apply parked on the row lock is also "waiting", and
+// an apply that never reached the lock holds no organization lock either.
+func assertParkedBeforeTheOrganizationRow(ctx context.Context, t *testing.T, holder pgx.Tx, holderPID int) {
+	t.Helper()
+
+	// The waiter, found through the lock manager rather than through
+	// pg_blocking_pids: every backend queued on an advisory lock this holder
+	// has been granted. The holder's own row is excluded by `granted`.
+	var waiter int
+	err := holder.QueryRow(ctx, `
+		SELECT w.pid
+		  FROM pg_locks w
+		  JOIN pg_locks h
+		    ON h.locktype = 'advisory' AND h.granted
+		   AND h.classid = w.classid AND h.objid = w.objid AND h.objsubid = w.objsubid
+		 WHERE w.locktype = 'advisory' AND NOT w.granted AND h.pid = $1
+		 LIMIT 1`, holderPID).Scan(&waiter)
+	if err != nil {
+		t.Fatalf("reading the lock manager for a backend queued on the name lock: %v", err)
+	}
+
+	// Which locks that backend holds on the organization table. AccessShareLock
+	// is a plain read and does not block a rename; RowShareLock and anything
+	// above it means it has taken the row a rename would edit, which is the
+	// cycle. Reported as the set, so a failure names what it found rather than
+	// asserting a boolean.
+	rows, err := holder.Query(ctx, `
+		SELECT mode FROM pg_locks
+		 WHERE pid = $1 AND locktype = 'relation' AND granted
+		   AND relation = 'organization'::regclass
+		   AND mode <> 'AccessShareLock'
+		 ORDER BY mode`, waiter)
+	if err != nil {
+		t.Fatalf("reading backend %d's locks on the organization table: %v", waiter, err)
+	}
+	defer rows.Close()
+	var held []string
+	for rows.Next() {
+		var mode string
+		if err := rows.Scan(&mode); err != nil {
+			t.Fatalf("scanning backend %d's lock modes: %v", waiter, err)
+		}
+		held = append(held, mode)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading backend %d's lock modes: %v", waiter, err)
+	}
+	if len(held) > 0 {
+		t.Fatalf("the apply is parked on the name lock while already holding %v on the organization table — "+
+			"it took the row a concurrent rename would edit BEFORE the lock that rename waits on, "+
+			"which is the cycle that deadlocks", held)
 	}
 }

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -213,6 +213,23 @@ func assertParkedBeforeTheOrganizationRow(ctx context.Context, t *testing.T, hol
 	// organization lookup below resolves an OID local to THIS database, so it
 	// would find nothing and the assertion would pass having examined the wrong
 	// backend. A false green on the exact ordering this exists to catch.
+	// The join below matches a waiter through any advisory lock this holder has
+	// been granted, so it is unambiguous only while the holder holds exactly one.
+	// It does today — holdOrgNameLock takes the name lock and nothing else — and
+	// asserting it is what keeps that true: a second advisory lock added to that
+	// transaction would silently let a waiter on the OTHER key answer here.
+	var advisoryHeld int
+	if err := holder.QueryRow(ctx, `
+		SELECT count(*) FROM pg_locks
+		 WHERE pid = $1 AND locktype = 'advisory' AND granted`, holderPID).Scan(&advisoryHeld); err != nil {
+		t.Fatalf("counting the holder's advisory locks: %v", err)
+	}
+	if advisoryHeld != 1 {
+		t.Fatalf("the lock holder holds %d advisory locks, want exactly 1 — with more than one, "+
+			"the waiter lookup below cannot tell which key a backend is queued on, and could report "+
+			"a waiter on the wrong lock as parked on the name lock", advisoryHeld)
+	}
+
 	var waiter int
 	err := holder.QueryRow(ctx, `
 		SELECT w.pid


### PR DESCRIPTION
`TestAnEvidenceApplyClearingANameWaitsOnTheNameLock` proved **where** the apply is parked by arming a 5s `lock_timeout` on the holder and reaching for the organization row: a quick return meant "parked before the row", a timeout meant "parked while holding it".

```go
if _, err := holder.Exec(ctx, `SET LOCAL lock_timeout = '5s'`); err != nil { … }
if _, err := holder.Exec(ctx,
    `SELECT id FROM organization WHERE id = $1 FOR UPDATE`, orgID); err != nil {
    t.Fatalf("the rename could not take the organization row while the apply waited (%v) — …")
}
```

**The timeout was doing two jobs: bounding the test, and *being* the assertion.** Splitting them is the fix. The observed failure took **4.67s** — right at the boundary — under a lane running 29 packages against one cluster.

And the failure mode is the wrong way round, which is why this is worth more than its label. The message names a real and serious defect, so a red run reads as *"the lock ordering regressed"* when it means *"the database was busy"*. A flake that cries wolf about a deadlock ordering is worse than a plain flake: the next person either burns a day on a live bug that isn't there, or learns to disbelieve the one message that must never be disbelieved.

## What replaces it

Postgres is asked directly. `pg_locks` shows the backend queued on the advisory lock, and every relation lock that backend holds — so *"parked on the name lock, and holding nothing on `organization`"* is **stated** rather than inferred, and **there is no clock in it**.

Two facts are asserted and both are needed: that the waiter is parked on the advisory lock says it reached the name lock at all; that it holds no write lock on `organization` says it hadn't touched the row first. Either alone passes over the defect.

⚠ `pg_locks` is **exempt** from the frozen-snapshot trap that #970 fixed in this package's other probes — it reads the lock manager directly, not the `pg_stat_activity` statistics snapshot, which is materialized once per transaction and cached until it ends. That is *why* this is the honest fix rather than merely a different poll, and the code comment says so, because the next author will otherwise assume the two views behave alike.

## The second half: #970's trap, made into a gate

#970's fix carries a trap held only in one engineer's head, and the memory of it is explicit that the obvious reading is wrong:

> Never conclude "the probe connection is not a transaction" from the probe's own code — it is a property of **every call site**.

`TestEveryContentionProbeClearsTheStatsSnapshot` derives that obligation from the tree: any function asking `pg_blocking_pids` must clear the snapshot first. **It was red on arrival, with two live subjects:**

- `approvals`' `TestTheRowLockProbeSeesABackendThatDialsAfterItsFirstLook` took its first look through `e.owner` — a bare `*pgx.Conn`, which *looks* exempt — while `competingTx` had opened a transaction on that same connection. **The test whose entire subject is a probe that cannot see a late-dialling backend was itself blind in exactly that way.**
- `compose`'s `waitForBlockedOn` probes a pool, where the snapshot is fresh today. It clears anyway: which connection a caller hands it is not a property that file can assert, and that is the whole lesson.

## The proof

| Step | Result |
|---|---|
| **RED**, the call-site guard | red against today's tree, naming both live subjects |
| **GREEN** | both fixed |
| **GREEN**, the ordering assertion | passes |
| **GREEN under load** | 40 busy loops on 10 cores — **0.11s**, where the 5s timeout was the failure boundary |
| **INVERSE** | inverting the production ordering turns it red, naming the mode it found: `RowShareLock` |

**Worth recording:** the *first* inverse attempt mutated `writeCanonicalOrgColumn`, which is not the path this apply takes — and the test **passed**. A vacuous gate looks exactly like a working one from the passing side, which is the entire reason the inverse step exists.

## Which of #492's three parts this closes

The issue accumulated three separate defects. **Only the first was still live**, verified against `main` before starting, and this PR fixes only that one:

| Part | State | This PR |
|---|---|---|
| The 5s `lock_timeout` **is** the assertion | **LIVE** | **fixed** |
| The probe helper's count-based bound (`maxProbes = 20_000`) | Fixed by #901 + #970 — `grep maxProbes` across `backend/`: no matches. #548 and #516 were closed on it | not re-fixed |
| The fixed host port 55432 colliding when two shards share a runner | Fixed — Postgres publishes `15432:5432` and `make check-host-ports` holds the floor | not re-fixed |

## Coverage

Test-only change: **no measured new-code coverage** by construction. The substitute proof is the red → green → inverse sequence above plus the call-site guard's own red run.

## Review status

Fable (`/code-review`) and CodeRabbit have run. **Codex has not** — every `/codex:*` command is `disable-model-invocation: true`, so an agent cannot invoke it; a human has to type `/codex:review`. Two reviewers, not three, and this note is here so it does not read as three.

Closes #492

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Asserts org-name lock ordering by reading Postgres’s lock manager instead of a 5s timeout, and adds a gate that prevents stale `pg_stat_activity` snapshots from blinding `pg_blocking_pids` probes.

- People tests: replace the timeout-and-select with assertParkedBeforeTheOrganizationRow, which reads `pg_locks`, predicates on the current database, and requires the holder to have exactly one advisory lock to avoid ambiguous joins; treats `pgx.ErrNoRows` as “waited on a different lock,” not an I/O failure.
- Gate: TestEveryContentionProbeClearsTheStatsSnapshot now requires three conditions—clear runs before the probe, on the same receiver, and not through a pool—and walks `backend`, `../extensions`, and `../fixtures`; it scopes like the toolchain does (excludes `testdata`, hidden/underscore dirs, `vendor`, `node_modules`, `build`) and names which condition is missing.
- Fix call sites: approvals and compose tests acquire one connection, call `pg_stat_clear_snapshot()`, then probe, so pool/transaction context cannot blind the probe.

Closes #492.

<sup>Written for commit fe2d73a2fbaceae014321bd1d142b28d099c9ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock-contention checks to consistently reflect current database activity.
  * Added validation that waiting operations do not acquire unintended write locks.
  * Enhanced diagnostics when contention checks encounter errors.

* **Tests**
  * Added automated coverage to ensure contention probes refresh database statistics before checking blocking activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->