### PR TITLE
feat(frontend): the results table, saved views, and export the Filters screen was missing

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5175,4 +5175,6 @@ export const de = {
     "Die erste Seite der Treffer \u2014 genug, um den Filter zu pr\u00fcfen, nicht die gesamte Auswahl.",
   "filters.noMatches": "Keine Datens\u00e4tze entsprechen diesem Filter.",
   "filters.loadView": "Gespeicherten Filter laden",
+  "filters.exportCsv": "Als CSV exportieren",
+  "filters.exportJson": "Als JSON exportieren",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5174,4 +5174,5 @@ export const de = {
   "filters.resultsCaption":
     "Die erste Seite der Treffer \u2014 genug, um den Filter zu pr\u00fcfen, nicht die gesamte Auswahl.",
   "filters.noMatches": "Keine Datens\u00e4tze entsprechen diesem Filter.",
+  "filters.loadView": "Gespeicherten Filter laden",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -383,6 +383,7 @@ export const de = {
   "table.rangeLoaded": "{first}–{last} von bisher {count} geladenen {unit}",
   "unit.contacts": "Kontakte",
   "unit.companies": "Firmen",
+  "unit.deals": "Deals",
   "unit.leads": "Leads",
   "unit.partners": "Partner",
   "unit.products": "Produkte",
@@ -5169,4 +5170,8 @@ export const de = {
   "filters.noFilterYet": "Bedingung hinzuf\u00fcgen, um die Treffer zu sehen",
   "filters.loadingVocabulary": "Filterbare Felder werden geladen\u2026",
   "filters.noFields": "Keine filterbaren Felder f\u00fcr diesen Datensatztyp.",
+  "filters.resultsTitle": "Passende Datens\u00e4tze",
+  "filters.resultsCaption":
+    "Die erste Seite der Treffer \u2014 genug, um den Filter zu pr\u00fcfen, nicht die gesamte Auswahl.",
+  "filters.noMatches": "Keine Datens\u00e4tze entsprechen diesem Filter.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5186,6 +5186,7 @@ export const en = {
   "filters.resultsCaption":
     "The first page of matches — enough to check the filter, not the whole selection.",
   "filters.noMatches": "No records match this filter.",
+  "filters.loadView": "Load a saved filter",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -404,6 +404,7 @@ export const en = {
   "table.rangeLoaded": "{first}–{last} of {count} {unit} loaded so far",
   "unit.contacts": "contacts",
   "unit.companies": "companies",
+  "unit.deals": "deals",
   "unit.leads": "leads",
   "unit.partners": "partners",
   "unit.products": "products",
@@ -5181,6 +5182,10 @@ export const en = {
   "filters.noFilterYet": "Add a clause to see what it selects",
   "filters.loadingVocabulary": "Loading the fields you can filter on\u2026",
   "filters.noFields": "No filterable fields for this record type.",
+  "filters.resultsTitle": "Matching records",
+  "filters.resultsCaption":
+    "The first page of matches — enough to check the filter, not the whole selection.",
+  "filters.noMatches": "No records match this filter.",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5187,6 +5187,8 @@ export const en = {
     "The first page of matches — enough to check the filter, not the whole selection.",
   "filters.noMatches": "No records match this filter.",
   "filters.loadView": "Load a saved filter",
+  "filters.exportCsv": "Export CSV",
+  "filters.exportJson": "Export JSON",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5135,4 +5135,5 @@ export const vi = {
     "Trang \u0111\u1ea7u c\u1ee7a k\u1ebft qu\u1ea3 kh\u1edbp \u2014 \u0111\u1ee7 \u0111\u1ec3 ki\u1ec3m tra b\u1ed9 l\u1ecdc, kh\u00f4ng ph\u1ea3i to\u00e0n b\u1ed9.",
   "filters.noMatches":
     "Kh\u00f4ng c\u00f3 b\u1ea3n ghi n\u00e0o kh\u1edbp b\u1ed9 l\u1ecdc n\u00e0y.",
+  "filters.loadView": "T\u1ea3i b\u1ed9 l\u1ecdc \u0111\u00e3 l\u01b0u",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -379,6 +379,7 @@ export const vi = {
   "table.rangeLoaded": "{first}–{last} trong {count} {unit} đã tải",
   "unit.contacts": "liên hệ",
   "unit.companies": "công ty",
+  "unit.deals": "thương vụ",
   "unit.leads": "khách hàng tiềm năng",
   "unit.partners": "đối tác",
   "unit.products": "sản phẩm",
@@ -5129,4 +5130,9 @@ export const vi = {
     "\u0110ang t\u1ea3i c\u00e1c tr\u01b0\u1eddng c\u00f3 th\u1ec3 l\u1ecdc\u2026",
   "filters.noFields":
     "Lo\u1ea1i b\u1ea3n ghi n\u00e0y kh\u00f4ng c\u00f3 tr\u01b0\u1eddng n\u00e0o l\u1ecdc \u0111\u01b0\u1ee3c.",
+  "filters.resultsTitle": "B\u1ea3n ghi kh\u1edbp",
+  "filters.resultsCaption":
+    "Trang \u0111\u1ea7u c\u1ee7a k\u1ebft qu\u1ea3 kh\u1edbp \u2014 \u0111\u1ee7 \u0111\u1ec3 ki\u1ec3m tra b\u1ed9 l\u1ecdc, kh\u00f4ng ph\u1ea3i to\u00e0n b\u1ed9.",
+  "filters.noMatches":
+    "Kh\u00f4ng c\u00f3 b\u1ea3n ghi n\u00e0o kh\u1edbp b\u1ed9 l\u1ecdc n\u00e0y.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5136,4 +5136,6 @@ export const vi = {
   "filters.noMatches":
     "Kh\u00f4ng c\u00f3 b\u1ea3n ghi n\u00e0o kh\u1edbp b\u1ed9 l\u1ecdc n\u00e0y.",
   "filters.loadView": "T\u1ea3i b\u1ed9 l\u1ecdc \u0111\u00e3 l\u01b0u",
+  "filters.exportCsv": "Xu\u1ea5t CSV",
+  "filters.exportJson": "Xu\u1ea5t JSON",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/aiexport.tsx
+++ b/frontend/src/screens/aiexport.tsx
@@ -10,6 +10,7 @@ import {
 import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
 import "./aiexport.css";
+import { downloadBytes } from "./download";
 
 export type AiCallDetail = Pick<
   components["schemas"]["AiCall"],
@@ -119,14 +120,7 @@ export function ExportScenarioDialog({
   }
 
   function downloadYaml() {
-    const url = URL.createObjectURL(
-      new Blob([yaml], { type: "application/yaml" }),
-    );
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `${scenarioSlug(name)}.yaml`;
-    anchor.click();
-    URL.revokeObjectURL(url);
+    downloadBytes(yaml, `${scenarioSlug(name)}.yaml`, "application/yaml");
   }
 
   return (

--- a/frontend/src/screens/download.test.ts
+++ b/frontend/src/screens/download.test.ts
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { downloadBytes, filenameFromDisposition } from "./download";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(URL, "createObjectURL");
+  Reflect.deleteProperty(URL, "revokeObjectURL");
+});
+
+describe("filenameFromDisposition", () => {
+  it("reads the name the server sent", () => {
+    expect(
+      filenameFromDisposition(
+        'attachment; filename="person-export.csv"',
+        "fallback.csv",
+      ),
+    ).toBe("person-export.csv");
+  });
+
+  it.each([
+    ["no header at all", null],
+    ["a header with no filename", "attachment"],
+    ["an empty name", 'attachment; filename=""'],
+    // RFC 6266's extended form carries a charset and percent-encoding. Half
+    // parsing it would produce a plausible-looking wrong name, which is worse
+    // than a name this code chose on purpose.
+    [
+      "only the extended form",
+      "attachment; filename*=UTF-8''r%C3%A9sum%C3%A9.csv",
+    ],
+    ["a name that is only a separator", 'attachment; filename="/"'],
+    ["a name that is only dots", 'attachment; filename=".."'],
+  ])("falls back on %s", (_name, header) => {
+    expect(filenameFromDisposition(header, "fallback.csv")).toBe(
+      "fallback.csv",
+    );
+  });
+
+  it("keeps only the leaf of a name carrying a path", () => {
+    // The header comes from our own server, but it is still input, and a path
+    // separator in a download name is how one talks a browser into writing
+    // somewhere other than the downloads folder.
+    expect(
+      filenameFromDisposition(
+        'attachment; filename="../../etc/passwd"',
+        "fallback.csv",
+      ),
+    ).toBe("passwd");
+  });
+});
+
+describe("downloadBytes", () => {
+  it("names the file, clicks it, and releases the blob", () => {
+    const createObjectURL = vi.fn(() => "blob:test");
+    const revokeObjectURL = vi.fn();
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: createObjectURL },
+      revokeObjectURL: { configurable: true, value: revokeObjectURL },
+    });
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    downloadBytes("id,name\n1,Ann\n", "person-export.csv", "text/csv");
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(click).toHaveBeenCalledOnce();
+    // The revoke is the step a second copy of this forgets: an object URL pins
+    // its blob for the document's lifetime, so a screen that exports repeatedly
+    // without it keeps every export it has ever made.
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:test");
+  });
+});

--- a/frontend/src/screens/download.ts
+++ b/frontend/src/screens/download.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Handing the reader a file, in one spelling.
+//
+// There is no browser API for "save this"; there is an object URL, an anchor
+// nobody sees, a click, and a revoke — four steps in an order that matters, and
+// the last one is the one a second copy forgets. So the sequence lives here
+// rather than in each screen that produces a file.
+//
+// This module is the DOM half only. What the bytes are, what the file is called,
+// and whether the reader may have it at all are the caller's business.
+
+/**
+ * Save `bytes` to the reader's downloads as `filename`.
+ *
+ * The revoke is not optional housekeeping: an object URL pins its blob in memory
+ * for the lifetime of the document, so a screen that exports repeatedly without
+ * it grows a copy of every export it has ever made.
+ */
+export function downloadBytes(bytes: BlobPart, filename: string, type: string) {
+  const url = URL.createObjectURL(new Blob([bytes], { type }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * The filename the server asked for, or `fallback` when it named none.
+ *
+ * Reading the header rather than composing a name locally is what keeps a
+ * download called what the export actually is: the server knows which table and
+ * which format it just rendered, and a name built here would be a second guess
+ * at it that drifts the moment either changes.
+ *
+ * Only the quoted `filename="…"` form is read, which is the form this API sends.
+ * RFC 6266's `filename*` extended form carries a charset and percent-encoding,
+ * and half-parsing it would produce a plausible-looking wrong name — worse than
+ * falling back to one this code chose deliberately.
+ */
+export function filenameFromDisposition(
+  disposition: string | null,
+  fallback: string,
+): string {
+  const quoted = /filename="([^"]+)"/.exec(disposition ?? "");
+  const name = quoted?.[1]?.trim();
+  if (!name) {
+    return fallback;
+  }
+  // A path separator in a download name is how a header talks a browser into
+  // writing outside the downloads folder. The header is the server's, but it is
+  // still input, and the leaf is the only part that is ever wanted.
+  const leaf = name.split(/[/\\]/).pop() ?? "";
+  return leaf === "" || leaf === "." || leaf === ".." ? fallback : leaf;
+}

--- a/frontend/src/screens/filterexport.stories.tsx
+++ b/frontend/src/screens/filterexport.stories.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { ExportFilterMenu } from "./filterexport";
+import { newGroup, newLeaf } from "./segmentpredicate";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// Exporting what a filter selects. Two labelled buttons rather than a menu,
+// because there are exactly two formats and hiding a two-item list behind a
+// click costs a reader more than it saves — and the header this sits under
+// already spends its one unlabelled "…" on the saved-view rail.
+//
+// A success hands the browser a file and leaves the page looking exactly as it
+// did, so there is nothing to screenshot in it. The states worth capturing are
+// the two where something is visibly different: the export withheld, and the
+// export refused.
+const meta: Meta<typeof ExportFilterMenu> = {
+  title: "Patterns/Filter export",
+  component: ExportFilterMenu,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+export default meta;
+
+const COMPLETE = newGroup("and", [newLeaf("city", "eq", "Berlin")]);
+
+type Story = StoryObj<typeof ExportFilterMenu>;
+
+export const Offered: Story = {
+  render: () => {
+    installFetchStub({});
+    return <ExportFilterMenu resource="person" tree={COMPLETE} />;
+  },
+};
+
+export const WithheldForAnIncompleteFilter: Story = {
+  // A clause with nothing typed in it is refused per-leaf by the engine, so an
+  // export button here would answer 422 and tell the reader nothing they could
+  // not have been spared. Deliberately an empty capture — that IS the behaviour.
+  render: () => {
+    installFetchStub({});
+    return (
+      <ExportFilterMenu
+        resource="person"
+        tree={newGroup("and", [newLeaf("city", "eq", "")])}
+      />
+    );
+  },
+};
+
+export const Refused: Story = {
+  // The server's own reason, beside the button that failed. Not "request
+  // failed": a bulk read can be refused for something a reader can act on, and
+  // the refusal has to land somewhere or somebody waits for a file that is
+  // never coming.
+  render: () => {
+    installFetchStub({
+      "POST /exports": () =>
+        jsonResponse(
+          {
+            title: "Export refused",
+            status: 403,
+            detail: "Bulk record read is human-only.",
+          },
+          403,
+        ),
+    });
+    return <ExportFilterMenu resource="person" tree={COMPLETE} />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Export CSV" }));
+    await canvas.findByRole("alert");
+  },
+};

--- a/frontend/src/screens/filterexport.tsx
+++ b/frontend/src/screens/filterexport.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Exporting what the filter selects (AC-filters-and-views-8).
+//
+// `/exports` takes the same predicate the preview does, so this sends the tree
+// the reader is looking at rather than a saved view's id: what you export is
+// what the count above it says, through the one filter engine. Nothing here
+// re-derives a slice.
+//
+// Two things this file does NOT do, both deliberately. It does not page the
+// export — the server renders the whole matching slice, and a client-side
+// stitch of preview pages would be a second, wrong answer to the same question.
+// And it does not ask the reader to confirm: clicking "Export CSV" IS the
+// confirmation, and the server writes the audit row that makes the export
+// accountable (P7/P12).
+
+import { useMutation } from "@tanstack/react-query";
+import { api } from "../api/client";
+import { Button } from "../design-system/atoms";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, throwProblem } from "./common";
+import { downloadBytes, filenameFromDisposition } from "./download";
+import type { FilterResource } from "./filterdata";
+import { encode, isComplete, type Node } from "./segmentpredicate";
+
+/** The formats the contract offers. Closed — the server enumerates these two. */
+const FORMATS = ["csv", "json"] as const;
+type Format = (typeof FORMATS)[number];
+
+const MIME: Record<Format, string> = {
+  csv: "text/csv",
+  json: "application/json",
+};
+
+/** A table rather than a ternary, so adding a third format cannot forget one. */
+const LABEL: Record<Format, MessageKey> = {
+  csv: "filters.exportCsv",
+  json: "filters.exportJson",
+};
+
+/**
+ * "Export" beside the builder, one item per format.
+ *
+ * Gated on `isComplete` for the same reason Save is: an incomplete tree is one
+ * the engine refuses, and an export button that answers 422 has told the reader
+ * nothing they could not have been spared.
+ */
+export function ExportFilterMenu({
+  resource,
+  tree,
+}: Readonly<{ resource: FilterResource; tree: Node }>) {
+  const t = useT();
+  const run = useMutation({
+    // The tree arrives as a variable rather than through a closure: the click
+    // belongs to the committed render, so what it hands over cannot be older
+    // than the filter the reader is looking at.
+    mutationFn: async (input: Readonly<{ format: Format }>) => {
+      const { data, error, response } = await api.POST("/exports", {
+        body: { object: resource, filter: encode(tree), format: input.format },
+        // The body is a rendered file, not a document to parse. Asking for text
+        // keeps CSV intact — JSON.parse over a CSV would throw, and over the
+        // JSON format it would reparse bytes we are about to write out verbatim.
+        parseAs: "text",
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      downloadBytes(
+        data,
+        // The server knows which table and format it just rendered, so its name
+        // is the true one; the fallback only covers a response that sent none.
+        filenameFromDisposition(
+          response.headers.get("Content-Disposition"),
+          `${resource}-export.${input.format}`,
+        ),
+        MIME[input.format],
+      );
+    },
+  });
+
+  if (!isComplete(tree)) {
+    return null;
+  }
+
+  return (
+    <>
+      {/* Two labelled buttons rather than a menu. There are exactly two formats,
+          so a menu would hide a short list behind a click — and the saved-view
+          rail beside this already spends the one unlabelled "…" this header can
+          afford. Two of those side by side is a header where nothing says which
+          is which, which is what the rendered screen showed. */}
+      {FORMATS.map((format) => (
+        <Button
+          key={format}
+          small
+          disabled={run.isPending}
+          onClick={() => run.mutate({ format })}
+        >
+          {t(LABEL[format])}
+        </Button>
+      ))}
+      {run.isError && (
+        // Spoken, and it carries the server's own reason: a bulk read can be
+        // refused for reasons a reader can act on, and "request failed" is not
+        // one of them.
+        <span className="filters-export-error" role="alert">
+          {problemMessageOf(run.error, t)}
+        </span>
+      )}
+    </>
+  );
+}

--- a/frontend/src/screens/filterresults.stories.tsx
+++ b/frontend/src/screens/filterresults.stories.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { FilterPreview, VocabularyField } from "./filterdata";
+import { FilterResults } from "./filterresults";
+import { StoryProviders } from "./story-utils";
+
+// FilterResults takes everything as props — the preview response, the vocabulary
+// it heads its columns from — so it needs no fetch and no query client of its
+// own. StoryProviders is here for the locale, which every string on it reads
+// through.
+//
+// The three stories are the three things a reader can be looking at: rows behind
+// a count, a filter that selected nothing, and the recount that has not answered
+// yet. The middle one matters most, because "nothing matched" and "something
+// failed" look identical in a table that only knows how to be empty.
+const meta: Meta<typeof FilterResults> = {
+  title: "Screens/Filter results",
+  component: FilterResults,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+export default meta;
+
+const FIELDS: readonly VocabularyField[] = [
+  {
+    name: "full_name",
+    type: "text",
+    operators: ["eq", "neq", "in", "contains", "exists"],
+    custom: false,
+  },
+  {
+    name: "cf_loyalty_tier",
+    type: "picklist",
+    operators: ["eq", "neq", "in", "exists"],
+    custom: true,
+  },
+];
+
+const COLUMNS = ["id", "full_name", "city", "cf_loyalty_tier", "created_at"];
+
+/** A page of rows, one of them missing the value the filter asked about. */
+const ROWS = [
+  {
+    id: "p-1",
+    full_name: "Ann Lee",
+    city: "Berlin",
+    cf_loyalty_tier: "gold",
+    created_at: "2026-08-01",
+  },
+  {
+    id: "p-2",
+    full_name: "Bruno Sá",
+    city: "Lisbon",
+    cf_loyalty_tier: "silver",
+    created_at: "2026-07-19",
+  },
+  {
+    // The dash case, which is the reason a null does not render as blank: a
+    // reader checking an `exists` clause has to be able to see the absence.
+    id: "p-3",
+    full_name: "Chen Wei",
+    city: "Singapore",
+    cf_loyalty_tier: null,
+    created_at: "2026-06-30",
+  },
+] satisfies FilterPreview["rows"];
+
+function preview(rows: FilterPreview["rows"]): FilterPreview {
+  return {
+    resource: "person",
+    match_count: rows.length,
+    columns: COLUMNS,
+    rows,
+    truncated: false,
+  };
+}
+
+type Story = StoryObj<typeof FilterResults>;
+
+const shared = {
+  fields: FIELDS,
+  // The filter asked about tier, so tier is a column — the derivation this
+  // component exists to make, rather than a fixed product column list.
+  named: ["cf_loyalty_tier"],
+  unit: "contacts",
+  widthsKey: "story-filter-preview",
+  pending: false,
+};
+
+export const Rows: Story = {
+  args: { ...shared, preview: preview(ROWS) },
+};
+
+export const NothingMatched: Story = {
+  args: { ...shared, preview: preview([]) },
+};
+
+export const Recounting: Story = {
+  // The state between an edit and its answer. The rows on screen are the PREVIOUS
+  // filter's, which is why the screen marks the count stale rather than blanking
+  // it — a table that empties on every keystroke is unreadable.
+  args: { ...shared, preview: preview(ROWS), pending: true },
+};

--- a/frontend/src/screens/filterresults.test.tsx
+++ b/frontend/src/screens/filterresults.test.tsx
@@ -1,0 +1,164 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocaleProvider } from "../i18n";
+import type { FilterPreview, VocabularyField } from "./filterdata";
+import { FilterResults, previewColumnNames } from "./filterresults";
+
+// The preview answers every non-generated column of the table, so what this
+// component decides is which of them a reader sees first. That choice is the
+// logic here, and it is provable without rendering — so most of these tests ask
+// the function directly, and the render tests cover what only the DOM can show.
+
+describe("previewColumnNames", () => {
+  it("leads with the identity column, then the fields the filter named", () => {
+    const chosen = previewColumnNames(
+      ["id", "full_name", "city", "cf_tier", "created_at"],
+      ["cf_tier", "city"],
+    );
+
+    // The filter's own order, not the projection's: somebody who filtered on
+    // tier first is checking tier first.
+    expect(chosen).toEqual(["full_name", "cf_tier", "city", "created_at"]);
+  });
+
+  it("spends no column on the id once something else names the row", () => {
+    // The projection always carries the primary key, and a UUID beside the name
+    // it duplicates is a column spent on nothing a reader can use.
+    const chosen = previewColumnNames(["id", "full_name", "city"], []);
+
+    expect(chosen).toEqual(["full_name", "city"]);
+  });
+
+  it("prefers a readable name over the id", () => {
+    // A UUID identifies a row to the database and to nobody else.
+    expect(previewColumnNames(["id", "full_name"], [])[0]).toBe("full_name");
+  });
+
+  it("falls back to the id when the record type has no name column", () => {
+    expect(previewColumnNames(["id", "amount_minor"], [])[0]).toBe("id");
+  });
+
+  it("ignores a filtered field the projection does not carry", () => {
+    // A tag leaf reads a join rather than a column, so naming it must not put a
+    // `tag` header over cells that will always be empty.
+    const chosen = previewColumnNames(["id", "name", "city"], ["tag", "city"]);
+
+    expect(chosen).toEqual(["name", "city"]);
+    expect(chosen).not.toContain("tag");
+  });
+
+  it("names each column once when the filter names a field twice", () => {
+    // A range is two clauses over one field. `fieldsNamed` already dedupes, so
+    // this is the belt to that brace: a caller passing a repeat cannot produce
+    // two identical column keys, which React would reject as duplicate keys.
+    const chosen = previewColumnNames(
+      ["id", "name", "cf_score"],
+      ["cf_score", "cf_score"],
+    );
+
+    expect(chosen).toEqual(["name", "cf_score"]);
+  });
+
+  it("stops at six, so the table opens as a table and not a scrollbar", () => {
+    const available = [
+      "id",
+      "name",
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+    ];
+
+    expect(previewColumnNames(available, [])).toHaveLength(6);
+    // And the cap holds when it is the FILTER that names too many, which is the
+    // path that would otherwise push the identity column past the ceiling.
+    expect(
+      previewColumnNames(available, ["a", "b", "c", "d", "e", "f", "g"]),
+    ).toEqual(["name", "a", "b", "c", "d", "e"]);
+  });
+
+  it("answers nothing when the projection is empty", () => {
+    // The shape before the first response arrives. A column list derived from a
+    // filter must not invent columns the response never offered.
+    expect(previewColumnNames([], ["city"])).toEqual([]);
+  });
+});
+
+const TIER_FIELD: VocabularyField = {
+  name: "cf_loyalty_tier",
+  type: "picklist",
+  operators: ["eq", "neq", "in", "exists"],
+  custom: true,
+};
+
+function preview(rows: readonly Record<string, unknown>[]): FilterPreview {
+  return {
+    resource: "person",
+    match_count: rows.length,
+    columns: ["id", "full_name", "cf_loyalty_tier"],
+    rows: rows as FilterPreview["rows"],
+    truncated: false,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <LocaleProvider>{children}</LocaleProvider>;
+}
+
+function results(rows: readonly Record<string, unknown>[]) {
+  return (
+    <FilterResults
+      preview={preview(rows)}
+      fields={[TIER_FIELD]}
+      named={["cf_loyalty_tier"]}
+      unit="contacts"
+      widthsKey="filter-preview-contacts"
+      pending={false}
+    />
+  );
+}
+
+afterEach(cleanup);
+
+it("heads a custom column the way the field picker named it", () => {
+  render(
+    results([{ id: "p1", full_name: "Ann Lee", cf_loyalty_tier: "gold" }]),
+    { wrapper },
+  );
+
+  // `cf_loyalty_tier` is the storage name; the picker a reader chose the field
+  // from reads it as "loyalty tier", and the column it selects has to agree — one
+  // field, one name, wherever it appears on this screen.
+  expect(
+    screen.getByRole("columnheader", { name: /loyalty tier/ }),
+  ).toBeTruthy();
+  expect(
+    screen.queryByRole("columnheader", { name: /cf_loyalty_tier/ }),
+  ).toBeNull();
+});
+
+it("shows a dash where a row has no value", () => {
+  render(results([{ id: "p1", full_name: "Ann Lee", cf_loyalty_tier: null }]), {
+    wrapper,
+  });
+
+  // Not blank: an empty cell cannot be told apart from a column that failed to
+  // render, and "nothing here" is what an `exists` clause is checked against.
+  expect(screen.getByText("—")).toBeTruthy();
+});
+
+it("says no records match rather than leaving the reason blank", () => {
+  render(results([]), { wrapper });
+
+  expect(screen.getByText("No records match this filter.")).toBeTruthy();
+});

--- a/frontend/src/screens/filterresults.tsx
+++ b/frontend/src/screens/filterresults.tsx
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The preview's first page as a table (AC-filters-and-views-5, the reading half).
+//
+// It renders through the catalog's ListTable rather than a grid of its own. That
+// was worth checking rather than assuming: ListTable reads as a record-list
+// component, but its column type is generic over the row — key, header, and a cell
+// function — so a schema-derived projection fits it without pretending to be a
+// record. A second table beside it would have been the easy mistake, and
+// frontend/CLAUDE.md records that this tree has twice grown a duplicate surface
+// exactly that way.
+//
+// What this file decides is WHICH columns to show, because the preview carries
+// every non-generated column of the table and thirty columns is not a table
+// anybody reads.
+
+import { type ListColumn, ListTable } from "../design-system/listtable";
+import { useT } from "../i18n";
+import {
+  type FilterPreview,
+  fieldLabel,
+  type VocabularyField,
+} from "./filterdata";
+
+/** A preview row: schema-derived, so its values span every type the table holds. */
+type PreviewRow = Record<string, unknown>;
+
+/**
+ * How many columns a preview opens with, before the column picker is used.
+ *
+ * A glance, not a report — the same reasoning that bounds the page. ListTable
+ * starts with every column it is given visible, so this is the number that
+ * decides whether a reader sees a table or a horizontal scrollbar.
+ */
+const MAX_COLUMNS = 6;
+
+/**
+ * Which column names a row, in preference order.
+ *
+ * `id` is last rather than first: a UUID identifies a row to the database and to
+ * nobody else, so a human-readable name wins wherever the record type has one.
+ */
+const IDENTITY_PREFERENCE = [
+  "full_name",
+  "display_name",
+  "name",
+  "title",
+  "id",
+] as const;
+
+/**
+ * The columns most likely to answer "is this filter right?": what identifies the
+ * row, then the fields the filter actually asked about.
+ *
+ * Deriving them from the filter is the point. AC-5 names five product columns for
+ * contacts, and inventing my own five for each of the other record types would be
+ * a list nobody agreed to; the fields a human just filtered on are the ones they
+ * are checking, and that rule needs no product decision to be defensible. The
+ * identity column leads because a row you cannot name is not a result you can act
+ * on, and the projection's own order fills whatever is left.
+ */
+export function previewColumnNames(
+  available: readonly string[],
+  named: readonly string[],
+): string[] {
+  const identity = IDENTITY_PREFERENCE.find((candidate) =>
+    available.includes(candidate),
+  );
+  const chosen: string[] = identity ? [identity] : [];
+  const take = (field: string) => {
+    // A filter may name a field the projection does not carry — a tag leaf reads
+    // a join, not a column — so membership is checked rather than assumed.
+    if (available.includes(field) && !chosen.includes(field)) {
+      chosen.push(field);
+    }
+  };
+  for (const field of named) {
+    if (chosen.length >= MAX_COLUMNS) {
+      return chosen;
+    }
+    take(field);
+  }
+  // A filter naming nothing the projection carries would otherwise leave a table
+  // of one column, so the remaining slots fill in the projection's order —
+  // except for the primary key, which is worth a column only when it is the ONLY
+  // thing that names the row. A UUID beside a name it already read is a column
+  // spent on nothing.
+  for (const field of available) {
+    if (chosen.length >= MAX_COLUMNS) {
+      break;
+    }
+    if (field !== "id") {
+      take(field);
+    }
+  }
+  return chosen;
+}
+
+export type FilterResultsProps = Readonly<{
+  preview: FilterPreview | undefined;
+  fields: readonly VocabularyField[];
+  /** The fields the filter names, in the order they were written. */
+  named: readonly string[];
+  /** The plural noun for these rows — "contacts". Translated by the caller. */
+  unit: string;
+  /** Names this table for the column widths it remembers between visits. */
+  widthsKey: string;
+  pending: boolean;
+}>;
+
+export function FilterResults({
+  preview,
+  fields,
+  named,
+  unit,
+  widthsKey,
+  pending,
+}: FilterResultsProps) {
+  const t = useT();
+  const rows: readonly PreviewRow[] = preview?.rows ?? [];
+  const names = previewColumnNames(preview?.columns ?? [], named);
+  const columns: ListColumn<PreviewRow>[] = names.map((name, index) => ({
+    key: name,
+    header: headerFor(name, fields),
+    // The identity column is fixed: it is what makes a row recognisable, so the
+    // picker may not hide it and the phone layout promotes it to the card's
+    // heading.
+    fixed: index === 0,
+    cell: (row) => cellText(row[name]),
+  }));
+
+  return (
+    <ListTable<PreviewRow>
+      rows={rows}
+      columns={columns}
+      rowKey={rowKey}
+      unit={unit}
+      widthsKey={widthsKey}
+      emptyNote={t("filters.noMatches")}
+      pending={pending}
+      caption={t("filters.resultsCaption")}
+      // The preview is deliberately a first page, and the reader's next step is
+      // to narrow the filter rather than to walk pages of it — so there is no
+      // pager to offer. Claiming `hasMore` without an `onLoadMore` would render
+      // a control that does nothing.
+      hasMore={false}
+    />
+  );
+}
+
+/**
+ * A row's React key.
+ *
+ * Every table this endpoint previews has an `id`, so the fallback is here for the
+ * type rather than for a case that arrives — and it falls back to the row's own
+ * contents rather than to an index, because an index key makes React reuse the
+ * wrong row when the result set shifts under a recount.
+ */
+function rowKey(row: PreviewRow): string {
+  return typeof row.id === "string" ? row.id : JSON.stringify(row);
+}
+
+/**
+ * A column's header: the admin's word for a custom field, the column's own name
+ * for a core one — the same reading the field picker gives, so a clause and the
+ * column it selects call the field by one name.
+ */
+function headerFor(name: string, fields: readonly VocabularyField[]): string {
+  const known = fields.find((field) => field.name === name);
+  return known ? fieldLabel(known) : name.replaceAll("_", " ");
+}
+
+/**
+ * One cell, as text.
+ *
+ * A null reads as a dash rather than as blank, because an empty cell cannot be
+ * told apart from a column that failed to render — and "nothing here" is exactly
+ * what a reader checking an `exists` clause needs to see. An object is
+ * stringified rather than dropped: a jsonb column is rare in a preview, and
+ * showing its shape beats showing nothing.
+ */
+function cellText(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/frontend/src/screens/filters.css
+++ b/frontend/src/screens/filters.css
@@ -38,3 +38,26 @@
   font-weight: 400;
   color: var(--textMuted);
 }
+
+/* The export sits under the builder, because it takes the filter as its
+ * argument. Empty until the filter is one the engine would accept, so it holds
+ * no space of its own then. */
+.filters-export-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.filters-export-row:not(:empty) {
+  margin-top: var(--space-4);
+}
+
+/* An export that failed, beside the button that failed — a reader waiting for a
+ * file has to be told there isn't one. It wraps rather than clipping: the reason
+ * comes from the server and can be a full sentence, and a truncated reason is
+ * one a reader cannot act on. */
+.filters-export-error {
+  color: var(--danger);
+  font-weight: var(--fw-medium);
+}

--- a/frontend/src/screens/filters.stories.tsx
+++ b/frontend/src/screens/filters.stories.tsx
@@ -6,15 +6,15 @@ import { userEvent, within } from "storybook/test";
 import { FiltersScreen } from "./filters";
 import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 
-// The screen reads two routes and no session probe — the vocabulary for the
-// object being filtered, and a preview once a clause is complete — so the stub
-// only has to answer those two.
+// The screen reads four routes and no session probe: the vocabulary for the
+// object being filtered, a preview once a clause is complete, the reader's saved
+// views, and the export.
 //
 // The states worth capturing are the ones a reader can actually be in, and the
-// difference between them is the judgement this screen carries: nothing asked
-// yet (no count, no table), and asked (a count, and the rows behind it). A
-// screenshot of the first is what proves the second is not the only state the
-// surface knows how to draw.
+// differences between them are the judgements this screen carries: nothing asked
+// yet (no count, no table), asked (a count, and the rows behind it), restored
+// from a saved view, and an export that was refused. A screenshot of the first is
+// what proves the others are not the only states the surface knows how to draw.
 const meta: Meta<typeof FiltersScreen> = {
   title: "Screens/Filters and views",
   component: FiltersScreen,
@@ -120,6 +120,18 @@ function routes(): void {
     "GET /filters/vocabulary": () => jsonResponse(PERSON_VOCAB),
     "POST /filters/preview": () => jsonResponse(PREVIEW),
     "GET /views": () => jsonResponse(SAVED_VIEWS),
+    // Refused rather than served, because the failure is the state worth a
+    // screenshot: a success hands the browser a file and leaves the page looking
+    // exactly as it did, which documents nothing.
+    "POST /exports": () =>
+      jsonResponse(
+        {
+          title: "Export refused",
+          status: 403,
+          detail: "Bulk record read is human-only.",
+        },
+        403,
+      ),
   });
 }
 
@@ -156,6 +168,27 @@ export const LoadedFromASavedView: Story = {
       await page.findByRole("button", { name: "Gold tier in Berlin" }),
     );
     await canvas.findByText("3 contacts match");
+  },
+};
+
+export const ExportRefused: Story = {
+  // What a reader sees when the export cannot be served. The menu closes on the
+  // click, so the refusal has to land somewhere on the page — otherwise somebody
+  // waits for a file that is never coming.
+  render: () => {
+    routes();
+    return <FiltersScreen />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Add clause" }),
+    );
+    await userEvent.type(canvas.getByLabelText("Value"), "Berlin");
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Export CSV" }),
+    );
+    await canvas.findByRole("alert");
   },
 };
 

--- a/frontend/src/screens/filters.stories.tsx
+++ b/frontend/src/screens/filters.stories.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { FiltersScreen } from "./filters";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The screen reads two routes and no session probe — the vocabulary for the
+// object being filtered, and a preview once a clause is complete — so the stub
+// only has to answer those two.
+//
+// The states worth capturing are the ones a reader can actually be in, and the
+// difference between them is the judgement this screen carries: nothing asked
+// yet (no count, no table), and asked (a count, and the rows behind it). A
+// screenshot of the first is what proves the second is not the only state the
+// surface knows how to draw.
+const meta: Meta<typeof FiltersScreen> = {
+  title: "Screens/Filters and views",
+  component: FiltersScreen,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+export default meta;
+
+const PERSON_VOCAB = {
+  resource: "person",
+  fields: [
+    {
+      name: "full_name",
+      type: "text",
+      operators: ["eq", "neq", "in", "contains", "exists"],
+      custom: false,
+    },
+    {
+      name: "city",
+      type: "text",
+      operators: ["eq", "neq", "in", "contains", "exists"],
+      custom: false,
+    },
+    {
+      name: "cf_loyalty_tier",
+      type: "picklist",
+      operators: ["eq", "neq", "in", "exists"],
+      custom: true,
+    },
+  ],
+};
+
+const PREVIEW = {
+  resource: "person",
+  match_count: 3,
+  columns: ["id", "full_name", "city", "cf_loyalty_tier", "created_at"],
+  rows: [
+    {
+      id: "p-1",
+      full_name: "Ann Lee",
+      city: "Berlin",
+      cf_loyalty_tier: "gold",
+      created_at: "2026-08-01",
+    },
+    {
+      id: "p-2",
+      full_name: "Bruno Sá",
+      city: "Lisbon",
+      cf_loyalty_tier: "silver",
+      created_at: "2026-07-19",
+    },
+    {
+      id: "p-3",
+      full_name: "Chen Wei",
+      city: "Singapore",
+      cf_loyalty_tier: null,
+      created_at: "2026-06-30",
+    },
+  ],
+  truncated: false,
+};
+
+function routes(): void {
+  installFetchStub({
+    "GET /filters/vocabulary": () => jsonResponse(PERSON_VOCAB),
+    "POST /filters/preview": () => jsonResponse(PREVIEW),
+  });
+}
+
+type Story = StoryObj<typeof FiltersScreen>;
+
+export const NothingAskedYet: Story = {
+  // The state the screen opens in. The count says so in words rather than
+  // showing a zero, and there is no results table at all — an empty one would
+  // report that nothing matches a filter nobody has written.
+  render: () => {
+    routes();
+    return <FiltersScreen />;
+  },
+};
+
+export const WithAClause: Story = {
+  // The builder owns its own tree, so the only way to reach the answered state
+  // is to author a clause the way a human does. fe-uat waits for a play()
+  // interaction to settle before it screenshots.
+  render: () => {
+    routes();
+    return <FiltersScreen />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Waited for, not assumed: the builder is a skeleton until the vocabulary
+    // answers, and there is no Add clause button to click before then.
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Add clause" }),
+    );
+    await userEvent.type(canvas.getByLabelText("Value"), "Berlin");
+    await canvas.findByText("3 contacts match");
+  },
+};

--- a/frontend/src/screens/filters.stories.tsx
+++ b/frontend/src/screens/filters.stories.tsx
@@ -83,10 +83,43 @@ const PREVIEW = {
   truncated: false,
 };
 
+// One readable view and one this build cannot read, because the menu's rule is
+// that the second kind is left out — a catalog page that only ever shows the
+// happy row documents half the behaviour.
+const SAVED_VIEWS = {
+  data: [
+    {
+      id: "v-1",
+      owner_id: "u-1",
+      resource: "people",
+      name: "Gold tier in Berlin",
+      query: {
+        filter: {
+          and: [
+            { field: "city", op: "eq", value: "Berlin" },
+            { field: "cf_loyalty_tier", op: "eq", value: "gold" },
+          ],
+        },
+      },
+      version: 1,
+    },
+    {
+      id: "v-2",
+      owner_id: "u-1",
+      resource: "people",
+      name: "Saved by an older build",
+      query: { filter: { and: [{ field: "city", op: "like", value: "Ber" }] } },
+      version: 1,
+    },
+  ],
+  page: { next_cursor: null, has_more: false },
+};
+
 function routes(): void {
   installFetchStub({
     "GET /filters/vocabulary": () => jsonResponse(PERSON_VOCAB),
     "POST /filters/preview": () => jsonResponse(PREVIEW),
+    "GET /views": () => jsonResponse(SAVED_VIEWS),
   });
 }
 
@@ -99,6 +132,30 @@ export const NothingAskedYet: Story = {
   render: () => {
     routes();
     return <FiltersScreen />;
+  },
+};
+
+export const LoadedFromASavedView: Story = {
+  // The whole round trip: a stored tree becomes an editable one, and the count
+  // comes back for it without a clause being retyped. The menu holds two rows
+  // and offers one — the unreadable view is not on it.
+  render: () => {
+    routes();
+    return <FiltersScreen />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The menu's panel is anchored to its trigger from OUTSIDE the canvas — a
+    // card clips its own overflow, so the panel cannot live inside one. Its items
+    // are therefore found through the document, not the story's root.
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Load a saved filter" }),
+    );
+    await userEvent.click(
+      await page.findByRole("button", { name: "Gold tier in Berlin" }),
+    );
+    await canvas.findByText("3 contacts match");
   },
 };
 

--- a/frontend/src/screens/filters.test.tsx
+++ b/frontend/src/screens/filters.test.tsx
@@ -79,6 +79,24 @@ function mount(
           truncated: false,
         });
       }
+      if (url.includes("/exports")) {
+        written.push(
+          request ? await request.json() : JSON.parse(String(init?.body)),
+        );
+        // A rendered file, not a document: served as text with the name the
+        // client is supposed to take its filename from.
+        //
+        // Deliberately NOT the name the client would compose for itself
+        // (`person-export.csv`): identical strings would make the assertion pass
+        // whether the header was read or ignored.
+        return new Response("id,full_name\np1,Ann Lee\n", {
+          status: 200,
+          headers: {
+            "Content-Type": "text/csv",
+            "Content-Disposition": 'attachment; filename="people-slice.csv"',
+          },
+        });
+      }
       if (url.includes("/views")) {
         // A save is recorded rather than answered with a fixture: what the
         // screen STORES is the thing worth asserting, and a canned view row
@@ -294,6 +312,77 @@ it("saves the tree under the key the server validates as a filter", async () => 
       filter: { and: [{ field: "full_name", op: "eq", value: "ann" }] },
     },
   });
+});
+
+it("exports the filter on screen, under the name the server gave it", async () => {
+  const createObjectURL = vi.fn(() => "blob:test");
+  const revokeObjectURL = vi.fn();
+  Object.defineProperties(URL, {
+    createObjectURL: { configurable: true, value: createObjectURL },
+    revokeObjectURL: { configurable: true, value: revokeObjectURL },
+  });
+  const anchors: HTMLAnchorElement[] = [];
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    anchors.push(this);
+  });
+  const { written, wrapper } = mount({ match_count: 2 });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await user.click(await screen.findByRole("button", { name: "Add clause" }));
+  await user.type(screen.getByLabelText("Value"), "ann");
+  await user.click(await screen.findByRole("button", { name: "Export CSV" }));
+
+  await waitFor(() => {
+    expect(written).toHaveLength(1);
+  });
+  // The tree on screen, not a saved view's id: what gets exported is what the
+  // count above the button just said, through the one filter engine.
+  expect(written[0]).toEqual({
+    object: "person",
+    filter: { and: [{ field: "full_name", op: "eq", value: "ann" }] },
+    format: "csv",
+  });
+  expect(anchors[0]?.download).toBe("people-slice.csv");
+});
+
+it("says so when an export is refused, instead of leaving the reader waiting", async () => {
+  const { wrapper } = mount({ match_count: 2 });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await user.click(await screen.findByRole("button", { name: "Add clause" }));
+  await user.type(screen.getByLabelText("Value"), "ann");
+  // The stub answers /exports with a 200 above; this test replaces just that
+  // route's answer so the failure path is the real one — a Problem body the
+  // screen has to read, not a thrown string.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            title: "Export refused",
+            status: 403,
+            detail: "Bulk record read is human-only.",
+          }),
+          {
+            status: 403,
+            headers: { "Content-Type": "application/problem+json" },
+          },
+        ),
+    ),
+  );
+  await user.click(await screen.findByRole("button", { name: "Export JSON" }));
+
+  // The SERVER's reason, not "request failed". A refused bulk read can be
+  // refused for something a reader can act on, and a generic line tells them
+  // nothing — which is what handing a ProblemError to the body reader produces.
+  expect((await screen.findByRole("alert")).textContent).toBe(
+    "Bulk record read is human-only.",
+  );
 });
 
 it("starts a fresh tree when the object changes", async () => {

--- a/frontend/src/screens/filters.test.tsx
+++ b/frontend/src/screens/filters.test.tsx
@@ -42,16 +42,22 @@ const DEAL_VOCAB = {
 
 /** Every request the screen made, so a test can assert what it asked rather than
  *  inferring it from what rendered. */
-function mount(preview?: {
-  match_count: number;
-  columns?: readonly string[];
-  rows?: readonly Record<string, unknown>[];
-}) {
+function mount(
+  preview?: {
+    match_count: number;
+    columns?: readonly string[];
+    rows?: readonly Record<string, unknown>[];
+  },
+  views: readonly Record<string, unknown>[] = [],
+) {
   const seen: string[] = [];
+  const written: unknown[] = [];
   vi.stubGlobal(
     "fetch",
-    vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input instanceof Request ? input.url : input);
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = String(request ? request.url : input);
+      const method = request?.method ?? init?.method ?? "GET";
       seen.push(url);
       const json = (body: unknown) =>
         new Response(JSON.stringify(body), {
@@ -73,6 +79,21 @@ function mount(preview?: {
           truncated: false,
         });
       }
+      if (url.includes("/views")) {
+        // A save is recorded rather than answered with a fixture: what the
+        // screen STORES is the thing worth asserting, and a canned view row
+        // would prove nothing about the blob that produced it.
+        if (method === "POST") {
+          written.push(
+            request ? await request.json() : JSON.parse(String(init?.body)),
+          );
+          return json({ id: "v-new", ...(views[0] ?? {}) });
+        }
+        return json({
+          data: views,
+          page: { next_cursor: null, has_more: false },
+        });
+      }
       return json({});
     }),
   );
@@ -84,7 +105,19 @@ function mount(preview?: {
       <LocaleProvider>{children}</LocaleProvider>
     </QueryClientProvider>
   );
-  return { seen, wrapper };
+  return { seen, written, wrapper };
+}
+
+/** A stored view row, with whatever `query` blob the test is about. */
+function viewRow(name: string, query: unknown) {
+  return {
+    id: `v-${name}`,
+    owner_id: "u-1",
+    resource: "people",
+    name,
+    query,
+    version: 1,
+  };
 }
 
 afterEach(cleanup);
@@ -182,6 +215,85 @@ it("names the count after the object, not after a placeholder", async () => {
   // "3 deals match", not "3 contacts match" and not "3 match" — the object is
   // part of the sentence, which is why the copy is keyed per object.
   expect(await screen.findByText("3 deals match")).toBeTruthy();
+});
+
+it("restores a saved filter, count and all, without a clause being retyped", async () => {
+  const { wrapper } = mount({ match_count: 7 }, [
+    viewRow("Berliners", {
+      filter: { and: [{ field: "full_name", op: "contains", value: "ann" }] },
+    }),
+  ]);
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await user.click(
+    await screen.findByRole("button", { name: "Load a saved filter" }),
+  );
+  await user.click(screen.getByRole("button", { name: "Berliners" }));
+
+  // The stored clause is on screen AND askable: a view that restores a tree the
+  // engine would refuse is a view that fails the moment it is opened.
+  expect(await screen.findByDisplayValue("ann")).toBeTruthy();
+  expect(await screen.findByText("7 contacts match")).toBeTruthy();
+});
+
+it("does not offer a view whose stored filter it cannot read", async () => {
+  const { wrapper } = mount({ match_count: 1 }, [
+    // A row written by an older build, or by hand: the operator is not one this
+    // engine has. An entry that lights up and restores nothing is worse than no
+    // entry, so the menu has nothing to show and does not render at all.
+    viewRow("Stale", {
+      filter: { and: [{ field: "c", op: "like", value: "x" }] },
+    }),
+    viewRow("List state", { list: { q: "ann", sort: "", filters: {} } }),
+  ]);
+  render(<FiltersScreen />, { wrapper });
+
+  await screen.findByRole("button", { name: "Add clause" });
+  expect(
+    screen.queryByRole("button", { name: "Load a saved filter" }),
+  ).toBeNull();
+});
+
+it("offers no save until the filter is one the engine would accept", async () => {
+  const { wrapper } = mount({ match_count: 2 });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await user.click(await screen.findByRole("button", { name: "Add clause" }));
+  // A clause with an empty value is refused per-leaf as filter_value_invalid, so
+  // saving it would store a view nobody can open.
+  expect(screen.queryByRole("button", { name: "Save view" })).toBeNull();
+
+  await user.type(screen.getByLabelText("Value"), "ann");
+
+  expect(await screen.findByRole("button", { name: "Save view" })).toBeTruthy();
+});
+
+it("saves the tree under the key the server validates as a filter", async () => {
+  const { written, wrapper } = mount({ match_count: 2 });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await user.click(await screen.findByRole("button", { name: "Add clause" }));
+  await user.type(screen.getByLabelText("Value"), "ann");
+  await user.click(await screen.findByRole("button", { name: "Save view" }));
+  await user.type(screen.getByLabelText("Name"), "Anns");
+  await user.click(screen.getByRole("button", { name: "Save" }));
+
+  await waitFor(() => {
+    expect(written).toHaveLength(1);
+  });
+  // `people`, not `person` — the two endpoint families spell the same object
+  // differently, and sending the filter vocabulary's word here would 422.
+  // And the tree goes under `filter`, carrying no editor ids.
+  expect(written[0]).toEqual({
+    resource: "people",
+    name: "Anns",
+    query: {
+      filter: { and: [{ field: "full_name", op: "eq", value: "ann" }] },
+    },
+  });
 });
 
 it("starts a fresh tree when the object changes", async () => {

--- a/frontend/src/screens/filters.test.tsx
+++ b/frontend/src/screens/filters.test.tsx
@@ -42,7 +42,11 @@ const DEAL_VOCAB = {
 
 /** Every request the screen made, so a test can assert what it asked rather than
  *  inferring it from what rendered. */
-function mount(preview?: { match_count: number }) {
+function mount(preview?: {
+  match_count: number;
+  columns?: readonly string[];
+  rows?: readonly Record<string, unknown>[];
+}) {
   const seen: string[] = [];
   vi.stubGlobal(
     "fetch",
@@ -64,8 +68,8 @@ function mount(preview?: { match_count: number }) {
         return json({
           resource: "person",
           match_count: preview?.match_count ?? 0,
-          columns: ["id"],
-          rows: [],
+          columns: preview?.columns ?? ["id"],
+          rows: preview?.rows ?? [],
           truncated: false,
         });
       }
@@ -118,6 +122,38 @@ it("asks for no preview until a clause is complete", async () => {
   expect(seen.some((url) => url.includes("/filters/preview"))).toBe(false);
   // And the count says nothing has been asked, which is NOT the same as zero.
   expect(screen.getByText("Add a clause to see what it selects")).toBeTruthy();
+  // Nor is there a results table: an empty one would say "no records match this
+  // filter" about a filter nobody has written.
+  expect(screen.queryByText("Matching records")).toBeNull();
+});
+
+// Which columns get chosen is proved directly against `previewColumnNames`; what
+// this asserts is the wiring — that the rows behind the count actually arrive on
+// the screen, keyed to the object being filtered.
+it("shows the rows behind the count", async () => {
+  const { wrapper } = mount({
+    match_count: 1,
+    columns: ["id", "full_name", "city", "created_at"],
+    rows: [
+      {
+        id: "p1",
+        full_name: "Ann Lee",
+        city: "Berlin",
+        created_at: "2026-08-01T00:00:00Z",
+      },
+    ],
+  });
+  const user = userEvent.setup();
+  render(<FiltersScreen />, { wrapper });
+
+  await screen.findByRole("button", { name: "Add clause" });
+  await user.click(screen.getByRole("button", { name: "Add clause" }));
+  await user.type(screen.getByLabelText("Value"), "ann");
+
+  // The identity column, and the row behind the count — a number alone cannot be
+  // checked, which is what AC-5's table is for.
+  expect(await screen.findByText("Ann Lee")).toBeTruthy();
+  expect(screen.getByRole("columnheader", { name: /full name/ })).toBeTruthy();
 });
 
 it("says how many match once a clause is complete", async () => {

--- a/frontend/src/screens/filters.tsx
+++ b/frontend/src/screens/filters.tsx
@@ -26,6 +26,7 @@ import {
   useFilterPreview,
   useFilterVocabulary,
 } from "./filterdata";
+import { ExportFilterMenu } from "./filterexport";
 import { FilterResults } from "./filterresults";
 import "./filters.css";
 import {
@@ -165,6 +166,15 @@ export function FiltersScreen({ id }: Readonly<{ id?: string }>) {
             fields={vocabulary.data?.fields ?? []}
           />
         </SurfaceState>
+        {/* Below the builder, not in the header beside the count: the export
+            takes the filter as its argument, so it belongs after the thing it
+            reads — and a refusal is a sentence, which the header row has no
+            width for. It also takes the FILTER vocabulary's word for the object
+            rather than the view rail's, because `/exports` enumerates `person`,
+            the same as the preview it has to agree with. */}
+        <div className="filters-export-row">
+          <ExportFilterMenu resource={resource} tree={tree} />
+        </div>
       </Card>
 
       {/* Only once something has been asked. An empty table under an unasked

--- a/frontend/src/screens/filters.tsx
+++ b/frontend/src/screens/filters.tsx
@@ -26,8 +26,9 @@ import {
   useFilterPreview,
   useFilterVocabulary,
 } from "./filterdata";
+import { FilterResults } from "./filterresults";
 import "./filters.css";
-import { type Node, newGroup } from "./segmentpredicate";
+import { fieldsNamed, type Node, newGroup } from "./segmentpredicate";
 
 /**
  * The three object tabs AC-1 names, and the record type each reads.
@@ -55,6 +56,13 @@ const MATCH_LABEL: Record<ObjectTab, MessageKey> = {
   contacts: "filters.matchContacts",
   companies: "filters.matchCompanies",
   deals: "filters.matchDeals",
+};
+
+/** The plural noun the results table counts and names its empty state by. */
+const UNIT_LABEL: Record<ObjectTab, MessageKey> = {
+  contacts: "unit.contacts",
+  companies: "unit.companies",
+  deals: "unit.deals",
 };
 
 /** A resource this screen can address, or the default when the route names none. */
@@ -136,6 +144,26 @@ export function FiltersScreen({ id }: Readonly<{ id?: string }>) {
           />
         </SurfaceState>
       </Card>
+
+      {/* Only once something has been asked. An empty table under an unasked
+          filter would say "no records match this filter" about a filter nobody
+          wrote — the same falsehood the count avoids by showing no number, and
+          the reason both read from the same `data === undefined`. */}
+      {preview.data !== undefined && (
+        <Card>
+          <SectionHeader level={2} title={t("filters.resultsTitle")} />
+          <FilterResults
+            preview={preview.data}
+            fields={vocabulary.data?.fields ?? []}
+            named={fieldsNamed(tree)}
+            unit={t(UNIT_LABEL[tab])}
+            // Per object, so switching tabs does not hand a deal's table the
+            // widths a reader dragged for a contact's columns.
+            widthsKey={`filter-preview-${tab}`}
+            pending={preview.isFetching}
+          />
+        </Card>
+      )}
     </div>
   );
 }

--- a/frontend/src/screens/filters.tsx
+++ b/frontend/src/screens/filters.tsx
@@ -28,6 +28,11 @@ import {
 } from "./filterdata";
 import { FilterResults } from "./filterresults";
 import "./filters.css";
+import {
+  LoadFilterViewMenu,
+  SaveFilterViewAction,
+  type ViewResource,
+} from "./savedviews";
 import { fieldsNamed, type Node, newGroup } from "./segmentpredicate";
 
 /**
@@ -63,6 +68,21 @@ const UNIT_LABEL: Record<ObjectTab, MessageKey> = {
   contacts: "unit.contacts",
   companies: "unit.companies",
   deals: "unit.deals",
+};
+
+/**
+ * The same three objects again, as `/views` spells them.
+ *
+ * A third spelling, and it is not a mistake to fix here: `/filters/*` takes
+ * `person` and `/views` takes `people`, both enumerated in the contract. So this
+ * screen is where the two vocabularies meet, and the correspondence is written
+ * down once — beside `RESOURCE_OF`, so a reader sees both mappings together —
+ * rather than derived at each call site by adding an "s".
+ */
+const VIEW_OF: Record<ObjectTab, ViewResource> = {
+  contacts: "people",
+  companies: "organizations",
+  deals: "deals",
 };
 
 /** A resource this screen can address, or the default when the route names none. */
@@ -123,6 +143,8 @@ export function FiltersScreen({ id }: Readonly<{ id?: string }>) {
                   A dynamic list recomputes on every event, and that is the
                   property a reader needs before trusting a count at all. */}
               <Badge tone="accent">{t("filters.dynamic")}</Badge>
+              <LoadFilterViewMenu resource={VIEW_OF[tab]} onLoad={setTree} />
+              <SaveFilterViewAction resource={VIEW_OF[tab]} tree={tree} />
             </span>
           }
         />

--- a/frontend/src/screens/savedviews.stories.tsx
+++ b/frontend/src/screens/savedviews.stories.tsx
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import type { ListQuery } from "./listquery";
+import {
+  LoadFilterViewMenu,
+  SaveFilterViewAction,
+  SaveViewAction,
+} from "./savedviews";
+import { newGroup, newLeaf } from "./segmentpredicate";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// A saved view is per-user list or filter state, by name. This module has three
+// visible surfaces and they are documented together because what they share is
+// the thing worth seeing: ONE naming dialog, so a list and the segment builder
+// ask the same question the same way.
+//
+// The offering rules are the other half. Both save actions render NOTHING until
+// there is something worth saving — an unnarrowed list, or an incomplete filter,
+// gets no button — so the stories that show the withheld state carry as much as
+// the ones that show the button.
+const meta: Meta = {
+  title: "Patterns/Saved views",
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+export default meta;
+
+const VIEWS = {
+  data: [
+    {
+      id: "v-1",
+      owner_id: "u-1",
+      resource: "people",
+      name: "Gold tier in Berlin",
+      query: {
+        filter: { and: [{ field: "city", op: "eq", value: "Berlin" }] },
+      },
+      version: 1,
+    },
+    {
+      // Not offered: `like` is not an operator this engine has, so the stored
+      // tree cannot be read, and an entry that restores nothing is worse than no
+      // entry at all.
+      id: "v-2",
+      owner_id: "u-1",
+      resource: "people",
+      name: "Saved by an older build",
+      query: { filter: { and: [{ field: "city", op: "like", value: "Ber" }] } },
+      version: 1,
+    },
+  ],
+  page: { next_cursor: null, has_more: false },
+};
+
+function routes(): void {
+  installFetchStub({ "GET /views": () => jsonResponse(VIEWS) });
+}
+
+const NARROWED: ListQuery = {
+  q: "ann",
+  sort: "-created_at",
+  includeArchived: false,
+  filters: { owner: "me" },
+  perPage: 25,
+};
+
+const UNNARROWED: ListQuery = {
+  q: "",
+  sort: "",
+  includeArchived: false,
+  filters: {},
+  perPage: 25,
+};
+
+type Story = StoryObj;
+
+export const NamingAView: Story = {
+  // The one dialog both surfaces share, opened.
+  render: () => {
+    routes();
+    return <SaveViewAction resource="people" query={NARROWED} />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Save view" }));
+  },
+};
+
+export const NothingWorthSaving: Story = {
+  // An unnarrowed list offers no save: the view would do what the All tab
+  // already does, and a rail of those is how a useful feature becomes clutter.
+  // Deliberately an empty capture — that IS the documented behaviour.
+  render: () => {
+    routes();
+    return <SaveViewAction resource="people" query={UNNARROWED} />;
+  },
+};
+
+export const SavingAFilter: Story = {
+  // The segment builder's side of the same dialog. Offered because the tree is
+  // complete; an incomplete one is refused by the engine, so saving it would
+  // store a view that fails the moment anybody opens it.
+  render: () => {
+    routes();
+    return (
+      <SaveFilterViewAction
+        resource="people"
+        tree={newGroup("and", [newLeaf("city", "eq", "Berlin")])}
+      />
+    );
+  },
+};
+
+export const NoSaveForAnIncompleteFilter: Story = {
+  // A clause with nothing typed in it. Also an empty capture, for the same
+  // reason as NothingWorthSaving.
+  render: () => {
+    routes();
+    return (
+      <SaveFilterViewAction
+        resource="people"
+        tree={newGroup("and", [newLeaf("city", "eq", "")])}
+      />
+    );
+  },
+};
+
+export const LoadingASavedFilter: Story = {
+  // Two stored views, one offered: the menu leaves out what it cannot read.
+  render: () => {
+    routes();
+    return <LoadFilterViewMenu resource="people" onLoad={() => undefined} />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Load a saved filter" }),
+    );
+  },
+};

--- a/frontend/src/screens/savedviews.tsx
+++ b/frontend/src/screens/savedviews.tsx
@@ -2,13 +2,20 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { Button, Field, Modal, TextInput } from "../design-system/atoms";
+import {
+  Button,
+  Field,
+  Modal,
+  OverflowMenu,
+  TextInput,
+} from "../design-system/atoms";
 import { useT } from "../i18n";
 import { problemMessage, throwProblem } from "./common";
 import type { ListQuery } from "./listquery";
+import { decode, encode, isComplete, type Node } from "./segmentpredicate";
 
 // A saved view is the reader's own list state, by name: the sort, the filters,
 // the search and the page size they were looking at, restored exactly.
@@ -20,8 +27,15 @@ import type { ListQuery } from "./listquery";
 
 type SavedView = components["schemas"]["SavedView"];
 
-/** The resources whose lists offer saved views, as the contract spells them. */
-export type ViewResource = "people" | "organizations";
+/**
+ * The resources whose lists offer saved views, as the contract spells them.
+ *
+ * Plural here and singular on `/filters/*` — `people` against `person` — because
+ * the two endpoint families spell their enums differently. That correspondence
+ * is written down once, where the two meet (the filters screen's `VIEW_OF`), and
+ * nowhere else.
+ */
+export type ViewResource = "people" | "organizations" | "deals";
 
 /**
  * The list state a view restores.
@@ -85,6 +99,36 @@ function listStateFrom(query: ListQuery): Record<string, unknown> {
   };
 }
 
+/**
+ * The key the segment builder's tree lives under — the one `LIST_STATE_KEY`
+ * above deliberately leaves free.
+ *
+ * The server validates this one as a filter TREE and compiles it against the
+ * resource's engine, which is exactly what it holds: the same predicate the
+ * builder sends to `/filters/preview` and the same one `/exports` takes. One
+ * filter dialect, whichever surface reads it.
+ */
+const FILTER_KEY = "filter";
+
+/**
+ * The filter tree a view restores, or null when it holds none this editor can
+ * read.
+ *
+ * Same contract as `listStateOf` and for the same reason: `query` is an open
+ * JSON object, so a row can carry a shape this build has never seen, and a
+ * builder that threw while reading its own view menu would take the screen with
+ * it. `decode` does the checking and answers null rather than guessing.
+ */
+export function filterTreeOf(view: SavedView): Node | null {
+  const stored = view.query as Record<string, unknown> | undefined;
+  return decode(stored?.[FILTER_KEY]);
+}
+
+/** What a view saves, given the filter the reader has just built. */
+function filterStateFrom(tree: Node): Record<string, unknown> {
+  return { [FILTER_KEY]: encode(tree) };
+}
+
 /** The caller's saved views for one resource, newest last. */
 export function useSavedViews(resource: ViewResource) {
   return useQuery({
@@ -138,13 +182,19 @@ export function useSaveView(resource: ViewResource) {
   const invalidate = () =>
     client.invalidateQueries({ queryKey: ["views", resource] });
 
+  // The blob is the caller's, not this hook's: a list saves its dials under one
+  // key and the segment builder saves a tree under another, and both go through
+  // ONE write so there is one place that stamps the resource and invalidates the
+  // rail. A second mutation per shape is how the two would drift.
   const create = useMutation({
-    mutationFn: async (input: Readonly<{ name: string; query: ListQuery }>) => {
+    mutationFn: async (
+      input: Readonly<{ name: string; query: Record<string, unknown> }>,
+    ) => {
       const { data, error } = await api.POST("/views", {
         body: {
           resource,
           name: input.name,
-          query: listStateFrom(input.query),
+          query: input.query,
         },
       });
       if (error) {
@@ -171,30 +221,31 @@ export function useSaveView(resource: ViewResource) {
 }
 
 /**
- * "Save this view" beside a list's own tools, plus the dialog that names it.
+ * "Save this view", and the dialog that names it.
  *
- * Offered only when the list is actually narrowed. Saving the unfiltered
- * default would create a tab that does what the All tab already does, and a
- * rail of those is how a useful feature becomes clutter.
+ * One spelling for both surfaces. What differs between a list and the segment
+ * builder is WHAT gets saved, so that arrives as the blob to store — the dialog,
+ * the naming rule, and the error placement are the same question either way, and
+ * a second copy of this is how the two would end up asking it differently.
+ *
+ * `blob` is read at click time rather than at render time: it is the committed
+ * render's state that the mutation is given, never a closure the observer might
+ * still hold from an earlier one.
  */
-export function SaveViewAction({
+function SaveViewButton({
   resource,
-  query,
-}: Readonly<{ resource: ViewResource; query: ListQuery }>) {
+  blob,
+}: Readonly<{
+  resource: ViewResource;
+  blob: () => Record<string, unknown>;
+}>) {
   const t = useT();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const { create } = useSaveView(resource);
-  const headingId = "save-view-heading";
-
-  const narrowed =
-    Boolean(query.q) ||
-    Boolean(query.sort) ||
-    query.includeArchived ||
-    Object.values(query.filters).some(Boolean);
-  if (!narrowed) {
-    return null;
-  }
+  // Minted rather than fixed: two save actions can share a page, and a repeated
+  // id points the dialog's label at whichever heading rendered first.
+  const headingId = useId();
 
   const submit = () => {
     const named = name.trim();
@@ -202,7 +253,7 @@ export function SaveViewAction({
       return;
     }
     create.mutate(
-      { name: named, query },
+      { name: named, query: blob() },
       {
         onSuccess: () => {
           setName("");
@@ -249,5 +300,83 @@ export function SaveViewAction({
         </div>
       </Modal>
     </>
+  );
+}
+
+/**
+ * "Save this view" beside a list's own tools.
+ *
+ * Offered only when the list is actually narrowed. Saving the unfiltered
+ * default would create a tab that does what the All tab already does, and a
+ * rail of those is how a useful feature becomes clutter.
+ */
+export function SaveViewAction({
+  resource,
+  query,
+}: Readonly<{ resource: ViewResource; query: ListQuery }>) {
+  const narrowed =
+    Boolean(query.q) ||
+    Boolean(query.sort) ||
+    query.includeArchived ||
+    Object.values(query.filters).some(Boolean);
+  if (!narrowed) {
+    return null;
+  }
+  return (
+    <SaveViewButton resource={resource} blob={() => listStateFrom(query)} />
+  );
+}
+
+/**
+ * "Save this view" beside the segment builder.
+ *
+ * The same completeness rule the count and the preview use, for the same reason:
+ * an incomplete tree is one the engine refuses, so saving it would store a view
+ * that fails the moment anybody opens it. `isComplete` is the one place that
+ * judgement lives.
+ */
+export function SaveFilterViewAction({
+  resource,
+  tree,
+}: Readonly<{ resource: ViewResource; tree: Node }>) {
+  if (!isComplete(tree)) {
+    return null;
+  }
+  return (
+    <SaveViewButton resource={resource} blob={() => filterStateFrom(tree)} />
+  );
+}
+
+/**
+ * The reader's saved filters for this object, each one click from being loaded.
+ *
+ * A menu rather than a picker: loading a view is an ACTION, and a select would
+ * keep claiming the loaded view is what the builder holds long after the reader
+ * has edited it into something else.
+ *
+ * A view whose stored tree cannot be read is left out, matching the list rail's
+ * rule — an entry that lights up and restores nothing is worse than no entry.
+ */
+export function LoadFilterViewMenu({
+  resource,
+  onLoad,
+}: Readonly<{ resource: ViewResource; onLoad: (tree: Node) => void }>) {
+  const t = useT();
+  const views = useSavedViews(resource);
+  const readable = (views.data ?? []).flatMap((view) => {
+    const tree = filterTreeOf(view);
+    return tree ? [{ id: view.id, name: view.name, tree }] : [];
+  });
+  if (readable.length === 0) {
+    return null;
+  }
+  return (
+    <OverflowMenu label={t("filters.loadView")}>
+      {readable.map((view) => (
+        <Button key={view.id} small onClick={() => onLoad(view.tree)}>
+          {view.name}
+        </Button>
+      ))}
+    </OverflowMenu>
   );
 }

--- a/frontend/src/screens/savedviews.tsx
+++ b/frontend/src/screens/savedviews.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
 } from "../design-system/atoms";
 import { useT } from "../i18n";
-import { problemMessage, throwProblem } from "./common";
+import { problemMessageOf, throwProblem } from "./common";
 import type { ListQuery } from "./listquery";
 import { decode, encode, isComplete, type Node } from "./segmentpredicate";
 
@@ -278,7 +278,11 @@ function SaveViewButton({
         </h2>
         <Field
           label={t("views.name")}
-          error={create.isError ? problemMessage(create.error, t) : undefined}
+          // `problemMessageOf`, not `problemMessage`: what a failed mutation
+          // carries is a ProblemError, and handing that to the body reader
+          // yields the generic "request failed" instead of the reason the
+          // server actually gave.
+          error={create.isError ? problemMessageOf(create.error, t) : undefined}
         >
           {(control) => (
             <TextInput

--- a/frontend/src/screens/segmentpredicate.test.ts
+++ b/frontend/src/screens/segmentpredicate.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   addToGroup,
   encode,
+  fieldsNamed,
   type Group,
   isComplete,
   isGroup,
@@ -206,5 +207,48 @@ describe("knowing when a tree is worth sending", () => {
     expect(isComplete(newGroup("and", [newLeaf("cf_score", "gte", 0)]))).toBe(
       true,
     );
+  });
+});
+
+// A surface deriving columns from the filter reads this, so what it answers has
+// to survive the shapes a real tree takes: nesting, a field named twice across
+// two clauses, and a half-written leaf that names nothing yet.
+describe("fieldsNamed", () => {
+  it("reads every depth, in the order the clauses were written", () => {
+    const tree = newGroup("and", [
+      newLeaf("city", "eq", "Berlin"),
+      newGroup("or", [
+        newLeaf("cf_tier", "in", ["gold"]),
+        newGroup("and", [newLeaf("status", "eq", "open")]),
+      ]),
+    ]);
+
+    expect(fieldsNamed(tree)).toEqual(["city", "cf_tier", "status"]);
+  });
+
+  it("names a field once however many clauses use it", () => {
+    // A range is two clauses over one field, and a column list built from this
+    // would otherwise carry that column twice.
+    const tree = newGroup("and", [
+      newLeaf("cf_score", "gte", 10),
+      newLeaf("cf_score", "lte", 90),
+    ]);
+
+    expect(fieldsNamed(tree)).toEqual(["cf_score"]);
+  });
+
+  it("skips a leaf that names no field yet", () => {
+    // The state a freshly added clause is in: it exists, but there is nothing
+    // for it to show a column of.
+    const tree = newGroup("and", [
+      newLeaf("", "eq", ""),
+      newLeaf("city", "eq", "Berlin"),
+    ]);
+
+    expect(fieldsNamed(tree)).toEqual(["city"]);
+  });
+
+  it("answers nothing for an empty tree", () => {
+    expect(fieldsNamed(newGroup("and"))).toEqual([]);
   });
 });

--- a/frontend/src/screens/segmentpredicate.test.ts
+++ b/frontend/src/screens/segmentpredicate.test.ts
@@ -4,6 +4,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   addToGroup,
+  decode,
   encode,
   fieldsNamed,
   type Group,
@@ -250,5 +251,92 @@ describe("fieldsNamed", () => {
 
   it("answers nothing for an empty tree", () => {
     expect(fieldsNamed(newGroup("and"))).toEqual([]);
+  });
+});
+
+// A saved view's `query` is an open JSON object the server persists verbatim, so
+// what `decode` is handed is untrusted: an older build's shape, a fixture, a
+// hand-written row. The property that matters is the round trip — a view that
+// restores a filter DIFFERENT from the one it was saved from selects rows nobody
+// asked for, under a name the reader trusts.
+describe("decode", () => {
+  it("restores what encode wrote, at every depth", () => {
+    const saved = newGroup("or", [
+      newLeaf("city", "eq", "Berlin"),
+      newGroup("and", [
+        newLeaf("cf_tier", "in", ["gold", "silver"]),
+        newLeaf("cf_score", "gte", 40),
+        newLeaf("tag", "exists", false),
+      ]),
+    ]);
+
+    const restored = decode(encode(saved));
+
+    // Compared through `encode` rather than by identity: the ids are minted
+    // fresh on the way back in, and that is the one thing that MUST differ.
+    expect(restored).not.toBeNull();
+    expect(encode(restored as Node)).toEqual(encode(saved));
+  });
+
+  it("mints fresh ids rather than restoring a tree with none", () => {
+    // Every node needs an id for React to key it and for "remove THIS clause" to
+    // name it, and the wire form deliberately carries none.
+    const restored = decode(
+      encode(newGroup("and", [newLeaf("city", "eq", "B")])),
+    );
+
+    expect(restored).not.toBeNull();
+    const group = restored as Group;
+    expect(group.id).not.toBe("");
+    expect(group.children[0]?.id).not.toBe("");
+    expect(group.children[0]?.id).not.toBe(group.id);
+  });
+
+  // Each of these is a stored blob a real row could carry, and every one of them
+  // has to answer null: the caller drops the view, which is the only honest
+  // outcome — a view that restores a filter it does not name is worse than one
+  // that is not offered.
+  it.each([
+    ["not an object at all", "and"],
+    ["null", null],
+    ["an array", [{ field: "city", op: "eq", value: "B" }]],
+    ["an empty group", { and: [] }],
+    ["a group joined two ways at once", { and: [], or: [] }],
+    ["a group whose children are not a list", { and: { field: "city" } }],
+    ["a leaf naming no field", { field: "", op: "eq", value: "B" }],
+    ["a leaf with no field key", { op: "eq", value: "B" }],
+    [
+      "an operator the engine does not have",
+      { field: "c", op: "like", value: "B" },
+    ],
+    ["an operand that is an object", { field: "c", op: "eq", value: { a: 1 } }],
+    ["a mixed list", { field: "c", op: "in", value: ["a", 1] }],
+    ["a null operand", { field: "c", op: "eq", value: null }],
+  ])("refuses %s", (_name, stored) => {
+    expect(decode(stored)).toBeNull();
+  });
+
+  it("refuses a whole tree when one clause inside it is unreadable", () => {
+    // Dropping the bad clause instead would silently WIDEN the filter: an `and`
+    // missing a leaf selects more rows than the one that was saved.
+    expect(
+      decode({
+        and: [
+          { field: "city", op: "eq", value: "Berlin" },
+          { field: "city", op: "like", value: "Ber" },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("restores a shape-valid clause the Save button would still refuse", () => {
+    // `contains ""` is readable and incomplete, and those are different
+    // questions: the tree decodes, and `isComplete` is what withholds Save.
+    const restored = decode({
+      and: [{ field: "c", op: "contains", value: "" }],
+    });
+
+    expect(restored).not.toBeNull();
+    expect(isComplete(restored as Node)).toBe(false);
   });
 });

--- a/frontend/src/screens/segmentpredicate.ts
+++ b/frontend/src/screens/segmentpredicate.ts
@@ -215,6 +215,115 @@ function hasUsableOperand(op: FilterOp, value: LeafValue): boolean {
   }
 }
 
+/** The operator names, as a set, so a decoded value can be checked against them. */
+const OPERATORS: ReadonlySet<string> = new Set<FilterOp>([
+  "eq",
+  "neq",
+  "gt",
+  "lt",
+  "gte",
+  "lte",
+  "in",
+  "contains",
+  "exists",
+]);
+
+/**
+ * A stored predicate back into an editable tree, or null when it is not one.
+ *
+ * The inverse of `encode`, and it lives beside it for the same reason the id
+ * stripping does: a round trip that loses or invents a clause is a filter that
+ * selects something other than what was saved, and both halves have to be
+ * readable together to see that they agree.
+ *
+ * The argument is `unknown` because that is what it really is. A saved view's
+ * `query` is an open JSON object the server persists verbatim — so this is
+ * handed rows written by an older build, by a fixture, or by hand, and every
+ * field is checked rather than trusted. Nothing here throws: a caller restoring
+ * a view gets null and drops it, because a view that lights up and restores a
+ * filter different from the one it names is worse than a view that is not
+ * offered.
+ *
+ * An empty group is refused rather than restored. It is a shape the engine
+ * would reject anyway (`filter_shape_invalid`), and restoring one hands the
+ * reader a named view indistinguishable from a blank builder.
+ */
+export function decode(stored: unknown): Node | null {
+  if (stored === null || typeof stored !== "object" || Array.isArray(stored)) {
+    return null;
+  }
+  const node = stored as Record<string, unknown>;
+  const isAnd = "and" in node;
+  const isOr = "or" in node;
+  // A group joins its children ONE way. A blob carrying both keys is not a
+  // stricter filter than either of them — it is a shape with no meaning, and
+  // picking one would restore a filter nobody saved.
+  if (isAnd && isOr) {
+    return null;
+  }
+  if (isAnd || isOr) {
+    const join = isAnd ? "and" : "or";
+    return decodeGroup(node[join], join);
+  }
+  return decodeLeaf(node);
+}
+
+function decodeGroup(children: unknown, join: "and" | "or"): Group | null {
+  if (!Array.isArray(children) || children.length === 0) {
+    return null;
+  }
+  const decoded: Node[] = [];
+  for (const child of children) {
+    const one = decode(child);
+    // One unreadable clause makes the whole tree unreadable. Dropping it would
+    // silently widen the filter — an `and` missing a leaf selects MORE rows
+    // than the one that was saved, under the name the reader trusts.
+    if (one === null) {
+      return null;
+    }
+    decoded.push(one);
+  }
+  return newGroup(join, decoded);
+}
+
+function decodeLeaf(node: Record<string, unknown>): Leaf | null {
+  const { field, op, value } = node;
+  if (typeof field !== "string" || field === "") {
+    return null;
+  }
+  if (typeof op !== "string" || !OPERATORS.has(op)) {
+    return null;
+  }
+  return isLeafValue(value) ? newLeaf(field, op as FilterOp, value) : null;
+}
+
+/**
+ * Whether a decoded operand is one the editor can hold.
+ *
+ * A shape check, not a completeness one: `contains ""` decodes fine and then
+ * fails `isComplete`, which is the honest split — the tree is readable, and the
+ * Save button is what refuses it.
+ *
+ * A mixed array is refused. `["a", 1]` is not a list this editor has a control
+ * for, and admitting it would put a value on screen that no edit can produce.
+ */
+function isLeafValue(value: unknown): value is LeafValue {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return (
+    value.every((item) => typeof item === "string") ||
+    value.every((item) => typeof item === "number")
+  );
+}
+
 /**
  * The fields this tree names, in the order a reader wrote them, each once.
  *

--- a/frontend/src/screens/segmentpredicate.ts
+++ b/frontend/src/screens/segmentpredicate.ts
@@ -214,3 +214,32 @@ function hasUsableOperand(op: FilterOp, value: LeafValue): boolean {
       return !Array.isArray(value) && value !== "";
   }
 }
+
+/**
+ * The fields this tree names, in the order a reader wrote them, each once.
+ *
+ * It lives here because it is a question about the tree, and the tree's shape is
+ * this module's business — a caller walking `and`/`or` itself would be the second
+ * place that knows how a group nests.
+ *
+ * Reading order rather than sorted: the clause somebody wrote first is the one
+ * they were thinking about, so a surface deriving columns from this shows the
+ * field they led with on the left. Deduped because naming a field twice — a range
+ * across two clauses — is one column, not two.
+ */
+export function fieldsNamed(tree: Node): string[] {
+  const seen = new Set<string>();
+  const walk = (node: Node) => {
+    if (!isGroup(node)) {
+      if (node.field !== "") {
+        seen.add(node.field);
+      }
+      return;
+    }
+    for (const child of node.children) {
+      walk(child);
+    }
+  };
+  walk(tree);
+  return [...seen];
+}


### PR DESCRIPTION
The rest of the Filters & views screen, now that [#1799](https://github.com/gradionhq/margince-poc-v1/pull/1799) has landed the shell: the results table, saved views, and export. `AC-filters-and-views-5`, `-7`, `-8`. Frontend only — no contract change; `/filters/preview`, `/views` and `/exports` all already existed.

Three commits, one per AC, because each carries its own judgement.

## The columns are derived from the filter, not invented

The preview answers every non-generated column of the table — around thirty for a person. AC-5 names five product columns for contacts; picking my own five for organizations and deals would be a list nobody agreed to. So the table shows **what identifies the row, plus the fields the filter actually names**, in the order they were written, capped at six with the picker holding the rest. What a reader is checking is the clause they just wrote.

The primary key earns a column only when nothing else names the row — I only saw that a `id` column was being spent on a UUID beside the name it duplicates by looking at the `fe-uat` capture.

It renders through `ListTable`. That was worth verifying rather than assuming: it reads as a record-list component, but `ListColumn` is generic over the row, so a schema-derived projection fits without pretending to be a record. `frontend/CLAUDE.md` records that this tree has twice grown a duplicate surface by hand-rolling instead.

## A saved view restores the filter it was saved from, or is not offered

`savedviews.tsx` had already reserved `query.filter` for this builder — its comment says so — so this is the second caller that key was left free for.

The load direction is the work: `query` is an open JSON object the server persists verbatim, so what comes back is untrusted. `decode` is the inverse of `encode`, lives beside it, and answers null rather than guessing.

**One unreadable clause makes the whole tree unreadable.** Dropping the bad clause instead would silently widen the filter — an `and` missing a leaf selects MORE rows than the one that was saved, under the name the reader trusts. Mutation-verified.

A menu, not a picker: loading a view is an action, and a select would keep claiming the loaded view is what the builder holds long after the reader has edited it into something else.

`/filters/*` says `person`, `/views` says `people` — both enumerated in the contract. The correspondence is written down once, beside `RESOURCE_OF` where a reader sees both mappings together. A test asserts the stored body carries the plural.

## The filter on screen is the slice that gets exported

Same predicate the preview takes, so what leaves the building is what the count says. Not paged: the server renders the whole match, and a client-side stitch of preview pages would be a second, wrong answer.

**Three defects the rendered screen taught, which reading the code would not have:**

| What the capture showed | Why it was wrong | Fix |
|---|---|---|
| Two identical `…` triggers | Nothing said which was the view menu and which the export | Two labelled buttons; the header keeps the one `…` it can afford |
| The reason clipped, colliding with the card title | The export takes the filter as its argument, so it belongs after it — and a refusal is a sentence | Moved below the builder |
| "request failed" | `problemMessage` reads a Problem *body*; a failed mutation carries a `ProblemError` | `problemMessageOf` — **two** call sites had it wrong, this one and a pre-existing one in `savedviews.tsx` |

`downloadBytes` is extracted rather than written twice: `aiexport.tsx` already had the object-URL/anchor/click/revoke sequence inline, and the revoke is the step a second copy forgets. The filename comes from `Content-Disposition` — only the quoted form, since half-parsing RFC 6266's extended form yields a plausible-looking wrong name, and only the leaf, because a path separator in a download name is how a header talks a browser into writing outside the downloads folder. The test fixture deliberately sends a name the client would NOT compose for itself; identical strings would pass whether the header was read or ignored.

## Story coverage

`make fe-uat` flagged `savedviews.tsx` and `filterexport.tsx` as changed components with no story — both pre-existing gaps, both now covered, including the states where a save or export action renders **nothing**. Those captures are empty on purpose: that is the documented behaviour.

## Deliberately not here

The NL bar (AC-2). LVS-EXT-6 does not exist, so there is nothing to compile a description against, and a bar that silently did nothing would be worse than a visible gap.

`make check-fe` green (3411 tests), `make fe-uat` green (18 stories).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the Filters & Views screen: shows the first page of matching rows, lets readers load/save filters as views, and exports the current filter as CSV/JSON. Previously only the shell rendered; now the table derives columns from the filter, saved views restore their filter (or are omitted), and export lives under the builder with clear failure messages.

- Columns come from the filter: identity column first, then the fields the filter names, capped at six; hide the id when another column names the row; nulls render as a dash; headers match the field picker.
- Saved views use `query.filter` and a strict decoder; unreadable views are not offered; Save is shown only when the tree is `isComplete`; fixes error handling to show the server’s message; maps `/filters/*` singulars (`person`) to `/views` plurals (`people`) once via `VIEW_OF`.
- Export sends the on-screen tree to `/exports` (no paging); replaces the second “…” with two labeled buttons; moves below the builder; uses `Content-Disposition` to name files via `filenameFromDisposition`; shares a safe `downloadBytes` helper (also used by the AI export screen).

**Review notes**
- New components: `FilterResults` (table) and `ExportFilterMenu` (CSV/JSON).
- New tree helpers in `segmentpredicate`: `fieldsNamed` and `decode` (inverse of `encode`) with “fail the whole tree on one bad clause.”
- Story and test coverage added for results, saved views, export; i18n adds `unit.deals` and filter strings.

**Rollout / QA**
- No contract changes; uses existing `/filters/preview`, `/views`, and `/exports`.
- Verify for contacts/companies/deals: count matches visible rows; export produces a file named by the server; Save is withheld for unnarrowed lists and incomplete filters; the load menu omits unreadable views.

<sup>Written for commit 5b587c57eeda09c1d648b143e5fc54f3f9030931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

