### PR TITLE
docs(status): phase D is down to 26 tables, and every record-bearing one is done

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -888,25 +888,53 @@ webhooks, agents, privacy. Configuration and machinery rather than records,
 which is why the stakes were low, but low is not none and a reader should not
 have to infer it from migration numbers.
 
-### Where phase D stands: 32 tables
+### Where phase D stands: 26 tables
 
 Merged: briefs (#1486), capture (#1491), overlay (#1510, fork-owned so it lands
 in `migrations/custom/`), ai + migration (#1525, split across both namespaces
 because the importer is fork-owned), deals quoting & delivery (#1543), activity
-satellites (#1547), deal spine (#1635), activity spine (#1655). 103 → 38.
+satellites (#1547), deal spine (#1635), activity spine (#1655), organization
+cluster (#1701), person cluster (#1720), lead/relationship/partner cluster
+(#1723). **103 → 26**, counted from the migrated schema rather than from this
+list — `make test-db-up`, then:
 
-Open and stacked, in merge order: **#1701** organization cluster → **#1720**
-person cluster → **#1723** lead/relationship/partner cluster. 38 → 32 when the
-three land.
+```sql
+SELECT c.relname FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  JOIN pg_attribute a ON a.attrelid = c.oid
+ WHERE n.nspname = 'public' AND c.relkind = 'r'
+   AND a.attname = 'workspace_id' AND a.attnum > 0 AND NOT a.attisdropped
+ ORDER BY 1;
+```
+
+Every record-bearing table is done. What remains is identity, search's two, a
+handful of singletons, and the two ledgers.
 
 **What is left, and the shape of each:**
 
 | group | tables | note |
 |---|---|---|
-| identity | `app_user`, `session`, `role`, `role_assignment`, `team`, `team_membership`, `passport`, `oauth_*`, `auth_token`, `record_grant`, `extension_secret`, `onboarding_wizard_state` | `app_user` is what `MustWorkspace` ultimately hangs on — take it last within the group |
+| identity | `app_user`, `session`, `role`, `role_assignment`, `team`, `team_membership`, `passport`, `oauth_client`, `oauth_grant`, `oauth_authorization_code`, `oauth_refresh_token`, `auth_token`, `record_grant`, `extension_secret`, `onboarding_wizard_state` | 15 tables. `app_user` is what `MustWorkspace` ultimately hangs on — take it last within the group |
 | search | `embedding`, `graph_interaction_edge` | see below: the fan-out is now redundant machinery over one corpus, and collapsing it is the prerequisite |
 | the rest | `idempotency_key`, `field_provenance`, `user_record_view`, `suggestion_dismissal`, `signal_thread_scan`, `linkedin_account`, `linkedin_connection` | singletons; one slice |
 | **last** | `audit_log`, `system_log` | the append-only ledgers, by the decision recorded above |
+
+**Two findings from the last three slices that outlive them**, both about a
+write shape or a number nobody was checking:
+
+- A per-workspace rollup got summed into a fleet total in **three** places,
+  and its entries are the SAME rows once no entity carries a tenant — so each
+  sum multiplied one corpus by the workspace count, and that figure prices the
+  re-embed. `Store.EntitiesPending` was fixed in #1723; the status transport
+  had its own copy of the arithmetic and never called it, so the number on the
+  wire did not change until #1767. The cost estimator is the third and still
+  has it — that one needs a ruling on whose rate sheet prices one shared
+  corpus (#1738). **Fixing the method and not grepping for the other summers
+  is the sibling-copy miss README rule 1 names**; it cost a round trip here.
+- Two capture-path writers (`plantEmploymentEdge`, `recordDedupeCandidate`)
+  commit the domain row with no `audit_log` and no `event_outbox` row. Both
+  predate ADR-0091 and are filed as #1745; the fix needs an event-vocabulary
+  decision, not just the two calls.
 
 **Slice by ownership, not by convenience.** Two of the four merged slices had to
 be split or moved mid-flight because a table turned out to be fork-owned


### PR DESCRIPTION
Docs only.

#1701, #1720 and #1723 landed, so ADR-0091 §8 phase D is **103 → 26** tables.
Every record-bearing table is done; what remains is identity (15), search's two,
seven singletons, and the two append-only ledgers.

The count now ships with the query that produces it — read it off the migrated
schema, not off the list in this file, which is what let the previous number
drift between updates.

Two findings from those three slices are recorded because they outlive the
slices:

- **`EntitiesPending` summed a rollup it shouldn't.** Once no entity carries a
  tenant, every workspace's entry is the same rows, so the total multiplied one
  corpus by the workspace count — and that figure prices the re-embed. Fixed in
  #1723. The cost estimator folds the same rollup into a *priced* fleet total
  and still has it; that half needs a ruling on whose rate sheet prices one
  shared corpus (#1738).
- **Two capture-path writers skip half the write shape.** `plantEmploymentEdge`
  and `recordDedupeCandidate` commit the domain row with no `audit_log` and no
  `event_outbox` row. Both predate ADR-0091 (#1745); the fix needs an
  event-vocabulary decision, not two added calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates STATUS.md to show ADR-0091 phase D is down to 26 tables, with the count derived from the migrated schema to avoid drift. All record-bearing tables are done; only identity, search, singletons, and the ledgers remain.

- Count source changed: previously hand-maintained; now computed via the embedded SQL query (run after `make test-db-up`).
- Remaining scope: identity (15 tables, take `app_user` last), search’s two, seven singletons, and the two append-only ledgers.
- Recorded follow-ups: fixed double-count in `EntitiesPending` (#1723); the status transport had the same sum and was corrected in #1767; the cost estimator still needs a pricing decision (#1738). Two capture-path writers miss `audit_log` and `event_outbox` rows; needs an event vocabulary decision (#1745).

<sup>Written for commit d456302d1dca681344cff1efd3074487d36cb32c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase D migration status from 32 to 26 remaining tables.
  * Documented completed consolidation of organization, person, lead, relationship, and partner data areas.
  * Added the query used to track remaining tables.
  * Recorded follow-up items for cost-estimator pricing and audit/outbox coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->