### PR TITLE
fix(records): an employment is recorded once, and a person's only employer is their primary one

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5037,9 +5037,12 @@ paths:
       summary: Create a relationship edge (employment or deal stakeholder).
       description: |
         `employment` requires person_id + organization_id; `deal_stakeholder` requires
-        deal_id + person_id. At most one current-primary employer per person, and a
-        person's only current employment is that one. An employment they already
-        hold is refused 409: end the existing one before recording a new one.
+        deal_id + person_id. An employment they already hold is refused 409: end the
+        existing one before recording a new one. At most one current-primary employer
+        per person; `is_current_primary` is decided here only when you OMIT it — an
+        employment for somebody with no other current one then becomes their primary
+        — and an employment that has already ended never takes the flag. Send the
+        field to decide it yourself; a later PATCH always wins over both.
       requestBody:
         required: true
         content:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5037,7 +5037,9 @@ paths:
       summary: Create a relationship edge (employment or deal stakeholder).
       description: |
         `employment` requires person_id + organization_id; `deal_stakeholder` requires
-        deal_id + person_id. At most one current-primary employer per person.
+        deal_id + person_id. At most one current-primary employer per person, and a
+        person's only current employment is that one. An employment they already
+        hold is refused 409: end the existing one before recording a new one.
       requestBody:
         required: true
         content:

--- a/backend/internal/compose/flipassoc.go
+++ b/backend/internal/compose/flipassoc.go
@@ -95,10 +95,13 @@ func (w *flipWriters) Associate(ctx context.Context, a migration.Assoc) (migrati
 		personID := ids.From[ids.PersonKind](fromID)
 		orgID := ids.From[ids.OrganizationKind](toID)
 		_, err := w.people.CreateRelationship(ctx, people.CreateRelationshipInput{
-			Kind:             "employment",
-			PersonID:         &personID,
-			OrganizationID:   &orgID,
-			IsCurrentPrimary: strings.EqualFold(a.Label, "primary"),
+			Kind:           "employment",
+			PersonID:       &personID,
+			OrganizationID: &orgID,
+			// The mirrored label is the incumbent's own answer, so it is stated
+			// either way — a non-primary association must not be promoted by the
+			// store's own rule for a caller who said nothing.
+			IsCurrentPrimary: ptrBool(strings.EqualFold(a.Label, "primary")),
 			Source:           w.provenance("relationship", a.FromID+"→"+a.ToID),
 		})
 		if err != nil {

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -423,7 +423,7 @@ func TestThePersonListNarrowsToOneEmployer(t *testing.T) {
 
 	// Seeded through the real writer, so the edge carries whatever that writer
 	// stamps: a hand-inserted row proves nothing about the rows production makes.
-	employ := func(person ids.UUID, org ids.UUID, current bool) {
+	employ := func(person ids.UUID, org ids.UUID, ended *time.Time) {
 		t.Helper()
 		personID := ids.From[ids.PersonKind](person)
 		orgID := ids.From[ids.OrganizationKind](org)
@@ -431,18 +431,22 @@ func TestThePersonListNarrowsToOneEmployer(t *testing.T) {
 			Kind:             "employment",
 			PersonID:         &personID,
 			OrganizationID:   &orgID,
-			IsCurrentPrimary: current,
+			IsCurrentPrimary: ended == nil,
+			EndedAt:          ended,
 			Source:           "manual",
 		}); err != nil {
 			t.Fatalf("seeding the employment edge: %v", err)
 		}
 	}
-	employ(staff, acme, true)
+	left := time.Date(2021, 6, 30, 0, 0, 0, 0, time.UTC)
+	employ(staff, acme, nil)
 	// A past employer at the same account: the filter answers who works there,
 	// not who has ever worked there, and returning the leaver beside the staff
-	// is the wrong answer wearing the right shape.
-	employ(leaver, acme, false)
-	employ(elsewhere, other, true)
+	// is the wrong answer wearing the right shape. DATED as over, because that
+	// is what past is — an undated non-primary job cannot say it, now that a
+	// person's only employment is their current primary one.
+	employ(leaver, acme, &left)
+	employ(elsewhere, other, nil)
 
 	orgID := ids.From[ids.OrganizationKind](acme)
 	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{OrganizationID: &orgID})

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -431,7 +431,7 @@ func TestThePersonListNarrowsToOneEmployer(t *testing.T) {
 			Kind:             "employment",
 			PersonID:         &personID,
 			OrganizationID:   &orgID,
-			IsCurrentPrimary: ended == nil,
+			IsCurrentPrimary: boolPtr(ended == nil),
 			EndedAt:          ended,
 			Source:           "manual",
 		}); err != nil {

--- a/backend/internal/compose/integration/employment_dedupe_integration_test.go
+++ b/backend/internal/compose/integration/employment_dedupe_integration_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The two rules that make a person's employer a single readable fact: an
+// employment they already hold cannot be recorded a second time, and a person
+// whose only employment this is holds it as their current primary one.
+//
+// Both are enforced in Postgres — a partial unique index and a subquery inside
+// the insert — so they are proved here, over HTTP, against the real store.
+// Each rule is paired with the case it must NOT refuse, because a rule tested
+// only where it fires reads identically to one that refuses everything.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+// employment posts one edge and returns the status plus what the store made of
+// it — the created id, whether it landed primary, and the refusal detail when
+// it did not land at all.
+func (e *relEnv) employment(t *testing.T, orgID string, body apptest.AnyMap) (status int, id string, primary bool, detail string) {
+	t.Helper()
+	body["kind"] = "employment"
+	body["person_id"] = e.personID
+	body["organization_id"] = orgID
+	body["source"] = "ui"
+	var out struct {
+		ID               string `json:"id"`
+		IsCurrentPrimary bool   `json:"is_current_primary"`
+		Detail           string `json:"detail"`
+	}
+	status = e.Call(t, "POST", "/v1/relationships", body, nil, &out)
+	return status, out.ID, out.IsCurrentPrimary, out.Detail
+}
+
+// secondOrg creates one more company to employ the same person at.
+func (e *relEnv) secondOrg(t *testing.T, name string) string {
+	t.Helper()
+	var org struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": name}, nil, &org); status != http.StatusCreated {
+		t.Fatalf("create %s → %d", name, status)
+	}
+	return org.ID
+}
+
+func TestASecondCurrentEmploymentAtTheSameCompanyIsRefused(t *testing.T) {
+	e := setupRelationships(t)
+
+	status, first, _, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	if status != http.StatusCreated {
+		t.Fatalf("first employment → %d", status)
+	}
+
+	// The same pair again. Before uq_rel_employment both rows landed, and the
+	// account then counted the person twice.
+	status, _, _, detail := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	if status != http.StatusConflict {
+		t.Fatalf("duplicate employment → %d, want 409", status)
+	}
+	const want = "this person already works at that company — end the employment they have there before recording a new one"
+	if detail != want {
+		t.Errorf("refusal detail = %q, want %q — the caller is told which rule fired, never the index name", detail, want)
+	}
+
+	// The role is not part of the key: the same person cannot hold the same job
+	// twice under two titles either.
+	if status, _, _, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "ceo"}); status != http.StatusConflict {
+		t.Errorf("duplicate under a different role → %d, want 409", status)
+	}
+
+	// The mirror. Once they have LEFT, being hired again by the same company is
+	// a new fact, not a duplicate — which is why the index predicate carries
+	// ended_at IS NULL and deliberately differs from uq_rel_project_stakeholder.
+	var ended struct {
+		IsCurrentPrimary bool `json:"is_current_primary"`
+	}
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+first,
+		apptest.AnyMap{"ended_at": "2026-01-31"}, nil, &ended); status != http.StatusOK {
+		t.Fatalf("ending the first employment → %d", status)
+	}
+	if ended.IsCurrentPrimary {
+		t.Error("a job the person has left is still flagged as their CURRENT primary employer")
+	}
+	status, _, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	if status != http.StatusCreated {
+		t.Errorf("re-employment after leaving → %d, want 201: a former employer may hire someone back", status)
+	}
+	if !primary {
+		t.Error("the re-employment is the person's only current job and did not land as their primary one")
+	}
+}
+
+// Setting the flag on a job that is already over does not take either — the
+// same rule read from the other direction, and the reason it is written against
+// the row rather than as a condition on the patch.
+func TestAnEndedEmploymentCannotBeMadeTheCurrentPrimaryOne(t *testing.T) {
+	e := setupRelationships(t)
+
+	status, edge, _, _ := e.employment(t, e.orgID, apptest.AnyMap{
+		"started_at": "2019-01-01", "ended_at": "2021-06-30",
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("historical employment → %d", status)
+	}
+	var patched struct {
+		IsCurrentPrimary bool `json:"is_current_primary"`
+	}
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge,
+		apptest.AnyMap{"is_current_primary": true}, nil, &patched); status != http.StatusOK {
+		t.Fatalf("patching the flag onto an ended employment → %d", status)
+	}
+	if patched.IsCurrentPrimary {
+		t.Error("an employment that ended in 2021 now reads as the person's current primary employer")
+	}
+}
+
+func TestAPersonsOnlyCurrentEmploymentIsTheirPrimaryOne(t *testing.T) {
+	e := setupRelationships(t)
+
+	// Nobody asked for primary. is_current_primary defaults to false, so before
+	// this rule the person ended up employed by exactly one company and having
+	// no primary employer — a state every reader of the column has to guess at.
+	status, _, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	if status != http.StatusCreated {
+		t.Fatalf("first employment → %d", status)
+	}
+	if !primary {
+		t.Error("a person's only employment did not land as their current primary one")
+	}
+
+	// A SECOND concurrent job is not promoted. Which of two employers is the
+	// primary one is a fact about the person that the second insert does not
+	// carry, and guessing it would overwrite the answer the first one gave.
+	if status, _, primary, _ := e.employment(t, e.secondOrg(t, "Moonlight Ltd"), apptest.AnyMap{}); status != http.StatusCreated || primary {
+		t.Errorf("second concurrent employment → %d primary=%t, want 201 and not primary", status, primary)
+	}
+}
+
+// An employment recorded as already over is history being backfilled. Promoting
+// it would tell every reader the person currently works somewhere they left —
+// and asking for it to be primary must not cost them the employer they have.
+func TestAnAlreadyEndedEmploymentIsNeverPromoted(t *testing.T) {
+	e := setupRelationships(t)
+
+	status, current, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{"role": "cto"})
+	if status != http.StatusCreated || !primary {
+		t.Fatalf("the job they actually hold → %d primary=%t, want 201 and primary", status, primary)
+	}
+
+	// Backfilled WITH the flag asked for. The row does not take it, and the
+	// demotion that would have cleared the incumbent never runs — so the
+	// employer they actually have keeps the flag instead of the job they left.
+	status, _, primary, _ = e.employment(t, e.secondOrg(t, "Former Employer GmbH"), apptest.AnyMap{
+		"started_at": "2019-01-01", "ended_at": "2021-06-30", "is_current_primary": true,
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("historical employment → %d", status)
+	}
+	if primary {
+		t.Error("an employment created already ended took the current-primary flag because the request asked for it")
+	}
+
+	if !e.isPrimary(t, current) {
+		t.Error("backfilling a job they left in 2021 took the primary flag off the job they hold today")
+	}
+}
+
+// isPrimary re-reads one edge through the person's employment list — the only
+// read this surface offers for a single relationship.
+func (e *relEnv) isPrimary(t *testing.T, edgeID string) bool {
+	t.Helper()
+	var listed struct {
+		Data []struct {
+			ID               string `json:"id"`
+			IsCurrentPrimary bool   `json:"is_current_primary"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/relationships?kind=employment&person_id="+e.personID, nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("listing employments → %d", status)
+	}
+	for _, edge := range listed.Data {
+		if edge.ID == edgeID {
+			return edge.IsCurrentPrimary
+		}
+	}
+	t.Fatalf("employment %s is not in the person's own list of %d", edgeID, len(listed.Data))
+	return false
+}

--- a/backend/internal/compose/integration/employment_dedupe_integration_test.go
+++ b/backend/internal/compose/integration/employment_dedupe_integration_test.go
@@ -144,6 +144,32 @@ func TestAPersonsOnlyCurrentEmploymentIsTheirPrimaryOne(t *testing.T) {
 	}
 }
 
+// The store decides the flag only for a caller who left it out. A request that
+// SENDS false is a person unticking "current employer" in the rail, and
+// deriving over it would hand back the opposite of what they chose.
+func TestAnExplicitlyUnsetPrimaryFlagIsHonouredOnTheOnlyEmployment(t *testing.T) {
+	e := setupRelationships(t)
+
+	status, first, primary, _ := e.employment(t, e.orgID, apptest.AnyMap{
+		"role": "cto", "is_current_primary": false,
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("employment with the flag explicitly unset → %d", status)
+	}
+	if primary {
+		t.Error("a request that said is_current_primary=false got true back — the derivation overrode the caller")
+	}
+
+	// The choice sticks. Nothing later re-derives it, so the person keeps the
+	// employer they recorded and no primary flag until somebody says otherwise.
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+first, apptest.AnyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
+		t.Fatalf("patching an unrelated field → %d", status)
+	}
+	if e.isPrimary(t, first) {
+		t.Error("editing the role re-derived the flag the caller had explicitly unset")
+	}
+}
+
 // An employment recorded as already over is history being backfilled. Promoting
 // it would tell every reader the person currently works somewhere they left —
 // and asking for it to be primary must not cost them the employer they have.

--- a/backend/internal/compose/integration/lastactivity_integration_test.go
+++ b/backend/internal/compose/integration/lastactivity_integration_test.go
@@ -40,7 +40,7 @@ func TestLastActivity_MovesThePersonAndEveryAccountItReaches(t *testing.T) {
 	personID := ids.From[ids.PersonKind](staff)
 	orgID := ids.From[ids.OrganizationKind](acme)
 	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
-		Kind: "employment", PersonID: &personID, OrganizationID: &orgID, IsCurrentPrimary: true, Source: "manual",
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID, IsCurrentPrimary: boolPtr(true), Source: "manual",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestLastActivity_MovesThePersonAndEveryAccountItReaches(t *testing.T) {
 	// the new account: the reach set moved without any activity being written.
 	lateID := ids.From[ids.OrganizationKind](late)
 	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
-		Kind: "employment", PersonID: &personID, OrganizationID: &lateID, IsCurrentPrimary: false, Source: "manual",
+		Kind: "employment", PersonID: &personID, OrganizationID: &lateID, IsCurrentPrimary: boolPtr(false), Source: "manual",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func TestLastActivity_TheAccountClockSeeksInsteadOfScanningTheTimeline(t *testin
 	personID := ids.From[ids.PersonKind](staff)
 	orgID := ids.From[ids.OrganizationKind](acme)
 	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
-		Kind: "employment", PersonID: &personID, OrganizationID: &orgID, IsCurrentPrimary: true, Source: "manual",
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID, IsCurrentPrimary: boolPtr(true), Source: "manual",
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/organization_counts_integration_test.go
+++ b/backend/internal/compose/integration/organization_counts_integration_test.go
@@ -14,6 +14,7 @@ package integration
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
@@ -31,21 +32,24 @@ func TestOrganizationCounts_ListAndSingleReadAgreeWithTheEdges(t *testing.T) {
 	second := e.SeedPerson(t, "Also At Acme", nil)
 	leaver := e.SeedPerson(t, "Left Acme", nil)
 
-	employ := func(person, org ids.UUID, current bool) {
+	employ := func(person, org ids.UUID, ended *time.Time) {
 		t.Helper()
 		personID := ids.From[ids.PersonKind](person)
 		orgID := ids.From[ids.OrganizationKind](org)
 		if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
 			Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
-			IsCurrentPrimary: current, Source: "manual",
+			IsCurrentPrimary: ended == nil, EndedAt: ended, Source: "manual",
 		}); err != nil {
 			t.Fatalf("seeding the employment edge: %v", err)
 		}
 	}
-	employ(staff, acme, true)
-	employ(second, acme, true)
-	// A past employer is not a contact: the column answers who works here.
-	employ(leaver, acme, false)
+	left := time.Date(2021, 6, 30, 0, 0, 0, 0, time.UTC)
+	employ(staff, acme, nil)
+	employ(second, acme, nil)
+	// A past employer is not a contact: the column answers who works here. Dated
+	// as over, because that is what past is — an undated non-primary job cannot
+	// say it, now that a person's only employment is their current primary one.
+	employ(leaver, acme, &left)
 
 	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
 	for _, name := range []string{"D1", "D2", "D3"} {

--- a/backend/internal/compose/integration/organization_counts_integration_test.go
+++ b/backend/internal/compose/integration/organization_counts_integration_test.go
@@ -38,7 +38,7 @@ func TestOrganizationCounts_ListAndSingleReadAgreeWithTheEdges(t *testing.T) {
 		orgID := ids.From[ids.OrganizationKind](org)
 		if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
 			Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
-			IsCurrentPrimary: ended == nil, EndedAt: ended, Source: "manual",
+			IsCurrentPrimary: boolPtr(ended == nil), EndedAt: ended, Source: "manual",
 		}); err != nil {
 			t.Fatalf("seeding the employment edge: %v", err)
 		}
@@ -97,7 +97,7 @@ func TestOrganizationCounts_UngatedRoleSeesContactsButNoDealCount(t *testing.T) 
 	pID := ids.From[ids.PersonKind](staff)
 	oID := ids.From[ids.OrganizationKind](acme)
 	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
-		Kind: "employment", PersonID: &pID, OrganizationID: &oID, IsCurrentPrimary: true, Source: "manual",
+		Kind: "employment", PersonID: &pID, OrganizationID: &oID, IsCurrentPrimary: boolPtr(true), Source: "manual",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestOrganizationCounts_FollowTheCallersRowScope(t *testing.T) {
 		orgID := ids.From[ids.OrganizationKind](acme)
 		if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
 			Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
-			IsCurrentPrimary: true, Source: "manual",
+			IsCurrentPrimary: boolPtr(true), Source: "manual",
 		}); err != nil {
 			t.Fatalf("seeding the employment edge: %v", err)
 		}

--- a/backend/internal/compose/integration/relationship_seam_integration_test.go
+++ b/backend/internal/compose/integration/relationship_seam_integration_test.go
@@ -188,6 +188,44 @@ func TestAnEmploymentEdgeLivesItsWholeLifeThroughTheToolSurface(t *testing.T) {
 	}
 }
 
+// The tri-state reaches the tool surface, or it is a rule only REST has. An
+// agent calling create_record sends `fields` as JSON, and an omitted key has to
+// survive StrictDecode into a nil *bool — a seam that defaulted it to false
+// would make a person's only employer unmarked over MCP while REST marked it,
+// and both halves would look correct in isolation.
+//
+// Sending it explicitly is the other half: the store decides only for a caller
+// who said nothing, and a tool that could not say false would have no way to
+// record a job somebody holds without claiming it is their main one.
+func TestTheToolSurfaceCanBothOmitAndStateTheCurrentPrimaryFlag(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+	person, org := seedEndpointPair(ctx, t, e, "Ida Omitted", "Only Employer GmbH")
+
+	_, derived := createEmployment(ctx, t, registry, person, org, "")
+	if !primaryFlag(t, derived) {
+		t.Error("is_current_primary came back false with the key omitted — their only employment is their primary one")
+	}
+
+	other, secondOrg := seedEndpointPair(ctx, t, e, "Ida Stated", "Side Job GmbH")
+	_, stated := createEmployment(ctx, t, registry, other, secondOrg, `,"is_current_primary":false`)
+	if primaryFlag(t, stated) {
+		t.Error("is_current_primary came back true with false sent explicitly — the store overrode what the caller stated")
+	}
+}
+
+// primaryFlag reads the flag the surface answered with. Absent is a failure of
+// its own: the contract declares the field on every relationship, so a missing
+// one is a wire-mapping fault, not a false.
+func primaryFlag(t *testing.T, fields edgeFields) bool {
+	t.Helper()
+	if fields.IsCurrentPrimary == nil {
+		t.Fatalf("the edge answered without is_current_primary at all: %+v", fields)
+	}
+	return *fields.IsCurrentPrimary
+}
+
 func TestAnEdgeIsInvisibleWhenEitherEndpointIsOutOfTheCallersRowScope(t *testing.T) {
 	e := Setup(t)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})

--- a/backend/internal/modules/people/dedupe_integration_test.go
+++ b/backend/internal/modules/people/dedupe_integration_test.go
@@ -127,9 +127,13 @@ func (e *dedupeEnv) seedEmployedPerson(ctx context.Context, t *testing.T, name, 
 	}
 	personID := ids.From[ids.PersonKind](ids.UUID(person.Id))
 	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+	// Stated, not left to the store's own rule: this seed is about the person
+	// HAVING a current employer, so it says so rather than relying on a
+	// derivation another test could change.
+	primary := true
 	if _, err := e.store.CreateRelationship(ctx, CreateRelationshipInput{
 		Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
-		IsCurrentPrimary: true, Source: "manual",
+		IsCurrentPrimary: &primary, Source: "manual",
 	}); err != nil {
 		t.Fatalf("seed employment: %v", err)
 	}

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -62,8 +62,12 @@ func organizationIsLive(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 
 // plantEmploymentEdge attaches one person to one company, and only when they
 // have no current primary employer: capture SUGGESTS an employer, it never
-// reassigns somebody's. The current-primary partial unique is the structural
-// guard; the NOT EXISTS keeps a concurrent race from surfacing as a 500.
+// reassigns somebody's. TWO partial uniques are the structural guard — the
+// current-primary one and uq_rel_employment, which refuses a second live edge
+// for the same pair — and ON CONFLICT DO NOTHING is what makes either of them
+// a no-op here rather than a failure: capture has nothing to add to an
+// employment that already exists. The NOT EXISTS keeps a concurrent race with
+// the first from surfacing as a 500.
 func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyInput, personID ids.PersonID, orgID ids.OrganizationID) error {
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -88,10 +88,16 @@ type CreateRelationshipInput struct {
 	DealID            *ids.DealID
 	ProjectID         *ids.ProjectID
 	Role              *string
-	IsCurrentPrimary  bool
-	StartedAt         *time.Time
-	EndedAt           *time.Time
-	Source            string
+	// IsCurrentPrimary is TRI-STATE, and the third state is what makes the rule
+	// in the insert safe: nil means the caller expressed no opinion and the
+	// store decides, false means they said this is NOT the person's current
+	// primary employment. Collapsing the two would silently invert a choice the
+	// caller can see themselves making — the person rail's "current employer"
+	// checkbox sends exactly that false.
+	IsCurrentPrimary *bool
+	StartedAt        *time.Time
+	EndedAt          *time.Time
+	Source           string
 }
 
 func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInput) (relationshipRow, error) {
@@ -125,11 +131,22 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 		if err := ensureRelationshipEndpoints(ctx, tx, in); err != nil {
 			return err
 		}
+		// Both rules below read the person's OTHER employments and then write
+		// against what they read, so they are one unit per person or they are a
+		// race: two concurrent unmarked employments at different companies would
+		// each see no primary, each claim it, and one would come back 409 naming
+		// a flag its caller never sent.
+		if in.Kind == "employment" && in.PersonID != nil {
+			if err := storekit.LockWriteIdentity(ctx, tx, "employment", in.PersonID.String()); err != nil {
+				return err
+			}
+		}
 		// One current primary employer per person: demote the incumbent
 		// inside the same transaction rather than failing the write. An
 		// employment that arrives already ended claims nothing, so it displaces
 		// nobody — see the insert below, which refuses it the flag.
-		if in.Kind == "employment" && in.IsCurrentPrimary && in.EndedAt == nil && in.PersonID != nil {
+		if in.Kind == "employment" && in.IsCurrentPrimary != nil && *in.IsCurrentPrimary &&
+			in.EndedAt == nil && in.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
 				WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL`,
@@ -141,13 +158,15 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 		// returned row is the row that landed — a follow-up UPDATE would bump
 		// the version under the caller about to read it back.
 		//
-		// A person's ONLY current employment is their current primary one. The
-		// column defaults to false and nothing else ever promotes, so without
-		// this a person with exactly one employer has none marked: a state no
-		// reader of the column expects and none of them can repair. The
-		// subquery excludes an ended-but-still-primary row as well as a current
-		// one, because promoting past either would violate
-		// uq_rel_current_primary_employer.
+		// A person's ONLY current employment is their current primary one, WHEN
+		// THE CALLER SAID NOTHING ($8 IS NULL). The column defaults to false and
+		// nothing else ever promotes, so without this a person with exactly one
+		// employer has none marked: a state no reader of the column expects and
+		// none of them can repair. A caller who sent the field keeps their
+		// answer, including an explicit false — deriving over it would invert a
+		// choice they can see themselves making. The subquery excludes an
+		// ended-but-still-primary row as well as a current one, because
+		// promoting past either would violate uq_rel_current_primary_employer.
 		//
 		// And an employment that arrives already ended never holds the flag,
 		// however it was asked for — history being backfilled is not where
@@ -157,10 +176,10 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 			INSERT INTO relationship (kind, person_id, organization_id, counterparty_org_id,
 			                          deal_id, project_id, role, is_current_primary, started_at, ended_at, source, captured_by)
 			VALUES ($1, $2, $3, $4, $5, $6, $7,
-			        ($8 OR ($1 = 'employment' AND NOT EXISTS (
+			        coalesce($8, $1 = 'employment' AND NOT EXISTS (
 			          SELECT 1 FROM relationship
 			           WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL
-			             AND (ended_at IS NULL OR is_current_primary))))
+			             AND (ended_at IS NULL OR is_current_primary)))
 			          AND ($1 <> 'employment' OR $10::date IS NULL),
 			        $9, $10, $11, $12)
 			RETURNING `+relationshipColumns,

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -126,8 +126,10 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 			return err
 		}
 		// One current primary employer per person: demote the incumbent
-		// inside the same transaction rather than failing the write.
-		if in.Kind == "employment" && in.IsCurrentPrimary && in.PersonID != nil {
+		// inside the same transaction rather than failing the write. An
+		// employment that arrives already ended claims nothing, so it displaces
+		// nobody — see the insert below, which refuses it the flag.
+		if in.Kind == "employment" && in.IsCurrentPrimary && in.EndedAt == nil && in.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
 				WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL`,
@@ -135,10 +137,32 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 				return err
 			}
 		}
+		// Two rules about is_current_primary, spelled in the insert so the
+		// returned row is the row that landed — a follow-up UPDATE would bump
+		// the version under the caller about to read it back.
+		//
+		// A person's ONLY current employment is their current primary one. The
+		// column defaults to false and nothing else ever promotes, so without
+		// this a person with exactly one employer has none marked: a state no
+		// reader of the column expects and none of them can repair. The
+		// subquery excludes an ended-but-still-primary row as well as a current
+		// one, because promoting past either would violate
+		// uq_rel_current_primary_employer.
+		//
+		// And an employment that arrives already ended never holds the flag,
+		// however it was asked for — history being backfilled is not where
+		// somebody works today. That is the same rule the UPDATE below applies,
+		// and both read it off the row rather than off the request.
 		row := tx.QueryRow(ctx, `
 			INSERT INTO relationship (kind, person_id, organization_id, counterparty_org_id,
 			                          deal_id, project_id, role, is_current_primary, started_at, ended_at, source, captured_by)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			VALUES ($1, $2, $3, $4, $5, $6, $7,
+			        ($8 OR ($1 = 'employment' AND NOT EXISTS (
+			          SELECT 1 FROM relationship
+			           WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL
+			             AND (ended_at IS NULL OR is_current_primary))))
+			          AND ($1 <> 'employment' OR $10::date IS NULL),
+			        $9, $10, $11, $12)
 			RETURNING `+relationshipColumns,
 			in.Kind, in.PersonID, in.OrganizationID, in.CounterpartyOrgID, in.DealID, in.ProjectID,
 			in.Role, in.IsCurrentPrimary, in.StartedAt, in.EndedAt, in.Source, capturedBy)
@@ -214,7 +238,12 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		if in.IfVersion != nil && *in.IfVersion != current.Version {
 			return apperrors.ErrVersionSkew
 		}
+		// Not for an employment this patch leaves ended, and not for one that
+		// already was: the UPDATE below refuses such a row the flag, so
+		// demoting the incumbent for it would clear the person's primary
+		// employer and put nothing in its place.
 		if in.IsCurrentPrimary != nil && *in.IsCurrentPrimary &&
+			in.EndedAt == nil && current.EndedAt == nil &&
 			current.Kind == "employment" && current.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
@@ -226,7 +255,13 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		row := tx.QueryRow(ctx, `
 			UPDATE relationship SET
 			  role = coalesce($2, role),
-			  is_current_primary = coalesce($3, is_current_primary),
+			  -- An employment somebody has LEFT is not their CURRENT primary
+			  -- one, whichever half of the patch makes it so: ending the job
+			  -- clears the flag, and setting the flag on a job already ended
+			  -- does not take. Written against the row rather than as a Go
+			  -- condition, so the two halves cannot drift apart.
+			  is_current_primary = coalesce($3, is_current_primary)
+			    AND (kind <> 'employment' OR coalesce($5, ended_at) IS NULL),
 			  started_at = coalesce($4, started_at),
 			  ended_at = coalesce($5, ended_at)
 			WHERE id = $1

--- a/backend/internal/modules/people/relationship_conflict_test.go
+++ b/backend/internal/modules/people/relationship_conflict_test.go
@@ -23,12 +23,11 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
+// Derived from relationshipConflictDetails, not restated beside it: a rule
+// added to the mapper without being covered here would otherwise be a rule
+// nothing checks, and the mapper is the one list that has to be complete.
 func TestRelationshipUniquenessRefusalKeepsBothTheSentinelAndTheConstraint(t *testing.T) {
-	for _, constraint := range []string{
-		"uq_rel_current_primary_employer",
-		"uq_rel_deal_person_role",
-		"uq_rel_project_stakeholder",
-	} {
+	for constraint := range relationshipConflictDetails {
 		t.Run(constraint, func(t *testing.T) {
 			mapped := mapRelationshipConstraint(
 				&pgconn.PgError{Code: "23505", ConstraintName: constraint}, "project_stakeholder")
@@ -67,11 +66,20 @@ func TestRelationshipUniquenessRefusalKeepsBothTheSentinelAndTheConstraint(t *te
 // and a message describing the wrong pair sends them hunting a row that does
 // not exist.
 func TestEachUniquenessRuleDescribesWhatItActuallyRefused(t *testing.T) {
-	for constraint, want := range map[string]string{
+	described := map[string]string{
 		"uq_rel_current_primary_employer": "current primary employer",
 		"uq_rel_deal_person_role":         "role on the deal",
-		"uq_rel_project_stakeholder":      "stakeholder on the project",
-	} {
+		employmentUnique:                  "already works at that company",
+		projectStakeholderUnique:          "stakeholder on the project",
+	}
+	// The generic fallback below is a truthful refusal but a vague one, so no
+	// rule may reach it by being forgotten here.
+	for constraint := range relationshipConflictDetails {
+		if _, covered := described[constraint]; !covered {
+			t.Errorf("%s is mapped to a client message that nothing asserts", constraint)
+		}
+	}
+	for constraint, want := range described {
 		t.Run(constraint, func(t *testing.T) {
 			got := (&RelationshipConflictError{Constraint: constraint}).Error()
 			if !strings.Contains(got, want) {

--- a/backend/internal/modules/people/relationship_mapping.go
+++ b/backend/internal/modules/people/relationship_mapping.go
@@ -30,10 +30,13 @@ import (
 // their refusal into a lie about what the caller sent.
 func relationshipCreateInput(req crmcontracts.CreateRelationshipRequest) CreateRelationshipInput {
 	in := CreateRelationshipInput{
-		Kind:              string(req.Kind),
-		Role:              req.Role,
-		Source:            req.Source,
-		IsCurrentPrimary:  req.IsCurrentPrimary != nil && *req.IsCurrentPrimary,
+		Kind:   string(req.Kind),
+		Role:   req.Role,
+		Source: req.Source,
+		// Passed through as the pointer, not collapsed to a bool: the store
+		// decides the flag only for a caller who omitted it, and an omitted
+		// field and an explicit false are different requests.
+		IsCurrentPrimary:  req.IsCurrentPrimary,
 		PersonID:          idArg[ids.PersonKind](req.PersonId),
 		OrganizationID:    idArg[ids.OrganizationKind](req.OrganizationId),
 		CounterpartyOrgID: idArg[ids.OrganizationKind](req.CounterpartyOrgId),

--- a/backend/internal/modules/people/relationshiperrors.go
+++ b/backend/internal/modules/people/relationshiperrors.go
@@ -100,15 +100,22 @@ func (e *RelationshipDatesError) FieldFault() (field, code, message string) {
 // its transcript, which would put SQLSTATE text in a model prompt.
 type RelationshipConflictError struct{ Constraint string }
 
+// employmentUnique is the index that makes a second employment at the same
+// company detectable rather than duplicated (migration 1787111736). Named here
+// because the mapper below and its client-facing detail must not drift apart.
+const employmentUnique = "uq_rel_employment"
+
 // relationshipConflictDetails says what each rule actually refused, in the
-// caller's terms. One shared sentence cannot serve all three: the primary-
+// caller's terms. One shared sentence cannot serve all four: the primary-
 // employer index is keyed on the PERSON alone, so its conflict is with a
 // different company entirely — telling that caller "this already exists
 // between these records" would name the wrong pair and send them looking for
-// a row that is not there.
+// a row that is not there. Its neighbour employmentUnique, keyed on the PAIR,
+// is the one that sentence would have fitted.
 var relationshipConflictDetails = map[string]string{
 	"uq_rel_current_primary_employer": "this person already has a current primary employer — end that employment, or add this one without the primary flag",
 	"uq_rel_deal_person_role":         "this person already holds that role on the deal",
+	employmentUnique:                  "this person already works at that company — end the employment they have there before recording a new one",
 	projectStakeholderUnique:          "this person is already a stakeholder on the project",
 }
 
@@ -145,7 +152,7 @@ func mapRelationshipConstraint(err error, kind string) error {
 	}
 	if constraint, ok := storekit.UniqueViolation(err); ok {
 		switch constraint {
-		case "uq_rel_current_primary_employer", "uq_rel_deal_person_role", projectStakeholderUnique:
+		case "uq_rel_current_primary_employer", "uq_rel_deal_person_role", employmentUnique, projectStakeholderUnique:
 			return &RelationshipConflictError{Constraint: constraint}
 		}
 	}

--- a/backend/migrations/core/1787111736_employment_dedupe.down.sql
+++ b/backend/migrations/core/1787111736_employment_dedupe.down.sql
@@ -1,0 +1,6 @@
+-- Only the constraint comes off. The rows the up half archived stay archived:
+-- reviving them would recreate the duplicates the index was added to end, and
+-- a down migration that restores a defect is worse than one that leaves the
+-- repair standing. Anything wrongly archived is un-archivable by hand — the
+-- rows are all still there.
+DROP INDEX IF EXISTS uq_rel_employment;

--- a/backend/migrations/core/1787111736_employment_dedupe.up.sql
+++ b/backend/migrations/core/1787111736_employment_dedupe.up.sql
@@ -36,6 +36,26 @@ UPDATE relationship SET archived_at = now()
  WHERE kind = 'employment' AND ended_at IS NULL AND archived_at IS NULL
    AND id NOT IN (SELECT id FROM keeper);
 
+-- The second half of the repair, and the same rule the store now applies to
+-- every write: a person whose ONE current employment carries no primary flag
+-- has it promoted. Without this the defect is fixed for everything written from
+-- here and left standing in exactly the rows that produced the report.
+--
+-- Only where the answer is unambiguous. The NOT EXISTS excludes a person who
+-- has another current employment (which of two employers is primary is a
+-- question nothing here can answer) and one who already holds a live primary
+-- flag on an ended row (promoting past it would violate
+-- uq_rel_current_primary_employer). It runs after the dedupe above so an
+-- archived duplicate no longer counts as a second current employment.
+UPDATE relationship r SET is_current_primary = true
+ WHERE r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
+   AND NOT r.is_current_primary
+   AND NOT EXISTS (
+     SELECT 1 FROM relationship o
+      WHERE o.kind = 'employment' AND o.person_id = r.person_id
+        AND o.archived_at IS NULL AND o.id <> r.id
+        AND (o.ended_at IS NULL OR o.is_current_primary));
+
 CREATE UNIQUE INDEX uq_rel_employment
   ON relationship (person_id, organization_id)
   WHERE kind = 'employment' AND ended_at IS NULL AND archived_at IS NULL;

--- a/backend/migrations/core/1787111736_employment_dedupe.up.sql
+++ b/backend/migrations/core/1787111736_employment_dedupe.up.sql
@@ -1,0 +1,41 @@
+-- An employment edge is unique per (person, employer) while it is current.
+--
+-- `relationship` already dedupes every other kind that has a natural duplicate:
+-- uq_rel_deal_person_role (0007) and uq_rel_project_stakeholder (0131). Only
+-- employment had none, so the same person could be recorded as working at the
+-- same company any number of times — and each extra row is counted by every
+-- reader of the table, from the account's headcount to the relationship graph.
+-- idx_rel_employer_people (1787044474) covers exactly this pair but is a plain
+-- index, added for a query plan; it accepts duplicates.
+--
+-- THE PREDICATE DELIBERATELY DIVERGES FROM ITS SIBLING. uq_rel_project_stakeholder
+-- keys on `archived_at IS NULL` alone, so a person may not be a stakeholder on
+-- the same project twice, ever. Employment carries `ended_at IS NULL` as well,
+-- which is a different rule: a person who LEFT a company may be hired by it
+-- again, and that second employment is a new fact rather than a duplicate of
+-- the old one. The two kinds differ because re-employment is real and
+-- re-stakeholding is not; the divergence is the decision, not a copy-paste slip.
+
+-- The repair half. CREATE UNIQUE INDEX fails outright on a database that
+-- already holds duplicates, and at least one live installation does — so the
+-- index cannot ship without this, or applying it bricks that deployment.
+--
+-- Archived, never deleted: an edge carries its own source, captured_by and
+-- dates, so dropping the row would destroy provenance that nothing else holds.
+-- The survivor is the current primary if there is one — never demote somebody's
+-- recorded employer to resolve a duplicate — and otherwise the oldest row,
+-- which is the one every earlier reader has already seen. id breaks a tie so
+-- that two rows written in the same transaction still resolve deterministically.
+WITH keeper AS (
+  SELECT DISTINCT ON (person_id, organization_id) id
+    FROM relationship
+   WHERE kind = 'employment' AND ended_at IS NULL AND archived_at IS NULL
+   ORDER BY person_id, organization_id, is_current_primary DESC, created_at, id
+)
+UPDATE relationship SET archived_at = now()
+ WHERE kind = 'employment' AND ended_at IS NULL AND archived_at IS NULL
+   AND id NOT IN (SELECT id FROM keeper);
+
+CREATE UNIQUE INDEX uq_rel_employment
+  ON relationship (person_id, organization_id)
+  WHERE kind = 'employment' AND ended_at IS NULL AND archived_at IS NULL;

--- a/backend/migrations/core/1787111736_employment_dedupe.up.sql
+++ b/backend/migrations/core/1787111736_employment_dedupe.up.sql
@@ -16,6 +16,36 @@
 -- the old one. The two kinds differ because re-employment is real and
 -- re-stakeholding is not; the divergence is the decision, not a copy-paste slip.
 
+-- WRITERS OUT FIRST, for the whole migration. The repair below and the index
+-- at the bottom are two statements, and dbmigrate's advisory lock coordinates
+-- only other MIGRATION runners: an application replica still serving traffic
+-- holds ROW EXCLUSIVE, which the repair's UPDATE does not conflict with. It
+-- could therefore insert a fresh duplicate for a pair the repair had just
+-- cleared, and CREATE UNIQUE INDEX would abort on a row that did not exist
+-- when the migration started. That is the ordinary rolling deploy — the new
+-- container migrates at boot while the old one is still up.
+--
+-- SHARE ROW EXCLUSIVE, not EXCLUSIVE: it blocks INSERT/UPDATE/DELETE and lets
+-- readers through, which is the smallest lock that closes the window.
+LOCK TABLE relationship IN SHARE ROW EXCLUSIVE MODE;
+
+-- An employment somebody has LEFT is not their CURRENT primary one, and until
+-- this migration nothing enforced that: UpdateRelationship carried the flag
+-- through an `ended_at` patch untouched, so a deployed database holds rows that
+-- are ended and still flagged. They are not cosmetic. Every reader of the
+-- column filters on the flag ALONE — the person-by-employer list, the account
+-- contact count, enrichment's employer lookup and the auto-enrich sweep — so
+-- such a row still counts its person at a company they left.
+--
+-- It also has to run BEFORE the promotion at the bottom, which cannot promote
+-- past a live primary flag without violating uq_rel_current_primary_employer.
+-- Leaving these rows would therefore leave the person the report is about with
+-- an employer they left and no current one, which is the defect wearing a
+-- different face.
+UPDATE relationship SET is_current_primary = false
+ WHERE kind = 'employment' AND is_current_primary
+   AND ended_at IS NOT NULL AND archived_at IS NULL;
+
 -- The repair half. CREATE UNIQUE INDEX fails outright on a database that
 -- already holds duplicates, and at least one live installation does — so the
 -- index cannot ship without this, or applying it bricks that deployment.
@@ -41,12 +71,16 @@ UPDATE relationship SET archived_at = now()
 -- has it promoted. Without this the defect is fixed for everything written from
 -- here and left standing in exactly the rows that produced the report.
 --
--- Only where the answer is unambiguous. The NOT EXISTS excludes a person who
--- has another current employment (which of two employers is primary is a
--- question nothing here can answer) and one who already holds a live primary
--- flag on an ended row (promoting past it would violate
--- uq_rel_current_primary_employer). It runs after the dedupe above so an
+-- Only where the answer is unambiguous: the NOT EXISTS excludes a person who has
+-- another current employment, because which of two employers is primary is a
+-- question nothing here can answer. It runs after the dedupe above so an
 -- archived duplicate no longer counts as a second current employment.
+--
+-- Its `OR o.is_current_primary` arm reads as dead now that the step at the top
+-- has cleared every ended-and-flagged row, and it is not: it is the same
+-- predicate the store's insert uses, and it is what keeps this statement from
+-- ever violating uq_rel_current_primary_employer if a flagged row survives for
+-- a reason this migration did not anticipate.
 UPDATE relationship r SET is_current_primary = true
  WHERE r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
    AND NOT r.is_current_primary

--- a/backend/migrations/employment_dedupe_repair_integration_test.go
+++ b/backend/migrations/employment_dedupe_repair_integration_test.go
@@ -44,7 +44,7 @@ func seedEmploymentDuplicates(t *testing.T, conn *pgx.Conn, rows []employmentRow
 	t.Helper()
 	ctx := context.Background()
 	people := map[string]string{}
-	for _, name := range []string{"duplicated", "unmarked", "undecided"} {
+	for _, name := range []string{"duplicated", "unmarked", "undecided", "stale primary"} {
 		var id string
 		if err := conn.QueryRow(ctx, `
 			INSERT INTO person (full_name, source, captured_by)
@@ -127,6 +127,14 @@ func TestTheEmploymentDedupeIndexRepairsTheDuplicatesItWouldRefuseToApplyOver(t 
 		// this migration cannot answer, so it answers neither (#1781).
 		{label: "undecided A", person: "undecided", org: "employer", survives: true},
 		{label: "undecided B", person: "undecided", org: "other", survives: true},
+
+		// The state a deployed database is actually in: until this migration
+		// nothing cleared the flag when an employment ended, so somebody's
+		// former employer still reads as where they work — and blocks the
+		// promotion of the job they DO hold, because the primary index is keyed
+		// on the person alone.
+		{label: "left but still flagged", person: "stale primary", org: "other", primary: true, ended: true, survives: true},
+		{label: "the job they hold", person: "stale primary", org: "employer", survives: true, endsPrimary: true},
 	}
 	seeded := seedEmploymentDuplicates(t, conn, rows)
 

--- a/backend/migrations/employment_dedupe_repair_integration_test.go
+++ b/backend/migrations/employment_dedupe_repair_integration_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations
+
+// 1787111736 adds a UNIQUE index to a table that is already allowed to hold
+// the rows it forbids, so it ships with a repair. A repair needs a test that
+// carries the duplicates through it: applied to a fresh schema the repair
+// matches nothing, and a wrong ORDER BY, a wrong predicate or no repair at all
+// would every one of them pass.
+//
+// The precedent for testing a data-carrying migration directly rather than
+// through TestMigrations_applyReverseReapply is
+// capture_auto_enrich_rollback_integration_test.go, and this follows it,
+// including deriving the step count instead of writing a literal.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+)
+
+// employmentRow is one seeded edge and what the repair is expected to do to it.
+type employmentRow struct {
+	label    string
+	org      string // which of the two seeded organizations
+	primary  bool
+	ended    bool
+	survives bool
+}
+
+// seedEmploymentDuplicates plants the state a deployed database is in on the
+// day it applies 1787111736 and returns each row's id by label.
+func seedEmploymentDuplicates(t *testing.T, conn *pgx.Conn, rows []employmentRow) map[string]string {
+	t.Helper()
+	ctx := context.Background()
+	var person string
+	if err := conn.QueryRow(ctx, `
+		INSERT INTO person (full_name, source, captured_by)
+		VALUES ('Ronny Duplicate', 'test', 'human:test') RETURNING id`).Scan(&person); err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	orgs := map[string]string{}
+	for _, name := range []string{"employer", "other"} {
+		var id string
+		if err := conn.QueryRow(ctx, `
+			INSERT INTO organization (display_name, source, captured_by)
+			VALUES ($1, 'test', 'human:test') RETURNING id`, name).Scan(&id); err != nil {
+			t.Fatalf("seeding organization %s: %v", name, err)
+		}
+		orgs[name] = id
+	}
+	ids := map[string]string{}
+	for i, row := range rows {
+		var ended any
+		if row.ended {
+			ended = "2020-01-01"
+		}
+		var id string
+		// created_at is set explicitly and DESCENDING, so the oldest row is
+		// seeded last: a repair that keeps whatever it happens to reach first
+		// cannot pass by accident.
+		if err := conn.QueryRow(ctx, `
+			INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, ended_at,
+			                          source, captured_by, created_at)
+			VALUES ('employment', $1, $2, $3, $4::date, 'test', 'human:test', now() - make_interval(mins => $5))
+			RETURNING id`,
+			person, orgs[row.org], row.primary, ended, i).Scan(&id); err != nil {
+			t.Fatalf("seeding employment %q: %v", row.label, err)
+		}
+		ids[row.label] = id
+	}
+	return ids
+}
+
+func TestTheEmploymentDedupeIndexRepairsTheDuplicatesItWouldRefuseToApplyOver(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	resetSchema(t, conn)
+	ctx := context.Background()
+
+	core, err := Core()
+	if err != nil {
+		t.Fatalf("loading core: %v", err)
+	}
+	if _, err := dbmigrate.Up(ctx, conn, core); err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	// Back to the schema this migration lands on, so the duplicates below are
+	// insertable exactly as they were on the day the defect was reported.
+	if _, err := dbmigrate.Down(ctx, conn, core, stepsDownTo(t, core, "1787111736")); err != nil {
+		t.Fatalf("reverting down to 1787111736: %v", err)
+	}
+
+	rows := []employmentRow{
+		// Three live current edges for one pair. The primary survives even
+		// though it is the NEWEST — demoting somebody's recorded employer to
+		// resolve a duplicate would be the repair inventing a fact.
+		{label: "primary", org: "employer", primary: true, survives: true},
+		{label: "duplicate", org: "employer", survives: false},
+		{label: "oldest duplicate", org: "employer", survives: false},
+		// An employment they LEFT at the same company is history, not a
+		// duplicate — the index's predicate excludes it and so does the repair.
+		{label: "former", org: "employer", ended: true, survives: true},
+		// A concurrent job elsewhere is a different pair entirely.
+		{label: "elsewhere", org: "other", survives: true},
+	}
+	seeded := seedEmploymentDuplicates(t, conn, rows)
+
+	if _, err := dbmigrate.Up(ctx, conn, core); err != nil {
+		t.Fatalf("re-applying 1787111736 over duplicates — the repair did not clear the way for the index: %v", err)
+	}
+
+	for _, row := range rows {
+		var live bool
+		if err := conn.QueryRow(ctx,
+			`SELECT archived_at IS NULL FROM relationship WHERE id = $1`, seeded[row.label]).Scan(&live); err != nil {
+			t.Fatalf("reading back %q: %v", row.label, err)
+		}
+		if live != row.survives {
+			t.Errorf("%q live = %t, want %t", row.label, live, row.survives)
+		}
+	}
+
+	// The index is the point of the whole migration: a fourth edge for the
+	// repaired pair must now be refused rather than added to the pile.
+	_, err = conn.Exec(ctx, `
+		INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		SELECT 'employment', person_id, organization_id, 'test', 'human:test'
+		  FROM relationship WHERE id = $1`, seeded["primary"])
+	if err == nil {
+		t.Fatal("a second live employment at the same company was accepted; uq_rel_employment is not in force")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.ConstraintName != "uq_rel_employment" {
+		t.Fatalf("second employment refused with %v, want a uq_rel_employment unique violation", err)
+	}
+}

--- a/backend/migrations/employment_dedupe_repair_integration_test.go
+++ b/backend/migrations/employment_dedupe_repair_integration_test.go
@@ -29,11 +29,13 @@ import (
 
 // employmentRow is one seeded edge and what the repair is expected to do to it.
 type employmentRow struct {
-	label    string
-	org      string // which of the two seeded organizations
-	primary  bool
-	ended    bool
-	survives bool
+	label       string
+	person      string // which of the seeded people
+	org         string // which of the seeded organizations
+	primary     bool
+	ended       bool
+	survives    bool
+	endsPrimary bool
 }
 
 // seedEmploymentDuplicates plants the state a deployed database is in on the
@@ -41,11 +43,15 @@ type employmentRow struct {
 func seedEmploymentDuplicates(t *testing.T, conn *pgx.Conn, rows []employmentRow) map[string]string {
 	t.Helper()
 	ctx := context.Background()
-	var person string
-	if err := conn.QueryRow(ctx, `
-		INSERT INTO person (full_name, source, captured_by)
-		VALUES ('Ronny Duplicate', 'test', 'human:test') RETURNING id`).Scan(&person); err != nil {
-		t.Fatalf("seeding the person: %v", err)
+	people := map[string]string{}
+	for _, name := range []string{"duplicated", "unmarked", "undecided"} {
+		var id string
+		if err := conn.QueryRow(ctx, `
+			INSERT INTO person (full_name, source, captured_by)
+			VALUES ($1, 'test', 'human:test') RETURNING id`, name).Scan(&id); err != nil {
+			t.Fatalf("seeding person %s: %v", name, err)
+		}
+		people[name] = id
 	}
 	orgs := map[string]string{}
 	for _, name := range []string{"employer", "other"} {
@@ -72,7 +78,7 @@ func seedEmploymentDuplicates(t *testing.T, conn *pgx.Conn, rows []employmentRow
 			                          source, captured_by, created_at)
 			VALUES ('employment', $1, $2, $3, $4::date, 'test', 'human:test', now() - make_interval(mins => $5))
 			RETURNING id`,
-			person, orgs[row.org], row.primary, ended, i).Scan(&id); err != nil {
+			people[row.person], orgs[row.org], row.primary, ended, i).Scan(&id); err != nil {
 			t.Fatalf("seeding employment %q: %v", row.label, err)
 		}
 		ids[row.label] = id
@@ -103,14 +109,24 @@ func TestTheEmploymentDedupeIndexRepairsTheDuplicatesItWouldRefuseToApplyOver(t 
 		// Three live current edges for one pair. The primary survives even
 		// though it is the NEWEST — demoting somebody's recorded employer to
 		// resolve a duplicate would be the repair inventing a fact.
-		{label: "primary", org: "employer", primary: true, survives: true},
-		{label: "duplicate", org: "employer", survives: false},
-		{label: "oldest duplicate", org: "employer", survives: false},
+		{label: "primary", person: "duplicated", org: "employer", primary: true, survives: true, endsPrimary: true},
+		{label: "duplicate", person: "duplicated", org: "employer", survives: false},
+		{label: "oldest duplicate", person: "duplicated", org: "employer", survives: false},
 		// An employment they LEFT at the same company is history, not a
 		// duplicate — the index's predicate excludes it and so does the repair.
-		{label: "former", org: "employer", ended: true, survives: true},
-		// A concurrent job elsewhere is a different pair entirely.
-		{label: "elsewhere", org: "other", survives: true},
+		{label: "former", person: "duplicated", org: "employer", ended: true, survives: true},
+		// A concurrent job elsewhere is a different pair entirely, and it is not
+		// promoted: this person already has a primary employer.
+		{label: "elsewhere", person: "duplicated", org: "other", survives: true},
+
+		// The reported symptom, and the half a unique index alone leaves
+		// standing: one employer, no duplicate, and nothing marked primary.
+		{label: "sole unmarked", person: "unmarked", org: "employer", survives: true, endsPrimary: true},
+
+		// Two current employers and no primary. Which one wins is a question
+		// this migration cannot answer, so it answers neither (#1781).
+		{label: "undecided A", person: "undecided", org: "employer", survives: true},
+		{label: "undecided B", person: "undecided", org: "other", survives: true},
 	}
 	seeded := seedEmploymentDuplicates(t, conn, rows)
 
@@ -119,13 +135,17 @@ func TestTheEmploymentDedupeIndexRepairsTheDuplicatesItWouldRefuseToApplyOver(t 
 	}
 
 	for _, row := range rows {
-		var live bool
+		var live, primary bool
 		if err := conn.QueryRow(ctx,
-			`SELECT archived_at IS NULL FROM relationship WHERE id = $1`, seeded[row.label]).Scan(&live); err != nil {
+			`SELECT archived_at IS NULL, is_current_primary FROM relationship WHERE id = $1`,
+			seeded[row.label]).Scan(&live, &primary); err != nil {
 			t.Fatalf("reading back %q: %v", row.label, err)
 		}
 		if live != row.survives {
 			t.Errorf("%q live = %t, want %t", row.label, live, row.survives)
+		}
+		if primary != row.endsPrimary {
+			t.Errorf("%q current primary = %t, want %t", row.label, primary, row.endsPrimary)
 		}
 	}
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3211,9 +3211,12 @@ export interface paths {
         /**
          * Create a relationship edge (employment or deal stakeholder).
          * @description `employment` requires person_id + organization_id; `deal_stakeholder` requires
-         *     deal_id + person_id. At most one current-primary employer per person, and a
-         *     person's only current employment is that one. An employment they already
-         *     hold is refused 409: end the existing one before recording a new one.
+         *     deal_id + person_id. An employment they already hold is refused 409: end the
+         *     existing one before recording a new one. At most one current-primary employer
+         *     per person; `is_current_primary` is decided here only when you OMIT it — an
+         *     employment for somebody with no other current one then becomes their primary
+         *     — and an employment that has already ended never takes the flag. Send the
+         *     field to decide it yourself; a later PATCH always wins over both.
          */
         post: operations["createRelationship"];
         delete?: never;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3211,7 +3211,9 @@ export interface paths {
         /**
          * Create a relationship edge (employment or deal stakeholder).
          * @description `employment` requires person_id + organization_id; `deal_stakeholder` requires
-         *     deal_id + person_id. At most one current-primary employer per person.
+         *     deal_id + person_id. At most one current-primary employer per person, and a
+         *     person's only current employment is that one. An employment they already
+         *     hold is refused 409: end the existing one before recording a new one.
          */
         post: operations["createRelationship"];
         delete?: never;


### PR DESCRIPTION
Closes #1775.

Found by driving the live server from a chat window: an employment edge was
created twice for the same person and the same employer. Both rows landed, and
neither was primary — so the account counted the contact twice and nothing said
where they actually work.

## The gap was a missing member of an existing convention

`relationship` carries a partial unique index for every kind that has a natural
duplicate. Employment had one for the *primary flag* and none for the *edge*:

| kind | index | since |
|---|---|---|
| `deal_stakeholder` | `uq_rel_deal_person_role (deal_id, person_id, role)` | `core/0007` |
| `project_stakeholder` | `uq_rel_project_stakeholder (project_id, person_id)` | `core/0131` |
| employment — primary flag | `uq_rel_current_primary_employer (person_id)` | `core/0007` |
| employment — the edge | **nothing** | — |

The nearest thing, `idx_rel_employer_people`, covers exactly this pair — but it
is a plain index added for a query plan, so the database accepted duplicates.
So a project stakeholder could not be linked twice and an employer could.

## The predicate diverges from its sibling on purpose

`uq_rel_project_stakeholder` keys on `archived_at IS NULL` alone.
`uq_rel_employment` also carries `ended_at IS NULL`, because **a person who left
a company may be hired by it again** and that second employment is a new fact,
not a duplicate — which re-stakeholding a project is not. The migration says so
in full, so the next reader does not take the difference for a copy-paste slip.

## The migration repairs before it constrains — three times

`CREATE UNIQUE INDEX` fails outright on a database that already holds
duplicates, and at least one live installation does. It opens by locking writers
out (`LOCK TABLE relationship IN SHARE ROW EXCLUSIVE MODE`) — `dbmigrate`'s
advisory lock coordinates only other *migration* runners, so without it a replica
still serving traffic during a rolling deploy could reintroduce a duplicate
between the repair and the index, and the index would abort on a row that did not
exist when the migration started. Readers still get through.

Then three repairs, in order:

1. **An employment somebody has LEFT stops claiming to be their current primary
   one.** Nothing ever cleared the flag on ending an employment, so deployed data
   holds ended-and-flagged rows — and every reader of the column filters on the
   flag alone, so such a row still counts its person at a company they left. It
   also blocked the promotion below, because the primary index is keyed on the
   person alone. This step is why the person in the report ends up with the
   employer they actually have.
2. **Duplicates are archived, never deleted** — an edge carries its own
   `source`, `captured_by` and dates that nothing else holds. The survivor is
   the current primary when there is one (demoting somebody's recorded employer
   to resolve a duplicate would be the repair inventing a fact), otherwise the
   oldest row, which is the one every earlier reader has already seen.
3. **A person whose one current employment carries no primary flag has it
   promoted.** Without this the defect would be fixed for every write from here
   and left standing in exactly the rows that produced the report. It promotes
   only where the answer is unambiguous — a person with two current employers
   and no primary is left alone (#1781).

## `is_current_primary` now holds three rules, all read off the row

- a person's **only current employment IS their current primary one** — but only
  when the caller **omitted** the field. The input is tri-state: `nil` means no
  opinion and the store decides, `false` means they said this is not the primary
  one, and the person rail's "current employer" checkbox sends exactly that
  `false`. It is decided inside the `INSERT` so the row the caller reads back is
  the row that landed (a follow-up `UPDATE` would bump the version under them),
  and the read-then-write runs under `storekit.LockWriteIdentity` on the person
  so two concurrent unmarked employments cannot both claim it;
- **ending an employment clears the flag** — a job somebody has left is not
  where they currently work;
- **an employment that arrives or ends up ended never takes the flag**, however
  it was asked for, and it demotes nobody on the way past.

## Verification

| Lane | What it proves |
|---|---|
| `backend/migrations/employment_dedupe_repair_integration_test.go` | The repair carries real duplicates through a real `Down`/`Up`, then the index applies. Three seeded people: one duplicated, one with a sole unmarked employment, one with two employers and no primary. |
| `backend/internal/compose/integration/employment_dedupe_integration_test.go` | Over HTTP against the real store: the duplicate is refused 409 with the caller-facing sentence; the same person under a different role is still refused; **re-employment after leaving is accepted**; the sole employment lands primary; a second concurrent job does not; an ended one never takes the flag from either direction. |
| `relationship_conflict_test.go` | Now **derived from `relationshipConflictDetails`** instead of restating it, and fails when a rule is mapped without a message anything asserts. |

Every new gate was mutation-verified — the ordering, each arm of each guard, and
the promotion removed entirely — and each mutation fails the test that names it.

`make check` (backend + frontend) and the full `make test-integration` lane are
green locally.

## Review round

Three independent reviewers ran over this: Fable (`/code-review high`), Codex,
and CodeRabbit. **Two of them found the same defect** — the repair leaving a
stale primary flag on ended rows — which is a fair signal it was the most
consequential thing in the diff. Four defects were fixed in the second commit:

| Defect | Consequence | Fix |
|---|---|---|
| The repair left legacy ended-but-primary rows | the person in the report keeps an employer they left, and the promotion is blocked | the migration clears them first, with a defect test that fails when the step is removed |
| The repair raced an application writer | `CREATE UNIQUE INDEX` aborts during an ordinary rolling deploy | `LOCK TABLE … SHARE ROW EXCLUSIVE` up front |
| Auto-promotion was check-then-insert | two concurrent unmarked employments at *different* companies 409'd, naming a flag the caller never sent — and `flipassoc.go` maps any conflict to `Applied: true`, so an import would have dropped the edge and reported success | `storekit.LockWriteIdentity` on the person |
| An explicit `is_current_primary: false` was inverted | unticking "current employer" in the person rail handed back `true` | the input is tri-state |

One finding was **not** taken: that a `PATCH` can clear the flag and leave a
person with a current employment and no primary. An explicit demotion is a
human's deliberate act and refusing it would be worse. What was wrong is that the
contract sentence claimed more than the code did — it now says what create
actually decides, and that a later `PATCH` wins over both.

## Deliberately not here

- **A person's employer is still invisible over MCP.** The query grammar derives
  a relation only from a scalar `<type>_id` column, so it cannot see a join
  table at all — employment and activity-linking alike. Different root cause,
  filed as **#1776** (it also explains why `activity` → `person` has always been
  missing without anyone noticing).
- **Nothing promotes a successor** when the primary employment is archived or
  ended and another current one remains. Choosing between two employers writes a
  fact nobody asserted; that is a product call, filed as **#1781**.
- **No MCP tool copy changed**, so no aicert lane re-run is owed. The refusal
  itself carries the guidance a caller needs, and adding it to the write
  vocabulary resource would have put a sentence in front of every model for a
  rule the 409 already states in the caller's own terms.
