### PR TITLE
chore(infra): the dev stack runs the Redis the docs promise

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -149,7 +149,11 @@ services:
       retries: 15
 
   redis:
-    image: redis:7@sha256:e9b2e45ecd47fbb69b877cf8d045d5cccaaaed52524b6e098b4abe8212994f73
+    # 7.2 is the newest Redis the product supports
+    # (docs/reference/system-requirements.md): 7.4 left the BSD license
+    # family. renovate.json holds this image below 7.3; digest updates
+    # within the 7.2 tag still flow, which is how patch releases arrive.
+    image: redis:7.2@sha256:6461ca4ac0c5c9d81d53685c3bf76aa81f464a9de6cf3a97b80a1da8d1bb1de4
     # 64 logical dbs, not the default 16. The integration lane gives each package
     # its own db so two packages can never share one — several of them FLUSHDB
     # between tests, which makes a shared db a silent corruption rather than a

--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,12 @@
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "enabled": false
+    },
+    {
+      "description": "The documented supported Redis range tops out at 7.2 (docs/reference/system-requirements.md) — 7.4 left the BSD license family — and the version CI tests must stay inside the range operators are told to run. This cap blocks the 7.4/8.x tag bumps Renovate would otherwise raise; digest updates within the 7.2 tag still flow, which is how 7.2.x patch releases arrive.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["redis"],
+      "allowedVersions": "<7.3"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
The documented supported Redis range tops out at 7.2 (docs/reference/system-requirements.md, #1265), but the compose pin tracked the `redis:7` tag — which resolves to 7.4.10 today — so the one version the product demonstrably ran against sat outside the range operators are told to run.

Two changes make the tested version and the documented range agree, and keep them agreeing:

- `infra/docker-compose.dev.yml` pins `redis:7.2` by its index digest.
- `renovate.json` caps the `redis` docker image below 7.3, so a scheduled bump cannot silently cross the 7.4 license boundary. Digest updates within the 7.2 tag still flow, which is how 7.2.x patch releases arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the dev stack with our documented Redis support by pinning to 7.2 and preventing auto-bumps past 7.2. Previously the stack used `redis:7` (currently 7.4.10), which fell outside the supported range and license; now it uses `redis:7.2` by digest and Renovate caps `redis` to `<7.3`.

**Reviewer notes**
- Verify the pinned digest for `redis:7.2` in `infra/docker-compose.dev.yml`.
- Confirm the Renovate rule scopes only to the `redis` Docker image and sets `allowedVersions: "<7.3"`.
- Patch updates to `redis:7.2` will still arrive via digest updates; dev/CI behavior should remain consistent.

**Rollout**
- Run: `docker compose pull redis && docker compose up -d` to pick up the pinned image.

<sup>Written for commit 830c11d654bc1065a481e9603e1ccef8668a40d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

