### PR TITLE
refactor(identity): the credential tables drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/agenttaskhandle_integration_test.go
+++ b/backend/internal/compose/agenttaskhandle_integration_test.go
@@ -112,9 +112,9 @@ func seedTaskPassport(t *testing.T, e *integration.Env, label string) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.Pool.Exec(context.Background(), `
-		INSERT INTO passport (id, workspace_id, label, on_behalf_of, granted_by, token_hash, scopes, expires_at)
-		VALUES ($1, $2, $3, $4, $4, $5, $6, now() + interval '30 days')`,
-		id, e.WS, label, e.Rep1, "hash-"+id.String(), []string{"read", "write"}); err != nil {
+		INSERT INTO passport (id, label, on_behalf_of, granted_by, token_hash, scopes, expires_at)
+		VALUES ($1, $2, $3, $3, $4, $5, now() + interval '30 days')`,
+		id, label, e.Rep1, "hash-"+id.String(), []string{"read", "write"}); err != nil {
 		t.Fatalf("seeding the %s passport: %v", label, err)
 	}
 	return id

--- a/backend/internal/compose/integration/agentaccess/oauth_consent_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_consent_integration_test.go
@@ -89,8 +89,8 @@ func TestSelectablePassportsExcludesEveryUnlendableShape(t *testing.T) {
 	bound := o.mintPassport(t, "bound", []string{"read"})
 	if _, err := o.Owner.Exec(ctx,
 		`WITH new_grant AS (
-		   INSERT INTO oauth_grant (workspace_id, client_id, user_id, scopes, refresh_allowed)
-		   SELECT workspace_id, $2, on_behalf_of, ARRAY['read']::text[], false
+		   INSERT INTO oauth_grant (client_id, user_id, scopes, refresh_allowed)
+		   SELECT $2, on_behalf_of, ARRAY['read']::text[], false
 		   FROM passport WHERE id = $1 RETURNING id)
 		 UPDATE passport SET oauth_grant_id = new_grant.id
 		 FROM new_grant WHERE passport.id = $1`, bound, o.clientID); err != nil {
@@ -184,8 +184,8 @@ func TestSelectablePassportsExcludesAnotherUsersPassport(t *testing.T) {
 		t.Fatalf("inviting a second user → %d", status)
 	}
 	if _, err := o.Owner.Exec(ctx,
-		`INSERT INTO passport (workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
-		 SELECT workspace_id, id, id, 'not mine', ARRAY['read']::text[], 'other-user-'||id, now() + interval '1 day'
+		`INSERT INTO passport (on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
+		 SELECT id, id, 'not mine', ARRAY['read']::text[], 'other-user-'||id, now() + interval '1 day'
 		 FROM app_user WHERE id = $1`, other.ID); err != nil {
 		t.Fatalf("minting a passport for the second user: %v", err)
 	}
@@ -209,9 +209,8 @@ func registerClientDirectly(t *testing.T, e *apptest.AppEnv, clientID string) {
 		t.Fatalf("looking up the workspace: %v", err)
 	}
 	if _, err := e.Owner.Exec(ctx,
-		`INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
-		 VALUES ($1, $2, 'directly registered', ARRAY['https://client.example/cb']::text[])`,
-		wsID, clientID); err != nil {
+		`INSERT INTO oauth_client (client_id, client_name, redirect_uris)
+		 VALUES ($1, 'directly registered', ARRAY['https://client.example/cb']::text[])`, clientID); err != nil {
 		t.Fatalf("inserting a live oauth_client row: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -186,9 +186,9 @@ func (e *Env) SeedPassport(t *testing.T, owner *pgx.Conn, label string) ids.UUID
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := owner.Exec(context.Background(), `
-		INSERT INTO passport (id, workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
-		VALUES ($1, $2, $3, $3, $4, ARRAY['read','write'], $5, now() + interval '1 day')`,
-		id, e.WS, e.Rep1, label, "hash-"+id.String()); err != nil {
+		INSERT INTO passport (id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
+		VALUES ($1, $2, $2, $3, ARRAY['read','write'], $4, now() + interval '1 day')`,
+		id, e.Rep1, label, "hash-"+id.String()); err != nil {
 		t.Fatalf("seeding passport %s: %v", label, err)
 	}
 	return id

--- a/backend/internal/compose/integration/scheduledsendagent_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendagent_integration_test.go
@@ -287,10 +287,10 @@ func (p *preflightEnv) issuePassport(t *testing.T) ids.UUID {
 	id := ids.NewV7()
 	if err := apptest.InWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
-			`INSERT INTO passport (id, workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
-			 VALUES ($1, (SELECT id FROM workspace WHERE slug = $2), $3, $3, 'scheduled-send probe',
-			         ARRAY['read','write'], $4, now() + interval '30 days')`,
-			id, p.Slug, uuidOf(t, p.user), "probe-"+id.String())
+			`INSERT INTO passport (id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
+			 VALUES ($1, $2, $2, 'scheduled-send probe',
+			         ARRAY['read','write'], $3, now() + interval '30 days')`,
+			id, uuidOf(t, p.user), "probe-"+id.String())
 		return err
 	}); err != nil {
 		t.Fatalf("issuing a passport: %v", err)

--- a/backend/internal/modules/approvals/quotarelease_integration_test.go
+++ b/backend/internal/modules/approvals/quotarelease_integration_test.go
@@ -33,9 +33,9 @@ func (e *stagingEnv) asAgent(t *testing.T) context.Context {
 	// fabricated id would exercise a shape the database refuses.
 	passport := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO passport (id, workspace_id, on_behalf_of, granted_by, token_hash, scopes, expires_at)
-		VALUES ($1, $2, $3, $3, $4, ARRAY['read'], now() + interval '30 days')`,
-		passport, e.ws, e.rep, "hash-"+passport.String()); err != nil {
+		INSERT INTO passport (id, on_behalf_of, granted_by, token_hash, scopes, expires_at)
+		VALUES ($1, $2, $2, $3, ARRAY['read'], now() + interval '30 days')`,
+		passport, e.rep, "hash-"+passport.String()); err != nil {
 		t.Fatalf("seeding the lent passport: %v", err)
 	}
 	ctx := principal.WithWorkspaceID(context.Background(), e.ws)

--- a/backend/internal/modules/approvals/stageagentcall_integration_test.go
+++ b/backend/internal/modules/approvals/stageagentcall_integration_test.go
@@ -54,9 +54,9 @@ func (e *stagingEnv) seedPassport(t *testing.T) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO passport (id, workspace_id, label, on_behalf_of, granted_by, token_hash, scopes, expires_at)
-		VALUES ($1, $2, $3, $4, $4, $5, $6, now() + interval '30 days')`,
-		id, e.ws, "agent "+id.String(), e.rep, "hash-"+id.String(), []string{"read", "enrich"}); err != nil {
+		INSERT INTO passport (id, label, on_behalf_of, granted_by, token_hash, scopes, expires_at)
+		VALUES ($1, $2, $3, $3, $4, $5, now() + interval '30 days')`,
+		id, "agent "+id.String(), e.rep, "hash-"+id.String(), []string{"read", "enrich"}); err != nil {
 		t.Fatalf("seeding a passport: %v", err)
 	}
 	return id

--- a/backend/internal/modules/identity/oauth.go
+++ b/backend/internal/modules/identity/oauth.go
@@ -92,8 +92,8 @@ func (h Handlers) oauthRegister(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	err = h.svc.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3)`,
+			INSERT INTO oauth_client (client_id, client_name, redirect_uris)
+			VALUES ($1, $2, $3)`,
 			clientID, req.ClientName, req.RedirectURIs)
 		return err
 	})

--- a/backend/internal/modules/identity/oauth_cimd.go
+++ b/backend/internal/modules/identity/oauth_cimd.go
@@ -198,8 +198,8 @@ func (s *Service) upsertCIMDClient(ctx context.Context, doc cimdDocument, ttl ti
 		// running ahead serves a client's redirect list past the window its
 		// publisher was promised.
 		_, err := tx.Exec(ctx, `
-			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris, created_via, metadata_expires_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, 'cimd', now() + $4::interval)
+			INSERT INTO oauth_client (client_id, client_name, redirect_uris, created_via, metadata_expires_at)
+			VALUES ($1, $2, $3, 'cimd', now() + $4::interval)
 			ON CONFLICT (client_id) DO UPDATE SET
 			  client_name         = EXCLUDED.client_name,
 			  redirect_uris       = EXCLUDED.redirect_uris,

--- a/backend/internal/modules/identity/oauth_cimd_integration_test.go
+++ b/backend/internal/modules/identity/oauth_cimd_integration_test.go
@@ -237,8 +237,8 @@ func TestADocumentCannotTakeOverARegisteredClient(t *testing.T) {
 	clientID := e.docs.URL + "/client.json"
 	err := database.WithWorkspaceTx(e.ctx, e.svc.db.Pool(), func(tx pgx.Tx) error {
 		_, err := tx.Exec(e.ctx, `
-			INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris, created_via)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, 'Registered', $2, 'dcr')`,
+			INSERT INTO oauth_client (client_id, client_name, redirect_uris, created_via)
+			VALUES ($1, 'Registered', $2, 'dcr')`,
 			clientID, []string{"https://registered.example/cb"})
 		return err
 	})

--- a/backend/internal/modules/identity/oauth_grant.go
+++ b/backend/internal/modules/identity/oauth_grant.go
@@ -113,10 +113,10 @@ func issueGrant(ctx context.Context, tx pgx.Tx, in issueGrantInput) (grantID ids
 		return ids.Nil, "", err
 	}
 	err = tx.QueryRow(ctx, `
-		INSERT INTO oauth_grant (workspace_id, client_id, user_id, scopes, refresh_allowed, resource, lent_passport_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO oauth_grant (client_id, user_id, scopes, refresh_allowed, resource, lent_passport_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING id`,
-		in.WorkspaceID, in.ClientID, in.UserID, in.Scopes, in.RefreshAllowed, in.Resource,
+		in.ClientID, in.UserID, in.Scopes, in.RefreshAllowed, in.Resource,
 		in.LentPassportID).Scan(&grantID)
 	if err != nil {
 		return ids.Nil, "", err
@@ -150,9 +150,9 @@ func issueGrant(ctx context.Context, tx pgx.Tx, in issueGrantInput) (grantID ids
 	// replaced_by stays NULL: the first token in a chain succeeds nothing,
 	// and rotation is what fills the forward link.
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO oauth_refresh_token (workspace_id, grant_id, token_hash, expires_at)
-		VALUES ($1, $2, $3, now() + $4::interval)`,
-		in.WorkspaceID, grantID, hashToken(refresh), refreshTokenTTL.String()); err != nil {
+		INSERT INTO oauth_refresh_token (grant_id, token_hash, expires_at)
+		VALUES ($1, $2, now() + $3::interval)`,
+		grantID, hashToken(refresh), refreshTokenTTL.String()); err != nil {
 		return ids.Nil, "", err
 	}
 	return grantID, refresh, nil

--- a/backend/internal/modules/identity/oauth_lend.go
+++ b/backend/internal/modules/identity/oauth_lend.go
@@ -164,10 +164,9 @@ func writeAuthorizationCode(
 	var codeID ids.UUID
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO oauth_authorization_code
-		  (workspace_id, code_hash, client_id, user_id, scopes, code_challenge, redirect_uri, resource, expires_at,
+		  (code_hash, client_id, user_id, scopes, code_challenge, redirect_uri, resource, expires_at,
 		   lent_passport_id)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, $4, $5, $6, NULLIF($7, ''), now() + $8::interval,
+		VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''), now() + $8::interval,
 		        $9)
 		RETURNING id`,
 		hashOAuthCode(code), req.ClientID, id.UserID, storedScopes, req.CodeChallenge,

--- a/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
+++ b/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
@@ -160,7 +160,7 @@ func waitUntilBlockingSomebody(t *testing.T, tx pgx.Tx) {
 func (e *lendEnv) codesAndLendAudits(t *testing.T) (codes, audits int) {
 	t.Helper()
 	if err := e.owner.QueryRow(context.Background(), `
-		SELECT (SELECT count(*) FROM oauth_authorization_code WHERE workspace_id = $1),
+		SELECT (SELECT count(*) FROM oauth_authorization_code),
 		       (SELECT count(*) FROM audit_log
 		         WHERE workspace_id = $1 AND entity_type = 'oauth_authorization_code')`,
 		e.admin.WorkspaceID).Scan(&codes, &audits); err != nil {
@@ -314,8 +314,8 @@ func TestAnUncontendedLendCommitsTheCodeAndItsAudit(t *testing.T) {
 	}
 	var scopes []string
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT scopes FROM oauth_authorization_code WHERE workspace_id = $1 AND code_hash = $2`,
-		e.admin.WorkspaceID, hashOAuthCode(code)).Scan(&scopes); err != nil {
+		`SELECT scopes FROM oauth_authorization_code WHERE code_hash = $1`,
+		hashOAuthCode(code)).Scan(&scopes); err != nil {
 		t.Fatalf("reading the code row behind the returned courier: %v", err)
 	}
 	if !slices.Equal(scopes, []string{"read", "write"}) {

--- a/backend/internal/modules/identity/oauth_lockorder_integration_test.go
+++ b/backend/internal/modules/identity/oauth_lockorder_integration_test.go
@@ -61,9 +61,9 @@ func (e *revocationEnv) connectOAuthLent(
 	// client.
 	clientID := "client-" + ids.NewV7().String()
 	if _, err := e.owner.Exec(context.Background(), `
-		INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
-		VALUES ($1, $2, $3, ARRAY['https://client.example/cb'])`,
-		consenter.WorkspaceID, clientID, clientName); err != nil {
+		INSERT INTO oauth_client (client_id, client_name, redirect_uris)
+		VALUES ($1, $2, ARRAY['https://client.example/cb'])`,
+		clientID, clientName); err != nil {
 		t.Fatalf("registering the client: %v", err)
 	}
 

--- a/backend/internal/modules/identity/oauth_refresh.go
+++ b/backend/internal/modules/identity/oauth_refresh.go
@@ -231,15 +231,14 @@ func grantOfPresentedToken(ctx context.Context, tx pgx.Tx, tokenHash string) (id
 func lockPresentedRefreshToken(ctx context.Context, tx pgx.Tx, tokenHash string) (lockedGrant, error) {
 	var l lockedGrant
 	err := tx.QueryRow(ctx, `
-		SELECT r.id, r.consumed_at, r.expires_at, r.replaced_by, r.workspace_id,
+		SELECT r.id, r.consumed_at, r.expires_at, r.replaced_by, u.workspace_id,
 		       g.id, g.user_id, g.client_id, g.scopes, g.resource, g.revoked_at, g.refresh_allowed,
 		       c.disabled_at, c.deleted_at, u.status, u.archived_at
 		  FROM oauth_refresh_token r
-		  JOIN oauth_grant  g ON (g.workspace_id, g.id)        = (r.workspace_id, r.grant_id)
-		  JOIN oauth_client c ON (c.workspace_id, c.client_id) = (g.workspace_id, g.client_id)
-		  JOIN app_user     u ON (u.workspace_id, u.id)        = (g.workspace_id, g.user_id)
-		 WHERE r.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-		   AND r.token_hash = $1
+		  JOIN oauth_grant  g ON g.id        = r.grant_id
+		  JOIN oauth_client c ON c.client_id = g.client_id
+		  JOIN app_user     u ON u.id        = g.user_id
+		 WHERE r.token_hash = $1
 		   FOR UPDATE OF r, g`,
 		tokenHash).Scan(&l.tokenID, &l.consumedAt, &l.expiresAt, &l.replacedBy, &l.workspaceID,
 		&l.grantID, &l.userID, &l.clientID, &l.scopes, &l.resource, &l.grantRevokedAt, &l.refreshAllowed,
@@ -356,10 +355,10 @@ func spendAndReissue(ctx context.Context, tx pgx.Tx, l lockedGrant, scopes []str
 	// The renewal window slides: a connection that keeps renewing never has
 	// to bring the human back, which is what the human approved.
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO oauth_refresh_token (workspace_id, grant_id, token_hash, expires_at)
-		VALUES ($1, $2, $3, now() + $4::interval)
+		INSERT INTO oauth_refresh_token (grant_id, token_hash, expires_at)
+		VALUES ($1, $2, now() + $3::interval)
 		RETURNING id`,
-		l.workspaceID, l.grantID, hashToken(refresh), refreshTokenTTL.String()).Scan(&successorID); err != nil {
+		l.grantID, hashToken(refresh), refreshTokenTTL.String()).Scan(&successorID); err != nil {
 		return IssuedPassport{}, "", err
 	}
 	// The forward link is application-maintained (replaced_by carries no FK)

--- a/backend/internal/modules/identity/oauth_token.go
+++ b/backend/internal/modules/identity/oauth_token.go
@@ -233,10 +233,15 @@ func (h Handlers) consumeAuthCode(r *http.Request, tx pgx.Tx, code, verifier str
 	// vanish, so the answer is the same invalid_grant a spent code gets — the
 	// endpoint stays silent about which of the two it was.
 	err := tx.QueryRow(r.Context(), `
-		SELECT a.user_id, a.workspace_id, a.scopes, a.code_challenge, a.client_id, a.redirect_uri, a.resource,
+		SELECT a.user_id, u.workspace_id, a.scopes, a.code_challenge, a.client_id, a.redirect_uri, a.resource,
 		       a.lent_passport_id
 		FROM oauth_authorization_code a
-		JOIN oauth_client c ON (c.workspace_id, c.client_id) = (a.workspace_id, a.client_id)
+		JOIN oauth_client c ON c.client_id = a.client_id
+		-- The workspace the minted principal carries. It used to come off the
+		-- code row; since ADR-0091 §8 phase D the code carries no tenant, so it
+		-- comes from the human the code was issued to — the same value, and the
+		-- subject the credential was always about.
+		JOIN app_user u ON u.id = a.user_id
 		WHERE a.code_hash = $1 AND a.consumed_at IS NULL AND a.expires_at > now()
 		  AND `+liveClientPredicate,
 		hashOAuthCode(code)).

--- a/backend/internal/modules/identity/passport.go
+++ b/backend/internal/modules/identity/passport.go
@@ -162,10 +162,10 @@ func mintPassport(ctx context.Context, tx pgx.Tx, id Identity, in IssuePassportI
 	out := IssuedPassport{Token: token, Scopes: in.Scopes}
 
 	if err := tx.QueryRow(ctx,
-		`INSERT INTO passport (workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at, oauth_grant_id)
-		 VALUES ($1, $2, $2, $3, $4, $5, now() + $6::interval, $7)
+		`INSERT INTO passport (on_behalf_of, granted_by, label, scopes, token_hash, expires_at, oauth_grant_id)
+		 VALUES ($1, $1, $2, $3, $4, now() + $5::interval, $6)
 		 RETURNING id, expires_at`,
-		id.WorkspaceID, id.UserID, in.Label, in.Scopes, hashToken(token), ttl.String(), grantID).
+		id.UserID, in.Label, in.Scopes, hashToken(token), ttl.String(), grantID).
 		Scan(&out.ID, &out.ExpiresAt); err != nil {
 		return IssuedPassport{}, err
 	}
@@ -333,8 +333,8 @@ const liveClientPredicate = `c.disabled_at IS NULL AND c.deleted_at IS NULL`
 // row means the grant points at a client that no longer exists, which must
 // fail closed rather than pass for want of a disabled_at to read.
 const agentLivenessJoins = `
-	LEFT JOIN oauth_grant  g ON (g.workspace_id, g.id)        = (p.workspace_id, p.oauth_grant_id)
-	LEFT JOIN oauth_client c ON (c.workspace_id, c.client_id) = (g.workspace_id, g.client_id)`
+	LEFT JOIN oauth_grant  g ON g.id        = p.oauth_grant_id
+	LEFT JOIN oauth_client c ON c.client_id = g.client_id`
 
 // A human who owes a credential rotation is held to nothing over REST, and
 // "agent ≤ human" is a runtime property: their passports must therefore resolve
@@ -366,7 +366,7 @@ const (
 // makes the liveness rule above impossible to have on one path and miss on
 // the other.
 func agentAuthQuery(predicate string) string {
-	return `SELECT p.id, p.workspace_id, p.on_behalf_of, p.scopes, u.seat_type
+	return `SELECT p.id, u.workspace_id, p.on_behalf_of, p.scopes, u.seat_type
 		FROM passport p
 		JOIN app_user u ON u.id = p.on_behalf_of` + agentLivenessJoins + `
 		WHERE ` + predicate + `

--- a/backend/internal/modules/identity/passport_list.go
+++ b/backend/internal/modules/identity/passport_list.go
@@ -95,9 +95,9 @@ const listPassportsSQL = `
 		       g.created_at AS connected_at, g.refresh_allowed AS renewable,
 		       g.lent_passport_id, lent.label AS lent_passport_label
 		FROM passport p
-		LEFT JOIN oauth_grant g ON (g.workspace_id, g.id) = (p.workspace_id, p.oauth_grant_id)
-		LEFT JOIN oauth_client c ON (c.workspace_id, c.client_id) = (g.workspace_id, g.client_id)
-		LEFT JOIN passport lent ON (lent.workspace_id, lent.id) = (g.workspace_id, g.lent_passport_id)
+		LEFT JOIN oauth_grant g ON g.id = p.oauth_grant_id
+		LEFT JOIN oauth_client c ON c.client_id = g.client_id
+		LEFT JOIN passport lent ON lent.id = g.lent_passport_id
 		WHERE %s
 		ORDER BY p.oauth_grant_id IS NULL, COALESCE(p.oauth_grant_id, p.id), p.created_at DESC, p.id DESC
 	) newest_per_connection

--- a/backend/internal/modules/identity/passport_list_integration_test.go
+++ b/backend/internal/modules/identity/passport_list_integration_test.go
@@ -141,23 +141,23 @@ func TestAPassportAndAGrantSharingAnIDAreStillTwoRows(t *testing.T) {
 
 	clientID := "client-" + ids.NewV7().String()
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
-		VALUES ($1, $2, 'collision', ARRAY['https://client.example/cb'])`,
-		e.admin.WorkspaceID, clientID); err != nil {
+		INSERT INTO oauth_client (client_id, client_name, redirect_uris)
+		VALUES ($1, 'collision', ARRAY['https://client.example/cb'])`,
+		clientID); err != nil {
 		t.Fatalf("registering the client: %v", err)
 	}
 	// The grant takes the minted passport's id as its OWN id: the collision the
 	// grouping key has to survive.
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO oauth_grant (id, workspace_id, client_id, user_id, scopes, refresh_allowed)
-		VALUES ($1, $2, $3, $4, ARRAY['read']::text[], false)`,
-		minted, e.admin.WorkspaceID, clientID, e.admin.UserID); err != nil {
+		INSERT INTO oauth_grant (id, client_id, user_id, scopes, refresh_allowed)
+		VALUES ($1, $2, $3, ARRAY['read']::text[], false)`,
+		minted, clientID, e.admin.UserID); err != nil {
 		t.Fatalf("issuing the colliding grant: %v", err)
 	}
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO passport (workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at, oauth_grant_id)
-		VALUES ($1, $2, $2, 'oauth:collision', ARRAY['read']::text[], $3, now() + interval '30 days', $4)`,
-		e.admin.WorkspaceID, e.admin.UserID, "collision-hash-"+minted.String(), minted); err != nil {
+		INSERT INTO passport (on_behalf_of, granted_by, label, scopes, token_hash, expires_at, oauth_grant_id)
+		VALUES ($1, $1, 'oauth:collision', ARRAY['read']::text[], $2, now() + interval '30 days', $3)`,
+		e.admin.UserID, "collision-hash-"+minted.String(), minted); err != nil {
 		t.Fatalf("minting the connection's credential: %v", err)
 	}
 

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -229,9 +229,9 @@ func (s *Service) CreatePasswordReset(ctx context.Context, email string) (string
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO auth_token (workspace_id, user_id, purpose, token_hash, expires_at)
-			 VALUES ($1, $2, 'password_reset', $3, now() + $4::interval)`,
-			wsID, userID, tokenHash, resetTokenTTL.String()); err != nil {
+			`INSERT INTO auth_token (user_id, purpose, token_hash, expires_at)
+			 VALUES ($1, 'password_reset', $2, now() + $3::interval)`,
+			userID, tokenHash, resetTokenTTL.String()); err != nil {
 			return err
 		}
 		minted = true

--- a/backend/internal/modules/identity/reset_integration_test.go
+++ b/backend/internal/modules/identity/reset_integration_test.go
@@ -199,22 +199,22 @@ func TestOperatorResetPasswordRevokesALiveOAuthGrantToo(t *testing.T) {
 
 	clientID := "client-" + ids.NewV7().String()
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
-		VALUES ($1, $2, 'operator-reset-cascade', ARRAY['https://client.example/cb'])`,
-		e.admin.WorkspaceID, clientID); err != nil {
+		INSERT INTO oauth_client (client_id, client_name, redirect_uris)
+		VALUES ($1, 'operator-reset-cascade', ARRAY['https://client.example/cb'])`,
+		clientID); err != nil {
 		t.Fatalf("registering the client: %v", err)
 	}
 	grantID := ids.NewV7()
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO oauth_grant (id, workspace_id, client_id, user_id, scopes, refresh_allowed)
-		VALUES ($1, $2, $3, $4, ARRAY['read']::text[], false)`,
-		grantID, e.admin.WorkspaceID, clientID, e.member.UserID); err != nil {
+		INSERT INTO oauth_grant (id, client_id, user_id, scopes, refresh_allowed)
+		VALUES ($1, $2, $3, ARRAY['read']::text[], false)`,
+		grantID, clientID, e.member.UserID); err != nil {
 		t.Fatalf("issuing the grant: %v", err)
 	}
 	if _, err := e.owner.Exec(ctx, `
-		INSERT INTO passport (workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at, oauth_grant_id)
-		VALUES ($1, $2, $2, 'operator-reset-cascade', ARRAY['read']::text[], $3, now() + interval '30 days', $4)`,
-		e.admin.WorkspaceID, e.member.UserID, "operator-reset-cascade-hash-"+grantID.String(), grantID); err != nil {
+		INSERT INTO passport (on_behalf_of, granted_by, label, scopes, token_hash, expires_at, oauth_grant_id)
+		VALUES ($1, $1, 'operator-reset-cascade', ARRAY['read']::text[], $2, now() + interval '30 days', $3)`,
+		e.member.UserID, "operator-reset-cascade-hash-"+grantID.String(), grantID); err != nil {
 		t.Fatalf("minting the connection's credential: %v", err)
 	}
 

--- a/backend/internal/modules/identity/userpasswordlink.go
+++ b/backend/internal/modules/identity/userpasswordlink.go
@@ -85,8 +85,11 @@ func (s *Service) IssuePasswordLink(ctx context.Context, actor Identity, userID 
 	if !principal.SeatType(actor.SeatType).CanMutate() {
 		return "", time.Time{}, apperrors.ErrSeatTierInsufficient
 	}
-	wsID, ok := workspaceFrom(ctx)
-	if !ok {
+	// The value is no longer needed — auth_token carries no tenant since
+	// ADR-0091 §8 phase D — but the CHECK is: this refuses a caller that is not
+	// workspace-bound, before it mints an account-takeover credential. Dropping
+	// it with the column would turn a guard into a coincidence.
+	if _, ok := workspaceFrom(ctx); !ok {
 		return "", time.Time{}, apperrors.ErrNotFound
 	}
 	raw, tokenHash, err := mintSessionToken()
@@ -101,10 +104,10 @@ func (s *Service) IssuePasswordLink(ctx context.Context, actor Identity, userID 
 			return err
 		}
 		if err := tx.QueryRow(ctx,
-			`INSERT INTO auth_token (workspace_id, user_id, purpose, token_hash, expires_at)
-			 VALUES ($1, $2, 'password_reset', $3, now() + $4::interval)
+			`INSERT INTO auth_token (user_id, purpose, token_hash, expires_at)
+			 VALUES ($1, 'password_reset', $2, now() + $3::interval)
 			 RETURNING expires_at`,
-			wsID, userID, tokenHash, inviteTokenTTL.String()).Scan(&expiresAt); err != nil {
+			userID, tokenHash, inviteTokenTTL.String()).Scan(&expiresAt); err != nil {
 			return err
 		}
 		auditID, err := storekit.Audit(ctx, tx, auditVerbPasswordLinkIssued, "user", userID.UUID,

--- a/backend/internal/modules/identity/users.go
+++ b/backend/internal/modules/identity/users.go
@@ -119,9 +119,9 @@ func (s *Service) InviteUser(ctx context.Context, actor Identity, in InviteUserI
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO auth_token (workspace_id, user_id, purpose, token_hash, expires_at)
-			 VALUES ($1, $2, 'password_reset', $3, now() + $4::interval)`,
-			wsID, newUserID, tokenHash, inviteTokenTTL.String()); err != nil {
+			`INSERT INTO auth_token (user_id, purpose, token_hash, expires_at)
+			 VALUES ($1, 'password_reset', $2, now() + $3::interval)`,
+			newUserID, tokenHash, inviteTokenTTL.String()); err != nil {
 			return err
 		}
 		auditID, err := storekit.Audit(ctx, tx, "create", "user", newUserID.UUID,

--- a/backend/migrations/core/1787109970_credentials_drop_workspace.down.sql
+++ b/backend/migrations/core/1787109970_credentials_drop_workspace.down.sql
@@ -1,0 +1,62 @@
+-- Reverse of 1787109970: the credential tables carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE passport ADD COLUMN workspace_id uuid;
+ALTER TABLE oauth_client ADD COLUMN workspace_id uuid;
+ALTER TABLE oauth_grant ADD COLUMN workspace_id uuid;
+ALTER TABLE oauth_authorization_code ADD COLUMN workspace_id uuid;
+ALTER TABLE oauth_refresh_token ADD COLUMN workspace_id uuid;
+ALTER TABLE auth_token ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'passport', 'oauth_client', 'oauth_grant',
+    'oauth_authorization_code', 'oauth_refresh_token', 'auth_token'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE passport ADD CONSTRAINT passport_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE oauth_client ADD CONSTRAINT oauth_client_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE oauth_grant ADD CONSTRAINT oauth_grant_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE oauth_authorization_code ADD CONSTRAINT oauth_authorization_code_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE oauth_refresh_token ADD CONSTRAINT oauth_refresh_token_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE auth_token ADD CONSTRAINT auth_token_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_passport_obo;
+DROP INDEX passport_oauth_grant_ix;
+DROP INDEX oauth_grant_user_live_ix;
+DROP INDEX oauth_grant_lent_passport_ix;
+DROP INDEX oauth_code_lent_passport_ix;
+DROP INDEX oauth_refresh_token_grant_ix;
+DROP INDEX idx_auth_token_user;
+
+CREATE INDEX idx_passport_obo ON passport (workspace_id, on_behalf_of) WHERE revoked_at IS NULL;
+CREATE INDEX passport_oauth_grant_ix ON passport (workspace_id, oauth_grant_id);
+CREATE INDEX oauth_grant_user_live_ix ON oauth_grant (workspace_id, user_id, id) WHERE revoked_at IS NULL;
+CREATE INDEX oauth_grant_lent_passport_ix ON oauth_grant (workspace_id, lent_passport_id);
+CREATE INDEX oauth_code_lent_passport_ix ON oauth_authorization_code (workspace_id, lent_passport_id);
+CREATE INDEX oauth_refresh_token_grant_ix ON oauth_refresh_token (workspace_id, grant_id);
+CREATE INDEX idx_auth_token_user ON auth_token (workspace_id, user_id, purpose) WHERE used_at IS NULL;

--- a/backend/migrations/core/1787109970_credentials_drop_workspace.up.sql
+++ b/backend/migrations/core/1787109970_credentials_drop_workspace.up.sql
@@ -1,0 +1,62 @@
+-- 1787109970: the credential tables drop the tenant column (ADR-0091 §8 phase D).
+--
+-- Six tables, all of them about a credential rather than a record:
+--
+--   passport                  an agent seat's delegated credential
+--   oauth_client              a registered client (DCR or configured)
+--   oauth_grant               a human's standing consent to one client
+--   oauth_authorization_code  the one-shot code between consent and token
+--   oauth_refresh_token       a grant's renewable half
+--   auth_token                password reset / invite, one purpose per row
+--
+-- These go before app_user and session deliberately. Every one hangs off a USER
+-- rather than off the tenant — the subject a passport acts for, the human a
+-- grant belongs to, the recipient a reset names — so the foreign key already
+-- carries the bound the tenant column was restating, and none of the six is
+-- what MustWorkspace resolves through.
+--
+-- Two reads used to take Identity.WorkspaceID off the credential row itself
+-- (the refresh-token lock and the authorization-code redemption). They now take
+-- it from app_user, which still carries the column and is the credential's own
+-- subject: the same value by a shorter path, and no new authority. When
+-- app_user loses the column in the last slice of this group, that is the point
+-- at which the installation has to resolve itself — deliberately NOT decided
+-- here, where it would be decided by whichever spelling compiled.
+--
+-- None carries a phase-B leftover constraint: their keys already name something
+-- narrower than the tenant, and the only thing the column still held was its
+-- foreign key to workspace.
+
+ALTER TABLE auth_token DROP CONSTRAINT auth_token_workspace_id_fkey;
+ALTER TABLE auth_token DROP COLUMN workspace_id;
+
+ALTER TABLE oauth_refresh_token DROP CONSTRAINT oauth_refresh_token_workspace_id_fkey;
+ALTER TABLE oauth_refresh_token DROP COLUMN workspace_id;
+
+ALTER TABLE oauth_authorization_code DROP CONSTRAINT oauth_authorization_code_workspace_id_fkey;
+ALTER TABLE oauth_authorization_code DROP COLUMN workspace_id;
+
+ALTER TABLE oauth_grant DROP CONSTRAINT oauth_grant_workspace_id_fkey;
+ALTER TABLE oauth_grant DROP COLUMN workspace_id;
+
+ALTER TABLE oauth_client DROP CONSTRAINT oauth_client_workspace_id_fkey;
+ALTER TABLE oauth_client DROP COLUMN workspace_id;
+
+ALTER TABLE passport DROP CONSTRAINT passport_workspace_id_fkey;
+ALTER TABLE passport DROP COLUMN workspace_id;
+
+-- The indexes that led with the column, recreated on what actually selects
+-- rows: the subject a passport acts for, the grant a token renews, the user a
+-- reset names. Every predicate carries over unchanged — what these serve did
+-- not change, only what they had to seek past to get there.
+CREATE INDEX idx_passport_obo ON passport (on_behalf_of) WHERE revoked_at IS NULL;
+CREATE INDEX passport_oauth_grant_ix ON passport (oauth_grant_id);
+
+CREATE INDEX oauth_grant_user_live_ix ON oauth_grant (user_id, id) WHERE revoked_at IS NULL;
+CREATE INDEX oauth_grant_lent_passport_ix ON oauth_grant (lent_passport_id);
+
+CREATE INDEX oauth_code_lent_passport_ix ON oauth_authorization_code (lent_passport_id);
+
+CREATE INDEX oauth_refresh_token_grant_ix ON oauth_refresh_token (grant_id);
+
+CREATE INDEX idx_auth_token_user ON auth_token (user_id, purpose) WHERE used_at IS NULL;


### PR DESCRIPTION
Six tables lose `workspace_id` — `passport`, `oauth_client`, `oauth_grant`,
`oauth_authorization_code`, `oauth_refresh_token`, `auth_token` — and the seven
indexes that led with it are narrowed to what they were actually seeking. None
carried a phase-B leftover constraint. Phase D: 26 → 20.

## Why these before `app_user` and `session`

Every one hangs off a **user** rather than off the tenant — the subject a
passport acts for, the human a grant belongs to, the recipient a reset names —
so the foreign key already carries the bound the tenant column was restating,
and none of the six is what `MustWorkspace` resolves through.

## The one real decision, and why it is the conservative one

Two reads took `Identity.WorkspaceID` off the credential row itself: the
refresh-token lock and the authorization-code redemption. That value backs the
JWS `"ws"` claim, so it still has to be populated once the row stops carrying
it.

It now comes from **`app_user`** — which still has the column, and is the
credential's own subject:

```diff
-SELECT r.id, ..., r.workspace_id, ...
-  JOIN oauth_grant  g ON (g.workspace_id, g.id) = (r.workspace_id, r.grant_id)
-  JOIN app_user     u ON (u.workspace_id, u.id) = (g.workspace_id, g.user_id)
+SELECT r.id, ..., u.workspace_id, ...
+  JOIN oauth_grant  g ON g.id = r.grant_id
+  JOIN app_user     u ON u.id = g.user_id
```

The same value by a shorter path, and **no new authority**. The refresh lock
already joined `app_user`; the code redemption gains that join.

Sourcing it from `InstallationWorkspace` would also compile and would also pass
the suite — but it moves *where a token's workspace comes from*, and a principal
minted in the wrong scope is the failure mode SECURITY.md exists for. That
question belongs to the slice that takes `app_user`'s own column, when it has to
be answered rather than chosen in passing. Written up as #1766.

## One guard kept on purpose

`userpasswordlink` keeps its `workspaceFrom` check and discards the value. The
value is dead — `auth_token` carries no tenant now — but the **check** refuses a
caller that is not workspace-bound before it mints an account-takeover
credential. Dropping it along with the column would have turned a guard into a
coincidence.

## Verification

- `make check-backend` — exit 0
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor

The identity group's remaining tables (`role`, `role_assignment`, `team`,
`team_membership`, `record_grant`, `extension_secret`,
`onboarding_wizard_state`, then `app_user` and `session` last) are unaffected by
this PR and keep their column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the tenant column from all credential tables and sources the token workspace from the user instead. This removes redundancy, simplifies joins, and keeps the JWS "ws" claim unchanged.

- Old behavior: `workspace_id` lived on credential rows and powered refresh-token locks and auth-code redemption. New behavior: those paths read the workspace from `app_user` (the credential’s subject); the refresh path already joined `app_user`, the code path now does. No new authority and same value.

**What changed**
- Schema: remove `workspace_id` from `passport`, `oauth_client`, `oauth_grant`, `oauth_authorization_code`, `oauth_refresh_token`, `auth_token`; recreate seven indexes on the actual lookup keys (e.g., `on_behalf_of`, `oauth_grant_id`, `user_id`).
- Queries: convert composite `(workspace_id, …)` joins to ID-only joins; add an `app_user` join where needed to carry the workspace for token minting.
- Guard: `userpasswordlink` still requires a workspace-bound caller, even though `auth_token` no longer stores a workspace.
- Scope: other identity tables (roles, teams, grants-of-record, `app_user`, `session`) are unchanged here.

**Review and rollout**
- Review: focus on the migration SQL and the two paths that changed source-of-truth for workspace (`oauth_refresh.go` lock and `oauth_token.go` code redemption), plus list/agent queries that dropped composite joins.
- Rollout: apply the migration with the code; this is not dual-write compatible with old binaries. Rollback re-adds `workspace_id` and backfills to the live workspace; it fails if tables have rows and no live workspace exists.

<sup>Written for commit 55539767bebd6e55366ea3aec0c149493f24301b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

