### PR TITLE
feat(frontend): the Filters & views screen, with a count that says which of three things it means

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,6 +106,11 @@ const DedupeScreen = lazy(
     import("./screens/dedupe").then((m) => ({ default: m.DedupeScreen })),
   ),
 );
+const FiltersScreen = lazy(
+  routed(() =>
+    import("./screens/filters").then((m) => ({ default: m.FiltersScreen })),
+  ),
+);
 const HomeScreen = lazy(
   routed(() =>
     import("./screens/home").then((m) => ({ default: m.HomeScreen })),
@@ -363,6 +368,10 @@ const SCREEN_VIEWS: Readonly<Record<Screen, (args: ScreenArgs) => ReactNode>> =
     ai: () => <AskAiScreen />,
     settings: ({ id }) => <SettingsScreen tab={id} />,
     dedupe: () => <DedupeScreen />,
+    // The object rides the URL so a filter surface can be linked to; an
+    // unknown segment falls back to contacts inside the screen rather than
+    // rendering a page with no vocabulary to offer.
+    filters: ({ id }) => <FiltersScreen id={id} />,
     offers: ({ id }) =>
       id ? (
         <OfferScreen id={id} />

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -29,6 +29,7 @@ const SCREENS = [
   "ai",
   "settings",
   "dedupe",
+  "filters",
   "offers",
   "search",
   "share",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5436,4 +5436,21 @@ export const de = {
   "filters.op.atLeast": "ist mindestens",
   "filters.op.lessThan": "ist kleiner als",
   "filters.op.atMost": "ist h\u00f6chstens",
+
+  // Die Oberfl\u00e4che \u201eFilter & Ansichten\u201c.
+  "filters.title": "Filter & Ansichten",
+  "filters.subtitle":
+    "Filter erstellen, Treffer beobachten und als Ansicht speichern.",
+  "filters.objectLabel": "Welche Datens\u00e4tze gefiltert werden",
+  "filters.tab.contacts": "Kontakte",
+  "filters.tab.companies": "Firmen",
+  "filters.tab.deals": "Gesch\u00e4fte",
+  "filters.builderTitle": "Filter",
+  "filters.dynamic": "Dynamisch \u2014 bei jedem Ereignis neu berechnet",
+  "filters.matchContacts": "{count} Kontakte treffen zu",
+  "filters.matchCompanies": "{count} Firmen treffen zu",
+  "filters.matchDeals": "{count} Gesch\u00e4fte treffen zu",
+  "filters.noFilterYet": "Bedingung hinzuf\u00fcgen, um die Treffer zu sehen",
+  "filters.loadingVocabulary": "Filterbare Felder werden geladen\u2026",
+  "filters.noFields": "Keine filterbaren Felder f\u00fcr diesen Datensatztyp.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5433,6 +5433,26 @@ export const en = {
   "filters.op.atLeast": "is at least",
   "filters.op.lessThan": "is less than",
   "filters.op.atMost": "is at most",
+
+  // The Filters & views screen's own chrome. The match line is keyed per object
+  // because "3 contacts match" and "3 companies match" are different sentences in
+  // every language, and a shared "{count} match" would make the object a
+  // placeholder that some grammars cannot place.
+  "filters.title": "Filters & views",
+  "filters.subtitle":
+    "Build a filter, watch what it selects, and save it as a view.",
+  "filters.objectLabel": "Which records to filter",
+  "filters.tab.contacts": "Contacts",
+  "filters.tab.companies": "Companies",
+  "filters.tab.deals": "Deals",
+  "filters.builderTitle": "Filter",
+  "filters.dynamic": "Dynamic \u2014 recomputes on every event",
+  "filters.matchContacts": "{count} contacts match",
+  "filters.matchCompanies": "{count} companies match",
+  "filters.matchDeals": "{count} deals match",
+  "filters.noFilterYet": "Add a clause to see what it selects",
+  "filters.loadingVocabulary": "Loading the fields you can filter on\u2026",
+  "filters.noFields": "No filterable fields for this record type.",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5396,4 +5396,25 @@ export const vi = {
   "filters.op.atLeast": "\u00edt nh\u1ea5t l\u00e0",
   "filters.op.lessThan": "nh\u1ecf h\u01a1n",
   "filters.op.atMost": "nhi\u1ec1u nh\u1ea5t l\u00e0",
+
+  // Giao di\u1ec7n B\u1ed9 l\u1ecdc & Ch\u1ee7 \u0111\u1ec1.
+  "filters.title": "B\u1ed9 l\u1ecdc & ch\u1ee7 \u0111\u1ec1",
+  "filters.subtitle":
+    "T\u1ea1o b\u1ed9 l\u1ecdc, xem n\u00f3 ch\u1ecdn nh\u1eefng g\u00ec, r\u1ed3i l\u01b0u th\u00e0nh ch\u1ee7 \u0111\u1ec1.",
+  "filters.objectLabel": "L\u1ecdc lo\u1ea1i b\u1ea3n ghi n\u00e0o",
+  "filters.tab.contacts": "Li\u00ean h\u1ec7",
+  "filters.tab.companies": "C\u00f4ng ty",
+  "filters.tab.deals": "Th\u01b0\u01a1ng v\u1ee5",
+  "filters.builderTitle": "B\u1ed9 l\u1ecdc",
+  "filters.dynamic":
+    "\u0110\u1ed9ng \u2014 t\u00ednh l\u1ea1i sau m\u1ecdi s\u1ef1 ki\u1ec7n",
+  "filters.matchContacts": "{count} li\u00ean h\u1ec7 kh\u1edbp",
+  "filters.matchCompanies": "{count} c\u00f4ng ty kh\u1edbp",
+  "filters.matchDeals": "{count} th\u01b0\u01a1ng v\u1ee5 kh\u1edbp",
+  "filters.noFilterYet":
+    "Th\u00eam \u0111i\u1ec1u ki\u1ec7n \u0111\u1ec3 xem k\u1ebft qu\u1ea3",
+  "filters.loadingVocabulary":
+    "\u0110ang t\u1ea3i c\u00e1c tr\u01b0\u1eddng c\u00f3 th\u1ec3 l\u1ecdc\u2026",
+  "filters.noFields":
+    "Lo\u1ea1i b\u1ea3n ghi n\u00e0y kh\u00f4ng c\u00f3 tr\u01b0\u1eddng n\u00e0o l\u1ecdc \u0111\u01b0\u1ee3c.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/filters.css
+++ b/frontend/src/screens/filters.css
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BUSL-1.1
+ * SPDX-FileCopyrightText: 2026 Gradion
+ *
+ * The Filters & views screen. Layout only — every colour and space is a token. */
+
+.filters-screen {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.filters-count-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.filters-count {
+  font-weight: 600;
+  color: var(--textContent);
+  /* Tabular figures so the number does not shift the badge beside it as the
+   * count crosses a digit — a count that recomputes on every keystroke would
+   * otherwise nudge the row on each edit. */
+  font-variant-numeric: tabular-nums;
+}
+
+/* A count being recomputed is the LAST answer, dimmed — not a spinner. It reads
+ * as "this is a moment behind", which is true, where a spinner reads as "there
+ * is no answer", which is not. */
+.filters-count[data-stale="true"] {
+  color: var(--textMuted);
+}
+
+/* No complete clause yet: not a number at all, because zero would claim nothing
+ * matches when in fact nothing has been asked. */
+.filters-count-unasked {
+  font-weight: 400;
+  color: var(--textMuted);
+}

--- a/frontend/src/screens/filters.test.tsx
+++ b/frontend/src/screens/filters.test.tsx
@@ -1,0 +1,166 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { FiltersScreen } from "./filters";
+
+// What this screen owns is the WIRING and one judgement: how a count that is a
+// moment behind should read. So these tests are about which request went out for
+// which object, and about the three readings of the count — answered, stale, and
+// not-yet-asked, which are three different things and must not collapse into one.
+
+const PERSON_VOCAB = {
+  resource: "person",
+  fields: [
+    {
+      name: "full_name",
+      type: "text",
+      operators: ["eq", "neq", "in", "contains", "exists"],
+      custom: false,
+    },
+  ],
+};
+
+const DEAL_VOCAB = {
+  resource: "deal",
+  fields: [
+    {
+      name: "stage_id",
+      type: "id",
+      operators: ["eq", "neq", "in", "exists"],
+      custom: false,
+    },
+  ],
+};
+
+/** Every request the screen made, so a test can assert what it asked rather than
+ *  inferring it from what rendered. */
+function mount(preview?: { match_count: number }) {
+  const seen: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      seen.push(url);
+      const json = (body: unknown) =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      if (url.endsWith("/v1/me")) {
+        return json(meFixture({}));
+      }
+      if (url.includes("/filters/vocabulary")) {
+        return json(url.includes("resource=deal") ? DEAL_VOCAB : PERSON_VOCAB);
+      }
+      if (url.includes("/filters/preview")) {
+        return json({
+          resource: "person",
+          match_count: preview?.match_count ?? 0,
+          columns: ["id"],
+          rows: [],
+          truncated: false,
+        });
+      }
+      return json({});
+    }),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <LocaleProvider>{children}</LocaleProvider>
+    </QueryClientProvider>
+  );
+  return { seen, wrapper };
+}
+
+afterEach(cleanup);
+
+it("reads the vocabulary for the object the route names", async () => {
+  const { seen, wrapper } = mount();
+  render(<FiltersScreen id="deals" />, { wrapper });
+
+  await waitFor(() => {
+    expect(seen.some((url) => url.includes("resource=deal"))).toBe(true);
+  });
+  // And not the default: a route naming deals must not read the person
+  // vocabulary, or the picker offers fields the deal engine refuses.
+  expect(seen.some((url) => url.includes("resource=person"))).toBe(false);
+});
+
+it("falls back to contacts when the route names something unknown", async () => {
+  const { seen, wrapper } = mount();
+  render(<FiltersScreen id="widgets" />, { wrapper });
+
+  await waitFor(() => {
+    expect(seen.some((url) => url.includes("resource=person"))).toBe(true);
+  });
+});
+
+it("asks for no preview until a clause is complete", async () => {
+  const { seen, wrapper } = mount();
+  render(<FiltersScreen />, { wrapper });
+
+  await waitFor(() => {
+    expect(seen.some((url) => url.includes("/filters/vocabulary"))).toBe(true);
+  });
+  // The tree starts as an empty group, which the engine refuses as
+  // filter_shape_invalid — asking would spend a request to be told so.
+  expect(seen.some((url) => url.includes("/filters/preview"))).toBe(false);
+  // And the count says nothing has been asked, which is NOT the same as zero.
+  expect(screen.getByText("Add a clause to see what it selects")).toBeTruthy();
+});
+
+it("says how many match once a clause is complete", async () => {
+  const { wrapper } = mount({ match_count: 12 });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await screen.findByRole("button", { name: "Add clause" });
+  await user.click(screen.getByRole("button", { name: "Add clause" }));
+  // The clause starts on full_name with `eq` and an empty value, so it is still
+  // incomplete — typing a value is what makes it askable.
+  await user.type(screen.getByLabelText("Value"), "ann");
+
+  expect(await screen.findByText("12 contacts match")).toBeTruthy();
+});
+
+it("names the count after the object, not after a placeholder", async () => {
+  const { wrapper } = mount({ match_count: 3 });
+  const user = userEvent.setup();
+  render(<FiltersScreen id="deals" />, { wrapper });
+
+  await screen.findByRole("button", { name: "Add clause" });
+  await user.click(screen.getByRole("button", { name: "Add clause" }));
+  await user.type(screen.getByLabelText("Value"), "s1");
+
+  // "3 deals match", not "3 contacts match" and not "3 match" — the object is
+  // part of the sentence, which is why the copy is keyed per object.
+  expect(await screen.findByText("3 deals match")).toBeTruthy();
+});
+
+it("starts a fresh tree when the object changes", async () => {
+  const { wrapper } = mount({ match_count: 4 });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await screen.findByRole("button", { name: "Add clause" });
+  await user.click(screen.getByRole("button", { name: "Add clause" }));
+  expect(screen.getByLabelText("Value")).toBeTruthy();
+
+  await user.click(screen.getByRole("button", { name: "Deals" }));
+
+  // The person clause is gone rather than carried onto deals, where the field it
+  // names does not exist — a filter the new vocabulary would refuse.
+  expect(screen.queryByLabelText("Value")).toBeNull();
+  expect(screen.getByText("Add a clause to see what it selects")).toBeTruthy();
+});

--- a/frontend/src/screens/filters.tsx
+++ b/frontend/src/screens/filters.tsx
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The Filters & views screen (AC-filters-and-views-1/3/4): the surface a
+// human authors a dynamic filter on, which until now existed only through the API.
+//
+// It hosts three things and owns none of them. The object control picks which
+// record type's vocabulary to read; the builder draws the tree; the count comes
+// back from the preview. What this file adds is the wiring and one judgement — how
+// to report a count that is one edit behind, which is the honest state of any live
+// recount over a moving table.
+
+import { useState } from "react";
+import {
+  Badge,
+  Card,
+  SectionHeader,
+  SegmentedControl,
+} from "../design-system/atoms";
+import { type SectionState, SurfaceState } from "../design-system/surfacestate";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { FilterBuilder } from "./filterbuilder";
+import {
+  type FilterResource,
+  useFilterPreview,
+  useFilterVocabulary,
+} from "./filterdata";
+import "./filters.css";
+import { type Node, newGroup } from "./segmentpredicate";
+
+/**
+ * The three object tabs AC-1 names, and the record type each reads.
+ *
+ * The tab says "Contacts" and the vocabulary says "person": the wire's word and
+ * the product's word differ, and this is the one place that correspondence is
+ * written down rather than assumed at each call site.
+ */
+const OBJECT_TABS = ["contacts", "companies", "deals"] as const;
+type ObjectTab = (typeof OBJECT_TABS)[number];
+
+const RESOURCE_OF: Record<ObjectTab, FilterResource> = {
+  contacts: "person",
+  companies: "organization",
+  deals: "deal",
+};
+
+const TAB_LABEL: Record<ObjectTab, MessageKey> = {
+  contacts: "filters.tab.contacts",
+  companies: "filters.tab.companies",
+  deals: "filters.tab.deals",
+};
+
+const MATCH_LABEL: Record<ObjectTab, MessageKey> = {
+  contacts: "filters.matchContacts",
+  companies: "filters.matchCompanies",
+  deals: "filters.matchDeals",
+};
+
+/** A resource this screen can address, or the default when the route names none. */
+function tabFromRoute(id: string | undefined): ObjectTab {
+  return OBJECT_TABS.find((tab) => tab === id) ?? "contacts";
+}
+
+export function FiltersScreen({ id }: Readonly<{ id?: string }>) {
+  const t = useT();
+  const [tab, setTab] = useState<ObjectTab>(tabFromRoute(id));
+  // A fresh tree per object, because a clause naming a person's field means
+  // nothing on a deal — carrying the tree across would offer the human a filter
+  // the new vocabulary refuses.
+  const [tree, setTree] = useState<Node>(() => newGroup("and"));
+
+  const resource = RESOURCE_OF[tab];
+  const vocabulary = useFilterVocabulary(resource);
+  const preview = useFilterPreview(resource, tree);
+
+  const switchTab = (next: ObjectTab) => {
+    setTab(next);
+    setTree(newGroup("and"));
+  };
+
+  return (
+    <div className="filters-screen">
+      <SectionHeader
+        level={1}
+        title={t("filters.title")}
+        sub={t("filters.subtitle")}
+        actions={
+          <SegmentedControl
+            options={OBJECT_TABS}
+            value={tab}
+            onChange={switchTab}
+            labels={{
+              contacts: t(TAB_LABEL.contacts),
+              companies: t(TAB_LABEL.companies),
+              deals: t(TAB_LABEL.deals),
+            }}
+            label={t("filters.objectLabel")}
+          />
+        }
+      />
+
+      <Card>
+        <SectionHeader
+          level={2}
+          title={t("filters.builderTitle")}
+          actions={
+            <span className="filters-count-row">
+              <MatchCount
+                tab={tab}
+                count={preview.data?.match_count}
+                stale={preview.isFetching}
+              />
+              {/* AC-1's live badge: what this filter IS, not what it is doing.
+                  A dynamic list recomputes on every event, and that is the
+                  property a reader needs before trusting a count at all. */}
+              <Badge tone="accent">{t("filters.dynamic")}</Badge>
+            </span>
+          }
+        />
+        {vocabulary.isPending && (
+          // SurfaceState's loading state is a shimmer with no text, so a reader
+          // who cannot see it hears nothing between mount and the first field.
+          <span className="sr-only" role="status">
+            {t("filters.loadingVocabulary")}
+          </span>
+        )}
+        <SurfaceState
+          state={vocabularyState(vocabulary.isPending, vocabulary.isError)}
+          emptyLabel={t("filters.noFields")}
+        >
+          <FilterBuilder
+            tree={tree}
+            onChange={setTree}
+            fields={vocabulary.data?.fields ?? []}
+          />
+        </SurfaceState>
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * The count, and whether it is behind.
+ *
+ * Three readings, and keeping them apart is the point. A count the server has
+ * answered reads plainly. A count being recomputed reads as the LAST answer,
+ * marked stale — not as a spinner, because a number that vanishes on every
+ * keystroke is harder to read than one that lags a moment. And a tree with no
+ * complete clause has no count at all, which is different from a count of zero:
+ * zero means "nothing matches", and this means "you have not asked yet".
+ */
+function MatchCount({
+  tab,
+  count,
+  stale,
+}: Readonly<{ tab: ObjectTab; count: number | undefined; stale: boolean }>) {
+  const t = useT();
+  if (count === undefined) {
+    return (
+      <span className="filters-count filters-count-unasked">
+        {t("filters.noFilterYet")}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="filters-count"
+      // Spoken, because the count changing is the feedback for every edit — a
+      // sighted reader sees the number move and a screen-reader user would
+      // otherwise get nothing back from adding a clause.
+      role="status"
+      aria-busy={stale}
+      data-stale={stale ? "true" : undefined}
+    >
+      {t(MATCH_LABEL[tab], { count })}
+    </span>
+  );
+}
+
+/**
+ * The vocabulary read's three outcomes as a surface state.
+ *
+ * An error is `unavailable` rather than `empty`: an empty field list would tell a
+ * reader this record type has nothing to filter on, which is a different and false
+ * statement — and the endpoint 404s rather than answering an empty set, so a
+ * genuine empty cannot arrive.
+ */
+function vocabularyState(pending: boolean, failed: boolean): SectionState {
+  if (pending) {
+    return "loading";
+  }
+  return failed ? "unavailable" : "ready";
+}


### PR DESCRIPTION
The screen that hosts the predicate builder and makes it reachable, now that [#1779](https://github.com/gradionhq/margince-poc-v1/pull/1779) has landed it. Frontend only. `AC-filters-and-views-1` and the live half of `-4`.

One commit. It owns almost nothing: the object control picks whose vocabulary to read, the builder draws the tree, the count comes back from the preview. What it adds is the wiring and one judgement.

## The judgement: a live count has three states, not two

Collapsing any two of them tells the reader something false.

| State | What it shows | Why not otherwise |
|---|---|---|
| Answered | the number | — |
| Recomputing | the **last** number, dimmed, `aria-busy` | a spinner reads as "there is no answer"; the previous answer is still the best information available, and a number that vanishes each keystroke is harder to read than one that lags |
| Not yet asked | no number at all | zero would claim nothing matches; this says you have not asked |

The third is the same decision as the data layer's `isComplete` gate seen from the other side — the request is not made either, so an empty group costs nothing and earns no 422 the reader cannot act on.

The count is spoken (`role="status"`), because it **is** the feedback for every edit: a sighted reader watches the number move, and without this a screen-reader user gets nothing back from adding a clause.

## Two smaller decisions

**Switching objects starts a fresh tree.** A clause naming a person's field means nothing on a deal, and carrying it over would hand somebody a filter the new vocabulary refuses — reintroducing, in the screen, exactly the failure the vocabulary read exists to prevent.

**The match line is keyed per object**, not shared with a placeholder: "3 contacts match" and "3 companies match" are different sentences in every language, and one `{count} {object} match` puts the object somewhere several grammars cannot. A vocabulary error reads as *unavailable*, never as an empty field list — "this type has nothing to filter on" is a different and false statement, and the endpoint 404s rather than answering empty, so a genuine empty cannot arrive.

## Deliberately not here: the results table

`ListTable` is built for a record list with query dials against a list endpoint; the preview answers a schema-derived `columns`/`rows` projection. Forcing one into the other, or hand-rolling a second table beside it, are both worse than deciding it properly — `frontend/CLAUDE.md` records that this tree has twice grown a second spelling of a surface exactly that way. It gets its own change.

The NL bar (AC-2) also stays out: LVS-EXT-6 does not exist, so there is nothing to compile a description against, and a bar that silently did nothing would be worse than a visible gap.

## Rebase note

`main`'s routing was refactored while this sat behind #1779 — from a `switch` to a table total over a `Screen` type, with lazy screens. The route is wired the new way (an entry in `SCREENS`, a lazy import, a table entry) rather than by resolving the conflict mechanically, which would have left a `case` in a file that no longer has one.

`make check-fe` green — 3302 tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Filters & views screen at /#/filters/<object> and introduces a three‑state match count. Users can now build dynamic filters with accurate, accessible feedback.

- Satisfies AC-filters-and-views-1 and the live half of -4.
- Routing: adds `filters` to `SCREENS`; lazy loads `FiltersScreen`; `id` selects contacts/companies/deals; unknown `id` falls back to contacts.
- Object switch resets the tree to avoid invalid clauses crossing objects.
- Preview: makes no request until a clause is complete; count states—answered shows the number; recomputing shows the last number dimmed with aria-busy; not-yet-asked shows helper text (not zero). Count uses role=status and tabular numerals.
- Match line is per object (“{count} contacts/companies/deals match”) for correct i18n; adds strings in `en`, `de`, `vi`.
- Vocabulary loading uses `SurfaceState`; errors render as unavailable, not empty.
- Tests cover vocabulary selection, route fallback, preview gating, per-object count, and tree reset.
- Out of scope: results table and NL bar.

<sup>Written for commit 80115f4a0fce978572e40f9050427d35e7d4be67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

