### PR TITLE
fix(ai-models): the reindex estimate prices one corpus, not one per workspace

### DIFF
--- a/backend/internal/compose/costestimate/embedreindex.go
+++ b/backend/internal/compose/costestimate/embedreindex.go
@@ -98,7 +98,8 @@ func NewEmbedReindexEstimator(pending PendingReader, rates RateResolver, model E
 // EstimateEmbedReindex prices what starting a fleet-wide reindex now would
 // touch: one Row per live tenant workspace carrying its pending entities,
 // pending tokens, priced cost (nil when unrated), and budget-impact
-// disclosure, plus the fleet total folding every workspace's figures.
+// disclosure, plus the installation's own total — which is NOT the sum of the
+// rows; see installationTotal.
 // currentIdentity is the live embed binding's provider/model@dims (Task 9) —
 // the same string PendingByWorkspace/TokenSumByWorkspace key their pending
 // set on. Every port read propagates its error (never swallowed).
@@ -119,43 +120,68 @@ func (e *EmbedReindexEstimator) EstimateEmbedReindex(ctx context.Context, curren
 	today := e.clock.Now()
 
 	perWorkspace = make([]Row, 0, len(counts))
-	var totalEntities int
-	var totalTokens, totalCostMinor int64
-	pricedRows := 0
-	anyPendingUnrated := false
-
 	for _, wsID := range sortedWorkspaceIDs(counts) {
 		row, err := e.priceWorkspaceRow(ctx, wsID, counts[wsID], tokens[wsID], ref, bound, today)
 		if err != nil {
 			return nil, Row{}, err
 		}
 		perWorkspace = append(perWorkspace, row)
-
-		totalEntities += row.Entities
-		totalTokens += row.Tokens
-		if row.CostMinor != nil {
-			totalCostMinor += *row.CostMinor
-			pricedRows++
-		} else if row.Entities > 0 {
-			// A workspace with real pending work but no resolvable rate means
-			// the fleet total would be a PARTIAL cost — presenting it as the
-			// whole understates the spend. Suppress the total cost rather than
-			// fabricate completeness (the same never-fabricated-0 honesty the
-			// per-row field already keeps).
-			anyPendingUnrated = true
-		}
 	}
+	return perWorkspace, installationTotal(perWorkspace), nil
+}
 
-	total = Row{
-		Entities: totalEntities,
-		Tokens:   totalTokens,
+// installationTotal is the estimate for the whole installation, and it is
+// deliberately NOT the sum of the rows.
+//
+// Since ADR-0091 §8 phase D no embeddable entity carries a tenant, so every row
+// counts and prices the SAME corpus — one pass rebuilds it and the rest find
+// every row already fresh. Summing reported an installation with two workspaces
+// as having twice the work at twice the cost, and this figure is what an
+// operator reads before confirming the spend.
+//
+// The COST is the one part that can legitimately differ between rows:
+// ai_model_rate is workspace-scoped under RLS, so each row prices the shared
+// corpus against its own sheet. When the priced rows agree there is one price
+// and it is reported; when they disagree the installation has no single price
+// to state, and suppressing it is the same never-fabricate honesty the per-row
+// field already keeps for an unresolvable rate.
+func installationTotal(rows []Row) Row {
+	if len(rows) == 0 {
+		return Row{Currency: currencyUSD, Quality: QualityHeuristic}
+	}
+	// Entities and tokens come from the first row rather than any aggregate:
+	// the rows are the same corpus, so they hold the same numbers.
+	total := Row{
+		Entities: rows[0].Entities,
+		Tokens:   rows[0].Tokens,
 		Currency: currencyUSD,
 		Quality:  QualityHeuristic,
 	}
-	if pricedRows > 0 && !anyPendingUnrated {
-		total.CostMinor = &totalCostMinor
+	for _, row := range rows {
+		if row.CostMinor == nil {
+			// A row with real pending work and no resolvable rate: no price to
+			// agree on, so none is stated — including any a priced row before
+			// it had already set, which would otherwise report one sheet's
+			// figure as the installation's.
+			if row.Entities > 0 {
+				total.CostMinor = nil
+				return total
+			}
+			continue
+		}
+		if total.CostMinor == nil {
+			cost := *row.CostMinor
+			total.CostMinor = &cost
+			continue
+		}
+		if *row.CostMinor != *total.CostMinor {
+			// Two sheets price the same corpus differently. There is no single
+			// installation cost to report.
+			total.CostMinor = nil
+			return total
+		}
 	}
-	return perWorkspace, total, nil
+	return total
 }
 
 // priceWorkspaceRow prices one workspace's share of the estimate: its pending

--- a/backend/internal/compose/costestimate/embedreindex_test.go
+++ b/backend/internal/compose/costestimate/embedreindex_test.go
@@ -5,10 +5,13 @@ package costestimate
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // ---- fakes for the embed-reindex estimate's four ports (no DB; mirrors the
@@ -62,7 +65,7 @@ func testWorkspaceID(b byte) ids.WorkspaceID {
 // zero across this file's scenarios (each one prices from a clean
 // calendar-month baseline), so it is fixed here rather than threaded as
 // a parameter every call site would pass the same value for.
-func newEmbedEstimator(pending fakePending, rates fakeRates, model fakeEmbedModel, budget fakeMonthlyBudget) *EmbedReindexEstimator {
+func newEmbedEstimator(pending fakePending, rates RateResolver, model fakeEmbedModel, budget fakeMonthlyBudget) *EmbedReindexEstimator {
 	return NewEmbedReindexEstimator(pending, rates, model, budget, fakeSpent(0), fixedClock{})
 }
 
@@ -168,14 +171,44 @@ func TestEstimateEmbedReindexUnboundEmbedLaneIsNilCost(t *testing.T) {
 	}
 }
 
-// Case D — two workspaces, only one priced: the fleet total folds BOTH
-// workspaces' entities/tokens, but its cost reflects only the priced share
-// (never a fabricated cost for the unpriced workspace).
-func TestEstimateEmbedReindexFoldsMultipleWorkspacesIntoTotal(t *testing.T) {
+// fakeRatesPerWorkspace prices per workspace, which fakeRates cannot: the
+// estimator resolves a rate inside each workspace's own context, and
+// ai_model_rate is workspace-scoped under RLS. A workspace absent from the map
+// resolves no rate at all, which is the reachable form of two sheets
+// disagreeing about one corpus.
+type fakeRatesPerWorkspace map[ids.WorkspaceID]fakeRates
+
+var errNoWorkspaceInRateContext = errors.New("costestimate test: rate resolved outside a workspace context")
+
+func (f fakeRatesPerWorkspace) RateFor(ctx context.Context, provider, model string, at time.Time) (*ai.ModelRate, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		// The estimator always resolves a rate inside a workspace context, so
+		// an unbound one is a wiring fault in the test rather than a workspace
+		// that happens to price nothing.
+		return nil, errNoWorkspaceInRateContext
+	}
+	return f[ids.From[ids.WorkspaceKind](ws)].RateFor(ctx, provider, model, at)
+}
+
+// Case D — two workspaces over ONE corpus: the total is what the installation
+// will actually rebuild and pay, not the rows added up.
+//
+// The fixture gives both workspaces the same figures because that is what the
+// production reads now return: since ADR-0091 §8 phase D no embeddable entity
+// carries a tenant, so `PendingByWorkspace` holds the same rows under every
+// workspace it enumerates. Summing them said an installation with two
+// workspaces had twice the work at twice the cost, and this figure is what an
+// operator reads before confirming the spend.
+//
+// The assertion is deliberately the arithmetic that must NOT hold — a test
+// pinning only the value would pass against the summing version on any
+// single-workspace fixture, which is exactly how that version survived.
+func TestEstimateEmbedReindexTotalsOneCorpusNotTheSumOfTheRows(t *testing.T) {
 	wsA, wsB := testWorkspaceID(4), testWorkspaceID(5)
 	pending := fakePending{
-		counts: map[ids.WorkspaceID]int{wsA: 4, wsB: 6},
-		tokens: map[ids.WorkspaceID]int64{wsA: 400_000, wsB: 600_000},
+		counts: map[ids.WorkspaceID]int{wsA: 6, wsB: 6},
+		tokens: map[ids.WorkspaceID]int64{wsA: 600_000, wsB: 600_000},
 	}
 	model := fakeEmbedModel{ref: ai.ModelRef{Provider: "gemini", Model: "embed"}, ok: true}
 	rates := fakeRates{rateKey("gemini", "embed"): pricedRate}
@@ -188,16 +221,109 @@ func TestEstimateEmbedReindexFoldsMultipleWorkspacesIntoTotal(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("len(rows) = %d, want 2", len(rows))
 	}
-	if total.Entities != 10 {
-		t.Fatalf("total.Entities = %d, want 10 (4+6 folded)", total.Entities)
+	if total.Entities != 6 {
+		t.Fatalf("total.Entities = %d, want 6 — the corpus once, not once per workspace", total.Entities)
 	}
-	if total.Tokens != 1_000_000 {
-		t.Fatalf("total.Tokens = %d, want 1000000 (400000+600000 folded)", total.Tokens)
+	if total.Tokens != 600_000 {
+		t.Fatalf("total.Tokens = %d, want 600000 — the corpus once", total.Tokens)
 	}
-	wantAMinor := ai.PriceCall(ai.Usage{TokensIn: 400_000}, *pricedRate) / microsPerMinor
-	wantBMinor := ai.PriceCall(ai.Usage{TokensIn: 600_000}, *pricedRate) / microsPerMinor
-	if total.CostMinor == nil || *total.CostMinor != wantAMinor+wantBMinor {
-		t.Fatalf("total.CostMinor = %v, want %d", total.CostMinor, wantAMinor+wantBMinor)
+	if total.Entities == rows[0].Entities+rows[1].Entities {
+		t.Fatalf("total.Entities = %d is the sum of the rows, and the rows are the same corpus", total.Entities)
+	}
+	wantMinor := ai.PriceCall(ai.Usage{TokensIn: 600_000}, *pricedRate) / microsPerMinor
+	if total.CostMinor == nil || *total.CostMinor != wantMinor {
+		t.Fatalf("total.CostMinor = %v, want %d (both sheets price the one corpus the same)", total.CostMinor, wantMinor)
+	}
+}
+
+// The cost is the one figure two workspaces can legitimately disagree on:
+// ai_model_rate is workspace-scoped under RLS, so each prices the shared corpus
+// against its own sheet. With no single price to state, none is stated — the
+// same never-fabricate honesty the per-row field keeps for an unresolvable rate.
+func TestEstimateEmbedReindexWithholdsACostTwoRateSheetsDisagreeOn(t *testing.T) {
+	wsA, wsB := testWorkspaceID(7), testWorkspaceID(8)
+	pending := fakePending{
+		counts: map[ids.WorkspaceID]int{wsA: 6, wsB: 6},
+		tokens: map[ids.WorkspaceID]int64{wsA: 600_000, wsB: 600_000},
+	}
+	model := fakeEmbedModel{ref: ai.ModelRef{Provider: "gemini", Model: "embed"}, ok: true}
+	// wsB resolves no rate at all, which is the reachable form of disagreement:
+	// one sheet prices the corpus and the other cannot.
+	rates := fakeRatesPerWorkspace{wsA: fakeRates{rateKey("gemini", "embed"): pricedRate}}
+	e := newEmbedEstimator(pending, rates, model, fakeMonthlyBudget(1_000_000))
+
+	_, total, err := e.EstimateEmbedReindex(context.Background(), "gemini/embed@1024")
+	if err != nil {
+		t.Fatalf("EstimateEmbedReindex: %v", err)
+	}
+	if total.Entities != 6 {
+		t.Fatalf("total.Entities = %d, want 6 — the corpus is the corpus whatever it costs", total.Entities)
+	}
+	if total.CostMinor != nil {
+		t.Fatalf("total.CostMinor = %d, want none: one workspace prices this corpus and the other cannot, "+
+			"so there is no installation price to state", *total.CostMinor)
+	}
+}
+
+// Two sheets that BOTH price the shared corpus, at different rates. This is the
+// case the "no single installation price" rule was written for — the sibling
+// above only covers one sheet pricing and one unable to, which a rule that
+// merely propagated the first non-nil cost would also pass.
+func TestEstimateEmbedReindexWithholdsACostTwoSheetsPriceDifferently(t *testing.T) {
+	wsA, wsB := testWorkspaceID(9), testWorkspaceID(10)
+	pending := fakePending{
+		counts: map[ids.WorkspaceID]int{wsA: 6, wsB: 6},
+		tokens: map[ids.WorkspaceID]int64{wsA: 600_000, wsB: 600_000},
+	}
+	dearerRate := &ai.ModelRate{InputPerMTokMicroUSD: 9_000_000, OutputPerMTokMicroUSD: 9_000_000}
+	model := fakeEmbedModel{ref: ai.ModelRef{Provider: "gemini", Model: "embed"}, ok: true}
+	rates := fakeRatesPerWorkspace{
+		wsA: fakeRates{rateKey("gemini", "embed"): pricedRate},
+		wsB: fakeRates{rateKey("gemini", "embed"): dearerRate},
+	}
+	e := newEmbedEstimator(pending, rates, model, fakeMonthlyBudget(100_000_000))
+
+	rows, total, err := e.EstimateEmbedReindex(context.Background(), "gemini/embed@1024")
+	if err != nil {
+		t.Fatalf("EstimateEmbedReindex: %v", err)
+	}
+	// The premise: the rows really do disagree, so the assertion below is about
+	// the rule and not about two rows that happened to match.
+	if rows[0].CostMinor == nil || rows[1].CostMinor == nil || *rows[0].CostMinor == *rows[1].CostMinor {
+		t.Fatalf("the fixture's two sheets priced the corpus the same (%v, %v); this case needs them to differ",
+			rows[0].CostMinor, rows[1].CostMinor)
+	}
+	if total.CostMinor != nil {
+		t.Errorf("total.CostMinor = %d, want none: two sheets price this one corpus differently, "+
+			"so there is no installation price — reporting either sheet's figure states one tenant's "+
+			"rate as the installation's", *total.CostMinor)
+	}
+	if total.Entities != 6 {
+		t.Errorf("total.Entities = %d, want 6 — the corpus is the corpus whatever it costs", total.Entities)
+	}
+}
+
+// A workspace with nothing pending and no rate does not withhold the price: it
+// has no share of this corpus to disagree about, so the priced rows still speak
+// for the installation.
+func TestEstimateEmbedReindexIgnoresAnEmptyWorkspaceWithoutARate(t *testing.T) {
+	wsA, wsB := testWorkspaceID(11), testWorkspaceID(12)
+	pending := fakePending{
+		counts: map[ids.WorkspaceID]int{wsA: 6, wsB: 0},
+		tokens: map[ids.WorkspaceID]int64{wsA: 600_000, wsB: 0},
+	}
+	model := fakeEmbedModel{ref: ai.ModelRef{Provider: "gemini", Model: "embed"}, ok: true}
+	rates := fakeRatesPerWorkspace{wsA: fakeRates{rateKey("gemini", "embed"): pricedRate}}
+	e := newEmbedEstimator(pending, rates, model, fakeMonthlyBudget(1_000_000))
+
+	_, total, err := e.EstimateEmbedReindex(context.Background(), "gemini/embed@1024")
+	if err != nil {
+		t.Fatalf("EstimateEmbedReindex: %v", err)
+	}
+	wantMinor := ai.PriceCall(ai.Usage{TokensIn: 600_000}, *pricedRate) / microsPerMinor
+	if total.CostMinor == nil || *total.CostMinor != wantMinor {
+		t.Fatalf("total.CostMinor = %v, want %d — an empty workspace has no share to disagree about",
+			total.CostMinor, wantMinor)
 	}
 }
 


### PR DESCRIPTION
Fixes #1738, per the decision recorded there.

`EstimateEmbedReindex` summed its per-workspace rows into the fleet total. Since
ADR-0091 §8 phase D no embeddable entity carries a tenant, so every row counts
and prices the **same corpus** — one pass rebuilds it and the rest find every row
already fresh. The sum reported an installation with two workspaces as having
twice the work at twice the cost, and that figure is what an operator reads
before confirming the spend.

The contract fields stay; what fills them changes. Entities and tokens come from
one row, because the rows hold the same numbers.

## The cost is the part that can legitimately differ

`ai_model_rate` is workspace-scoped under RLS, so each row prices the shared
corpus against its own sheet. When the priced rows agree there is one price and
it is reported; when they disagree the installation has no single price to state,
and none is — the same never-fabricate honesty the per-row field already keeps
for an unresolvable rate.

## Writing that test found a real bug in my own first fix

A priced row set the total's cost, and a later unpriced row returned early
**without clearing it** — reporting one sheet's figure as the installation's. The
case that caught it is the two-sheets-disagree one, which the summing version
never had to answer, so it could not have been carried over.

## The other assertion is the arithmetic that must not hold

```go
if total.Entities == rows[0].Entities+rows[1].Entities {
    t.Fatalf("total.Entities = %d is the sum of the rows, and the rows are the same corpus", ...)
}
```

A test pinning only the value would pass against the summing version on any
single-workspace fixture — which is exactly how that version survived in the
status transport after the store stopped doing it (#1767). The old Case D also
had to change premise, not just numbers: its fixture gave two workspaces
*different* counts, which the production reads can no longer return.

## Verification

- `make check-backend` — exit 0
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prices embed reindex as one corpus across workspaces. Previously `EstimateEmbedReindex` summed per-workspace rows into the installation total; now the total reflects a single corpus, and a cost is shown only when all priced rows agree.

- Introduces `installationTotal(rows []Row)` and updates `EstimateEmbedReindex` to use it. Entities/tokens come from one row; cost is set only if every priced row matches; any unpriced row with pending work suppresses the cost; empty unpriced workspaces are ignored.
- Fixes a bug that left a stale total cost after encountering an unpriced row. Response shape is unchanged. Tests add “one corpus, not sum,” “rate sheets disagree (including one unpriced),” and “ignore empty workspace without a rate,” plus `fakeRatesPerWorkspace` for workspace-scoped `ai_model_rate`.

<sup>Written for commit 1ed53d1a99076a6b13e3603baeb325f60020288e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

