### PR TITLE
feat(collections): the segment vocabulary gains the team and relationship leaves

### DIFF
--- a/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
+++ b/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package collections
+
+// The two vocabulary leaves that reach a row OTHER than the one being selected:
+// the ownership dial's team half, which walks team_membership, and an account's
+// relationship to us, which is multi-valued and lives in its own table.
+//
+// Both are correlated subqueries, so what they compile to can be read in the unit
+// lane but what they SELECT cannot. These are the scenarios only real Postgres
+// answers — and the harness already seeds the shape they need: Rep1 and Rep2
+// share Team1, Rep3 sits in Team2.
+
+import (
+	"testing"
+
+	collectionsmod "github.com/gradionhq/margince/backend/internal/modules/collections"
+	peoplemod "github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// ownedOrg seeds one account owned by one seat, through the real writer.
+func (f fixture) ownedOrg(t *testing.T, name string, owner ids.UUID) ids.UUID {
+	t.Helper()
+	seat := ids.From[ids.UserKind](owner)
+	org, err := f.people.CreateOrganization(f.ctx, peoplemod.CreateOrganizationInput{
+		DisplayName: name, OwnerID: &seat, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create organization %q: %v", name, err)
+	}
+	return ids.UUID(org.Id)
+}
+
+// "Owned by my team" is the form a manager's saved view actually takes, and the
+// engine had only the person half of the dial until now. The team is walked
+// through team_membership, so this is the whole membership edge under test and
+// not just a column comparison.
+func TestATeamFilterSelectsEveryMembersRecords(t *testing.T) {
+	f := setupFixture(t)
+	firstMember := f.ownedOrg(t, "Held by Rep1", f.e.Rep1)
+	secondMember := f.ownedOrg(t, "Held by Rep2", f.e.Rep2)
+	otherTeam := f.ownedOrg(t, "Held by Rep3", f.e.Rep3)
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "my team's accounts", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "owner_team_id", "op": "eq", "value": f.e.Team1.String(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+
+	got := memberIDs(t, f, list.ID)
+	// Both members of the team, not just the one who happens to be the caller:
+	// the dial names a team, and a filter that answered only the viewer's own
+	// rows would be `owner_id` wearing a different label.
+	if !got[firstMember] || !got[secondMember] {
+		t.Errorf("the team filter missed a member's records: %v", got)
+	}
+	if got[otherTeam] {
+		t.Error("the team filter reached another team's records")
+	}
+}
+
+// `exists: false` on the team leaf finds the records no team's review covers, and
+// an unowned record is one of them.
+//
+// It does NOT cover the other arm — a record whose owner exists and belongs to no
+// team — and the name says so, because that arm is what distinguishes this leaf
+// from `owner_id exists: false` and a wrong implementation would pass here
+// without it. The harness puts all three of its seats in a team, so the arm needs
+// a teamless seat that does not exist yet; adding one touches shared identity
+// seeding that the seat-ceiling and licence-entitlement suites count rows in.
+// Tracked rather than faked.
+func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
+	f := setupFixture(t)
+	inATeam := f.ownedOrg(t, "Held by Rep1", f.e.Rep1)
+	unowned, err := f.people.CreateOrganization(f.ctx, peoplemod.CreateOrganizationInput{
+		DisplayName: "Nobody's account", Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create unowned organization: %v", err)
+	}
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "no team covers these", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "owner_team_id", "op": "exists", "value": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+
+	got := memberIDs(t, f, list.ID)
+	if !got[ids.UUID(unowned.Id)] {
+		t.Error("an account with no owner at all is not counted as covered by no team")
+	}
+	if got[inATeam] {
+		t.Error("an account whose owner IS in a team is reported as covered by none")
+	}
+}
+
+// An account can be a customer and a supplier at once, so the leaf selects
+// accounts that are AT LEAST the named type. A filter that meant "is only this"
+// would answer a different and much smaller question.
+func TestARelationshipFilterSelectsAccountsThatAreAtLeastThatType(t *testing.T) {
+	f := setupFixture(t)
+	both := f.customerAndSupplier(t, "Acme, both")
+	customerOnly := f.withRelationshipTypes(t, "Beta, customer only", []string{"customer"})
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "suppliers", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "relationship_type", "op": "eq", "value": "supplier",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+
+	got := memberIDs(t, f, list.ID)
+	if !got[both] {
+		t.Error("an account that is a customer AND a supplier is not selected as a supplier")
+	}
+	if got[customerOnly] {
+		t.Error("a customer with no supplier row is selected as a supplier")
+	}
+}
+
+// A withdrawn relationship is one the account no longer has. Without the
+// archived_at guard inside the wrapper, a segment would keep selecting accounts
+// on a fact somebody deliberately took back.
+func TestAWithdrawnRelationshipStopsMatching(t *testing.T) {
+	f := setupFixture(t)
+	account := f.customerAndSupplier(t, "Acme, both")
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "suppliers", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "relationship_type", "op": "eq", "value": "supplier",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+	assertSoleMember(t, f, list.ID, account)
+
+	// Through the real reconcile path: the desired live set is now customer
+	// alone, which archives the supplier row rather than deleting it.
+	f.setRelationshipTypes(t, account, []string{"customer"})
+
+	if got := memberIDs(t, f, list.ID); got[account] {
+		t.Error("an account whose supplier relationship was withdrawn is still selected as a supplier")
+	}
+}
+
+// customerAndSupplier is the multi-valued fixture both relationship scenarios
+// need, named once so they cannot drift into testing different shapes.
+//
+// Supplier rather than partner, and not arbitrarily: `partner` carries a product
+// invariant of its own — an account is a partner only while a partner programme
+// row backs it, and reconcile refuses the type without one. Borrowing that
+// fixture would make these tests fail for a reason that has nothing to do with
+// the vocabulary leaf under test.
+func (f fixture) customerAndSupplier(t *testing.T, name string) ids.UUID {
+	t.Helper()
+	return f.withRelationshipTypes(t, name, []string{"customer", "supplier"})
+}
+
+func (f fixture) withRelationshipTypes(t *testing.T, name string, types []string) ids.UUID {
+	t.Helper()
+	org, err := f.people.CreateOrganization(f.ctx, peoplemod.CreateOrganizationInput{
+		DisplayName: name, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create organization %q: %v", name, err)
+	}
+	f.setRelationshipTypes(t, ids.UUID(org.Id), types)
+	return ids.UUID(org.Id)
+}
+
+// setRelationshipTypes drives the real update path, so the rows under test are
+// the ones production writes — including the archive-not-delete behaviour a
+// withdrawal depends on.
+func (f fixture) setRelationshipTypes(t *testing.T, org ids.UUID, types []string) {
+	t.Helper()
+	if _, err := f.people.UpdateOrganization(
+		f.ctx,
+		ids.From[ids.OrganizationKind](org),
+		peoplemod.UpdateOrganizationInput{RelationshipTypes: &types},
+	); err != nil {
+		t.Fatalf("set relationship types %v: %v", types, err)
+	}
+}

--- a/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
+++ b/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
@@ -22,7 +22,10 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// ownedOrg seeds one account owned by one seat, through the real writer.
+// ownedOrg goes through CreateOrganization so the owner_id the team leaf joins on
+// is the one production stamps. A hand-inserted row could carry an owner no
+// membership edge reaches, and the join would then be proven against a shape the
+// product cannot produce.
 func (f fixture) ownedOrg(t *testing.T, name string, owner ids.UUID) ids.UUID {
 	t.Helper()
 	seat := ids.From[ids.UserKind](owner)

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -74,7 +74,8 @@ func taggableEntityTypes() []string {
 // (storekit.Field.Link) rather than against the base table. The entity_type is
 // baked in per resource because that is what makes the polymorphic join answer
 // for THIS record type and no other. taggable carries no workspace_id (dropped
-// by 0228); the surrounding transaction is what binds the tenant.
+// by 0228), and no link subquery here names one — see customerLink below for why
+// that is the tenancy model rather than a hole in it.
 func tagLinkFor(entity string) storekit.Field {
 	return storekit.Field{
 		Expr: "tg.tag_id",
@@ -82,6 +83,51 @@ func tagLinkFor(entity string) storekit.Field {
 		Link: "EXISTS (SELECT 1 FROM taggable tg WHERE tg.entity_type = '" + entity +
 			"' AND tg.entity_id = t.id AND %s)",
 	}
+}
+
+// ownerTeamIDField is the vocabulary's name for the team half of the ownership
+// dial — as distinct from ownerTeamField below, the leaf it names.
+const ownerTeamIDField = "owner_team_id"
+
+// ownerTeamField selects the records owned by any member of one team: the same
+// rows the `owner_team_id` list parameter answers, reached the way a link leaf
+// can express.
+//
+// ONE value, shared by every owner-scoped engine rather than built per resource,
+// because it varies by nothing — a constructor like tagLinkFor would be a
+// function returning a constant. It reads colOwnerID for the same reason the
+// base-table owner leaf does: one spelling of the owner column.
+//
+// The dial has a third position the vocabulary needs no leaf for: unassigned is
+// `owner_id` with `exists: false`. A reader looking for it here should not
+// conclude it is missing.
+//
+// This is a FILTER, not a scope. The executor ANDs it with the caller's
+// row-scope clause, so naming a team the caller cannot see answers their own
+// visible rows filtered to nothing — never that team's rows.
+var ownerTeamField = storekit.Field{
+	Expr: "tm.team_id",
+	Type: storekit.FieldID,
+	Link: "EXISTS (SELECT 1 FROM team_membership tm WHERE tm.user_id = " + colOwnerID +
+		" AND %s)",
+}
+
+// relationshipTypeField is the account's relationship to us, which is
+// MULTI-VALUED: an account can be a customer and a partner at once, so the fact
+// lives in its own table and this leaf selects accounts that are AT LEAST this.
+//
+// Archived rows are excluded inside the wrapper. A retired relationship is one
+// the account no longer has, and a segment naming it would otherwise keep
+// selecting accounts on a fact somebody deliberately withdrew.
+//
+// A picklist leaf compares text and the engine holds no per-field enum, so a
+// value no row carries selects nothing rather than being refused.
+// TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt gates that.
+var relationshipTypeField = storekit.Field{
+	Expr: "rt.relationship_type",
+	Type: storekit.FieldPicklist,
+	Link: "EXISTS (SELECT 1 FROM organization_relationship_type rt" +
+		" WHERE rt.organization_id = t.id AND rt.archived_at IS NULL AND %s)",
 }
 
 // customerLink is the EXISTS template a deal's filter reaches its customer
@@ -96,9 +142,11 @@ func tagLinkFor(entity string) storekit.Field {
 // somebody archived a company — a pipeline figure shifting for a reason nobody
 // filtering could see.
 //
-// The organization table is read inside the caller's own transaction, so the RLS
-// GUC contract binds it exactly as it binds the base table: there is no path
-// here that reaches another workspace's rows.
+// The subquery names no tenant column, and neither does any sibling here: core
+// 0217 (ADR-0091 phase A) retired every row-level-security policy, so the
+// workspace GUC binds nothing on its own and an installation serves ONE
+// organization (ADR-0061). That is what makes the read tenant-safe — not a
+// policy, which is why this says so rather than claiming one.
 const customerLink = "EXISTS (SELECT 1 FROM organization o WHERE o.id = t.organization_id AND %s)"
 
 // customerField types one organization column as a deal-side filter leaf. The
@@ -113,8 +161,9 @@ var segmentEngines = map[string]storekit.Query{
 		Table:     "person",
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			ownerIDField:   {Expr: colOwnerID, Type: storekit.FieldID},
-			tagFilterField: tagLinkFor("person"),
+			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerTeamIDField: ownerTeamField,
+			tagFilterField:   tagLinkFor("person"),
 		},
 	},
 	"organization": {
@@ -126,18 +175,20 @@ var segmentEngines = map[string]storekit.Query{
 		// export built on one can carry it.
 		BaseWhere: whereArchivedNull + " AND NOT t.is_anchor",
 		Fields: map[string]storekit.Field{
-			ownerIDField: {Expr: colOwnerID, Type: storekit.FieldID},
-			"industry":   {Expr: "t.industry", Type: storekit.FieldText},
-			"size_band":  {Expr: "t.size_band", Type: storekit.FieldPicklist},
-			"lifecycle":  {Expr: "t.lifecycle", Type: storekit.FieldPicklist},
+			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerTeamIDField: ownerTeamField,
+			"industry":       {Expr: "t.industry", Type: storekit.FieldText},
+			"size_band":      {Expr: "t.size_band", Type: storekit.FieldPicklist},
+			"lifecycle":      {Expr: "t.lifecycle", Type: storekit.FieldPicklist},
 			// RETIRED with the column (ADR-0079/A124), and kept here for the one
 			// release it survives: a saved segment written against it must keep
 			// evaluating until its author has moved it to lifecycle. Dropping the
 			// field would turn every such list into an error at read time, which
 			// is a worse answer than a stale one. Named in retiredCoreFields
 			// below, so no surface OFFERS it for a new clause.
-			"classification": {Expr: "t.classification", Type: storekit.FieldPicklist},
-			tagFilterField:   tagLinkFor("organization"),
+			"classification":    {Expr: "t.classification", Type: storekit.FieldPicklist},
+			"relationship_type": relationshipTypeField,
+			tagFilterField:      tagLinkFor("organization"),
 		},
 	},
 	"deal": {
@@ -147,6 +198,7 @@ var segmentEngines = map[string]storekit.Query{
 			"pipeline_id":       {Expr: "t.pipeline_id", Type: storekit.FieldID},
 			"stage_id":          {Expr: "t.stage_id", Type: storekit.FieldID},
 			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerTeamIDField:    ownerTeamField,
 			"organization_id":   {Expr: "t.organization_id", Type: storekit.FieldID},
 			"partner_org_id":    {Expr: "t.partner_org_id", Type: storekit.FieldID},
 			"project_id":        {Expr: "t.project_id", Type: storekit.FieldID},
@@ -173,6 +225,7 @@ var segmentEngines = map[string]storekit.Query{
 		Fields: map[string]storekit.Field{
 			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
 			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerTeamIDField:    ownerTeamField,
 			"candidate_org_key": {Expr: "t.candidate_org_key", Type: storekit.FieldText},
 			tagFilterField:      tagLinkFor("lead"),
 		},
@@ -182,6 +235,7 @@ var segmentEngines = map[string]storekit.Query{
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
 			ownerIDField:      {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerTeamIDField:  ownerTeamField,
 			"organization_id": {Expr: "t.organization_id", Type: storekit.FieldID},
 			"phase":           {Expr: "t.phase", Type: storekit.FieldPicklist},
 			tagFilterField:    tagLinkFor(projectEntity),

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -43,6 +43,145 @@ func TestEveryTaggableTypeCanBeFilteredByTag(t *testing.T) {
 	}
 }
 
+// The ownership dial is ONE dial, so an engine that offers half of it offers a
+// broken one: a saved view can say "owned by this person" and a manager's view
+// — "owned by my team" — is the form that actually gets saved.
+//
+// Derived from the engines themselves rather than from a written-out list of
+// resources, so a sixth engine that carries `owner_id` cannot quietly ship
+// without the team half.
+func TestEveryEngineWithAnOwnerAlsoFiltersByTeam(t *testing.T) {
+	checked := 0
+	for resource, engine := range segmentEngines {
+		_, owned := engine.Fields[ownerIDField]
+		team, teamed := engine.Fields[ownerTeamIDField]
+		// Both directions. An engine offering the team half without the person
+		// half is equally half a dial, and asserting only the one direction would
+		// let that ship.
+		if owned && !teamed {
+			t.Errorf("%s filters by owner and not by owner's team: half an ownership dial", resource)
+			continue
+		}
+		if teamed && !owned {
+			t.Errorf("%s filters by owner's team and not by owner: half an ownership dial", resource)
+			continue
+		}
+		if !owned {
+			continue
+		}
+		checked++
+		// Definitionally identical to the shared leaf, which is the enforceable
+		// invariant: whatever the join is, every engine runs the same one. This
+		// cannot tell a copy from the original — storekit.Field is a comparable
+		// struct of three strings, so an identical literal passes — and catching
+		// the copy itself would be a lint job, not an assertion.
+		if team != ownerTeamField {
+			t.Errorf("%s's team leaf differs from the shared one: %+v", resource, team)
+		}
+	}
+	// Without this the loop asserts nothing the day ownerIDField stops matching
+	// any engine's key, and the test keeps passing over an empty sweep.
+	if checked == 0 {
+		t.Fatal("no engine carries an owner leaf, so this gate checked nothing")
+	}
+}
+
+// Every link template takes exactly one comparison. A template with any other
+// number of verbs formats wrong — fmt writes %!(EXTRA …) or a bare %!s(MISSING)
+// straight into the query text — so this is a syntax error waiting on whichever
+// leaf a filter happens to name.
+//
+// Swept over every engine's every field rather than asserted per leaf, so a new
+// link field is covered the day it is added.
+func TestEveryLinkTemplateTakesExactlyOneComparison(t *testing.T) {
+	swept := 0
+	for resource, engine := range segmentEngines {
+		for name, field := range engine.Fields {
+			if field.Link == "" {
+				continue
+			}
+			swept++
+			if count := strings.Count(field.Link, "%s"); count != 1 {
+				t.Errorf("%s.%s has %d %%s verbs in its link template, want exactly 1: %q",
+					resource, name, count, field.Link)
+			}
+			if field.Expr == "" {
+				t.Errorf("%s.%s is a link leaf with no column to compare inside it", resource, name)
+			}
+		}
+	}
+	if swept == 0 {
+		t.Fatal("no link fields found, so this gate checked nothing")
+	}
+}
+
+// The team leaf reaches the same rows the record lists already answer for
+// `owner_team_id`, and reaches them the way the link mechanism can carry.
+func TestTheTeamLeafJoinsMembershipOnTheOwnerColumn(t *testing.T) {
+	if ownerTeamField.Link == "" {
+		t.Fatal("the team leaf is not a link leaf, so it cannot reach team_membership")
+	}
+	for _, want := range []string{"team_membership", "tm.user_id = " + colOwnerID} {
+		if !strings.Contains(ownerTeamField.Link, want) {
+			t.Errorf("the team leaf does not carry %q: %q", want, ownerTeamField.Link)
+		}
+	}
+	if count := strings.Count(ownerTeamField.Link, "%s"); count != 1 {
+		t.Errorf("the team leaf has %d %%s verbs, want exactly 1: %q", count, ownerTeamField.Link)
+	}
+	// An id, so a malformed team fails validation (422) rather than execution.
+	if ownerTeamField.Type != storekit.FieldID {
+		t.Errorf("the team leaf is typed %s, want id", ownerTeamField.Type)
+	}
+}
+
+// A picklist leaf compares text, so a value outside the contract's enum compiles
+// and selects nothing. The list parameter for the same fact 422s a typo instead,
+// and that divergence is deliberate rather than overlooked: the engine holds no
+// per-field enum, and every picklist leaf here behaves this way — status,
+// lifecycle, size_band, forecast_category, phase and the custom ones alike.
+//
+// Gated rather than explained, because a comment claiming it cannot notice the
+// day someone adds validation to one leaf and leaves the rest.
+func TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt(t *testing.T) {
+	engine, ok, err := (&Store{}).SegmentEngine(context.Background(), "organization")
+	if err != nil || !ok {
+		t.Fatalf("segmentEngine: ok=%v err=%v", ok, err)
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	sql, err := storekit.CompilePredicate(
+		storekit.Predicate{Field: "relationship_type", Op: storekit.OpEq, Value: "custmer"},
+		engine.Fields, arg,
+	)
+	if err != nil {
+		t.Fatalf("an unrecognised picklist value was refused: %v", err)
+	}
+	if len(args) != 1 || args[0] != "custmer" {
+		t.Errorf("the value did not travel as a bind parameter: %#v", args)
+	}
+	// The typo reaches SQL as a parameter, never as text — which is what makes
+	// "selects nothing" safe rather than merely unhelpful.
+	if strings.Contains(sql, "custmer") {
+		t.Errorf("the operand was inlined into the query text: %q", sql)
+	}
+}
+
+// An account's relationship to us is multi-valued, and a withdrawn one is a fact
+// it no longer carries.
+func TestTheRelationshipLeafExcludesWithdrawnRows(t *testing.T) {
+	field, ok := segmentEngines["organization"].Fields["relationship_type"]
+	if !ok {
+		t.Fatal("organizations cannot be filtered by relationship type")
+	}
+	if !strings.Contains(field.Link, "rt.archived_at IS NULL") {
+		t.Errorf("the relationship leaf keeps selecting on withdrawn rows: %q", field.Link)
+	}
+	if !strings.Contains(field.Link, "rt.organization_id = t.id") {
+		t.Errorf("the relationship leaf does not correlate to the account: %q", field.Link)
+	}
+}
+
 // A project is a taggable record (taggable's own CHECK admits it) and its
 // list membership must offer the same filter every other taggable type does.
 func TestProjectIsFilterableByTag(t *testing.T) {


### PR DESCRIPTION
Two of the three leaves [#1657](https://github.com/gradionhq/margince-poc-v1/issues/1657) found missing against the spec's DM-VOCAB table. Contract-first: the table is the promise and the engine owes it, so these are additions rather than a spec correction. No contract change, no new engine capability — `storekit.Field.Link` already does correlated-EXISTS.

## `owner_team_id`, once, for every owner-scoped engine

That was the issue's one open design question, and the spec answers it: the ownership dial is **one** vocabulary bound once, not five per-resource implementations. So this is a single `storekit.Field` shared by all five engines rather than a template string copied into each.

`TestEveryEngineWithAnOwnerAlsoFiltersByTeam` derives the obligation from the engines themselves — every engine carrying `owner_id` must carry the team half, and vice versa, since a team leaf without an owner leaf is equally half a dial. It fails if it ever sweeps nothing, and asserts each engine's leaf is **definitionally identical** to the shared one. Mutation-verified in both directions.

It selects the same rows the `owner_team_id` list parameter answers, said as the EXISTS a link leaf can express. It is a **filter, not a scope**: the executor ANDs it with the caller's row-scope clause, so naming a team the caller cannot see answers their own visible rows filtered to nothing rather than reaching that team's.

## `relationship_type` on organizations

Multi-valued, so the fact lives in its own table and the leaf selects accounts that are **at least** the named type. Archived rows are excluded inside the wrapper — a withdrawn relationship is one the account no longer has, and a segment naming it would otherwise keep selecting on a fact somebody deliberately took back.

The engine does **not** check the value against the contract's enum, where the list parameter 422s a typo. That is the call every picklist leaf here already makes (custom picklists included) and the outcome is honest: a value no row carries selects nothing. It is **gated by a test** rather than explained in prose, and the systemic version is [#1851](https://github.com/gradionhq/margince-poc-v1/issues/1851).

## What only Postgres can prove

Both are correlated subqueries, so what they compile to is readable in the unit lane and what they **select** is not. Four integration scenarios cover that half, using the harness's own seeding (Rep1 and Rep2 share Team1, Rep3 sits in Team2):

- a team filter reaches every member's records and no other team's;
- `exists: false` selects an unowned record as covered by no team (the owner-in-no-team arm needs a fixture the harness lacks — [#1852](https://github.com/gradionhq/margince-poc-v1/issues/1852));
- an account that is a customer **and** a supplier is selected as a supplier;
- withdrawing that relationship stops it matching.

The fixture uses `supplier` rather than `partner` deliberately, and the comment says why: `partner` carries a product invariant of its own — an account is a partner only while a partner programme row backs it — so borrowing it would make these tests fail for a reason unrelated to the leaf under test. I found that out by having the invariant refuse the write, which is the invariant doing its job.

They live in `linkedleaves_integration_test.go` — named for what unites them, leaves that reach a row other than the one being selected.

## `domain` is deliberately not here

It is the third leaf #1657 listed, and it is **not** a third map entry. The list path folds the caller's value through `values.ParseDomain` before comparing, so a leaf that skipped that would answer nothing for a pasted URL — silently, and under the same field name. Same stored column, two different answers, and the wrong one invisible.

Closing it properly needs either a normalizing field type (a new member in the contract's vocabulary type enum, which #1657 did not anticipate) or an operand transform at the compile boundary. Filed as [#1848](https://github.com/gradionhq/margince-poc-v1/issues/1848) with both options and a recommendation, rather than shipped half-right here.

`make check-backend` green, `make craft-static` green (0 findings), and the four integration scenarios pass against real Postgres.

---

## Review round (craft-reviewer + security-redteam)

Both ran on this diff. The security pass found **no exploitable finding** — row scope holds (`query.go:predicateWhere` is the only execution point and ANDs `auth.ScopeClauseFor`), identifiers come only from Go constants, the `relationship_type` value is a bind parameter, and `neq`/`exists:false` negate the wrapper so a withdrawn row never leaks.

It also corrected a premise **I had wrong in shipped code**: I wrote in [#1837](https://github.com/gradionhq/margince-poc-v1/pull/1837) that "the RLS GUC contract binds it exactly as it binds the base table". Core 0217 (ADR-0091 phase A) retired every policy, and `database.go` says so outright — *"the GUC binds nothing on its own now"*. Verified before acting. Both tenancy comments in this file now name the real model (one organization per installation, ADR-0061) instead of a policy that no longer exists.

The craftsmanship pass found one factual error and several honesty problems, all applied:

| Finding | Applied |
|---|---|
| The "identity, not string" claim was **impossible** — `storekit.Field` is a comparable struct of three strings, so `!=` *is* the string comparison the comment disclaimed | Restated as *definitionally identical*, which is the enforceable invariant; the commit message said it wrong too and is corrected |
| The ownership gate could pass vacuously and checked one direction | Fails on an empty sweep; asserts both directions; mutation-verified both ways |
| The enum non-validation was a gap **rationalized in prose** (rule 5) | Gated by a test, prose cut to one line, systemic gap filed as [#1851](https://github.com/gradionhq/margince-poc-v1/issues/1851) |
| The header narrated the 1000-line test ceiling (rule 4: build-process residue) | Deleted |
| The comment **transcribed** the sibling's SQL, inexactly, ungated | Names the behaviour instead |
| `TestNoTeamSelectsTheRecordsNoTeamCovers` promised an arm its body did not prove | Renamed to `TestAnUnownedRecordIsCoveredByNoTeam`; the missing arm needs a teamless seat the shared harness lacks — [#1852](https://github.com/gradionhq/margince-poc-v1/issues/1852), with the blast radius spelled out |
| The 18-line note sat on the const while describing the var; listed a three-member dial with two leaves | Moved onto the leaf; `unassigned` explained as `owner_id exists:false` |
| Filename described half its contents | `linkedleaves_integration_test.go` |
| Needless local `desired := types` | Dropped |

The security pass's `%s`-verb-count nit is applied as a **sweep over every link field in every engine** rather than a per-field assertion, so a new link leaf is covered the day it lands. Mutation-verified.

One judgment call I did **not** take: adding a teamless seat to `integration.Setup` to close that test arm here. Four suites count `app_user` rows, so it belongs in its own change with the full lane behind it.
