### PR TITLE
fix(siteread): the address the legal census proved now reaches the company's fields

### DIFF
--- a/backend/internal/compose/deepreadreport.go
+++ b/backend/internal/compose/deepreadreport.go
@@ -62,7 +62,10 @@ func (w *siteDeepReadWorker) gateLegalCensus(ctx context.Context, args SiteDeepR
 	// The gate answers THAT it abstained; a human is owed WHY, so the cause is
 	// read from the same census the gate votes on.
 	warning := legalAbstentionOf(extraction.merged.entities, extraction.legalCensusIncomplete).warning()
-	mergedFields, _, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
+	kinds := pageKindsOf(crawl.Pages)
+	mergedFields, abstained, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, kinds, extraction.legalCensusIncomplete)
+	// What the census proved fills what the profile lane's excerpt missed.
+	mergedFields = fillLegalTrioFromCensus(mergedFields, extraction.merged.entities, kinds, abstained)
 	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, mergedFields)
 	w.extract.reportDrops(ctx, laneLegal, legalDrops)
 	if warning != "" {

--- a/backend/internal/compose/deepreadtriage.go
+++ b/backend/internal/compose/deepreadtriage.go
@@ -124,7 +124,10 @@ func (w *siteDeepReadWorker) readAndResolveTriage(ctx context.Context, args Site
 	if crawl.SeedURL != "" {
 		claim.SeedURL = crawl.SeedURL
 	}
-	fields, _, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
+	kinds := pageKindsOf(crawl.Pages)
+	fields, abstained, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, kinds, extraction.legalCensusIncomplete)
+	// What the census proved fills what the profile lane's excerpt missed.
+	fields = fillLegalTrioFromCensus(fields, extraction.merged.entities, kinds, abstained)
 	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, fields)
 	w.extract.reportDrops(ctx, laneLegal, legalDrops)
 

--- a/backend/internal/compose/sitecorpuslegal.go
+++ b/backend/internal/compose/sitecorpuslegal.go
@@ -144,6 +144,69 @@ func enrichLegalEntitiesFromProfile(entities []corpusLegalEntity, fields []evide
 	return out
 }
 
+// fillLegalTrioFromCensus is the other direction, and the one that was
+// missing: what the CENSUS proved reaches the profile fields.
+//
+// The two lanes read the same legal page and disagree about what survived.
+// The census reads the whole page and gates each detail with groundedDetail;
+// the profile lane reads a bounded excerpt and gates against the one passage
+// the model cited. So an address the census confirmed was routinely dropped by
+// the profile lane for citing a neighbouring passage — communicode.de had
+// "Wittekindstr. 1a, 45131 Essen" on its entity and no registered_address
+// field at all, which is the state 136 of the demo dataset's 190 companies
+// were in.
+//
+// This adds nothing unevidenced. Every value copied here already passed the
+// census's own no-guess gate against the page that printed it, and it carries
+// that page's URL and evidence with it, so applyLegalGate judges it exactly as
+// it judges a profile-lane field. It fills only what is ABSENT: a field the
+// profile lane produced and the gate kept is the more specific answer and
+// stands.
+//
+// Called AFTER applyLegalGate on purpose. The gate abstains wholesale when the
+// census cannot say which entity the company is, and filling from a census
+// that was just judged untrustworthy would reintroduce exactly what the
+// abstention withheld.
+func fillLegalTrioFromCensus(fields []evidencedField, entities []corpusLegalEntity, pageKind map[string]crmcontracts.SiteReadPageKind, abstained bool) []evidencedField {
+	// One entity, or the company's legal identity is not settled and the
+	// abstention owns this decision rather than us.
+	if abstained || len(entities) != 1 {
+		return fields
+	}
+	entity := entities[0]
+	// Only a legal page speaks for legal identity — the same authority test
+	// applyLegalGate applies, so a census sighting from anywhere else cannot
+	// enter through this door either.
+	if pageKind[entity.SourceURL] != crmcontracts.SiteReadPageKindImpressum || !legalAuthorityPage(entity.SourceURL) {
+		return fields
+	}
+	present := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		present[f.Field] = true
+	}
+	out := fields
+	for field, value := range map[string]string{
+		string(crmcontracts.ColdStartFieldFieldLegalName):         entity.Name,
+		string(crmcontracts.ColdStartFieldFieldRegisteredAddress): entity.RegisteredAddress,
+		string(crmcontracts.ColdStartFieldFieldRegisterVat):       entity.RegisterNumber,
+	} {
+		if present[field] || strings.TrimSpace(value) == "" {
+			continue
+		}
+		out = append(out, evidencedField{
+			Field:           field,
+			Value:           value,
+			EvidenceSnippet: entity.EvidenceSnippet,
+			SourceURL:       entity.SourceURL,
+			// The census gates on the page rather than scoring, so there is
+			// no model confidence to carry. Full confidence states what is
+			// true of it: the page printed this, verbatim, and it was checked.
+			Confidence: 1,
+		})
+	}
+	return out
+}
+
 // legalEntityDetail counts how much of an entity block was actually
 // printed — the tie-break when the same entity is seen twice.
 func legalEntityDetail(entity corpusLegalEntity) int {

--- a/backend/internal/compose/sitecorpuslegal.go
+++ b/backend/internal/compose/sitecorpuslegal.go
@@ -184,28 +184,45 @@ func fillLegalTrioFromCensus(fields []evidencedField, entities []corpusLegalEnti
 	for _, f := range fields {
 		present[f.Field] = true
 	}
+	// A FIXED order, not a map's. These fields end up in the proposal whose
+	// JSON is hashed, so iterating a map would give identical evidence a
+	// different hash on every run.
 	out := fields
-	for field, value := range map[string]string{
-		string(crmcontracts.ColdStartFieldFieldLegalName):         entity.Name,
-		string(crmcontracts.ColdStartFieldFieldRegisteredAddress): entity.RegisteredAddress,
-		string(crmcontracts.ColdStartFieldFieldRegisterVat):       entity.RegisterNumber,
+	for _, candidate := range []struct {
+		field string
+		value string
+	}{
+		{string(crmcontracts.ColdStartFieldFieldLegalName), entity.Name},
+		{string(crmcontracts.ColdStartFieldFieldRegisteredAddress), entity.RegisteredAddress},
+		{string(crmcontracts.ColdStartFieldFieldRegisterVat), entity.RegisterNumber},
 	} {
-		if present[field] || strings.TrimSpace(value) == "" {
+		if present[candidate.field] || strings.TrimSpace(candidate.value) == "" {
 			continue
 		}
 		out = append(out, evidencedField{
-			Field:           field,
-			Value:           value,
+			Field:           candidate.field,
+			Value:           candidate.value,
 			EvidenceSnippet: entity.EvidenceSnippet,
 			SourceURL:       entity.SourceURL,
-			// The census gates on the page rather than scoring, so there is
-			// no model confidence to carry. Full confidence states what is
-			// true of it: the page printed this, verbatim, and it was checked.
-			Confidence: 1,
+			Confidence:      censusFieldConfidence,
 		})
 	}
 	return out
 }
+
+// censusFieldConfidence is what a census-filled field carries.
+//
+// The census does not score: it checks the value against the page that
+// printed it and keeps it or drops it. So this is not a model's number, and
+// the honest question is what a consumer of the field should do with it.
+//
+// 1 is right for the same reason the profile lane's own legal trio arrives at
+// 1: these are the hard-gated, verbatim fields, matched against the page
+// rather than judged. A lower number would read as doubt about a value that
+// was checked more strictly than any scored field, and would fall under the
+// 0.55 cold-start floor that decides whether a human is shown the field at
+// all — withholding evidence the page plainly printed.
+const censusFieldConfidence = 1
 
 // legalEntityDetail counts how much of an entity block was actually
 // printed — the tie-break when the same entity is seen twice.

--- a/backend/internal/compose/sitecorpuslegal_test.go
+++ b/backend/internal/compose/sitecorpuslegal_test.go
@@ -295,3 +295,29 @@ func TestCensusFillAddsNothingWhenTheCensusHasNothing(t *testing.T) {
 		t.Fatalf("want just the legal name, got %v", out)
 	}
 }
+
+// TestCensusFillIsDeterministic pins the field order.
+//
+// These fields reach the proposal whose JSON is hashed, so iterating a Go map
+// — which the first version of this did — gave identical evidence a different
+// hash on each run.
+func TestCensusFillIsDeterministic(t *testing.T) {
+	const impressum = "https://example.com/impressum"
+	kinds := map[string]crmcontracts.SiteReadPageKind{impressum: crmcontracts.SiteReadPageKindImpressum}
+	entities := []corpusLegalEntity{{
+		Name: "Order GmbH", RegisteredAddress: "Weg 1 11111 Ort", RegisterNumber: "HRB 999",
+		EvidenceSnippet: "Order GmbH Weg 1 11111 Ort HRB 999", SourceURL: impressum,
+	}}
+	want := []string{"legal_name", "registered_address", "register_vat"}
+	for range 20 {
+		out := fillLegalTrioFromCensus(nil, entities, kinds, false)
+		if len(out) != len(want) {
+			t.Fatalf("got %d fields, want %d", len(out), len(want))
+		}
+		for i, field := range want {
+			if out[i].Field != field {
+				t.Fatalf("field %d is %q, want %q — the order is not stable", i, out[i].Field, field)
+			}
+		}
+	}
+}

--- a/backend/internal/compose/sitecorpuslegal_test.go
+++ b/backend/internal/compose/sitecorpuslegal_test.go
@@ -6,6 +6,8 @@ package compose
 import (
 	"strings"
 	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 )
 
 // A group's legal notice states the same entity more than once: every
@@ -164,5 +166,132 @@ func TestLegalAbstentionNamesTheCauseThatFired(t *testing.T) {
 	}
 	if strings.Contains(legalWarningCensusIncomplete, "more than one entity") {
 		t.Errorf("the incomplete-census warning must claim nothing about the number of entities: %q", legalWarningCensusIncomplete)
+	}
+}
+
+// TestCensusFillsTheAddressTheProfileLaneMissed is the fix for the gap that
+// left 136 of the demo dataset's 190 companies with no address at all.
+//
+// The two legal lanes read the same page and disagree. The census reads the
+// whole page; the profile lane reads a bounded excerpt and gates against the
+// single passage the model cited. communicode.de's census carried
+// "Wittekindstr. 1a, 45131 Essen" while its profile lane dropped the same
+// address for citing a neighbouring passage, so the field never existed.
+func TestCensusFillsTheAddressTheProfileLaneMissed(t *testing.T) {
+	const impressum = "https://example.com/impressum"
+	kinds := map[string]crmcontracts.SiteReadPageKind{
+		impressum: crmcontracts.SiteReadPageKindImpressum,
+	}
+	entities := []corpusLegalEntity{{
+		Name:              "communicode GmbH",
+		RegisteredAddress: "Wittekindstr. 1a, 45131 Essen",
+		RegisterNumber:    "HRB 37643",
+		EvidenceSnippet:   "Impressum communicode GmbH, Wittekindstr. 1a in 45131 Essen",
+		SourceURL:         impressum,
+	}}
+	// The profile lane produced only the display name: its legal trio was
+	// dropped, which is the real state this replays.
+	fields := []evidencedField{{Field: "display_name", Value: "communicode", SourceURL: impressum, Confidence: 1}}
+
+	out := fillLegalTrioFromCensus(fields, entities, kinds, false)
+	got := map[string]string{}
+	for _, f := range out {
+		got[f.Field] = f.Value
+	}
+	if got["registered_address"] != "Wittekindstr. 1a, 45131 Essen" {
+		t.Errorf("registered_address = %q, want the address the census proved", got["registered_address"])
+	}
+	if got["legal_name"] != "communicode GmbH" {
+		t.Errorf("legal_name = %q", got["legal_name"])
+	}
+	if got["register_vat"] != "HRB 37643" {
+		t.Errorf("register_vat = %q", got["register_vat"])
+	}
+	// Every filled field must carry the evidence and the page, so the legal
+	// gate can judge it exactly as it judges a profile-lane field.
+	for _, f := range out {
+		if f.Field == "display_name" {
+			continue
+		}
+		if f.EvidenceSnippet == "" || f.SourceURL != impressum {
+			t.Errorf("%s arrived without evidence or a source page", f.Field)
+		}
+	}
+}
+
+// TestCensusFillNeverOverwritesTheProfileLane — a field the profile lane
+// produced and the gate kept is the more specific answer and stands.
+func TestCensusFillNeverOverwritesTheProfileLane(t *testing.T) {
+	const impressum = "https://example.com/impressum"
+	kinds := map[string]crmcontracts.SiteReadPageKind{impressum: crmcontracts.SiteReadPageKindImpressum}
+	entities := []corpusLegalEntity{{
+		Name: "Census GmbH", RegisteredAddress: "Census Weg 1 12345 Ort",
+		EvidenceSnippet: "Census GmbH Census Weg 1 12345 Ort", SourceURL: impressum,
+	}}
+	fields := []evidencedField{{
+		Field: "registered_address", Value: "Profile Strasse 2 54321 Stadt",
+		EvidenceSnippet: "Profile Strasse 2 54321 Stadt", SourceURL: impressum, Confidence: 0.9,
+	}}
+	out := fillLegalTrioFromCensus(fields, entities, kinds, false)
+	count := 0
+	for _, f := range out {
+		if f.Field != "registered_address" {
+			continue
+		}
+		count++
+		if f.Value != "Profile Strasse 2 54321 Stadt" {
+			t.Errorf("the profile lane's value was replaced by %q", f.Value)
+		}
+	}
+	if count != 1 {
+		t.Errorf("registered_address appears %d times, want exactly one", count)
+	}
+}
+
+// TestCensusFillRespectsTheAbstentionAndTheAuthorityRule pins the two ways
+// this must refuse. Filling from a census the gate just judged untrustworthy
+// would put back exactly what the abstention withheld, and a sighting from a
+// page that is not a legal notice must not speak for legal identity.
+func TestCensusFillRespectsTheAbstentionAndTheAuthorityRule(t *testing.T) {
+	const impressum = "https://example.com/impressum"
+	entity := corpusLegalEntity{
+		Name: "Anything GmbH", RegisteredAddress: "Irgendwo 1 11111 Ort",
+		EvidenceSnippet: "Anything GmbH Irgendwo 1 11111 Ort", SourceURL: impressum,
+	}
+	legalKinds := map[string]crmcontracts.SiteReadPageKind{impressum: crmcontracts.SiteReadPageKindImpressum}
+
+	if got := fillLegalTrioFromCensus(nil, []corpusLegalEntity{entity}, legalKinds, true); len(got) != 0 {
+		t.Error("an abstained read was filled from the census it abstained on")
+	}
+	two := []corpusLegalEntity{entity, {Name: "Other GmbH", SourceURL: impressum}}
+	if got := fillLegalTrioFromCensus(nil, two, legalKinds, false); len(got) != 0 {
+		t.Error("an unsettled census with two entities was used to fill legal identity")
+	}
+	// A contact page is not legal authority, however plainly it prints an address.
+	contactOnly := map[string]crmcontracts.SiteReadPageKind{
+		impressum: crmcontracts.SiteReadPageKindContact,
+	}
+	if got := fillLegalTrioFromCensus(nil, []corpusLegalEntity{entity}, contactOnly, false); len(got) != 0 {
+		t.Error("a non-legal page was allowed to state the company's legal identity")
+	}
+	// And a deep path is content ABOUT a legal page, not one.
+	deep := entity
+	deep.SourceURL = "https://example.com/a/b/c/impressum"
+	deepKinds := map[string]crmcontracts.SiteReadPageKind{deep.SourceURL: crmcontracts.SiteReadPageKindImpressum}
+	if got := fillLegalTrioFromCensus(nil, []corpusLegalEntity{deep}, deepKinds, false); len(got) != 0 {
+		t.Error("a deep-path legal page was treated as the company's own")
+	}
+}
+
+// TestCensusFillAddsNothingWhenTheCensusHasNothing — an entity stating a name
+// and no details fills only the name; the absent details stay absent rather
+// than becoming empty fields.
+func TestCensusFillAddsNothingWhenTheCensusHasNothing(t *testing.T) {
+	const impressum = "https://example.com/impressum"
+	kinds := map[string]crmcontracts.SiteReadPageKind{impressum: crmcontracts.SiteReadPageKindImpressum}
+	entities := []corpusLegalEntity{{Name: "Bare GmbH", SourceURL: impressum, EvidenceSnippet: "Bare GmbH"}}
+	out := fillLegalTrioFromCensus(nil, entities, kinds, false)
+	if len(out) != 1 || out[0].Field != "legal_name" {
+		t.Fatalf("want just the legal name, got %v", out)
 	}
 }

--- a/backend/internal/compose/sitereaddebug.go
+++ b/backend/internal/compose/sitereaddebug.go
@@ -168,7 +168,10 @@ func siteReadDebugRun(ctx context.Context, opts SiteReadDebugOptions, crawler *s
 
 	// Read the cause before the enrichment rewrites the census the gate judged.
 	legalWarning := legalAbstentionOf(extraction.merged.entities, extraction.legalCensusIncomplete).warning()
-	mergedFields, _, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
+	kinds := pageKindsOf(crawl.Pages)
+	mergedFields, abstained, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, kinds, extraction.legalCensusIncomplete)
+	// What the census proved fills what the profile lane's excerpt missed.
+	mergedFields = fillLegalTrioFromCensus(mergedFields, extraction.merged.entities, kinds, abstained)
 	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, mergedFields)
 	extract.reportDrops(ctx, laneLegal, legalDrops)
 	if legalWarning != "" {


### PR DESCRIPTION
Company addresses are empty on **189 of 190** crawled companies. #1800 fixed
three evidence gates and did not fix this, because the cause was somewhere
else: the two legal lanes never told each other what they found.

## What actually happens

The **census** (`sitepageentities.go`) reads the whole legal page and gates
each detail with `groundedDetail`. The **profile lane** (`siteprofile.go`)
reads a bounded excerpt and gates the value against the single passage the
model cited.

On `communicode.de` the census carried the address on its legal entity:

```json
{"name": "communicode GmbH",
 "registered_address": "Wittekindstr. 1a 45131 Essen /NRW Deutschland",
 "register_number": "HRB 37643"}
```

...while the profile lane dropped **the same address** as
`value_not_in_snippet` for citing a neighbouring passage. `registered_address`
— the field the dataset actually reads — was never written.

`enrichLegalEntitiesFromProfile` already shares values the other way, so a
human is not asked to retype a VAT number one lane recovered.
`fillLegalTrioFromCensus` is the missing direction.

## Why this is not a relaxed gate

It adds nothing unevidenced. Every value it copies **already passed the
census's own no-guess gate** against the page that printed it, and it carries
that page's URL and evidence snippet, so `applyLegalGate` judges it exactly as
it judges a profile-lane field. It fills only what is **absent** — a field the
profile lane produced and the gate kept is the more specific answer and stands.

Three refusals are pinned by tests, because each is a way this could have
become a hole:

| Refuses when | Why |
|---|---|
| the gate abstained | filling from a census just judged untrustworthy would put back exactly what the abstention withheld |
| the census has ≠1 entity | if it cannot say which company this is, neither can we |
| the page fails `legalAuthorityPage` | a contact page is not legal authority however plainly it prints an address; a deep path is content *about* a legal page |

## Verified against the live sites, not just the tests

Five companies that had no address, re-crawled with this build:

| company | result |
|---|---|
| `communicode.de` | ✅ `Wittekindstr. 1a 45131 Essen /NRW Deutschland` |
| `fact-finder.com` | ✅ `Habermehlstr. 17 75172 Pforzheim Germany` |
| `doofinder.com` | ✅ `Madrid 28037 Rufino González 23 bis, 1º` |
| `laudert.com` | correctly abstains — two entities |
| `fis-gmbh.de` | correctly abstains — two entities |

The two abstentions are the feature working: each Impressum names both the KG
and its managing `Verwaltungsgesellschaft`, so the census cannot choose and the
trio is withheld.

`doofinder.com` also confirms the `aviso-legal` classifier from #1800 — its
address comes off a Spanish legal notice.

## Gates

`backend/make check` exit 0, `0 issues`, composition reproducible.
`make craft-static`, `make rls-store-path`, `make no-jurisdiction` all pass.
Four new tests on the fill and its three refusals.

`make lint-modules` hit the documented stale-cache/concurrent-run condition
(`golangci answered from another checkout`) — the `lint` stage itself reported
`0 issues`, and no file in this diff is outside `backend/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills missing legal legal_name, registered_address, and register_vat in company profiles from the legal census when the profile lane drops them. Previously these fields often stayed empty; now we fill absent values from authoritative census evidence after the legal gate.

- Introduces fillLegalTrioFromCensus and calls it after applyLegalGate in deepreadreport, deepreadtriage, and the debug path. Copies only absent fields, carries the census evidence and source URL, and uses confidence=1 (hard-gated verbatim values), emitting fields in a fixed order to keep proposal hashes stable.
- Safety: does nothing if the gate abstained; requires exactly one census entity; requires a legal authority page (not contact pages or deep paths). Never overwrites a kept profile value.
- Tests pin the fill, the three refusals, and deterministic field order.

<sup>Written for commit 28173bc478c4584b140599731013e166544328f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Legal profiles can now be enriched with missing company name, registered address, and registration or VAT details from authoritative census evidence.
  * Existing legal information is preserved when already available.
  * Supporting source URLs and evidence are included for newly added details.
  * Data is not filled when results are uncertain, abstained, or sourced from non-authoritative pages.
  * Legal information is now applied consistently across reports, triage, and profile enrichment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->