### PR TITLE
fix(frontend): refusals that explain themselves, and lists that reach past their first page

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1393,6 +1393,8 @@ export const de = {
   "deal.archive": "Deal archivieren",
   "deal.archiveConfirm":
     "Durch das Archivieren wird dieser Deal aus der aktiven Pipeline entfernt. Dies kann in der Oberfläche nicht rückgängig gemacht werden.",
+  "deal.archivedReadOnly":
+    "Dieser Deal ist archiviert und nimmt keine Änderungen an.",
   "deal.reopen": "Wieder öffnen",
   "deal.reopenPick": "Diesen Deal in eine offene Phase zurücksetzen",
   "deal.reopenConfirm": "Wieder öffnen",
@@ -1503,6 +1505,31 @@ export const de = {
   "inbox.status.approved": "Genehmigt",
   "inbox.status.rejected": "Abgelehnt",
   "inbox.status.expired": "Abgelaufen",
+
+  "inbox.bundle.why":
+    "Eine Aktion hat diese {count} Vorschläge zusammen vorgemerkt. Entscheide sie in einem Zug oder öffne sie und entscheide einzeln.",
+  "inbox.bundle.members": "Die {count} Vorschläge",
+  "inbox.bundle.approveAll": "Alle {count} genehmigen",
+  "inbox.bundle.rejectAll": "Alle {count} ablehnen",
+  "inbox.bundle.approveAllConfirm":
+    "Jeder Vorschlag wird weiterhin für sich entschieden: einer, der abgelaufen ist oder den jemand schon beantwortet hat, wird zurückgemeldet statt überschrieben — die übrigen gehen durch.",
+  "inbox.bundle.rejectReasonHint":
+    "Wird bei jedem abgelehnten Vorschlag festgehalten und mit den Personen geteilt, für die sie vorgemerkt wurden.",
+  "inbox.bundle.expiresIn": "erster läuft ab in {countdown}",
+  "inbox.bundle.result.approved": "{count} genehmigt",
+  "inbox.bundle.result.rejected": "{count} abgelehnt",
+  "inbox.bundle.result.alreadyDecided.one":
+    "{count} war bereits entschieden und bleibt, wie es war.",
+  "inbox.bundle.result.alreadyDecided.other":
+    "{count} waren bereits entschieden und bleiben, wie sie waren.",
+  "inbox.bundle.result.expired.one":
+    "{count} war schon abgelaufen — merke es neu vor, um zu entscheiden.",
+  "inbox.bundle.result.expired.other":
+    "{count} waren schon abgelaufen — merke sie neu vor, um zu entscheiden.",
+  "inbox.bundle.result.effectFailed.one":
+    "{count} wurde genehmigt, aber die Änderung ist nicht angekommen — dieser Datensatz ist unverändert.",
+  "inbox.bundle.result.effectFailed.other":
+    "{count} wurden genehmigt, aber die Änderungen sind nicht angekommen — diese Datensätze sind unverändert.",
 
   "home.brief": "Morgenbriefing",
   "home.sub": "aus echten Signalen sortiert — Vorgemerktes zuerst",
@@ -1768,6 +1795,10 @@ export const de = {
   "docs.add.aboutHint":
     "Ein Dokument an einem Deal kann für Deal-Felder gelesen werden, eines an der Firma nicht.",
   "docs.add.thisCompany": "Diese Firma",
+  "docs.add.aDeal": "Ein Deal",
+  "docs.add.dealSearch": "Deals dieses Accounts durchsuchen",
+  "docs.add.dealSearchReach":
+    "Die Suche erfasst die {deals} neuesten Deals dieses Accounts und zeigt die ersten {matches} Treffer. Ein älterer Deal lässt sich hier nicht auswählen.",
   "docs.add.category": "Kategorie",
   "docs.add.name": "Titel",
   "docs.add.nameHint":
@@ -1779,6 +1810,8 @@ export const de = {
   "docs.add.submit": "Hochladen",
   "docs.add.uploading": "Wird hochgeladen…",
   "docs.add.errNoFile": "Wählen Sie eine Datei zum Hochladen.",
+  "docs.add.errNoDeal":
+    "Wählen Sie den Deal, dem das Dokument zugeordnet werden soll.",
   "docs.add.errRefused":
     "Sie dürfen zu diesem Datensatz keine Dokumente hinzufügen.",
   "docs.add.errInFlight": "Dieses Dokument wird noch hochgeladen.",
@@ -1790,8 +1823,6 @@ export const de = {
   "docs.add.partialTitle": "Hochgeladen, aber nicht eingeordnet",
   "docs.add.partial":
     "Die Datei liegt am Datensatz und steht unten in der Liste. Nur Kategorie und Titel wurden nicht gespeichert, sie ist daher unter Sonstiges abgelegt.",
-  "docs.add.dealsFailed":
-    "Die Deals dieses Accounts konnten nicht geladen werden; das Dokument kann daher nur der Firma zugeordnet werden.",
 
   // Das Panel für die abgelegte Dokumentenlesung (RD-AC-N-2/-3). Drei Zustände,
   // die auch in den Worten getrennt bleiben müssen: noch keine Antwort, gelesen
@@ -2869,6 +2900,39 @@ export const de = {
   "consumerMail.baselinePlaceholder": "gmail.com",
   "consumerMail.baselineNone": "Keine mitgelieferte Domain passt.",
   "consumerMail.baselineMore": "Die ersten {shown} von {matched} Treffern.",
+
+  "blockedDomains.title": "Abgelehnte Domains",
+  "blockedDomains.sub":
+    "Welchen Domains diese Installation die Firma verweigert und was das jeweils entschieden hat — ein Modellurteil, eine Heuristik oder ein Mensch. Eine Domain wieder zuzulassen stellt die Firmenfrage neu, statt nur eine Markierung zu entfernen.",
+  "blockedDomains.domainLabel": "Domain",
+  "blockedDomains.domainPlaceholder": "anbieter.example",
+  "blockedDomains.admissionLabel": "Entscheidung",
+  "blockedDomains.admission.suppressed": "Nie eine Firma",
+  "blockedDomains.admission.admitted": "Zugelassen, und zwar dauerhaft",
+  "blockedDomains.reasonLabel": "Begründung",
+  "blockedDomains.reasonHint":
+    "Ein Satz, mit dem jemand später etwas anfangen kann.",
+  "blockedDomains.reasonPlaceholder":
+    "ein Werkzeug, das wir nutzen — kein Kunde",
+  "blockedDomains.save": "Entscheidung speichern",
+  "blockedDomains.stored": "Gespeichert: {domain} — {admission}.",
+  "blockedDomains.adminOnly":
+    "Nur Admin- oder Ops-Plätze dürfen eine Domain-Entscheidung ändern. Die Liste selbst darfst du lesen.",
+  "blockedDomains.none":
+    "Bisher wurde keiner Domain die Firma verweigert. Urteile über Massenversender landen von selbst hier, ebenso alles, was du selbst ablehnst.",
+  "blockedDomains.unit": "Domain-Entscheidungen",
+  "blockedDomains.openCompany": "die Firma",
+  "blockedDomains.col.domain": "Domain",
+  "blockedDomains.col.admission": "Entscheidung",
+  "blockedDomains.col.source": "Entschieden von",
+  "blockedDomains.col.reason": "Begründung",
+  "blockedDomains.col.decided": "Wann",
+  "blockedDomains.col.revise": "Ändern",
+  "blockedDomains.source.verdict": "Ein Modellurteil",
+  "blockedDomains.source.heuristic": "Eine Heuristik",
+  "blockedDomains.source.human": "Ein Mensch",
+  "blockedDomains.rowAdmit": "Diese zulassen",
+  "blockedDomains.rowRefuse": "Diese ablehnen",
 
   "ob.s4.googleFailed": "Die Google-Verbindung wurde nicht abgeschlossen",
   "ob.s4.imapHost": "IMAP-Host",
@@ -4814,7 +4878,7 @@ export const de = {
   "person.research.capturedBy": "Erfasst von",
   "person.action.email": "E-Mail",
   "person.action.call": "Anrufen",
-  "person.action.book": "Termin",
+  "person.action.meetings": "Termine ansehen",
   "person.action.addTask": "Aufgabe",
   "person.action.research": "Recherche",
   "person.action.more": "Weitere Aktionen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1404,6 +1404,7 @@ export const en = {
   "deal.archive": "Archive deal",
   "deal.archiveConfirm":
     "Archiving removes this deal from the active pipeline. This cannot be undone from the UI.",
+  "deal.archivedReadOnly": "This deal is archived and takes no changes.",
   "deal.reopen": "Reopen",
   "deal.reopenPick": "Move this deal back to an open stage",
   "deal.reopenConfirm": "Reopen",
@@ -1510,6 +1511,36 @@ export const en = {
   "inbox.status.approved": "Approved",
   "inbox.status.rejected": "Rejected",
   "inbox.status.expired": "Expired",
+
+  // One act's proposals, read as one question (a site read publishes the
+  // company's facts plus a lead per person on the team page). The count is
+  // always two or more — a bundle of one is drawn as an ordinary row — so these
+  // sentences need no singular form; the per-member report does, because any
+  // one of its outcomes can hold a single proposal.
+  "inbox.bundle.why":
+    "One action staged these {count} proposals together. Answer them all at once, or open them and decide one at a time.",
+  "inbox.bundle.members": "The {count} proposals",
+  "inbox.bundle.approveAll": "Approve all {count}",
+  "inbox.bundle.rejectAll": "Reject all {count}",
+  "inbox.bundle.approveAllConfirm":
+    "Every proposal is still decided on its own: one that has lapsed, or that somebody has already answered, is reported back rather than overwritten, and the rest go through.",
+  "inbox.bundle.rejectReasonHint":
+    "Recorded on every proposal this rejects, and shared with the people they were staged for.",
+  "inbox.bundle.expiresIn": "first expires in {countdown}",
+  "inbox.bundle.result.approved": "{count} approved",
+  "inbox.bundle.result.rejected": "{count} rejected",
+  "inbox.bundle.result.alreadyDecided.one":
+    "{count} already carried a verdict, which stands as it was.",
+  "inbox.bundle.result.alreadyDecided.other":
+    "{count} already carried verdicts, which stand as they were.",
+  "inbox.bundle.result.expired.one":
+    "{count} had already lapsed — propose it again to decide it.",
+  "inbox.bundle.result.expired.other":
+    "{count} had already lapsed — propose them again to decide them.",
+  "inbox.bundle.result.effectFailed.one":
+    "{count} was approved, but its change did not land — that record is unchanged.",
+  "inbox.bundle.result.effectFailed.other":
+    "{count} were approved, but their changes did not land — those records are unchanged.",
 
   "home.brief": "Morning brief",
   "home.sub": "ranked from live signals — staged actions first",
@@ -1771,6 +1802,10 @@ export const en = {
   "docs.add.aboutHint":
     "A document on a deal can be read for deal fields; one on the company cannot.",
   "docs.add.thisCompany": "This company",
+  "docs.add.aDeal": "A deal",
+  "docs.add.dealSearch": "Search this account's deals",
+  "docs.add.dealSearchReach":
+    "The search covers this account's {deals} newest deals and offers the first {matches} matches. A deal older than those cannot be picked here.",
   "docs.add.category": "Category",
   "docs.add.name": "Title",
   "docs.add.nameHint": "Optional. Left blank, the row shows the filename.",
@@ -1781,6 +1816,7 @@ export const en = {
   "docs.add.submit": "Upload",
   "docs.add.uploading": "Uploading…",
   "docs.add.errNoFile": "Choose a file to upload.",
+  "docs.add.errNoDeal": "Pick the deal to file this against.",
   "docs.add.errRefused": "You may not add documents to this record.",
   "docs.add.errInFlight": "This document is still uploading.",
   "docs.add.errTooLarge":
@@ -1790,8 +1826,6 @@ export const en = {
   "docs.add.partialTitle": "Uploaded, but not filed",
   "docs.add.partial":
     "The file is on the record and listed below. Only its category and title were not saved, so it is filed under Other.",
-  "docs.add.dealsFailed":
-    "This account's deals could not be loaded, so the document can only be filed against the company.",
 
   // The staged-document-reading panel (RD-AC-N-2/-3). Three states that must
   // stay apart in the words as well as in the data: not answered yet, answered
@@ -2864,6 +2898,38 @@ export const en = {
   "consumerMail.baselineNone": "No shipped domain matches.",
   "consumerMail.baselineMore":
     "Showing the first {shown} of {matched} matches.",
+
+  "blockedDomains.title": "Refused domains",
+  "blockedDomains.sub":
+    "Which domains this installation refuses a company, and what decided each one — a model verdict, a heuristic, or a person. Letting a domain back in re-opens the company question rather than merely clearing a flag.",
+  "blockedDomains.domainLabel": "Domain",
+  "blockedDomains.domainPlaceholder": "vendor.example",
+  "blockedDomains.admissionLabel": "Decision",
+  "blockedDomains.admission.suppressed": "Never a company",
+  "blockedDomains.admission.admitted": "Allowed, and kept",
+  "blockedDomains.reasonLabel": "Why",
+  "blockedDomains.reasonHint":
+    "One sentence somebody reviewing this later can act on.",
+  "blockedDomains.reasonPlaceholder": "a tool we use, not a customer",
+  "blockedDomains.save": "Save decision",
+  "blockedDomains.stored": "Stored: {domain} — {admission}.",
+  "blockedDomains.adminOnly":
+    "Only an admin or ops seat may change a domain decision. The list itself is yours to read.",
+  "blockedDomains.none":
+    "No domain has been refused a company yet. Bulk-sender verdicts land here on their own, and so does anything you refuse by hand.",
+  "blockedDomains.unit": "domain decisions",
+  "blockedDomains.openCompany": "the company",
+  "blockedDomains.col.domain": "Domain",
+  "blockedDomains.col.admission": "Decision",
+  "blockedDomains.col.source": "Decided by",
+  "blockedDomains.col.reason": "Why",
+  "blockedDomains.col.decided": "When",
+  "blockedDomains.col.revise": "Change",
+  "blockedDomains.source.verdict": "A model verdict",
+  "blockedDomains.source.heuristic": "A heuristic",
+  "blockedDomains.source.human": "A person",
+  "blockedDomains.rowAdmit": "Allow this one",
+  "blockedDomains.rowRefuse": "Refuse this one",
 
   "ob.s4.googleFailed": "The Google connection didn't complete",
   "ob.s4.imapHost": "IMAP host",
@@ -4821,7 +4887,7 @@ export const en = {
   "person.research.capturedBy": "Captured by",
   "person.action.email": "Email",
   "person.action.call": "Call",
-  "person.action.book": "Book",
+  "person.action.meetings": "See meetings",
   "person.action.addTask": "Add task",
   "person.action.research": "Research",
   "person.action.more": "More actions",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1385,6 +1385,7 @@ export const vi = {
   "deal.archive": "Lưu trữ deal",
   "deal.archiveConfirm":
     "Lưu trữ sẽ đưa deal này ra khỏi pipeline đang hoạt động. Không thể hoàn tác từ giao diện.",
+  "deal.archivedReadOnly": "Deal này đã lưu trữ và không nhận thay đổi.",
   "deal.reopen": "Mở lại",
   "deal.reopenPick": "Chuyển deal này về một giai đoạn đang mở",
   "deal.reopenConfirm": "Mở lại",
@@ -1492,6 +1493,31 @@ export const vi = {
   "inbox.status.approved": "Đã duyệt",
   "inbox.status.rejected": "Đã từ chối",
   "inbox.status.expired": "Đã hết hạn",
+
+  "inbox.bundle.why":
+    "Một hành động đã xếp {count} đề xuất này chờ duyệt cùng lúc. Hãy trả lời tất cả một lần, hoặc mở ra và quyết định từng đề xuất.",
+  "inbox.bundle.members": "{count} đề xuất trong hành động này",
+  "inbox.bundle.approveAll": "Duyệt cả {count}",
+  "inbox.bundle.rejectAll": "Từ chối cả {count}",
+  "inbox.bundle.approveAllConfirm":
+    "Mỗi đề xuất vẫn được quyết định riêng: đề xuất đã hết hạn hoặc đã có người trả lời sẽ được báo lại chứ không bị ghi đè, những đề xuất còn lại sẽ được thực hiện.",
+  "inbox.bundle.rejectReasonHint":
+    "Lý do được ghi vào mọi đề xuất bị từ chối, và những người mà các đề xuất được xếp chờ duyệt cho sẽ thấy.",
+  "inbox.bundle.expiresIn": "đề xuất đầu tiên hết hạn sau {countdown}",
+  "inbox.bundle.result.approved": "Đã duyệt {count}",
+  "inbox.bundle.result.rejected": "Đã từ chối {count}",
+  "inbox.bundle.result.alreadyDecided.one":
+    "{count} đề xuất đã có quyết định trước đó và được giữ nguyên.",
+  "inbox.bundle.result.alreadyDecided.other":
+    "{count} đề xuất đã có quyết định trước đó và đều được giữ nguyên.",
+  "inbox.bundle.result.expired.one":
+    "{count} đề xuất đã hết hạn — hãy xếp lại để quyết định.",
+  "inbox.bundle.result.expired.other":
+    "{count} đề xuất đã hết hạn — hãy xếp lại để quyết định chúng.",
+  "inbox.bundle.result.effectFailed.one":
+    "{count} đề xuất đã được duyệt nhưng thay đổi không được áp dụng — bản ghi đó không đổi.",
+  "inbox.bundle.result.effectFailed.other":
+    "{count} đề xuất đã được duyệt nhưng các thay đổi không được áp dụng — những bản ghi đó không đổi.",
 
   "home.brief": "Tóm tắt buổi sáng",
   "home.sub": "xếp hạng từ tín hiệu trực tiếp — việc chờ xác nhận lên trước",
@@ -1754,6 +1780,10 @@ export const vi = {
   "docs.add.aboutHint":
     "Tài liệu gắn với một thương vụ có thể được đọc để lấy các trường của thương vụ; gắn với công ty thì không.",
   "docs.add.thisCompany": "Công ty này",
+  "docs.add.aDeal": "Một thương vụ",
+  "docs.add.dealSearch": "Tìm trong các thương vụ của tài khoản này",
+  "docs.add.dealSearchReach":
+    "Tìm kiếm chỉ quét {deals} thương vụ mới nhất của tài khoản này và hiển thị {matches} kết quả đầu tiên. Thương vụ cũ hơn thế thì không chọn được ở đây.",
   "docs.add.category": "Phân loại",
   "docs.add.name": "Tiêu đề",
   "docs.add.nameHint": "Không bắt buộc. Để trống thì dòng hiển thị tên tệp.",
@@ -1764,6 +1794,7 @@ export const vi = {
   "docs.add.submit": "Tải lên",
   "docs.add.uploading": "Đang tải lên…",
   "docs.add.errNoFile": "Hãy chọn một tệp để tải lên.",
+  "docs.add.errNoDeal": "Hãy chọn thương vụ để gắn tài liệu này vào.",
   "docs.add.errRefused": "Bạn không được thêm tài liệu vào bản ghi này.",
   "docs.add.errInFlight": "Tài liệu này vẫn đang được tải lên.",
   "docs.add.errTooLarge":
@@ -1773,8 +1804,6 @@ export const vi = {
   "docs.add.partialTitle": "Đã tải lên, nhưng chưa xếp loại",
   "docs.add.partial":
     "Tệp đã nằm trên bản ghi và có trong danh sách bên dưới. Chỉ phân loại và tiêu đề là chưa lưu được, nên tệp đang xếp ở mục Khác.",
-  "docs.add.dealsFailed":
-    "Không tải được danh sách thương vụ của tài khoản này, nên tài liệu chỉ có thể gắn với công ty.",
 
   // Bảng đọc tài liệu đã lưu (RD-AC-N-2/-3). Ba trạng thái phải tách bạch cả
   // trong câu chữ: chưa trả lời, đã đọc và không nêu trường nào, và không đọc
@@ -2843,6 +2872,39 @@ export const vi = {
   "consumerMail.baselineNone": "Không có tên miền có sẵn nào khớp.",
   "consumerMail.baselineMore":
     "Hiển thị {shown} đầu tiên trong {matched} kết quả.",
+
+  "blockedDomains.title": "Tên miền bị từ chối",
+  "blockedDomains.sub":
+    "Những tên miền mà bản cài đặt này không cho thành công ty, và điều gì đã quyết định từng trường hợp — một phán định của mô hình, một quy tắc suy đoán, hay một con người. Cho một tên miền vào lại sẽ mở lại câu hỏi về công ty, chứ không chỉ xoá một dấu hiệu.",
+  "blockedDomains.domainLabel": "Tên miền",
+  "blockedDomains.domainPlaceholder": "nhacungcap.example",
+  "blockedDomains.admissionLabel": "Quyết định",
+  "blockedDomains.admission.suppressed": "Không bao giờ là công ty",
+  "blockedDomains.admission.admitted": "Được cho vào, và giữ nguyên",
+  "blockedDomains.reasonLabel": "Lý do",
+  "blockedDomains.reasonHint":
+    "Một câu mà người xem lại sau này có thể dựa vào.",
+  "blockedDomains.reasonPlaceholder":
+    "một công cụ chúng ta dùng, không phải khách hàng",
+  "blockedDomains.save": "Lưu quyết định",
+  "blockedDomains.stored": "Đã lưu: {domain} — {admission}.",
+  "blockedDomains.adminOnly":
+    "Chỉ ghế admin hoặc ops mới được đổi quyết định về tên miền. Bạn vẫn đọc được danh sách.",
+  "blockedDomains.none":
+    "Chưa có tên miền nào bị từ chối làm công ty. Phán định về người gửi hàng loạt sẽ tự xuất hiện ở đây, cùng với mọi thứ bạn tự tay từ chối.",
+  "blockedDomains.unit": "quyết định tên miền",
+  "blockedDomains.openCompany": "công ty",
+  "blockedDomains.col.domain": "Tên miền",
+  "blockedDomains.col.admission": "Quyết định",
+  "blockedDomains.col.source": "Ai quyết định",
+  "blockedDomains.col.reason": "Lý do",
+  "blockedDomains.col.decided": "Khi nào",
+  "blockedDomains.col.revise": "Đổi",
+  "blockedDomains.source.verdict": "Phán định của mô hình",
+  "blockedDomains.source.heuristic": "Quy tắc suy đoán",
+  "blockedDomains.source.human": "Một con người",
+  "blockedDomains.rowAdmit": "Cho tên miền này vào",
+  "blockedDomains.rowRefuse": "Từ chối tên miền này",
 
   "ob.s4.googleFailed": "Kết nối Google chưa hoàn tất",
   "ob.s4.imapHost": "Máy chủ IMAP",
@@ -4776,7 +4838,7 @@ export const vi = {
   "person.research.capturedBy": "Ghi nhận bởi",
   "person.action.email": "Email",
   "person.action.call": "Gọi",
-  "person.action.book": "Đặt lịch",
+  "person.action.meetings": "Xem lịch hẹn",
   "person.action.addTask": "Thêm việc",
   "person.action.research": "Nghiên cứu",
   "person.action.more": "Thao tác khác",

--- a/frontend/src/screens/adddocument.stories.tsx
+++ b/frontend/src/screens/adddocument.stories.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
 import { AddDocumentDialog } from "./adddocument";
 import {
   installFetchStub,
@@ -10,9 +11,14 @@ import {
   StoryProviders,
 } from "./story-utils";
 
-// Adding a document. The state worth looking at is not the empty form — it is
-// the refusal, which has to say WHICH thing is missing, and the deal list,
-// which is what makes the extraction panel reachable at all.
+// Adding a document. The states worth looking at are not the empty form — they
+// are the refusal, which has to say WHICH thing is missing; the deal question,
+// which is what makes the extraction panel reachable at all; and the contact's
+// version of the same dialog, which has no deal question to ask.
+//
+// The dialog is a Modal, so it renders into the document body rather than into
+// the story canvas: a `play` has to scope past `canvasElement` or it never sees
+// the form at all.
 
 const meta: Meta = {
   title: "Records/Company 360/Add a document",
@@ -24,6 +30,10 @@ type Story = StoryObj;
 
 const page = { has_more: false, next_cursor: null };
 
+// More deals than anybody reads in a dropdown, which is the whole of what issue
+// 1536 was about: the control is a search over the account's deals, so the two
+// named ones below are found by typing part of a name rather than by scrolling
+// past sixty framework agreements.
 const deals = [
   {
     id: "deal-1",
@@ -37,15 +47,26 @@ const deals = [
     organization_id: "o-1",
     status: "open",
   },
+  ...Array.from({ length: 60 }, (_unused, index) => ({
+    id: `deal-bulk-${index}`,
+    name: `Spare parts framework ${2020 + (index % 6)} — lot ${index}`,
+    organization_id: "o-1",
+    status: "open",
+  })),
 ];
 
 function Dialog({
   seat = "full",
+  onPerson = false,
   dealsFail = false,
-}: Readonly<{ seat?: "full" | "read"; dealsFail?: boolean }>) {
+}: Readonly<{
+  seat?: "full" | "read";
+  onPerson?: boolean;
+  dealsFail?: boolean;
+}>) {
   installFetchStub({
     "GET /me": meRoute(
-      { deal: ["update"], organization: ["update"] },
+      { deal: ["update"], organization: ["update"], person: ["update"] },
       { seat },
     ),
     "GET /deals": () =>
@@ -53,25 +74,61 @@ function Dialog({
         ? jsonResponse({ title: "Server error", status: 500 }, 500)
         : jsonResponse({ data: deals, page }),
   });
+  const anchor = onPerson
+    ? ({ record: "person", id: "p-1" } as const)
+    : ({ record: "organization", id: "o-1" } as const);
   return (
     <StoryProviders>
-      <AddDocumentDialog orgId="o-1" open onClose={() => {}} />
+      <AddDocumentDialog anchor={anchor} open onClose={() => {}} />
     </StoryProviders>
   );
 }
 
-/** The form as it opens: the company preselected, and Upload refused until a
- * file is chosen — with the refusal naming what is missing. */
+/** Choose "A deal", then search for one by name. */
+async function searchForADeal(canvasElement: HTMLElement, term: string) {
+  const body = within(canvasElement.ownerDocument.body);
+  await userEvent.click(await body.findByRole("radio", { name: /A deal/ }));
+  await userEvent.type(
+    await body.findByRole("searchbox", { name: /Search this account/ }),
+    term,
+  );
+}
+
+/** The form as it opens on an account: the company chosen, and Upload refused
+ * until a file is picked — with the refusal naming what is missing. */
 export const Default: Story = { render: () => <Dialog /> };
+
+/** "A deal" chosen and a name typed. The candidate is a pick, and the sentence
+ * under the field says how far the search reaches — stated whatever the
+ * account's size, because a caption that only appeared once a walk ran out
+ * would be a claim about the last search rather than about the control. */
+export const FilingAgainstADeal: Story = {
+  render: () => <Dialog />,
+  play: async ({ canvasElement }) => {
+    await searchForADeal(canvasElement, "graz");
+    await within(canvasElement.ownerDocument.body).findByRole("button", {
+      name: /Pallet Handling Programme/,
+    });
+  },
+};
+
+/** The same dialog opened from a CONTACT's file library. There is no deal
+ * question: a deal hangs off a company, and nothing on a contact's page names
+ * one — so the file is filed against the contact and the form asks nothing it
+ * has no second answer for. */
+export const OnAContact: Story = { render: () => <Dialog onPerson /> };
 
 /** A read seat holding the same grants. The refusal changes from "choose a
  * file" to "you may not add documents here", which is a different sentence
  * about a different problem. */
 export const ReadOnlySeat: Story = { render: () => <Dialog seat="read" /> };
 
-/** The deals could not be read. The dialog says so rather than quietly
- * offering the company as the only option, which would look identical to an
- * account that genuinely has no deals. */
-export const DealsUnavailable: Story = {
+/** The deal search cannot reach the server. The picker reports the failure on
+ * its own line and offers no candidates, rather than an empty result set that
+ * reads as an account with no matching deal. */
+export const DealSearchUnavailable: Story = {
   render: () => <Dialog dealsFail />,
+  play: async ({ canvasElement }) => {
+    await searchForADeal(canvasElement, "graz");
+  },
 };

--- a/frontend/src/screens/adddocument.test.tsx
+++ b/frontend/src/screens/adddocument.test.tsx
@@ -23,9 +23,21 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+const COMPANY = { record: "organization", id: "o-1" } as const;
+const CONTACT = { record: "person", id: "p-1" } as const;
+
 const DEAL = {
   id: "deal-1",
   name: "Pallet Handling Programme — Graz",
+  organization_id: "o-1",
+  status: "open",
+};
+
+// A deal on the SECOND page of the account's deals — the one a flat, capped
+// Select could never offer, and the reason the picker walks the pages.
+const OLDER_DEAL = {
+  id: "deal-99",
+  name: "Wash cycle retrofit — Graz plant",
   organization_id: "o-1",
   status: "open",
 };
@@ -35,20 +47,20 @@ const DEAL = {
 // reason the test was not testing.
 const USER = { id: "u-1", email: "rep@example.com", name: "Demo Rep" };
 
+const GRANTS = {
+  deal: { update: true },
+  organization: { update: true },
+  person: { update: true },
+};
+
 const FULL_SEAT = {
   user: USER,
-  authorization: {
-    seat_type: "full",
-    objects: { deal: { update: true }, organization: { update: true } },
-  },
+  authorization: { seat_type: "full", objects: GRANTS },
 };
 
 const READ_SEAT = {
   user: USER,
-  authorization: {
-    seat_type: "read",
-    objects: { deal: { update: true }, organization: { update: true } },
-  },
+  authorization: { seat_type: "read", objects: GRANTS },
 };
 
 type Recorded = { url: string; method: string; body: unknown };
@@ -77,6 +89,8 @@ function stubApi(
     // Refuses the installation read outright — the other way the client can end
     // up without a limit.
     settingsStatus?: number;
+    // Refuses the deal read, so the picker has a failure to report.
+    dealsStatus?: number;
   } = {},
 ) {
   const calls: Recorded[] = [];
@@ -118,7 +132,22 @@ function stubApi(
         });
       }
       if (url.includes("/v1/deals")) {
-        return json({ data: [DEAL], page: { next_cursor: null } });
+        if (options.dealsStatus) {
+          return json(
+            { title: "The deal list is unavailable", status: 500 },
+            options.dealsStatus,
+          );
+        }
+        // TWO pages, walked by cursor. The second one holds a deal that no
+        // single request offers, which is the whole point of the walk: the flat
+        // Select this replaced could not reach it at any page size.
+        const cursor = new URL(url).searchParams.get("cursor");
+        return cursor === "page-2"
+          ? json({ data: [OLDER_DEAL], page: { has_more: false } })
+          : json({
+              data: [DEAL],
+              page: { has_more: true, next_cursor: "page-2" },
+            });
       }
       if (url.includes("/metadata")) {
         if (options.metadataThrows) {
@@ -167,7 +196,7 @@ function dialog(open: boolean, onClose = () => {}) {
   return (
     <QueryClientProvider client={shared}>
       <LocaleProvider initial="en">
-        <AddDocumentDialog orgId="o-1" open={open} onClose={onClose} />
+        <AddDocumentDialog anchor={COMPANY} open={open} onClose={onClose} />
       </LocaleProvider>
     </QueryClientProvider>
   );
@@ -191,7 +220,7 @@ function Hosted() {
     <>
       <Button onClick={() => setOpen(true)}>reopen</Button>
       <AddDocumentDialog
-        orgId="o-1"
+        anchor={COMPANY}
         open={open}
         onClose={() => setOpen(false)}
       />
@@ -248,6 +277,22 @@ function uploadedForm(calls: Recorded[]): FormData {
  * file is chosen lands on a disabled control and does nothing — a test that
  * skipped this wait would assert against an upload that was never attempted.
  */
+/**
+ * Choose "A deal", search for one by name, and pick it.
+ *
+ * The candidate is awaited rather than assumed: RecordPicker debounces the
+ * typed term, and every page the walk reads is a request — so the button only
+ * exists once the walk that found it has come back.
+ */
+async function pickDeal(user: UserEvent, term: string, name: RegExp) {
+  await user.click(screen.getByRole("radio", { name: /A deal/ }));
+  await user.type(
+    screen.getByRole("searchbox", { name: /Search this account/ }),
+    term,
+  );
+  await user.click(await screen.findByRole("button", { name }));
+}
+
 async function pressUpload(user: UserEvent) {
   const submit = screen.getByRole("button", { name: "Upload" });
   await waitFor(() => expect(submit.hasAttribute("disabled")).toBe(false));
@@ -275,11 +320,7 @@ describe("adding a document from the account", () => {
     const calls = stubApi(FULL_SEAT);
     show();
 
-    await pickOption(
-      user,
-      await screen.findByRole("combobox", { name: /About/ }),
-      "Pallet Handling Programme — Graz",
-    );
+    await pickDeal(user, "pallet", /Pallet Handling Programme/);
     await user.upload(screen.getByLabelText(/File/), orderForm());
     await pressUpload(user);
 
@@ -287,6 +328,110 @@ describe("adding a document from the account", () => {
     const sent = uploadedForm(calls);
     expect(sent.get("entity_type")).toBe("deal");
     expect(sent.get("entity_id")).toBe("deal-1");
+  });
+
+  it("reaches a deal on a later page, which no single request offers", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT);
+    show();
+
+    // `/deals` carries no text query, so the words are matched over pages this
+    // dialog walks. A deal past the first page is exactly the one the capped
+    // Select could not offer at any size.
+    await pickDeal(user, "wash", /Wash cycle retrofit/);
+    await user.upload(screen.getByLabelText(/File/), orderForm());
+    await pressUpload(user);
+
+    await waitFor(() => expect(uploadedForm(calls)).toBeTruthy());
+    expect(uploadedForm(calls).get("entity_id")).toBe("deal-99");
+    // The walk continued with the cursor the first page handed back, rather
+    // than asking the same question twice with a larger limit.
+    const walked = calls.filter((call) => call.url.includes("/v1/deals"));
+    expect(
+      walked.some(
+        (call) => new URL(call.url).searchParams.get("cursor") === "page-2",
+      ),
+    ).toBe(true);
+  });
+
+  it("says how far the deal search reaches, before the reader fails to find something", async () => {
+    const user = userEvent.setup();
+    stubApi(FULL_SEAT);
+    show();
+
+    await user.click(screen.getByRole("radio", { name: /A deal/ }));
+
+    // An unfound deal and a deal that does not exist read identically, so the
+    // control states its own reach rather than leaving the reader to conclude
+    // the account has no such deal.
+    expect(
+      screen.getByText(/covers this account's 2000 newest deals/),
+    ).toBeTruthy();
+  });
+
+  it("refuses the upload while the chosen filing has no deal, rather than falling back to the company", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT);
+    show();
+
+    await user.click(screen.getByRole("radio", { name: /A deal/ }));
+    await user.upload(screen.getByLabelText(/File/), orderForm());
+
+    // Filing it against the company instead would put the document somewhere
+    // the reader did not choose — and only a deal's documents can be read for
+    // deal fields, so the fallback is a silent downgrade.
+    const submit = screen.getByRole("button", { name: "Upload" });
+    await waitFor(() => expect(submit.hasAttribute("disabled")).toBe(true));
+    expect(
+      screen.getByText("Pick the deal to file this against."),
+    ).toBeTruthy();
+    await user.click(submit);
+    expect(uploads(calls)).toHaveLength(0);
+  });
+
+  it("reports a failed deal search in the picker rather than offering nothing", async () => {
+    const user = userEvent.setup();
+    stubApi(FULL_SEAT, { dealsStatus: 500 });
+    show();
+
+    await user.click(screen.getByRole("radio", { name: /A deal/ }));
+    await user.type(
+      screen.getByRole("searchbox", { name: /Search this account/ }),
+      "graz",
+    );
+
+    // An empty candidate list would say "this account has no such deal", which
+    // is a claim about the account made from a request that failed.
+    expect(
+      await screen.findByText("The deal list is unavailable"),
+    ).toBeTruthy();
+  });
+
+  it("asks nothing about deals when the dialog was opened from a contact", async () => {
+    const user = userEvent.setup();
+    const calls = stubApi(FULL_SEAT);
+    shared = client();
+    render(
+      <QueryClientProvider client={shared}>
+        <LocaleProvider initial="en">
+          <AddDocumentDialog anchor={CONTACT} open onClose={() => {}} />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+
+    // A deal hangs off a company and nothing on a contact's page names one, so
+    // the question has no second answer — and a control whose one option is the
+    // record you are already on is a control that asks nothing.
+    expect(screen.queryByRole("radio", { name: /A deal/ })).toBeNull();
+    await user.upload(screen.getByLabelText(/File/), orderForm());
+    await pressUpload(user);
+
+    await waitFor(() => expect(uploadedForm(calls)).toBeTruthy());
+    const sent = uploadedForm(calls);
+    expect(sent.get("entity_type")).toBe("person");
+    expect(sent.get("entity_id")).toBe("p-1");
+    // Nothing asked the account's deals about a contact's file.
+    expect(calls.some((call) => call.url.includes("/v1/deals"))).toBe(false);
   });
 
   it("sends the category and title as a second request, because the upload cannot carry them", async () => {
@@ -300,7 +445,7 @@ describe("adding a document from the account", () => {
         }
       >
         <LocaleProvider initial="en">
-          <AddDocumentDialog orgId="o-1" open onClose={closed} />
+          <AddDocumentDialog anchor={COMPANY} open onClose={closed} />
         </LocaleProvider>
       </QueryClientProvider>,
     );
@@ -403,28 +548,6 @@ describe("adding a document from the account", () => {
     // claim about markup rather than about behaviour.
     await user.click(screen.getByRole("button", { name: "Upload" }));
     expect(calls.some((call) => call.method === "POST")).toBe(false);
-  });
-
-  it("says the deals could not be loaded rather than silently offering only the company", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url = input instanceof Request ? input.url : String(input);
-        if (url.includes("/v1/deals")) {
-          return new Response(JSON.stringify({ title: "Server error" }), {
-            status: 500,
-            headers: { "content-type": "application/json" },
-          });
-        }
-        return new Response(JSON.stringify(FULL_SEAT), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }),
-    );
-    show();
-
-    expect(await screen.findByText(/deals could not be loaded/)).toBeTruthy();
   });
 
   it("refuses a second press while the first upload is still in flight", async () => {

--- a/frontend/src/screens/adddocument.tsx
+++ b/frontend/src/screens/adddocument.tsx
@@ -1,21 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useId, useRef, useState } from "react";
-import { api } from "../api/client";
+import {
+  type QueryKey,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
 import { formatUploadLimit, useMaxUploadBytes } from "../app/uploadlimit";
 import { Button, Field, Modal, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
+import { ChoiceList } from "../design-system/choicelist";
 import { FileDropzone } from "../design-system/filedropzone";
+import {
+  RecordPicker,
+  type RecordPickerCandidate,
+} from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
 
-// Adding a document to an account, from the account.
+// Adding a document to the record the dialog was opened from — an account's
+// document library, or a contact's.
 //
 // WHY THE PARENT IS A QUESTION AND NOT A DEFAULT. A document filed against the
 // company is a document about the company; one filed against a deal is evidence
@@ -31,9 +41,17 @@ import { problemMessageOf, throwProblem } from "./common";
 // `PATCH /attachments/{id}/metadata`. So the second call can fail on its own
 // with the file already stored, and this dialog says exactly that rather than
 // reporting a failure the reader would answer by uploading the same file twice.
+//
+// WHY THE QUESTION IS ONLY ASKED ON AN ACCOUNT. Deals hang off a company, so
+// the account's library can offer its own deals as filing targets and a
+// contact's cannot: nothing on a contact's page names a deal, and a contact is
+// seated on deals at companies they may not even work for. The contact's
+// library therefore files against the contact, with no choice to make, rather
+// than growing a control whose one option is the record you are already on.
 
 type Attachment = components["schemas"]["Attachment"];
 type Category = NonNullable<Attachment["category"]>;
+type DealPage = components["schemas"]["DealListResponse"];
 
 const CATEGORY_KEYS: Record<Category, MessageKey> = {
   contract: "docs.category.contract",
@@ -43,17 +61,47 @@ const CATEGORY_KEYS: Record<Category, MessageKey> = {
   other: "docs.category.other",
 };
 
-// The parent the file hangs off, as one string the Select can carry. "org" is
-// the account itself; anything else is a deal id behind this prefix.
-const DEAL_PREFIX = "deal:";
-const THIS_COMPANY = "org";
+/**
+ * The record whose document library this dialog was opened from.
+ *
+ * `record` is also the wire's own `entity_type`, which is why it is one string
+ * rather than two shapes: the upload takes the parent as an (entity_type,
+ * entity_id) pair, and the RBAC object the server checks IS that same string
+ * (`auth.Require(ctx, entityType, update)`), so a second vocabulary here would
+ * be a mapping table with nothing to map.
+ */
+export type DocumentAnchor = Readonly<{
+  record: "organization" | "person";
+  id: string;
+}>;
 
-type Parent = { entityType: "organization" | "deal"; entityId: string };
+type Parent = Readonly<{
+  entityType: DocumentAnchor["record"] | "deal";
+  entityId: string;
+}>;
 
-function parseParent(choice: string, orgId: string): Parent {
-  return choice.startsWith(DEAL_PREFIX)
-    ? { entityType: "deal", entityId: choice.slice(DEAL_PREFIX.length) }
-    : { entityType: "organization", entityId: orgId };
+// Which record the file hangs off: the one this dialog was opened from, or one
+// of that account's deals. Two named answers rather than a Select carrying a
+// sentinel value beside a list of deal ids — filing against the account is a
+// different KIND of decision from picking one deal out of hundreds, and the two
+// spent a release smuggled into one dropdown where the account read as the
+// zeroth deal.
+type Filing = "anchor" | "deal";
+
+/**
+ * The parent the bytes will be filed against, or null when the reader has
+ * chosen "a deal" and not yet picked one — which is a refusal to state, not a
+ * parent to guess.
+ */
+function parentOf(
+  anchor: DocumentAnchor,
+  filing: Filing,
+  deal: RecordPickerCandidate | null,
+): Parent | null {
+  if (filing === "deal") {
+    return deal ? { entityType: "deal", entityId: deal.id } : null;
+  }
+  return { entityType: anchor.record, entityId: anchor.id };
 }
 
 type Submission = {
@@ -109,43 +157,86 @@ function metadataFor(submitted: Submission) {
   return patch;
 }
 
-// How many deals the picker offers. A Select is a list, not a search, and one
-// carrying every deal an old account ever had is not a control anybody can use.
-// The cap is therefore deliberate — and it is a real limit: an account past it
-// cannot file a document against its oldest deals from here. Issue 1536 tracks
-// giving this a searchable picker, which is the shape that removes the cap
-// rather than raising it.
-const DEAL_CHOICES = 50;
+// HOW THE DEAL SEARCH WORKS, AND WHERE IT STOPS.
+//
+// `GET /deals` is cursor-paginated and takes no text query — the contract
+// offers a cursor, a limit, a sort and a set of id filters, and nothing
+// textual. So the words the reader types are matched HERE, over pages this
+// dialog walks, and a client-side match has to stop somewhere or one settled
+// keystroke walks every deal an old account ever had.
+//
+// The bound is pages, not results: DEAL_SEARCH_PAGES pages of the contract's
+// maximum page size, in the list endpoint's own default order, which is
+// newest-created first. What the search therefore covers is this account's
+// DEAL_SEARCH_REACH newest deals, and what it cannot reach is anything older —
+// which the picker STATES, under the field, before the reader goes looking. An
+// unfound deal and a deal that does not exist read identically otherwise, and
+// that silence is the whole of what issue 1536 was about.
+const DEAL_PAGE_SIZE = 200;
+const DEAL_SEARCH_PAGES = 10;
+const DEAL_SEARCH_REACH = DEAL_PAGE_SIZE * DEAL_SEARCH_PAGES;
 
-/** The deals this document could be filed against, in the API's own order. */
-function useAccountDeals(orgId: string, open: boolean) {
-  return useQuery({
-    queryKey: ["dealsForOrg", orgId],
-    // A closed dialog asks nothing: the parent card renders on every company
-    // page, and this list is only a question once somebody opens the form.
-    enabled: open,
-    queryFn: async () => {
-      const { data, error } = await api.GET("/deals", {
-        params: { query: { organization_id: orgId, limit: DEAL_CHOICES } },
-      });
-      if (error) {
-        throwProblem(error);
+// How many matches are worth offering at once. Past this the walk stops: a
+// list of a hundred pickable buttons is not a pick, and the reader has a
+// cheaper way to shorten it, which is one more word.
+const DEAL_MATCH_LIMIT = 25;
+
+// How long a walked page is reused. The reader re-runs the whole walk every
+// time they change a word, so the pages are cached under their own cursor;
+// a minute outlasts a dialog and is far shorter than the age of the deals a
+// walk this deep is reaching.
+const DEAL_PAGE_FRESH_MS = 60_000;
+
+/**
+ * Walk the account's deals, newest first, keeping the ones whose name contains
+ * what the reader typed.
+ *
+ * `fetchPage` is injected rather than called directly so the walk reads pages
+ * through the caller's cache: the second search over one account re-reads what
+ * the first already fetched instead of spending the whole page budget again.
+ */
+async function walkAccountDeals(
+  fetchPage: (cursor: string | null) => Promise<DealPage>,
+  needle: string,
+): Promise<RecordPickerCandidate[]> {
+  const matches: RecordPickerCandidate[] = [];
+  let cursor = FIRST_PAGE;
+  for (let page = 0; page < DEAL_SEARCH_PAGES; page += 1) {
+    const answered = await fetchPage(cursor);
+    for (const deal of answered.data) {
+      if (deal.name.toLocaleLowerCase().includes(needle)) {
+        matches.push({ id: deal.id, name: deal.name });
       }
-      return data?.data ?? [];
-    },
-  });
+    }
+    if (matches.length >= DEAL_MATCH_LIMIT) {
+      return matches.slice(0, DEAL_MATCH_LIMIT);
+    }
+    // The CURSOR is what the walk can continue with, and `has_more` without one
+    // is a cut list nothing can read the rest of — so both ends of the walk end
+    // it here rather than looping on a cursor that will not move.
+    cursor = answered.page.next_cursor ?? null;
+    if (!cursor) {
+      return matches;
+    }
+  }
+  return matches;
 }
 
 export function AddDocumentDialog({
-  orgId,
+  anchor,
   open,
   onClose,
-}: Readonly<{ orgId: string; open: boolean; onClose: () => void }>) {
+}: Readonly<{
+  anchor: DocumentAnchor;
+  open: boolean;
+  onClose: () => void;
+}>) {
   const t = useT();
   const titleId = useId();
   const queryClient = useQueryClient();
 
-  const [choice, setChoice] = useState(THIS_COMPANY);
+  const [filing, setFiling] = useState<Filing>("anchor");
+  const [deal, setDeal] = useState<RecordPickerCandidate | null>(null);
   const [category, setCategory] = useState<Category>("other");
   const [title, setTitle] = useState("");
   const [file, setFile] = useState<File | undefined>();
@@ -170,24 +261,77 @@ export function AddDocumentDialog({
   const maxUploadBytes = useMaxUploadBytes();
   const limitLabel = maxUploadBytes ? formatUploadLimit(maxUploadBytes) : "";
 
-  const deals = useAccountDeals(orgId, open);
-  const parent = parseParent(choice, orgId);
+  // One page of the account's deals, read through the query cache so a second
+  // search re-uses what the first walked. Keyed by the CURSOR, because that is
+  // what identifies a page of a keyset walk.
+  //
+  // Built on every anchor, called only from the deal picker — which only the
+  // account branch below renders. A hook cannot be conditional, and an
+  // uncalled callback asks nothing.
+  const fetchDealPage = useCallback(
+    (cursor: string | null) =>
+      queryClient.fetchQuery({
+        queryKey: ["dealsForOrg", anchor.id, cursor],
+        staleTime: DEAL_PAGE_FRESH_MS,
+        queryFn: async (): Promise<DealPage> => {
+          const { data, error } = await api.GET("/deals", {
+            params: {
+              query: {
+                organization_id: anchor.id,
+                limit: DEAL_PAGE_SIZE,
+                ...(cursor ? { cursor } : {}),
+              },
+            },
+          });
+          if (error) {
+            throwProblem(error);
+          }
+          return data;
+        },
+      }),
+    [anchor.id, queryClient],
+  );
+
+  // Kept on `fetchDealPage` alone. RecordPicker reads a new `searchTargets`
+  // identity as a new search space and empties the candidates it is showing, so
+  // a callback rebuilt on anything that changes while the reader types would
+  // clear the list under them.
+  const searchDeals = useCallback(
+    (query: string) =>
+      walkAccountDeals(fetchDealPage, query.trim().toLocaleLowerCase()),
+    [fetchDealPage],
+  );
+
+  const parent = parentOf(anchor, filing, deal);
+  // All three asked unconditionally: the number of hooks a render performs must
+  // not depend on which record the reader is filing against.
   const canWriteOrg = useCanWrite("organization", "update");
   const canWriteDeal = useCanWrite("deal", "update");
-  const permitted = parent.entityType === "deal" ? canWriteDeal : canWriteOrg;
+  const canWritePerson = useCanWrite("person", "update");
+  // The upload's RBAC object IS the parent's entity type, so the grant this
+  // dialog checks follows the CHOICE rather than the record it was opened from.
+  // With "a deal" chosen and none picked yet there is no parent, and the grant
+  // that governs the press is still the deal one.
+  const writable: Readonly<Record<Parent["entityType"], boolean>> = {
+    organization: canWriteOrg,
+    person: canWritePerson,
+    deal: canWriteDeal,
+  };
+  const permitted = writable[parent?.entityType ?? "deal"];
 
   // Emptying the form is separate from closing it, because the two happen at
   // different moments: every close empties, and the partial-failure path
   // empties the file without closing.
   const clearDraft = () => {
-    setChoice(THIS_COMPANY);
+    setFiling("anchor");
+    setDeal(null);
     setCategory("other");
     setTitle("");
     setFile(undefined);
   };
 
   // Everything the request needs arrives as a variable. A mutationFn closing
-  // over `file` or `choice` would submit whatever the previous render held.
+  // over `file` or `parent` would submit whatever the previous render held.
   const upload = useMutation({
     mutationFn: async (submitted: Submission) => {
       const id = await uploadFile(submitted);
@@ -218,12 +362,9 @@ export function AddDocumentDialog({
       }
     },
     onSuccess: async (result) => {
-      await queryClient.invalidateQueries({
-        queryKey: ["orgDocuments", orgId],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ["organization360", orgId],
-      });
+      for (const queryKey of staleAfterUpload(anchor)) {
+        await queryClient.invalidateQueries({ queryKey });
+      }
       if (result.filed) {
         closeAndClear();
         return;
@@ -254,12 +395,13 @@ export function AddDocumentDialog({
     onClose();
   }
 
-  const refusal = uploadRefusal(
+  const refusal = uploadRefusal({
     file,
+    parent,
     permitted,
-    upload.isPending,
-    maxUploadBytes,
-  );
+    pending: upload.isPending,
+    maxBytes: maxUploadBytes,
+  });
 
   return (
     <Modal open={open} onClose={closeAndClear} labelledBy={titleId}>
@@ -279,28 +421,55 @@ export function AddDocumentDialog({
           {problemMessageOf(upload.error, t, t("docs.add.failed"))}
         </Callout>
       )}
-      {deals.isError && (
-        <Callout tone="warn" live="status">
-          {t("docs.add.dealsFailed")}
-        </Callout>
-      )}
 
-      <Field label={t("docs.add.about")} hint={t("docs.add.aboutHint")}>
-        {(control) => (
-          <Select
-            {...control}
-            value={choice}
-            onChange={setChoice}
-            options={[
-              { value: THIS_COMPANY, label: t("docs.add.thisCompany") },
-              ...(deals.data ?? []).map((deal) => ({
-                value: `${DEAL_PREFIX}${deal.id}`,
-                label: deal.name,
-              })),
+      {/* Asked only on an account, and asked as a QUESTION WITH TWO ANSWERS
+          rather than a dropdown: both answers have to be readable at rest,
+          because choosing between them is the decision this dialog exists to
+          put in front of the reader, and a menu covering two options makes
+          somebody open it to find out what the alternative was
+          (design-system/choicelist.tsx). A contact's library has no second
+          answer, so it asks nothing. */}
+      {anchor.record === "organization" && (
+        <>
+          <ChoiceList
+            legend={t("docs.add.about")}
+            value={filing}
+            onChange={setFiling}
+            choices={[
+              { value: "anchor", label: t("docs.add.thisCompany") },
+              {
+                value: "deal",
+                label: t("docs.add.aDeal"),
+                description: t("docs.add.aboutHint"),
+              },
             ]}
           />
-        )}
-      </Field>
+          {filing === "deal" && (
+            <div className="field">
+              <RecordPicker
+                label={t("docs.add.dealSearch")}
+                searchTargets={searchDeals}
+                selected={deal}
+                onPick={setDeal}
+                disabled={upload.isPending}
+              />
+              {/* The reach, stated up front rather than after the reader has
+                  failed to find something. It is the same sentence whatever
+                  the account's size, which is what makes it trustworthy: a
+                  caption that only appeared once a walk ran out would be a
+                  claim about the last search rather than about the control,
+                  and RecordPicker hands its caller no way to know which search
+                  an answer belonged to. */}
+              <p className="t-caption">
+                {t("docs.add.dealSearchReach", {
+                  deals: String(DEAL_SEARCH_REACH),
+                  matches: String(DEAL_MATCH_LIMIT),
+                })}
+              </p>
+            </div>
+          )}
+        </>
+      )}
 
       <Field label={t("docs.add.category")}>
         {(control) => (
@@ -346,15 +515,36 @@ export function AddDocumentDialog({
         <Button
           variant="primary"
           reason={refusal ? t(refusal, { size: limitLabel }) : undefined}
-          onClick={() =>
-            file && upload.mutate({ parent, category, title, file })
-          }
+          onClick={() => {
+            if (file && parent) {
+              upload.mutate({ parent, category, title, file });
+            }
+          }}
         >
           {t(upload.isPending ? "docs.add.uploading" : "docs.add.submit")}
         </Button>
       </div>
     </Modal>
   );
+}
+
+/**
+ * What a landed upload makes stale, per anchor.
+ *
+ * The two libraries are read by different surfaces and so by different keys:
+ * the account's is one unpaginated read plus the 360 that counts it, the
+ * contact's is its own cursor-paginated tab and nothing else — the person 360
+ * carries no attachments section, so invalidating it would refetch a composite
+ * that says nothing about the file just filed.
+ */
+function staleAfterUpload(anchor: DocumentAnchor): readonly QueryKey[] {
+  if (anchor.record === "person") {
+    return [["attachments", "person", anchor.id]];
+  }
+  return [
+    ["orgDocuments", anchor.id],
+    ["organization360", anchor.id],
+  ];
 }
 
 // Why the upload cannot be offered, in the order the reader can act on: a
@@ -365,17 +555,31 @@ export function AddDocumentDialog({
 // request it would repeat has already left: a second press lands a second copy
 // of the document on the record, and nothing downstream can tell that from two
 // deliberate uploads of the same file.
-function uploadRefusal(
-  file: File | undefined,
-  permitted: boolean,
-  pending: boolean,
-  maxBytes: number | undefined,
-): MessageKey | null {
+function uploadRefusal({
+  file,
+  parent,
+  permitted,
+  pending,
+  maxBytes,
+}: Readonly<{
+  file: File | undefined;
+  parent: Parent | null;
+  permitted: boolean;
+  pending: boolean;
+  maxBytes: number | undefined;
+}>): MessageKey | null {
   if (!permitted) {
     return "docs.add.errRefused";
   }
   if (!file) {
     return "docs.add.errNoFile";
+  }
+  // "A deal" chosen and none picked. Named as its own refusal rather than left
+  // to fall back on the account: a document filed somewhere the reader did not
+  // choose is worse than one not filed at all, and only a deal's documents can
+  // be read for deal fields.
+  if (!parent) {
+    return "docs.add.errNoDeal";
   }
   if (pending) {
     return "docs.add.errInFlight";

--- a/frontend/src/screens/blocked-domains.stories.tsx
+++ b/frontend/src/screens/blocked-domains.stories.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BlockedDomainsCard } from "./blocked-domains";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// The three sources side by side, because telling them apart is the card's whole
+// job: a model verdict, a heuristic, and a person who deliberately let a domain
+// back in. The admitted row carries a company id — the McKinsey case, where
+// unblocking re-asked the company question and one landed.
+const BY_VERDICT = {
+  domain: "substack.example",
+  admission: "suppressed",
+  reason: "a newsletter platform, not a customer",
+  source: "verdict",
+  decided_at: "2026-07-30T09:12:00Z",
+  organization_id: null,
+};
+const BY_HEURISTIC = {
+  domain: "expensify.example",
+  admission: "suppressed",
+  reason: "bulk sender: no reply address, list-unsubscribe header",
+  source: "heuristic",
+  decided_at: "2026-08-02T14:40:00Z",
+  organization_id: null,
+};
+const BY_HUMAN = {
+  domain: "mckinsey.example",
+  admission: "admitted",
+  reason: "they became a client in July",
+  source: "human",
+  decided_at: "2026-08-11T07:05:00Z",
+  organization_id: "018f3a1b-0000-7000-8000-00000000c001",
+};
+
+function story(
+  entries: Record<string, unknown>[],
+  total: number,
+  allow: Parameters<typeof meRoute>[0],
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute(allow),
+      "GET /capture/blocked-domains": () =>
+        jsonResponse({ data: entries, total }),
+      "PUT /capture/blocked-domains": (body) => jsonResponse(body),
+    });
+    return (
+      <StoryProviders>
+        <BlockedDomainsCard />
+      </StoryProviders>
+    );
+  };
+}
+
+// Reading is every human role's; changing an entry is organization:update.
+const OPS = { organization: ["read", "update"] } as const;
+const READER = { organization: ["read"] } as const;
+
+const meta: Meta<typeof BlockedDomainsCard> = {
+  title: "Settings/Organization/Capture/Refused domains",
+  component: BlockedDomainsCard,
+};
+export default meta;
+type Story = StoryObj<typeof BlockedDomainsCard>;
+
+export const Populated: Story = {
+  render: story([BY_VERDICT, BY_HEURISTIC, BY_HUMAN], 3, OPS),
+};
+
+// Nothing refused yet. It has to read as a fact about the installation rather
+// than as a table that failed to draw.
+export const Empty: Story = { render: story([], 0, OPS) };
+
+// Refusals accumulate on their own from every bulk-sender verdict, so the list
+// is paged at 200 and the response says how many exist. The count line under the
+// table is the only thing that stops "past the end of this page" reading as
+// "never refused".
+export const PastTheFirstPage: Story = {
+  render: story([BY_VERDICT, BY_HEURISTIC, BY_HUMAN], 412, OPS),
+};
+
+// A seat that may read the posture and not change it: the controls disable and
+// say why, rather than vanishing and leaving the reader to guess whether the
+// list is complete.
+export const ReadOnly: Story = {
+  render: story([BY_VERDICT, BY_HEURISTIC, BY_HUMAN], 3, READER),
+};
+
+// The card at 390px. A reason is a whole sentence and a domain is one unbroken
+// token, so this is where the table decides which of them gets the width.
+export const PopulatedPhone: Story = {
+  globals: { viewport: { value: "phone" } },
+  tags: ["uat-phone"],
+  render: story([BY_VERDICT, BY_HEURISTIC, BY_HUMAN], 3, OPS),
+};

--- a/frontend/src/screens/blocked-domains.test.tsx
+++ b/frontend/src/screens/blocked-domains.test.tsx
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GrantSpec } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { BlockedDomainsCard } from "./blocked-domains";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  type RouteMap,
+} from "./story-utils";
+
+// Settings → Capture: the domains this installation refuses a company. The card
+// answers one question nothing else can — a company that never appeared, was it
+// refused and by whom — so what it must never do is lose the difference between
+// a machine's refusal and a person's, claim an empty list is a broken one, or
+// offer a write it has no reason to send.
+
+const LIST = "GET /capture/blocked-domains";
+const WRITE = "PUT /capture/blocked-domains";
+
+// Read is every human role's; changing an entry is organization:update.
+const OPS: GrantSpec = { organization: ["read", "update"] };
+const READER: GrantSpec = { organization: ["read"] };
+
+const BY_HEURISTIC = {
+  domain: "expensify.example",
+  admission: "suppressed",
+  reason: "bulk sender: no reply address",
+  source: "heuristic",
+  decided_at: "2026-08-02T14:40:00Z",
+  organization_id: null,
+};
+const BY_HUMAN = {
+  domain: "mckinsey.example",
+  admission: "admitted",
+  reason: "they became a client in July",
+  source: "human",
+  decided_at: "2026-08-11T07:05:00Z",
+  organization_id: "018f3a1b-0000-7000-8000-00000000c001",
+};
+
+function mount(allow: GrantSpec, routes: RouteMap) {
+  installFetchStub({ "GET /me": meRoute(allow), ...routes });
+  return rtlRender(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">
+        <BlockedDomainsCard />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** The row a domain is on, so an assertion is about that domain's own cells. */
+function rowFor(domain: string): HTMLElement {
+  const cell = screen.getByText(domain);
+  const row = cell.closest("tr");
+  if (row === null) {
+    throw new Error(`${domain} is not in a table row`);
+  }
+  return row;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("BlockedDomainsCard", () => {
+  it("says of every decision whether a machine or a person made it", async () => {
+    mount(OPS, {
+      [LIST]: () => jsonResponse({ data: [BY_HEURISTIC, BY_HUMAN], total: 2 }),
+    });
+
+    await screen.findByText("expensify.example");
+    // The distinction the card exists for: the same outcome, two different
+    // facts. A row that named only the admission would leave an operator
+    // unable to tell a bulk-sender verdict from somebody's deliberate call.
+    expect(
+      within(rowFor("expensify.example")).getByText(
+        en["blockedDomains.source.heuristic"],
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(rowFor("mckinsey.example")).getByText(
+        en["blockedDomains.source.human"],
+      ),
+    ).toBeInTheDocument();
+    // And the reason, which is why the server requires one.
+    expect(
+      within(rowFor("expensify.example")).getByText(
+        "bulk sender: no reply address",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("reads as nothing-refused rather than as a table that failed to draw", async () => {
+    mount(OPS, { [LIST]: () => jsonResponse({ data: [], total: 0 }) });
+
+    expect(await screen.findByText(en["blockedDomains.none"])).toBeVisible();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("says how many decisions exist, not only how many this page carries", async () => {
+    // Refusals accumulate on their own from every bulk-sender verdict, so the
+    // server pages the list. An operator hunting a company that never appeared
+    // must be able to tell "not refused" from "past the end of this page".
+    mount(OPS, {
+      [LIST]: () =>
+        jsonResponse({ data: [BY_HEURISTIC, BY_HUMAN], total: 412 }),
+    });
+
+    await screen.findByText("expensify.example");
+    expect(screen.getByText(/412/)).toBeInTheDocument();
+  });
+
+  it("sends the domain, the decision and the reason a human typed", async () => {
+    const user = userEvent.setup();
+    const sent: unknown[] = [];
+    mount(OPS, {
+      [LIST]: () => jsonResponse({ data: [], total: 0 }),
+      [WRITE]: (body) => {
+        sent.push(body);
+        return jsonResponse({
+          ...BY_HEURISTIC,
+          domain: "expensify.example",
+          source: "human",
+          reason: "a tool we use, not a customer",
+        });
+      },
+    });
+
+    await screen.findByText(en["blockedDomains.none"]);
+    await user.type(
+      screen.getByTestId("blocked-domain-input"),
+      "mail.expensify.example",
+    );
+    await user.type(
+      screen.getByTestId("blocked-domain-reason"),
+      "a tool we use, not a customer",
+    );
+    await user.click(
+      screen.getByRole("button", { name: en["blockedDomains.save"] }),
+    );
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0]).toEqual({
+      domain: "mail.expensify.example",
+      admission: "suppressed",
+      reason: "a tool we use, not a customer",
+    });
+    // The server normalizes the domain and the write REPLACES any decision
+    // already on it, so what landed is named: without it a sub-domain silently
+    // becomes its parent, and a second decision on a listed domain looks like
+    // nothing happened.
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "expensify.example",
+    );
+  });
+
+  it("refuses the write until there is a reason somebody can review", async () => {
+    const user = userEvent.setup();
+    mount(OPS, { [LIST]: () => jsonResponse({ data: [], total: 0 }) });
+
+    await screen.findByText(en["blockedDomains.none"]);
+    const save = screen.getByRole("button", {
+      name: en["blockedDomains.save"],
+    });
+    await user.type(
+      screen.getByTestId("blocked-domain-input"),
+      "expensify.example",
+    );
+    // A domain with no reason is exactly what the server 422s, and a refusal
+    // nobody can explain is one nobody can review — so the card never sends it.
+    expect(save).toBeDisabled();
+    await user.type(screen.getByTestId("blocked-domain-reason"), "a vendor");
+    expect(save).toBeEnabled();
+  });
+
+  it("says why the write was refused rather than leaving the form silent", async () => {
+    const user = userEvent.setup();
+    mount(OPS, {
+      [LIST]: () => jsonResponse({ data: [], total: 0 }),
+      [WRITE]: () =>
+        jsonResponse(
+          {
+            title: "Unprocessable Entity",
+            detail:
+              "expected a domain name like example.com; a full email address or a URL is not one",
+          },
+          422,
+        ),
+    });
+
+    await screen.findByText(en["blockedDomains.none"]);
+    await user.type(
+      screen.getByTestId("blocked-domain-input"),
+      "someone@expensify.example",
+    );
+    await user.type(screen.getByTestId("blocked-domain-reason"), "a vendor");
+    await user.click(
+      screen.getByRole("button", { name: en["blockedDomains.save"] }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /a full email address or a URL is not one/,
+    );
+  });
+
+  it("hands a row's flip to the form, because a reversal still owes a reason", async () => {
+    const user = userEvent.setup();
+    mount(OPS, {
+      [LIST]: () => jsonResponse({ data: [BY_HUMAN], total: 1 }),
+    });
+
+    await screen.findByText("mckinsey.example");
+    // The row's verb is the OPPOSITE of the standing decision, and taking it
+    // fills the form rather than writing: the contract demands a reason and a
+    // one-click flip has nowhere to get one.
+    await user.click(
+      within(rowFor("mckinsey.example")).getByRole("button", {
+        name: en["blockedDomains.rowRefuse"],
+      }),
+    );
+
+    expect(screen.getByTestId("blocked-domain-input")).toHaveValue(
+      "mckinsey.example",
+    );
+    expect(screen.getByTestId("blocked-domain-reason")).toHaveValue("");
+    expect(screen.getByTestId("blocked-domain-reason")).toHaveFocus();
+  });
+
+  it("keeps the list readable for a seat that may not change it, and says so", async () => {
+    mount(READER, {
+      [LIST]: () => jsonResponse({ data: [BY_HUMAN], total: 1 }),
+    });
+
+    // Withheld, never absent: hiding the card from a reader who may read the
+    // posture would answer "was this domain refused" with silence.
+    await screen.findByText("mckinsey.example");
+    const save = screen.getByRole("button", {
+      name: en["blockedDomains.save"],
+    });
+    expect(save).toBeDisabled();
+    const denial = screen.getByText(en["blockedDomains.adminOnly"]);
+    expect(save.getAttribute("aria-describedby")).toBe(denial.id);
+    expect(screen.getByTestId("blocked-domain-input")).toBeDisabled();
+  });
+});

--- a/frontend/src/screens/blocked-domains.tsx
+++ b/frontend/src/screens/blocked-domains.tsx
@@ -1,0 +1,401 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useId, useRef, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
+import { isOption } from "../app/options";
+import {
+  Badge,
+  Button,
+  DataTable,
+  EmptyState,
+  Field,
+  TextInput,
+} from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { CountLine } from "../design-system/listsurface";
+import { Panel, PanelBody } from "../design-system/panel";
+import { Select } from "../design-system/select";
+import { formatDate } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+// The domains this installation refuses a company (ADR-0072). A vendor the
+// business merely USES has a real corporate website, so every piece of evidence
+// a crawl can gather says "company" — only a standing decision says otherwise,
+// which is why the refusal lives on the domain rather than on any sender or
+// read.
+//
+// The card exists for one question an operator cannot otherwise answer: a
+// company that never appeared — was it refused, and by whom? So `source` is a
+// first-class column, not a detail: a bulk-sender verdict and somebody's
+// deliberate call look identical in the outcome and are completely different
+// facts. Every human role reads the list (`organization:read`); changing an
+// entry demands `organization:update`, so the controls disable rather than hide,
+// like the capture cards beside it.
+//
+// The write is a PUT that is idempotent on the normalized domain: there is no
+// version to quote and none to send, so no `ifMatch` here — an entry for a
+// domain already on the list REPLACES it, which is also how a refusal is undone.
+
+// The row shape comes from the generated contract rather than being restated
+// here: a hand-written copy would drift the first time the contract gains a
+// field, and drift silently, since nothing compares the two.
+type BlockedDomain = components["schemas"]["BlockedDomain"];
+
+// The two decisions an entry can carry, as ONE list: the type is derived from
+// it and the Select's options are built from it, so the offered choices, their
+// labels and the runtime narrowing cannot drift apart (the shape
+// consumer-mail-domains.tsx uses for the same reason).
+const ADMISSIONS = ["suppressed", "admitted"] as const;
+type Admission = (typeof ADMISSIONS)[number];
+
+const ADMISSION_LABEL: Record<Admission, MessageKey> = {
+  suppressed: "blockedDomains.admission.suppressed",
+  admitted: "blockedDomains.admission.admitted",
+};
+
+// The contract's own ceiling on `reason` (SetBlockedDomainRequest.maxLength).
+// Held on the control so the reader stops at the limit rather than typing past
+// it and losing the sentence to a 422 — the server enforces it either way.
+const REASON_MAX = 500;
+
+const SOURCE_LABEL: Record<BlockedDomain["source"], MessageKey> = {
+  verdict: "blockedDomains.source.verdict",
+  heuristic: "blockedDomains.source.heuristic",
+  human: "blockedDomains.source.human",
+};
+
+function useBlockedDomains() {
+  return useQuery({
+    queryKey: ["blocked-domains"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/capture/blocked-domains",
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+function useSetBlockedDomain() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // Every input arrives as a variable rather than through a closure: the
+    // handler belongs to the committed render, so what it passes cannot be
+    // older than the control the operator pressed.
+    mutationFn: async (
+      decision: Readonly<{
+        domain: string;
+        admission: Admission;
+        reason: string;
+      }>,
+    ) => {
+      const { data, error } = await api.PUT("/capture/blocked-domains", {
+        body: decision,
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["blocked-domains"] });
+    },
+  });
+}
+
+/**
+ * Every description a control here can carry, in one attribute.
+ *
+ * `Field` names its own hint in `aria-describedby`, and this card also has one
+ * sentence saying the seat may not write. Overriding the attribute would pick
+ * which of the two a screen reader gets; a caller that has both owes the
+ * control both.
+ */
+function describedBy(
+  ...ids: readonly (string | undefined)[]
+): string | undefined {
+  return (
+    ids.filter((id): id is string => id !== undefined).join(" ") || undefined
+  );
+}
+
+export function BlockedDomainsCard() {
+  const t = useT();
+  const { locale } = useLocale();
+  // An operator investigating a company that never appeared reads the decision
+  // time on their own wall clock, the same choice the audit trail makes — a
+  // fixed workspace zone would put the moment they are correlating against an
+  // hour they were not working.
+  const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const canManage = useCanWrite("organization", "update");
+  const query = useBlockedDomains();
+  const set = useSetBlockedDomain();
+  const [domain, setDomain] = useState("");
+  const [admission, setAdmission] = useState<Admission>("suppressed");
+  const [reason, setReason] = useState("");
+  const reasonInput = useRef<HTMLInputElement>(null);
+  // The denial, said once and POINTED AT — the wiring `Switch`'s `reason` prop
+  // does for a toggle (design-system README), spelled with an id and
+  // `aria-describedby` for the controls that are not switches. A reason
+  // floating below the form is one a screen reader never reads out with the
+  // control it explains. The id is minted unconditionally, because a hook may
+  // not depend on a permission.
+  const denialId = useId();
+  const denial = canManage ? undefined : denialId;
+
+  // Revising a standing decision starts on its row and finishes in the form.
+  // The contract requires a reason for every write, so a one-click flip has
+  // nowhere to get one — and a refusal nobody can explain is one nobody can
+  // review, which is the whole point of the column. The row therefore hands
+  // the form the domain and the OPPOSITE decision, clears the reason, and puts
+  // the cursor where the operator now has to type: that is the McKinsey case, a
+  // newsletter publisher that became a client.
+  const revise = useCallback((entry: BlockedDomain) => {
+    setDomain(entry.domain);
+    setAdmission(entry.admission === "suppressed" ? "admitted" : "suppressed");
+    setReason("");
+    reasonInput.current?.focus();
+  }, []);
+
+  const columns = [
+    {
+      key: "domain",
+      header: t("blockedDomains.col.domain"),
+      render: (row: BlockedDomain) => (
+        <>
+          <span className="t-mono">{row.domain}</span>
+          {/* The company an admitted domain produced, when there is one. A
+              link rather than the id it is built from: the payload carries no
+              name, and printing a UUID at an operator is not a fact they can
+              use. */}
+          {row.organization_id != null && (
+            <>
+              {" "}
+              <a href={`#/companies/${row.organization_id}`}>
+                {t("blockedDomains.openCompany")}
+              </a>
+            </>
+          )}
+        </>
+      ),
+    },
+    {
+      key: "admission",
+      header: t("blockedDomains.col.admission"),
+      render: (row: BlockedDomain) => (
+        <Badge tone={row.admission === "admitted" ? "success" : "warn"}>
+          {t(ADMISSION_LABEL[row.admission])}
+        </Badge>
+      ),
+    },
+    {
+      key: "source",
+      header: t("blockedDomains.col.source"),
+      // A human decision is the one an operator is hunting for, so it is the
+      // one the eye finds: the machine sources read as plain pills beside it.
+      render: (row: BlockedDomain) => (
+        <Badge tone={row.source === "human" ? "accent" : undefined}>
+          {t(SOURCE_LABEL[row.source])}
+        </Badge>
+      ),
+    },
+    {
+      key: "reason",
+      header: t("blockedDomains.col.reason"),
+      render: (row: BlockedDomain) => row.reason,
+    },
+    {
+      key: "decided",
+      header: t("blockedDomains.col.decided"),
+      render: (row: BlockedDomain) => (
+        <time dateTime={row.decided_at}>
+          {formatDate(row.decided_at, locale, zone)}
+        </time>
+      ),
+    },
+    {
+      key: "revise",
+      header: t("blockedDomains.col.revise"),
+      render: (row: BlockedDomain) => (
+        <Button
+          small
+          variant="ghost"
+          disabled={!canManage || set.isPending}
+          aria-describedby={denial}
+          onClick={() => revise(row)}
+        >
+          {t(
+            row.admission === "suppressed"
+              ? "blockedDomains.rowAdmit"
+              : "blockedDomains.rowRefuse",
+          )}
+        </Button>
+      ),
+    },
+  ];
+
+  const trimmedDomain = domain.trim();
+  const trimmedReason = reason.trim();
+
+  return (
+    <Panel title={t("blockedDomains.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("blockedDomains.sub")}</p>
+        <form
+          className="form-stack"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!canManage || trimmedDomain === "" || trimmedReason === "") {
+              return;
+            }
+            set.mutate({
+              domain: trimmedDomain,
+              admission,
+              reason: trimmedReason,
+            });
+          }}
+        >
+          <div className="form-row">
+            <Field label={t("blockedDomains.domainLabel")} required>
+              {(control) => (
+                <TextInput
+                  {...control}
+                  data-testid="blocked-domain-input"
+                  placeholder={t("blockedDomains.domainPlaceholder")}
+                  value={domain}
+                  disabled={!canManage}
+                  aria-describedby={describedBy(
+                    control["aria-describedby"],
+                    denial,
+                  )}
+                  onChange={(event) => setDomain(event.target.value)}
+                />
+              )}
+            </Field>
+            <Field label={t("blockedDomains.admissionLabel")}>
+              {(control) => (
+                <Select
+                  {...control}
+                  value={admission}
+                  disabled={!canManage}
+                  aria-describedby={describedBy(
+                    control["aria-describedby"],
+                    denial,
+                  )}
+                  onChange={(value) => {
+                    if (isOption(value, ADMISSIONS)) {
+                      setAdmission(value);
+                    }
+                  }}
+                  options={ADMISSIONS.map((value) => ({
+                    value,
+                    label: t(ADMISSION_LABEL[value]),
+                  }))}
+                />
+              )}
+            </Field>
+          </div>
+          <Field
+            label={t("blockedDomains.reasonLabel")}
+            hint={t("blockedDomains.reasonHint")}
+            required
+          >
+            {(control) => (
+              <TextInput
+                {...control}
+                ref={reasonInput}
+                data-testid="blocked-domain-reason"
+                maxLength={REASON_MAX}
+                placeholder={t("blockedDomains.reasonPlaceholder")}
+                value={reason}
+                disabled={!canManage}
+                aria-describedby={describedBy(
+                  control["aria-describedby"],
+                  denial,
+                )}
+                onChange={(event) => setReason(event.target.value)}
+              />
+            )}
+          </Field>
+          <div className="form-actions">
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={
+                !canManage ||
+                set.isPending ||
+                trimmedDomain === "" ||
+                trimmedReason === ""
+              }
+              aria-describedby={denial}
+            >
+              {t("blockedDomains.save")}
+            </Button>
+          </div>
+        </form>
+        {!canManage && (
+          <p className="t-small" id={denialId}>
+            {t("blockedDomains.adminOnly")}
+          </p>
+        )}
+        {set.isError && (
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(set.error, t)}
+          </Callout>
+        )}
+        {/* What LANDED, named. The server normalizes the domain to its
+            registrable form and the write replaces any entry already on it, so
+            without this a sub-domain silently became its parent and a second
+            decision on a domain already listed looked like nothing had
+            happened at all. */}
+        {set.data && (
+          <Callout tone="success" live="status">
+            {t("blockedDomains.stored", {
+              domain: set.data.domain,
+              admission: t(ADMISSION_LABEL[set.data.admission]),
+            })}
+          </Callout>
+        )}
+        <QueryGate query={query}>
+          {(list) =>
+            list.data.length === 0 ? (
+              // `empty`, and only `empty`: no decision has been recorded, which
+              // is a fact about the installation rather than a read that failed.
+              // The states that are not this one are the query gate's above.
+              <EmptyState>
+                <p className="t-small">{t("blockedDomains.none")}</p>
+              </EmptyState>
+            ) : (
+              <>
+                <DataTable
+                  columns={columns}
+                  rows={list.data}
+                  rowKey={(row) => row.domain}
+                />
+                {/* Refusals accumulate on their own from every bulk-sender
+                    verdict, so the server pages the list and answers with how
+                    many decisions EXIST. An operator hunting a company that
+                    never appeared has to be able to tell "not refused" from
+                    "past the end of this page". */}
+                <p className="t-small">
+                  <CountLine
+                    unit={t("blockedDomains.unit")}
+                    first={1}
+                    last={list.data.length}
+                    total={list.total}
+                  />
+                </p>
+              </>
+            )
+          }
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -2168,15 +2168,27 @@ describe("company view — the account's primary actions", () => {
     ).toBeTruthy();
   });
 
-  it("offers neither on an archived company", async () => {
+  it("refuses both on an archived company, over one stated reason", async () => {
     stub(view(), 200, { ...org, archived_at: "2026-07-01T09:00:00Z" });
     renderCompany();
     await screen.findByRole("complementary", { name: "Context" });
 
-    // The server refuses a write against a retired record, so the button would
-    // only open a form that fails on save.
-    expect(screen.queryByRole("button", { name: "Log activity" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Add task" })).toBeNull();
+    // The server refuses a write against a retired record — but REMOVING the
+    // verb told a reader nothing, because an absent button reads as a build
+    // without the feature. Both are offered and refused, and both point at the
+    // one sentence that says what is true of the record.
+    const log = await screen.findByRole("button", { name: "Log activity" });
+    const task = await screen.findByRole("button", { name: "Add task" });
+    expect(log.hasAttribute("disabled")).toBe(true);
+    expect(task.hasAttribute("disabled")).toBe(true);
+
+    const reasonId = log.getAttribute("aria-describedby");
+    expect(reasonId).toBeTruthy();
+    // One fact about the record, said once: the two verbs share the sentence.
+    expect(task.getAttribute("aria-describedby")).toBe(reasonId);
+    expect(document.getElementById(reasonId ?? "")?.textContent).toContain(
+      "archived",
+    );
   });
 });
 

--- a/frontend/src/screens/companydocuments.tsx
+++ b/frontend/src/screens/companydocuments.tsx
@@ -217,7 +217,7 @@ export function CompanyDocumentsCard({ orgId }: Readonly<{ orgId: string }>) {
       }
     >
       <AddDocumentDialog
-        orgId={orgId}
+        anchor={{ record: "organization", id: orgId }}
         open={adding}
         onClose={() => setAdding(false)}
       />

--- a/frontend/src/screens/companyheader.stories.tsx
+++ b/frontend/src/screens/companyheader.stories.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { screen, userEvent } from "storybook/test";
 import type { components } from "../api/schema";
 import {
   CompanyActionBadges,
@@ -164,4 +165,25 @@ export const AuthorNamed: Story = {
   render: () => (
     <Header view={withWayIn} record={{ ...org, captured_by: "human:u-2" }} />
   ),
+};
+
+// An archived account. Its verbs stay in the menu, refused, over the one
+// sentence that says why — a control blocked by the record's STATE is disabled
+// with its reason, never dropped (STATE-4a), because a missing button reads as
+// a build without the feature. The play() opens the menu, since the refusal is
+// the thing worth seeing here.
+export const ArchivedAccount: Story = {
+  render: () => (
+    <Header
+      view={withWayIn}
+      record={{ ...org, archived_at: "2026-07-13T00:00:00Z" }}
+    />
+  ),
+  play: async () => {
+    // The panel portals to document.body, so it is reached through `screen`
+    // rather than a canvas-scoped query that would find nothing.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "More actions" }),
+    );
+  },
 };

--- a/frontend/src/screens/companyheader.test.tsx
+++ b/frontend/src/screens/companyheader.test.tsx
@@ -254,3 +254,45 @@ describe("the owner the edit form prefills", () => {
     ).toBeNull();
   });
 });
+
+// STATE-4a decides absent-vs-disabled by CAUSE, and an archive is state: the
+// menu used to drop every verb on an archived account, leaving a reader unable
+// to tell a record that is closed from a build without an edit button.
+describe("an archived account's verbs", () => {
+  it("stay in the menu, refused, each reachable from the one sentence naming the archive", async () => {
+    stub([{ id: "u-owner", display_name: "Mira Voss" }]);
+    const user = userEvent.setup();
+    renderInApp(
+      <CompanyActionBadges
+        org={{ ...ORG, archived_at: "2026-07-13T00:00:00Z" }}
+        onOpenHistory={() => undefined}
+        onSetUpPartner={() => undefined}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "More actions" }),
+    );
+    const refused = [
+      await screen.findByTestId("edit-record"),
+      screen.getByTestId("merge-record"),
+      screen.getByTestId("archive-record"),
+      screen.getByTestId("share-record"),
+    ];
+    for (const control of refused) {
+      expect(control.hasAttribute("disabled")).toBe(true);
+      // The reason has to be reachable FROM the control: a disabled button
+      // cannot be focused and a `title` on it is announced by nobody, so a
+      // sentence the control does not point at reaches no reader who needed it.
+      const describedBy = control.getAttribute("aria-describedby");
+      expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+        "This company is archived. Restore it to change anything on it.",
+      );
+    }
+    // The reads next to them are untouched: what happened to a record is
+    // exactly what a reader wants after it has been put away.
+    expect(
+      screen.getByTestId("company-full-history").hasAttribute("disabled"),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Fragment, type ReactElement } from "react";
+import { Fragment, type ReactElement, useId } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -76,20 +76,38 @@ export function CompanyPrimaryActions({
   composerOpen: boolean;
   onComposerOpen: (open: boolean) => void;
 }>) {
-  // Archived records take no new activity: the write is refused server-side,
-  // so offering the verb would only produce a modal that fails on save.
-  if (org.archived_at) {
-    return null;
-  }
+  const t = useT();
+  const archivedId = useId();
+  // An archived record takes no new activity — the write is refused
+  // server-side — so all three verbs are refused rather than removed. Removing
+  // them told a reader nothing: an absent button reads as a build without the
+  // feature, and this account has the feature and will not accept it. One
+  // sentence for the three of them, because it is one fact about the record.
+  const archived = org.archived_at ? archivedId : undefined;
   return (
     <>
-      <WriteEmailAction org={org} open={composerOpen} onOpen={onComposerOpen} />
-      <LogActivityAction entityType="organization" entityId={org.id} />
+      {archived && (
+        <p className="t-caption" id={archivedId}>
+          {t("record.archivedReadOnly")}
+        </p>
+      )}
+      <WriteEmailAction
+        org={org}
+        open={composerOpen}
+        onOpen={onComposerOpen}
+        disabledReasonId={archived}
+      />
+      <LogActivityAction
+        entityType="organization"
+        entityId={org.id}
+        disabledReasonId={archived}
+      />
       <LogActivityAction
         entityType="organization"
         entityId={org.id}
         initialKind="task"
         triggerLabel="log.addTask"
+        disabledReasonId={archived}
       />
     </>
   );
@@ -103,15 +121,21 @@ function WriteEmailAction({
   org,
   open,
   onOpen,
+  disabledReasonId,
 }: Readonly<{
   org: Organization;
   open: boolean;
   onOpen: (open: boolean) => void;
+  disabledReasonId?: string;
 }>) {
   const t = useT();
   return (
     <>
-      <Button variant="primary" onClick={() => onOpen(true)}>
+      <Button
+        variant="primary"
+        reasonId={disabledReasonId}
+        onClick={() => onOpen(true)}
+      >
         {t("co.writeEmail")}
       </Button>
       {open && (
@@ -340,7 +364,14 @@ export function CompanyOwnerControl({
 function CompanyEditAction({
   org,
   overlay,
-}: Readonly<{ org: Organization; overlay: boolean }>) {
+  disabledReasonId,
+}: Readonly<{
+  org: Organization;
+  overlay: boolean;
+  // Passed straight to EditAction: the id of the sentence saying why this
+  // account takes no edits, when it does not.
+  disabledReasonId?: string;
+}>) {
   const t = useT();
   const cf = useObjectCustomFields("organization");
   const roster = useRoster("user", true);
@@ -365,6 +396,7 @@ function CompanyEditAction({
   }
   return (
     <EditAction
+      disabledReasonId={disabledReasonId}
       label={t("record.edit")}
       notice={overlay ? t("overlay.partialWriteBack") : undefined}
       fields={[
@@ -438,10 +470,16 @@ export function CompanyActionBadges({
   const t = useT();
   const overlay = useSorMode() === "overlay";
   // An archived record is read-only: the backend rejects edit/merge/archive
-  // on a non-live row (there is no unarchive path), so those items would only
-  // 404. Its history stays readable — what happened to a record is exactly
-  // what a reader wants after it has been put away.
-  const writable = !org.archived_at;
+  // on a non-live row (there is no unarchive path). The verbs stay VISIBLE
+  // and refused rather than disappearing (STATE-4a) — a control blocked by
+  // the record's STATE says why, because the reason is the information and a
+  // missing button reads as a build without the feature. Its history stays
+  // readable — what happened to a record is exactly what a reader wants after
+  // it has been put away.
+  //
+  // Undefined on a live account, which is what leaves those verbs pressable.
+  const archivedReasonId = useId();
+  const refusedByArchive = org.archived_at ? archivedReasonId : undefined;
   return (
     <>
       {/* What the company IS to us. Where it STANDS is a separate question,
@@ -455,106 +493,120 @@ export function CompanyActionBadges({
         </Badge>
       ))}
       {org.archived_at && <Badge tone="warn">{t("record.archived")}</Badge>}
-      {/* An archived record read from a mirror offers nothing at all: every
-          write is refused and the history is a native read the mirror has no
-          row for. Rendering the trigger anyway would open an empty popover. */}
-      {(writable || !overlay) && (
-        <OverflowMenu label={t("record.moreActions")}>
-          {writable && <CompanyEditAction org={org} overlay={overlay} />}
-          {/* Merge has no incumbent-first projection — the seam refuses it
+      {/* The trigger is unconditional because the menu always holds something
+          to say: an archived account's verbs are refused rather than dropped,
+          and the sentence refusing them travels with them. Only a panel with
+          no items at all would be worth hiding. */}
+      <OverflowMenu label={t("record.moreActions")}>
+        {/* Stated ONCE at the head of the menu it refuses, so the items below
+            point at this element by id rather than each printing the same
+            line. It sits here rather than in the page's header band because
+            the band belongs to the caller (organizations.tsx) while these
+            verbs and their one reason belong together. */}
+        {org.archived_at && (
+          <p id={archivedReasonId} className="t-caption">
+            {t("record.archivedReadOnly")}
+          </p>
+        )}
+        <CompanyEditAction
+          org={org}
+          overlay={overlay}
+          disabledReasonId={refusedByArchive}
+        />
+        {/* Merge has no incumbent-first projection — the seam refuses it
             outright (overlay/provider_writes.go Merge) — unlike
-            edit/archive above, which it serves, so it stays hidden here. */}
-          {writable && !overlay && (
-            <MergeAction
-              label={t("merge.org")}
-              sourceId={org.id}
-              sourceName={org.display_name}
-              searchTargets={searchOrgTargets}
-              merge={async (targetId) => {
-                const { data, error } = await api.POST(
-                  "/organizations/{id}/merge",
-                  {
-                    params: {
-                      path: { id: org.id },
-                      ...ifMatch(requireVersion(org.version)),
-                    },
-                    body: { target_id: targetId },
+            edit/archive above, which it serves, so it stays hidden here.
+            Unsupported is the OTHER cause STATE-4a sorts, and absence is
+            its answer: there is no fact about this account to report. */}
+        {!overlay && (
+          <MergeAction
+            disabledReasonId={refusedByArchive}
+            label={t("merge.org")}
+            sourceId={org.id}
+            sourceName={org.display_name}
+            searchTargets={searchOrgTargets}
+            merge={async (targetId) => {
+              const { data, error } = await api.POST(
+                "/organizations/{id}/merge",
+                {
+                  params: {
+                    path: { id: org.id },
+                    ...ifMatch(requireVersion(org.version)),
                   },
-                );
-                if (error) {
-                  throwProblem(error, t);
-                }
-                return data;
-              }}
-              invalidate="organizations"
-              recordKey="organization"
-              survivorRoute={(targetId) => ({
-                screen: "companies",
-                id: targetId,
-              })}
-            />
-          )}
-          {writable && (
-            <ArchiveAction
-              label={t("record.archive")}
-              confirmText={t("record.archiveConfirm")}
-              archive={async () => {
-                const { data, error } = await api.DELETE(
-                  "/organizations/{id}",
-                  {
-                    params: { path: { id: org.id } },
-                  },
-                );
-                if (error) {
-                  throwProblem(error);
-                }
-                return data;
-              }}
-              invalidate="organizations"
-              recordKey="organization"
-              onArchived={() => navigate({ screen: "companies" })}
-            />
-          )}
-          {/* A record grant probes the native row via auth.EnsureLinkTarget,
+                  body: { target_id: targetId },
+                },
+              );
+              if (error) {
+                throwProblem(error, t);
+              }
+              return data;
+            }}
+            invalidate="organizations"
+            recordKey="organization"
+            survivorRoute={(targetId) => ({
+              screen: "companies",
+              id: targetId,
+            })}
+          />
+        )}
+        <ArchiveAction
+          disabledReasonId={refusedByArchive}
+          label={t("record.archive")}
+          confirmText={t("record.archiveConfirm")}
+          archive={async () => {
+            const { data, error } = await api.DELETE("/organizations/{id}", {
+              params: { path: { id: org.id } },
+            });
+            if (error) {
+              throwProblem(error);
+            }
+            return data;
+          }}
+          invalidate="organizations"
+          recordKey="organization"
+          onArchived={() => navigate({ screen: "companies" })}
+        />
+        {/* A record grant probes the native row via auth.EnsureLinkTarget,
             which a mirrored record has no row for — sharing stays hidden
             in overlay regardless of record type (see deals.tsx's
             DealBadges). */}
-          {writable && !overlay && (
-            <ShareAction recordType="organization" recordId={org.id} />
-          )}
-          {/* The way in to the partner programme for an account that has none.
+        {!overlay && (
+          <ShareAction
+            recordType="organization"
+            recordId={org.id}
+            disabledReasonId={refusedByArchive}
+          />
+        )}
+        {/* The way in to the partner programme for an account that has none.
             The tab only shows once there IS one, so without this the first
             partner row would be unreachable — this is the same form, asked
             for rather than offered. */}
-          {writable &&
-            !overlay &&
-            !(org.relationship_types ?? []).includes("partner") && (
-              <Button small onClick={onSetUpPartner}>
-                {t("org.partnerSetUp")}
-              </Button>
-            )}
-          {/* The audit spine: who changed this record and when. It reads as an
+        {!overlay && !(org.relationship_types ?? []).includes("partner") && (
+          <Button small reasonId={refusedByArchive} onClick={onSetUpPartner}>
+            {t("org.partnerSetUp")}
+          </Button>
+        )}
+        {/* The audit spine: who changed this record and when. It reads as an
             inspection of the record rather than part of its story, so it sits
             with the other rare verbs instead of beside the account's own
             timeline. */}
-          {!overlay && (
-            <Button
-              small
-              data-testid="company-full-history"
-              onClick={onOpenHistory}
-            >
-              {t("record.fullHistory")}
-            </Button>
-          )}
-          {/* The account's own waiting decisions. It reads as a count in the
+        {!overlay && (
+          <Button
+            small
+            data-testid="company-full-history"
+            onClick={onOpenHistory}
+          >
+            {t("record.fullHistory")}
+          </Button>
+        )}
+        {/* The account's own waiting decisions. It reads as a count in the
               header, which is a state, and this is the verb that answers it —
               so it sits with the other rare verbs rather than as a chip beside
               the account's name. Absent when nothing waits. */}
-          {onOpenDecisions && (
-            <DecisionsChip view={view} onOpen={onOpenDecisions} />
-          )}
-        </OverflowMenu>
-      )}
+        {onOpenDecisions && (
+          <DecisionsChip view={view} onOpen={onOpenDecisions} />
+        )}
+      </OverflowMenu>
     </>
   );
 }

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -67,6 +67,7 @@ export function CompanyPrimaryActions({
   org,
   composerOpen,
   onComposerOpen,
+  archivedReasonId,
 }: Readonly<{
   org: Organization;
   // The composer's open state belongs to the PAGE, not to this button: the
@@ -75,19 +76,29 @@ export function CompanyPrimaryActions({
   // privately, which is what kept the rail rendering underneath it.
   composerOpen: boolean;
   onComposerOpen: (open: boolean) => void;
+  // The sentence the caller states once for the whole action strip. Both groups
+  // in that strip refuse for the same reason, so the reason is the page's to
+  // say — a component that minted its own would put a second copy of one fact
+  // on screen the moment the other group drew its own.
+  archivedReasonId?: string;
 }>) {
-  const t = useT();
-  const archivedId = useId();
   // An archived record takes no new activity — the write is refused
   // server-side — so all three verbs are refused rather than removed. Removing
   // them told a reader nothing: an absent button reads as a build without the
   // feature, and this account has the feature and will not accept it. One
   // sentence for the three of them, because it is one fact about the record.
-  const archived = org.archived_at ? archivedId : undefined;
+  const t = useT();
+  const ownReasonId = useId();
+  // The caller's id when it has stated the sentence for the whole strip, our
+  // own when nobody has. The refusal never depends on being handed one: a
+  // caller that forgot would otherwise turn an archived account back into one
+  // that LOOKS writable, which is worse than saying it twice.
+  const reasonId = archivedReasonId ?? ownReasonId;
+  const archived = org.archived_at ? reasonId : undefined;
   return (
     <>
-      {archived && (
-        <p className="t-caption" id={archivedId}>
+      {archived && !archivedReasonId && (
+        <p className="t-caption" id={ownReasonId}>
           {t("record.archivedReadOnly")}
         </p>
       )}
@@ -460,12 +471,15 @@ export function CompanyActionBadges({
   onOpenHistory,
   onSetUpPartner,
   onOpenDecisions,
+  archivedReasonId,
 }: Readonly<{
   org: Organization;
   view?: Organization360View;
   onOpenHistory: () => void;
   onSetUpPartner: () => void;
   onOpenDecisions?: () => void;
+  // Stated by the caller for the whole strip; see CompanyPrimaryActions.
+  archivedReasonId?: string;
 }>) {
   const t = useT();
   const overlay = useSorMode() === "overlay";
@@ -478,8 +492,11 @@ export function CompanyActionBadges({
   // it has been put away.
   //
   // Undefined on a live account, which is what leaves those verbs pressable.
-  const archivedReasonId = useId();
-  const refusedByArchive = org.archived_at ? archivedReasonId : undefined;
+  // See CompanyPrimaryActions: the id is an override, never what decides
+  // whether these verbs are refused.
+  const ownReasonId = useId();
+  const menuReasonId = archivedReasonId ?? ownReasonId;
+  const refusedByArchive = org.archived_at ? menuReasonId : undefined;
   return (
     <>
       {/* What the company IS to us. Where it STANDS is a separate question,
@@ -498,13 +515,8 @@ export function CompanyActionBadges({
           and the sentence refusing them travels with them. Only a panel with
           no items at all would be worth hiding. */}
       <OverflowMenu label={t("record.moreActions")}>
-        {/* Stated ONCE at the head of the menu it refuses, so the items below
-            point at this element by id rather than each printing the same
-            line. It sits here rather than in the page's header band because
-            the band belongs to the caller (organizations.tsx) while these
-            verbs and their one reason belong together. */}
-        {org.archived_at && (
-          <p id={archivedReasonId} className="t-caption">
+        {org.archived_at && !archivedReasonId && (
+          <p id={ownReasonId} className="t-caption">
             {t("record.archivedReadOnly")}
           </p>
         )}

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -879,6 +879,38 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
   });
 });
 
+describe("DealScreen — an archived deal keeps its verbs, refused", () => {
+  beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
+
+  it("shows Edit, Archive, Share and Reopen disabled, each reachable from the one sentence naming the archive", async () => {
+    const d = deal({
+      id: "x",
+      status: "won",
+      stage_id: "s3",
+      archived_at: "2026-07-13T00:00:00Z",
+    });
+    vi.stubGlobal("fetch", stubBackend([d], { single: d }));
+    render(<DealScreen id="x" />);
+
+    const refused = [
+      await screen.findByTestId("edit-record"),
+      screen.getByTestId("archive-record"),
+      screen.getByTestId("share-record"),
+      screen.getByTestId("reopen-open"),
+    ];
+    for (const control of refused) {
+      expect(control.hasAttribute("disabled")).toBe(true);
+      // The reason has to be reachable FROM the control: a disabled button
+      // cannot be focused and a `title` on it is announced by nobody, so a
+      // sentence the control does not point at reaches no reader who needed it.
+      const describedBy = control.getAttribute("aria-describedby");
+      expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+        "This deal is archived and takes no changes.",
+      );
+    }
+  });
+});
+
 describe("DealScreen — overlay mode write affordances", () => {
   beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
 

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -7,7 +7,9 @@ import {
 import {
   type Dispatch,
   type DragEvent,
+  type ReactNode,
   type SetStateAction,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -1420,6 +1422,7 @@ function ReopenAction({
   dealId,
   dealVersion,
   openStages,
+  disabledReasonId,
 }: Readonly<{
   dealId: string;
   // The version the header this button sits in was rendered from, so the reopen
@@ -1428,6 +1431,11 @@ function ReopenAction({
   // and a fresh one would be the wrong answer anyway.
   dealVersion: number | undefined;
   openStages: Stage[];
+  // The id of the sentence saying why this reopen is refused, when it is.
+  // STATE-4a: a control blocked by the record's STATE rather than by a
+  // permission stays visible and says why, because the reason is the
+  // information and hiding the control hides a fact the reader needs.
+  disabledReasonId?: string;
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -1462,7 +1470,12 @@ function ReopenAction({
   });
   return (
     <>
-      <Button small data-testid="reopen-open" onClick={() => setOpen(true)}>
+      <Button
+        small
+        reasonId={disabledReasonId}
+        data-testid="reopen-open"
+        onClick={() => setOpen(true)}
+      >
         {t("deal.reopen")}
       </Button>
       <Modal
@@ -1523,18 +1536,26 @@ function ReopenAction({
 
 // The status badge plus the edit/archive affordances — split out of
 // DealScreen's render so the record-view callback stays readably small. An
-// archived deal is read-only (no edit/merge/archive path exists server-side
-// for a non-live row), so it renders the status badge alone.
+// archived deal is read-only (no edit/archive/advance path exists server-side
+// for a non-live row), so its verbs render REFUSED rather than missing: the
+// page's one sentence about the archive says why, and each of them points at
+// it (STATE-4a). A missing control says nothing about the deal, while a
+// refused one names the reason.
 function DealBadges({
   deal,
   orgs,
   meId,
   openStages,
+  archivedReasonId,
 }: Readonly<{
   deal: Deal;
   orgs: { id: string; display_name: string }[];
   meId: string;
   openStages: Stage[];
+  // The id of the page's sentence about this deal being archived. Every verb
+  // the archive refuses points at that one element instead of printing the
+  // same line four times.
+  archivedReasonId: string;
 }>) {
   const t = useT();
   const cf = useObjectCustomFields("deal");
@@ -1547,13 +1568,14 @@ function DealBadges({
   // has no row in, so the grant 404s — overlay visibility is governed by
   // mirror_visibility, which record_grant does not feed.
   const overlay = useSorMode() === "overlay";
-  if (deal.archived_at != null) {
-    return <Badge tone={dealStatusTone(deal.status)}>{deal.status}</Badge>;
-  }
+  // One fact refuses every write below, so it is named once. Undefined while
+  // the deal is live, which is what leaves the verbs pressable.
+  const refusedByArchive = deal.archived_at ? archivedReasonId : undefined;
   return (
     <>
       <Badge tone={dealStatusTone(deal.status)}>{deal.status}</Badge>
       <EditAction
+        disabledReasonId={refusedByArchive}
         label={t("deal.edit")}
         notice={overlay ? t("overlay.partialWriteBack") : undefined}
         fields={[
@@ -1606,6 +1628,7 @@ function DealBadges({
         recordKey="deal"
       />
       <ArchiveAction
+        disabledReasonId={refusedByArchive}
         label={t("deal.archive")}
         confirmText={t("deal.archiveConfirm")}
         archive={async () => {
@@ -1621,12 +1644,22 @@ function DealBadges({
         recordKey="deal"
         onArchived={() => navigate({ screen: "deals" })}
       />
-      {!overlay && <ShareAction recordType="deal" recordId={deal.id} />}
+      {!overlay && (
+        <ShareAction
+          recordType="deal"
+          recordId={deal.id}
+          disabledReasonId={refusedByArchive}
+        />
+      )}
+      {/* Reopen answers a CLOSED deal, so an open one has no reason to be
+          told about it — absent, not refused. An archived closed deal keeps
+          it, refused: the reader came asking whether this can come back. */}
       {!overlay && (deal.status === "won" || deal.status === "lost") && (
         <ReopenAction
           dealId={deal.id}
           dealVersion={deal.version}
           openStages={openStages}
+          disabledReasonId={refusedByArchive}
         />
       )}
     </>
@@ -1908,10 +1941,34 @@ function DealOverviewPane({
   );
 }
 
+// The page's ONE sentence about this deal being archived, said across the
+// whole header rather than repeated beside each of the four verbs the archive
+// refuses. Nothing at all while the deal is live — `undefined` rather than an
+// element that renders null, because RecordView reserves the band's space for
+// anything it is handed, and a page that always kept the gap would read as a
+// record with something to say about itself and nothing said.
+function archivedDealBand(
+  deal: Deal,
+  reasonId: string,
+  t: ReturnType<typeof useT>,
+): ReactNode | undefined {
+  if (deal.archived_at == null) {
+    return undefined;
+  }
+  return (
+    <p id={reasonId} className="t-caption">
+      {t("deal.archivedReadOnly")}
+    </p>
+  );
+}
+
 export function DealScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();
+  // Minted here because the band that carries the sentence and the verbs that
+  // point at it are two different slots of the same header.
+  const archivedReasonId = useId();
   const [tab, setTab] = useState<DealTab>("overview");
   const dealQuery = useQuery({
     queryKey: ["deal", id],
@@ -2056,8 +2113,10 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                   orgs={orgs.data?.data ?? []}
                   meId={me.data?.user.id ?? ""}
                   openStages={openStages}
+                  archivedReasonId={archivedReasonId}
                 />
               }
+              band={archivedDealBand(deal, archivedReasonId, t)}
               timeline={
                 timelineQuery.isSuccess
                   ? activityTimeline(

--- a/frontend/src/screens/inbox.bundle.test.tsx
+++ b/frontend/src/screens/inbox.bundle.test.tsx
@@ -1,0 +1,328 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { InboxScreen } from "./inbox";
+
+// The inbox reads one act as one question (D2/R7). The server stamps every
+// proposal ONE act staged with a shared `bundle_id` — a site read publishes the
+// company's facts plus a lead per person on the team page — and the queue used
+// to render each of them as its own top-level card, so a ten-person team page
+// asked eleven questions about one decision.
+//
+// What is asserted here: the grouping itself, that the group's own controls
+// decide it in ONE call through the bundle routes, that a member stays
+// individually decidable underneath (the routes have no edit arm, so a reader
+// who wants to change one must be able to reach it), that the per-member
+// outcomes are reported rather than flattened into "done", and that a bundle of
+// one is a row rather than a group holding a single child.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+type Approval = components["schemas"]["Approval"];
+
+const BUNDLE = "018f3a1b-0000-7000-8000-0000000000b1";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const render = (ui: ReactNode) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+};
+
+const facts: Approval = {
+  id: "ap-facts",
+  kind: "deepread",
+  status: "pending",
+  proposed_by: "agent:runner",
+  bundle_id: BUNDLE,
+  summary: "Deep site read of acme.example: 6 fields, 4 facts from 3 pages",
+  proposed_change: { source_url: "https://acme.example" },
+  created_at: "2026-07-05T05:00:00Z",
+} as Approval;
+
+function lead(id: string, name: string): Approval {
+  return {
+    ...facts,
+    id,
+    kind: "site_lead",
+    summary: `Lead from acme.example: ${name} — Head of Operations`,
+    proposed_change: { name },
+  } as Approval;
+}
+
+const siteRead: Approval[] = [
+  facts,
+  lead("ap-lead-1", "Anna Weber"),
+  lead("ap-lead-2", "Kilian Wenzel"),
+  lead("ap-lead-3", "Mira Osei"),
+];
+
+// The subject the card leads with: what the act HOLDS, in the order it staged
+// it. A count on its own ("4 proposals") is not something a reader can answer.
+const SUBJECT = "Read the company site · Add a person found on the site";
+
+type Call = { url: string; method: string; body: unknown };
+
+async function bodyOf(
+  request: Request | null,
+  init?: RequestInit,
+): Promise<unknown> {
+  try {
+    return request ? await request.json() : JSON.parse(String(init?.body));
+  } catch {
+    // A POST the screen sends with no body at all — the bundle routes take an
+    // optional one — is a call with no body, not a failure to read it.
+    return null;
+  }
+}
+
+// The queue the reader is looking at, plus whatever the bundle routes answer.
+function inboxBackend(
+  calls: Call[],
+  pending: Approval[],
+  bundleResponse: () => Response = () =>
+    jsonResponse({
+      bundle_id: BUNDLE,
+      data: pending.map((approval) => ({
+        approval: { ...approval, status: "approved" },
+        outcome: "decided",
+      })),
+    }),
+) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : null;
+    const url = String(request ? request.url : input);
+    const method = request ? request.method : (init?.method ?? "GET");
+    if (url.includes("/agent-tools")) {
+      return jsonResponse({ data: [], page: { next_cursor: null } });
+    }
+    if (method === "POST") {
+      calls.push({ url, method, body: await bodyOf(request, init) });
+      if (url.includes("/approval-bundles/")) {
+        return bundleResponse();
+      }
+      return jsonResponse({ ...pending[0], status: "approved" });
+    }
+    if (/\/approvals(\?|$)/.test(url)) {
+      const status = /[?&]status=([^&]+)/.exec(url)?.[1];
+      return jsonResponse({
+        data: status === "pending" ? pending : [],
+        page: { next_cursor: null, has_more: false },
+      });
+    }
+    return jsonResponse({ data: [], page: { next_cursor: null } });
+  });
+}
+
+function bundleCard(): HTMLElement {
+  return screen.getByRole("article", { name: SUBJECT });
+}
+
+describe("the inbox groups one act's proposals (issue #662)", () => {
+  it("draws one card for the act and holds its members inside it", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", inboxBackend(calls, siteRead));
+    render(<InboxScreen />);
+
+    const card = await waitFor(bundleCard);
+    // The defect was four cards where the act asked one question: every staged
+    // row now sits INSIDE the group rather than beside it.
+    const rows = document.querySelectorAll(".staging-card");
+    expect(rows).toHaveLength(4);
+    for (const row of rows) {
+      expect(card.contains(row)).toBe(true);
+    }
+    // A list, not an indent: the group's size and boundaries have to reach a
+    // reader who is hearing the page.
+    expect(within(card).getAllByRole("listitem")).toHaveLength(4);
+    expect(
+      within(card).getByText("The 4 proposals", { selector: "span" }),
+    ).toBeTruthy();
+    // One act, one author — stated by the GROUP, not read off one member. Its
+    // own header line is the assertion: every member row carries the same tag,
+    // so a document-wide lookup would pass on a card that said nothing.
+    expect(card.querySelector(".approval-bundle-meta")?.textContent).toContain(
+      "Automated by runner",
+    );
+  });
+
+  it("approves the whole act in ONE call to the bundle route", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", inboxBackend(calls, siteRead));
+    const user = userEvent.setup();
+    render(<InboxScreen />);
+
+    const card = await waitFor(bundleCard);
+    await user.click(
+      within(card).getByRole("button", { name: "Approve all 4" }),
+    );
+    // Approving four effects at once is not a press to make by accident.
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].url).toContain(`/approval-bundles/${BUNDLE}/approve`);
+    // Not four per-member decisions dressed up as one control.
+    expect(
+      calls.some((call) => /\/approvals\/[^/]+\/approve/.test(call.url)),
+    ).toBe(false);
+  });
+
+  it("rejects the act with one stated reason, recorded on every member", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", inboxBackend(calls, siteRead));
+    const user = userEvent.setup();
+    render(<InboxScreen />);
+
+    const card = await waitFor(bundleCard);
+    await user.click(
+      within(card).getByRole("button", { name: "Reject all 4" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.type(
+      within(dialog).getByRole("textbox", { name: "Reason" }),
+      "The site is a reseller, not the company.",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "Reject" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].url).toContain(`/approval-bundles/${BUNDLE}/reject`);
+    expect(calls[0].body).toEqual({
+      reason: "The site is a reseller, not the company.",
+    });
+  });
+
+  it("keeps every member decidable on its own", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", inboxBackend(calls, siteRead));
+    const user = userEvent.setup();
+    render(<InboxScreen />);
+
+    const card = await waitFor(bundleCard);
+    // The bundle routes carry no edit arm — an edit re-hashes ONE diff — so a
+    // reader who disagrees with one proposal has to be able to reach it.
+    const member = within(card)
+      .getByText("Lead from acme.example: Anna Weber — Head of Operations")
+      .closest(".staging-card");
+    if (!(member instanceof HTMLElement)) {
+      throw new Error("the member row is not rendered inside the group");
+    }
+    await user.click(within(member).getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].url).toContain("/approvals/ap-lead-1/approve");
+  });
+
+  it("reports what each member did, not just that the call succeeded", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal(
+      "fetch",
+      inboxBackend(calls, siteRead, () =>
+        jsonResponse({
+          bundle_id: BUNDLE,
+          data: [
+            { approval: facts, outcome: "decided" },
+            { approval: siteRead[1], outcome: "already_decided" },
+            { approval: siteRead[2], outcome: "expired" },
+            { approval: siteRead[3], outcome: "effect_failed" },
+          ],
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    render(<InboxScreen />);
+
+    const card = await waitFor(bundleCard);
+    await user.click(
+      within(card).getByRole("button", { name: "Approve all 4" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Accept" }));
+
+    // Deciding a bundle is not all-or-nothing, so "approved" alone would claim
+    // three things the response did not say.
+    const report = await screen.findByRole("status");
+    expect(within(report).getByText("1 approved")).toBeTruthy();
+    expect(
+      within(report).getByText(
+        "1 already carried a verdict, which stands as it was.",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(report).getByText(
+        "1 had already lapsed — propose it again to decide it.",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(report).getByText(
+        "1 was approved, but its change did not land — that record is unchanged.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("reads a bundle of one as a plain row", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", inboxBackend(calls, [facts]));
+    render(<InboxScreen />);
+
+    // A group holding a single child hides the very question it exists to
+    // present, and costs the reader a click for nothing.
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Deep site read of acme.example: 6 fields, 4 facts from 3 pages",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByRole("article", { name: SUBJECT })).toBeNull();
+    expect(document.querySelectorAll(".staging-card")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Accept" })).toBeTruthy();
+  });
+
+  it("says WHEN the act starts losing proposals, not that all of it lapses then", async () => {
+    const soon = new Date(Date.now() + 90 * 60_000).toISOString();
+    const later = new Date(Date.now() + 40 * 60 * 60_000).toISOString();
+    const calls: Call[] = [];
+    vi.stubGlobal(
+      "fetch",
+      inboxBackend(calls, [
+        { ...facts, expires_at: later },
+        { ...siteRead[1], expires_at: soon },
+        { ...siteRead[2], expires_at: later },
+        { ...siteRead[3], expires_at: later },
+      ]),
+    );
+    render(<InboxScreen />);
+
+    const card = await waitFor(bundleCard);
+    // The soonest member's countdown, said as the FIRST one: members keep their
+    // own expiries, and a bare countdown in a group header reads as one deadline
+    // shared by all of them.
+    expect(within(card).getByText(/^first expires in 1h/)).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/inbox.css
+++ b/frontend/src/screens/inbox.css
@@ -1,0 +1,62 @@
+/* The approval inbox's one grouped surface: a bundle — the proposals ONE act
+   staged together — drawn as a single card with its members inside it. */
+
+/* The queue itself, clearing the tabs above it. A class rather than a margin on
+   each branch: the pending and the decided list are one rhythm, and two inline
+   copies of it is how they drift apart. */
+.approval-queue {
+  margin-top: var(--space-3);
+}
+
+/* Staged, like the rows it holds, so a reader can tell it apart from a card of
+   persisted facts — but with a SOLID border on the ordinary card ground. A
+   second dashed, AI-tinted box wrapped around dashed, AI-tinted rows reads as a
+   render glitch rather than as containment. */
+.approval-bundle {
+  border: 1.5px solid var(--aiMed);
+  margin-bottom: var(--space-3);
+}
+
+/* Who staged the act, and when it starts losing proposals. Wraps, because a
+   provenance tag and a countdown are both unbounded strings in some locales. */
+.approval-bundle-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* The line under the subject: what the group IS and how to answer it. Close to
+   the headline it explains — a full line of air between the two would read as a
+   second, unrelated fact — and demoted by size rather than by ink. */
+.approval-bundle-why {
+  margin-top: var(--space-1);
+  color: var(--textContent);
+}
+
+.approval-bundle-error {
+  margin-top: var(--space-2);
+  color: var(--danger);
+}
+
+/* The disclosure sits at the FOOT of a card that already carries its own
+   padding, so it keeps its rule above and drops the standing bottom margin it
+   uses between record-page sections. */
+.approval-bundle .approval-bundle-open {
+  margin-top: var(--space-3);
+  margin-bottom: 0;
+}
+
+/* The members are a list so the group's size and boundaries reach a reader who
+   is hearing the page; the markers are what would be noise, not the semantics. */
+.approval-bundle-members {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* The per-member report of a bundle decision, which outlives the card that made
+   it: it sits above the queue the decision has just changed. */
+.approval-bundle-result {
+  margin-top: var(--space-3);
+}

--- a/frontend/src/screens/inbox.queries.ts
+++ b/frontend/src/screens/inbox.queries.ts
@@ -17,6 +17,15 @@ export type Approval = components["schemas"]["Approval"];
 export type ApprovalStatus = "pending" | "approved" | "rejected";
 export type ApprovalPage = { data: Approval[] };
 
+// What one bundle decision did, member by member. The route answers 200 with a
+// per-member outcome rather than a single verdict, because the members were
+// always independent authorities: one that expired, one somebody else already
+// answered and one whose follow-on change failed each report for themselves
+// while their siblings decide normally.
+export type BundleDecision = components["schemas"]["ApprovalBundleDecision"];
+export type BundleOutcome =
+  components["schemas"]["ApprovalBundleMember"]["outcome"];
+
 // A single page tops out at 50 (the server's page cap) — a 51st pending
 // approval, or decided history past 50 rows, must still be reachable. The
 // pending/decided partition below (and the expired salvage inside it) needs

--- a/frontend/src/screens/inbox.stories.tsx
+++ b/frontend/src/screens/inbox.stories.tsx
@@ -105,6 +105,39 @@ const heldDraft: Approval = {
   },
 } as Approval;
 
+// One act's proposals: a site read publishes the company's facts plus a lead per
+// person it found on the team page, all carrying the act's `bundle_id`. Rendered
+// flat this was four questions; the inbox reads it as one.
+const BUNDLE = "018f3a1b-0000-7000-8000-0000000000b1";
+
+const siteFacts: Approval = {
+  ...base,
+  id: "ap-facts",
+  kind: "deepread",
+  bundle_id: BUNDLE,
+  summary: "Deep site read of acme.example: 6 fields, 4 facts from 3 pages",
+  proposed_change: { source_url: "https://acme.example" },
+  expires_at: new Date(Date.now() + 40 * 60 * 60_000).toISOString(),
+} as Approval;
+
+function siteLead(id: string, name: string, expiresInMs: number): Approval {
+  return {
+    ...siteFacts,
+    id,
+    kind: "site_lead",
+    summary: `Lead from acme.example: ${name} — Head of Operations`,
+    proposed_change: { name },
+    expires_at: new Date(Date.now() + expiresInMs).toISOString(),
+  } as Approval;
+}
+
+const siteRead: Approval[] = [
+  siteFacts,
+  siteLead("ap-lead-1", "Anna Weber", 90 * 60_000),
+  siteLead("ap-lead-2", "Kilian Wenzel", 40 * 60 * 60_000),
+  siteLead("ap-lead-3", "Mira Osei", 40 * 60 * 60_000),
+];
+
 function statusOf(url: string): string | null {
   const match = /[?&]status=([^&]+)/.exec(url);
   return match ? match[1] : null;
@@ -114,6 +147,10 @@ type StubConfig = {
   byStatus: Record<string, Approval[]>;
   detail?: Approval;
   post?: () => Response;
+  // What the two bundle routes answer. They report PER MEMBER, so the catalog
+  // needs its own hook here: a story that let the per-row stub answer would
+  // document a decision the route cannot make.
+  bundlePost?: () => Response;
 };
 
 function isDecideUrl(url: string): boolean {
@@ -130,8 +167,19 @@ function isDetailUrl(url: string): boolean {
 function resolveApprovals(
   url: string,
   method: string,
-  { byStatus, detail, post }: StubConfig,
+  { byStatus, detail, post, bundlePost }: StubConfig,
 ): Response {
+  if (method === "POST" && url.includes("/approval-bundles/")) {
+    return bundlePost
+      ? bundlePost()
+      : jsonResponse({
+          bundle_id: BUNDLE,
+          data: siteRead.map((approval) => ({
+            approval: { ...approval, status: "approved" },
+            outcome: "decided",
+          })),
+        });
+  }
   if (method === "POST" && isDecideUrl(url)) {
     return post ? post() : jsonResponse({ ...base, status: "approved" });
   }
@@ -300,4 +348,52 @@ export const AlreadyDecided: Story = {
 // AC-7: the live expiry countdown chip (fixed future expires_at).
 export const LiveCountdown: Story = {
   render: inbox({ byStatus: { pending: [pendingSoon] } }),
+};
+
+// D2/R7: one act as one question. Collapsed, the card says what the act HOLDS
+// (the kinds and how many of each), who staged it, and when it starts losing
+// proposals — the soonest member expiry, named as the first one.
+export const Bundle: Story = {
+  render: inbox({ byStatus: { pending: siteRead } }),
+};
+
+// The members, opened: each one a full row with its own decision cluster,
+// because the bundle routes carry no edit arm and a reader who disagrees with
+// one proposal decides that one where it is.
+export const BundleMembers: Story = {
+  render: inbox({ byStatus: { pending: siteRead } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByText("The 4 proposals"));
+  },
+};
+
+// A bundle decision is not all-or-nothing: the members were always independent
+// authorities, so the report names what happened to each of them.
+export const BundleOutcomes: Story = {
+  render: inbox({
+    byStatus: { pending: siteRead },
+    bundlePost: () =>
+      jsonResponse({
+        bundle_id: BUNDLE,
+        data: [
+          { approval: siteFacts, outcome: "decided" },
+          { approval: siteRead[1], outcome: "already_decided" },
+          { approval: siteRead[2], outcome: "expired" },
+          { approval: siteRead[3], outcome: "effect_failed" },
+        ],
+      }),
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Approve all 4" }),
+    );
+    // `screen`, not the canvas: the confirm is portalled to document.body.
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      await within(dialog).findByRole("button", { name: "Accept" }),
+    );
+    await canvas.findByRole("status");
+  },
 };

--- a/frontend/src/screens/inbox.tsx
+++ b/frontend/src/screens/inbox.tsx
@@ -16,12 +16,14 @@ import {
   Badge,
   Button,
   Card,
+  Disclosure,
   Field,
   Modal,
   SegmentedControl,
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Select } from "../design-system/select";
 import {
@@ -32,8 +34,9 @@ import {
   ProvenanceTag,
 } from "../design-system/trust";
 import { formatDateTime } from "../format/format";
-import { formatCountdown, useNow } from "../format/now";
+import { formatCountdown, type Translator, useNow } from "../format/now";
 import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import {
   approvalKindLabel,
   EDITABLE_FIELDS,
@@ -52,9 +55,12 @@ import {
 } from "./common";
 import {
   type Approval,
+  type BundleDecision,
+  type BundleOutcome,
   useDecidedApprovals,
   usePendingApprovals,
 } from "./inbox.queries";
+import "./inbox.css";
 
 // Re-exported so existing consumers (home.tsx) keep importing from "./inbox".
 export { useDecidedApprovals, usePendingApprovals } from "./inbox.queries";
@@ -247,6 +253,37 @@ function ApprovalDetailModal({
   );
 }
 
+// When a staged proposal lapses, in wall-clock ms — null for one that never
+// does. Read by a row and by the bundle card above it, which needs the same
+// answer for every member it holds.
+function expiryMsOf(approval: Approval): number | null {
+  return approval.expires_at ? new Date(approval.expires_at).getTime() : null;
+}
+
+// Lapsed either because the wire already stamped it (the server expires lazily
+// at read time) or because the live clock crossed expires_at since the list was
+// fetched. Both mean the same thing to a reader: it is no longer approvable.
+function hasLapsed(approval: Approval, now: number): boolean {
+  const expiresAtMs = expiryMsOf(approval);
+  return (
+    approval.status === "expired" || (expiresAtMs != null && now >= expiresAtMs)
+  );
+}
+
+// TTL as a chip that escalates as expiry nears (mockup's amber→red): warn under
+// 6h, danger under 1h, neutral beyond — never inert gray text. Shared by a
+// row's countdown and a bundle's, so one deadline cannot read as urgent in the
+// group header and calm in the member row under it.
+function expiryTone(msRemaining: number): "danger" | "warn" | undefined {
+  if (msRemaining < 60 * 60 * 1000) {
+    return "danger";
+  }
+  if (msRemaining < 6 * 60 * 60 * 1000) {
+    return "warn";
+  }
+  return undefined;
+}
+
 // The header chip: a status badge in the read-only Decided view, else the
 // live countdown that flips to the Expired badge at/after expires_at.
 function RowStatusChip({
@@ -276,17 +313,9 @@ function RowStatusChip({
   if (isExpired) {
     return <Badge tone="danger">{t("inbox.expired")}</Badge>;
   }
-  // TTL as a chip that escalates as expiry nears (mockup's amber→red): warn
-  // under 6h, danger under 1h, neutral beyond — never inert gray text.
   const remaining = expiresAtMs - now;
-  const urgency =
-    remaining < 60 * 60 * 1000
-      ? "danger"
-      : remaining < 6 * 60 * 60 * 1000
-        ? "warn"
-        : undefined;
   return (
-    <Badge tone={urgency}>
+    <Badge tone={expiryTone(remaining)}>
       {t("inbox.expiresIn", { countdown: formatCountdown(remaining, t) })}
     </Badge>
   );
@@ -617,14 +646,8 @@ export function ApprovalRow({
     decide.reset();
   };
 
-  const expiresAtMs = approval.expires_at
-    ? new Date(approval.expires_at).getTime()
-    : null;
-  // Expired either because the wire already stamped it (lazy server expiry)
-  // or the live clock crossed expires_at since this row was fetched.
-  const isExpired =
-    approval.status === "expired" ||
-    (expiresAtMs != null && now >= expiresAtMs);
+  const expiresAtMs = expiryMsOf(approval);
+  const isExpired = hasLapsed(approval, now);
 
   return (
     <article
@@ -829,6 +852,456 @@ export function ApprovalRow({
   );
 }
 
+// One act's proposals, or one proposal on its own — what the pending queue is
+// actually a list of.
+//
+// The server stamps every proposal ONE act staged with a shared `bundle_id` (a
+// site read publishes the company's facts plus a lead per person it found), so a
+// read of a ten-person team page arrives as eleven rows. Rendered flat that is
+// eleven questions for one act, which is the whole defect: the reader cannot see
+// that answering them is one decision.
+//
+// A bundle of ONE is deliberately not a group. A group holding a single child
+// hides the very question it exists to present, and the reader gains nothing for
+// the click — so it reads as the plain row it is.
+type InboxItem =
+  | { readonly kind: "single"; readonly approval: Approval }
+  | {
+      readonly kind: "bundle";
+      readonly bundleId: string;
+      readonly members: readonly Approval[];
+    };
+
+// Groups the queue by act WITHOUT reordering it: each bundle is emitted at the
+// position of its first member, so the order the caller sorted (oldest staged
+// first) still decides where a group sits.
+function groupByBundle(approvals: readonly Approval[]): InboxItem[] {
+  const byBundle = new Map<string, Approval[]>();
+  for (const approval of approvals) {
+    if (approval.bundle_id) {
+      const held = byBundle.get(approval.bundle_id);
+      if (held) {
+        held.push(approval);
+      } else {
+        byBundle.set(approval.bundle_id, [approval]);
+      }
+    }
+  }
+  const items: InboxItem[] = [];
+  const emitted = new Set<string>();
+  for (const approval of approvals) {
+    const bundleId = approval.bundle_id;
+    const members = bundleId ? byBundle.get(bundleId) : undefined;
+    if (!bundleId || !members || members.length < 2) {
+      items.push({ kind: "single", approval });
+    } else if (!emitted.has(bundleId)) {
+      emitted.add(bundleId);
+      items.push({ kind: "bundle", bundleId, members });
+    }
+  }
+  return items;
+}
+
+// What the group HOLDS, which is the only thing that makes it one thing: "4
+// proposals" is a count nobody can answer, while "Read the company site · Add a
+// person found on the site" says what saying yes would do. Kinds in the order
+// the act staged them, each named once — how many there are is the line under
+// it, and which ones they are is the list inside.
+function bundleSubject(members: readonly Approval[], t: Translator): string {
+  return [...new Set(members.map((member) => member.kind))]
+    .map((kind) => approvalKindLabel(kind, t))
+    .join(" · ");
+}
+
+// Who staged the act, shown only where every member agrees. One act has one
+// author, so a disagreement means the grouping is not what it claims — and
+// naming one member's proposer for all of them would be the wrong half of an
+// honest answer.
+function sharedProposer(members: readonly Approval[]): string | null {
+  const first = members[0]?.proposed_by;
+  return first && members.every((member) => member.proposed_by === first)
+    ? first
+    : null;
+}
+
+// The group's countdown: the SOONEST live member expiry, because that is when
+// this act starts losing proposals. The copy says "first" — a bare countdown in
+// a group header reads as one deadline shared by every member, and members keep
+// their own expiries (the bundle is a grouping, never a second authority).
+//
+// `live` is the members that have not lapsed, so an empty list means this act
+// has run out of time rather than that it never had a member.
+function BundleExpiryChip({
+  live,
+  now,
+}: Readonly<{ live: readonly Approval[]; now: number }>) {
+  const t = useT();
+  if (live.length === 0) {
+    return <Badge tone="danger">{t("inbox.expired")}</Badge>;
+  }
+  const expiries = live
+    .map(expiryMsOf)
+    .filter((expiresAtMs): expiresAtMs is number => expiresAtMs != null);
+  if (expiries.length === 0) {
+    return null;
+  }
+  const remaining = Math.min(...expiries) - now;
+  return (
+    <Badge tone={expiryTone(remaining)}>
+      {t("inbox.bundle.expiresIn", {
+        countdown: formatCountdown(remaining, t),
+      })}
+    </Badge>
+  );
+}
+
+type BundleVerdict = "approve" | "reject";
+
+// One act, as one question — with every member still reachable underneath it.
+//
+// The two bundle routes decide every still-pending member in one call and answer
+// per member, so the collapsed card can carry the whole decision. What it must
+// NOT carry is an edit: an edit re-hashes one diff and re-pins one entity, so
+// there is no such thing as one edit spanning several proposals (the request
+// body has no arm for it). That is why the members open as full rows rather than
+// as a read-only manifest — a reader who wants to change one goes to it, decides
+// it there, and answers the rest here.
+function BundleCard({
+  bundleId,
+  members,
+  onApproved,
+  onAlreadyDecided,
+  onDecided,
+}: Readonly<{
+  bundleId: string;
+  members: readonly Approval[];
+  onApproved?: (approvalId: string, token: string) => void;
+  onAlreadyDecided?: () => void;
+  // Lifts the per-member report to a surface that survives this card's unmount:
+  // the decision invalidates the pending list, which takes the card with it.
+  onDecided: (verdict: BundleVerdict, decision: BundleDecision) => void;
+}>) {
+  const t = useT();
+  const viewerId = useViewerId();
+  const queryClient = useQueryClient();
+  const tierMap = useAgentTierMap();
+  const [confirming, setConfirming] = useState<BundleVerdict | null>(null);
+  const [reason, setReason] = useState("");
+  // Only a group holding an expiry needs the per-second clock (interval 0 ⇒
+  // useNow does not tick).
+  const needsCountdown = members.some((member) => member.expires_at != null);
+  const now = useNow(needsCountdown ? 1000 : 0);
+
+  const decide = useMutation({
+    mutationFn: async (input: {
+      bundleId: string;
+      verdict: BundleVerdict;
+      reason: string;
+    }) => {
+      const path =
+        input.verdict === "approve"
+          ? "/approval-bundles/{bundle_id}/approve"
+          : "/approval-bundles/{bundle_id}/reject";
+      const { data, error } = await api.POST(path, {
+        params: { path: { bundle_id: input.bundleId } },
+        // One stated reason for one decision, recorded on every member it
+        // decides. An unstated one is omitted rather than sent empty: the
+        // request body is closed, and a blank string would be recorded as
+        // though somebody had written it.
+        ...(input.reason ? { body: { reason: input.reason } } : {}),
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: (data, input) => {
+      // Report FIRST — the invalidation below unmounts this card, so the
+      // screen-level surface has to have the outcomes before it goes.
+      onDecided(input.verdict, data);
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+    },
+    onError: (error) => {
+      const problem = error instanceof ProblemError ? error.problem : null;
+      if (problem && isAlreadyDecided(problem)) {
+        onAlreadyDecided?.();
+        queryClient.invalidateQueries({ queryKey: ["approvals", "pending"] });
+      }
+    },
+  });
+
+  const subject = bundleSubject(members, t);
+  const live = members.filter((member) => !hasLapsed(member, now));
+  const proposedBy = sharedProposer(members);
+  // The autonomy dot every row carries, raised to the group only where the
+  // members agree on it: one dot over a mix would claim a tier half of them do
+  // not have, and the rows inside say it for themselves either way.
+  const tiers = new Set(
+    members.map((member) => approvalDotTier(member.kind, tierMap)),
+  );
+  const sharedTier = tiers.size === 1 ? [...tiers][0] : null;
+
+  const send = (verdict: BundleVerdict, stated: string) => {
+    decide.mutate({ bundleId, verdict, reason: stated });
+    setConfirming(null);
+    setReason("");
+  };
+
+  return (
+    <Card as="article" className="approval-bundle" ariaLabel={subject}>
+      <div className="approval-bundle-meta">
+        {sharedTier && <AutonomyDot tier={sharedTier} />}
+        {proposedBy && (
+          <ProvenanceTag provenance={provenanceOf(proposedBy, viewerId)} />
+        )}
+        <BundleExpiryChip live={live} now={now} />
+      </div>
+      <p className="t-h2">{subject}</p>
+      <p className="t-small approval-bundle-why">
+        {t("inbox.bundle.why", { count: members.length })}
+      </p>
+      {live.length > 0 && (
+        <div className="approval-gate">
+          {/* Approve-all is what STARTED the write, so it is the control that
+              goes busy; Reject-all is merely unavailable while a verdict is out
+              and stays `disabled`. Both count the LIVE members: a lapsed one is
+              not something this press can decide. */}
+          <Button
+            variant="primary"
+            small
+            pending={decide.isPending}
+            onClick={() => setConfirming("approve")}
+          >
+            {t("inbox.bundle.approveAll", { count: live.length })}
+          </Button>
+          <Button
+            small
+            disabled={decide.isPending}
+            onClick={() => setConfirming("reject")}
+          >
+            {t("inbox.bundle.rejectAll", { count: live.length })}
+          </Button>
+        </div>
+      )}
+      {decide.isError && (
+        <p className="t-caption approval-bundle-error">
+          {problemMessageOf(decide.error, t)}
+        </p>
+      )}
+      <Disclosure
+        className="approval-bundle-open"
+        summary={t("inbox.bundle.members", { count: members.length })}
+      >
+        {/* A list, not an indent: the count and the boundaries of the group have
+            to reach a reader who is hearing this page rather than seeing it. */}
+        <ul className="approval-bundle-members">
+          {members.map((member) => (
+            <li key={member.id}>
+              <ApprovalRow
+                approval={member}
+                onApproved={onApproved}
+                onAlreadyDecided={onAlreadyDecided}
+              />
+            </li>
+          ))}
+        </ul>
+      </Disclosure>
+      <ConfirmModal
+        open={confirming === "approve"}
+        onClose={() => setConfirming(null)}
+        title={t("inbox.bundle.approveAll", { count: live.length })}
+        confirmLabel={t("trust.accept")}
+        pending={decide.isPending}
+        onConfirm={() => send("approve", "")}
+      >
+        <p className="t-small">{t("inbox.bundle.approveAllConfirm")}</p>
+      </ConfirmModal>
+      <ConfirmModal
+        open={confirming === "reject"}
+        onClose={() => setConfirming(null)}
+        title={t("inbox.bundle.rejectAll", { count: live.length })}
+        confirmLabel={t("inbox.reject")}
+        confirmVariant="danger"
+        pending={decide.isPending}
+        onConfirm={() => send("reject", reason)}
+      >
+        <Field
+          label={t("inbox.rejectReason")}
+          hint={t("inbox.bundle.rejectReasonHint")}
+        >
+          {(control) => (
+            <Textarea
+              {...control}
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+            />
+          )}
+        </Field>
+      </ConfirmModal>
+    </Card>
+  );
+}
+
+type BundleResult = {
+  readonly verdict: BundleVerdict;
+  readonly decision: BundleDecision;
+};
+
+// The outcomes that are NOT a verdict this call recorded, each in the two number
+// forms its sentence needs. Keyed off the wire enum minus `decided`, so an
+// outcome the contract adds fails the type here rather than dropping silently
+// out of a report whose whole job is to be complete.
+const OUTCOME_KEYS: Readonly<
+  Record<
+    Exclude<BundleOutcome, "decided">,
+    { readonly one: MessageKey; readonly other: MessageKey }
+  >
+> = {
+  already_decided: {
+    one: "inbox.bundle.result.alreadyDecided.one",
+    other: "inbox.bundle.result.alreadyDecided.other",
+  },
+  expired: {
+    one: "inbox.bundle.result.expired.one",
+    other: "inbox.bundle.result.expired.other",
+  },
+  effect_failed: {
+    one: "inbox.bundle.result.effectFailed.one",
+    other: "inbox.bundle.result.effectFailed.other",
+  },
+};
+
+// The order the report reads in: what somebody else settled, what ran out of
+// time, and last the one that needs somebody to look at a record.
+const REPORTED_OUTCOMES = [
+  "already_decided",
+  "expired",
+  "effect_failed",
+] as const satisfies readonly (keyof typeof OUTCOME_KEYS)[];
+
+// How many members came back in each outcome.
+function outcomeCounts(decision: BundleDecision): Map<BundleOutcome, number> {
+  const counts = new Map<BundleOutcome, number>();
+  for (const member of decision.data) {
+    counts.set(member.outcome, (counts.get(member.outcome) ?? 0) + 1);
+  }
+  return counts;
+}
+
+// One sentence per outcome the response reported, verdict first.
+//
+// Deciding a bundle is not all-or-nothing, so "approved" on its own would be a
+// claim the response does not make: a member that had lapsed, one somebody else
+// had already answered, and one whose follow-on change failed to land each came
+// back saying so, and each is a different thing for the reader to do next.
+function outcomeLines(result: BundleResult, t: Translator): string[] {
+  const counts = outcomeCounts(result.decision);
+  const lines: string[] = [];
+  const decided = counts.get("decided") ?? 0;
+  if (decided > 0) {
+    lines.push(
+      t(
+        result.verdict === "approve"
+          ? "inbox.bundle.result.approved"
+          : "inbox.bundle.result.rejected",
+        { count: decided },
+      ),
+    );
+  }
+  for (const outcome of REPORTED_OUTCOMES) {
+    const count = counts.get(outcome) ?? 0;
+    if (count > 0) {
+      const keys = OUTCOME_KEYS[outcome];
+      lines.push(t(count === 1 ? keys.one : keys.other, { count }));
+    }
+  }
+  return lines;
+}
+
+// The worst thing that happened, which is what the notice's tone has to say: an
+// approved member whose change did not land leaves a record that did NOT change
+// while its approval stands, and that outranks anything else in the report.
+function outcomeTone(decision: BundleDecision): "danger" | "warn" | "success" {
+  const outcomes = new Set(decision.data.map((member) => member.outcome));
+  if (outcomes.has("effect_failed")) {
+    return "danger";
+  }
+  return outcomes.has("already_decided") || outcomes.has("expired")
+    ? "warn"
+    : "success";
+}
+
+// What the decision actually did, member by member.
+//
+// Screen-level, like the minted token, because the decision invalidates the
+// pending list and unmounts the card that made it.
+function BundleOutcomeNote({
+  result,
+  onDismiss,
+}: Readonly<{ result: BundleResult; onDismiss: () => void }>) {
+  const t = useT();
+  const lines = outcomeLines(result, t);
+  // A report with nothing in it says nothing: a call that decided no member
+  // answers 404, so there is no honest sentence to put in an empty box here.
+  if (lines.length === 0) {
+    return null;
+  }
+  const tone = outcomeTone(result.decision);
+  return (
+    <Callout
+      tone={tone}
+      live="status"
+      className="approval-bundle-result"
+      actions={
+        <Button small onClick={onDismiss}>
+          {t("inbox.dismiss")}
+        </Button>
+      }
+    >
+      {lines.map((line) => (
+        <p key={line}>{line}</p>
+      ))}
+    </Callout>
+  );
+}
+
+// The pending queue: one card per act, one row per proposal staged alone.
+function PendingList({
+  approvals,
+  onApproved,
+  onAlreadyDecided,
+  onBundleDecided,
+}: Readonly<{
+  approvals: readonly Approval[];
+  onApproved: (approvalId: string, token: string) => void;
+  onAlreadyDecided: () => void;
+  onBundleDecided: (verdict: BundleVerdict, decision: BundleDecision) => void;
+}>) {
+  return (
+    <>
+      {groupByBundle(approvals).map((item) =>
+        item.kind === "bundle" ? (
+          <BundleCard
+            key={item.bundleId}
+            bundleId={item.bundleId}
+            members={item.members}
+            onApproved={onApproved}
+            onAlreadyDecided={onAlreadyDecided}
+            onDecided={onBundleDecided}
+          />
+        ) : (
+          <ApprovalRow
+            key={item.approval.id}
+            approval={item.approval}
+            onApproved={onApproved}
+            onAlreadyDecided={onAlreadyDecided}
+          />
+        ),
+      )}
+    </>
+  );
+}
+
 export function InboxScreen() {
   const t = useT();
   const [tab, setTab] = useState<"pending" | "decided">("pending");
@@ -838,6 +1311,9 @@ export function InboxScreen() {
   // someone else" note (AC-6).
   const { onApproved, onAlreadyDecided, tokenModal, decidedNote } =
     useApprovalTokenSink();
+  // The per-member report of a bundle decision, held here for the same reason:
+  // the decision unmounts the card that made it.
+  const [bundleResult, setBundleResult] = useState<BundleResult | null>(null);
   const pendingQuery = usePendingApprovals();
   const decidedQuery = useDecidedApprovals(tab === "decided");
   const query = tab === "pending" ? pendingQuery : decidedQuery;
@@ -857,20 +1333,43 @@ export function InboxScreen() {
         />
       </div>
       {decidedNote}
+      {bundleResult && (
+        <BundleOutcomeNote
+          result={bundleResult}
+          onDismiss={() => setBundleResult(null)}
+        />
+      )}
       <QueryGate query={query} empty={(page) => page.data.length === 0}>
-        {(page) => (
-          <div style={{ marginTop: 12 }}>
-            {page.data.map((approval) => (
-              <ApprovalRow
-                key={approval.id}
-                approval={approval}
-                decided={tab === "decided"}
+        {(page) =>
+          tab === "pending" ? (
+            <div className="approval-queue">
+              <PendingList
+                approvals={page.data}
                 onApproved={onApproved}
                 onAlreadyDecided={onAlreadyDecided}
+                onBundleDecided={(verdict, decision) =>
+                  setBundleResult({ verdict, decision })
+                }
               />
-            ))}
-          </div>
-        )}
+            </div>
+          ) : (
+            // Decided stays ungrouped on purpose: it is history in the order the
+            // verdicts were recorded, and each member carries its OWN verdict —
+            // a group header over it would have to state a status the group does
+            // not have (three approved, one rejected, one lapsed).
+            <div className="approval-queue">
+              {page.data.map((approval) => (
+                <ApprovalRow
+                  key={approval.id}
+                  approval={approval}
+                  decided
+                  onApproved={onApproved}
+                  onAlreadyDecided={onAlreadyDecided}
+                />
+              ))}
+            </div>
+          )
+        }
       </QueryGate>
       {tokenModal}
     </div>

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -298,6 +298,7 @@ export function LogActivityAction({
   initialKind,
   openOnMount,
   triggerLabel,
+  disabledReasonId,
   onClose,
 }: Readonly<{
   entityType: EntityKind;
@@ -314,6 +315,11 @@ export function LogActivityAction({
   // own verb; two buttons both reading "Log activity" is a toolbar that has
   // stopped telling the reader anything.
   triggerLabel?: MessageKey;
+  // The sentence that refuses this verb, already on the page. A record that
+  // takes no new activity must still SHOW the verb it will not accept — a
+  // reader who cannot tell "this record is archived" from "this build has no
+  // such button" learns nothing from the absence.
+  disabledReasonId?: string;
   onClose?: () => void;
 }>) {
   const t = useT();
@@ -330,7 +336,7 @@ export function LogActivityAction({
   return (
     <>
       {!openOnMount && (
-        <Button small onClick={() => setOpen(true)}>
+        <Button small reasonId={disabledReasonId} onClick={() => setOpen(true)}>
           {t(triggerLabel ?? "log.title")}
         </Button>
       )}

--- a/frontend/src/screens/merge.stories.tsx
+++ b/frontend/src/screens/merge.stories.tsx
@@ -28,6 +28,20 @@ export default meta;
 
 type Story = StoryObj<typeof MergeAction>;
 
+const SOURCE = {
+  label: "Merge into…",
+  sourceId: "p-1",
+  sourceName: "Anna Weber",
+  searchTargets: () => Promise.resolve([{ id: "p-2", name: "Otto Fischer" }]),
+  merge: (targetId: string) => Promise.resolve({ id: targetId }),
+  invalidate: "people",
+  recordKey: "person",
+  survivorRoute: (targetId: string) => ({
+    screen: "contacts" as const,
+    id: targetId,
+  }),
+};
+
 export const TargetPicked: Story = {
   // The merge dialog mounts record chrome that reads the session, so the probe
   // has to be routed — an unrouted one fails every grant closed and renders a
@@ -35,16 +49,7 @@ export const TargetPicked: Story = {
   beforeEach: () => {
     installFetchStub({ "GET /me": meRoute({ person: ["read", "update"] }) });
   },
-  args: {
-    label: "Merge into…",
-    sourceId: "p-1",
-    sourceName: "Anna Weber",
-    searchTargets: () => Promise.resolve([{ id: "p-2", name: "Otto Fischer" }]),
-    merge: (targetId: string) => Promise.resolve({ id: targetId }),
-    invalidate: "people",
-    recordKey: "person",
-    survivorRoute: (targetId: string) => ({ screen: "contacts", id: targetId }),
-  },
+  args: SOURCE,
   play: async ({ canvasElement }) => {
     // The trigger is in the canvas; everything after it is inside the merge
     // Modal, which portals to document.body — so the picker is reached through
@@ -55,4 +60,23 @@ export const TargetPicked: Story = {
     await new Promise((resolve) => setTimeout(resolve, 400));
     await userEvent.click(await screen.findByText("Otto Fischer"));
   },
+};
+
+// An archived source cannot be folded into anything — a refusal by the
+// record's STATE, so the verb stays and says why (STATE-4a). The sentence
+// lives on the page that owns the record, and the control points at it, which
+// is the half a `title` on a disabled button cannot do.
+export const RefusedByArchive: Story = {
+  beforeEach: () => {
+    installFetchStub({ "GET /me": meRoute({ person: ["read", "update"] }) });
+  },
+  args: { ...SOURCE, disabledReasonId: "merge-refusal" },
+  render: (args) => (
+    <>
+      <MergeAction {...args} />
+      <p id="merge-refusal" className="t-caption">
+        This contact is archived. Restore them to change anything here.
+      </p>
+    </>
+  ),
 };

--- a/frontend/src/screens/merge.tsx
+++ b/frontend/src/screens/merge.tsx
@@ -30,6 +30,7 @@ export function MergeAction<Survivor extends { id: string }>({
   invalidate,
   recordKey,
   survivorRoute,
+  disabledReasonId,
 }: Readonly<{
   label: string;
   sourceId: string;
@@ -44,6 +45,14 @@ export function MergeAction<Survivor extends { id: string }>({
   invalidate: string;
   recordKey: string;
   survivorRoute: (targetId: string) => Route;
+  // Why this merge is unavailable, when it is: the id of an element on the
+  // page already carrying the sentence. STATE-4a settles the absent-vs-
+  // disabled question by CAUSE — a merge blocked by the source record's
+  // STATE, an archived row the server will not fold into anything, stays
+  // visible and disabled WITH the reason, because the reason is the
+  // information and hiding the control hides a fact the reader needs. The
+  // overlay refusal below is the other cause and keeps the other answer.
+  disabledReasonId?: string;
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -120,7 +129,12 @@ export function MergeAction<Survivor extends { id: string }>({
 
   return (
     <>
-      <Button small onClick={() => setOpen(true)} data-testid="merge-record">
+      <Button
+        small
+        reasonId={disabledReasonId}
+        onClick={() => setOpen(true)}
+        data-testid="merge-record"
+      >
         {label}
       </Button>
       <Modal open={open} onClose={close} labelledBy={headingId}>

--- a/frontend/src/screens/onboarding-conversation/artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/artifact.tsx
@@ -191,7 +191,7 @@ function RefusalNotice({
           <Button
             small
             variant="ghost"
-            disabled={refusal.retry.busy}
+            pending={refusal.retry.busy}
             onClick={refusal.retry.run}
           >
             {t("common.retry")}

--- a/frontend/src/screens/onboarding-conversation/artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/artifact.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import type { components } from "../../api/schema";
 import { Button } from "../../design-system/atoms";
+import { Callout } from "../../design-system/callout";
 import { useT } from "../../i18n";
 import type { CompanyDraft, CompanyFieldName } from "../onboarding";
 import { CompanyStep } from "../onboarding-company-form";
@@ -27,6 +28,25 @@ export type FindingHighlight = Readonly<{
 // Matches the ob-conv-pulse animation length in conversation.css.
 const PULSE_MS = 1200;
 
+/** The one look that can turn the state a refusal names into a different one,
+ * where there is one — the route forward wherever the refusal is also what
+ * holds Continue down. */
+export type RefusalRetry = Readonly<{ run: () => void; busy: boolean }>;
+
+/**
+ * A confirm the server refused in a way pressing the same button again cannot
+ * change, said on the surface that carries the button rather than in the
+ * transcript beside it.
+ *
+ * The sentence arrives already translated: which of the refusals this is, and
+ * therefore which words it takes, is the driver's knowledge — this pane only
+ * knows where a refusal belongs.
+ */
+export type ConfirmRefusal = Readonly<{
+  message: string;
+  retry: RefusalRetry | null;
+}>;
+
 type CompanyActArtifactProps = Readonly<{
   mode: ArtifactMode;
   /** The manual interview replaces the dossier until its review begins. */
@@ -47,6 +67,13 @@ type CompanyActArtifactProps = Readonly<{
   confirmPending: boolean;
   confirmDisabled: boolean;
   saveError: string | null;
+  /** A confirm the server refused, if one stands. It renders once, at the head
+   * of this pane, for every scene the pane can be showing — the review board,
+   * the edit form and the manual interview all press the same Continue.
+   * Optional like `review`: a caller mounting this pane to inspect one scene has
+   * no refusal to report, and an absent prop must read as "none" rather than as
+   * a notice with nothing in it. */
+  refusal?: ConfirmRefusal | null;
 }>;
 
 export function CompanyActArtifact(props: CompanyActArtifactProps) {
@@ -138,8 +165,42 @@ export function CompanyActArtifact(props: CompanyActArtifactProps) {
           </p>
         </div>
       )}
+      {props.refusal != null && <RefusalNotice refusal={props.refusal} />}
       <ArtifactBody {...props} />
     </div>
+  );
+}
+
+// What the pane says about the press it just refused. `alert`, not `status`:
+// the reader pressed Continue and nothing happened, so this interrupts —
+// exactly the case the Callout contract reserves it for. The action beside it
+// is the one look that can end the state named, where there is one; where
+// Continue is blocked it IS the route forward, which is why it is the notice
+// that carries it rather than the board's foot bar.
+function RefusalNotice({
+  refusal,
+}: Readonly<{ refusal: ConfirmRefusal }>): ReactNode {
+  const t = useT();
+  return (
+    <Callout
+      tone="warn"
+      live="alert"
+      className="ob-conv-refusal"
+      actions={
+        refusal.retry === null ? undefined : (
+          <Button
+            small
+            variant="ghost"
+            disabled={refusal.retry.busy}
+            onClick={refusal.retry.run}
+          >
+            {t("common.retry")}
+          </Button>
+        )
+      }
+    >
+      <p>{refusal.message}</p>
+    </Callout>
   );
 }
 

--- a/frontend/src/screens/onboarding-conversation/company-act-refusal.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act-refusal.test.tsx
@@ -1,0 +1,240 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import { LocaleProvider } from "../../i18n";
+import { en } from "../../i18n/en";
+import { installFetchStub, jsonResponse, type RouteMap } from "../story-utils";
+import { CompanyAct } from "./company-act";
+import type { ConversationState } from "./conversation-machine";
+import { initialConversationState } from "./conversation-machine";
+
+// WHERE a refused confirm says so. The board carries Continue, so the board is
+// where its refusal belongs: the sentence used to render in the conversation
+// rail, a scroller the reader who just pressed a button on the other pane is
+// not looking at, and a press that earned a 409 therefore had no on-screen life
+// at all. company-act.test.tsx pins which notice each server code produces and
+// when Continue re-arms; this file pins only the one thing those cases never
+// asked — that a reader can tell their press was rejected.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type Proposal = components["schemas"]["OnboardingCompanyProposal"];
+type ColdField = components["schemas"]["ColdStartField"];
+
+const SITE_URL = "https://gradion.com";
+const READ_ID = "018f3a1b-0000-7000-8000-0000000000e2";
+const CONFIRM_PATH = `POST /company/site-reads/${READ_ID}/confirm`;
+
+function grounded(field: ColdField["field"], value: string): ColdField {
+  return {
+    field,
+    value,
+    evidence_snippet: "seen on the site",
+    source_kind: "url",
+    source_url: SITE_URL,
+    confidence: 0.95,
+  };
+}
+
+// The three fields `confirmCompanySiteRead` 422s without. Filled, so nothing
+// but the server's own refusal can hold Continue down.
+const REQUIRED_TRIO: ColdField[] = [
+  grounded("display_name", "Gradion"),
+  grounded("offer_summary", "CRM software"),
+  grounded("icp", "Mid-market B2B"),
+];
+
+const READ: CompanySiteRead = {
+  id: READ_ID,
+  target_kind: "onboarding",
+  organization_id: null,
+  root_url: SITE_URL,
+  status: "ready",
+  status_code: null,
+  status_detail: null,
+  next_attempt_at: null,
+  phase: null,
+  pages_read: 1,
+  pages: [{ url: SITE_URL, status: "fetched", kind: "home" }],
+  profile_fields: REQUIRED_TRIO,
+  facts: [],
+  comparisons: [],
+  people: [],
+  legal_entities: [],
+  warnings: [],
+  draft_version: 1,
+  proposal_hash: "proposal-1",
+  created_at: "2026-07-22T08:00:00Z",
+  updated_at: "2026-07-22T08:00:01Z",
+};
+
+function proposal(hash: string): Proposal {
+  return {
+    ready: true,
+    // The proposal states a definite source for every field it carries, and
+    // `grounded` supplies one — so the fixture asserts that rather than
+    // widening the contract's own type to admit a missing URL.
+    fields: REQUIRED_TRIO.map((field) => ({
+      field: field.field,
+      value: field.value,
+      confidence: field.confidence,
+      evidence_snippet: field.evidence_snippet ?? "",
+      source_url: field.source_url ?? SITE_URL,
+    })),
+    facts: [],
+    open_questions: [],
+    remaining_required_fields: [],
+    draft_version: READ.draft_version,
+    proposal_hash: hash,
+  };
+}
+
+const REVIEW_STATE: ConversationState = {
+  ...initialConversationState,
+  act: "company",
+  phase: "co.review",
+  activeReadId: READ_ID,
+  readCompleted: true,
+  pendingQuestion: null,
+};
+
+function renderReview(routes: RouteMap): void {
+  installFetchStub({
+    [`GET /company/site-reads/${READ_ID}`]: () => jsonResponse(READ),
+    "GET /onboarding/company/proposal": () =>
+      jsonResponse(proposal("proposal-1")),
+    ...routes,
+  });
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">
+        <CompanyAct
+          state={REVIEW_STATE}
+          dispatch={vi.fn()}
+          profile={null}
+          persist={vi.fn(async () => true)}
+        />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// The two panes by name, so every assertion below is about WHICH of them a
+// sentence landed on. Throwing rather than asserting: a missing pane means the
+// shell never rendered, and every case after it would report the wrong failure.
+function pane(selector: string): HTMLElement {
+  const found = document.querySelector<HTMLElement>(selector);
+  if (found === null) {
+    throw new Error(`the conversation shell rendered no ${selector}`);
+  }
+  return found;
+}
+
+/** The work surface: the review board and the Continue it carries. */
+function surface(): HTMLElement {
+  return pane(".mw-artifact");
+}
+
+/** The conversation rail: narration and history, and a scroller. */
+function rail(): HTMLElement {
+  return pane(".mw-thread");
+}
+
+async function pressContinue(): Promise<HTMLElement> {
+  const button = await screen.findByRole("button", { name: /Continue/ });
+  expect(button).toBeEnabled();
+  fireEvent.click(button);
+  return button;
+}
+
+it("says on the work surface, not in the rail, that the server refused the press", async () => {
+  renderReview({
+    [CONFIRM_PATH]: () =>
+      jsonResponse({ title: "conflict", code: "not_confirmable" }, 409),
+  });
+
+  await pressContinue();
+
+  const notice = await within(surface()).findByText(
+    en["ob.conv.review.confirmNotReady"],
+  );
+  // Once, and on the pane that carries the button. A second copy in the rail
+  // would leave the reader deciding which of the two is about their press.
+  expect(
+    screen.getAllByText(en["ob.conv.review.confirmNotReady"]),
+  ).toHaveLength(1);
+  expect(
+    within(rail()).queryByText(en["ob.conv.review.confirmNotReady"]),
+  ).toBeNull();
+  // A DIRECT child of the pane's own surface, because that is what pins it:
+  // conversation.css sticks `.ob-conv-artifact > .ob-conv-refusal` to the pane's
+  // head, and a selector that quietly stops matching would leave the notice
+  // scrolling away again with nothing failing.
+  const strip = notice.closest(".ob-conv-refusal");
+  expect(strip?.parentElement?.classList.contains("ob-conv-artifact")).toBe(
+    true,
+  );
+  // An alert, because it appeared in answer to a press the reader has already
+  // made and may not be looking for.
+  expect(notice.closest('[role="alert"]')).not.toBeNull();
+});
+
+it("puts the one look that could end the refusal on the same surface as the refusal", async () => {
+  renderReview({
+    [CONFIRM_PATH]: () =>
+      jsonResponse({ title: "conflict", code: "not_confirmable" }, 409),
+  });
+
+  await pressContinue();
+
+  await within(surface()).findByText(en["ob.conv.review.confirmNotReady"]);
+  // Continue is blocked here, so the re-check IS the route forward — it may
+  // not sit one pane away from the sentence that tells the reader to take it.
+  expect(
+    await within(surface()).findByRole("button", { name: "Retry" }),
+  ).toBeInTheDocument();
+  expect(within(rail()).queryByRole("button", { name: "Retry" })).toBeNull();
+});
+
+it("keeps the skew sentence on the surface after the refetch re-arms Continue", async () => {
+  // The whole race in the field report: the refetch lands a genuinely newer
+  // draft, Continue becomes safe to press again, and the reader still has to
+  // be able to see why their first press did nothing.
+  let proposalCalls = 0;
+  renderReview({
+    "GET /onboarding/company/proposal": () => {
+      proposalCalls += 1;
+      return jsonResponse(
+        proposal(proposalCalls === 1 ? "proposal-1" : "proposal-2"),
+      );
+    },
+    [CONFIRM_PATH]: () =>
+      jsonResponse({ title: "conflict", code: "version_skew" }, 409),
+  });
+
+  const button = await pressContinue();
+
+  await within(surface()).findByText(en["ob.conv.review.confirmVersionSkew"]);
+  await waitFor(() => expect(button).toBeEnabled());
+  expect(
+    within(surface()).getByText(en["ob.conv.review.confirmVersionSkew"]),
+  ).toBeInTheDocument();
+});

--- a/frontend/src/screens/onboarding-conversation/company-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.test.tsx
@@ -994,7 +994,14 @@ describe("recovering from a rejected confirm", () => {
     // The re-check landed a read that still has nothing to confirm, so the
     // block stands: re-arming here would send the identical submission back
     // into the identical 409.
-    await vi.waitFor(() => expect(retry).toBeEnabled());
+    //
+    // Waited on `aria-busy` rather than on the control being enabled: a
+    // pending write keeps its button focusable and swallows a second press, so
+    // "enabled" is true the whole way through and the next click would land
+    // inside the look it is meant to follow.
+    await vi.waitFor(() =>
+      expect(retry).not.toHaveAttribute("aria-busy", "true"),
+    );
     expect(continueButton).toBeDisabled();
 
     fireEvent.click(retry);

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -3,7 +3,6 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
-import { Button } from "../../design-system/atoms";
 import { useLocale, useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import {
@@ -23,7 +22,12 @@ import {
 } from "../onboarding";
 import { OnboardingGate } from "../onboarding-gate";
 import type { SuggestedCompanyChange } from "../onboarding-read";
-import type { ArtifactMode, FindingHighlight } from "./artifact";
+import type {
+  ArtifactMode,
+  ConfirmRefusal,
+  FindingHighlight,
+  RefusalRetry,
+} from "./artifact";
 import { CompanyActArtifact } from "./artifact";
 import {
   draftWithLegalEntity,
@@ -91,10 +95,6 @@ function initialDraft(profile: CompanyProfile | null): CompanyDraft {
 // Which server state a confirm 409 named — see the state declaration in the
 // driver for what each one means to the reader.
 type ConfirmNotice = "skew" | "notReady" | "checkFailed";
-
-// What a notice offers the reader instead of the Continue button: the one
-// look that can turn the state it describes into a different one.
-type NoticeRetry = Readonly<{ run: () => void; busy: boolean }>;
 
 // Whether the version pair the next confirm would quote is the one this read
 // carries — the whole question a readiness re-check has to answer about the
@@ -793,8 +793,9 @@ export function CompanyAct({
   // The generic "I could not save that: {detail}" banner, but ONLY for a
   // confirm failure this driver has not already turned into something more
   // useful: `confirmNotice` covers version_skew (a fresh fetch is already in
-  // flight; the thread's own alert says so) and the other two documented
-  // 409s, so this stays null for those rather than doubling the message.
+  // flight; the pane's own refusal notice says so) and the other two
+  // documented 409s, so this stays null for those rather than doubling the
+  // message.
   // `already_confirmed` is the one refusal that carries no notice while it
   // resolves — its whole recovery is the company lookup — and that lookup
   // ends either in the review's exit or in the "checkFailed" notice, so a
@@ -810,15 +811,33 @@ export function CompanyAct({
   // "notReady" the re-check is the reader's ONLY route, because Continue is
   // blocked, and for "checkFailed" the load is the only thing that can turn
   // "I could not load it" into the company itself.
-  const noticeRetries: Readonly<Record<ConfirmNotice, NoticeRetry | null>> = {
+  const noticeRetries: Readonly<Record<ConfirmNotice, RefusalRetry | null>> = {
     skew: skewStuck
       ? { run: refreshAfterSkew, busy: awaitingProposalRefresh }
       : null,
     notReady: { run: recheckReadiness, busy: awaitingReadinessCheck },
     checkFailed: { run: loadConfirmedCompany, busy: awaitingCompanyLoad },
   };
-  const noticeRetry =
-    confirmNotice === null ? null : noticeRetries[confirmNotice];
+  // A confirm 409 this driver already turned into a next step rather than a
+  // bare failure — see the `confirm` mutation's onError, refreshAfterSkew,
+  // recheckReadiness and loadConfirmedCompany for which server state each one
+  // names, and why none of them is "fix your input and press the same button
+  // again".
+  //
+  // It travels to the WORK SURFACE, not to the transcript beside it. The
+  // control that earned the refusal is on the board, and the rail is a
+  // scroller the reader pressing Continue is not looking at — a sentence
+  // there explained the block to nobody, which is how two rejections
+  // thirteen seconds apart read as a button that had simply stopped working.
+  // One copy, on the pane: the same sentence in two places only makes the
+  // reader decide which of them is about their press.
+  const refusal: ConfirmRefusal | null =
+    confirmNotice === null
+      ? null
+      : {
+          message: t(confirmNoticeKey(confirmNotice, skewStuck)),
+          retry: noticeRetries[confirmNotice],
+        };
   const reviewScene =
     state.phase === "co.review" && reviewProposal ? (
       <div className="ob-scene">
@@ -896,6 +915,7 @@ export function CompanyAct({
             confirmBlocked
           }
           saveError={confirmBannerMessage}
+          refusal={refusal}
         />
       }
     >
@@ -1031,34 +1051,8 @@ export function CompanyAct({
               />
             </div>
           )}
-          {/* A confirm 409 this driver already turned into a next step
-              rather than a bare failure — see the `confirm` mutation's
-              onError, refreshAfterSkew, recheckReadiness and
-              loadConfirmedCompany for which server state each one names, and
-              why none is "fix your input and press the same button again".
-              Each carries the look that could end it (see noticeRetry), and
-              where Continue is blocked that look is the route forward. */}
-          {confirmNotice !== null && (
-            <div role="alert">
-              <NarrationBubble
-                entry={{
-                  kind: "narration",
-                  id: `confirm:${confirmNotice}${skewStuck ? ":stuck" : ""}`,
-                  i18nKey: confirmNoticeKey(confirmNotice, skewStuck),
-                }}
-              />
-              {noticeRetry !== null && (
-                <Button
-                  small
-                  variant="ghost"
-                  onClick={noticeRetry.run}
-                  disabled={noticeRetry.busy}
-                >
-                  {t("common.retry")}
-                </Button>
-              )}
-            </div>
-          )}
+          {/* A refused confirm says so on the work surface, beside the
+              control that earned it — see `refusal` above. */}
         </ConversationThread>
       </div>
     </ConversationWorkbench>

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -569,6 +569,38 @@
   margin-block-start: auto;
 }
 
+/*
+ * The refusal a confirm earned, at the head of the pane whose own Continue
+ * earned it.
+ *
+ * Pinned, because the failure this exists to end had no on-screen life at all:
+ * the sentence used to render in the conversation rail, a scroller the reader
+ * who just pressed a button on THIS pane is not looking at, and two rejections
+ * thirteen seconds apart therefore read as a button that had quietly stopped
+ * working. A notice the board can scroll away from is the same defect one pane
+ * over.
+ *
+ * Pinned at the pane's HEAD rather than beside the foot bar the button sits in:
+ * that bar is sticky too, and two strips claiming the same bottom edge can only
+ * be stacked by asserting the bar's own height — which changes with its wrap,
+ * its container query and the length of its status line. An assertion that
+ * wrong covers the action it is explaining.
+ *
+ * `top: 0` rests it on the pane's own top inset rather than against the border:
+ * sticky offsets measure from the scroller's CONTENT box, the same finding
+ * .ob-triage-continue's negative offsets are built on. `flex: none` keeps it out
+ * of the scene's `flex: 1` bargaining — a refusal is not the thing that gives
+ * up room. The layer puts it over the review board's section map (z-index 1),
+ * whose first rows pass under it while a refusal stands: the map is a
+ * convenience a reader can scroll back to, the refusal is the reason they
+ * cannot get on. */
+.ob-conv-artifact > .ob-conv-refusal {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  flex: none;
+}
+
 /* A one-line artifact is a real state, not a half-drawn one — before a read
    there is nothing sourced, and that has to look deliberate in a pane sized
    for a sixteen-row review. Given the pane's width, a stated recess and room

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
@@ -1975,6 +1975,7 @@ function CompanyPage({
   onTab: (next: CompanyTab) => void;
 }>) {
   const t = useT();
+  const archivedReasonId = useId();
   // ONE composer, opened two ways. Anchored on a timeline message it answers
   // that message; anchored on a person it starts a new one and grounds on the
   // account instead of a thread (ADR-0087 §1). Two pieces of state would let
@@ -2057,16 +2058,27 @@ function CompanyPage({
       // own story below the fold before a word of it was read.
       actions={
         <>
+          {/* One sentence for the whole strip. Both action groups below refuse
+              for the same reason, so the reason belongs to the page rather than
+              to whichever group is drawing — stated in each, an archived
+              account said the same thing twice as soon as the menu opened. */}
+          {org.archived_at && (
+            <p className="t-caption" id={archivedReasonId}>
+              {t("record.archivedReadOnly")}
+            </p>
+          )}
           <CompanyPrimaryActions
             org={org}
             composerOpen={writingEmail}
             onComposerOpen={setWritingEmail}
+            archivedReasonId={archivedReasonId}
           />
           {/* Last in the row, after the verbs it holds the remainder of: a
               menu of everything-else read as the first thing to press when it
               led them. */}
           <CompanyActionBadges
             org={org}
+            archivedReasonId={archivedReasonId}
             view={view}
             onOpenHistory={() => setAuditOpen(true)}
             onSetUpPartner={() => onTab("partner")}

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -864,7 +864,7 @@ describe("PersonScreen — relationship-strength card (P-4)", () => {
 });
 
 describe("PersonScreen — archived is read-only (P-3)", () => {
-  it("hides edit/merge/archive and shows the Archived badge on an archived person", async () => {
+  it("keeps edit/merge/archive/share visible but refused, each reachable from the one sentence naming the archive", async () => {
     stubFetch(async (url) => {
       if (url.includes("/activities")) {
         return jsonResponse({ data: [] });
@@ -874,9 +874,22 @@ describe("PersonScreen — archived is read-only (P-3)", () => {
     render(<PersonScreen id="p-1" />);
 
     await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
-    expect(screen.queryByTestId("edit-record")).toBeNull();
-    expect(screen.queryByTestId("merge-record")).toBeNull();
-    expect(screen.queryByTestId("archive-record")).toBeNull();
+    const refused = [
+      screen.getByTestId("edit-record"),
+      screen.getByTestId("merge-record"),
+      screen.getByTestId("archive-record"),
+      screen.getByTestId("share-record"),
+    ];
+    for (const control of refused) {
+      expect(control.hasAttribute("disabled")).toBe(true);
+      // The reason has to be reachable FROM the control: a disabled button
+      // cannot be focused and a `title` on it is announced by nobody, so a
+      // sentence the control does not point at reaches no reader who needed it.
+      const describedBy = control.getAttribute("aria-describedby");
+      expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+        "This contact is archived. Restore them to change anything here.",
+      );
+    }
   });
 });
 

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -437,6 +437,10 @@ type PersonTab = (typeof PERSON_TABS)[number];
 export function PersonScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const cf = useObjectCustomFields("person");
+  // ONE sentence about this contact being archived, minted here and pointed at
+  // by every verb the archive refuses. Said once for the page rather than
+  // beside each of four buttons.
+  const archivedReasonId = useId();
   const [tab, setTab] = useState<PersonTab>("overview");
   const personQuery = useQuery({
     queryKey: ["person", id],
@@ -485,116 +489,136 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
                     <EntityRef kind="lead" id={person.converted_from_lead_id} />
                   </Badge>
                 )}
-                {person.archived_at ? (
-                  // An archived record is read-only: the backend rejects
-                  // edit/merge/archive on a non-live row (there is no
-                  // unarchive path), so offering those buttons would only
-                  // 404. The badge is the whole affordance.
+                {person.archived_at && (
                   <Badge tone="warn">{t("record.archived")}</Badge>
-                ) : (
-                  <>
-                    <EditAction
-                      label={t("record.edit")}
-                      notice={
-                        overlay ? t("overlay.partialWriteBack") : undefined
+                )}
+                {/* An archived record is read-only: the backend rejects
+                    edit/merge/archive on a non-live row (there is no
+                    unarchive path). The verbs stay VISIBLE and refused,
+                    pointing at the page's one sentence about the archive
+                    (STATE-4a): a missing control says nothing about the
+                    record, while a refused one names the reason. */}
+                <EditAction
+                  disabledReasonId={
+                    person.archived_at ? archivedReasonId : undefined
+                  }
+                  label={t("record.edit")}
+                  notice={overlay ? t("overlay.partialWriteBack") : undefined}
+                  fields={[...personEditFields, ...cf.formFields]}
+                  record={{
+                    id: person.id,
+                    version: person.version,
+                    full_name: person.full_name,
+                    first_name: person.first_name ?? "",
+                    last_name: person.last_name ?? "",
+                    title: person.title ?? "",
+                    "social.linkedin": stringField(person.social?.linkedin),
+                    ...cf.recordSlice(person),
+                  }}
+                  update={async (values) => {
+                    const { data, error } = await api.PATCH("/people/{id}", {
+                      params: {
+                        path: { id },
+                        ...ifMatch(requireVersion(person.version)),
+                      },
+                      body: {
+                        ...mapPersonUpdate(values),
+                        ...cf.toBody(values),
+                      },
+                    });
+                    if (error) {
+                      throwProblem(error);
+                    }
+                    return data;
+                  }}
+                  invalidate="people"
+                  recordKey="person"
+                />
+                {/* Merge has no incumbent-first projection — the seam
+                    refuses it outright (overlay/provider_writes.go
+                    Merge) — unlike edit/archive below, which it
+                    serves, so it stays hidden here. */}
+                {!overlay && (
+                  <MergeAction
+                    disabledReasonId={
+                      person.archived_at ? archivedReasonId : undefined
+                    }
+                    label={t("merge.person")}
+                    sourceId={person.id}
+                    sourceName={person.full_name}
+                    searchTargets={searchPeopleTargets}
+                    merge={async (targetId) => {
+                      const { data, error } = await api.POST(
+                        "/people/{id}/merge",
+                        {
+                          params: {
+                            path: { id: person.id },
+                            ...ifMatch(requireVersion(person.version)),
+                          },
+                          body: { target_id: targetId },
+                        },
+                      );
+                      if (error) {
+                        throwProblem(error, t);
                       }
-                      fields={[...personEditFields, ...cf.formFields]}
-                      record={{
-                        id: person.id,
-                        version: person.version,
-                        full_name: person.full_name,
-                        first_name: person.first_name ?? "",
-                        last_name: person.last_name ?? "",
-                        title: person.title ?? "",
-                        "social.linkedin": stringField(person.social?.linkedin),
-                        ...cf.recordSlice(person),
-                      }}
-                      update={async (values) => {
-                        const { data, error } = await api.PATCH(
-                          "/people/{id}",
-                          {
-                            params: {
-                              path: { id },
-                              ...ifMatch(requireVersion(person.version)),
-                            },
-                            body: {
-                              ...mapPersonUpdate(values),
-                              ...cf.toBody(values),
-                            },
-                          },
-                        );
-                        if (error) {
-                          throwProblem(error);
-                        }
-                        return data;
-                      }}
-                      invalidate="people"
-                      recordKey="person"
-                    />
-                    {/* Merge has no incumbent-first projection — the seam
-                        refuses it outright (overlay/provider_writes.go
-                        Merge) — unlike edit/archive below, which it
-                        serves, so it stays hidden here. */}
-                    {!overlay && (
-                      <MergeAction
-                        label={t("merge.person")}
-                        sourceId={person.id}
-                        sourceName={person.full_name}
-                        searchTargets={searchPeopleTargets}
-                        merge={async (targetId) => {
-                          const { data, error } = await api.POST(
-                            "/people/{id}/merge",
-                            {
-                              params: {
-                                path: { id: person.id },
-                                ...ifMatch(requireVersion(person.version)),
-                              },
-                              body: { target_id: targetId },
-                            },
-                          );
-                          if (error) {
-                            throwProblem(error, t);
-                          }
-                          return data;
-                        }}
-                        invalidate="people"
-                        recordKey="person"
-                        survivorRoute={(targetId) => ({
-                          screen: "contacts",
-                          id: targetId,
-                        })}
-                      />
-                    )}
-                    <ArchiveAction
-                      label={t("record.archive")}
-                      confirmText={t("record.archiveConfirm")}
-                      archive={async () => {
-                        const { data, error } = await api.DELETE(
-                          "/people/{id}",
-                          {
-                            params: { path: { id } },
-                          },
-                        );
-                        if (error) {
-                          throwProblem(error);
-                        }
-                        return data;
-                      }}
-                      invalidate="people"
-                      recordKey="person"
-                      onArchived={() => navigate({ screen: "contacts" })}
-                    />
-                    {/* A record grant probes the native row via
-                        auth.EnsureLinkTarget, which a mirrored record has
-                        no row for — sharing stays hidden in overlay
-                        regardless of record type (see deals.tsx's
-                        DealBadges). */}
-                    {!overlay && (
-                      <ShareAction recordType="person" recordId={person.id} />
-                    )}
-                  </>
+                      return data;
+                    }}
+                    invalidate="people"
+                    recordKey="person"
+                    survivorRoute={(targetId) => ({
+                      screen: "contacts",
+                      id: targetId,
+                    })}
+                  />
+                )}
+                <ArchiveAction
+                  disabledReasonId={
+                    person.archived_at ? archivedReasonId : undefined
+                  }
+                  label={t("record.archive")}
+                  confirmText={t("record.archiveConfirm")}
+                  archive={async () => {
+                    const { data, error } = await api.DELETE("/people/{id}", {
+                      params: { path: { id } },
+                    });
+                    if (error) {
+                      throwProblem(error);
+                    }
+                    return data;
+                  }}
+                  invalidate="people"
+                  recordKey="person"
+                  onArchived={() => navigate({ screen: "contacts" })}
+                />
+                {/* A record grant probes the native row via
+                    auth.EnsureLinkTarget, which a mirrored record has
+                    no row for — sharing stays hidden in overlay
+                    regardless of record type (see deals.tsx's
+                    DealBadges). */}
+                {!overlay && (
+                  <ShareAction
+                    recordType="person"
+                    recordId={person.id}
+                    disabledReasonId={
+                      person.archived_at ? archivedReasonId : undefined
+                    }
+                  />
                 )}
               </>
+            }
+            // The archive is a fact about the whole record, so it is stated
+            // once across the header rather than repeated beside each verb it
+            // refuses. The rail says the same thing about its own inline
+            // edits (personrail.tsx) off this same key, so the two cannot
+            // drift into two spellings of one fact. Absent while the contact
+            // is live: a line always reserved would read as a record with
+            // something to say about itself and nothing said.
+            band={
+              person.archived_at ? (
+                <p id={archivedReasonId} className="t-caption">
+                  {t("person.rail.archivedReadOnly")}
+                </p>
+              ) : undefined
             }
             timeline={
               timelineQuery.isSuccess

--- a/frontend/src/screens/personfiles.stories.tsx
+++ b/frontend/src/screens/personfiles.stories.tsx
@@ -2,13 +2,20 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
 import type { components } from "../api/schema";
 import { PersonFilesTab } from "./personfiles";
-import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
 
 // The person's own file library — its own fetch, distinct from the 360's
 // composite read, so its own set of stories: rows present, an unfiltered
-// empty library, and a read that failed and can be retried.
+// empty library, a read that failed and can be retried, and the upload the
+// header band offers in every one of those states.
 
 const meta: Meta = {
   title: "Records/Person record/Files tab",
@@ -57,6 +64,7 @@ const olderFiles: Attachment[] = files.map((file, index) => ({
 
 function Files({ data }: Readonly<{ data: Attachment[] }>) {
   installFetchStub({
+    "GET /me": meRoute({ person: ["update"] }),
     "GET /attachments": () => jsonResponse({ data, page }),
   });
   return (
@@ -73,8 +81,25 @@ export const Populated: Story = {
 };
 
 // An unfiltered zero is this person's own emptiness — the tab has no filter
-// to clear, so an empty page is always this state.
+// to clear, so an empty page is always this state. The upload is still offered:
+// an empty library is the state the verb exists to leave.
 export const Empty: Story = { render: () => <Files data={[]} /> };
+
+// The upload the header band opens — the ACCOUNT library's own dialog, anchored
+// on this contact. It asks no "about" question: a deal hangs off a company, and
+// nothing on a contact's page names one.
+export const Uploading: Story = {
+  render: () => <Files data={files} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Add a document" }),
+    );
+    await within(canvasElement.ownerDocument.body).findByRole("heading", {
+      name: "Add a document",
+    });
+  },
+};
 
 // The older files behind the first page: the tab says the list is cut and
 // offers the walk that finishes it, so the truncation is a step rather than a
@@ -84,6 +109,7 @@ export const Paged: Story = {
   render: () => {
     let served = 0;
     installFetchStub({
+      "GET /me": meRoute({ person: ["update"] }),
       "GET /attachments": () => {
         served += 1;
         return served === 1
@@ -107,6 +133,7 @@ export const Paged: Story = {
 export const Failed: Story = {
   render: () => {
     installFetchStub({
+      "GET /me": meRoute({ person: ["update"] }),
       "GET /attachments": () =>
         jsonResponse({ title: "Error", status: 500 }, 500),
     });

--- a/frontend/src/screens/personfiles.test.tsx
+++ b/frontend/src/screens/personfiles.test.tsx
@@ -31,56 +31,92 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function stub(body: unknown, status = 200) {
+// The session and the installation read that the upload in this tab's header
+// band makes. Answered from fixtures rather than left to the attachment body,
+// because /me rejects a payload with no `user` and a malformed session renders
+// every control refused for a reason none of these tests is about.
+const SESSION = {
+  user: { id: "u-1", email: "rep@example.com", name: "Demo Rep" },
+  authorization: {
+    seat_type: "full",
+    objects: { person: { update: true } },
+  },
+};
+
+const INSTALLATION = {
+  name: "Demo",
+  timezone: "Europe/Berlin",
+  base_currency: "EUR",
+  base_currency_locked: false,
+  max_upload_bytes: 26_214_400,
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * A stub that answers the tab's OWN reads through `handler` and everything the
+ * header's upload asks for from the fixtures above.
+ *
+ * Only a request the tab itself made reaches `lastRequest`: the scoping tests
+ * read it to prove which person was asked about, and a session probe landing
+ * there would answer a question nobody asked.
+ */
+function stubTab(handler: (request: Request) => Promise<Response> | Response) {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: Request) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.endsWith("/me")) {
+        return json(SESSION);
+      }
+      if (pathname.endsWith("/installation/settings")) {
+        return json(INSTALLATION);
+      }
       lastRequest = request;
-      return new Response(JSON.stringify(body), {
-        status,
-        headers: { "content-type": "application/json" },
-      });
+      return handler(request);
     }),
   );
+}
+
+function stub(body: unknown, status = 200) {
+  stubTab(() => json(body, status));
 }
 
 // A cursor-paginated library: the first page hands back the cursor the second
 // one is only reachable with, so a test that renders the second page has
 // proven the walk, not just the button.
 function stubTwoPages() {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (request: Request) => {
-      lastRequest = request;
-      const cursor = new URL(request.url).searchParams.get("cursor");
-      const body =
-        cursor === "cur-2"
-          ? {
-              data: [
-                attachment({
-                  id: "f-2",
-                  entity_id: "p-1",
-                  filename: "older.pdf",
-                }),
-              ],
-              page: { has_more: false, next_cursor: null },
-            }
-          : {
-              data: [
-                attachment({
-                  id: "f-1",
-                  entity_id: "p-1",
-                  filename: "newest.pdf",
-                }),
-              ],
-              page: { has_more: true, next_cursor: "cur-2" },
-            };
-      return new Response(JSON.stringify(body), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }),
-  );
+  stubTab((request) => {
+    const cursor = new URL(request.url).searchParams.get("cursor");
+    return json(
+      cursor === "cur-2"
+        ? {
+            data: [
+              attachment({
+                id: "f-2",
+                entity_id: "p-1",
+                filename: "older.pdf",
+              }),
+            ],
+            page: { has_more: false, next_cursor: null },
+          }
+        : {
+            data: [
+              attachment({
+                id: "f-1",
+                entity_id: "p-1",
+                filename: "newest.pdf",
+              }),
+            ],
+            page: { has_more: true, next_cursor: "cur-2" },
+          },
+    );
+  });
 }
 
 let lastRequest: Request | undefined;
@@ -270,33 +306,20 @@ describe("the person's files tab", () => {
     // refusing a press is the walk being out; it becoming pressable again is
     // the failure having landed, and only then is the tab worth asking.
     const secondPage = heldPage();
-    let call = 0;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => {
-        call += 1;
-        if (call === 1) {
-          return new Response(
-            JSON.stringify({
-              data: [
-                attachment({
-                  id: "f-1",
-                  entity_id: "p-1",
-                  filename: "newest.pdf",
-                }),
-              ],
-              page: { has_more: true, next_cursor: "cur-2" },
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          );
-        }
-        await secondPage.arrival;
-        return new Response(JSON.stringify({ title: "Error" }), {
-          status: 500,
-          headers: { "content-type": "application/json" },
+    let page = 0;
+    stubTab(async () => {
+      page += 1;
+      if (page === 1) {
+        return json({
+          data: [
+            attachment({ id: "f-1", entity_id: "p-1", filename: "newest.pdf" }),
+          ],
+          page: { has_more: true, next_cursor: "cur-2" },
         });
-      }),
-    );
+      }
+      await secondPage.arrival;
+      return json({ title: "Error" }, 500);
+    });
     const user = userEvent.setup();
     show(<PersonFilesTab personId="p-1" />);
 
@@ -314,6 +337,52 @@ describe("the person's files tab", () => {
     // the button is still there to try the same page again.
     expect(screen.getByRole("link", { name: "newest.pdf" })).toBeTruthy();
     expect(screen.queryByText("This section did not load.")).toBeNull();
+  });
+
+  it("files an uploaded document against this contact, from this tab", async () => {
+    // Both request shapes reach one stub: the generated client hands `fetch` a
+    // whole Request, and the multipart upload calls it the plain way.
+    const uploads: FormData[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        // The multipart upload is answered FIRST, because it is the one call
+        // made with a relative path — `new URL("/v1/attachments")` throws, so
+        // parsing before this branch would fail the request under test.
+        if (init?.body instanceof FormData) {
+          uploads.push(init.body);
+          return json({ id: "att-1", filename: "cv.pdf" }, 201);
+        }
+        const request = input instanceof Request ? input : null;
+        const { pathname } = new URL(request ? request.url : String(input));
+        if (pathname.endsWith("/me")) {
+          return json(SESSION);
+        }
+        if (pathname.endsWith("/installation/settings")) {
+          return json(INSTALLATION);
+        }
+        return json({ data: [], page: { has_more: false } });
+      }),
+    );
+    const user = userEvent.setup();
+    show(<PersonFilesTab personId="p-7" />);
+
+    // The verb the tab shipped without: a reader who wants a CV on a contact
+    // had to reach the upload from the account's library and change its parent.
+    await user.click(
+      await screen.findByRole("button", { name: "Add a document" }),
+    );
+    await user.upload(
+      screen.getByLabelText(/File/),
+      new File(["…"], "cv.pdf", { type: "application/pdf" }),
+    );
+    const submit = screen.getByRole("button", { name: "Upload" });
+    await waitFor(() => expect(submit.hasAttribute("disabled")).toBe(false));
+    await user.click(submit);
+
+    await waitFor(() => expect(uploads).toHaveLength(1));
+    expect(uploads[0].get("entity_type")).toBe("person");
+    expect(uploads[0].get("entity_id")).toBe("p-7");
   });
 
   it("scopes the request to the person whose files these are", async () => {

--- a/frontend/src/screens/personfiles.tsx
+++ b/frontend/src/screens/personfiles.tsx
@@ -1,12 +1,14 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
-import { Badge } from "../design-system/atoms";
+import { Badge, Button } from "../design-system/atoms";
 import { Panel, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatDateAbbrev } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { AddDocumentDialog } from "./adddocument";
 import { LoadMoreButton, throwProblem } from "./common";
 import { RECORD_ZONE } from "./company360";
 import "./person360.css";
@@ -16,6 +18,11 @@ import "./person360.css";
 // so it fetches its own page and classifies its own state rather than reusing
 // `sectionState`, which exists for a section of a payload this tab never
 // receives.
+//
+// It is also the one tab here that WRITES. The upload is the account library's
+// own dialog (adddocument.tsx), anchored on this contact rather than on a
+// company — a second upload form for the same endpoint would be a second set of
+// answers about size limits, partial failures and what a category means.
 
 type Attachment = components["schemas"]["Attachment"];
 type Category = NonNullable<Attachment["category"]>;
@@ -35,6 +42,7 @@ const CATEGORY_LABELS: Record<Category, MessageKey> = {
 export function PersonFilesTab({ personId }: Readonly<{ personId: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const [adding, setAdding] = useState(false);
 
   const query = useInfiniteQuery({
     queryKey: ["attachments", "person", personId],
@@ -90,6 +98,18 @@ export function PersonFilesTab({ personId }: Readonly<{ personId: string }>) {
   return (
     <Panel
       title={t("tab.documents")}
+      // The verb sits in the header band, where the ACCOUNT's document panel
+      // keeps the same one, and it is offered in every state for the reason
+      // recorded there: an empty library is what the upload exists to leave, so
+      // withholding it on an empty or failed read hides the control exactly
+      // when it is wanted. That is also why it is not `Panel`'s `actions` band,
+      // which the primitive documents as a place for verbs a caller renders
+      // only once the panel's content is real.
+      titleAction={
+        <Button small onClick={() => setAdding(true)}>
+          {t("docs.add.action")}
+        </Button>
+      }
       // The walk's control belongs to the SECTION, not to any file in it, so it
       // takes the panel's own foot band rather than trailing the rows as one
       // more of them. Passed only where another page exists: the band draws
@@ -97,6 +117,11 @@ export function PersonFilesTab({ personId }: Readonly<{ personId: string }>) {
       // chrome a reader can see and cannot use.
       footer={query.hasNextPage ? <LoadMoreButton query={query} /> : undefined}
     >
+      <AddDocumentDialog
+        anchor={{ record: "person", id: personId }}
+        open={adding}
+        onClose={() => setAdding(false)}
+      />
       <SurfaceState
         state={state}
         emptyLabel={t("person.documents.empty")}

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-  CalendarPlus,
+  CalendarDays,
   CheckSquare,
   Link as LinkIcon,
   Mail,
@@ -495,7 +495,8 @@ function PersonActions({
           navigate({ screen: "contacts", id: personId, id2: "meetings" })
         }
       >
-        <CalendarPlus size={15} aria-hidden="true" /> {t("person.action.book")}
+        <CalendarDays size={15} aria-hidden="true" />{" "}
+        {t("person.action.meetings")}
       </Button>
       <Button onClick={() => navigate({ screen: "tasks" })}>
         <CheckSquare size={15} aria-hidden="true" />{" "}

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -74,6 +74,7 @@ import { AiCallsCard } from "./aicalls";
 import { AiUsageCard } from "./aiusage";
 import { ActorTag } from "./audit";
 import { AutomationsAdmin } from "./automations";
+import { BlockedDomainsCard } from "./blocked-domains";
 import { CaptureActivityTab } from "./capture-activity";
 import { CaptureSettingsCard } from "./capture-settings";
 import {
@@ -255,6 +256,11 @@ function tabContent(id: SettingsTabId): ReactNode {
           <OwnDomainsCard />
           <CaptureSettingsCard />
           <ConsumerMailDomainsCard />
+          {/* Last, because it is the OUTCOME of the three above rather than a
+              fourth rule: which domains ended up refused a company, and whether
+              a machine or a person decided it. An operator hunting a company
+              that never arrived reads down the page and finishes here. */}
+          <BlockedDomainsCard />
         </>
       );
     case "data-model":


### PR DESCRIPTION
Five open `area: frontend` issues, and one theme again: **a surface should offer what it can do and explain what it cannot.** A verb hidden because the record is archived, several proposals shown as unrelated rows, a picker capped at fifty, a refused confirm explaining itself in the other pane, and an operator decision readable nowhere.

Branched off `origin/main` after #1773.

## Closed here

| Issue | What was wrong |
|---|---|
| #1325 | Terminal records dropped Edit/Archive/Share/Reopen entirely instead of refusing them |
| #662 | The inbox showed a bundle's members as unrelated rows (**high**) |
| #1536 | Filing a document offered deals as a flat `Select` capped at 50 |
| #1159 *(one of three)* | The domains an installation refused had no UI at all |
| #595 | A confirm losing a version-skew race said nothing where the reader was looking |

Plus #1694's Documents half: a contact's Documents tab had no upload.

**#1159 stays open** — it names three surfaces and this is one of them.

## The findings that shaped the work

**#1325's real content was a taxonomy, not a list of call sites.** Sorting each hidden control by *cause* is what decides the answer: withheld for the record's STATE is a defect (the record has the feature and will not accept it), withheld because the seam cannot support it is correct (a record grant probes a native row a mirror deal does not have). Nothing in the four files turned out to be permission-shaped. One sentence per record rather than per button, because three verbs sharing a fact share its statement.

It also could not be finished as filed: `LogActivityAction` had no reason prop, so the company header could refuse one of its three verbs and had to keep hiding the other two. The prop is added here, so all three say the same thing at once instead of a cluster being half-refused.

**#662's wire carries less than the issue assumed** — a `bundle_id` and nothing else. No bundle entity, no count, no title: every member keeps its own diff hash, version pin and expiry, because the staged row *is* the authority object. Two consequences drove the design. Grouping is client-side over the queue the screen already walks, and it does not reorder anything. And since the endpoints decide each member on its own terms and refuse a bundle-wide edit — one edit re-hashes one diff and cannot span several — **an expanded member keeps its own verbs**, because a read-only manifest would strand a reader who agrees with three proposals and not the fourth.

A bundle of one renders as a plain row; the decided tab stays flat, since each member holds its own verdict and a group header there would state a status the group does not have.

**#1536's search had to be built against what the contract actually offers.** `GET /deals` has no `q` — checked, not assumed — so search is a bounded walk over cursor pages, and the bound is stated **up front** rather than after a search comes back short: the picker cannot know which search an answer belonged to, so a caption that appears only when a walk runs out is a claim about the last search rather than about the control. "This company" also stopped being the zeroth row of the deal list, which had made the account read as a deal.

**#595 was purely a location defect**, and its second complaint had already been fixed since filing. The notice is on the pane that refused, not in the conversation scroller — and deliberately not stacked against the sticky button bar, because doing so means asserting that bar's height, which changes with its wrap and its container-query stacking, and an assertion that goes wrong there covers the very control it explains.

## Two live defects found on the way and fixed

- **The Book button** navigated to a read-only meetings tab — a label promising a booking the click cannot make, the same class as #1085 and #934. It says what it does now. (A booking surface exists but takes a typed attendee address and no person, so wiring it to a contact is a real change, not a corrected route.)
- **`company360.test.tsx` pinned the old hiding behaviour** and now pins the refusal, including that the two verbs share one sentence.

## Not blocked by the contract, contrary to earlier belief

**Seating a contact on a deal is buildable today**: `POST /relationships` with `kind: deal_stakeholder` exists and is RBAC-anchored on the deal. What blocks it is the same gap as #1536, worse — a contact can be seated on any company's deal, so a person-scoped picker has nothing to bound a walk with and would have to walk every deal in the installation. **Adding `q` to `GET /deals` upstream removes both this and the walk above**; `/projects` already has it, same shape. Worth raising as a spec change rather than building a second unbounded walk.

## Gates

`make check-fe` green, full Playwright suite green (91 passed), `tsc` clean including the composed-tests project — which is where two fixture type errors surfaced that `tsconfig.app.json` cannot see, since it excludes tests. Every new test in this branch was verified to fail against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several UX defects and clarifies refusals: archived records keep actions visible but disabled with a single, linkable reason; approval bundles render as one question; document filing reaches paginated deals and contacts; confirm refusals are announced on the pane that earned them. Also deduplicates the archive reason (stated once per page) and keeps retry buttons focusable while pending.

- Archived records: Old behavior hid Edit/Archive/Share/Reopen. New behavior keeps them visible but disabled, all linking to one on-page explanation. Applies to companies, deals, and people; `LogActivityAction`, `MergeAction`, and `ReopenAction` now accept `disabledReasonId`.
- Approval inbox bundles: Old behavior rendered each bundled proposal as a separate row. New behavior groups by `bundle_id` without reordering; bundles offer approve-all/reject-all with per-member outcomes; members remain individually decidable; single-member bundles render as plain rows; decided history stays flat.
- Document filing: Old deal picker was a flat, capped list of 50. New picker searches across paginated `GET /deals` (no `q`; bounded walk stated up front). “This company” is a distinct choice. You can now file to a contact; the person’s Files tab exposes an Upload in its header band.
- Refused confirms: Old behavior surfaced the message in the other pane’s scroller. New behavior pins a single alert at the head of the work pane and keeps Retry focusable while its re-check is pending.
- Blocked domains UI: Adds a settings card listing refused domains with source and totals, supports upsert and reversal with a reason, and shows controls refused on read-only seats.
- Minor: Person header Book button navigates to Meetings (icon adjusted). i18n strings and tests/stories added. No server contract changes.

- Required follow-ups for adopters:
  - Update any remaining callers to `AddDocumentDialog` to pass `anchor` ({ record, id }) instead of `orgId`.
  - When offering disabled actions due to record state, pass the shared reason element’s id via `disabledReasonId` to `LogActivityAction`, `MergeAction`, and `ReopenAction` so buttons link to the explanation.

<sup>Written for commit 63608de22cb0d104ab23637f31785ed04b50ebbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage blocked-domain decisions from Capture settings, including reasons, revisions, and read-only states.
  * Group inbox approvals into bundles, review individual outcomes, and approve or reject bundles.
  * Add documents directly to people and select or search associated deals.
  * Access a person’s meetings from their record.
  * Retry confirmation refusals directly within the review workspace.

* **Improvements**
  * Archived records keep actions visible but clearly disabled with explanations.
  * Improved validation, expiration, upload, and approval-result messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->