### PR TITLE
refactor(identity): the authorization satellites drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/extingressauthority.go
+++ b/backend/internal/compose/extingressauthority.go
@@ -118,13 +118,27 @@ func extensionMemberConsented(ctx context.Context, pool *pgxpool.Pool, unit stri
 	}
 	var consented bool
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		// The join to app_user is the scope, and it is load-bearing rather than
+		// decorative. extension_secret carried a tenant until ADR-0091 §8 phase
+		// D and does not now, so without this the read answers about a member of
+		// SOME installation — a consent row saying "that person asked us to act
+		// for them" about somebody this installation cannot act for at all.
+		//
+		// The consequence is not a leak, because the authority read below still
+		// refuses: it is a WRONGLY CLASSIFIED refusal. Consent would answer yes,
+		// the ingest would walk on, and the unit would be handed "the core could
+		// not land this record" — an unclassified failure it can neither act on
+		// nor report — for a question that had a clean ErrForbidden two steps
+		// earlier. app_user is where the tenant still lives, so that is where
+		// the scope comes from.
 		return tx.QueryRow(ctx, `
 			SELECT EXISTS (
-				SELECT 1 FROM extension_secret
-				WHERE extension_name = $1
-				  AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
-				  AND user_id = $2
-				  AND key = ANY($3)
+				SELECT 1 FROM extension_secret s
+				  JOIN app_user u ON u.id = s.user_id
+				WHERE s.extension_name = $1
+				  AND s.user_id = $2
+				  AND s.key = ANY($3)
+				  AND u.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 			)`, unit, member, declared).Scan(&consented)
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -49,8 +49,8 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 		t.Fatalf("pre-grant search: %v %+v", err, page.Hits)
 	}
 
-	grantID := e.Seed(t, `INSERT INTO record_grant (id, workspace_id, record_type, record_id, subject_type, subject_id, access, granted_by)
-		VALUES ($1, $2, 'person', $3, 'user', $4, 'read', $5)`, foreign, e.Rep1, e.Rep3)
+	grantID := e.SeedID(t, `INSERT INTO record_grant (id, record_type, record_id, subject_type, subject_id, access, granted_by)
+		VALUES ($1, 'person', $2, 'user', $3, 'read', $4)`, foreign, e.Rep1, e.Rep3)
 
 	// After: the direct read, the search branch, and the link probe all
 	// see the record through the SAME widened predicate.

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -89,14 +89,14 @@ func Setup(t *testing.T) *Env {
 	}
 	for _, team := range []ids.UUID{e.Team1, e.Team2} {
 		if _, err := owner.Exec(ctx,
-			`INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, $3)`, team, e.WS, team.String()); err != nil {
+			`INSERT INTO team (id, name) VALUES ($1, $2)`, team, team.String()); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for user, team := range map[ids.UUID]ids.UUID{e.Rep1: e.Team1, e.Rep2: e.Team1, e.Rep3: e.Team2} {
 		if _, err := owner.Exec(ctx,
-			`INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)`,
-			e.WS, team, user); err != nil {
+			`INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)`,
+			team, user); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -274,9 +274,8 @@ func TestOrgRollupRestrictedNodeDisclosedAndGrantRestores(t *testing.T) {
 			pre.RestrictedExcluded)
 	}
 
-	e.WsExec(t, `INSERT INTO record_grant (workspace_id, record_type, record_id, subject_type, subject_id, access, granted_by)
-		VALUES ($1, 'organization', $2, 'user', $3, 'read', $3)`,
-		e.WS, child, e.Rep1)
+	e.WsExec(t, `INSERT INTO record_grant (record_type, record_id, subject_type, subject_id, access, granted_by)
+		VALUES ('organization', $1, 'user', $2, 'read', $2)`, child, e.Rep1)
 
 	post, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree", time.Now)
 	if err != nil {

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -64,7 +64,7 @@ func seedQuotaTeam(t *testing.T, e *apptest.AppEnv, name string) string {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	if err := tx.QueryRow(ctx,
-		`INSERT INTO team (workspace_id, name) VALUES ($1, $2) RETURNING id`, wsID, name).Scan(&teamID); err != nil {
+		`INSERT INTO team (name) VALUES ($1) RETURNING id`, name).Scan(&teamID); err != nil {
 		t.Fatalf("insert team: %v", err)
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -92,9 +92,9 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 		t, e, wsA,
 		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'rep@example.com', 'Rep One')`, rep, wsA),
 		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'bob@example.com', 'Bob Two')`, bob, wsA),
-		stmt(`INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, 'Deal Desk')`, deskTeam, wsA),
-		stmt(`INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($2, $1, $3)`, deskTeam, wsA, rep),
-		stmt(`INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($2, $1, $3)`, deskTeam, wsA, bob),
+		stmt(`INSERT INTO team (id, name) VALUES ($1, 'Deal Desk')`, deskTeam),
+		stmt(`INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)`, deskTeam, rep),
+		stmt(`INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)`, deskTeam, bob),
 	)
 
 	// A second tenant with its own member — its rows must never surface

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -84,12 +84,12 @@ func SetupSearch(t *testing.T) *SearchEnv {
 		}
 	}
 	for _, tm := range []ids.UUID{e.Team1, e.Team2} {
-		if _, err := owner.Exec(ctx, `INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, $3)`, tm, e.WS, tm.String()); err != nil {
+		if _, err := owner.Exec(ctx, `INSERT INTO team (id, name) VALUES ($1, $2)`, tm, tm.String()); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for u, tm := range map[ids.UUID]ids.UUID{e.Rep1: e.Team1, e.Rep3: e.Team2} {
-		if _, err := owner.Exec(ctx, `INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)`, e.WS, tm, u); err != nil {
+		if _, err := owner.Exec(ctx, `INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)`, tm, u); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/compose/integration/seatmatrix_integration_test.go
+++ b/backend/internal/compose/integration/seatmatrix_integration_test.go
@@ -287,9 +287,8 @@ func teamFixture(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var id string
 	if err := e.Owner.QueryRow(t.Context(), `
-		INSERT INTO team (workspace_id, name)
-		VALUES ((SELECT id FROM workspace WHERE slug = $1), 'Matrix Team') RETURNING id::text`,
-		e.Slug).Scan(&id); err != nil {
+		INSERT INTO team (name)
+		VALUES ('Matrix Team') RETURNING id::text`).Scan(&id); err != nil {
 		t.Fatalf("seed team: %v", err)
 	}
 	return id

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -98,12 +98,12 @@ func setupForecast(t *testing.T) *forecastEnv {
 		}
 	}
 	for _, tm := range []ids.UUID{e.Team1, e.Team2} {
-		if _, err := owner.Exec(ctx, `INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, $3)`, tm, e.WS, tm.String()); err != nil {
+		if _, err := owner.Exec(ctx, `INSERT INTO team (id, name) VALUES ($1, $2)`, tm, tm.String()); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for u, tm := range map[ids.UUID]ids.UUID{e.Rep1: e.Team1, e.Rep3: e.Team2} {
-		if _, err := owner.Exec(ctx, `INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)`, e.WS, tm, u); err != nil {
+		if _, err := owner.Exec(ctx, `INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)`, tm, u); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -210,10 +210,9 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 		// `granted_by` moves to the caller, who is accountable for the access
 		// now in force.
 		if out, err = scanGrant(tx.QueryRow(ctx, `
-			INSERT INTO record_grant (workspace_id, record_type, record_id, subject_type, subject_id,
+			INSERT INTO record_grant (record_type, record_id, subject_type, subject_id,
 			                          access, granted_by, reason, expires_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, $2, $3, $4, $5, $6, $7, $8)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 			ON CONFLICT (record_type, record_id, subject_type, subject_id) DO UPDATE
 			SET access     = EXCLUDED.access,
 			    expires_at = EXCLUDED.expires_at,

--- a/backend/internal/modules/identity/onboarding.go
+++ b/backend/internal/modules/identity/onboarding.go
@@ -307,9 +307,9 @@ func (s *OnboardingStore) createOnboardingState(
 	completed := in.Step == OnboardingStepComplete
 	var storedDraft []byte
 	row := tx.QueryRow(ctx, `INSERT INTO onboarding_wizard_state
-		(workspace_id, user_id, path, step, source_mode, website_url, site_read_id,
+		(user_id, path, step, source_mode, website_url, site_read_id,
 		 company_draft, selected_fact_keys, voice_skipped, connect_skipped, completed_at)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4,
+		VALUES ($1, $2, $3, $4,
 		        $5, $6, $7, $8, $9, $10, CASE WHEN $11 THEN now() ELSE NULL END)
 		RETURNING id, path, step, source_mode, website_url, site_read_id, company_draft,
 		 selected_fact_keys, voice_skipped, connect_skipped, version, completed_at, created_at, updated_at`,

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -176,7 +176,6 @@ type ListTeamsInput struct {
 
 type teamRow struct {
 	ID          ids.UUID
-	WorkspaceID ids.UUID
 	Name        string
 	MemberCount int
 	CreatedAt   time.Time
@@ -185,7 +184,7 @@ type teamRow struct {
 // teamColumns is the roster team SELECT list: the active-member count
 // joins app_user so a suspended/deactivated seat's membership row never
 // inflates the count (mirrors the active-only gate on ListUsers).
-const teamColumns = `t.id, t.workspace_id, t.name, COUNT(u.id) AS member_count, t.created_at`
+const teamColumns = `t.id, t.name, COUNT(u.id) AS member_count, t.created_at`
 
 const teamFromJoin = `
 	FROM team t
@@ -195,7 +194,6 @@ const teamFromJoin = `
 const listTeamsQuery = `
 	SELECT ` + teamColumns + teamFromJoin + `
 	WHERE t.archived_at IS NULL
-	  AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 	  AND ($1::timestamptz IS NULL OR (t.created_at, t.id) > ($1, $2))
 	GROUP BY t.id
 	ORDER BY t.created_at, t.id
@@ -204,7 +202,6 @@ const listTeamsQuery = `
 const listTeamsFilteredQuery = `
 	SELECT ` + teamColumns + teamFromJoin + `
 	WHERE t.archived_at IS NULL AND t.name ILIKE $1
-	  AND t.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 	  AND ($2::timestamptz IS NULL OR (t.created_at, t.id) > ($2, $3))
 	GROUP BY t.id
 	ORDER BY t.created_at, t.id
@@ -212,13 +209,17 @@ const listTeamsFilteredQuery = `
 
 func scanTeam(r pgx.Row) (teamRow, error) {
 	var tm teamRow
-	err := r.Scan(&tm.ID, &tm.WorkspaceID, &tm.Name, &tm.MemberCount, &tm.CreatedAt)
+	err := r.Scan(&tm.ID, &tm.Name, &tm.MemberCount, &tm.CreatedAt)
 	return tm, err
 }
 
-// ListTeams returns one keyset page of the caller's workspace's active
-// teams, bounded by each query's own workspace predicate, with each team's
-// active-membership count, optionally filtered by in.Q.
+// ListTeams returns one keyset page of the installation's active teams, with
+// each team's active-membership count, optionally filtered by in.Q.
+//
+// No workspace predicate: team carries no tenant since ADR-0091 §8 phase D. The
+// MEMBER count still narrows to this installation's people, because the join to
+// app_user does — that table keeps its tenant until the last slice of this
+// group.
 func (s *Service) ListTeams(ctx context.Context, in ListTeamsInput) ([]teamRow, storekit.Page, error) {
 	return listRosterPage(ctx, s.db, in.Q, in.Cursor, in.Limit, rosterQuery[teamRow]{
 		plain:     listTeamsQuery,

--- a/backend/internal/modules/identity/roster_test.go
+++ b/backend/internal/modules/identity/roster_test.go
@@ -209,11 +209,9 @@ func highestPlaceholder(query string) int {
 
 func TestWireTeam(t *testing.T) {
 	id := ids.NewV7()
-	ws := ids.NewV7()
 	created := time.Date(2026, 6, 2, 9, 30, 0, 0, time.UTC)
 	got := wireTeam(teamRow{
 		ID:          id,
-		WorkspaceID: ws,
 		Name:        "Deal Desk",
 		MemberCount: 3,
 		CreatedAt:   created,

--- a/backend/internal/modules/people/captureprivacy_integration_test.go
+++ b/backend/internal/modules/people/captureprivacy_integration_test.go
@@ -82,8 +82,8 @@ func setupCapturePrivacy(t *testing.T) *privacyEnv {
 		t.Fatal(err)
 	}
 	if _, err := conn.Exec(ctx,
-		`INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, 'Sales')`,
-		e.team, e.ws); err != nil {
+		`INSERT INTO team (id, name) VALUES ($1, 'Sales')`,
+		e.team); err != nil {
 		t.Fatal(err)
 	}
 	for _, u := range []struct {
@@ -99,8 +99,7 @@ func setupCapturePrivacy(t *testing.T) *privacyEnv {
 	// Owner and teammate share a team; the admin does not need one.
 	for _, u := range []ids.UUID{e.owner, e.teammate} {
 		if _, err := conn.Exec(ctx,
-			`INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)`,
-			e.ws, e.team, u); err != nil {
+			`INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)`, e.team, u); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/platform/extsecrets/scope.go
+++ b/backend/internal/platform/extsecrets/scope.go
@@ -21,13 +21,15 @@ import (
 )
 
 // whereScope is the prefix every row-addressing statement shares: this unit,
-// this tenant. The workspace predicate is the statement's OWN — core 0217
-// (ADR-0091) retired every tenant-isolation policy, so nothing behind this
-// query scopes it — and it is also what lets the planner reach the partial
-// unique indexes, which are keyed (extension_name, workspace_id, …).
+// this key. There is no tenant term because extension_secret carries no tenant
+// since ADR-0091 §8 phase D, and the partial unique indexes it has to reach are
+// keyed (extension_name, user_id, key) and (extension_name, key) — neither
+// names a workspace, so naming one here would only cost the index.
+//
+// What still refuses a user from another installation is requireMember, on
+// app_user, which is where the tenant lives now.
 const whereScope = `
 	WHERE extension_name = $1
-	  AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 	  AND key = $2
 	  `
 
@@ -132,13 +134,13 @@ func (s *store) lockKey(ctx context.Context, tx pgx.Tx, user *ids.UserID, key st
 // Postgres infers a partial unique index.
 func (s *store) upsert(ctx context.Context, tx pgx.Tx, user *ids.UserID, key string, ref keyvault.Ref) error {
 	const workspaceScoped = `
-		INSERT INTO extension_secret (extension_name, workspace_id, user_id, key, vault_ref)
-		VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, NULL, $2, $3)
+		INSERT INTO extension_secret (extension_name, user_id, key, vault_ref)
+		VALUES ($1, NULL, $2, $3)
 		ON CONFLICT (extension_name, key) WHERE user_id IS NULL
 		DO UPDATE SET vault_ref = EXCLUDED.vault_ref, updated_at = now()`
 	const userScoped = `
-		INSERT INTO extension_secret (extension_name, workspace_id, user_id, key, vault_ref)
-		VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, $3, $4)
+		INSERT INTO extension_secret (extension_name, user_id, key, vault_ref)
+		VALUES ($1, $2, $3, $4)
 		ON CONFLICT (extension_name, user_id, key) WHERE user_id IS NOT NULL
 		DO UPDATE SET vault_ref = EXCLUDED.vault_ref, updated_at = now()`
 

--- a/backend/internal/platform/extsecrets/store.go
+++ b/backend/internal/platform/extsecrets/store.go
@@ -41,8 +41,10 @@ import (
 var (
 	// ErrUserOutsideWorkspace refuses a user-scoped operation naming somebody
 	// who is not a member of the calling workspace. The composite FK on
-	// extension_secret refuses such a row too, but as a constraint violation
-	// nobody can read; the store asks first and answers by name.
+	// extension_secret used to refuse such a row too — as a constraint violation
+	// nobody could read — and since ADR-0091 §8 phase D took the tenant column
+	// off that table, this check is the ONLY thing refusing it. It was always
+	// the one that answered by name; it is now also the one that answers.
 	ErrUserOutsideWorkspace = errors.New("extsecrets: that user is not a member of this workspace")
 
 	// ErrInvalidUserID refuses a UserID that is not a canonical UUID. The

--- a/backend/internal/platform/extsecrets/store_integration_test.go
+++ b/backend/internal/platform/extsecrets/store_integration_test.go
@@ -127,8 +127,8 @@ func (e *env) currentRef(t *testing.T, ws ids.UUID, unit, key string) keyvault.R
 	var ref string
 	err := e.owner.QueryRow(ctx, `
 		SELECT vault_ref FROM extension_secret
-		 WHERE extension_name = $1 AND workspace_id = $2 AND key = $3 AND user_id IS NULL`,
-		unit, ws, key).Scan(&ref)
+		 WHERE extension_name = $1 AND key = $2 AND user_id IS NULL`,
+		unit, key).Scan(&ref)
 	if err != nil {
 		t.Fatalf("reading the mapping row for %s/%s: %v", unit, key, err)
 	}

--- a/backend/migrations/core/1787123080_authz_drop_workspace.down.sql
+++ b/backend/migrations/core/1787123080_authz_drop_workspace.down.sql
@@ -1,0 +1,56 @@
+-- Reverse of 1787123080: the authorization satellites carry the tenant column
+-- again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE team ADD COLUMN workspace_id uuid;
+ALTER TABLE team_membership ADD COLUMN workspace_id uuid;
+ALTER TABLE record_grant ADD COLUMN workspace_id uuid;
+ALTER TABLE extension_secret ADD COLUMN workspace_id uuid;
+ALTER TABLE onboarding_wizard_state ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'team', 'team_membership',
+    'record_grant', 'extension_secret', 'onboarding_wizard_state'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE team ADD CONSTRAINT team_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE team_membership ADD CONSTRAINT team_membership_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE record_grant ADD CONSTRAINT record_grant_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE extension_secret ADD CONSTRAINT extension_secret_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE CASCADE;
+ALTER TABLE onboarding_wizard_state ADD CONSTRAINT onboarding_wizard_state_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+-- UNIQUE (id), which is what the migration before this one left: phase B
+-- collapsed it from its composite form and this restores that state.
+ALTER TABLE team ADD CONSTRAINT uq_team_ws_id UNIQUE (id);
+
+DROP INDEX idx_record_grant_record;
+DROP INDEX idx_record_grant_subject;
+DROP INDEX extension_secret_workspace_user;
+
+CREATE INDEX idx_record_grant_record ON record_grant (workspace_id, record_type, record_id);
+CREATE INDEX idx_record_grant_subject ON record_grant (workspace_id, subject_type, subject_id);
+CREATE INDEX extension_secret_workspace_user ON extension_secret (workspace_id, user_id);

--- a/backend/migrations/core/1787123080_authz_drop_workspace.up.sql
+++ b/backend/migrations/core/1787123080_authz_drop_workspace.up.sql
@@ -1,0 +1,53 @@
+-- 1787123080: the authorization satellites drop the tenant column
+-- (ADR-0091 §8 phase D).
+--
+-- Five tables that say who someone is and what they may reach:
+--
+--   team, team_membership      the row-scope grouping and its members
+--   record_grant               a record shared with one subject
+--   extension_secret           an extension's per-user or per-install secret
+--   onboarding_wizard_state    how far one human got through setup
+--
+-- Every uniqueness these tables rely on is already tenant-free — phase B did
+-- that — so nothing here changes what may collide. team.name is unique
+-- installation-wide, a record grant is unique by (record, subject), and an
+-- extension secret by (extension, user, key) or (extension, key) for the
+-- install-wide one.
+--
+-- uq_team_ws_id goes with the column: phase B collapsed it to UNIQUE (id), a
+-- second copy of the table's own primary key, kept alive only as a composite FK
+-- target that phase C rewrote away. Verified referenced by no foreign key
+-- before dropping.
+--
+-- role and role_assignment are NOT here, and not because they are hard to
+-- change. THREE SHIPPED MIGRATIONS name role.workspace_id — core/0192,
+-- custom/20260806120000 and custom/20260716130000 — and the RBAC replay suites
+-- re-apply them against a head schema to prove what they wrote. Dropping the
+-- column makes those historical statements unrunnable, so the column and the
+-- suites have to move together, in their own change.
+--
+-- app_user and session are NOT here either. They are what MustWorkspace
+-- ultimately resolves through, and they go last in this group.
+
+ALTER TABLE onboarding_wizard_state DROP CONSTRAINT onboarding_wizard_state_workspace_id_fkey;
+ALTER TABLE onboarding_wizard_state DROP COLUMN workspace_id;
+
+ALTER TABLE extension_secret DROP CONSTRAINT extension_secret_workspace_id_fkey;
+ALTER TABLE extension_secret DROP COLUMN workspace_id;
+
+ALTER TABLE record_grant DROP CONSTRAINT record_grant_workspace_id_fkey;
+ALTER TABLE record_grant DROP COLUMN workspace_id;
+
+ALTER TABLE team_membership DROP CONSTRAINT team_membership_workspace_id_fkey;
+ALTER TABLE team_membership DROP COLUMN workspace_id;
+
+ALTER TABLE team DROP CONSTRAINT uq_team_ws_id;
+ALTER TABLE team DROP CONSTRAINT team_workspace_id_fkey;
+ALTER TABLE team DROP COLUMN workspace_id;
+
+-- The three indexes that led with the column, recreated on what actually
+-- selects rows: the record a grant is about, the subject it is for, and the
+-- user an extension secret belongs to.
+CREATE INDEX idx_record_grant_record ON record_grant (record_type, record_id);
+CREATE INDEX idx_record_grant_subject ON record_grant (subject_type, subject_id);
+CREATE INDEX extension_secret_workspace_user ON extension_secret (user_id);

--- a/backend/tools/seed-demo/users.go
+++ b/backend/tools/seed-demo/users.go
@@ -71,7 +71,7 @@ func seedOrg(ctx context.Context, conn *pgx.Conn, cfg demoConfig, mode runMode) 
 		return fmt.Errorf("resolving the installation's workspace: %w", err)
 	}
 
-	teamIDs, teamsNew, err := ensureTeams(ctx, conn, workspace, cfg.Teams)
+	teamIDs, teamsNew, err := ensureTeams(ctx, conn, cfg.Teams)
 	if err != nil {
 		return err
 	}
@@ -86,13 +86,13 @@ func seedOrg(ctx context.Context, conn *pgx.Conn, cfg demoConfig, mode runMode) 
 	return nil
 }
 
-func ensureTeams(ctx context.Context, conn *pgx.Conn, workspace string, teams []demoTeam) (map[string]string, int, error) {
+func ensureTeams(ctx context.Context, conn *pgx.Conn, teams []demoTeam) (map[string]string, int, error) {
 	ids := map[string]string{}
 	created := 0
 	for _, team := range teams {
 		var id string
 		err := conn.QueryRow(ctx,
-			`SELECT id FROM team WHERE workspace_id = $1 AND name = $2`, workspace, team.Name).Scan(&id)
+			`SELECT id FROM team WHERE name = $1`, team.Name).Scan(&id)
 		switch {
 		case err == nil:
 			ids[team.Ref] = id
@@ -101,8 +101,8 @@ func ensureTeams(ctx context.Context, conn *pgx.Conn, workspace string, teams []
 			return nil, 0, fmt.Errorf("looking up team %q: %w", team.Name, err)
 		}
 		if err := conn.QueryRow(ctx,
-			`INSERT INTO team (workspace_id, name) VALUES ($1, $2) RETURNING id`,
-			workspace, team.Name).Scan(&id); err != nil {
+			`INSERT INTO team (name) VALUES ($1) RETURNING id`,
+			team.Name).Scan(&id); err != nil {
 			return nil, 0, fmt.Errorf("creating team %q: %w", team.Name, err)
 		}
 		ids[team.Ref] = id
@@ -136,8 +136,8 @@ func ensureUsers(ctx context.Context, conn *pgx.Conn, workspace string, cfg demo
 			return created, fmt.Errorf("user %s names team %q, which demo.json does not define", user.Email, user.Team)
 		}
 		if _, err := conn.Exec(ctx,
-			`INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)
-			 ON CONFLICT (team_id, user_id) DO NOTHING`, workspace, teamID, id); err != nil {
+			`INSERT INTO team_membership (team_id, user_id) VALUES ($1, $2)
+			 ON CONFLICT (team_id, user_id) DO NOTHING`, teamID, id); err != nil {
 			return created, fmt.Errorf("adding %s to team %q: %w", user.Email, user.Team, err)
 		}
 	}

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -129,18 +129,18 @@ BEGIN
 
   -- A team with admin + Rep One as members, so the roster picker and the
   -- "who has access" list have a demonstrable, non-trivial membership.
-  INSERT INTO team (workspace_id, name)
-  VALUES (ws, 'DACH Sales')
+  INSERT INTO team (name)
+  VALUES ('DACH Sales')
   ON CONFLICT (name) DO NOTHING;
 
   SELECT id INTO dach_team_id
     FROM team
-    WHERE workspace_id = ws AND name = 'DACH Sales';
+    WHERE name = 'DACH Sales';
 
-  INSERT INTO team_membership (workspace_id, team_id, user_id)
+  INSERT INTO team_membership (team_id, user_id)
   VALUES
-    (ws, dach_team_id, admin_id),
-    (ws, dach_team_id, rep_id)
+    (dach_team_id, admin_id),
+    (dach_team_id, rep_id)
   ON CONFLICT (team_id, user_id) DO NOTHING;
 
   -- A seat with no role_assignment has NO permissions — every object check


### PR DESCRIPTION
Five tables lose `workspace_id` — `team`, `team_membership`, `record_grant`,
`extension_secret`, `onboarding_wizard_state` — and the three indexes that led
with it are narrowed. `uq_team_ws_id` goes with the column: phase B collapsed it
to `UNIQUE (id)`, a second copy of the table's own primary key, referenced by no
foreign key (verified before dropping). Phase D: 20 → 15.

## `role` and `role_assignment` are deliberately not here

I started with all seven and backed out two. **Three shipped migrations name
`role.workspace_id`** — `core/0192`, `custom/20260806120000`,
`custom/20260716130000` — and the RBAC replay suites re-apply those historical
statements against a **head** schema to prove what they wrote:

```
rbac_repair_integration_test.go:98  applying the core/0192 repair:
    ERROR: column role.workspace_id does not exist
```

That only ever worked because the schema had not yet dropped what the migration
names. Fixing it means reworking those suites to roll back to each repair's own
era first — real work, about them rather than about the column. Splitting it out
keeps five tables landing clean instead of holding all seven behind it.

## The consent read gains a join rather than losing a predicate

`extingressauthority.go` read `extension_secret` with **no membership check** —
the tenant column was supplying one implicitly. Without it the read answers
about a member of some other installation.

That is not a leak: the authority read below still refuses. It is a **wrongly
classified** refusal — consent says yes, the ingest walks on, and the unit is
handed `the core could not land this record` for a question that had a clean
`ErrForbidden` two steps earlier. `TestACredentialDepositedInAnotherWorkspaceIsNotConsentHere`
caught exactly that, and its own doc comment had predicted the failure mode.

The scope now comes from `app_user`, which is where the tenant still lives:

```sql
SELECT 1 FROM extension_secret s
  JOIN app_user u ON u.id = s.user_id
 WHERE s.extension_name = $1 AND s.user_id = $2 AND s.key = ANY($3)
   AND u.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
```

`ErrUserOutsideWorkspace`'s comment claimed the composite FK on
`extension_secret` refuses such a row too. It did; it no longer exists. That
check is now the *only* thing refusing it, and the comment says so rather than
naming a guard that is gone.

## Roster

The team list drops its workspace predicate with the column. The **member count**
stays installation-narrow because the join to `app_user` does — the one table in
this group that keeps its tenant until last.

## Verification

- `make check-backend` — exit 0
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor
- `backend/tools/` built separately (second module, not reached by `go build ./...`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops workspace_id from authorization satellites — team, team_membership, record_grant, extension_secret, onboarding_wizard_state — per ADR-0091 §8 phase D. Consent checks now scope via app_user (not extension_secret), and ListTeams becomes installation-wide while member counts still scope via app_user.

- Old vs new behavior
  - Consent lookup: previously filtered extension_secret by workspace; now joins app_user to enforce membership. Side effect: returns ErrForbidden earlier instead of a late unclassified failure.
  - Roster teams: previously WHERE team.workspace_id = current workspace; now no workspace predicate on team, but member_count remains tenant-scoped through app_user.

- Migration and review notes
  - Schema/indexes: drop workspace_id columns and FKs; drop uq_team_ws_id; add indexes: record_grant by (record_type, record_id) and (subject_type, subject_id); extension_secret by (user_id).
  - Code: `extingressauthority` adds the app_user join; identity roster removes the team workspace predicate; `extsecrets` scope/upsert paths drop workspace terms; seeds and tests stop writing workspace_id.
  - Out of scope: role and role_assignment stay unchanged due to shipped migrations that reference role.workspace_id; move with the RBAC replay change later.
  - Migrations: Up removes columns/constraints and recreates indexes. Down restores columns, backfills to the single live workspace, and reinstates FKs and prior indexes.
  - Required: stop writing or filtering by workspace_id on these tables; ensure `extsecrets` user-scoped writes call the membership check before upsert.

<sup>Written for commit 5010f27b494ab5138bc141008424c14f63cc4097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Team and membership data now follows installation-wide rules while active member counts remain workspace-aware.
  * Access to extension secrets and grants is enforced through user membership, improving consistency across workspace contexts.
  * Onboarding and authorization records now use the streamlined data model.
* **Database**
  * Added a migration to remove workspace-specific authorization fields, with rollback support for restoring the previous schema.
* **Reliability**
  * Updated integrations, demo data, and authorization flows to remain compatible with the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->