### PR TITLE
test(migrations): the seed and ops scripts are checked against the schema they run on

### DIFF
--- a/backend/migrations/scriptschemadrift_integration_test.go
+++ b/backend/migrations/scriptschemadrift_integration_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations
+
+// The seed and ops scripts are build artifacts of the schema, and nothing was
+// checking that they still match it.
+//
+// Every ADR-0091 §8 phase D slice sweeps Go string literals for the column it
+// removes. scripts/*.sql and scripts/*.sh are not Go, so that sweep never sees
+// them: FOUR slices in a row shipped a scripts/seed-dev.sql naming a column
+// that had just been dropped. Each was caught by `live-boot`, the slowest job
+// on the board and the only one that runs the file — and
+// scripts/seed-demo-company.sh, which no job runs at all, was broken on main
+// until somebody read it (#1724).
+//
+// This asserts the property directly, against the migrated schema, in the lane
+// that already has one.
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// scriptRoots are the trees whose SQL is executed against this schema.
+var scriptRoots = []string{"../../scripts", "../../infra"}
+
+var (
+	insertColumns = regexp.MustCompile(`(?is)INSERT\s+INTO\s+([a-z_]+)\s*\(([^)]*)\)`)
+	plainName     = regexp.MustCompile(`^[a-z_]+$`)
+)
+
+// TestEveryScriptNamesColumnsTheSchemaHas parses the INSERT column lists out of
+// every script and checks each name against the live catalog.
+//
+// INSERT lists only, deliberately. An identifier in one is unambiguously a
+// column of the named table, so this fails loudly with no false positives — and
+// catching the INSERTs would have caught all four misses. A predicate
+// (`WHERE x.workspace_id = …`) needs statement boundaries to attribute
+// correctly, and a checker that cried wolf would be turned off, which is worse
+// than one that is narrow.
+func TestEveryScriptNamesColumnsTheSchemaHas(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	resetSchema(t, conn)
+	migrateAll(t, conn)
+
+	columns := schemaColumns(t, conn)
+	scripts := scriptFiles(t)
+	if len(scripts) == 0 {
+		t.Fatal("no scripts found to check — the roots moved and this gate now asserts nothing")
+	}
+
+	for _, path := range scripts {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		for _, m := range insertColumns.FindAllStringSubmatch(string(body), -1) {
+			table := strings.ToLower(m[1])
+			known, isTable := columns[table]
+			if !isTable {
+				// Not a table of this schema: a CTE name, or a table an
+				// extension owns. Nothing to say about its columns.
+				continue
+			}
+			for _, raw := range strings.Split(m[2], ",") {
+				column := strings.TrimSpace(raw)
+				// Anything that is not a bare identifier is a function call or
+				// an expression that has wandered in through the regex.
+				if !plainName.MatchString(column) {
+					continue
+				}
+				if !known[column] {
+					t.Errorf("%s: `INSERT INTO %s` names the column %q, which the migrated schema does not have. "+
+						"A script is a build artifact of the schema; this one no longer matches it.",
+						filepath.Base(path), table, column)
+				}
+			}
+		}
+	}
+}
+
+// schemaColumns reads the live catalog as table -> set of column names.
+func schemaColumns(t *testing.T, conn *pgx.Conn) map[string]map[string]bool {
+	t.Helper()
+	rows, err := conn.Query(context.Background(), `
+		SELECT c.relname, a.attname
+		  FROM pg_class c
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		  JOIN pg_attribute a ON a.attrelid = c.oid
+		 WHERE n.nspname = 'public' AND c.relkind = 'r'
+		   AND a.attnum > 0 AND NOT a.attisdropped`)
+	if err != nil {
+		t.Fatalf("reading the schema catalog: %v", err)
+	}
+	defer rows.Close()
+
+	out := map[string]map[string]bool{}
+	for rows.Next() {
+		var table, column string
+		if err := rows.Scan(&table, &column); err != nil {
+			t.Fatalf("scanning the schema catalog: %v", err)
+		}
+		if out[table] == nil {
+			out[table] = map[string]bool{}
+		}
+		out[table][column] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the schema catalog: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("the migrated schema has no tables — every check below would pass vacuously")
+	}
+	return out
+}
+
+// scriptFiles is every .sql and .sh under the roots above.
+func scriptFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, root := range scriptRoots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if ext := filepath.Ext(path); ext == ".sql" || ext == ".sh" {
+				out = append(out, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Closes #1725. One test file, no production change.

A script is a build artifact of the schema, and nothing was checking that it
still matched one. Every ADR-0091 §8 phase D slice sweeps Go string literals for
the column it removes; `scripts/` is not Go, so that sweep never sees it.

**Four slices in a row** shipped a `scripts/seed-dev.sql` naming a column that
had just been dropped — capture, organization, person, lead, and then `team` on
the slice I was writing when I stopped to build this. Each was caught by
`live-boot`: the slowest job on the board, and the only one that executes the
file. `scripts/seed-demo-company.sh`, which no job runs at all, was broken on
`main` until somebody read it (#1724).

## What it checks, and what it deliberately does not

INSERT column lists only. An identifier in one is unambiguously a column of the
named table, so this fails loudly **with no false positives** — and it would
have caught all four misses.

A predicate (`WHERE x.workspace_id = …`) needs statement boundaries to attribute
correctly. I had a heuristic for it that worked on a line window; I left it out.
A checker that cries wolf gets turned off, which is worse than one that is
narrow — and the narrow half already covers the observed failures.

## Why the integration lane

That is where a migrated schema already exists. `check-backend` is the
deterministic lane with no database; asking this question there would mean
standing one up for a single test.

## Verified

Planted a column the schema does not have:

```
scriptschemadrift_integration_test.go:84: seed-dev.sql: `INSERT INTO team` names
the column "no_such_column", which the migrated schema does not have. A script
is a build artifact of the schema; this one no longer matches it.
```

Nothing else in the lane moves. Restored: 41 packages, 0 skips.

The test also fails if the script roots go missing or the catalog reads empty —
a gate that silently checks nothing is the failure mode this one exists to
prevent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integration test that verifies seed and ops scripts reference only columns that exist in the migrated schema, preventing script/schema drift. Previously, scripts could name dropped columns and were only caught by the slow `live-boot` job.

- Parses INSERT INTO column lists from `.sql` and `.sh` under `scripts/` and `infra/`, compares against the live catalog, and reports file/table/column on mismatch.
- Runs only in the integration lane; no production behavior change.
- Intentionally checks INSERT column lists only to avoid false positives from predicates or expressions.
- Fails if script roots are missing or the schema catalog is empty to prevent silent passes.

<sup>Written for commit 44aad4cf842efa078a76857726628748c5242203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

