### PR TITLE
fix(siteread): a company address printed across two lines is evidence, not a guess

### DIFF
--- a/backend/internal/compose/sitecrawlrank.go
+++ b/backend/internal/compose/sitecrawlrank.go
@@ -97,7 +97,7 @@ func legalIdentityPath(rawURL string) bool {
 		return false
 	}
 	last := segments[len(segments)-1]
-	if containsAny(last, "impressum", "imprint") || last == "legal-notice" {
+	if containsAny(last, "impressum", "imprint") || legalNoticeSegment(last) {
 		return true
 	}
 	// "publisher" is an imprint only at the TOP of a site, because it is also
@@ -114,6 +114,36 @@ func legalIdentityPath(rawURL string) bool {
 		return false
 	}
 	return len(segments) == 1 || (len(segments) == 2 && (segments[0] == "c" || segments[0] == companyWord))
+}
+
+// legalNoticeSegments are the mandatory-legal-notice page names this
+// classifier recognises beyond the German and English forms above.
+//
+// Every one of them names the SAME legally required page an Impressum is —
+// France's mentions légales, Spain's aviso legal, Italy's note legali — so
+// treating them as legal authority widens the reader's reach without
+// loosening what counts as legal evidence.
+//
+// Deliberately NOT here: contact, about, company. Those are the pages the
+// non-German half of the dataset actually publishes, and a registered
+// address taken off a marketing page is exactly the guess the legal gate
+// exists to refuse. Widening the gate to reach them would trade the
+// no-guess property for coverage.
+var legalNoticeSegments = map[string]bool{
+	"legal-notice":            true,
+	"legal-notices":           true,
+	"legalnotice":             true,
+	"mentions-legales":        true,
+	"mentions-légales":        true,
+	"aviso-legal":             true,
+	"note-legali":             true,
+	"nota-legal":              true,
+	"colofon":                 true,
+	"juridische-kennisgeving": true,
+}
+
+func legalNoticeSegment(last string) bool {
+	return legalNoticeSegments[last]
 }
 
 func pathSegments(path string) []string {

--- a/backend/internal/compose/sitecrawlrank_test.go
+++ b/backend/internal/compose/sitecrawlrank_test.go
@@ -106,3 +106,38 @@ func TestAnIndustryPageNamedPublisherIsNotAnImprint(t *testing.T) {
 		}
 	}
 }
+
+// TestLegalIdentityPathKnowsOtherLanguagesNotMarketingPages widens the legal
+// classifier to the mandatory legal-notice page as other countries name it,
+// and pins the line it must not cross.
+//
+// The demo dataset had 60 companies where no page was classified as a legal
+// notice, and not one of them yielded a registered address. Most publish
+// only /contact and /about — those stay OUT, because an address taken off a
+// marketing page is the guess the legal gate exists to refuse.
+func TestLegalIdentityPathKnowsOtherLanguagesNotMarketingPages(t *testing.T) {
+	for _, url := range []string{
+		"https://example.com/mentions-legales",
+		"https://example.com/aviso-legal",
+		"https://example.com/note-legali",
+		"https://example.com/legal-notice",
+		"https://example.com/fr/mentions-legales",
+	} {
+		if !legalIdentityPath(url) {
+			t.Errorf("%s is a mandatory legal notice and was not treated as one", url)
+		}
+	}
+	for _, url := range []string{
+		"https://example.com/contact",
+		"https://example.com/contact-us",
+		"https://example.com/about",
+		"https://example.com/about-us",
+		"https://example.com/company",
+		"https://example.com/privacy-policy",
+		"https://example.com/terms",
+	} {
+		if legalIdentityPath(url) {
+			t.Errorf("%s is not a legal notice, and treating it as one lets an address come off a marketing page", url)
+		}
+	}
+}

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -41,7 +41,14 @@ const (
 	// for the trio and must reserve most of its corpus for what the company
 	// sells and whom it serves.
 	profileImpressumExcerptRunes = 2_500
-	profileMaxImpressumPages     = 1
+	// Three, not one. A large site's first legal page by corpus rank is
+	// routinely a privacy policy or terms of use, which name no address at
+	// all — so a one-page bound spent the entire legal budget on a page that
+	// could not ground the trio, and the profile returned nothing for 36 of
+	// the demo dataset's companies. Three pages reaches the actual Impressum
+	// on a multi-locale site while still leaving most of the corpus to what
+	// the company sells.
+	profileMaxImpressumPages = 3
 )
 
 // profileSystem is the profile call's prompt.

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -46,9 +46,21 @@ const (
 	// all — so a one-page bound spent the entire legal budget on a page that
 	// could not ground the trio, and the profile returned nothing for 36 of
 	// the demo dataset's companies. Three pages reaches the actual Impressum
-	// on a multi-locale site while still leaving most of the corpus to what
-	// the company sells.
+	// on a multi-locale site.
 	profileMaxImpressumPages = 3
+	// What the EXTRA legal pages may cost between them, and what each one
+	// gets. Legal pages outrank every commercial kind in corpus rank, so
+	// without a share of their own the two extra ones simply take the budget
+	// About, Services and Products would have had — measured on a site with
+	// pages long enough to fill the corpus, three full-width legal pages cut
+	// services from four to one.
+	//
+	// An address, a legal name and a registration number are short and sit
+	// at the top of the notice, so the extra pages are read at a fraction of
+	// a full excerpt. That is enough to find the trio on the second or third
+	// legal page and cheap enough that the commercial evidence barely moves.
+	profileExtraImpressumRunes = 900
+	profileLegalBudgetRunes    = 2 * profileExtraImpressumRunes
 )
 
 // profileSystem is the profile call's prompt.
@@ -123,14 +135,27 @@ func profileExcerptPages(pages []crawlPage) []crawlPage {
 	var out []crawlPage
 	used := 0
 	legalPages := 0
+	legalRunes := 0
 	selected := map[string]bool{}
 	addPage := func(page crawlPage) bool {
 		capRunes := profilePageExcerptRunes
-		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
+		legal := page.Kind == crmcontracts.SiteReadPageKindImpressum
+		if legal {
 			if legalPages >= profileMaxImpressumPages {
 				return false
 			}
 			capRunes = profileImpressumExcerptRunes
+			// The FIRST legal page is free and full width — it is the one
+			// the breadth pass buys, and every kind gets one. The extra two
+			// are read narrowly and charged against the legal share, so
+			// widening the bound cannot cost the commercial pages more than
+			// that share.
+			if legalPages > 0 {
+				capRunes = profileExtraImpressumRunes
+				if legalRunes+capRunes > profileLegalBudgetRunes {
+					return false
+				}
+			}
 		}
 		pageRunes := []rune(page.Text)
 		if len(pageRunes) > capRunes {
@@ -143,8 +168,11 @@ func profileExcerptPages(pages []crawlPage) []crawlPage {
 		out = append(out, page)
 		used += len(pageRunes)
 		selected[page.URL] = true
-		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
+		if legal {
 			legalPages++
+			if legalPages > 1 {
+				legalRunes += len(pageRunes)
+			}
 		}
 		return true
 	}
@@ -162,7 +190,7 @@ func profileExcerptPages(pages []crawlPage) []crawlPage {
 		}
 	}
 	// A small site may not publish every kind. Spend any room that remains
-	// on the next-best pages without weakening the one-legal-page bound.
+	// on the next-best pages without weakening the legal bounds above.
 	for _, page := range ranked {
 		if selected[page.URL] {
 			continue

--- a/backend/internal/compose/siteprofile_test.go
+++ b/backend/internal/compose/siteprofile_test.go
@@ -10,6 +10,7 @@ package compose
 // answers to the census gate.
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -211,4 +212,58 @@ func bytesOfRunes(r byte, n int) []byte {
 		out[i] = r
 	}
 	return out
+}
+
+// TestThreeLegalPagesCostAtMostOneCommercialPage prices the change from one
+// legal page to three, on a site whose pages are long enough that the corpus
+// budget genuinely binds.
+//
+// Legal pages outrank every commercial kind in corpus rank, so the extra two
+// come out of the budget About, Services and Products would have had. Read at
+// full width they cost two services pages of four. Read narrowly — which is
+// all the legal trio needs, being three short fields at the top of a notice —
+// they cost one. That is the trade this pins: one commercial page, against
+// reaching the actual Impressum on a multi-locale site.
+func TestThreeLegalPagesCostAtMostOneCommercialPage(t *testing.T) {
+	corpus := func(legalPages int) map[crmcontracts.SiteReadPageKind]int {
+		var pages []crawlPage
+		add := func(kind crmcontracts.SiteReadPageKind, path string, n int) {
+			for i := range n {
+				pages = append(pages, crawlPage{
+					URL:  fmt.Sprintf("https://example.com/%s%d", path, i),
+					Kind: kind,
+					Text: strings.Repeat("Inhalt dieser Seite in ausreichender Laenge fuer die Analyse. ", 120),
+				})
+			}
+		}
+		add(crmcontracts.SiteReadPageKindImpressum, "impressum", legalPages)
+		add(crmcontracts.SiteReadPageKindServices, "services", 8)
+		add(crmcontracts.SiteReadPageKindProducts, "products", 8)
+		add(crmcontracts.SiteReadPageKindAbout, "about", 2)
+		out := map[crmcontracts.SiteReadPageKind]int{}
+		for _, page := range profileExcerptPages(pages) {
+			out[page.Kind]++
+		}
+		return out
+	}
+
+	withLegal := corpus(5)
+	if got := withLegal[crmcontracts.SiteReadPageKindImpressum]; got != profileMaxImpressumPages {
+		t.Errorf("legal pages read = %d, want the bound %d", got, profileMaxImpressumPages)
+	}
+	// The commercial half must survive. Anything at or below one page is the
+	// starvation the narrow-read carve-out exists to prevent.
+	services := withLegal[crmcontracts.SiteReadPageKindServices]
+	if services < 2 {
+		t.Errorf("services pages read = %d — the legal pages starved the commercial evidence", services)
+	}
+	if withLegal[crmcontracts.SiteReadPageKindAbout] < 2 {
+		t.Error("the About pages were crowded out")
+	}
+	// And the whole point of reading three: a site that publishes several
+	// legal pages gets more than the first one, which on a large site is
+	// routinely a privacy policy naming no address at all.
+	if corpus(1)[crmcontracts.SiteReadPageKindImpressum] != 1 {
+		t.Error("a site with one legal page must still get it")
+	}
 }

--- a/backend/internal/compose/sitesnippet.go
+++ b/backend/internal/compose/sitesnippet.go
@@ -253,10 +253,61 @@ func (x snippetIndex) nameInCited(id, name string) (string, bool) {
 	// applies, and for the same reason it documents — a passage printing
 	// "24114 Kiel" and "HRB 123456" must never vouch for an invented
 	// "HRB 24114". Allowing gaps would confirm a fabricated identifier.
-	if printedInOrder(contentTokens(ref.norm), contentTokens(nameNorm)) {
+	if tokensPrintedTogether(ref.norm, nameNorm) {
 		return ref.passage, true
 	}
 	return "", false
+}
+
+// tokensPrintedTogether is the content-token comparison with the two guards
+// the raw printedInOrder does not carry on its own.
+//
+// A value of pure punctuation has NO content tokens, and an empty claim is
+// contained in everything — printedInOrder would compare an empty slice
+// against itself and vouch for "---" on any page at all. It is refused here
+// instead: nothing is not evidence.
+//
+// A value must also keep the SEPARATORS the page printed between digits.
+// Content tokens drop punctuation, which is right for an address whose parts
+// markup split apart, and wrong for an identifier: a page printing
+// "HRB 123/456" would otherwise ground "HRB 123-456", a registration number
+// that is not the one on the page. So a value whose tokens are joined by
+// punctuation rather than whitespace has to appear that way verbatim.
+func tokensPrintedTogether(passageNorm, valueNorm string) bool {
+	claimed := contentTokens(valueNorm)
+	if len(claimed) == 0 {
+		return false
+	}
+	if joinedByPunctuation(valueNorm) {
+		return strings.Contains(passageNorm, valueNorm)
+	}
+	return printedInOrder(contentTokens(passageNorm), claimed)
+}
+
+// joinedByPunctuation reports whether any two content tokens of the value sit
+// directly against a punctuation mark with no space — "123/456", "123-456".
+// Those separators are part of what the page said; whitespace between tokens
+// is only layout.
+func joinedByPunctuation(valueNorm string) bool {
+	prevAlnum := false
+	for i, r := range valueNorm {
+		alnum := unicode.IsLetter(r) || unicode.IsDigit(r)
+		if !alnum && r != ' ' && prevAlnum {
+			// A trailing mark ("Straße 8,") separates nothing.
+			rest := valueNorm[i+len(string(r)):]
+			for _, next := range rest {
+				if next == ' ' {
+					break
+				}
+				if unicode.IsLetter(next) || unicode.IsDigit(next) {
+					return true
+				}
+				break
+			}
+		}
+		prevAlnum = alnum
+	}
+	return false
 }
 
 // contentWordOverlap answers whether value and the cited passage share

--- a/backend/internal/compose/sitesnippet.go
+++ b/backend/internal/compose/sitesnippet.go
@@ -240,6 +240,22 @@ func (x snippetIndex) nameInCited(id, name string) (string, bool) {
 			return ref.passage + " " + x.refs[adjacent].passage, true
 		}
 	}
+	// Last resort: the value as a contiguous run of CONTENT tokens.
+	//
+	// This is the address case. An Impressum prints the street, the postcode
+	// and city, and the country as separate elements; a faithful reading
+	// joins them, and no contiguous run of page TEXT ever equals that join,
+	// because the join crossed markup. Comparing content tokens drops the
+	// punctuation and whitespace that markup inserted and compares the words
+	// themselves.
+	//
+	// Contiguous, not merely in-order: the same rule the legal census
+	// applies, and for the same reason it documents — a passage printing
+	// "24114 Kiel" and "HRB 123456" must never vouch for an invented
+	// "HRB 24114". Allowing gaps would confirm a fabricated identifier.
+	if printedInOrder(contentTokens(ref.norm), contentTokens(nameNorm)) {
+		return ref.passage, true
+	}
 	return "", false
 }
 

--- a/backend/internal/compose/sitesnippet_test.go
+++ b/backend/internal/compose/sitesnippet_test.go
@@ -130,6 +130,72 @@ func TestNameInCitedForgivesTheHeadingBoundaryNeverThePage(t *testing.T) {
 	}
 }
 
+// TestNameInCitedAcceptsAnAddressSplitByMarkup pins the case that cost the
+// demo dataset 94 company addresses.
+//
+// An Impressum prints the street, the postcode and city, and the country as
+// separate elements. A faithful reading joins them into one value, and no
+// contiguous run of the page ever equals that join — so the substring gate
+// refused real addresses that were demonstrably on the page.
+func TestNameInCitedAcceptsAnAddressSplitByMarkup(t *testing.T) {
+	idx := newSnippetIndex([]crawlPage{{
+		URL: seedURL + "/impressum",
+		Text: "Impressum\nadesso SE\nAdessoplatz 1\n44269 Dortmund\nDeutschland\n" +
+			strings.Repeat("Weitere Angaben nach Paragraf 5 TMG folgen an dieser Stelle. ", 4),
+	}})
+	for _, value := range []string{
+		"Adessoplatz 1 44269 Dortmund",
+		"Adessoplatz 1 44269 Dortmund Deutschland",
+		"adesso SE",
+	} {
+		if _, ok := idx.nameInCited("s0", value); !ok {
+			t.Errorf("the page carries %q across separate lines, and the gate refused it", value)
+		}
+	}
+}
+
+// TestNameInCitedStillRefusesWhatIsNotOnThePage is the other half of the
+// relaxation above: forgiving markup must not forgive invention. Every case
+// here has to keep failing, or the no-guess property is gone.
+func TestNameInCitedStillRefusesWhatIsNotOnThePage(t *testing.T) {
+	idx := newSnippetIndex([]crawlPage{{
+		URL: seedURL + "/impressum",
+		Text: "Impressum\nadesso SE\nAdessoplatz 1\n44269 Dortmund\nDeutschland\n" +
+			strings.Repeat("Weitere Angaben nach Paragraf 5 TMG folgen an dieser Stelle. ", 4),
+	}})
+	for name, value := range map[string]string{
+		"an invented street":     "Hauptstrasse 7 44269 Dortmund",
+		"an invented city":       "Adessoplatz 1 44269 Bielefeld",
+		"a wholly absent value":  "Rue de la Paix 4 75002 Paris",
+		"the words out of order": "Dortmund 44269 Adessoplatz 1",
+		"a fragment of a word":   "essoplat 1",
+		"a single absent token":  "Bielefeld",
+	} {
+		if _, ok := idx.nameInCited("s0", value); ok {
+			t.Errorf("%s was evidenced: %q", name, value)
+		}
+	}
+}
+
+// TestNameInCitedRefusesTokensAssembledAcrossAGap is the hole the legal
+// census documents and this fallback must not open: a passage printing
+// "24114 Kiel" and "HRB 123456" separately must never vouch for the
+// invented "HRB 24114". Contiguity of content tokens is what forbids it.
+func TestNameInCitedRefusesTokensAssembledAcrossAGap(t *testing.T) {
+	idx := newSnippetIndex([]crawlPage{{
+		URL: seedURL + "/impressum",
+		Text: "Sitz der Gesellschaft: 24114 Kiel\nRegistergericht Kiel HRB 123456\n" +
+			strings.Repeat("Weitere Pflichtangaben folgen hier. ", 5),
+	}})
+	if _, ok := idx.nameInCited("s0", "HRB 24114"); ok {
+		t.Error("an identifier assembled from tokens printed apart was evidenced")
+	}
+	// The real, contiguous one still passes.
+	if _, ok := idx.nameInCited("s0", "HRB 123456"); !ok {
+		t.Error("the printed registration number was refused")
+	}
+}
+
 func TestContentWordOverlapIsAWarningSignalNotAGate(t *testing.T) {
 	passage := normalizeEvidence("Wir liefern Automatisierung für die Industrie seit 1998.")
 	if !contentWordOverlap("Industrial Automatisierung provider", passage) {

--- a/backend/internal/compose/sitesnippet_test.go
+++ b/backend/internal/compose/sitesnippet_test.go
@@ -196,6 +196,85 @@ func TestNameInCitedRefusesTokensAssembledAcrossAGap(t *testing.T) {
 	}
 }
 
+// TestRealDroppedAddressesFromTheDemoCorpus replays actual values the demo
+// dataset lost to value_not_in_snippet, against an Impressum laid out the way
+// the real pages lay them out: one element per line.
+func TestRealDroppedAddressesFromTheDemoCorpus(t *testing.T) {
+	cases := []struct {
+		page  string
+		value string
+	}{
+		{
+			page:  "Impressum\ncommunicode AG\nWittekindstr. 1a\n45131 Essen /NRW\nDeutschland\n",
+			value: "Wittekindstr. 1a 45131 Essen /NRW Deutschland",
+		},
+		{
+			page:  "Impressum\nFACT-Finder\nHabermehlstr. 17\n75172 Pforzheim\nGermany\n",
+			value: "Habermehlstr. 17 75172 Pforzheim Germany",
+		},
+		{
+			page:  "Kontakt\nFIS GmbH\nRöthleiner Weg 1\nD-97506 Grafenrheinfeld\n",
+			value: "Röthleiner Weg 1 D-97506 Grafenrheinfeld",
+		},
+		{
+			page:  "Impressum\nLaudert GmbH + Co. KG\nVon-Braun-Straße 8,\n48691 Vreden\n",
+			value: "Von-Braun-Straße 8, 48691 Vreden",
+		},
+		{
+			page:  "Aviso legal\nDoofinder S.L.\nRufino González 23 bis, 1º,\nMadrid 28037\n",
+			value: "Rufino González 23 bis, 1º, Madrid 28037",
+		},
+	}
+	for _, c := range cases {
+		idx := newSnippetIndex([]crawlPage{{
+			URL:  "https://example.com/impressum",
+			Text: c.page + strings.Repeat("Weitere Pflichtangaben folgen an dieser Stelle. ", 4),
+		}})
+		if _, ok := idx.nameInCited("s0", c.value); !ok {
+			t.Errorf("still dropped: %q", c.value)
+		}
+	}
+}
+
+// TestNameInCitedRefusesAValueWithNoWords closes a hole the token fallback
+// opened: a punctuation-only value has no content tokens, and an empty claim
+// is contained in everything, so "---" was grounded by any page at all.
+// Nothing is not evidence.
+func TestNameInCitedRefusesAValueWithNoWords(t *testing.T) {
+	idx := newSnippetIndex([]crawlPage{{
+		URL:  seedURL + "/impressum",
+		Text: "Impressum\nadesso SE\nAdessoplatz 1\n44269 Dortmund\n" + strings.Repeat("Weitere Angaben folgen. ", 6),
+	}})
+	for _, junk := range []string{"---", "...", "///", "-", "•", "  "} {
+		if _, ok := idx.nameInCited("s0", junk); ok {
+			t.Errorf("a value with no words was evidenced: %q", junk)
+		}
+	}
+}
+
+// TestNameInCitedKeepsTheSeparatorsThePagePrinted is the other half of the
+// token relaxation. Dropping punctuation is right for an address whose parts
+// markup split apart, and wrong for an identifier: a page printing
+// "HRB 123/456" must not ground "HRB 123-456", which is a different
+// registration number from the one the page carries.
+func TestNameInCitedKeepsTheSeparatorsThePagePrinted(t *testing.T) {
+	idx := newSnippetIndex([]crawlPage{{
+		URL:  seedURL + "/impressum",
+		Text: "Impressum\nRegistergericht Kiel HRB 123/456\nAdessoplatz 1\n44269 Dortmund\n" + strings.Repeat("Weitere Angaben folgen. ", 6),
+	}})
+	if _, ok := idx.nameInCited("s0", "HRB 123-456"); ok {
+		t.Error("a reformatted registration number was evidenced")
+	}
+	if _, ok := idx.nameInCited("s0", "HRB 123/456"); !ok {
+		t.Error("the registration number as printed was refused")
+	}
+	// The address still passes: its parts are separated by spaces, which is
+	// layout, not something the page said.
+	if _, ok := idx.nameInCited("s0", "Adessoplatz 1 44269 Dortmund"); !ok {
+		t.Error("the address was refused")
+	}
+}
+
 func TestContentWordOverlapIsAWarningSignalNotAGate(t *testing.T) {
 	passage := normalizeEvidence("Wir liefern Automatisierung für die Industrie seit 1998.")
 	if !contentWordOverlap("Industrial Automatisierung provider", passage) {


### PR DESCRIPTION
Company addresses are empty on **189 of 190** crawled companies in the demo
dataset. The reader was finding them; three separate gates threw them away.

## 1. The substring gate — 94 companies

`nameInCited` required the value to be a contiguous run of page **text**. An
Impressum prints the street, the postcode and city, and the country as
separate elements. A faithful reading joins them, and that join never equals
any contiguous run of the page, because the join crossed markup.

Real addresses the page plainly carried were refused:

```
Adessoplatz 1 44269 Dortmund
Wittekindstr. 1a 45131 Essen /NRW Deutschland
Habermehlstr. 17 75172 Pforzheim Germany
```

The new last-resort fallback compares **content tokens**, reusing
`printedInOrder`/`contentTokens` from the legal census rather than inventing a
second rule.

**Contiguous, not merely in-order** — and that distinction is the whole safety
argument. The census already documents why: a passage printing `24114 Kiel`
and `HRB 123456` must never vouch for an invented `HRB 24114`. A gap-tolerant
test would confirm exactly that fabrication. My first attempt allowed gaps;
reusing the census rule closes it. Pinned by `TestNameInCitedRefusesTokens
AssembledAcrossAGap`.

This gate is the **largest single source of dropped facts in the corpus**:

| reason | dropped |
|---|---|
| **`value_not_in_snippet`** | **7,517** |
| no_published_email | 2,084 |
| duplicate | 1,111 |
| name_role_not_in_snippet | 405 |

By field: 1,309 served_industry, 1,245 product, **1,088 location**, 1,013
service, 105 registered_address, 79 register_vat. The location figure is why
`country` is empty on every company.

## 2. The one-legal-page budget — 36 companies

`profileMaxImpressumPages` was 1. On a large site the first legal page by
corpus rank is routinely a privacy policy or terms of use, which name no
address — so the entire legal budget went to a page that could not ground the
trio, and the profile emitted nothing at all. Akeneo crawled 1 Impressum of 40
pages; Centric Software crawled 4 and only one was read.

Now 3: reaches the real Impressum on a multi-locale site, still leaves most of
the corpus to what the company sells.

## 3. The German-only classifier — partial

`legalIdentityPath` knew `impressum`, `imprint`, `legal-notice`. It now also
knows `mentions-légales`, `aviso-legal`, `note-legali` and siblings — every one
the **same legally mandated page**, so this widens reach without loosening what
counts as legal evidence.

**Deliberately not widened: `contact`, `about`, `company`.** That is what the
remaining 60 companies publish, and it is where this stops. An address taken
off a marketing page is precisely the guess the legal gate exists to refuse.
A test pins both halves.

## Verification

`make check-backend` green (exit 0). `make craft-static`, `make rls-store-path`,
`make no-jurisdiction` all pass. Four `nameInCited` tests including the
pre-existing negative cases, plus the new classifier test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts company addresses printed across multiple lines as evidence and bounds the cost of reading more legal pages. Previously we required a contiguous page-text substring and read one legal page; now we fall back to a contiguous content-token match with safeguards and read up to three legal pages within a small budget.

- `nameInCited`: add last-resort contiguous content-token match; forbid gaps; refuse values with no content tokens; require verbatim punctuation when tokens are punctuation-joined (identifiers stay exact; addresses still pass). Tests cover split-address acceptance and HRB gap/reformatted-number rejection.
- Legal-page budget: increase `profileMaxImpressumPages` to 3; first legal page full width, extra pages capped at 900 runes and charged to `profileLegalBudgetRunes` to limit commercial impact to at most one page.
- Classifier: extend `legalIdentityPath` to FR/ES/IT and similar slugs (`legal-notices`, `legalnotice`, `mentions-légales`, `aviso-legal`, `note-legali`, `colofon`, `juridische-kennisgeving`); still excludes marketing/policy pages (contact/about/company/privacy/terms).

<sup>Written for commit 75466c0fcd06a46fad0e45fcccc6ae5d02ec1f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of legal and imprint pages across multiple languages and URL naming variations.
  * Increased the amount of imprint-page content considered when generating site profiles.
  * Improved name matching when text is separated by formatting, punctuation, or whitespace.
  * Added safeguards to reject incomplete, reordered, fabricated, or non-contiguous name matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->