### PR TITLE
fix(search): the reindex status reports the backlog once, not once per workspace

### DIFF
--- a/backend/internal/compose/embedreindextransport.go
+++ b/backend/internal/compose/embedreindextransport.go
@@ -331,18 +331,15 @@ func (e *embedReindexEngine) statusBody(ctx context.Context) (crmcontracts.Embed
 	if err != nil {
 		return crmcontracts.EmbedReindexStatus{}, err
 	}
-	counts, err := e.store.PendingByWorkspace(ctx, configured)
+	// The store's own total, NOT the sum of PendingByWorkspace. Since ADR-0091
+	// §8 phase D no embeddable entity carries a tenant, so that rollup holds the
+	// same rows under every workspace it enumerates — summing it reported an
+	// installation with two of them as having twice the backlog. The previous
+	// comment here had the premise exactly right ("a per-workspace breakdown of
+	// it is the total repeated") and drew the opposite conclusion from it.
+	total, err := e.store.EntitiesPending(ctx, configured)
 	if err != nil {
 		return crmcontracts.EmbedReindexStatus{}, err
-	}
-
-	// The counts arrive keyed by workspace and are summed straight to the fleet
-	// total: an installation serves one organization (ADR-0061/A107), so a
-	// per-workspace breakdown of it is the total repeated, and the wire no
-	// longer carries one (ADR-0091 §6).
-	total := 0
-	for _, c := range counts {
-		total += c
 	}
 
 	return crmcontracts.EmbedReindexStatus{

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -272,6 +272,46 @@ func embedReindexDecode[T any](t *testing.T, e *apptest.AppEnv, method, path str
 // read ops (status: returns reindex_needed after a stale-identity row is
 // present; preview: labeled per-workspace+total) over the real handler +
 // search.Store.
+// TestStatusEntitiesPendingDoesNotGrowWithTheWorkspaceCount pins the arithmetic
+// the status read must NOT do. Since ADR-0091 §8 phase D no embeddable entity
+// carries a tenant, so PendingByWorkspace holds the SAME rows under every
+// workspace it enumerates; summing that rollup reports an installation with two
+// of them as having twice the backlog. `entities_pending` is what an operator
+// reads before confirming a reindex and what the preview prices, so the
+// exaggeration would be a bill rather than a display.
+//
+// The assertion is a DELTA rather than an absolute count, so it holds whatever
+// else the harness happens to seed: adding a workspace changes no entity, so it
+// must change no number. A test pinning an absolute would have to be rewritten
+// every time the fixture grows, and would have passed against the summing
+// version for a single-workspace installation — which is exactly how the
+// summing version survived in the transport after the store stopped doing it.
+func TestStatusEntitiesPendingDoesNotGrowWithTheWorkspaceCount(t *testing.T) {
+	router := embedReindexRouter(t, "reindex-count-v1")
+	e := setupEmbedReindex(t, router)
+	wsID := embedReindexWorkspaceID(t, e)
+	seedStaleEmbeddingRow(t, e, wsID)
+
+	status, before, _ := embedStatus(t, e)
+	if status != http.StatusOK {
+		t.Fatalf("baseline status -> %d, want 200", status)
+	}
+	if before.EntitiesPending < 1 {
+		t.Fatalf("entities_pending = %d, want >= 1 — the delta below proves nothing against an empty backlog", before.EntitiesPending)
+	}
+
+	SeedExtraWorkspace(t, e.Owner, "reindex-count-second", false)
+
+	status, after, _ := embedStatus(t, e)
+	if status != http.StatusOK {
+		t.Fatalf("status after the second workspace -> %d, want 200", status)
+	}
+	if after.EntitiesPending != before.EntitiesPending {
+		t.Fatalf("entities_pending went %d -> %d when a second workspace was added and no entity was: the total is summing a rollup whose entries are the same rows",
+			before.EntitiesPending, after.EntitiesPending)
+	}
+}
+
 func TestEmbedReindexStatusAndPreviewReflectPendingEntities(t *testing.T) {
 	router := embedReindexRouter(t, "reindex-status-v1")
 	e := setupEmbedReindex(t, router)


### PR DESCRIPTION
Caught by CodeRabbit on #1753, and it was right: I marked this fixed when half
of it was.

`statusBody` summed `PendingByWorkspace` itself instead of asking the store for
the total. Since ADR-0091 §8 phase D no embeddable entity carries a tenant, so
that rollup holds the **same rows** under every workspace it enumerates — the
sum reported an installation with two of them as having twice the backlog.
`entities_pending` is what an operator reads before confirming a reindex and
what the preview prices, so the exaggeration is a bill rather than a display.

```diff
-counts, err := e.store.PendingByWorkspace(ctx, configured)
-total := 0
-for _, c := range counts {
-    total += c
-}
+total, err := e.store.EntitiesPending(ctx, configured)
```

## Why #1723 missed it

That PR fixed `Store.EntitiesPending` and stopped there. **The transport never
called it** — it carried its own copy of the arithmetic — so the number on the
wire never changed. Fixing the method and leaving a second summation downstream
is exactly the sibling-copy miss README rule 1 is about ("fix the invariant, not
the call site"); the grep for other summers should have followed the fix. It has
now: the only remaining one is the cost estimator, which is #1738 and needs a
ruling rather than a patch.

The comment standing over the sum had the premise exactly right and drew the
opposite conclusion from it — *"an installation serves one organization, so a
per-workspace breakdown of it is the total repeated"* is precisely why summing
multiplies.

## The test asserts a delta, not a count

Adding a workspace changes no entity, so it must change no number.

An absolute assertion would need rewriting whenever the fixture grows, and —
being single-workspace — **would have passed against the summing version**,
which is how that version survived in the transport after the store stopped
doing it. The existing `entities_pending` assertion is `>= 1`, a lower bound
that cannot detect multiplication at all.

**Verified by reverting the fix and re-running the lane:** the new test fails,
and nothing else does. With the fix restored: `check-backend` exit 0,
integration 41 packages / 0 skips, craft 0/0/0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reindex status to report the backlog once instead of once per workspace. Previously `statusBody` summed `PendingByWorkspace`, which repeats the same rows per workspace since ADR-0091; now it asks the store for the total via `EntitiesPending`. This corrects the `entities_pending` shown to operators and used for preview pricing.

- Replace local sum in `statusBody` with `e.store.EntitiesPending(ctx, configured)`; remove per-workspace aggregation.
- Add integration test `TestStatusEntitiesPendingDoesNotGrowWithTheWorkspaceCount` that asserts adding a workspace does not change `entities_pending` (delta-based; verified it fails without the fix).
- The cost estimator still folds the per-workspace rollup and is tracked separately (see #1738).

<sup>Written for commit 1551592cdd920173e2d62369d45121c6d95899af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

