### PR TITLE
refactor(platform): the last per-record singletons drop the tenant column (ADR-0091 §8 phase D)

### DIFF
--- a/backend/internal/compose/captureparticipant_integration_test.go
+++ b/backend/internal/compose/captureparticipant_integration_test.go
@@ -243,9 +243,9 @@ func TestDeletingAPersonOrAUserIsNotBlockedByGraphRows(t *testing.T) {
 		// A CONFIRMED ghost pointing at the contact.
 		_, err := tx.Exec(ctx, `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name, company_name,
+			  (owner_user_id, full_name, normalized_name, company_name,
 			   normalized_company, matched_person_id, match_status, source)
-			VALUES (`+ws+`, $1, 'Departing Contact', 'departing contact', 'Acme',
+			VALUES ($1, 'Departing Contact', 'departing contact', 'Acme',
 			        'acme', $2, 'confirmed', 'csv_export')`, e.Rep1, contact)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -257,8 +257,8 @@ func TestAContactAddedLaterMeetsTheGhostThatWasWaiting(t *testing.T) {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name, email, source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			  (owner_user_id, full_name, normalized_name, email, source)
+			VALUES (
 			        $1, 'Dana Buyer', 'dana buyer', 'dana@acme.test', 'csv_export')`, e.Rep1)
 		return err
 	}); err != nil {
@@ -326,8 +326,8 @@ func TestTheSweepNeverMatchesOutsideTheGhostOwnersRowScope(t *testing.T) {
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name, email, source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			  (owner_user_id, full_name, normalized_name, email, source)
+			VALUES (
 			        $1, 'Dana Buyer', 'dana buyer', 'dana@acme.test', 'csv_export')`, e.Rep3)
 		return err
 	}); err != nil {
@@ -393,8 +393,8 @@ func TestThePerPersonSweepNeverMatchesOutsideTheGhostOwnersRowScope(t *testing.T
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name, email, source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			  (owner_user_id, full_name, normalized_name, email, source)
+			VALUES (
 			        $1, 'Dana Buyer', 'dana buyer', 'dana@acme.test', 'csv_export')`, e.Rep3)
 		return err
 	}); err != nil {
@@ -408,8 +408,8 @@ func TestThePerPersonSweepNeverMatchesOutsideTheGhostOwnersRowScope(t *testing.T
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name, source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			  (owner_user_id, full_name, normalized_name, source)
+			VALUES (
 			        $1, 'Someone Else', 'someone else', 'csv_export')`, e.Rep2)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -228,8 +228,8 @@ func claimKey(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoin
 // (workspace, principal, key, endpoint) already exists.
 func insertClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (bool, error) {
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO idempotency_key (workspace_id, principal_id, key, endpoint, request_digest)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
+		INSERT INTO idempotency_key (principal_id, key, endpoint, request_digest)
+		VALUES ($1, $2, $3, $4)
 		ON CONFLICT (principal_id, key, endpoint) DO NOTHING`,
 		principalID, key, endpoint, digest)
 	if err != nil {

--- a/backend/internal/compose/idempotencyretention_integration_test.go
+++ b/backend/internal/compose/idempotencyretention_integration_test.go
@@ -27,12 +27,12 @@ func seedSettledClaim(t *testing.T, e *integration.Env, key, ageOffset string) {
 	t.Helper()
 	e.WsExec(t, `
 		INSERT INTO idempotency_key
-		  (workspace_id, principal_id, key, endpoint, request_digest,
+		  (principal_id, key, endpoint, request_digest,
 		   response_status, response_body, response_content_type, created_at)
-		VALUES ($1, $2, $3, 'POST /v1/people', 'digest',
+		VALUES ($1, $2, 'POST /v1/people', 'digest',
 		        201, '{"full_name":"Snapshot Subject","email":"subject@example.org"}',
-		        'application/json', now() - $4::interval)`,
-		e.WS, "human:"+ids.NewV7().String(), key, ageOffset)
+		        'application/json', now() - $3::interval)`,
+		"human:"+ids.NewV7().String(), key, ageOffset)
 }
 
 func claimExists(t *testing.T, e *integration.Env, key string) bool {

--- a/backend/internal/compose/linkedinmatchproposal_integration_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_integration_test.go
@@ -50,9 +50,9 @@ func linkedInMatchFixture(ctx context.Context, t *testing.T, e *integration.Env)
 	seedAsAdmin(t, e, func(c context.Context, tx pgx.Tx) error {
 		_, err := tx.Exec(c, `
 			INSERT INTO linkedin_connection
-			    (workspace_id, owner_user_id, full_name, normalized_name, company_name,
+			    (owner_user_id, full_name, normalized_name, company_name,
 			     normalized_company, profile_url, matched_org_id, source)
-			VALUES (`+wsGUC+`, $1, 'Andreas Müller', 'andreas muller', 'Acme GmbH',
+			VALUES ($1, 'Andreas Müller', 'andreas muller', 'Acme GmbH',
 			        'acme', 'https://www.linkedin.com/in/amueller', $2, 'csv_export')`,
 			e.Rep1, orgID)
 		return err

--- a/backend/internal/compose/org360/dismissal.go
+++ b/backend/internal/compose/org360/dismissal.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -89,10 +88,10 @@ func (s *Service) DismissSuggestion(ctx context.Context, orgID ids.OrganizationI
 		// reads a dismissal's age, and the id is a v7 uuid, so the instant stays
 		// recoverable for support without a column nobody reads.
 		_, err = tx.Exec(ctx, `
-			INSERT INTO suggestion_dismissal (workspace_id, user_id, organization_id, fingerprint)
-			VALUES ($1, $2, $3, $4)
+			INSERT INTO suggestion_dismissal (user_id, organization_id, fingerprint)
+			VALUES ($1, $2, $3)
 			ON CONFLICT (user_id, organization_id, fingerprint) DO NOTHING`,
-			storekit.MustWorkspace(ctx), userID, orgID, fingerprint)
+			userID, orgID, fingerprint)
 		if err != nil {
 			return fmt.Errorf("record the suggestion dismissal: %w", err)
 		}

--- a/backend/internal/compose/org360/viewbaseline.go
+++ b/backend/internal/compose/org360/viewbaseline.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -71,12 +70,12 @@ func (s *Service) Acknowledge(ctx context.Context, orgID ids.OrganizationID) (cr
 			return err
 		}
 		return tx.QueryRow(ctx, `
-			INSERT INTO user_record_view (workspace_id, user_id, entity_type, entity_id, last_viewed_at)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)
+			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (user_id, entity_type, entity_id)
 			DO UPDATE SET last_viewed_at = GREATEST(user_record_view.last_viewed_at, EXCLUDED.last_viewed_at)
 			RETURNING last_viewed_at`,
-			storekit.MustWorkspace(ctx), userID, entityTypeOrganization, orgID, now).Scan(&stored)
+			userID, entityTypeOrganization, orgID, now).Scan(&stored)
 	})
 	if err != nil {
 		return crmcontracts.RecordViewAck{}, err

--- a/backend/internal/compose/person360/handlers.go
+++ b/backend/internal/compose/person360/handlers.go
@@ -19,7 +19,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -136,12 +135,12 @@ func (s *Service) Acknowledge(ctx context.Context, personID ids.PersonID) (crmco
 			return err
 		}
 		return tx.QueryRow(ctx, `
-			INSERT INTO user_record_view (workspace_id, user_id, entity_type, entity_id, last_viewed_at)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)
+			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (user_id, entity_type, entity_id)
 			DO UPDATE SET last_viewed_at = GREATEST(user_record_view.last_viewed_at, EXCLUDED.last_viewed_at)
 			RETURNING last_viewed_at`,
-			storekit.MustWorkspace(ctx), userID, entityTypePerson, personID, now).Scan(&stored)
+			userID, entityTypePerson, personID, now).Scan(&stored)
 	})
 	if err != nil {
 		return crmcontracts.RecordViewAck{}, err

--- a/backend/internal/compose/signalextract.go
+++ b/backend/internal/compose/signalextract.go
@@ -161,7 +161,7 @@ func (x *SignalExtractor) deferRefusedReading(
 ) error {
 	var refusals int
 	if markErr := database.WithWorkspaceTx(ctx, x.pool, func(tx pgx.Tx) error {
-		counted, countErr := recordThreadRefusal(ctx, tx, wsID, thread, now)
+		counted, countErr := recordThreadRefusal(ctx, tx, thread, now)
 		refusals = counted
 		return countErr
 	}); markErr != nil {
@@ -207,7 +207,7 @@ func (x *SignalExtractor) commitReading(
 				raised++
 			}
 		}
-		return markThreadScanned(ctx, tx, wsID, thread, now)
+		return markThreadScanned(ctx, tx, thread, now)
 	}); err != nil {
 		return 0, err
 	}

--- a/backend/internal/compose/signalextractread.go
+++ b/backend/internal/compose/signalextractread.go
@@ -288,14 +288,14 @@ func threadMessages(ctx context.Context, tx pgx.Tx, key string) ([]threadMessage
 // lose whatever it says; counting without pinning would let a growing
 // conversation inherit the refusals of text it no longer contains.
 func recordThreadRefusal(
-	ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, thread settledThread, now time.Time,
+	ctx context.Context, tx pgx.Tx, thread settledThread, now time.Time,
 ) (int, error) {
 	var refusals int
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO signal_thread_scan
-		  (workspace_id, thread_key, last_activity_at, message_count, scanned_at,
+		  (thread_key, last_activity_at, message_count, scanned_at,
 		   refusals, refused_activity_at, refused_message_count)
-		VALUES ($1, $2, '-infinity', 0, $5, 1, $3, $4)
+		VALUES ($1, '-infinity', 0, $4, 1, $2, $3)
 		ON CONFLICT (thread_key) DO UPDATE
 		   SET refusals = CASE
 		         WHEN signal_thread_scan.refused_activity_at IS NOT DISTINCT FROM excluded.refused_activity_at
@@ -310,7 +310,7 @@ func recordThreadRefusal(
 		       -- is what the park window is measured from.
 		       scanned_at = excluded.scanned_at
 		RETURNING refusals`,
-		wsID, thread.Key, thread.Newest, thread.Count, now).Scan(&refusals); err != nil {
+		thread.Key, thread.Newest, thread.Count, now).Scan(&refusals); err != nil {
 		return 0, fmt.Errorf("count the refused reading: %w", err)
 	}
 	return refusals, nil
@@ -326,12 +326,12 @@ func recordThreadRefusal(
 // count is overwritten, because a backfill that adds older messages legitimately
 // lowers nothing and raises the count, and clamping it would hide exactly the
 // change it exists to notice.
-func markThreadScanned(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, thread settledThread, now time.Time) error {
+func markThreadScanned(ctx context.Context, tx pgx.Tx, thread settledThread, now time.Time) error {
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO signal_thread_scan
-		  (workspace_id, thread_key, last_activity_at, message_count, scanned_at,
+		  (thread_key, last_activity_at, message_count, scanned_at,
 		   resolved_org_id)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (thread_key) DO UPDATE
 		   SET last_activity_at = greatest(signal_thread_scan.last_activity_at, excluded.last_activity_at),
 		       message_count = excluded.message_count,
@@ -347,7 +347,7 @@ func markThreadScanned(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, thr
 		       refusals = 0,
 		       refused_activity_at = NULL,
 		       refused_message_count = NULL`,
-		wsID, thread.Key, thread.Newest, thread.Count, now, thread.OrganizationID); err != nil {
+		thread.Key, thread.Newest, thread.Count, now, thread.OrganizationID); err != nil {
 		return fmt.Errorf("record where the read got to: %w", err)
 	}
 	return nil

--- a/backend/internal/modules/people/linkedin_integration_test.go
+++ b/backend/internal/modules/people/linkedin_integration_test.go
@@ -402,9 +402,9 @@ func TestRenormalizingCollapsesTheDuplicatesAnOldKeyLeft(t *testing.T) {
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		insert := `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name,
+			  (owner_user_id, full_name, normalized_name,
 			   company_name, normalized_company, match_status, source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			VALUES (
 			        $1, 'Abbas Fawaz', 'abbas fawaz', 'najahak.io | Growth',
 			        $2, $3, 'csv_export')
 			RETURNING id`
@@ -472,9 +472,9 @@ func TestCollapsingADuplicateKeepsWhatEachCopyKnew(t *testing.T) {
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		insert := `
 			INSERT INTO linkedin_connection
-			  (workspace_id, owner_user_id, full_name, normalized_name, company_name,
+			  (owner_user_id, full_name, normalized_name, company_name,
 			   normalized_company, position, email, connected_on, match_status, source)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+			VALUES (
 			        $1, 'Abbas Fawaz', 'abbas fawaz', 'najahak.io | Growth',
 			        $2, $3, $4, NULL, $5, 'csv_export')`
 		// The stale copy carries the address and nothing else of note.

--- a/backend/internal/modules/people/linkedinaccount.go
+++ b/backend/internal/modules/people/linkedinaccount.go
@@ -130,9 +130,8 @@ func (s *Store) SaveMyLinkedInAccount(ctx context.Context, in SaveMyLinkedInAcco
 			return err
 		}
 		_, err = tx.Exec(ctx, `
-			INSERT INTO linkedin_account (workspace_id, user_id, profile_url, connected_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        $1, NULLIF($2, ''), CASE WHEN $3 THEN now() END)
+			INSERT INTO linkedin_account (user_id, profile_url, connected_at)
+			VALUES ($1, NULLIF($2, ''), CASE WHEN $3 THEN now() END)
 			ON CONFLICT (user_id) DO UPDATE SET
 			    profile_url = NULLIF($2, ''),
 			    connected_at = CASE

--- a/backend/internal/modules/people/linkedinimport.go
+++ b/backend/internal/modules/people/linkedinimport.go
@@ -317,11 +317,10 @@ func upsertGhost(ctx context.Context, tx pgx.Tx, owner ids.UUID, row linkedInRow
 	}
 	_, err := tx.Exec(ctx, `
 		INSERT INTO linkedin_connection
-		    (workspace_id, owner_user_id, full_name, normalized_name, position,
+		    (owner_user_id, full_name, normalized_name, position,
 		     company_name, normalized_company, connected_on, email, profile_url,
 		     source, synced_at)
-		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, ''), $7, NULLIF($8, ''),
+		VALUES ($1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, ''), $7, NULLIF($8, ''),
 	        NULLIF($9, ''), 'csv_export', now())
 		ON CONFLICT (owner_user_id, normalized_name,
 		             coalesce(normalized_company, ''), coalesce(connected_on, 'epoch'::date))

--- a/backend/internal/modules/people/linkedinreview_integration_test.go
+++ b/backend/internal/modules/people/linkedinreview_integration_test.go
@@ -240,10 +240,10 @@ func TestCollapseNeverLetsAMachineGuessOverrideAHumanConfirmation(t *testing.T) 
 		} {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO linkedin_connection
-				    (id, workspace_id, owner_user_id, full_name, normalized_name,
+				    (id, owner_user_id, full_name, normalized_name,
 				     company_name, normalized_company, matched_person_id, match_status,
 				     source, synced_at)
-				VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid,
+				VALUES ($1,
 				        $2, 'Dup Person', 'dup person', $3, $4, $5, $6, 'csv_export', $7::date)`,
 				row.id, e.rep, row.company, NormalizeOrgName(row.company),
 				row.person.UUID, row.status, row.syncedAt); err != nil {

--- a/backend/internal/platform/database/storekit/fieldprovenance.go
+++ b/backend/internal/platform/database/storekit/fieldprovenance.go
@@ -36,15 +36,19 @@ func StampFields(ctx context.Context, tx pgx.Tx, objectType string, objectID ids
 	if len(stamps) == 0 {
 		return nil
 	}
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
+	// The value is dead — field_provenance carries no tenant since ADR-0091 §8
+	// phase D — but the CHECK is not: it refuses a caller that reached this
+	// write outside a workspace context at all, which is a wiring fault rather
+	// than a row problem and is worth naming here instead of surfacing as a
+	// constraint violation somewhere downstream.
+	if _, ok := principal.WorkspaceID(ctx); !ok {
 		return fmt.Errorf("storekit: field provenance outside workspace context")
 	}
 	for _, s := range stamps {
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO field_provenance (workspace_id, object_type, object_id, field_name, source, captured_by, confidence, evidence_ref)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			wsID, objectType, objectID, s.Field, source, capturedBy, s.Confidence, s.EvidenceRef); err != nil {
+			`INSERT INTO field_provenance (object_type, object_id, field_name, source, captured_by, confidence, evidence_ref)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			objectType, objectID, s.Field, source, capturedBy, s.Confidence, s.EvidenceRef); err != nil {
 			return fmt.Errorf("storekit: stamp field provenance: %w", err)
 		}
 	}

--- a/backend/migrations/core/1787128082_singletons_drop_workspace.down.sql
+++ b/backend/migrations/core/1787128082_singletons_drop_workspace.down.sql
@@ -1,0 +1,66 @@
+-- Reverse of 1787128082: the singletons carry the tenant column again.
+--
+-- The backfill reads the LIVE workspace — archived_at IS NULL, oldest first.
+-- 0217 refuses more than one live tenant and 0272 refuses to proceed while an
+-- archived one still holds records, so there was exactly one workspace these
+-- rows could have belonged to when the forward half ran. Ordering by created_at
+-- alone would hand every restored row to whichever workspace was created first,
+-- archived or not.
+--
+-- If no live workspace exists and a table is not empty, SET NOT NULL fails and
+-- the rollback stops — the honest outcome, since no value this migration could
+-- write would be true. A rollback on an empty database (the reverse-and-reapply
+-- lane) has nothing to attribute and passes.
+ALTER TABLE field_provenance ADD COLUMN workspace_id uuid;
+ALTER TABLE idempotency_key ADD COLUMN workspace_id uuid;
+ALTER TABLE linkedin_account ADD COLUMN workspace_id uuid;
+ALTER TABLE linkedin_connection ADD COLUMN workspace_id uuid;
+ALTER TABLE signal_thread_scan ADD COLUMN workspace_id uuid;
+ALTER TABLE suggestion_dismissal ADD COLUMN workspace_id uuid;
+ALTER TABLE user_record_view ADD COLUMN workspace_id uuid;
+
+DO $$
+DECLARE
+  live uuid := (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+  t    text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'field_provenance', 'idempotency_key', 'linkedin_account',
+    'linkedin_connection', 'signal_thread_scan', 'suggestion_dismissal',
+    'user_record_view'
+  ] LOOP
+    EXECUTE format('UPDATE %I SET workspace_id = $1 WHERE workspace_id IS NULL', t) USING live;
+    EXECUTE format('ALTER TABLE %I ALTER COLUMN workspace_id SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE idempotency_key ADD CONSTRAINT idempotency_key_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE linkedin_account ADD CONSTRAINT linkedin_account_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE linkedin_connection ADD CONSTRAINT linkedin_connection_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE signal_thread_scan ADD CONSTRAINT signal_thread_scan_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE CASCADE;
+ALTER TABLE suggestion_dismissal ADD CONSTRAINT suggestion_dismissal_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+ALTER TABLE user_record_view ADD CONSTRAINT user_record_view_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+DROP INDEX idx_field_provenance_object;
+DROP INDEX idx_linkedin_connection_email;
+DROP INDEX idx_linkedin_connection_match;
+DROP INDEX idx_linkedin_connection_org;
+DROP INDEX suggestion_dismissal_organization_ix;
+
+CREATE INDEX idx_field_provenance_object ON field_provenance
+  (workspace_id, object_type, object_id, field_name, captured_at DESC);
+CREATE INDEX idx_linkedin_connection_email ON linkedin_connection (workspace_id, lower(email))
+  WHERE email IS NOT NULL AND tombstoned_at IS NULL;
+CREATE INDEX idx_linkedin_connection_match ON linkedin_connection
+  (workspace_id, normalized_name, normalized_company) WHERE tombstoned_at IS NULL;
+CREATE INDEX idx_linkedin_connection_org ON linkedin_connection (workspace_id, matched_org_id)
+  WHERE matched_org_id IS NOT NULL AND tombstoned_at IS NULL;
+CREATE INDEX suggestion_dismissal_organization_ix ON suggestion_dismissal (workspace_id, organization_id);

--- a/backend/migrations/core/1787128082_singletons_drop_workspace.up.sql
+++ b/backend/migrations/core/1787128082_singletons_drop_workspace.up.sql
@@ -1,0 +1,54 @@
+-- 1787128082: the last per-record singletons drop the tenant column
+-- (ADR-0091 §8 phase D).
+--
+-- Seven tables, each a sidecar on something that already lost its own tenant:
+--
+--   field_provenance       where one field's current value came from
+--   idempotency_key        a replayed request's stored answer
+--   linkedin_account       a human's connected LinkedIn identity
+--   linkedin_connection    one imported connection of theirs, pre-match
+--   signal_thread_scan     how far the signal reader got through a thread
+--   suggestion_dismissal   a suggestion this reader has waved away
+--   user_record_view       when a reader last opened a record
+--
+-- Every one hangs off a user or a record whose own tenant column is already
+-- gone, so the foreign key carries what this column was restating. None has a
+-- uniqueness that names the tenant and none carries a phase-B leftover: the
+-- only thing the column still held was its foreign key to workspace.
+
+ALTER TABLE user_record_view DROP CONSTRAINT user_record_view_workspace_id_fkey;
+ALTER TABLE user_record_view DROP COLUMN workspace_id;
+
+ALTER TABLE suggestion_dismissal DROP CONSTRAINT suggestion_dismissal_workspace_id_fkey;
+ALTER TABLE suggestion_dismissal DROP COLUMN workspace_id;
+
+ALTER TABLE signal_thread_scan DROP CONSTRAINT signal_thread_scan_workspace_id_fkey;
+ALTER TABLE signal_thread_scan DROP COLUMN workspace_id;
+
+ALTER TABLE linkedin_connection DROP CONSTRAINT linkedin_connection_workspace_id_fkey;
+ALTER TABLE linkedin_connection DROP COLUMN workspace_id;
+
+ALTER TABLE linkedin_account DROP CONSTRAINT linkedin_account_workspace_id_fkey;
+ALTER TABLE linkedin_account DROP COLUMN workspace_id;
+
+ALTER TABLE idempotency_key DROP CONSTRAINT idempotency_key_workspace_id_fkey;
+ALTER TABLE idempotency_key DROP COLUMN workspace_id;
+
+ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_workspace_id_fkey;
+ALTER TABLE field_provenance DROP COLUMN workspace_id;
+
+-- The indexes that led with the column, recreated on what actually selects
+-- rows: the field a provenance row is about, the address or name a connection
+-- is matched by, the account a dismissal is against. Every predicate carries
+-- over unchanged.
+CREATE INDEX idx_field_provenance_object ON field_provenance
+  (object_type, object_id, field_name, captured_at DESC);
+
+CREATE INDEX idx_linkedin_connection_email ON linkedin_connection (lower(email))
+  WHERE email IS NOT NULL AND tombstoned_at IS NULL;
+CREATE INDEX idx_linkedin_connection_match ON linkedin_connection
+  (normalized_name, normalized_company) WHERE tombstoned_at IS NULL;
+CREATE INDEX idx_linkedin_connection_org ON linkedin_connection (matched_org_id)
+  WHERE matched_org_id IS NOT NULL AND tombstoned_at IS NULL;
+
+CREATE INDEX suggestion_dismissal_organization_ix ON suggestion_dismissal (organization_id);


### PR DESCRIPTION
Seven tables lose `workspace_id` — `field_provenance`, `idempotency_key`,
`linkedin_account`, `linkedin_connection`, `signal_thread_scan`,
`suggestion_dismissal`, `user_record_view` — and the five indexes that led with
it are narrowed. Phase D: 15 → 8.

Each is a sidecar on something that already lost its own tenant: the field a
provenance row is about, the request a stored answer replays, the human a
LinkedIn identity belongs to, the record a reader last opened. The foreign key
already carries what this column was restating; none has a uniqueness naming the
tenant, and none carried a phase-B leftover.

## Two guards keep their check and discard their value

Because the value was dead and the check was not.

`storekit.StampFields` still refuses a caller that reached a provenance write
outside a workspace context at all — a **wiring fault**, worth naming there
rather than surfacing as a constraint violation somewhere downstream.

## One parameter goes entirely

`recordThreadRefusal` and `markThreadScanned` lose their `wsID` argument.
`signal_thread_scan` is keyed on `thread_key` alone, so the workspace was being
threaded through two call sites purely to reach a column that no longer exists.

## The new drift gate ran on this slice

#1829 landed while this was in progress, so it rebased onto it and the
`scripts/` check ran against this schema — the first slice where that happened
before `live-boot` rather than after. Clean.

## Verification

- `make check-backend` — exit 0
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor

Remaining after this: `role`/`role_assignment` (blocked on #1826), `app_user`,
`session`, `embedding`, `graph_interaction_edge`, and `audit_log`/`system_log`
last.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops workspace_id from seven per-record singleton tables and narrows five indexes to the fields we actually query. This removes duplicated tenancy while preserving row scope via existing foreign keys.

- Affected tables: field_provenance, idempotency_key, linkedin_account, linkedin_connection, signal_thread_scan, suggestion_dismissal, user_record_view.
- Old vs new: previously sidecar rows stored a tenant; now they do not. Uniqueness and matching logic remain unchanged. `storekit.StampFields` still rejects writes without a workspace context, but it no longer writes a workspace_id. `recordThreadRefusal` and `markThreadScanned` drop their wsID parameter because `signal_thread_scan` is keyed by thread_key alone.

**Rollout and migration**
- Forward: drop workspace_id and related FKs on all seven tables; recreate indexes without the leading workspace_id. No data rewrite.
- Backward: re-add columns, FKs, and composite indexes; backfill workspace_id to the single live workspace (archived_at IS NULL, oldest first). Rollback intentionally fails if rows exist and no live workspace is present.
- Required code migration: callers of `recordThreadRefusal` and `markThreadScanned` must remove the wsID argument (updated here). No client-visible API changes.

<sup>Written for commit b97d9f2d3263e0c939d1e14c5535dc04422a8b9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified data storage for singleton records by removing obsolete workspace-specific fields.
  * Updated LinkedIn, activity tracking, acknowledgements, and signal processing to use streamlined records.
  * Added rollback support to restore the previous workspace-scoped schema if needed.

* **Tests**
  * Updated integration test fixtures to match the revised data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->