### PR TITLE
feat(frontend): the companies list gains a size dial

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -556,6 +556,7 @@ export const de = {
   "list.viewProspects": "Interessenten",
   "org.filterLifecycleAll": "Alle Phasen",
   "org.filterRelTypeAll": "Alle Typen",
+  "org.filterSizeBandAll": "Alle Größen",
   "person.consent": "Einwilligung",
   "consent.grant": "Erteilen",
   "consent.withdraw": "Widerrufen",
@@ -593,6 +594,7 @@ export const de = {
   // die die abgelöste Einstufung mit einem Wert beantworten wollte.
   "org.lifecycle": "Account-Status",
   "org.relationshipTypes": "Beziehung zu uns",
+  "org.sizeBand": "Unternehmensgröße",
   "org.lifecycle.unknown": "Nicht eingeschätzt",
   "org.lifecycle.target": "Zielkunde",
   "org.lifecycle.prospect": "Interessent",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -572,6 +572,7 @@ export const en = {
   "list.viewProspects": "Prospects",
   "org.filterLifecycleAll": "Any stage",
   "org.filterRelTypeAll": "Any type",
+  "org.filterSizeBandAll": "Any size",
   "person.consent": "Consent",
   "consent.grant": "Grant",
   "consent.withdraw": "Withdraw",
@@ -608,6 +609,7 @@ export const en = {
   // questions the retired classification answered with one value.
   "org.lifecycle": "Account lifecycle",
   "org.relationshipTypes": "Relationship to us",
+  "org.sizeBand": "Company size",
   "org.lifecycle.unknown": "Not assessed",
   "org.lifecycle.target": "Target",
   "org.lifecycle.prospect": "Prospect",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -547,6 +547,7 @@ export const vi = {
   "list.viewProspects": "Khách tiềm năng",
   "org.filterLifecycleAll": "Mọi giai đoạn",
   "org.filterRelTypeAll": "Mọi loại",
+  "org.filterSizeBandAll": "Mọi quy mô",
   "person.consent": "Chấp thuận",
   "consent.grant": "Cấp chấp thuận",
   "consent.withdraw": "Rút lại",
@@ -583,6 +584,7 @@ export const vi = {
   // questions the retired classification answered with one value.
   "org.lifecycle": "Trạng thái tài khoản",
   "org.relationshipTypes": "Quan hệ với chúng ta",
+  "org.sizeBand": "Quy mô công ty",
   "org.lifecycle.unknown": "Chưa đánh giá",
   "org.lifecycle.target": "Mục tiêu",
   "org.lifecycle.prospect": "Tiềm năng",

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -615,8 +615,18 @@ describe("CompaniesScreen — list dials reach the server (P-14)", () => {
     // The wire's own parameter name and the band as written. A dial that sent
     // anything else would be ignored by the server, which answers the WHOLE
     // list with 200 OK — a filter that reads as working and is not.
+    // The parsed parameter, not a substring of the URL: `includes` would also
+    // accept a longer value that merely starts this way, so it asserts less than
+    // it appears to — and it would keep passing if the band set ever grew one.
     await waitFor(() =>
-      expect(urls.some((url) => url.includes("size_band=51-200"))).toBe(true),
+      expect(
+        urls.some(
+          (url) =>
+            new URL(url, window.location.origin).searchParams.get(
+              "size_band",
+            ) === "51-200",
+        ),
+      ).toBe(true),
     );
   });
 

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -602,6 +602,24 @@ describe("CompaniesScreen — list dials reach the server (P-14)", () => {
     );
   });
 
+  it("narrows to one company size through the server", async () => {
+    const user = userEvent.setup();
+    const { urls } = stubFetch(async () => emptyPage());
+    render(<CompaniesScreen />);
+    await waitFor(() => expect(urls.length).toBeGreaterThan(0));
+
+    await user.click(await screen.findByRole("button", { name: "Filter" }));
+    await user.click(screen.getByRole("button", { name: "Company size" }));
+    await user.click(screen.getByRole("button", { name: "51-200" }));
+
+    // The wire's own parameter name and the band as written. A dial that sent
+    // anything else would be ignored by the server, which answers the WHOLE
+    // list with 200 OK — a filter that reads as working and is not.
+    await waitFor(() =>
+      expect(urls.some((url) => url.includes("size_band=51-200"))).toBe(true),
+    );
+  });
+
   it("reads whole rendered pages at whatever size the reader picked", async () => {
     const user = userEvent.setup();
     const { urls } = stubFetch(async () => emptyPage());

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -25,6 +25,7 @@ import {
   EvidenceMark,
   type EvidenceMarkSource,
 } from "../design-system/evidencemark";
+import type { ListChip } from "../design-system/listsurface";
 import { sectionState } from "../design-system/surfacestate";
 import {
   AutonomyDot,
@@ -557,6 +558,20 @@ export function CompaniesScreen() {
   const viewerId = useViewerId();
   const ownerChips = useOwnerChips();
   const savedViews = useSavedViewTabs("organizations");
+  // Beside the owner dial rather than in `chips`, and the reason is the option
+  // labels. A `chips` entry runs every label through `t()`, so its options must
+  // be message keys — and a size band is a numeral range that reads identically
+  // in English, German and Vietnamese. Seven keys whose three translations all
+  // coincide would be noise standing in for meaning. The dial's own name still
+  // needs translating, which is what `t()` is doing here.
+  const sizeChip: readonly ListChip[] = [
+    {
+      key: "size_band",
+      label: t("org.sizeBand"),
+      allLabel: t("org.filterSizeBandAll"),
+      options: SIZE_BAND_OPTIONS.map((value) => ({ value, label: value })),
+    },
+  ];
 
   return (
     <div className="wrap">
@@ -684,7 +699,7 @@ export function CompaniesScreen() {
         tools={<SaveViewAction resource="organizations" query={state.query} />}
         rowKey={(org) => org.id}
         rowRoute={(org) => ({ screen: "companies", id: org.id })}
-        dataChips={ownerChips}
+        dataChips={[...ownerChips, ...sizeChip]}
         chips={[
           {
             key: "lifecycle",


### PR DESCRIPTION
Part of [#721](https://github.com/gradionhq/margince-poc-v1/issues/721)'s UI point, and small: `GET /organizations` has accepted `size_band` for a while — with enum validation in the handler — but no screen offered it, so the capability was only reachable by hand-writing a URL.

## One thing worth explaining

The dial sits in `dataChips`, not `chips`, which the prop name argues against. A `chips` entry runs **every** label through `t()`, so its options must be message keys — and a size band is a numeral range that reads identically in English, German and Vietnamese. Seven keys whose three translations all coincide would be noise standing in for meaning. The dial's own name and its "any size" entry *do* need translating, and those are the two strings this passes through `t()` itself.

If that reads as a misuse of the prop, the alternative is a `chips` entry plus 21 lines of `"1-10": "1-10"`. I took the comment over the boilerplate; happy to flip it if you'd rather the prop name stayed literal.

## The test

It asserts the **wire spelling**, not that a request went out. A chip whose key does not match the server's parameter name is ignored, and an ignored filter answers the *whole* list with `200 OK` — a filter that reads as working and is not. `listquery.tsx` already carries a comment about that failure mode, having shipped it once (`owner=unassigned:true` instead of `unassigned=true`).

Mutation-verified: renaming the key to `sizeBand` fails the test.

## What this does not do

`industry` is the other half of #721's UI point and is **not** here, because it needs a decision rather than code:

- The column is free text, so a chip has no bounded option list to offer.
- `ListChip.search` is the designed mechanism for an unbounded set — but it needs a source of distinct industry values, and no endpoint returns one. `q` searches names, not industries.
- `translateChip` also drops `search`, so today only a `dataChips` entry could carry it.

So the options are: add a distinct-values endpoint (a contract change #721 does not ask for), make `industry` an enum (a product decision), or add a text dial to `ListSurface` (a shared surface every list uses). I have not picked one.

Worth noting the gap is narrower than #721 states: a user **can** filter companies by industry today — on Filters & views, with saved views and export, via the segment engine. What is missing is an inline dial on the companies list.

`make check-fe` green (3365 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Company size dial to the Companies list, wired to `size_band` on `GET /organizations`, so users can filter by size inline instead of editing the URL. Supports the UI requirement in #721.

- Sends `size_band` with literal band values (e.g., `51-200`) to filter server-side.
- Places the dial in `dataChips` (not `chips`) to avoid auto-translation of numeric range labels; only the dial name (`org.sizeBand`) and “Any size” (`org.filterSizeBandAll`) are translated in `en`, `de`, and `vi`.
- Test now reads the parsed `size_band` query param and expects `51-200` rather than matching a URL substring, preventing false positives and guarding the parameter name.

<sup>Written for commit a4bace0fd15a9ba576c88ce5f61b82f6962eb566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a company-size filter to the organizations list.
  * Selected size ranges are displayed alongside existing filters.
  * Added English, German, and Vietnamese labels for company-size filtering and fields.

* **Tests**
  * Added coverage confirming that selecting the 51–200 company-size range applies the correct filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->