### PR TITLE
chore(backend): close the gaps the phase-D column removals left in SQL literals

### DIFF
--- a/backend/internal/compose/captureautoenrich_integration_test.go
+++ b/backend/internal/compose/captureautoenrich_integration_test.go
@@ -90,7 +90,7 @@ func insertDomainOrg(t *testing.T, e *integration.Env, domain string) ids.Organi
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-			VALUES ( $1, $2, true, 'connector:gmail', 'connector:gmail')`, orgID, domain)
+			VALUES ($1, $2, true, 'connector:gmail', 'connector:gmail')`, orgID, domain)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/capturedomaintriage_integration_test.go
+++ b/backend/internal/compose/capturedomaintriage_integration_test.go
@@ -45,7 +45,7 @@ func openQuestion(t *testing.T, e *integration.Env, domain string) {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_domain_disposition (domain, status, owner_id)
-			VALUES ( $1, 'pending', $2)`, domain, e.Rep1)
+			VALUES ($1, 'pending', $2)`, domain, e.Rep1)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/captureenrich_integration_test.go
+++ b/backend/internal/compose/captureenrich_integration_test.go
@@ -56,7 +56,7 @@ func seedEnrichPerson(t *testing.T, e *integration.Env, email, body string) ids.
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO person_email (person_id, email, email_type, is_primary, source, captured_by)
-			VALUES ( $1, $2, 'work', true, 'gmail:seed', 'connector:gmail')`, person, email); err != nil {
+			VALUES ($1, $2, 'work', true, 'gmail:seed', 'connector:gmail')`, person, email); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
@@ -67,7 +67,7 @@ func seedEnrichPerson(t *testing.T, e *integration.Env, email, body string) ids.
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, activity, person)
+			VALUES ($1, 'person', $2)`, activity, person)
 		return err
 	})
 	if err != nil {
@@ -150,7 +150,7 @@ func TestSignatureEnrichPass(t *testing.T) {
 			}
 			_, err := tx.Exec(ctx, `
 				INSERT INTO activity_link (activity_id, entity_type, person_id)
-				VALUES ( $1, 'person', $2)`, newer, person)
+				VALUES ($1, 'person', $2)`, newer, person)
 			return err
 		})
 		if err != nil {

--- a/backend/internal/compose/captureparticipant_integration_test.go
+++ b/backend/internal/compose/captureparticipant_integration_test.go
@@ -218,7 +218,7 @@ func TestDeletingAPersonOrAUserIsNotBlockedByGraphRows(t *testing.T) {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
-			VALUES ( 'Departing Contact', $1, 'manual', 'human:test', 'workspace')
+			VALUES ('Departing Contact', $1, 'manual', 'human:test', 'workspace')
 			RETURNING id`, e.Rep1).Scan(&contact); err != nil {
 			return err
 		}
@@ -230,14 +230,14 @@ func TestDeletingAPersonOrAUserIsNotBlockedByGraphRows(t *testing.T) {
 		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-			VALUES ( 'email', 'Letzte Mail', 'outbound', now(), 'manual', 'human:test')
+			VALUES ('email', 'Letzte Mail', 'outbound', now(), 'manual', 'human:test')
 			RETURNING id`).Scan(&activityID); err != nil {
 			return err
 		}
 		// A user-ONLY participant row: no person arm, no address arm.
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, 'from')`, activityID, doomed); err != nil {
+			VALUES ($1, $2, 'from')`, activityID, doomed); err != nil {
 			return err
 		}
 		// A CONFIRMED ghost pointing at the contact.
@@ -301,13 +301,13 @@ func TestRelinkRepointsOnlyThePersonItDisplaced(t *testing.T) {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-			VALUES ( 'email', 'Verwechslung', 'inbound', now(), 'gmail:m-9', 'connector:gmail')
+			VALUES ('email', 'Verwechslung', 'inbound', now(), 'gmail:m-9', 'connector:gmail')
 			RETURNING id`).Scan(&activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, activityID, linked); err != nil {
+			VALUES ($1, 'person', $2)`, activityID, linked); err != nil {
 			return err
 		}
 		// Two participants: one matching the link, one that never had a link.

--- a/backend/internal/compose/channelprovider_axis_integration_test.go
+++ b/backend/internal/compose/channelprovider_axis_integration_test.go
@@ -102,7 +102,7 @@ func TestActivityChannelProviderFKRefusesAnUnregisteredProvider(t *testing.T) {
 
 	_, err := integration.OwnerConn(t).Exec(context.Background(), `
 		INSERT INTO activity (kind, channel_provider, source, captured_by)
-		VALUES ( 'message', 'no_such_transport', 'manual', 'test')`)
+		VALUES ('message', 'no_such_transport', 'manual', 'test')`)
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) || pgErr.ConstraintName != "activity_channel_provider_fkey" {
 		t.Fatalf("insert failed with %v, want a foreign_key_violation on activity_channel_provider_fkey specifically — "+

--- a/backend/internal/compose/channelprovider_migration_integration_test.go
+++ b/backend/internal/compose/channelprovider_migration_integration_test.go
@@ -90,7 +90,7 @@ func TestActivityKindFKRefusesAnUnregisteredKind(t *testing.T) {
 
 	_, err := integration.OwnerConn(t).Exec(ctx, `
 		INSERT INTO activity (kind, source, captured_by)
-		VALUES ( 'dispact', 'manual', 'test')`)
+		VALUES ('dispact', 'manual', 'test')`)
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) || pgErr.ConstraintName != "activity_kind_fkey" {
 		t.Fatalf("insert failed with %v, want a foreign_key_violation on activity_kind_fkey specifically — "+

--- a/backend/internal/compose/coldstart_integration_test.go
+++ b/backend/internal/compose/coldstart_integration_test.go
@@ -376,7 +376,7 @@ func seedAcmeOrgWithHumanIndustry(t *testing.T, e *integration.Env, admin contex
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-			VALUES ( $1, 'acme.example', true, 'manual', 'human:owner')`, orgID)
+			VALUES ($1, 'acme.example', true, 'manual', 'human:owner')`, orgID)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -489,7 +489,7 @@ func TestCompanyContextIsScopedProvenanceBearingAndChangesWithTheProfile(t *test
 	}
 	e.WsExec(t, `
 		INSERT INTO organization_fact (organization_id, category, field, value, value_key, evidence_snippet, source_url, confidence, source, captured_by)
-		VALUES ( $1, 'offering', 'service', 'CRM rollout', 'crm rollout',
+		VALUES ($1, 'offering', 'service', 'CRM rollout', 'crm rollout',
 		        '', '', 1, 'human', $2)`, saved.OrganizationID, "human:"+e.Rep1.String())
 
 	// The cross-tenant arm is gone with the mechanism it tested. It seeded a

--- a/backend/internal/compose/costestimate/estimator_integration_test.go
+++ b/backend/internal/compose/costestimate/estimator_integration_test.go
@@ -191,7 +191,7 @@ func (e *estEnv) insertLabeledActivity(t *testing.T, ws ids.UUID) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
 		INSERT INTO activity (kind, source, captured_by, capture_labeled_at)
-		VALUES ( 'email', 'gmail', 'system', $1)`, inWindow); err != nil {
+		VALUES ('email', 'gmail', 'system', $1)`, inWindow); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/backend/internal/compose/deepreadaccept_integration_test.go
+++ b/backend/internal/compose/deepreadaccept_integration_test.go
@@ -68,7 +68,7 @@ func TestDeepReadOfferingsDedupeOnValueKeyAndAcceptRespectsHumanPrecedence(t *te
 	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_fact (organization_id, category, field, value, value_key, evidence_snippet, source_url, confidence, source, captured_by)
-			VALUES ( $1, 'offering', 'service', 'CRM Rollout (human curated)', 'crm rollout',
+			VALUES ($1, 'offering', 'service', 'CRM Rollout (human curated)', 'crm rollout',
 			        'set by hand', '', 1, 'human', $2)`,
 			org, "human:"+e.Rep1.String())
 		return err
@@ -190,7 +190,7 @@ func TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous(t *testing.T) {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_fact (organization_id, category, field, value, value_key, evidence_snippet, source_url, confidence, source, captured_by)
-			VALUES ( $1, 'company', 'employee_range', '11-50', '',
+			VALUES ($1, 'company', 'employee_range', '11-50', '',
 			        'set by hand', '', 1, 'human', $2)`,
 			claimed, "human:"+e.Rep1.String())
 		return err

--- a/backend/internal/compose/erasureapprovals_integration_test.go
+++ b/backend/internal/compose/erasureapprovals_integration_test.go
@@ -39,7 +39,7 @@ func erasureSubject(t *testing.T, e *integration.Env) (ids.PersonID, ids.Approva
 	const addr = "anna.erasure@example.com"
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, $2, true, 'test', 'human:seed')`, person, addr)
+		VALUES ($1, $2, true, 'test', 'human:seed')`, person, addr)
 
 	id, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind: "held_draft",
@@ -199,7 +199,7 @@ func TestErasureLeavesALookalikeAddressAlone(t *testing.T) {
 	subject := e.SeedPerson(t, "Pattern Subject", nil)
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, 't_m@example.com', true, 'test', 'human:seed')`, subject)
+		VALUES ($1, 't_m@example.com', true, 'test', 'human:seed')`, subject)
 
 	bystander, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind:           "held_draft",
@@ -239,7 +239,7 @@ func TestErasureLeavesAnAddressThatMerelyContainsTheSubjectsAlone(t *testing.T) 
 	subject := e.SeedPerson(t, "Suffix Subject", nil)
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, 'm@example.com', true, 'test', 'human:seed')`, subject)
+		VALUES ($1, 'm@example.com', true, 'test', 'human:seed')`, subject)
 
 	bystander, err := approvals.NewService(e.DB()).Stage(e.Admin(), approvals.StageInput{
 		Kind:           "held_draft",

--- a/backend/internal/compose/erasuregraph_integration_test.go
+++ b/backend/internal/compose/erasuregraph_integration_test.go
@@ -56,24 +56,24 @@ func TestErasureRemovesTheSubjectFromTheRelationshipGraph(t *testing.T) {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
-			VALUES ( 'Erase Me', $1, 'manual', 'human:test', 'workspace')
+			VALUES ('Erase Me', $1, 'manual', 'human:test', 'workspace')
 			RETURNING id`, e.Rep1).Scan(&person); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-			VALUES ( $1, $2, true, 'manual', 'human:test')`, person, subjectEmail); err != nil {
+			VALUES ($1, $2, true, 'manual', 'human:test')`, person, subjectEmail); err != nil {
 			return err
 		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-			VALUES ( 'email', 'Angebot', 'inbound', $1, 'manual', 'human:test')
+			VALUES ('email', 'Angebot', 'inbound', $1, 'manual', 'human:test')
 			RETURNING id`, now.AddDate(0, 0, -1)).Scan(&activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, 'to')`, activityID, e.Rep1); err != nil {
+			VALUES ($1, $2, 'to')`, activityID, e.Rep1); err != nil {
 			return err
 		}
 		// The subject appears twice: as a resolved person, and — on a second
@@ -81,12 +81,12 @@ func TestErasureRemovesTheSubjectFromTheRelationshipGraph(t *testing.T) {
 		// never became a record.
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, address, role)
-			VALUES ( $1, $2, $3, 'from')`, activityID, person, subjectEmail); err != nil {
+			VALUES ($1, $2, $3, 'from')`, activityID, person, subjectEmail); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, activityID, person); err != nil {
+			VALUES ($1, 'person', $2)`, activityID, person); err != nil {
 			return err
 		}
 		return nil

--- a/backend/internal/compose/erasurequotations_integration_test.go
+++ b/backend/internal/compose/erasurequotations_integration_test.go
@@ -56,12 +56,12 @@ func transcriptSubject(t *testing.T, e *integration.Env) (ids.PersonID, ids.UUID
 	person := e.SeedPerson(t, "Mara Kessler", nil)
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, 'mara.kessler@example.com', true, 'test', 'human:seed')`, person)
+		VALUES ($1, 'mara.kessler@example.com', true, 'test', 'human:seed')`, person)
 
 	activityID := seedTranscript(t, e, "1: Tom: Where did we land on pricing?\n2: "+quotedTranscriptLine)
 	e.WsExec(t, `
 		INSERT INTO activity_link (activity_id, entity_type, person_id)
-		VALUES ( $1, 'person', $2)`, activityID, person)
+		VALUES ($1, 'person', $2)`, activityID, person)
 	e.WsExec(t, `
 		INSERT INTO transcript_read (id, activity_id, status, line_count, requested_by, started_at, finished_at)
 		VALUES ($1, $2, 'done', 2, 'human:seed', now(), now())`, ids.NewV7(), activityID)
@@ -192,7 +192,7 @@ func TestErasureLeavesTheQuotationOfAMeetingItMayNotDestroy(t *testing.T) {
 	const addr = "mara.kessler@example.com"
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, $2, true, 'test', 'human:seed')`, subject, addr)
+		VALUES ($1, $2, true, 'test', 'human:seed')`, subject, addr)
 	colleague := e.SeedPerson(t, "Bob Ferrer", nil)
 
 	quote := "Tom: loop in " + addr + " on the renewal."
@@ -200,7 +200,7 @@ func TestErasureLeavesTheQuotationOfAMeetingItMayNotDestroy(t *testing.T) {
 	for _, participant := range []any{subject, colleague} {
 		e.WsExec(t, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, shared, participant)
+			VALUES ($1, 'person', $2)`, shared, participant)
 	}
 	approvalID := stageQuotingProposal(t, e, shared, quote, "Loop in the renewal contact")
 
@@ -293,7 +293,7 @@ func TestSubjectAccessWithholdsAQuotationFromARecordTheSubjectHasNoPartIn(t *tes
 	const addr = "mara.kessler@example.com"
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, $2, true, 'test', 'human:seed')`, subject, addr)
+		VALUES ($1, $2, true, 'test', 'human:seed')`, subject, addr)
 
 	const theirsAlone = "Tom: Bob, hold the line at list price - Contoso got thirty percent and nobody is to know."
 	elsewhere := seedTranscript(t, e, "1: "+theirsAlone)

--- a/backend/internal/compose/graphedge_integration_test.go
+++ b/backend/internal/compose/graphedge_integration_test.go
@@ -59,13 +59,13 @@ func (v edgeEnv) interaction(t *testing.T, user ids.UUID, person ids.PersonID, a
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, $3)`,
+			VALUES ($1, $2, $3)`,
 			activityID, user, userRole); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, $3)`,
+			VALUES ($1, $2, $3)`,
 			activityID, person, personRole)
 		return err
 	}); err != nil {
@@ -80,7 +80,7 @@ func (v edgeEnv) person(t *testing.T, name string) ids.PersonID {
 	if err := database.WithWorkspaceTx(v.e.Admin(), v.e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person (id, full_name, owner_id, source, captured_by, visibility)
-			VALUES ( $1, $2, $3, 'manual', 'human:test', 'workspace')`,
+			VALUES ($1, $2, $3, 'manual', 'human:test', 'workspace')`,
 			id, name, v.e.Rep1)
 		return err
 	}); err != nil {
@@ -381,7 +381,7 @@ func TestOneMessageCountsOnceHoweverManyRolesItNames(t *testing.T) {
 	if err := database.WithWorkspaceTx(v.e.Admin(), v.e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'cc')`,
+			VALUES ($1, $2, 'cc')`,
 			activityID, contact)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/graphjobs_integration_test.go
+++ b/backend/internal/compose/graphjobs_integration_test.go
@@ -34,14 +34,14 @@ func legacyInteraction(t *testing.T, e *integration.Env, person ids.UUID, captur
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by, counterparty_email)
-			VALUES ( 'email', 'Alt', 'outbound', now() - interval '3 days',
+			VALUES ('email', 'Alt', 'outbound', now() - interval '3 days',
 			        'manual', $1, 'pat@counterparty.test')
 			RETURNING id`, capturedBy).Scan(&id); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, id, person)
+			VALUES ($1, 'person', $2)`, id, person)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding a legacy activity: %v", err)
@@ -55,7 +55,7 @@ func seedGraphPerson(t *testing.T, e *integration.Env, name string) ids.UUID {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
-			VALUES ( $1, $2,
+			VALUES ($1, $2,
 			        'manual', 'human:test', 'workspace')
 			RETURNING id`, name, e.Rep1).Scan(&id)
 	}); err != nil {
@@ -121,12 +121,12 @@ func TestTheReconcileWorkerRebuildsTheProjection(t *testing.T) {
 		ctx := context.Background()
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, 'from')`, activityID, e.Rep1); err != nil {
+			VALUES ($1, $2, 'from')`, activityID, e.Rep1); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'to')`, activityID, person)
+			VALUES ($1, $2, 'to')`, activityID, person)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding participants: %v", err)

--- a/backend/internal/compose/heldrelease_integration_test.go
+++ b/backend/internal/compose/heldrelease_integration_test.go
@@ -92,7 +92,7 @@ func seedHeldDraft(t *testing.T, e *integration.Env, svc *approvals.Service) hel
 	// release under test.
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		VALUES ( $1, $2, true, 'test', 'human:seed')`, person, to)
+		VALUES ($1, $2, true, 'test', 'human:seed')`, person, to)
 
 	// The counterparty on the thread, carrying the address a reply answers.
 	e.WsExec(t, `

--- a/backend/internal/compose/integration/activity_links_and_query_integration_test.go
+++ b/backend/internal/compose/integration/activity_links_and_query_integration_test.go
@@ -33,7 +33,7 @@ func TestListActivitiesCarriesItsLinks(t *testing.T) {
 	// The organization arm is inserted here rather than through
 	// LinkActivity, whose column map covers person and deal only.
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, activity, org)
+		VALUES ($1, 'organization', $2)`, activity, org)
 	LinkActivity(t, owner, activity, "person", person)
 
 	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{})

--- a/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
@@ -46,7 +46,7 @@ func TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg(t *testing.T) {
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-			VALUES ( $1, 'gitex.com', true, 'connector:gmail', 'connector:gmail')`, orgID)
+			VALUES ($1, 'gitex.com', true, 'connector:gmail', 'connector:gmail')`, orgID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the captured org: %v", err)

--- a/backend/internal/compose/integration/capture/capture_env_test.go
+++ b/backend/internal/compose/integration/capture/capture_env_test.go
@@ -233,7 +233,7 @@ func newCaptureEnv(t *testing.T) captureEnv {
 		}
 		_, err := tx.Exec(wsCtx, `
 			INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-			VALUES ( $1, 'myco.example', true, 'manual', 'human:test')`, orgID)
+			VALUES ($1, 'myco.example', true, 'manual', 'human:test')`, orgID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the anchor company: %v", err)

--- a/backend/internal/compose/integration/capture_shape_producers_integration_test.go
+++ b/backend/internal/compose/integration/capture_shape_producers_integration_test.go
@@ -247,7 +247,7 @@ func TestAConversationWithNoNameableReaderIsRefusedRatherThanShared(t *testing.T
 	notice := seedUnlinkedMessage(t, e, "thread-nameless", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", captureShapeClock.Add(-48*time.Hour))
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, notice, org)
+		VALUES ($1, 'organization', $2)`, notice, org)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}
@@ -285,7 +285,7 @@ func TestAPrivateAccountSuppliesTheReaderItsOwnMailAnswersTo(t *testing.T) {
 	notice := seedUnlinkedMessage(t, e, "thread-private-account", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", captureShapeClock.Add(-48*time.Hour))
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, notice, org)
+		VALUES ($1, 'organization', $2)`, notice, org)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}

--- a/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/channels/channelidentity_lifecycle_integration_test.go
@@ -366,7 +366,7 @@ func seedPersonEmail(t *testing.T, e *integration.Env, person ids.UUID, email st
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, source, captured_by)
-		VALUES ( $1, $2, 'manual', 'user:test')`,
+		VALUES ($1, $2, 'manual', 'user:test')`,
 		person, email)
 }
 

--- a/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_identity_integration_test.go
@@ -225,7 +225,7 @@ func (c *telegramEnv) bindChannelIdentity(t *testing.T, person string, identity 
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
-			VALUES ( $1, $2, $3, $4, 'telegram', 'connector:telegram')`,
+			VALUES ($1, $2, $3, $4, 'telegram', 'connector:telegram')`,
 			person, identity.Provider, identity.ChannelUserID, identity.Username)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -103,7 +103,7 @@ func (c *channelSendEnv) bindIdentity(t *testing.T) {
 	if err := apptest.InWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
-			VALUES ( $1, 'telegram', $2, 'buyer', 'telegram', 'connector:telegram')`,
+			VALUES ($1, 'telegram', $2, 'buyer', 'telegram', 'connector:telegram')`,
 			c.personID, channelSendAccountID)
 		return err
 	}); err != nil {
@@ -122,14 +122,14 @@ func (c *channelSendEnv) seedInboundMessage(t *testing.T) {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, channel_provider, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key)
-			VALUES ( 'message', 'telegram', 'Is this still available?', now(), 'inbound',
+			VALUES ('message', 'telegram', 'Is this still available?', now(), 'inbound',
 			        'telegram', '8100:770011:5', 'telegram:8100:770011:5', 'connector:telegram', $1)
 			RETURNING id`, channelSendThreadKey).Scan(&c.activityID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, c.activityID, c.personID)
+			VALUES ($1, 'person', $2)`, c.activityID, c.personID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the inbound conversation: %v", err)

--- a/backend/internal/compose/integration/documents_integration_test.go
+++ b/backend/internal/compose/integration/documents_integration_test.go
@@ -337,7 +337,7 @@ func seedActivityWithDeal(t *testing.T, e *Env, deal ids.UUID) ids.UUID {
 		id, activityOccurredAt)
 	e.WsExec(t, `
 		INSERT INTO activity_link (activity_id, entity_type, deal_id)
-		VALUES ( $1, 'deal', $2)`, id, deal)
+		VALUES ($1, 'deal', $2)`, id, deal)
 	return id
 }
 

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -161,7 +161,7 @@ func seedStaleEmbeddingRow(t *testing.T, e *apptest.AppEnv, wsID string) {
 	ctx := context.Background()
 	var personID string
 	if err := e.Owner.QueryRow(ctx,
-		`INSERT INTO person (full_name, source, captured_by) VALUES ( 'Stale Row Person', 'manual', 'human:x') RETURNING id`).Scan(&personID); err != nil {
+		`INSERT INTO person (full_name, source, captured_by) VALUES ('Stale Row Person', 'manual', 'human:x') RETURNING id`).Scan(&personID); err != nil {
 		t.Fatalf("seeding the stale-row person: %v", err)
 	}
 	if _, err := e.Owner.Exec(ctx, `

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -56,7 +56,7 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO person_email (person_id, email, source, captured_by)
-			 VALUES ( $1, $2, 'manual', 'human:x')`, personID, subjectEmail); err != nil {
+			 VALUES ($1, $2, 'manual', 'human:x')`, personID, subjectEmail); err != nil {
 			return err
 		}
 		activityID := ids.NewV7()
@@ -67,7 +67,7 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, person_id)
-			 VALUES ( $1, 'person', $2)`, activityID, personID); err != nil {
+			 VALUES ($1, 'person', $2)`, activityID, personID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
@@ -295,12 +295,12 @@ func TestErasurePreservesActivityUnderTransitiveHold(t *testing.T) {
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, person_id)
-			 VALUES ( $1, 'person', $2)`, heldActivity, personID); err != nil {
+			 VALUES ($1, 'person', $2)`, heldActivity, personID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, organization_id)
-			 VALUES ( $1, 'organization', $2)`, heldActivity, orgID); err != nil {
+			 VALUES ($1, 'organization', $2)`, heldActivity, orgID); err != nil {
 			return err
 		}
 		// The sibling note: subject-only, NOT transitively held, and (being a
@@ -313,7 +313,7 @@ func TestErasurePreservesActivityUnderTransitiveHold(t *testing.T) {
 		}
 		_, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, person_id)
-			 VALUES ( $1, 'person', $2)`, freeActivity, personID)
+			 VALUES ($1, 'person', $2)`, freeActivity, personID)
 		return err
 	})
 	if err != nil {
@@ -393,7 +393,7 @@ func TestErasePersonHonoursCommercialCorrespondenceFloor(t *testing.T) {
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, person_id)
-			 VALUES ( $1, 'person', $2)`, email, personID); err != nil {
+			 VALUES ($1, 'person', $2)`, email, personID); err != nil {
 			return err
 		}
 		// A same-age internal note — no statutory floor.
@@ -405,7 +405,7 @@ func TestErasePersonHonoursCommercialCorrespondenceFloor(t *testing.T) {
 		}
 		_, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, person_id)
-			 VALUES ( $1, 'person', $2)`, note, personID)
+			 VALUES ($1, 'person', $2)`, note, personID)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/erasure_restriction_integration_test.go
+++ b/backend/internal/compose/integration/erasure_restriction_integration_test.go
@@ -54,7 +54,7 @@ func seedRestrictionFixture(t *testing.T, e *Env) restrictionFixture {
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO person_email (person_id, email, source, captured_by)
-			 VALUES ( $1, 'held@example.test', 'manual', 'human:x')`, f.person); err != nil {
+			 VALUES ($1, 'held@example.test', 'manual', 'human:x')`, f.person); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx,
@@ -72,7 +72,7 @@ func seedRestrictionFixture(t *testing.T, e *Env) restrictionFixture {
 		for _, a := range []ids.UUID{f.email, f.note} {
 			if _, err := tx.Exec(ctx,
 				`INSERT INTO activity_link (activity_id, entity_type, person_id)
-				 VALUES ( $1, 'person', $2)`, a, f.person); err != nil {
+				 VALUES ($1, 'person', $2)`, a, f.person); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -370,7 +370,7 @@ func TestFieldHistoryErasureBoundsCollateralScrubs(t *testing.T) {
 	// The subject's address is what ties the twin to the person: the
 	// eraser wipes any lead carrying one of the subject's emails.
 	e.WsExec(t, `INSERT INTO person_email (person_id, email, source, captured_by)
-		 VALUES ( $1, $2, 'manual', 'human:x')`,
+		 VALUES ($1, $2, 'manual', 'human:x')`,
 		personID, twinEmail)
 	leadID := seedLead(t, e, "Selma Subject", twinEmail, nil)
 

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -173,7 +173,7 @@ func seatInRoom(t *testing.T, owner *pgx.Conn, ws, activity, person ids.UUID) {
 	t.Helper()
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO activity_participant (activity_id, role, person_id)
-		 VALUES ( $1, 'attendee', $2)`, activity, person); err != nil {
+		 VALUES ($1, 'attendee', $2)`, activity, person); err != nil {
 		t.Fatalf("seating a participant: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -75,7 +75,7 @@ func seedDealContextActivity(t *testing.T, e *apptest.AppEnv, wsID, dealID, subj
 		t.Fatalf("seed deal context activity: %v", err)
 	}
 	if _, err := e.Owner.Exec(context.Background(),
-		`INSERT INTO activity_link (activity_id, entity_type, deal_id) VALUES ( $1, 'deal', $2)`, activityID, dealID); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, deal_id) VALUES ($1, 'deal', $2)`, activityID, dealID); err != nil {
 		t.Fatalf("link deal context activity: %v", err)
 	}
 	return "activity:" + activityID.String()

--- a/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
@@ -80,13 +80,13 @@ func seedTouch(t *testing.T, e *integration.Env, owner *pgx.Conn, kind string, c
 		if colleague != nil {
 			if _, err := owner.Exec(ctx, `
 				INSERT INTO activity_participant (activity_id, user_id, role)
-				VALUES ( $1, $2, 'from')`, id, *colleague); err != nil {
+				VALUES ($1, $2, 'from')`, id, *colleague); err != nil {
 				t.Fatalf("seeding the our-side participant: %v", err)
 			}
 		}
 		if _, err := owner.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'to')`, id, person); err != nil {
+			VALUES ($1, $2, 'to')`, id, person); err != nil {
 			t.Fatalf("seeding the counterparty participant: %v", err)
 		}
 	}

--- a/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
@@ -37,7 +37,7 @@ func seedUnansweredOutbound(t *testing.T, e *integration.Env, org ids.UUID) {
 		VALUES ($1, 'email', 'outbound', 'Proposal — following up',
 		        '2026-05-10T09:00:00Z', '2026-05-10T09:00:00Z', 'manual', 'human:x')`)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, sent, org)
+		VALUES ($1, 'organization', $2)`, sent, org)
 }
 
 // The rules must look PAST the section page cap.
@@ -66,7 +66,7 @@ func TestSuggestionsLookPastTheSectionPageCap(t *testing.T) {
 			t.Fatalf("seeding note %d: %v", i, err)
 		}
 		e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-			VALUES ( $1, 'organization', $2)`, note, org.UUID)
+			VALUES ($1, 'organization', $2)`, note, org.UUID)
 	}
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), org)
@@ -233,7 +233,7 @@ func TestNoNextStepSeesATaskThePageDoesNot(t *testing.T) {
 		t.Fatalf("seeding the task: %v", err)
 	}
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
-		VALUES ( $1, 'deal', $2)`, task, deal)
+		VALUES ($1, 'deal', $2)`, task, deal)
 
 	view, err := svc.Assemble(rep, org)
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_visit_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_visit_integration_test.go
@@ -141,7 +141,7 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 	old := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by)
 		VALUES ($1, 'note', 'before the visit', '2026-05-01T09:00:00Z', '2026-05-01T09:00:00Z', 'manual', 'human:x')`)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, old, org.UUID)
+		VALUES ($1, 'organization', $2)`, old, org.UUID)
 
 	if _, err := svc.Acknowledge(admin, org); err != nil {
 		t.Fatalf("acknowledge: %v", err)
@@ -152,7 +152,7 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 	fresh := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by)
 		VALUES ($1, 'note', 'after the visit', '2026-06-15T09:00:00Z', '2026-06-15T09:00:00Z', 'manual', 'human:x')`)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, fresh, org.UUID)
+		VALUES ($1, 'organization', $2)`, fresh, org.UUID)
 	created := e.SeedDeal(t, "Brand new deal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, created, org.UUID)
 	if _, err := e.Deals.AdvanceDeal(admin, ids.From[ids.DealKind](before), deals.AdvanceDealInput{ToStageID: won, WonWithoutContractReason: integration.WonByImport()}); err != nil {
@@ -193,7 +193,7 @@ func TestOrganization360CountsTheWholeHistoryOnAFirstVisit(t *testing.T) {
 	logged := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, 'note', 'first contact', now(), 'manual', 'human:x')`)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, logged, org.UUID)
+		VALUES ($1, 'organization', $2)`, logged, org.UUID)
 
 	view, err := svc.Assemble(e.Admin(), org)
 	if err != nil {

--- a/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
+++ b/backend/internal/compose/integration/privacy_channel_delivery_integration_test.go
@@ -57,7 +57,7 @@ func seedChannelSubject(t *testing.T, e *Env) ids.UUID {
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
-			VALUES ( $1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`,
+			VALUES ($1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`,
 			personID, channelSubjectAccount)
 		return err
 	})
@@ -85,7 +85,7 @@ func seedChannelDelivery(t *testing.T, e *Env, age, body, status string, person 
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO activity_link (activity_id, entity_type, person_id)
-			 VALUES ( $1, 'person', $2)`, out.activity, person); err != nil {
+			 VALUES ($1, 'person', $2)`, out.activity, person); err != nil {
 			return err
 		}
 		// cc and references_chain are named as NULL for the reason

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -71,7 +71,7 @@ func seedMailRecipient(t *testing.T, e *Env) ids.UUID {
 		}
 		_, err := tx.Exec(ctx,
 			`INSERT INTO person_email (person_id, email, source, captured_by)
-			 VALUES ( $1, $2, 'manual', 'human:x')`, personID, mailRecipientEmail)
+			 VALUES ($1, $2, 'manual', 'human:x')`, personID, mailRecipientEmail)
 		return err
 	})
 	if err != nil {
@@ -125,7 +125,7 @@ func seedAddressedDelivery(t *testing.T, e *Env, age, subject, body, status stri
 		if !linkTo.IsZero() {
 			if _, err := tx.Exec(ctx,
 				`INSERT INTO activity_link (activity_id, entity_type, person_id)
-				 VALUES ( $1, 'person', $2)`, out.activity, linkTo); err != nil {
+				 VALUES ($1, 'person', $2)`, out.activity, linkTo); err != nil {
 				return err
 			}
 		}
@@ -386,7 +386,7 @@ func linkToHeldDeal(t *testing.T, e *Env, activityID ids.UUID) {
 	e.WsExec(t, `UPDATE deal SET legal_hold = true WHERE id = $1`, dealID)
 	e.WsExec(t,
 		`INSERT INTO activity_link (activity_id, entity_type, deal_id)
-		 VALUES ( $1, 'deal', $2)`,
+		 VALUES ($1, 'deal', $2)`,
 		activityID, dealID)
 }
 

--- a/backend/internal/compose/integration/providerclaims_integration_test.go
+++ b/backend/internal/compose/integration/providerclaims_integration_test.go
@@ -113,7 +113,7 @@ func seedMergeSubject(t *testing.T, e *Env, name string) ids.UUID {
 		}
 		_, err := tx.Exec(ctx,
 			`INSERT INTO person_email (person_id, email, source, captured_by)
-			 VALUES ( $1, $2, 'manual', 'human:x')`,
+			 VALUES ($1, $2, 'manual', 'human:x')`,
 			personID, personID.String()+"@example.com")
 		return err
 	})
@@ -203,7 +203,7 @@ func TestErasureReachesAnArchivedDuplicatesPurchasedClaims(t *testing.T) {
 		}
 		_, err := tx.Exec(ctx,
 			`INSERT INTO person_email (person_id, email, source, captured_by, archived_at)
-			 VALUES ( $1, $2, 'manual', 'human:x', now())`, archived, subjectEmail)
+			 VALUES ($1, $2, 'manual', 'human:x', now())`, archived, subjectEmail)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/integration/recordcontext_http_integration_test.go
+++ b/backend/internal/compose/integration/recordcontext_http_integration_test.go
@@ -90,7 +90,7 @@ func seedMeetingLinkedTo(t *testing.T, e *apptest.AppEnv, personID string) strin
 	}
 	if _, err := e.Owner.Exec(t.Context(), `
 		INSERT INTO activity_participant (activity_id, role, address)
-		VALUES ( $1, 'attendee', 'nobody@example.test')`, meeting.ID); err != nil {
+		VALUES ($1, 'attendee', 'nobody@example.test')`, meeting.ID); err != nil {
 		t.Fatalf("seeding the unmatched attendee: %v", err)
 	}
 	return meeting.ID

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -334,7 +334,7 @@ func TestRecordHistoryErasureBoundsCollateralScrubs(t *testing.T) {
 	// The subject's address is what ties the twin to the person: the
 	// eraser wipes any lead carrying one of the subject's emails.
 	e.WsExec(t, `INSERT INTO person_email (person_id, email, source, captured_by)
-		 VALUES ( $1, $2, 'manual', 'human:x')`,
+		 VALUES ($1, $2, 'manual', 'human:x')`,
 		personID, twinEmail)
 	leadID := seedLead(t, e, "Selma Subject", twinEmail, nil)
 

--- a/backend/internal/compose/integration/replyaddress_integration_test.go
+++ b/backend/internal/compose/integration/replyaddress_integration_test.go
@@ -101,10 +101,10 @@ func TestAParticipantWithNoAddressFallsBackToThePrimaryEmail(t *testing.T) {
 	// returns this one on insertion order and the test fails loudly.
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, position, source, captured_by)
-		VALUES ( $1, 'anna.private@example.com', false, 0, 'test', 'human:seed')`, person)
+		VALUES ($1, 'anna.private@example.com', false, 0, 'test', 'human:seed')`, person)
 	e.WsExec(t, `
 		INSERT INTO person_email (person_id, email, is_primary, position, source, captured_by)
-		VALUES ( $1, 'anna@work.example.com', true, 1, 'test', 'human:seed')`, person)
+		VALUES ($1, 'anna@work.example.com', true, 1, 'test', 'human:seed')`, person)
 
 	anchor := seedReplyThread(t, e, "inbound",
 		replyParty{role: "from", person: &person},

--- a/backend/internal/compose/integration/retention_authoring_integration_test.go
+++ b/backend/internal/compose/integration/retention_authoring_integration_test.go
@@ -562,7 +562,7 @@ func TestRetentionAnonymizesAnUnattachedPersonAndArchivesAnAgedNote(t *testing.T
 		VALUES ($1, 'Old Contact', 'Old', 'Contact', 'Buyer', 'manual', 'human:x', now() - interval '800 days')`,
 		personID)
 	e.WsExec(t, `INSERT INTO person_email (person_id, email, source, captured_by)
-		VALUES ( $1, 'old.contact@example.test', 'manual', 'human:x')`, personID)
+		VALUES ($1, 'old.contact@example.test', 'manual', 'human:x')`, personID)
 	// A NOTE, deliberately: an internal note is not commercial correspondence, so
 	// it carries no statutory floor and the 1095-day archive reaches it. An email
 	// of the same age would be shielded, which is the boundary

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -120,7 +120,7 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 		for _, a := range []ids.UUID{email, janEmail, message} {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO activity_link (activity_id, entity_type, deal_id)
-				VALUES ( $1, 'deal', $2)`, a, deal); err != nil {
+				VALUES ($1, 'deal', $2)`, a, deal); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/integration/retention_stamp_integration_test.go
+++ b/backend/internal/compose/integration/retention_stamp_integration_test.go
@@ -53,7 +53,7 @@ func seedStampFixture(t *testing.T, e *Env) stampFixture {
 		VALUES ($1, 'email', 'Order confirmation', 'the agreed price was 4200 EUR', now(), 'manual', 'human:x')`,
 		email)
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, deal_id)
-		VALUES ( $1, 'deal', $2)`, email, deal)
+		VALUES ($1, 'deal', $2)`, email, deal)
 
 	return stampFixture{deal: deal, wonStage: ids.StageID{UUID: wonStage}, email: email}
 }

--- a/backend/internal/compose/integration/signalextract_integration_test.go
+++ b/backend/internal/compose/integration/signalextract_integration_test.go
@@ -437,7 +437,7 @@ func TestAThreadLinkedStraightToTheAccountIsStillRead(t *testing.T) {
 	notice := seedUnlinkedMessage(t, e, "thread-direct", "Renewal for 2027",
 		"We have decided not to renew.", "inbound", extractClock.Add(-48*time.Hour))
 	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, organization_id)
-		VALUES ( $1, 'organization', $2)`, notice, org)
+		VALUES ($1, 'organization', $2)`, notice, org)
 
 	brain := &scriptedBrain{reply: reply(t, "contract_ended", notice,
 		"They wrote that they will not renew.", 0.95)}

--- a/backend/internal/compose/linkedinmatchproposal_integration_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_integration_test.go
@@ -36,7 +36,7 @@ func linkedInMatchFixture(ctx context.Context, t *testing.T, e *integration.Env)
 	seedAsAdmin(t, e, func(c context.Context, tx pgx.Tx) error {
 		return tx.QueryRow(c, `
 			INSERT INTO organization (display_name, source, captured_by)
-			VALUES ( 'Acme GmbH', 'manual', 'human:test') RETURNING id`).Scan(&orgID)
+			VALUES ('Acme GmbH', 'manual', 'human:test') RETURNING id`).Scan(&orgID)
 	}, "seeding the account")
 
 	person, err := e.People.CreatePerson(ctx, people.CreatePersonInput{

--- a/backend/internal/compose/orgconnections_integration_test.go
+++ b/backend/internal/compose/orgconnections_integration_test.go
@@ -74,7 +74,7 @@ func TestConnectorCapturedMailPutsAColleagueOnTheAccount(t *testing.T) {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-			VALUES ( 'email', 'Angebot', 'inbound', $1, 'gmail:m-1', 'connector:gmail')
+			VALUES ('email', 'Angebot', 'inbound', $1, 'gmail:m-1', 'connector:gmail')
 			RETURNING id`, now.AddDate(0, 0, -1)).Scan(&activityID); err != nil {
 			return err
 		}
@@ -82,12 +82,12 @@ func TestConnectorCapturedMailPutsAColleagueOnTheAccount(t *testing.T) {
 		// counterparty. This is the fact the old derivation had no access to.
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, 'to')`, activityID, owner); err != nil {
+			VALUES ($1, $2, 'to')`, activityID, owner); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'from')`, activityID, contact)
+			VALUES ($1, $2, 'from')`, activityID, contact)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding connector-captured mail: %v", err)
@@ -127,18 +127,18 @@ func TestADepartedColleagueIsNotOfferedAsAWayIn(t *testing.T) {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-			VALUES ( 'email', 'Alt', 'outbound', $1, 'manual', 'human:test')
+			VALUES ('email', 'Alt', 'outbound', $1, 'manual', 'human:test')
 			RETURNING id`, now.AddDate(0, 0, -2)).Scan(&activityID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, user_id, role)
-			VALUES ( $1, $2, 'from')`, activityID, e.Rep2); err != nil {
+			VALUES ($1, $2, 'from')`, activityID, e.Rep2); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_participant (activity_id, person_id, role)
-			VALUES ( $1, $2, 'to')`, activityID, contact)
+			VALUES ($1, $2, 'to')`, activityID, contact)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the interaction: %v", err)

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -131,7 +131,7 @@ func addPersonEmail(t *testing.T, e *integration.Env, personID ids.UUID, email s
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_email (person_id, email, email_type, is_primary, source, captured_by)
-			VALUES ( $1, $2, 'work', true, 'manual', 'human:x')`,
+			VALUES ($1, $2, 'work', true, 'manual', 'human:x')`,
 			personID, email)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/profilefieldvocab_integration_test.go
+++ b/backend/internal/compose/profilefieldvocab_integration_test.go
@@ -38,7 +38,7 @@ func TestEveryExtractionFieldIsAccepted_ByTheLiveCheckConstraint(t *testing.T) {
 		for _, field := range extractionFieldNames {
 			if _, err := tx.Exec(context.Background(),
 				`INSERT INTO organization_profile_field (organization_id, field, value, evidence_snippet, source_url, confidence, captured_by)
-				 VALUES ( $1, $2, 'v', 'e', 'https://example.test', 0.9, 'agent:test')`,
+				 VALUES ($1, $2, 'v', 'e', 'https://example.test', 0.9, 'agent:test')`,
 				orgID, field); err != nil {
 				t.Errorf("the live CHECK constraint refuses extraction field %q — widen it with the vocabulary (see 0084's pattern)", field)
 				return err

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -111,7 +111,7 @@ func (e *reconcileEnv) seedTask(t *testing.T, dealID ids.UUID, done bool) ids.UU
 func (e *reconcileEnv) linkActivity(t *testing.T, activityID, dealID ids.UUID) {
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO activity_link (activity_id, entity_type, deal_id) VALUES ( $1, 'deal', $2)`, activityID, dealID); err != nil {
+		`INSERT INTO activity_link (activity_id, entity_type, deal_id) VALUES ($1, 'deal', $2)`, activityID, dealID); err != nil {
 		t.Fatalf("link activity to deal: %v", err)
 	}
 }

--- a/backend/internal/compose/retentiongraph_integration_test.go
+++ b/backend/internal/compose/retentiongraph_integration_test.go
@@ -58,7 +58,7 @@ func TestRetentionCorrectsTheRelationshipGraphInItsOwnTransaction(t *testing.T) 
 			ctx := context.Background()
 			if err := tx.QueryRow(ctx, `
 				INSERT INTO activity (kind, subject, direction, occurred_at, source, captured_by)
-				VALUES ( 'email', 'Alt', $1, $2, 'manual', 'human:test')
+				VALUES ('email', 'Alt', $1, $2, 'manual', 'human:test')
 				RETURNING id`, direction, at).Scan(&id); err != nil {
 				return err
 			}
@@ -68,12 +68,12 @@ func TestRetentionCorrectsTheRelationshipGraphInItsOwnTransaction(t *testing.T) 
 			}
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO activity_participant (activity_id, user_id, role)
-				VALUES ( $1, $2, $3)`, id, e.Rep1, userRole); err != nil {
+				VALUES ($1, $2, $3)`, id, e.Rep1, userRole); err != nil {
 				return err
 			}
 			_, err := tx.Exec(ctx, `
 				INSERT INTO activity_participant (activity_id, person_id, role)
-				VALUES ( $1, $2, $3)`, id, contact, personRole)
+				VALUES ($1, $2, $3)`, id, contact, personRole)
 			return err
 		}); err != nil {
 			t.Fatalf("seeding an interaction: %v", err)

--- a/backend/internal/compose/scrape_integration_test.go
+++ b/backend/internal/compose/scrape_integration_test.go
@@ -63,7 +63,7 @@ func insertOrg(t *testing.T, e *integration.Env, owner ids.UUID, domain, industr
 		}
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-			VALUES ( $1, $2, true, 'manual', 'human:owner')`, orgID, domain)
+			VALUES ($1, $2, true, 'manual', 'human:owner')`, orgID, domain)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/activities/channelsend_integration_test.go
+++ b/backend/internal/modules/activities/channelsend_integration_test.go
@@ -116,7 +116,7 @@ func (e *sendEnv) linkPerson(t *testing.T, anchor ids.ActivityID, name string) i
 	}
 	if _, err := e.owner.Exec(ctx,
 		`INSERT INTO activity_link (activity_id, entity_type, person_id)
-		 VALUES ( $1, 'person', $2)`, anchor, person); err != nil {
+		 VALUES ($1, 'person', $2)`, anchor, person); err != nil {
 		t.Fatalf("linking the person: %v", err)
 	}
 	return person

--- a/backend/internal/modules/activities/email_integration_test.go
+++ b/backend/internal/modules/activities/email_integration_test.go
@@ -237,7 +237,7 @@ func (e *sendEnv) linkToPersonOwnedBy(t *testing.T, anchor ids.ActivityID, owner
 	}
 	if _, err := e.owner.Exec(context.Background(),
 		`INSERT INTO activity_link (activity_id, entity_type, person_id)
-		 VALUES ( $1, 'person', $2)`, anchor, person); err != nil {
+		 VALUES ($1, 'person', $2)`, anchor, person); err != nil {
 		t.Fatalf("linking the anchor: %v", err)
 	}
 }

--- a/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_absorb_integration_test.go
@@ -123,7 +123,7 @@ func (e *sendEnv) link(t *testing.T, activityID ids.ActivityID, entityType strin
 	t.Helper()
 	if _, err := e.owner.Exec(context.Background(), `
 		INSERT INTO activity_link (activity_id, entity_type, person_id, project_id)
-		VALUES ( $1, $2,
+		VALUES ($1, $2,
 		        CASE WHEN $2 = 'person'  THEN $3::uuid END,
 		        CASE WHEN $2 = 'project' THEN $3::uuid END)`, activityID, entityType, target); err != nil {
 		t.Fatalf("linking the activity to a %s: %v", entityType, err)

--- a/backend/internal/modules/capture/owndomainstore_integration_test.go
+++ b/backend/internal/modules/capture/owndomainstore_integration_test.go
@@ -153,7 +153,7 @@ func TestTheListSeparatesTheCompanysOwnClaimFromTheRegistry(t *testing.T) {
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-			VALUES ( $1, 'ourcompany.example', true, 'manual', 'human:test')`, orgID)
+			VALUES ($1, 'ourcompany.example', true, 'manual', 'human:test')`, orgID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding the anchor company: %v", err)

--- a/backend/internal/modules/capture/sinkinternal_integration_test.go
+++ b/backend/internal/modules/capture/sinkinternal_integration_test.go
@@ -62,7 +62,7 @@ func bootstrapInternalMailWorkspace(t *testing.T, ownDomains ...string) (context
 			for i, d := range ownDomains {
 				if _, err := tx.Exec(wsCtx, `
 					INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-					VALUES ( $1, $2, $3, 'manual', 'human:test')`, orgID, d, i == 0); err != nil {
+					VALUES ($1, $2, $3, 'manual', 'human:test')`, orgID, d, i == 0); err != nil {
 					return err
 				}
 			}

--- a/backend/internal/modules/capture/tracelinks_integration_test.go
+++ b/backend/internal/modules/capture/tracelinks_integration_test.go
@@ -75,7 +75,7 @@ func seedTracedActivityOwnedBy(ctx context.Context, t *testing.T, db *database.D
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`,
+			VALUES ($1, 'person', $2)`,
 			activityID, personID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/channelconsent_integration_test.go
+++ b/backend/internal/modules/consent/channelconsent_integration_test.go
@@ -100,7 +100,7 @@ func setupChannelConsent(t *testing.T) *channelConsentEnv {
 	}
 	if _, err := owner.Exec(ctx, `
 		INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
-		VALUES ( $1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`, e.person, e.account); err != nil {
+		VALUES ($1, 'telegram', $2, 'tilda', 'connector:telegram', 'connector:telegram')`, e.person, e.account); err != nil {
 		t.Fatal(err)
 	}
 
@@ -225,7 +225,7 @@ func TestRequireGrantedForEmailsStillAnswersThroughTheSharedRule(t *testing.T) {
 	address := "tilda-" + e.person.String() + "@example.test"
 	if _, err := e.owner.Exec(context.Background(),
 		`INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
-		 VALUES ( $1, lower($2), true, 'test', 'human:x')`, e.person, address); err != nil {
+		 VALUES ($1, lower($2), true, 'test', 'human:x')`, e.person, address); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/modules/people/channelidentity.go
+++ b/backend/internal/modules/people/channelidentity.go
@@ -59,7 +59,7 @@ func ResolveOrCreateChannelIdentity(ctx context.Context, tx pgx.Tx, personID ids
 	// stamping — the binding outlives every message that refreshed it.
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by)
-		VALUES ( $1, $2, $3, NULLIF($4, ''), $2, $5)
+		VALUES ($1, $2, $3, NULLIF($4, ''), $2, $5)
 		ON CONFLICT (provider, channel_user_id) WHERE archived_at IS NULL
 		DO NOTHING`,
 		personID, ci.Provider, ci.ChannelUserID, ci.Username, by)

--- a/backend/internal/modules/people/companydomain.go
+++ b/backend/internal/modules/people/companydomain.go
@@ -70,7 +70,7 @@ func setCompanyDomain(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 	var owner ids.OrganizationID
 	err = tx.QueryRow(ctx,
 		`INSERT INTO organization_domain (organization_id, domain, is_primary, source, captured_by)
-		 VALUES ( $1, lower($2), true, 'manual', $3)
+		 VALUES ($1, lower($2), true, 'manual', $3)
 		 ON CONFLICT (domain) WHERE archived_at IS NULL
 		 DO UPDATE SET is_primary = true
 		 WHERE organization_domain.organization_id = EXCLUDED.organization_id

--- a/backend/internal/modules/people/domaintriage.go
+++ b/backend/internal/modules/people/domaintriage.go
@@ -153,7 +153,7 @@ func readDispositionTx(ctx context.Context, tx pgx.Tx, domain string) (DomainDis
 func recordPendingDispositionTx(ctx context.Context, tx pgx.Tx, domain string, ownerID ids.UUID) (bool, error) {
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO organization_domain_disposition (domain, status, owner_id)
-		VALUES ( $1, 'pending', $2)
+		VALUES ($1, 'pending', $2)
 		ON CONFLICT (domain) DO NOTHING`,
 		domain, ownerID)
 	if err != nil {

--- a/backend/internal/modules/people/enrichsignature.go
+++ b/backend/internal/modules/people/enrichsignature.go
@@ -99,7 +99,7 @@ func (s *Store) applySignatureField(ctx context.Context, tx pgx.Tx, personID ids
 	// first verdict wins — a later pass can never overwrite it.
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, confidence, source, captured_by)
-		VALUES ( $1, $2, $3, $4, $5, $6, $7, $8)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (person_id, field) DO NOTHING`,
 		personID, f.Name, value, f.Evidence, sourceRef, f.Confidence, enrichSource, enrichCapturedBy)
 	if err != nil {

--- a/backend/internal/modules/people/ensure_edges_integration_test.go
+++ b/backend/internal/modules/people/ensure_edges_integration_test.go
@@ -229,7 +229,7 @@ func TestApplySignatureFieldsWithdrawsEvidenceWhenTheFillLosesItsRace(t *testing
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by)
-			VALUES ( $1, '+49 30 9999999', 'work', true, 0, 'manual', 'human:test')`, personID)
+			VALUES ($1, '+49 30 9999999', 'work', true, 0, 'manual', 'human:test')`, personID)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -242,7 +242,7 @@ func writeLinkedInHandle(ctx context.Context, tx pgx.Tx, connectionID, personID 
 	}
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO person_social (person_id, platform, handle)
-		VALUES ( $1, $3, $2)
+		VALUES ($1, $3, $2)
 		ON CONFLICT (person_id, platform) DO NOTHING`, personID, *handle, socialLinkedIn)
 	if err != nil {
 		return false, fmt.Errorf("people: writing a confirmed contact's LinkedIn handle: %w", err)

--- a/backend/internal/modules/people/linkedinreview_integration_test.go
+++ b/backend/internal/modules/people/linkedinreview_integration_test.go
@@ -124,7 +124,7 @@ func TestApplyingAMatchNeverOverwritesAHandleTheContactAlreadyHad(t *testing.T) 
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO person_social (person_id, platform, handle)
-			VALUES ( $1, 'linkedin', $2)`,
+			VALUES ($1, 'linkedin', $2)`,
 			andreas.UUID, existing)
 		return err
 	}); err != nil {

--- a/backend/internal/modules/people/organization_relationship_types.go
+++ b/backend/internal/modules/people/organization_relationship_types.go
@@ -199,7 +199,7 @@ func reconcileOrgRelationshipTypes(
 		}
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO organization_relationship_type (organization_id, relationship_type, source, captured_by)
-			 VALUES ( $1, $2, $3, $4)`,
+			 VALUES ($1, $2, $3, $4)`,
 			orgID, t, source, by); err != nil {
 			return nil, fmt.Errorf("insert relationship type %q: %w", t, err)
 		}

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -59,7 +59,7 @@ func replacePersonSocial(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, p
 			continue
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO person_social (person_id, platform, handle) VALUES ( $1, $2, $3)`,
+			`INSERT INTO person_social (person_id, platform, handle) VALUES ($1, $2, $3)`,
 			personID, platform, text); err != nil {
 			return fmt.Errorf("insert person social row: %w", err)
 		}
@@ -99,7 +99,7 @@ func insertPersonEmails(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, pe
 	for _, e := range emails {
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO person_email (person_id, email, email_type, is_primary, position, source, captured_by, from_correspondence)
-			 VALUES ( $1, lower($2), $3, $4, $5, $6, $7, $8)`,
+			 VALUES ($1, lower($2), $3, $4, $5, $6, $7, $8)`,
 			personID, e.Email, e.EmailType, e.IsPrimary, e.Position, source, by,
 			!e.VouchedNotCorresponded); err != nil {
 			if name, ok := storekit.UniqueViolation(err); ok {
@@ -119,7 +119,7 @@ func insertPersonPhones(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, pe
 	for _, p := range phones {
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by)
-			 VALUES ( $1, $2, $3, $4, $5, $6, $7)`,
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 			personID, p.Phone, p.PhoneType, p.IsPrimary, p.Position, source, by); err != nil {
 			return fmt.Errorf("insert person phone: %w", err)
 		}

--- a/backend/internal/modules/people/researchclaim.go
+++ b/backend/internal/modules/people/researchclaim.go
@@ -116,7 +116,7 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 			// there, which is what a reader who just chose it expects.
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-				VALUES ( $1, $1, $2, $3, $4, $6, $5)
+				VALUES ($1, $1, $2, $3, $4, $6, $5)
 				ON CONFLICT (person_id, field) DO UPDATE
 				SET value = EXCLUDED.value,
 				    evidence_snippet = EXCLUDED.evidence_snippet,

--- a/backend/internal/modules/people/searchpersonfields.go
+++ b/backend/internal/modules/people/searchpersonfields.go
@@ -105,7 +105,7 @@ func fillDiscoveredFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		}
 		tag, err := tx.Exec(ctx, `
 			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			VALUES ( $1, $2, $3, $4, $5, $6, $7)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (person_id, field) DO NOTHING`,
 			personID, f.Field, value, snippet, f.SourceRef, searchFieldSource, by)
 		if err != nil {

--- a/backend/internal/modules/people/sitepersonfields.go
+++ b/backend/internal/modules/people/sitepersonfields.go
@@ -198,7 +198,7 @@ func fillSitePersonFields(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 		// overwrite what a signature (or a human) already answered.
 		tag, err := tx.Exec(ctx, `
 			INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-			VALUES ( $1, $2, $3, $4, $5, $6, $7)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (person_id, field) DO NOTHING`,
 			personID, field, value, in.EvidenceSnippet, sourceRef, siteFieldSource, by)
 		if err != nil {

--- a/backend/internal/modules/people/strengthasof_integration_test.go
+++ b/backend/internal/modules/people/strengthasof_integration_test.go
@@ -45,7 +45,7 @@ func (e *dedupeEnv) seedInteraction(t *testing.T, personID ids.PersonID, at time
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO activity_link (activity_id, entity_type, person_id)
-			VALUES ( $1, 'person', $2)`, id, personID)
+			VALUES ($1, 'person', $2)`, id, personID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding an interaction: %v", err)

--- a/backend/internal/modules/people/visibleaddresses_integration_test.go
+++ b/backend/internal/modules/people/visibleaddresses_integration_test.go
@@ -32,7 +32,7 @@ func (e *privacyEnv) seedAddress(t *testing.T, person ids.PersonID, email string
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO person_email (person_id, email, source, captured_by)
-			VALUES ( $1, $2, 'gmail:seed', 'connector:gmail')`,
+			VALUES ($1, $2, 'gmail:seed', 'connector:gmail')`,
 			person, email)
 		return err
 	}); err != nil {

--- a/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
+++ b/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
@@ -95,7 +95,7 @@ func seedChannelDeliveryForRollback(t *testing.T, conn *pgx.Conn, ws string, inF
 		}
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (kind, channel_provider, body, direction, occurred_at, source, captured_by)
-			VALUES ( 'message', 'telegram', 'Shipping Monday.', 'outbound', now(), 'manual', 'human:test')
+			VALUES ('message', 'telegram', 'Shipping Monday.', 'outbound', now(), 'manual', 'human:test')
 			RETURNING id`).Scan(&activityID); err != nil {
 			return err
 		}


### PR DESCRIPTION
Whitespace only. 127 occurrences, 72 files.

Removing a leading column from an INSERT left the opening paren separated from
the column that took its place, across every table ADR-0091 §8 phase D has
reached:

```diff
-INSERT INTO person ( full_name, source, captured_by)
-VALUES ( $1, 'Stakeholder', 'manual', 'human:x')
+INSERT INTO person (full_name, source, captured_by)
+VALUES ($1, 'Stakeholder', 'manual', 'human:x')
```

Valid SQL, and `craft-static` has nothing to say about it — but it reads as a
typo everywhere it appears, and there is now enough of it to look deliberate.
This is my own debris from the phase-D slices; separating it from those PRs kept
three functional diffs readable, and it was blocked until they landed because 56
of these files were also touched by the open stack.

**Reviewing this at 72 files:** the property to check is that it is a pure
whitespace substitution, which holds mechanically —

```
removed lines: 127  added lines: 127
lines differing by more than whitespace: 0
```

Both lanes green (`check-backend` exit 0, integration 41 packages / 0 skips).

One note for anyone who sees `TestTheClusterSeatsTheBudgetTheLaneComputed` fail
locally around now: that is a stale Postgres container, not this change —
`max_connections` is fixed at startup, so a container predating the current
compose file serves 100 against a lane that budgets 208.
`docker compose -f infra/docker-compose.dev.yml up -d --force-recreate postgres`
fixes it. The test says so itself, which is why it took thirty seconds rather
than an hour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes spacing in SQL INSERT literals left by phase-D column removals. Old: `( full_name`, `VALUES ( $1)`; new: `(full_name`, `VALUES ($1)`. No behavior change.

- Scope: 127 whitespace-only edits across 72 files; removed lines equal added lines after whitespace normalization.
- Tests: All backend checks and integration tests pass.
- Review: Whitespace-insensitive diff is sufficient; no functional changes.
- Local note: If `TestTheClusterSeatsTheBudgetTheLaneComputed` fails, recreate Postgres to refresh `max_connections`: `docker compose -f infra/docker-compose.dev.yml up -d --force-recreate postgres`.

<sup>Written for commit b68793f6c846f68da522a9ed63b3a4fc4ae4253c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

