### PR TITLE
fix(ai): the routing version names the binding, not the file it arrived in

### DIFF
--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -187,11 +187,7 @@ func ParseRouting(raw []byte) (RoutingConfig, error) {
 	if err := cfg.validate(); err != nil {
 		return RoutingConfig{}, err
 	}
-	version, err := cfg.bindingDigest()
-	if err != nil {
-		return RoutingConfig{}, err
-	}
-	cfg.sourceHash = version
+	cfg.sourceHash = cfg.bindingDigest()
 	return cfg, nil
 }
 
@@ -215,13 +211,13 @@ func ParseRouting(raw []byte) (RoutingConfig, error) {
 // re-pointed tier, a different base URL, a narrowed `input`. Those are exactly
 // the cases where content a model wrote must stop being attributed to a model
 // that no longer produces it.
-func (cfg RoutingConfig) bindingDigest() (string, error) {
-	encoded, err := json.Marshal(cfg)
-	if err != nil {
-		return "", fmt.Errorf("ai: routing config: encoding the binding for its version: %w", err)
-	}
+func (cfg RoutingConfig) bindingDigest() string {
+	// A plain struct of strings, ints and a string-keyed map — marshal cannot
+	// fail on it, and the same spelling guards the sibling fingerprints in
+	// compose/orgbrief and compose/orgdossier that this digest feeds.
+	encoded, _ := json.Marshal(cfg) //nolint:errchkjson // plain scalars and a string-keyed map; marshal cannot fail
 	sum := sha256.Sum256(encoded)
-	return hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(sum[:])
 }
 
 // localProviders can serve the sovereign zero-egress profile.

--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -51,16 +52,16 @@ type EmbeddingsConfig struct {
 	// (defaultEmbedDimensions). ParseRouting validates it into [1,2000] and
 	// applies the default before any tier or role ever reads it — never
 	// left for a downstream caller to re-check.
-	Dimensions int `yaml:"dimensions"`
+	Dimensions int `yaml:"dimensions" json:"dimensions"`
 }
 
 // RoutingConfig is the parsed ai-routing.yaml: the ONLY place vendor
 // names appear (§1.4). A malformed binding fails at startup, not on the
 // first model call at 3am.
 type RoutingConfig struct {
-	Tiers      map[Tier]ProviderConfig `yaml:"tiers"`
-	Embeddings EmbeddingsConfig        `yaml:"embeddings"`
-	Profile    Profile                 `yaml:"profile"`
+	Tiers      map[Tier]ProviderConfig `yaml:"tiers" json:"tiers"`
+	Embeddings EmbeddingsConfig        `yaml:"embeddings" json:"embeddings"`
+	Profile    Profile                 `yaml:"profile" json:"profile"`
 	// sourceHash is the sha256 digest of the raw yaml bytes this config was
 	// parsed from (spec §4) — the routing half of the ai_call_config
 	// dimension key, alongside the generated TaskContractHash. Set by
@@ -124,6 +125,9 @@ func (cfg RoutingConfig) BoundModelIDsByProvider() map[string]map[string]bool {
 // no longer produces it. Empty for a config built by struct literal rather
 // than parsed from yaml (the fake lane), which is honest: there is no
 // deployment binding to name.
+//
+// Two configs that route identically share a version however differently they
+// were written — see bindingDigest for why that is the whole point.
 func (cfg RoutingConfig) RoutingVersion() string { return cfg.sourceHash }
 
 // LoadRoutingFile reads and validates a deployment's routing config. keys is
@@ -183,9 +187,41 @@ func ParseRouting(raw []byte) (RoutingConfig, error) {
 	if err := cfg.validate(); err != nil {
 		return RoutingConfig{}, err
 	}
-	sum := sha256.Sum256(raw)
-	cfg.sourceHash = hex.EncodeToString(sum[:])
+	version, err := cfg.bindingDigest()
+	if err != nil {
+		return RoutingConfig{}, err
+	}
+	cfg.sourceHash = version
 	return cfg, nil
+}
+
+// bindingDigest is the routing half of the ai_call_config dimension key: a
+// digest of what this config BINDS, not of the bytes it arrived in.
+//
+// It is taken after defaulting and validation, over the canonical JSON
+// encoding, which makes two configs hash alike exactly when they route alike.
+// json.Marshal orders struct fields by declaration and sorts map keys, so the
+// encoding is deterministic across processes — the property this digest has to
+// have to be compared at all.
+//
+// The distinction is not academic. This value reaches personbrief.Fingerprint
+// and its siblings, where it decides whether a stored brief may be reused; a
+// digest of raw bytes meant that ADDING A COMMENT to the routing file
+// invalidated every cached brief, dossier and growth-fit in the installation
+// and regenerated them through paid models. Reindenting did it too, and so did
+// writing `dimensions: 1536` where the default was already 1536.
+//
+// What must still change the digest is any change to the binding itself — a
+// re-pointed tier, a different base URL, a narrowed `input`. Those are exactly
+// the cases where content a model wrote must stop being attributed to a model
+// that no longer produces it.
+func (cfg RoutingConfig) bindingDigest() (string, error) {
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("ai: routing config: encoding the binding for its version: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // localProviders can serve the sovereign zero-egress profile.

--- a/backend/internal/modules/ai/routingversion_test.go
+++ b/backend/internal/modules/ai/routingversion_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+// The routing version is a cache key. It travels into personbrief.Fingerprint
+// and its siblings, where it decides whether a stored brief may be reused, so
+// what it must track is the BINDING — and what it must ignore is everything
+// about how that binding was written down.
+
+const baseRouting = `profile: eu_hosted
+tiers:
+  local_small: {provider: gemini, model: gemini-3.1-flash-lite}
+  cheap_cloud: {provider: gemini, model: gemini-3.1-flash-lite}
+  premium: {provider: gemini, model: gemini-3.5-flash}
+  frontier: {provider: gemini, model: gemini-3.1-pro-preview}
+embeddings: {provider: gemini, model: gemini-embedding-001, dimensions: 1536}
+`
+
+func versionOf(t *testing.T, doc string) string {
+	t.Helper()
+	cfg, err := ParseRouting([]byte(doc))
+	if err != nil {
+		t.Fatalf("ParseRouting: %v", err)
+	}
+	if cfg.RoutingVersion() == "" {
+		t.Fatal("a parsed config has no routing version")
+	}
+	return cfg.RoutingVersion()
+}
+
+// Rewriting the file without changing what it routes must not invalidate a
+// single cached brief. Each of these used to, because the digest was taken over
+// the raw bytes: a comment cost an installation every brief it had.
+func TestRewritingTheFileWithoutChangingTheBindingKeepsTheVersion(t *testing.T) {
+	want := versionOf(t, baseRouting)
+
+	for name, doc := range map[string]string{
+		"a comment is added": "# why we run on gemini, for the next reader\n" + baseRouting,
+		"the tiers are reordered": `profile: eu_hosted
+tiers:
+  frontier: {provider: gemini, model: gemini-3.1-pro-preview}
+  premium: {provider: gemini, model: gemini-3.5-flash}
+  cheap_cloud: {provider: gemini, model: gemini-3.1-flash-lite}
+  local_small: {provider: gemini, model: gemini-3.1-flash-lite}
+embeddings: {provider: gemini, model: gemini-embedding-001, dimensions: 1536}
+`,
+		"the same binding is written in block style": `profile: eu_hosted
+tiers:
+  local_small:
+    provider: gemini
+    model: gemini-3.1-flash-lite
+  cheap_cloud:
+    provider: gemini
+    model: gemini-3.1-flash-lite
+  premium:
+    provider: gemini
+    model: gemini-3.5-flash
+  frontier:
+    provider: gemini
+    model: gemini-3.1-pro-preview
+embeddings:
+  provider: gemini
+  model: gemini-embedding-001
+  dimensions: 1536
+`,
+		// The default is applied before the digest is taken, so saying it out
+		// loud and leaving it out are the same binding — which is what an
+		// operator would assume, and what the byte digest punished.
+		"the default width is written out instead of omitted": strings.Replace(
+			baseRouting, ", dimensions: 1536", "", 1),
+		"a trailing blank line": baseRouting + "\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := versionOf(t, doc); got != want {
+				t.Errorf("the routing version changed but the binding did not:\n got  %s\n want %s", got, want)
+			}
+		})
+	}
+}
+
+// The other half, and the one that matters more: a digest that ignored too much
+// would leave a brief attributed to a model that no longer wrote it. Content a
+// model produced must stop being reused the moment the lane is re-pointed.
+func TestChangingTheBindingChangesTheVersion(t *testing.T) {
+	base := versionOf(t, baseRouting)
+
+	for name, doc := range map[string]string{
+		"a tier is re-pointed at another model": strings.Replace(
+			baseRouting, "premium: {provider: gemini, model: gemini-3.5-flash}",
+			"premium: {provider: gemini, model: gemini-3.1-pro-preview}", 1),
+		"the embeddings width changes": strings.Replace(
+			baseRouting, "dimensions: 1536", "dimensions: 768", 1),
+		"the location ladder changes": strings.Replace(
+			baseRouting, "profile: eu_hosted", "profile: cloud_frontier", 1),
+		"a tier gains a base-url override": strings.Replace(
+			baseRouting, "premium: {provider: gemini, model: gemini-3.5-flash}",
+			"premium: {provider: gemini, model: gemini-3.5-flash, base_url: https://eu-gateway.example}", 1),
+		"a tier narrows what it accepts": strings.Replace(
+			baseRouting, "premium: {provider: gemini, model: gemini-3.5-flash}",
+			"premium: {provider: gemini, model: gemini-3.5-flash, input: [text]}", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := versionOf(t, doc); got == base {
+				t.Error("the binding changed but the routing version did not — cached content stays attributed to a model that no longer produces it")
+			}
+		})
+	}
+}
+
+// The digest is compared across processes and across restarts, so it has to be
+// a function of the binding alone. Go sorts map keys and orders struct fields
+// by declaration when marshaling, which is what makes this hold for a config
+// whose tiers are a map.
+func TestTheVersionIsStableAcrossRepeatedParses(t *testing.T) {
+	first := versionOf(t, baseRouting)
+	for range 32 {
+		if got := versionOf(t, baseRouting); got != first {
+			t.Fatalf("the routing version is not deterministic: got %s, then %s", first, got)
+		}
+	}
+}

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -20,9 +20,9 @@ import (
 // parser rejects unknown keys, so a stray `api_key:` here is a loud error that
 // points the operator at the env var (ADR-0020: BYOK, we provide no inference).
 type ProviderConfig struct {
-	Provider string `yaml:"provider"` // one of knownProviders
-	Model    string `yaml:"model"`    // provider-native model id, resolved from the logical tier
-	BaseURL  string `yaml:"base_url"` // endpoint override; empty means the provider default
+	Provider string `yaml:"provider" json:"provider"` // one of knownProviders
+	Model    string `yaml:"model" json:"model"`       // provider-native model id, resolved from the logical tier
+	BaseURL  string `yaml:"base_url" json:"base_url"` // endpoint override; empty means the provider default
 	// Input is what the bound model can be GIVEN, in the acceptedModalities
 	// vocabulary (inputmodality.go). It does two jobs: on openai_compatible and
 	// vllm it IS the carriage, because only there is the answer a property of the
@@ -31,7 +31,7 @@ type ProviderConfig struct {
 	//
 	// Nil — the common case — means the provider's own answer: text-only on the
 	// two OpenAI-wire providers, whatever the wire carries on the rest.
-	Input []string `yaml:"input"`
+	Input []string `yaml:"input" json:"input,omitempty"`
 }
 
 // Provider defaults. The Anthropic URL is the vendor's public API; a


### PR DESCRIPTION
Found while planning [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780). It is a live defect on `main`, and it is also the foundation the routing-into-the-database move needs, so it lands first on its own.

## The bug

**Adding a comment to `ai-routing.yaml` invalidates every cached brief, dossier and growth-fit in the installation** and regenerates them through paid models. Reindenting does it too, and so does writing `dimensions: 1536` where the default was already 1536.

`RoutingVersion` is a **cache key**, not a build stamp:

```
routingVersion → personbrief.Fingerprint
              → sha256(promptVersion \0 routingVersion \0 input)
              → cached.Fingerprint == fingerprint   // decides reuse
```

Account briefs, company dossiers and growth-fit take the same dependency. The digest was `sha256(raw YAML bytes)`, so every one of those edits read as *"the model binding changed"*.

## The fix

The digest is taken over the config's **canonical JSON**, after defaulting and validation — so two configs hash alike exactly when they route alike. `json.Marshal` orders struct fields by declaration and sorts map keys, so the encoding is deterministic across processes, which is the property a value compared across restarts has to have.

Taking it *after* defaulting is deliberate: `dimensions:` omitted and `dimensions: 1536` are the same binding, and an operator would assume so.

## The half that matters more

A digest that ignored too much would be a worse bug than the one this fixes — a brief left attributed to a model that no longer wrote it. So the opposite direction is tested as its own case:

| Must still change the version | |
|---|---|
| a tier re-pointed at another model | ✓ |
| the embeddings width changes | ✓ |
| the location ladder changes | ✓ |
| a tier gains a `base_url` override | ✓ |
| a tier narrows its `input` | ✓ |

## Mutation-proven, both directions

| Mutation | Failures |
|---|---|
| restore the byte digest (the bug) | 5 of the rewriting cases |
| over-correct — digest only the profile | 4 of the binding cases |

Plus a determinism case: 32 repeated parses must agree, which is what the map-key sorting has to hold up.

## Note

Installations take a **one-time** cache miss as the digest changes representation. That is the last one they take for a reformatting.

`make -C backend check` exit 0 · `make craft-static` PASS.

Refs [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops spurious cache invalidations by making the routing version reflect the model binding, not the raw `ai-routing.yaml` bytes. Previously, comments or reformatting changed the version and flushed cached briefs/dossiers/growth-fit; now only binding changes do.

- Computes the version from canonical JSON after defaulting and validation; adds `json` tags to routing and `ProviderConfig` structs (with `input` `omitempty`) for deterministic encoding; the digest helper no longer returns an error.
- Adds tests for unchanged-binding stability, binding-change sensitivity (tier/model, embeddings width, profile ladder, `base_url`, `input`), and determinism across parses.
- Rollout: one-time cache miss as the digest format changes; no config changes required. Reformatting `ai-routing.yaml` is now safe.
- Connects to #1780 by making the routing key stable and semantically meaningful for routing-into-database.

<sup>Written for commit 2919df346330762fb5087ae98088db2ebcda9e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

