### PR TITLE
fix(migrations): main is red — the traversal indexes bound their lock wait

### DIFF
--- a/backend/migrations/core/1787133348_relationship_traversal_indexes.down.sql
+++ b/backend/migrations/core/1787133348_relationship_traversal_indexes.down.sql
@@ -1,3 +1,9 @@
+-- Dropping needs ACCESS EXCLUSIVE on `relationship`, which is stronger than the
+-- build's lock: the drop itself is instant, but the WAIT for it is not bounded
+-- without this, and a queued ACCESS EXCLUSIVE blocks every reader and writer
+-- behind it. Same three seconds, same reason as the up migration.
+SET LOCAL lock_timeout = '3s';
+
 DROP INDEX IF EXISTS idx_rel_traverse_project;
 DROP INDEX IF EXISTS idx_rel_traverse_deal;
 DROP INDEX IF EXISTS idx_rel_traverse_organization;

--- a/backend/migrations/core/1787133348_relationship_traversal_indexes.up.sql
+++ b/backend/migrations/core/1787133348_relationship_traversal_indexes.up.sql
@@ -28,6 +28,15 @@
 -- the modules issue (a person's employment list, an account's contact count),
 -- and the planner picks between them.
 
+-- The build takes SHARE on `relationship`, which blocks every writer to it for
+-- the duration. lock_timeout bounds only the WAIT for that lock, not the build:
+-- without it, one long-open transaction holding a conflicting lock leaves this
+-- migration queued forever and every write to the table queued behind it — the
+-- deploy the index is meant to improve becomes the deploy that stalls the table.
+-- Three seconds, matching core/0139, 0147 and 0165: take it in a quiet moment
+-- or fail fast and loud so an operator retries in one.
+SET LOCAL lock_timeout = '3s';
+
 CREATE INDEX idx_rel_traverse_person ON relationship (person_id)
   WHERE archived_at IS NULL;
 CREATE INDEX idx_rel_traverse_organization ON relationship (organization_id)


### PR DESCRIPTION
**`main` is RED. This is the fix.** Reproduced against `origin/main`:

```
--- FAIL: TestEveryMigrationTakingABlockingLockBoundsHowLongItWaits/core
    core/1787133348_relationship_traversal_indexes.up.sql   takes a lock that blocks writers
    core/1787133348_relationship_traversal_indexes.down.sql on a table it did not create,
                                                           and never bounds the wait.
```

## How it happened

Two PRs landed within minutes of each other, from different branches, and neither run saw the other:

- **#1831** added `core/1787133348_relationship_traversal_indexes` — four indexes on `relationship`.
- The **#1806** work added `TestEveryMigrationTakingABlockingLockBoundsHowLongItWaits`, which refuses exactly that migration.

Each was green on its own branch. The collision only exists on `main`, which is the failure mode a per-branch gate cannot see — and the reason `main`'s own tip is what gets gated.

## The finding is real, not a strict gate

The index build takes `SHARE` on `relationship`; the drop takes `ACCESS EXCLUSIVE`.

`lock_timeout` bounds the **wait**, not the work. Without it, one long-open transaction holding a conflicting lock leaves the migration queued indefinitely — and every write to `relationship` queued behind it. The deploy the index is meant to speed up becomes the deploy that stalls the table it indexes.

Three seconds, matching `core/0139`, `0147` and `0165`, which set the convention and explain it: take the lock in a quiet moment, or fail fast and loud so an operator retries in one. Both directions, because the down migration's lock is the stronger of the two.

## Disclosure

I wrote this fix on #1831's branch **before** that PR merged, and it did not reach it — #1831 merged while the fix was still local, so it stranded on a branch whose PR had already closed. That is my error: I should have confirmed the PR was still open before pushing, and I should not have been pushing to a branch whose merge I had stopped tracking. Cherry-picked here against `origin/main`, where the gate passes.

## Verification

- `go test ./migrations/` green against `origin/main` + this change (it fails without it — reproduced above).
- No behaviour change to the indexes themselves; the only difference is the bounded wait.

Refs #1776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds lock wait for the relationship traversal index migrations to prevent table-wide stalls and make main green. Previously the create/drop waited indefinitely for locks; now both set SET LOCAL lock_timeout = '3s' and fail fast if a conflicting lock is held.

- Applies to both up (SHARE on relationship) and down (ACCESS EXCLUSIVE) migrations; index definitions are unchanged.
- Aligns with the migration gate that requires bounded lock waits and with prior migrations (core/0139, 0147, 0165).
- Rollout: run migrations normally. If they fail after 3s, retry during a quiet window. No other actions.

<sup>Written for commit dd4411636d26c0589304a740cfda120b7ec394f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

