### PR TITLE
fix(ci): main's tip is the commit that gets gated, not every merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,26 +20,31 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
-# One live run per PR ref: a new push to the same branch cancels the stale run
-# instead of queueing behind it. A merge to main gets a group of its OWN, keyed
-# by commit, so every merge is gated.
+# ONE live run per ref, main included: a new push cancels the stale lane instead
+# of running beside it or queueing behind it. The invariant that buys is that the
+# commit being gated is always main's TIP.
 #
-# `cancel-in-progress: false` alone does not achieve that, which is what the
-# previous spelling assumed. It protects the run that is already RUNNING; a
-# group holds at most one QUEUED run, so with every main push in one group each
-# merge evicted the one queued behind the current lane and was reported
-# `cancelled` with zero jobs. That reads identically to a green skip on every
-# dashboard. It is not hypothetical: three consecutive merges landed ungated
-# behind one slow lane on 2026-08-16, and the daily scheduled backend lane —
-# which exists for exactly this mask — leaves a window up to a day wide.
+# Gating every main commit — what a group keyed by commit buys — is not
+# affordable at this repository's size. A full-stack merge schedules 28 jobs
+# against an org-wide ceiling of 20 concurrent, so two overlapping merges turn a
+# 9-minute gate into a two-hour one and starve every PR lane behind them. A
+# verdict that lands hours after the merge gates nothing.
 #
-# The cost is deliberate: several full lanes, twelve integration shards each,
-# can now run on main at once rather than one at a time. Runner minutes for a
-# gate that runs is the trade this repository wants while main is the only
-# integration point.
+# `cancel-in-progress: false` is the trap here rather than the safe choice: it
+# protects the RUNNING lane, and a group holds at most one QUEUED run, so each
+# new merge evicts the run queued behind the current lane — reported `cancelled`
+# with zero jobs, which is indistinguishable from a green skip on every
+# dashboard, and it is the TIP that gets dropped. Cancelling makes the surviving
+# lane the newest one by construction.
+#
+# main is a linear history of squash merges, so the tip's tree contains every
+# merge below it and "main is green" stays a true statement about all of them.
+# The price is per-commit attribution: a bisect over main cannot assume every
+# commit was gated, and a red lane can be superseded before anyone reads it —
+# `workflow_dispatch` on that commit brings the verdict back.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,15 @@ on:
 # 9-minute gate into a two-hour one and starve every PR lane behind them. A
 # verdict that lands hours after the merge gates nothing.
 #
-# `cancel-in-progress: false` is the trap here rather than the safe choice: it
-# protects the RUNNING lane, and a group holds at most one QUEUED run, so each
-# new merge evicts the run queued behind the current lane — reported `cancelled`
-# with zero jobs, which is indistinguishable from a green skip on every
-# dashboard, and it is the TIP that gets dropped. Cancelling makes the surviving
-# lane the newest one by construction.
+# `cancel-in-progress: false` is not the conservative setting it reads as, which
+# is the trap worth stating where the next reader will look: it protects the run
+# already RUNNING, and a group holds ONE pending run, so an arriving merge
+# cancels the pending one and takes its place. The superseded merge is reported
+# `cancelled` with zero jobs — indistinguishable from a green skip on every
+# dashboard — while the tip still waits out a lane gating an older tree.
+# `queue: max` lifts that pending limit to 100 and would gate every commit, but
+# it cannot be combined with cancellation, and it puts the tip's verdict behind
+# every lane ahead of it: the latency this setting exists to remove.
 #
 # main is a linear history of squash merges, so the tip's tree contains every
 # merge below it and "main is green" stays a true statement about all of them.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,19 +36,16 @@ on:
 permissions:
   contents: read
 
-# ONE live release per ref: a newer merge cancels the lane still working on an
-# older commit, so what gets drafted and published is always main's tip rather
-# than whatever the queue happened to reach. The alternative — letting the lane
-# run to completion — is what put a full docker bake between a merge and its own
-# release.
+# Cancellation is scoped per JOB below rather than to the whole workflow, because
+# the two halves of this flow want opposite treatment. Drafting and baking are
+# superseded work — a newer merge should not wait out a full docker bake for a
+# commit nobody will consume — while publishing is a mutation of the dist service
+# and must never be interrupted part-way, so it carries a group that serializes
+# instead of one that cancels.
 #
 # A release therefore describes the push that triggered it, not every commit
-# below it: the patch range is that push's before..after, and the commits whose
-# lane was superseded have no release of their own. The version is this
-# workflow's run number, so the surviving lane always carries the highest one.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# below it: the patch range is that push's before..after, and a commit whose lane
+# was superseded gets no release of its own.
 
 env:
   # The release-management CLI image, published :latest from constellation's
@@ -65,6 +62,11 @@ env:
 jobs:
   draft:
     name: Draft release
+    # Superseded by a newer merge on the same ref: the tip is the commit worth
+    # drafting.
+    concurrency:
+      group: ${{ github.workflow }}-draft-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -179,6 +181,11 @@ jobs:
   docker-image:
     name: Build docker container
     needs: [draft]
+    # The long half — and the reason cancellation is here at all. A bake for a
+    # commit the tip has already replaced is work nobody reads.
+    concurrency:
+      group: ${{ github.workflow }}-bake-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -282,6 +289,14 @@ jobs:
   publish:
     name: Publish release
     needs: [draft, docker-image]
+    # `cancel-in-progress: false` here and nowhere else: publishing mutates the
+    # dist service, so a running publish finishes. The group still bounds the
+    # damage a fast merge sequence can do — one publish at a time, and a publish
+    # still waiting when a newer one arrives gives up its place, so a lower
+    # version can never land after a higher one.
+    concurrency:
+      group: ${{ github.workflow }}-publish-${{ github.ref }}
+      cancel-in-progress: false
     # `!= 'false'`, not `== 'true'`: on a re-run of failed jobs the draft job
     # does not re-execute and GitHub drops its outputs, so an equality test
     # against 'true' silently skipped the publish of a fully patched release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,10 +290,11 @@ jobs:
     name: Publish release
     needs: [draft, docker-image]
     # `cancel-in-progress: false` here and nowhere else: publishing mutates the
-    # dist service, so a running publish finishes. The group still bounds the
-    # damage a fast merge sequence can do — one publish at a time, and a publish
-    # still waiting when a newer one arrives gives up its place, so a lower
-    # version can never land after a higher one.
+    # dist service, so a publish that has started always finishes. The group
+    # bounds how many can be in flight — one publish at a time per ref, and a
+    # publish still pending when a newer one arrives gives up its place. It is a
+    # mutual exclusion, not an ordering: which version reaches the dist service
+    # first is not something a concurrency group can decide.
     concurrency:
       group: ${{ github.workflow }}-publish-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,19 @@ on:
 permissions:
   contents: read
 
+# ONE live release per ref: a newer merge cancels the lane still working on an
+# older commit, so what gets drafted and published is always main's tip rather
+# than whatever the queue happened to reach. The alternative — letting the lane
+# run to completion — is what put a full docker bake between a merge and its own
+# release.
+#
+# A release therefore describes the push that triggered it, not every commit
+# below it: the patch range is that push's before..after, and the commits whose
+# lane was superseded have no release of their own. The version is this
+# workflow's run number, so the surviving lane always carries the highest one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   # The release-management CLI image, published :latest from constellation's

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -91,8 +91,10 @@ jobs:
   # It carries NO concurrency group either, so no later push can interrupt it: the
   # signature reaches Rekor before the bundles are uploaded, and a lane cut
   # between the two would leave a signature standing for a tree whose bundles
-  # nobody can fetch. A superseded run never gets this far — its `sbom` job is
-  # cancelled first.
+  # nobody can fetch. Superseding therefore only ever takes effect BEFORE signing
+  # begins — while `sbom` is still pending or running, which is where the wasted
+  # work is anyway. Once generation is done this job runs to completion whatever
+  # else lands on the ref behind it.
   sign:
     name: sign
     needs: sbom

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -45,18 +45,18 @@ on:
 permissions:
   contents: read
 
-# ONE live run per ref: the SBOMs and their signatures describe a tree, and the
-# newest tree on a ref is the only one anyone consumes, so a newer push cancels
-# the lane still cataloguing an older one. Nothing here is published outside the
-# run — both jobs end in an upload-artifact — so a cancelled lane leaves no
-# half-written state behind.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
+  # The cancellable half. An SBOM describes a tree and only the ref's newest tree
+  # is consumed, so a newer push supersedes the lane still cataloguing an older
+  # one — and the group sits on this JOB rather than on the workflow so that
+  # cancellation can never reach `sign` below. Cancelling generation stops
+  # signing before it starts (`sign` needs this job), which is the safe
+  # direction; cancelling it mid-flight would not be.
   sbom:
     name: sbom
+    concurrency:
+      group: ${{ github.workflow }}-sbom-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -88,6 +88,11 @@ jobs:
   # retracted, so a PR preview or a feature-branch dispatch must never produce
   # one. `needs: sbom` means the license gate has already passed, so a
   # policy-failing SBOM never reaches this job.
+  # It carries NO concurrency group either, so no later push can interrupt it: the
+  # signature reaches Rekor before the bundles are uploaded, and a lane cut
+  # between the two would leave a signature standing for a tree whose bundles
+  # nobody can fetch. A superseded run never gets this far — its `sbom` job is
+  # cancelled first.
   sign:
     name: sign
     needs: sbom

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -45,6 +45,15 @@ on:
 permissions:
   contents: read
 
+# ONE live run per ref: the SBOMs and their signatures describe a tree, and the
+# newest tree on a ref is the only one anyone consumes, so a newer push cancels
+# the lane still cataloguing an older one. Nothing here is published outside the
+# run — both jobs end in an upload-artifact — so a cancelled lane leaves no
+# half-written state behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sbom:
     name: sbom

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -321,8 +321,9 @@ Wiring details:
   supersedes a lane still cataloguing an older tree, but `sign` carries no group
   and cannot be interrupted — it writes to Rekor before the bundles upload, and a
   lane cut between the two would leave a permanent signature for a tree whose
-  bundles nobody can fetch. A superseded run never reaches `sign` at all, because
-  its `sbom` job is cancelled first.
+  bundles nobody can fetch. Superseding therefore only takes effect *before*
+  signing begins — while `sbom` is pending or running. A push arriving after
+  generation finished does not stop the signature it has already earned.
 - **`release.yml`** — on a push to `main`, cuts a margince-constellation
   release versioned `1970.<build>` (the year pinned to the epoch while the
   flow is a PoC, so these releases order below any real dated release; the
@@ -360,13 +361,17 @@ Wiring details:
   back to the parent commit (`HEAD~1..HEAD`). Merges that land close together
   release only the tip: `draft` and `docker-image` each carry a cancelling group
   so a bake for a superseded commit stops, while `publish` carries a group that
-  **serializes instead of cancelling** — a running publish always finishes, and a
-  publish still pending when a newer one arrives gives up its place, so a lower
-  version can never land after a higher one. The patch range is what makes that
-  consequential:
+  **serializes instead of cancelling** — a publish that has started always
+  finishes, and a publish still pending when a newer one arrives gives up its
+  place. That is mutual exclusion, not ordering: nothing on this path rejects a
+  stale version, so a re-run or a dispatch of an older commit can still publish
+  after a newer one
+  ([#1810](https://github.com/gradionhq/margince-poc-v1/issues/1810)). The patch
+  range is what makes that consequential:
   each push's range starts at the ref's previous tip, so when commit *N*'s lane
   is cancelled the next release's patch runs *N..N+1* and the files *N* changed
   appear in no published patch at all. A consumer applying patches in order is
   therefore one increment short. Deriving the base from the last **published**
-  release instead of the push's `before` is what closes that, and is tracked as
-  an issue. Not a gate — it never blocks a merge.
+  release instead of the push's `before` is what closes that
+  ([#1798](https://github.com/gradionhq/margince-poc-v1/issues/1798)). Not a
+  gate — it never blocks a merge.

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -25,18 +25,33 @@ likewise advisory.
 - `push` to `main`
 - `workflow_dispatch` (manual)
 
-One live run per PR ref (`concurrency` group): a new push cancels the stale run.
-A merge to `main` gets a group of its **own**, keyed by commit, so every merge is
-gated.
+One live run per ref, `main` included (`concurrency` group keyed on
+`github.ref`, `cancel-in-progress: true`): a new push cancels the stale lane, so
+the commit under gate is always the ref's tip. `release.yml` and `sbom.yml`
+carry the same rule. `scheduled.yml` is the exception — nothing supersedes a
+daily run, so it groups without cancelling.
 
-That last part is what `cancel-in-progress: false` alone does not buy, and
-assuming it did cost three ungated merges in one afternoon. The flag protects a
-run that is already *running*; a group holds at most one *queued* run, so while
-every `main` push shared one group, each merge evicted the one queued behind the
-current lane — reported `cancelled`, zero jobs, indistinguishable from a green
-skip on any dashboard. The daily scheduled `backend lane (main)` exists to catch
-exactly that mask and leaves a window up to a day wide. The deliberate cost is
-that several full lanes can now run on `main` at once.
+Gating every `main` commit — a group keyed by commit — is what this replaced,
+and the slot budget is the reason, not a smaller appetite for coverage. A
+full-stack merge schedules 28 jobs against an org-wide ceiling of 20 concurrent
+jobs, so two overlapping merges stretched a 9-minute gate past two hours and
+starved every PR lane behind them. A verdict that lands hours after the merge
+gates nothing.
+
+`cancel-in-progress: false` is not the conservative choice here, which is the
+trap worth remembering: it protects a run that is already *running*, and a group
+holds at most one *queued* run, so while every `main` push shared one group each
+merge evicted the run queued behind the current lane — reported `cancelled`,
+zero jobs, indistinguishable from a green skip on any dashboard, and the evicted
+run was the newest. Cancelling makes the survivor the tip by construction.
+
+What tip-only gating gives up is per-commit attribution. `main` is a linear
+history of squash merges, so the tip's tree contains every merge below it and
+"`main` is green" stays a true statement about all of them — but a bisect cannot
+assume every commit was gated, and a red lane can be superseded before anyone
+reads it. A `workflow_dispatch` on that commit brings the verdict back, and the
+daily `backend lane (main)` in `scheduled.yml` stays the backstop for a tree
+nothing is being merged into.
 
 ## Run only the checks a change can affect
 
@@ -295,7 +310,7 @@ Wiring details:
   the `license gate` job in `ci.yml` (above), so each event path runs the policy
   exactly once. Not itself a required check; the mechanics are in
   [docs/reference/supply-chain.md](../docs/reference/supply-chain.md).
-- **`release.yml`** — on every push to `main`, cuts a margince-constellation
+- **`release.yml`** — on a push to `main`, cuts a margince-constellation
   release versioned `1970.<build>` (the year pinned to the epoch while the
   flow is a PoC, so these releases order below any real dated release; the
   build is the workflow run number) in the dist service of the constellation
@@ -329,5 +344,11 @@ Wiring details:
   has no ancestor to diff from, so the release drafts **without a patch** and
   **stays an unpublished draft** (the dist completeness gate requires the
   patch), while a **manual dispatch** carries no push range at all and falls
-  back to the parent commit (`HEAD~1..HEAD`). Not a gate — it never blocks a
-  merge.
+  back to the parent commit (`HEAD~1..HEAD`). Merges that land close together
+  release only the tip, and the patch range is what makes that consequential:
+  each push's range starts at the ref's previous tip, so when commit *N*'s lane
+  is cancelled the next release's patch runs *N..N+1* and the files *N* changed
+  appear in no published patch at all. A consumer applying patches in order is
+  therefore one increment short. Deriving the base from the last **published**
+  release instead of the push's `before` is what closes that, and is tracked as
+  an issue. Not a gate — it never blocks a merge.

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -27,9 +27,11 @@ likewise advisory.
 
 One live run per ref, `main` included (`concurrency` group keyed on
 `github.ref`, `cancel-in-progress: true`): a new push cancels the stale lane, so
-the commit under gate is always the ref's tip. `release.yml` and `sbom.yml`
-carry the same rule. `scheduled.yml` is the exception — nothing supersedes a
-daily run, so it groups without cancelling.
+the commit under gate is always the ref's tip. `release.yml` and `sbom.yml` are
+superseded the same way, but scope their groups to the JOB rather than the
+workflow, so cancellation reaches the expensive generation halves and never the
+step that publishes or signs — see [The other workflows](#the-other-workflows).
+`scheduled.yml` groups without cancelling; nothing supersedes a daily run.
 
 Gating every `main` commit — a group keyed by commit — is what this replaced,
 and the slot budget is the reason, not a smaller appetite for coverage. A
@@ -39,11 +41,16 @@ starved every PR lane behind them. A verdict that lands hours after the merge
 gates nothing.
 
 `cancel-in-progress: false` is not the conservative choice here, which is the
-trap worth remembering: it protects a run that is already *running*, and a group
-holds at most one *queued* run, so while every `main` push shared one group each
-merge evicted the run queued behind the current lane — reported `cancelled`,
-zero jobs, indistinguishable from a green skip on any dashboard, and the evicted
-run was the newest. Cancelling makes the survivor the tip by construction.
+trap worth remembering. It protects a run that is already *running*, and a group
+holds **one** pending run: an arriving run cancels the pending one and takes its
+place, so while every `main` push shared one group the *intermediate* merges were
+the ones dropped — reported `cancelled`, zero jobs, indistinguishable from a
+green skip on any dashboard — while the tip still waited out a lane gating an
+older tree. `Release` shows the mechanism plainly in its own history: with run
+463 still running, run 464 sat pending from 02:52:53 and was cancelled at
+**02:55:24** — the second run 465 arrived, which then ran to success. `queue: max` lifts the pending limit to 100 and would gate every commit,
+but it cannot be combined with cancellation and it puts the tip's verdict behind
+every lane ahead of it — the latency this setting exists to remove.
 
 What tip-only gating gives up is per-commit attribution. `main` is a linear
 history of squash merges, so the tip's tree contains every merge below it and
@@ -310,6 +317,12 @@ Wiring details:
   the `license gate` job in `ci.yml` (above), so each event path runs the policy
   exactly once. Not itself a required check; the mechanics are in
   [docs/reference/supply-chain.md](../docs/reference/supply-chain.md).
+  Cancellation is scoped to the **`sbom` job**, not the workflow: a newer push
+  supersedes a lane still cataloguing an older tree, but `sign` carries no group
+  and cannot be interrupted — it writes to Rekor before the bundles upload, and a
+  lane cut between the two would leave a permanent signature for a tree whose
+  bundles nobody can fetch. A superseded run never reaches `sign` at all, because
+  its `sbom` job is cancelled first.
 - **`release.yml`** — on a push to `main`, cuts a margince-constellation
   release versioned `1970.<build>` (the year pinned to the epoch while the
   flow is a PoC, so these releases order below any real dated release; the
@@ -345,7 +358,12 @@ Wiring details:
   **stays an unpublished draft** (the dist completeness gate requires the
   patch), while a **manual dispatch** carries no push range at all and falls
   back to the parent commit (`HEAD~1..HEAD`). Merges that land close together
-  release only the tip, and the patch range is what makes that consequential:
+  release only the tip: `draft` and `docker-image` each carry a cancelling group
+  so a bake for a superseded commit stops, while `publish` carries a group that
+  **serializes instead of cancelling** — a running publish always finishes, and a
+  publish still pending when a newer one arrives gives up its place, so a lower
+  version can never land after a higher one. The patch range is what makes that
+  consequential:
   each push's range starts at the ref's previous tip, so when commit *N*'s lane
   is cancelled the next release's patch runs *N..N+1* and the files *N* changed
   appear in no published patch at all. A consumer applying patches in order is


### PR DESCRIPTION
## What this changes

All three `main`-triggered workflows now hold **one live run per ref and cancel the stale lane**, `main` included:

| Workflow | Before | After |
|---|---|---|
| `ci.yml` | group keyed by commit on push; `cancel-in-progress` false on `main` | group per ref, `cancel-in-progress: true` (workflow level — every job here is re-runnable) |
| `release.yml` | one workflow group, `cancel-in-progress: false` | per-job: `draft` + `docker-image` cancel; **`publish` serializes and is never interrupted** |
| `sbom.yml` | no `concurrency` at all | per-job: `sbom` cancels; **`sign` carries no group — Rekor entries are permanent** |

`scheduled.yml` is deliberately untouched — nothing supersedes a daily run.

Cancellation is scoped per **job** in the two non-gate workflows because their halves want opposite treatment: the expensive generation work (a draft, a docker bake, an SBOM catalogue) is worth superseding, while the step that publishes to the dist service or writes a permanent keyless signature to public Rekor must never be cut part-way. `publish` therefore carries a group that *serializes* rather than cancels — a running publish finishes, and a publish still pending when a newer one arrives gives up its place, so a lower version can never land after a higher one. Both of those came out of CodeRabbit's review (the `sign`/Rekor one was its finding; I applied the same lens to `release.yml`, which nothing had flagged).

**PR behaviour does not change.** A PR ref was already one group with `cancel-in-progress` true; it now reaches that through the same expression instead of a conditional.

## Why

A full-stack merge schedules **28 jobs** (twelve integration shards + `deterministic-gates`, `extension-reference`, `craftsmanship`, `craft-residue`, `secret-scan`, `integration-unit-coverage`, `integration`, `vuln`, `sonarcloud`, `live-boot`, `fe-quality`, `fe-unit`, `fe-bundle`, `frontend`, `uat`, `changes`) against an **org-wide ceiling of 20 concurrent jobs** (`gradionhq` is on the Free org plan). One main run already exceeds the whole org's slot budget, so keying the group by commit bought a queue rather than per-commit gating:

| Run started on `main` | Wall clock |
|---|---|
| 2026-08-19 03:07 — uncontended | **9 min** |
| 2026-08-19 02:55 | 1 h 05 m |
| 2026-08-18 12:46 | 1 h 57 m |
| 2026-08-18 12:16 — three overlapping | **2 h 22 m** |

A verdict that lands hours after the merge gates nothing, and the queue starves PR lanes at the same time.

## What is given up

Per-commit attribution. `main` is a linear history of squash merges, so the tip's tree contains every merge below it and "`main` is green" stays a true statement about all of them — but a bisect cannot assume every commit was gated, and a red lane can be superseded before anyone reads it. `workflow_dispatch` on that commit brings the verdict back, and the daily `backend lane (main)` in `scheduled.yml` stays the backstop for a tree nothing is being merged into.

The replaced comment argued for `cancel-in-progress: false` as the safe setting. It never was, and the new comment says so where the next reader will look — with the mechanism the right way round, which took a review round to get right. GitHub cancels the run that is **already pending** when a new one arrives (*"any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place"*), so `false` drops the **intermediate** merges and leaves the tip waiting out a lane gating an older tree. This repo's own history shows it: with `Release` run 463 still running, run **464** sat pending from 02:52:53 and was cancelled at **02:55:24** — the second run 465 arrived.

`queue: max` (available since 2026-05) lifts the pending limit to 100 and *would* gate every commit with no evictions. Not taken, and the comment says why: it cannot be combined with cancellation, and it puts the tip's verdict behind every lane ahead of it — the latency this change exists to remove.

## One consequence to flag on `release.yml`

Its patch range is the push's `before..after`, so when a lane is cancelled the files that commit changed appear in **no published patch** — a consumer applying patches in order ends up one increment short. That is a pre-existing hazard (commit `78dc5c3a` was already `cancelled` by queue eviction on 2026-08-19 02:52), and this change makes it routine rather than accidental. The fix is to derive the base from the last *published* release rather than the previous tip, which needs the release-management CLI and is filed as its own issue: https://github.com/gradionhq/margince-poc-v1/issues/1798

Also worth knowing: `release.yml` runs `draft` → `docker-image` → `publish` sequentially, so it never held more than one slot. Cancelling it is about not putting a full docker bake between a merge and its own release, not about the slot budget.

## Verification

- `make check-backend` green (exit 0), including the `ci.yml`-reading gates: `checked 43 path(s) from .github/workflows/ci.yml against infra/ci-pipeline.md`, `checked 12 path(s) from .github/workflows/sbom.yml against docs/reference/supply-chain.md`, `OK: every filtered path is documented`.
- `make check-fe` not run — no `frontend/` file changed.
- `infra/ci-pipeline.md` updated in the same commit: the Triggers section and the `release.yml` bullet described the old per-commit rule.
- The real test is this PR's own run plus the run on `main` after merge: one lane each, not three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates only main’s tip by keeping one live run per ref and cancelling superseded lanes. Previously main grouped by commit and didn’t cancel, causing long queues; now newer pushes cancel stale work so CI always gates the tip.

- `ci.yml`: concurrency group is ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true. PR refs unchanged; `scheduled.yml` unchanged.
- `release.yml`: job-level concurrency. `draft` and `docker-image` cancel on newer pushes; `publish` serializes (grouped with cancel-in-progress: false) so a running publish finishes and a pending publish yields to a newer one. This is mutual exclusion only—re-runs or manual dispatches can still publish an older version.
- `sbom.yml`: `sbom` job cancels on newer pushes; `sign` carries no concurrency group and never interrupts once started. Cancellation only takes effect before signing begins.
- Trade-off: lose per-commit attribution on main. Rerun with `workflow_dispatch` on a specific commit if needed.
- Release side effect: patches use the push’s before..after. If a lane is cancelled, that commit’s changes may appear in no published patch; will switch base to last published release in a follow-up.
- Documentation updated in infra/ci-pipeline.md to cover tip-only gating, cancellation scope, publish mutual exclusion, and the release caveat.

<sup>Written for commit f30cc3b310bed14fc3b76c2e4ee92f9717c6de93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Improvements**
  * Validation and draft/image build runs now replace outdated runs for the same branch or ref.
  * Release publishing runs are serialized so active publications can finish without interruption.
  * SBOM generation cancels superseded runs, while signing continues uninterrupted once started.
  * Main branch checks prioritize the latest push and reduce redundant queued runs.

* **Documentation**
  * Updated CI guidance to explain concurrency, queue limits, manual reruns, and potential patch-range effects from cancelled releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
