### PR TITLE
feat(deals): a deal filter reaches the customer's industry

### DIFF
--- a/backend/internal/compose/filtervocabularyenums_test.go
+++ b/backend/internal/compose/filtervocabularyenums_test.go
@@ -72,7 +72,10 @@ func vocabularyFieldEnum(t *testing.T, property string, itemsLevel bool) map[str
 func TestTheVocabularysOperatorEnumIsExactlyWhatTheEngineAdmits(t *testing.T) {
 	engine := map[string]bool{}
 	for _, fieldType := range everyFilterableFieldType() {
-		for _, op := range storekit.OperatorsFor(fieldType) {
+		// Base-table fields: the contract enum has to carry every operator ANY
+		// field can report, and a linked field only ever reports a subset of
+		// what its own type admits.
+		for _, op := range storekit.OperatorsFor(storekit.Field{Type: fieldType}) {
 			engine[op] = true
 		}
 	}

--- a/backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go
@@ -744,3 +744,145 @@ func TestACatalogueReadFailureIsNeverMisreportedAsAFilterMistake(t *testing.T) {
 		t.Fatalf("a catalogue failure was dressed up as a filter validation error: %v", pred)
 	}
 }
+
+// memberIDs reads a list's live membership as a set, for the scenarios whose
+// answer is more than one record. assertSoleMember above covers the single-row
+// case and says so more sharply; this is its plural sibling, not a replacement.
+func memberIDs(t *testing.T, f fixture, listID ids.ListID) map[ids.UUID]bool {
+	t.Helper()
+	rows, _, err := f.lists.ListMembers(f.ctx, listID, 50, "")
+	if err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	got := make(map[ids.UUID]bool, len(rows))
+	for _, row := range rows {
+		got[row.EntityID] = true
+	}
+	return got
+}
+
+// dealForCustomer seeds one deal against one organization through the real
+// writer, so the organization_id the filter joins on is the one CreateDeal
+// itself stamps.
+func (f fixture) dealForCustomer(
+	t *testing.T, name string, pipeline ids.PipelineID, stage ids.StageID, org *ids.OrganizationID,
+) ids.UUID {
+	t.Helper()
+	deal, err := f.e.Deals.CreateDeal(f.ctx, dealsmod.CreateDealInput{
+		Name: name, PipelineID: pipeline, StageID: stage, OrganizationID: org, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create deal %q: %v", name, err)
+	}
+	return ids.UUID(deal.Id)
+}
+
+// customerOrg seeds one organization with (or without) an industry.
+func (f fixture) customerOrg(t *testing.T, name string, industry *string) ids.OrganizationID {
+	t.Helper()
+	org, err := f.people.CreateOrganization(f.ctx, peoplemod.CreateOrganizationInput{
+		DisplayName: name, Industry: industry, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create organization %q: %v", name, err)
+	}
+	return ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+}
+
+// "Show me the pipeline for manufacturing" — a deal filtered by an attribute of
+// the company it belongs to, which is a correlated join and therefore something
+// only the real database can prove. The unit lane can check the SQL text; only
+// this can check which deals come back.
+func TestADealFilterReachesTheCustomersIndustry(t *testing.T) {
+	f := setupFixture(t)
+	pipeline, open, _ := integration.DealFixture(t, f.e)
+	manufacturing, services := "manufacturing", "services"
+
+	inManufacturing := f.dealForCustomer(t, "Factory renewal", pipeline, open,
+		orgPtr(f.customerOrg(t, "Vulcan Works", &manufacturing)))
+	f.dealForCustomer(t, "Agency retainer", pipeline, open,
+		orgPtr(f.customerOrg(t, "Bright Consulting", &services)))
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "manufacturing pipeline", EntityType: "deal", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "organization_industry", "op": "eq", "value": manufacturing,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+	assertSoleMember(t, f, list.ID, inManufacturing)
+}
+
+// `exists: false` on a linked field asks about the COLUMN, and the answer spans
+// both ways a deal can fail to have a known industry: a customer with none, and
+// no customer at all. Pinned because the row reading — "does a linked
+// organization exist" — is the plausible wrong one, and it would silently drop
+// every deal whose company simply has no industry recorded.
+func TestAnUnknownCustomerIndustryCoversBothWaysItCanBeUnknown(t *testing.T) {
+	f := setupFixture(t)
+	pipeline, open, _ := integration.DealFixture(t, f.e)
+	known := "manufacturing"
+
+	customerWithNoIndustry := f.dealForCustomer(t, "Unclassified account", pipeline, open,
+		orgPtr(f.customerOrg(t, "Quiet Holdings", nil)))
+	noCustomerAtAll := f.dealForCustomer(t, "Inbound, unattributed", pipeline, open, nil)
+	classified := f.dealForCustomer(t, "Factory renewal", pipeline, open,
+		orgPtr(f.customerOrg(t, "Vulcan Works", &known)))
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "customer industry unknown", EntityType: "deal", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "organization_industry", "op": "exists", "value": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+
+	got := memberIDs(t, f, list.ID)
+	if !got[customerWithNoIndustry] {
+		t.Error("a deal whose customer has no industry is not counted as unknown")
+	}
+	if !got[noCustomerAtAll] {
+		t.Error("a deal with no customer at all is not counted as unknown")
+	}
+	if got[classified] {
+		t.Error("a deal whose customer HAS an industry is reported as unknown")
+	}
+}
+
+// Archiving the customer does not move the deal out of the filter.
+//
+// The organization's own segment engine excludes archived and anchor rows,
+// because those answer "which of our accounts are segment MEMBERS". This leaf
+// answers a fact about the company a deal belongs to, and archiving does not
+// change that fact — so the exclusion is deliberately NOT carried over. Without
+// this test that decision is a comment; with it, re-adding the base clause fails
+// here instead of quietly moving somebody's pipeline figure.
+func TestArchivingTheCustomerLeavesItsDealsInTheIndustryFilter(t *testing.T) {
+	f := setupFixture(t)
+	pipeline, open, _ := integration.DealFixture(t, f.e)
+	manufacturing := "manufacturing"
+	org := f.customerOrg(t, "Vulcan Works", &manufacturing)
+	deal := f.dealForCustomer(t, "Factory renewal", pipeline, open, orgPtr(org))
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "manufacturing pipeline, archived customer", EntityType: "deal", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "organization_industry", "op": "eq", "value": manufacturing,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+	assertSoleMember(t, f, list.ID, deal)
+
+	if _, err := f.people.ArchiveOrganization(f.ctx, org); err != nil {
+		t.Fatalf("archive organization: %v", err)
+	}
+	assertSoleMember(t, f, list.ID, deal)
+}
+
+func orgPtr(id ids.OrganizationID) *ids.OrganizationID { return &id }

--- a/backend/internal/modules/collections/filtervocabulary.go
+++ b/backend/internal/modules/collections/filtervocabulary.go
@@ -105,7 +105,7 @@ func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]Vocabu
 		fields = append(fields, VocabularyField{
 			Name:      name,
 			Type:      string(field.Type),
-			Operators: storekit.OperatorsFor(field.Type),
+			Operators: storekit.OperatorsFor(field),
 			Custom:    !isCore,
 		})
 	}

--- a/backend/internal/modules/collections/filtervocabulary_test.go
+++ b/backend/internal/modules/collections/filtervocabulary_test.go
@@ -364,7 +364,9 @@ func operatorsByTypeForTest() [][]string {
 	}
 	out := make([][]string, 0, len(types))
 	for _, t := range types {
-		out = append(out, storekit.OperatorsFor(t))
+		// A base-table field: this gate is about the type matrix, and a linked
+		// field answers a deliberately narrower set of its own.
+		out = append(out, storekit.OperatorsFor(storekit.Field{Type: t}))
 	}
 	return out
 }

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -84,6 +84,30 @@ func tagLinkFor(entity string) storekit.Field {
 	}
 }
 
+// customerLink is the EXISTS template a deal's filter reaches its customer
+// through: one correlated subquery per leaf, on the organization the deal
+// already points at.
+//
+// It does NOT re-apply the organization engine's own base clause (archived and
+// is_anchor), and that is the substantive choice here. Those two exclusions
+// answer "which of our accounts are segment MEMBERS"; this leaf answers a fact
+// about the company a deal belongs to, which archiving does not change. Carrying
+// them over would move deals out of "the manufacturing pipeline" the moment
+// somebody archived a company — a pipeline figure shifting for a reason nobody
+// filtering could see.
+//
+// The organization table is read inside the caller's own transaction, so the RLS
+// GUC contract binds it exactly as it binds the base table: there is no path
+// here that reaches another workspace's rows.
+const customerLink = "EXISTS (SELECT 1 FROM organization o WHERE o.id = t.organization_id AND %s)"
+
+// customerField types one organization column as a deal-side filter leaf. The
+// operators it advertises narrow themselves — OperatorsFor reads Link — so an
+// industry reached this way offers everything text does except `contains`.
+func customerField(column string, fieldType storekit.FieldType) storekit.Field {
+	return storekit.Field{Expr: "o." + column, Type: fieldType, Link: customerLink}
+}
+
 var segmentEngines = map[string]storekit.Query{
 	"person": {
 		Table:     "person",
@@ -129,6 +153,18 @@ var segmentEngines = map[string]storekit.Query{
 			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
 			"forecast_category": {Expr: "t.forecast_category", Type: storekit.FieldPicklist},
 			tagFilterField:      tagLinkFor("deal"),
+			// The customer's own attributes, so "the pipeline for manufacturing"
+			// is a filter rather than a spreadsheet. Same columns and same types
+			// as the organization engine offers directly, reached through the
+			// deal's organization_id.
+			//
+			// classification is deliberately absent. It is retired (ADR-0079/A124)
+			// and survives on the organization engine only so segments already
+			// written against it keep evaluating — a NEW way to name it would be
+			// a fresh dependency on a column that is going away.
+			"organization_industry":  customerField("industry", storekit.FieldText),
+			"organization_size_band": customerField("size_band", storekit.FieldPicklist),
+			"organization_lifecycle": customerField("lifecycle", storekit.FieldPicklist),
 		},
 	},
 	"lead": {

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -18,21 +18,17 @@ package storekit
 // It lives in storekit because modules (people, deals, …) and compose
 // both consume it, and the DAG only lets platform sit under both.
 //
-// Compile is scope-neutral by design: it renders the caller's filter
-// and NOTHING else. Callers MUST AND the result with their row-scope
-// clause (auth.ScopeClauseFor) — the bundled Query executor does that
-// composition itself, so surface code cannot forget it.
+// This file COMPILES a filter and nothing else, which is why it reaches
+// for neither the database nor auth. Compilation is scope-neutral by
+// design: it renders the caller's filter and NOTHING more, so a caller
+// MUST AND the result with their row-scope clause
+// (auth.ScopeClauseFor). Nobody does that by hand — the Query executor
+// in query.go composes it, along with the object-RBAC admission and the
+// row bound, so surface code cannot forget any of the three.
 
 import (
-	"context"
 	"fmt"
 	"strings"
-
-	"github.com/jackc/pgx/v5"
-
-	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // Grammar bounds (B-E15.10 "bounded" acceptance): a filter is a UI
@@ -137,7 +133,22 @@ var operatorOrder = []string{
 	OpEq, OpNeq, OpGt, OpGte, OpLt, OpLte, OpIn, OpContains, OpExists,
 }
 
-// OperatorsFor answers the operators this field type admits, in operatorOrder.
+// linkOperators are the operators a correlated-link leaf can express, and the
+// authority compileLinkLeaf's own switch is held to.
+//
+// The comparison for a linked field builds INSIDE an EXISTS subquery, where the
+// question is whether a matching row is there. Equality, membership and presence
+// all say something about that; substring match and ordering do not have a
+// spelling the wrapper can carry, so they are not offered rather than offered
+// and refused.
+//
+// TestALinkedFieldAdvertisesExactlyWhatItCanCompile holds this set and that
+// switch together, so neither can gain an operator the other lacks.
+var linkOperators = map[string]bool{
+	OpEq: true, OpNeq: true, OpIn: true, OpExists: true,
+}
+
+// OperatorsFor answers the operators this field admits, in operatorOrder.
 //
 // It exists so a surface that has to TELL a caller what a field accepts —
 // the filter-vocabulary read — derives the answer from the same matrix
@@ -146,16 +157,26 @@ var operatorOrder = []string{
 // once: a vocabulary restated beside the engine offers a field the engine
 // rejects, and the caller learns the difference as a 422 it could not predict.
 //
+// It takes the FIELD and not merely its type, because the type is not the whole
+// answer: a correlated-link leaf compiles through a narrower set than its type
+// admits, so a text field reached through a link accepts everything text does
+// EXCEPT `contains`. Typing alone would advertise that operator and the engine
+// would then refuse it — the same drift, one layer down.
+//
 // An unknown type answers an empty slice, not every operator: a field the
 // matrix does not describe is one compileLeaf refuses outright, so promising
 // operators for it would be the exact drift this function prevents.
-func OperatorsFor(t FieldType) []string {
-	admitted := operatorsByType[t]
+func OperatorsFor(f Field) []string {
+	admitted := operatorsByType[f.Type]
 	ops := make([]string, 0, len(admitted))
 	for _, op := range operatorOrder {
-		if admitted[op] {
-			ops = append(ops, op)
+		if !admitted[op] {
+			continue
 		}
+		if f.Link != "" && !linkOperators[op] {
+			continue
+		}
+		ops = append(ops, op)
 	}
 	return ops
 }
@@ -326,13 +347,23 @@ func compileLeaf(p Predicate, fields map[string]Field, arg func(any) int, leaves
 	}
 }
 
-// compileLinkLeaf compiles a leaf whose fact is a link row. The comparison is
-// built against the column inside the subquery and then wrapped, and a negation
-// applies to the WRAPPER: "does not carry this tag" is NOT EXISTS(… = …), where
-// EXISTS(… <> …) would answer "carries some other tag" — a different question,
-// and true for almost every record. `exists` needs no operand at all: presence
-// of any link row is the whole question, so it binds nothing and the wrapper's
-// own correlation carries it.
+// compileLinkLeaf compiles a leaf whose fact lives on a linked row. The
+// comparison is built against the column inside the subquery and then wrapped,
+// and a negation applies to the WRAPPER: "does not carry this tag" is
+// NOT EXISTS(… = …), where EXISTS(… <> …) would answer "carries some other tag"
+// — a different question, and true for almost every record. The same reading
+// governs a column reached through a join: `neq` answers "has no linked row
+// matching this", which for a deal with no organization at all is true.
+//
+// `exists` binds nothing and asks about the COLUMN, not the row:
+// EXISTS(… AND <expr> IS NOT NULL). The distinction only shows up once a link
+// carries a nullable column. For a tag it makes no difference — taggable.tag_id
+// is NOT NULL, so the added test cannot change which rows the wrapper finds —
+// but for organization.industry the two readings differ, and the row reading is
+// the wrong one: "which deals is the customer's industry unknown for" would
+// answer "the ones with no customer", silently excluding every deal whose
+// company simply has no industry recorded. Asking about the column gives one
+// meaning to `exists` on every linked field.
 func compileLinkLeaf(p Predicate, field Field, arg func(any) int) (string, error) {
 	var inner string
 	negate := false
@@ -342,7 +373,7 @@ func compileLinkLeaf(p Predicate, field Field, arg func(any) int) (string, error
 		if err != nil {
 			return "", err
 		}
-		inner, negate = "TRUE", !present
+		inner, negate = field.Expr+" IS NOT NULL", !present
 	case OpIn:
 		values, err := inOperand(p, field)
 		if err != nil {
@@ -356,10 +387,13 @@ func compileLinkLeaf(p Predicate, field Field, arg func(any) int) (string, error
 		}
 		inner, negate = fmt.Sprintf("%s = $%d", field.Expr, arg(value)), p.Op == OpNeq
 	default:
-		// An operator that the link shape cannot express: the comparison
-		// builds inside an EXISTS subquery where only certain operators make
-		// sense. Reachable only if the field's operator set includes operators
-		// beyond {eq,neq,in,exists}, which the link template cannot support.
+		// An operator that the link shape cannot express: the comparison builds
+		// inside an EXISTS subquery where only certain operators make sense.
+		// linkOperators names exactly the cases above, and no surface OFFERS an
+		// operator this branch would refuse — OperatorsFor narrows a linked
+		// field's advertised set to that same map. So this is the guard for a
+		// filter that NAMES one anyway (a saved segment, a hand-written body),
+		// not a state a picker can put a reader in.
 		return "", &PredicateError{
 			Field: p.Field, Code: CodeFilterOpNotAllowed,
 			Message: fmt.Sprintf("operator %q does not apply to the linked field %q", p.Op, p.Field),
@@ -370,129 +404,4 @@ func compileLinkLeaf(p Predicate, field Field, arg func(any) int) (string, error
 		return "NOT " + sql, nil
 	}
 	return sql, nil
-}
-
-// Query is the one-engine executor (B-E15.10b): one resource's closed
-// vocabulary plus its fixed base clause, executing any Predicate as
-// bounded, indexable SQL over the real columns. Lists, saved views, and
-// filtered export all run their filters through here — never through a
-// per-surface variant.
-type Query struct {
-	// Table is the base table, aliased t in every Fields expression.
-	Table string
-	// Fields is the resource's §13.5 filter allow-list.
-	Fields map[string]Field
-	// BaseWhere is the resource's fixed visibility clause (e.g.
-	// "t.archived_at IS NULL"); empty means none.
-	BaseWhere string
-	// ActivityWalk selects the activity link-walk scope clause instead
-	// of the direct ownership clause (the timeline's visibility rule).
-	ActivityWalk bool
-}
-
-// predicateWhere is the admission point AND the clause composer for every
-// execution of a predicate: it takes the object read gate, then joins the
-// resource's base clause, the compiled predicate, and the caller's row scope.
-//
-// Both live here so a second executor cannot take two of the three, or the
-// clauses without the gate. The row scope is the one that matters most: it is
-// what makes a predicate able only to NARROW what the caller may already see,
-// and an executor that forgot it would still return plausible rows, just other
-// people's. One point of composition means "is this scoped?" has one answer for
-// every caller.
-func (q Query) predicateWhere(ctx context.Context, p Predicate) (string, []any, error) {
-	if err := auth.Require(ctx, q.Table, principal.ActionRead); err != nil {
-		return "", nil, err
-	}
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-
-	where := make([]string, 0, 3)
-	if q.BaseWhere != "" {
-		where = append(where, q.BaseWhere)
-	}
-	compiled, err := CompilePredicate(p, q.Fields, arg)
-	if err != nil {
-		return "", nil, err
-	}
-	where = append(where, compiled)
-
-	var scope string
-	if q.ActivityWalk {
-		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
-	} else {
-		scope, err = auth.ScopeClauseFor(ctx, q.Table, "t", arg)
-	}
-	if err != nil {
-		return "", nil, err
-	}
-	if scope != "" {
-		where = append(where, scope)
-	}
-	return strings.Join(where, " AND "), args, nil
-}
-
-// CountMatching answers how many rows the predicate selects for this caller.
-//
-// It is a COUNT rather than len(SelectIDs): SelectIDs is capped at
-// PredicateRowLimit, so counting its result would silently report 1000 for every
-// larger set — a number that looks exact and is not. The filter builder shows
-// this figure to a human deciding whether their filter is right, which is
-// precisely the situation where a plausible wrong number is worse than a slow
-// one.
-//
-// Unbounded on purpose, and it is the same WHERE SelectIDs runs: same base
-// clause, same predicate, same row scope, so the count and the page it labels
-// cannot disagree about what MATCHING MEANS. Whether they saw the same rows is a
-// question about the snapshot, not the clause, and the caller decides that by
-// choosing which transaction to run both in.
-func (q Query) CountMatching(ctx context.Context, tx pgx.Tx, p Predicate) (int, error) {
-	where, args, err := q.predicateWhere(ctx, p)
-	if err != nil {
-		return 0, err
-	}
-	var n int
-	sql := fmt.Sprintf("SELECT count(*) FROM %s t WHERE %s", q.Table, where)
-	if err := tx.QueryRow(ctx, sql, args...).Scan(&n); err != nil {
-		return 0, fmt.Errorf("predicate count on %s: %w", q.Table, err)
-	}
-	return n, nil
-}
-
-// SelectIDs runs the predicate inside the caller's workspace-bound
-// transaction and returns matching row ids, deterministically ordered
-// by id (the keyset tie-breaker) and hard-capped at PredicateRowLimit.
-//
-// The read gate and the row-scope clause both come from predicateWhere — see
-// there for why they live together — so a predicate can only ever narrow what
-// the caller is already allowed to see. The cap stays here rather than in the
-// helper: it bounds a PAGE, and a count must not inherit it.
-func (q Query) SelectIDs(ctx context.Context, tx pgx.Tx, p Predicate, limit int) ([]ids.UUID, error) {
-	if limit <= 0 || limit > PredicateRowLimit {
-		limit = PredicateRowLimit
-	}
-	where, args, err := q.predicateWhere(ctx, p)
-	if err != nil {
-		return nil, err
-	}
-	sql := fmt.Sprintf("SELECT t.id FROM %s t WHERE %s ORDER BY t.id LIMIT %d",
-		q.Table, where, limit)
-	rows, err := tx.Query(ctx, sql, args...)
-	if err != nil {
-		return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)
-	}
-	defer rows.Close()
-
-	var matched []ids.UUID
-	for rows.Next() {
-		var id ids.UUID
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)
-		}
-		matched = append(matched, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)
-	}
-	return matched, nil
 }

--- a/backend/internal/platform/database/storekit/predicate_test.go
+++ b/backend/internal/platform/database/storekit/predicate_test.go
@@ -288,15 +288,19 @@ func TestLinkLeafGoldenSQLPerOperator(t *testing.T) {
 			[]any{[]string{tagUUID, ownerUUID}},
 		},
 		{
+			// The nullability test is on the COLUMN, not the row. For a tag it
+			// changes nothing — taggable.tag_id is NOT NULL — and it is what
+			// makes exists mean the same thing on a link that carries a
+			// nullable column.
 			"exists true carries any tag and binds nothing",
 			leaf("tag", OpExists, true),
-			fmt.Sprintf(wrapper, "TRUE"),
+			fmt.Sprintf(wrapper, "tg.tag_id IS NOT NULL"),
 			nil,
 		},
 		{
 			"exists false finds the untagged",
 			leaf("tag", OpExists, false),
-			"NOT " + fmt.Sprintf(wrapper, "TRUE"),
+			"NOT " + fmt.Sprintf(wrapper, "tg.tag_id IS NOT NULL"),
 			nil,
 		},
 	}
@@ -351,7 +355,7 @@ func TestLinkLeafNestsInsideAGroup(t *testing.T) {
 	want := "(EXISTS (SELECT 1 FROM taggable tg WHERE tg.entity_type = 'person'" +
 		" AND tg.entity_id = t.id AND tg.tag_id = $1)" +
 		" OR NOT EXISTS (SELECT 1 FROM taggable tg WHERE tg.entity_type = 'person'" +
-		" AND tg.entity_id = t.id AND TRUE))"
+		" AND tg.entity_id = t.id AND tg.tag_id IS NOT NULL))"
 	if sql != want {
 		t.Errorf("sql = %q, want %q", sql, want)
 	}
@@ -406,7 +410,7 @@ func TestEveryOperatorInTheMatrixIsAlsoInTheReadingOrder(t *testing.T) {
 				t.Errorf("%s admits operator %q and operatorOrder omits it, so OperatorsFor never reports it and no vocabulary can offer it", fieldType, op)
 			}
 		}
-		if got, want := len(OperatorsFor(fieldType)), len(admitted); got != want {
+		if got, want := len(OperatorsFor(Field{Type: fieldType})), len(admitted); got != want {
 			t.Errorf("OperatorsFor(%s) answers %d operators, the matrix admits %d", fieldType, got, want)
 		}
 	}
@@ -415,4 +419,79 @@ func TestEveryOperatorInTheMatrixIsAlsoInTheReadingOrder(t *testing.T) {
 			t.Errorf("operatorOrder carries %q that no field type admits, so it is dead vocabulary", op)
 		}
 	}
+}
+
+// operandFor answers a valid operand for one type and operator, so the gate
+// below fails on the OPERATOR question and never on the value.
+//
+// It is keyed by type rather than shared, because a wrong operand answers
+// CodeFilterValueInvalid — which is not CodeFilterOpNotAllowed, so a
+// "this operator compiles" assertion would pass on a value the engine never
+// accepted and prove nothing about the operator.
+func operandFor(t FieldType, op string) any { //craft:ignore naked-any mirrors Predicate.Value, schemaless by contract
+	if op == OpExists {
+		return true
+	}
+	scalar := map[FieldType]any{
+		FieldText:     "manufacturing",
+		FieldPicklist: "customer",
+		FieldID:       ownerUUID,
+		FieldNumber:   float64(40),
+		FieldCurrency: float64(1000),
+		FieldDate:     "2026-08-19",
+		FieldBoolean:  true,
+	}[t]
+	if op == OpIn {
+		return []any{scalar}
+	}
+	return scalar
+}
+
+// A linked field advertises exactly the operators it can compile.
+//
+// The two halves of that claim live in different places — linkOperators narrows
+// what OperatorsFor offers, and compileLinkLeaf's switch decides what actually
+// builds — and nothing else in the tree can see both. Left apart they drift the
+// way this arc has already paid for once: a text column reached through a link
+// would advertise `contains`, a picker would offer it, and the engine would
+// answer a 422 the caller could not have predicted.
+//
+// Derived from the engine's own maps rather than a written-out list, so a new
+// FieldType or a new operator is covered the day it is added.
+func TestALinkedFieldAdvertisesExactlyWhatItCanCompile(t *testing.T) {
+	const wrapper = "EXISTS (SELECT 1 FROM organization o WHERE o.id = t.organization_id AND %s)"
+	for fieldType, admitted := range operatorsByType {
+		linked := Field{Expr: "o.industry", Type: fieldType, Link: wrapper}
+		offered := make(map[string]bool)
+		for _, op := range OperatorsFor(linked) {
+			offered[op] = true
+		}
+		for _, op := range operatorOrder {
+			if !admitted[op] {
+				continue
+			}
+			var args []any
+			arg := func(v any) int { args = append(args, v); return len(args) }
+			_, err := CompilePredicate(
+				leaf("industry", op, operandFor(fieldType, op)),
+				map[string]Field{"industry": linked},
+				arg,
+			)
+			refused := isOpNotAllowed(err)
+			if offered[op] && refused {
+				t.Errorf("a linked %s field offers %q and the compiler refuses it: a picker would put a caller in a 422 they could not predict", fieldType, op)
+			}
+			if !offered[op] && !refused {
+				t.Errorf("a linked %s field compiles %q and no surface offers it: the capability is unreachable, so either linkOperators or the compiler is wrong", fieldType, op)
+			}
+			if err != nil && !refused {
+				t.Errorf("linked %s %q failed on something other than the operator: %v", fieldType, op, err)
+			}
+		}
+	}
+}
+
+func isOpNotAllowed(err error) bool {
+	var predicateErr *PredicateError
+	return errors.As(err, &predicateErr) && predicateErr.Code == CodeFilterOpNotAllowed
 }

--- a/backend/internal/platform/database/storekit/query.go
+++ b/backend/internal/platform/database/storekit/query.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+// The one-engine EXECUTOR: a resource's compiled predicate, run as bounded SQL
+// inside the caller's workspace-bound transaction.
+//
+// Split from predicate.go, which compiles a filter and nothing else. That
+// separation is the point rather than a filing convenience: compilation is
+// scope-neutral by design, and every guard that makes a compiled filter SAFE to
+// run — the object-RBAC admission, the row-scope clause, the row bound — lives
+// on this side, in one place a surface cannot route around.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// Query is the one-engine executor (B-E15.10b): one resource's closed
+// vocabulary plus its fixed base clause, executing any Predicate as
+// bounded, indexable SQL over the real columns. Lists, saved views, and
+// filtered export all run their filters through here — never through a
+// per-surface variant.
+type Query struct {
+	// Table is the base table, aliased t in every Fields expression.
+	Table string
+	// Fields is the resource's §13.5 filter allow-list.
+	Fields map[string]Field
+	// BaseWhere is the resource's fixed visibility clause (e.g.
+	// "t.archived_at IS NULL"); empty means none.
+	BaseWhere string
+	// ActivityWalk selects the activity link-walk scope clause instead
+	// of the direct ownership clause (the timeline's visibility rule).
+	ActivityWalk bool
+}
+
+// predicateWhere is the admission point AND the clause composer for every
+// execution of a predicate: it takes the object read gate, then joins the
+// resource's base clause, the compiled predicate, and the caller's row scope.
+//
+// Both live here so a second executor cannot take two of the three, or the
+// clauses without the gate. The row scope is the one that matters most: it is
+// what makes a predicate able only to NARROW what the caller may already see,
+// and an executor that forgot it would still return plausible rows, just other
+// people's. One point of composition means "is this scoped?" has one answer for
+// every caller.
+func (q Query) predicateWhere(ctx context.Context, p Predicate) (string, []any, error) {
+	if err := auth.Require(ctx, q.Table, principal.ActionRead); err != nil {
+		return "", nil, err
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+
+	where := make([]string, 0, 3)
+	if q.BaseWhere != "" {
+		where = append(where, q.BaseWhere)
+	}
+	compiled, err := CompilePredicate(p, q.Fields, arg)
+	if err != nil {
+		return "", nil, err
+	}
+	where = append(where, compiled)
+
+	var scope string
+	if q.ActivityWalk {
+		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
+	} else {
+		scope, err = auth.ScopeClauseFor(ctx, q.Table, "t", arg)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return strings.Join(where, " AND "), args, nil
+}
+
+// CountMatching answers how many rows the predicate selects for this caller.
+//
+// It is a COUNT rather than len(SelectIDs): SelectIDs is capped at
+// PredicateRowLimit, so counting its result would silently report 1000 for every
+// larger set — a number that looks exact and is not. The filter builder shows
+// this figure to a human deciding whether their filter is right, which is
+// precisely the situation where a plausible wrong number is worse than a slow
+// one.
+//
+// Unbounded on purpose, and it is the same WHERE SelectIDs runs: same base
+// clause, same predicate, same row scope, so the count and the page it labels
+// cannot disagree about what MATCHING MEANS. Whether they saw the same rows is a
+// question about the snapshot, not the clause, and the caller decides that by
+// choosing which transaction to run both in.
+func (q Query) CountMatching(ctx context.Context, tx pgx.Tx, p Predicate) (int, error) {
+	where, args, err := q.predicateWhere(ctx, p)
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	sql := fmt.Sprintf("SELECT count(*) FROM %s t WHERE %s", q.Table, where)
+	if err := tx.QueryRow(ctx, sql, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("predicate count on %s: %w", q.Table, err)
+	}
+	return n, nil
+}
+
+// SelectIDs runs the predicate inside the caller's workspace-bound
+// transaction and returns matching row ids, deterministically ordered
+// by id (the keyset tie-breaker) and hard-capped at PredicateRowLimit.
+//
+// The read gate and the row-scope clause both come from predicateWhere — see
+// there for why they live together — so a predicate can only ever narrow what
+// the caller is already allowed to see. The cap stays here rather than in the
+// helper: it bounds a PAGE, and a count must not inherit it.
+func (q Query) SelectIDs(ctx context.Context, tx pgx.Tx, p Predicate, limit int) ([]ids.UUID, error) {
+	if limit <= 0 || limit > PredicateRowLimit {
+		limit = PredicateRowLimit
+	}
+	where, args, err := q.predicateWhere(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	sql := fmt.Sprintf("SELECT t.id FROM %s t WHERE %s ORDER BY t.id LIMIT %d",
+		q.Table, where, limit)
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)
+	}
+	defer rows.Close()
+
+	var matched []ids.UUID
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)
+		}
+		matched = append(matched, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("predicate query on %s: %w", q.Table, err)
+	}
+	return matched, nil
+}


### PR DESCRIPTION
Closes the filter half of [#721](https://github.com/gradionhq/margince-poc-v1/issues/721) — "show me the pipeline for manufacturing" is now a filter. The columns were already there and already enriched; what was missing was a way for a deal's filter to *name* them.

**No new engine capability.** `storekit.Field.Link` — the correlated `EXISTS` the tag leaf already compiles through — is exactly this shape, so the deal vocabulary gains three linked fields on the organization it already points at:

| Field | Type |
|---|---|
| `organization_industry` | text |
| `organization_size_band` | picklist |
| `organization_lifecycle` | picklist |

Because the filter screen and the export both read their vocabulary *from the engine*, dynamic lists, saved views and CSV/JSON export gain the filter at once, with no per-surface work. That is the property this arc's "one engine" rule buys.

## Two latent traps had to be fixed first

**A linked field advertised operators it could not compile.** `OperatorsFor` took a `FieldType`, so it could not know that a link compiles through a narrower set than its type admits. The tag field is `FieldID` and happened to line up — but industry is *text*, so the vocabulary would have offered `contains` while `compileLinkLeaf` refused it as `filter_op_not_allowed`. A 422 no caller could predict, from a picker that offered the operator.

It now takes the `Field`, and `TestALinkedFieldAdvertisesExactlyWhatItCanCompile` derives **both** directions from the engine's own maps: an offered operator must compile, and a compilable one must be offered. Mutation-verified — removing the narrowing fails it for currency and date as well as text.

**`exists` on a link asked about the ROW, not the column.** It compiled to `EXISTS(… AND TRUE)`. For a tag that *is* the whole question; for a joined column it is the wrong one — "which deals is the customer's industry unknown for" would have answered "the ones with no customer", silently excluding every deal whose company simply has no industry recorded.

It now tests the column: `EXISTS(… AND <expr> IS NOT NULL)`. Provably identical for tags (`taggable.tag_id` is `NOT NULL`, so the added test cannot change which rows the wrapper finds) and correct for both shapes. Mutation-verified against real Postgres — the old reading fails the new integration test with exactly the message above.

## The one product choice

`customerLink` does **not** re-apply the organization engine's `archived_at`/`is_anchor` exclusions. Those answer "which of our accounts are segment MEMBERS"; this leaf answers a fact about the company a deal belongs to, and archiving a company does not change that fact. Carrying them over would move deals out of the manufacturing pipeline the moment somebody archived a customer — a pipeline figure shifting for a reason nobody filtering could see.

`TestArchivingTheCustomerLeavesItsDealsInTheIndustryFilter` is what keeps that a decision rather than a comment.

`classification` is deliberately not offered: it is retired (ADR-0079/A124) and survives on the organization engine only so already-saved segments keep evaluating. A new way to name it would be a fresh dependency on a column that is going away — the trap #721 names in its fourth point.

## The file split

`predicate.go` crossed the 500-line cap, so the executor moved to `query.go`. The seam is the one the file's own header already described: `predicate.go` compiles a filter and reaches for neither the database nor `auth`, while every guard that makes a compiled filter safe to **run** — object admission, row scope, the row bound — now sits together on the other side of it.

## Still open on #721

- Accepting `industry` and `size_band` on the organization *list* endpoint, so the plain list agrees with the segment engine.
- The deals-screen filter bar.

The Filters & views screen needs nothing — it reads the vocabulary.

`make check-backend` green, `make craft-static` green (0 findings, including the moved lines the strict lint now treats as new), and the three new scenarios pass against real Postgres.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deal filters can now target customer attributes. Adds linked fields for `organization_industry`, `organization_size_band`, and `organization_lifecycle` so users can filter pipelines like “manufacturing.” Dynamic lists, saved views, and CSV/JSON exports pick this up automatically via the shared vocabulary.

- Review notes:
  - Narrowed operator exposure for linked fields: `storekit.OperatorsFor` now accepts a `storekit.Field` and hides operators a link cannot compile (e.g., text links no longer offer `contains`). Update any out-of-tree callers to pass a `storekit.Field`.
  - Fixed link `exists` semantics: previously asked about the row (`EXISTS … AND TRUE`); now asks about the column (`EXISTS … AND <expr> IS NOT NULL`). Behavior change: `exists: false` for `organization_industry` now returns deals with no customer and customers with a null industry.
  - Product choice: deal filters do not re-apply organization `archived_at`/`is_anchor` exclusions. Archived customers still count toward deal filters like industry.
  - Engine split: kept compilation in `predicate.go`; moved execution (admission, row scope, row bound) to `query.go` in `storekit`.
  - Intentional omission: no `classification` field (retired).
  - Follow-ups for #721 remain: accept `industry`/`size_band` on the organization list endpoint and add the deals-screen filter bar.

<sup>Written for commit 79c42248de7cc38ed083665b9feabc8a02a1a798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

