### PR TITLE
fix(frontend): the dev server takes tunnel hostnames from the environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -195,3 +195,12 @@ MARGINCE_OVERLAY_BACKFILL_LIMIT=
 # the boot. Overrides license.token_file in margince.yaml, so this is the
 # convenient place to hold one locally — a deployment uses the file reference.
 MARGINCE_LICENSE=
+
+# [optional] Hostnames the Vite dev server accepts in the Host header, beyond
+# localhost. Set this when a tunnel (cloudflared, ngrok) or a reverse proxy
+# fronts `make dev` — without the tunnel's hostname listed, Vite answers
+# "Blocked request. This host is not allowed". Comma-separated for more than
+# one; the hostname a quick tunnel mints dies with that tunnel, so it belongs
+# here and never in vite.config.ts.
+# Example: VITE_ALLOWED_HOSTS=abc-def-ghi.trycloudflare.com
+VITE_ALLOWED_HOSTS=

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,6 +46,21 @@ for (const artifact of [
 const backendPort = process.env.BACKEND_PORT ?? "18080";
 const proxyTarget = `http://localhost:${backendPort}`;
 
+// Hostnames a tunnel (cloudflared, ngrok, a reverse proxy) puts in front of
+// this dev server. Vite rejects a request whose Host header it does not
+// recognise, so exposing `pnpm dev` publicly needs the tunnel's hostname
+// listed. That hostname is minted fresh per tunnel and dies with it, which is
+// why it comes from the environment and is never committed:
+//
+//   VITE_ALLOWED_HOSTS=abc-def.trycloudflare.com pnpm dev
+//
+// Comma-separated for more than one. Unset (the normal case) leaves the list
+// empty, so the dev server keeps refusing every host but localhost.
+const allowedHosts = (process.env.VITE_ALLOWED_HOSTS ?? "")
+  .split(",")
+  .map((host) => host.trim())
+  .filter((host) => host.length > 0);
+
 export default defineConfig({
   // serveMcpApps is `apply: "serve"` — a dev-only middleware that adds nothing
   // to the SPA build. It has to live HERE rather than in vite.mcp-apps.config.ts
@@ -104,6 +119,7 @@ export default defineConfig({
     dedupe: ["react", "react-dom", "@tanstack/react-query"],
   },
   server: {
+    allowedHosts,
     // build/composition/ sits OUTSIDE the Vite root (frontend/), and Vite's
     // dev server refuses to serve a file it cannot prove is inside the
     // workspace. Listing the resolved directory keeps `pnpm dev` working in


### PR DESCRIPTION
## What was wrong

Exposing `make dev` through a tunnel (cloudflared, ngrok) requires the tunnel's
hostname in Vite's `server.allowedHosts` — without it, Vite answers
"Blocked request. This host is not allowed".

The workaround was to paste the hostname straight into `frontend/vite.config.ts`.
A trycloudflare quick-tunnel hostname is minted fresh per tunnel and dies with
it, so that edit is never committable. It sat in the working tree as an
uncommitted change and blocked the next `git pull`, which is how this was found.

## The change

`VITE_ALLOWED_HOSTS` supplies the list, read at the top of `vite.config.ts` the
same way `BACKEND_PORT` already is. Comma-separated for more than one; blanks
trimmed and dropped. Unset — the normal case — leaves the list empty, so the
dev server keeps accepting localhost and nothing else.

`scripts/dev.sh` sources `.env.local` with `set -a` before it launches vite, so
putting the line in `.env.local` is enough; `.env.template` documents it in the
non-production section.

## Verified

Ran a dev server on :5199 both ways and checked the Host header directly:

| Host header | `VITE_ALLOWED_HOSTS` set | Result |
|---|---|---|
| `test-tunnel.trycloudflare.com` | yes | `200` |
| `evil-other.trycloudflare.com` | yes (different host) | Blocked |
| `test-tunnel.trycloudflare.com` | **unset** | Blocked |
| localhost | either | `200` |

The control case matters: with the variable unset the same hostname is still
refused, so the variable is what flips the behaviour rather than a widened default.

`make check-fe` green. `backend/envcontract_test.go` gates `MARGINCE_*` names
only, so this variable is out of its scope — same as the BYOK provider keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads tunnel hostnames for the Vite dev server from the environment. Previously, you had to paste the hostname into `frontend/vite.config.ts`; now set `VITE_ALLOWED_HOSTS` (comma-separated). Default behavior is unchanged: only localhost is allowed when the variable is unset.

- Parses `VITE_ALLOWED_HOSTS` in `frontend/vite.config.ts` and passes it to `server.allowedHosts`.
- Documents the variable in `.env.template`. `scripts/dev.sh` already sources `.env.local`, so placing it there is enough. No production impact.

**Migration**
- If you expose `make dev` via Cloudflare/Ngrok, add `VITE_ALLOWED_HOSTS=<your-tunnel-host>` to `.env.local` (comma-separated for multiple). Remove any local edits to `vite.config.ts`.

<sup>Written for commit 1c96fc9e128f85fa598969ae0b8653a186a3623b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for allowing additional development-server hostnames.
  * Supports comma-separated hostnames, including those used by tunnels and reverse proxies.

* **Documentation**
  * Updated the environment variable template with the new host configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->