### PR TITLE
fix(capture): the two capture-path writers carry the rest of the write shape

### DIFF
--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -69,17 +70,27 @@ func organizationIsLive(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 // employment that already exists. The NOT EXISTS keeps a concurrent race with
 // the first from surfacing as a 500.
 func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyInput, personID ids.PersonID, orgID ids.OrganizationID) error {
-	if _, err := tx.Exec(ctx, `
+	var edgeID ids.UUID
+	err := tx.QueryRow(ctx, `
 		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
 		SELECT 'employment', $1, $2, true, $3, $4
 		WHERE NOT EXISTS (
 			SELECT 1 FROM relationship
 			WHERE kind = 'employment' AND person_id = $1 AND is_current_primary AND archived_at IS NULL)
-		ON CONFLICT DO NOTHING`,
-		personID, orgID, in.Source, in.CapturedBy); err != nil {
+		ON CONFLICT DO NOTHING
+		RETURNING id`,
+		personID, orgID, in.Source, in.CapturedBy).Scan(&edgeID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Either guard skipped it: the person already has a current primary
+		// employer, or this exact edge already exists. Nothing was written, so
+		// nothing is audited and nothing is published — a no-op must not mint
+		// history.
+		return nil
+	}
+	if err != nil {
 		return fmt.Errorf("people: insert employment edge: %w", err)
 	}
-	return nil
+	return auditCapturedEmployment(ctx, tx, edgeID, personID, orgID)
 }
 
 // adoptDispositionForOrg settles a domain onto the organization that already
@@ -151,3 +162,44 @@ func (s *Store) deferOrgToTriage(ctx context.Context, tx pgx.Tx, in EnsureCounte
 	res.TriagePending, res.TriageDomain = opened, base
 	return nil
 }
+
+// auditCapturedEmployment records an employment CAPTURE planted, and tells the
+// bus about it — the write shape's other two rows, in the same transaction as
+// the edge.
+//
+// The envelope is the anchor's own person.updated, exactly as a human-created
+// relationship uses, because that is what a relationship change publishes here:
+// there is no separate "employment created" kind to collide with. What the
+// delta carries that a human's does not is `origin: "capture"`. A consumer that
+// treats an employer as a fact somebody asserted can then tell an inference
+// from a statement, which is the whole difference between the two paths — and
+// it can do so without every existing consumer of person.updated changing.
+func auditCapturedEmployment(ctx context.Context, tx pgx.Tx, edgeID ids.UUID, personID ids.PersonID, orgID ids.OrganizationID) error {
+	auditID, err := storekit.Audit(ctx, tx, actionCreate, "relationship", edgeID, nil, map[string]any{
+		relationshipKindField: employmentKind, "origin": relationshipOriginCapture,
+	})
+	if err != nil {
+		return fmt.Errorf("people: audit the captured employment edge: %w", err)
+	}
+	delta := map[string]any{
+		eventKeyDelta: map[string]any{"relationship": map[string]any{
+			"id": edgeID, relationshipKindField: employmentKind, "action": actionCreate,
+			"organization_id": orgID, "origin": relationshipOriginCapture,
+		}},
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, personID.UUID,
+		relationshipUpdatedPayload("person", delta)); err != nil {
+		return fmt.Errorf("people: publish the captured employment edge: %w", err)
+	}
+	return nil
+}
+
+// relationshipOriginCapture marks an edge the capture path inferred rather than
+// one a human asserted. Spelled once because the audit row and the event delta
+// must agree — a reader comparing the two would otherwise have to decide which
+// spelling was authoritative.
+const relationshipOriginCapture = "capture"
+
+// employmentKind is the relationship kind this file plants, spelled once so the
+// SQL, the audit row and the event delta cannot drift apart.
+const employmentKind = "employment"

--- a/backend/internal/modules/people/ensure.go
+++ b/backend/internal/modules/people/ensure.go
@@ -364,15 +364,34 @@ func recordDedupeCandidate(ctx context.Context, tx pgx.Tx, entityType string, a,
 	case entityLead:
 		leftCol, rightCol = "left_lead_id", "right_lead_id"
 	}
-	tag, err := tx.Exec(ctx, fmt.Sprintf(`
+	var candidateID ids.UUID
+	err = tx.QueryRow(ctx, fmt.Sprintf(`
 		INSERT INTO dedupe_candidate (entity_type, %s, %s, confidence, evidence, source, captured_by)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		ON CONFLICT DO NOTHING`, leftCol, rightCol),
-		entityType, left, right, confidence, payload, source, by)
+		ON CONFLICT DO NOTHING
+		RETURNING id`, leftCol, rightCol),
+		entityType, left, right, confidence, payload, source, by).Scan(&candidateID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// This pair is already proposed. Nothing was written, so nothing is
+		// audited — a no-op must not mint history.
+		return false, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("people: recording dedupe candidate: %w", err)
 	}
-	return tag.RowsAffected() > 0, nil
+	// Audited, NOT published. A dedupe candidate is a question the system is
+	// asking about two records, not something that happened to either — nothing
+	// downstream acts on one, and an outbox row nobody consumes would be an
+	// event kind invented to satisfy a rule rather than a reader. What the
+	// audit row buys is the part that was actually missing: who proposed this
+	// merge, when, and on what evidence, on the record's own history rather
+	// than only in operator telemetry.
+	if _, err := storekit.Audit(ctx, tx, "create", "dedupe_candidate", candidateID, nil, map[string]any{
+		"entity_type": entityType, "confidence": confidence, auditKeySource: source,
+	}); err != nil {
+		return false, fmt.Errorf("people: audit the dedupe candidate: %w", err)
+	}
+	return true, nil
 }
 
 // nameColumn renders a parsed name part for the nullable split-name columns.

--- a/backend/internal/modules/people/ensure_edges_integration_test.go
+++ b/backend/internal/modules/people/ensure_edges_integration_test.go
@@ -122,6 +122,77 @@ func TestEnsureCounterpartyAttachesToAnOrganizationThatAlreadyExists(t *testing.
 	}
 }
 
+// The write shape on the capture path: an employment edge capture plants is a
+// domain row, an audit_log row and an event_outbox row in ONE transaction, and
+// a re-ensure that plants nothing writes none of the three.
+//
+// Both halves matter. Without the first, an employer appears on a contact with
+// nothing recording who attached it or on what evidence — and an employer is a
+// fact a human reads off the record and can be wrong about. Without the second,
+// every repeated capture of the same mail would mint history for a write that
+// did not happen, which is the failure ON CONFLICT DO NOTHING exists to avoid.
+func TestCapturedEmploymentCarriesTheWriteShapeAndANoOpCarriesNothing(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Write Shape GmbH", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "writeshape.test", IsPrimary: true}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, "erin@writeshape.test", "Erin Example", "writeshape.test"))
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	audits, events := ledgerRowsForRelationship(ctx, t, e, res.PersonID.UUID)
+	if audits != 1 {
+		t.Errorf("%d audit_log rows for the planted employment, want 1 — nothing records who attached this employer", audits)
+	}
+	if events != 1 {
+		t.Errorf("%d event_outbox rows for the planted employment, want 1 — no consumer is told the edge appeared", events)
+	}
+
+	// The same mail again: both guards refuse the insert, so neither ledger
+	// moves. Asserting the delta rather than a total is what makes this about
+	// the no-op rather than about the first call.
+	if _, err := e.store.EnsureCounterparty(ctx, e.ensureInput(ctx, t, "erin@writeshape.test", "Erin Example", "writeshape.test")); err != nil {
+		t.Fatalf("re-ensure: %v", err)
+	}
+	againAudits, againEvents := ledgerRowsForRelationship(ctx, t, e, res.PersonID.UUID)
+	if againAudits != audits || againEvents != events {
+		t.Errorf("a re-ensure that planted no edge still wrote history: audit %d→%d, outbox %d→%d",
+			audits, againAudits, events, againEvents)
+	}
+}
+
+// ledgerRowsForRelationship counts what the two ledgers hold for the employment
+// edges of one person. The join to relationship is what keeps this counting the
+// edge's own rows rather than everything the ensure wrote.
+func ledgerRowsForRelationship(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.UUID) (audits, events int) {
+	t.Helper()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		// The outbox carries no audit_id column — the link lives inside the
+		// envelope — so the event side matches on the edge id appearing in the
+		// envelope text. Crude, and adequate here because the id is a v7 UUID
+		// minted for this row: nothing else in a fresh fixture carries it.
+		return tx.QueryRow(ctx, `
+			SELECT (SELECT count(*) FROM audit_log a
+			          JOIN relationship r ON r.id = a.entity_id
+			         WHERE a.entity_type = 'relationship' AND r.person_id = $1 AND r.kind = 'employment'),
+			       (SELECT count(*) FROM event_outbox o
+			         WHERE EXISTS (
+			           SELECT 1 FROM relationship r
+			            WHERE r.person_id = $1 AND r.kind = 'employment'
+			              AND o.envelope::text LIKE '%' || r.id || '%'))`,
+			personID).Scan(&audits, &events)
+	}); err != nil {
+		t.Fatalf("counting the edge's ledger rows: %v", err)
+	}
+	return audits, events
+}
+
 func TestEnsureCounterpartyAsksNothingAboutConsumerMail(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()

--- a/backend/writeshape_test.go
+++ b/backend/writeshape_test.go
@@ -147,6 +147,7 @@ var auditOnlyWrites = gatekit.Waive(map[string]string{
 	"internal/compose/briefs:SnapshotRun":                   "the brief read model is ratified audit-only \u2014 the closed catalog (events.md \u00a75) defines no brief.* type and the closed-verb law forbids inventing one build-side",
 	"internal/compose/briefs:markItem":                      "the brief read model is ratified audit-only \u2014 the closed catalog (events.md \u00a75) defines no brief.* type and the closed-verb law forbids inventing one build-side",
 	"internal/compose/briefs:resurfaceExpiredSnoozes":       "the brief read model is ratified audit-only \u2014 the closed catalog (events.md \u00a75) defines no brief.* type and the closed-verb law forbids inventing one build-side",
+	"internal/modules/people:recordDedupeCandidate":         "a dedupe candidate is a QUESTION the system is asking about two records, not something that happened to either \u2014 the closed catalog (events.md \u00a75) defines no dedupe.* type, nothing downstream acts on a proposal, and an outbox row nobody consumes would be a kind invented to satisfy the rule rather than a reader. Audited because who proposed a merge, when, and on what evidence belongs on the record's own history rather than only in operator telemetry",
 	// WriteFiltered no longer belongs here: the bulk export is a non-entity
 	// operational event, so it moved from storekit.Audit to storekit.LogSystem
 	// (system_log, 0074) \u2014 it writes no audit_log row at all now.


### PR DESCRIPTION
Fixes #1745, per the decision recorded there.

`plantEmploymentEdge` committed a `relationship` row with no `audit_log` and no
`event_outbox` row. An employer is a fact a human reads off the contact and can
be wrong about, and nothing recorded who attached it or on what evidence.

## The event is the anchor's own `person.updated`, not a new kind

That is what a relationship change already publishes here — there is **no
separate "employment created" type** to collide with, which makes the vocabulary
risk in #1745 smaller than it looked. No existing consumer changes.

What the delta carries that a human-created edge's does not is
`origin: "capture"`. A consumer that treats an employer as something somebody
*asserted* can then tell an inference from a statement — the whole difference
between the two paths — without every consumer of `person.updated` changing.

## The dedupe candidate is audited and deliberately not published

Ratified in `auditOnlyWrites` with its reason. There is already a fitness test —
`TestEveryAuditedMutationEmitsAnEvent` — asserting audit ⇒ emit, with a ratified
exception list; that is exactly the right home for this, and I would not have
found it without the gate firing.

A dedupe candidate is a **question** about two records rather than something that
happened to either; the closed catalog defines no `dedupe.*` type, and an outbox
row nobody consumes would be a kind invented to satisfy the rule rather than a
reader. The audit row is the part that was missing — who proposed a merge, when,
on what evidence, on the record's own history instead of only in operator
telemetry.

## Both halves gate on a row actually landing

Both inserts are `ON CONFLICT DO NOTHING`, so both now `RETURNING id` and write
the ledger rows only when a row landed. A no-op must not mint history, and the
test asserts that half as a **delta**: a re-ensure that plants nothing moves
neither ledger.

**Verified by removing the emit and re-running:** the new test fails and nothing
else does.

## Note on `main`

`TestEveryMigrationTakingABlockingLockBoundsHowLongItWaits` fails on `main`
today — `core/1787133348_relationship_traversal_indexes` (#1831) takes a
blocking lock without `SET LOCAL lock_timeout`. Confirmed by stashing this
branch and re-running. Not from this PR, and it will fail this PR's
`deterministic-gates` too until it is fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture writes now carry the full write shape. Planting an employment edge audits and emits the anchor’s person.updated with origin: "capture"; recording a dedupe candidate is audited only and not published. This makes capture writes traceable without inventing new event kinds and avoids minting history on no-ops.

- Employment edge: insert the relationship, then in the same transaction write audit_log and emit person.updated with a relationship delta (id, kind, action: create, organization_id, origin: "capture"). No new event type; existing consumers continue to read person.updated.
- Dedupe candidate: insert returns id and is audited as dedupe_candidate (entity_type, confidence, source); not published and added to `auditOnlyWrites`.
- No-ops: both inserts use ON CONFLICT DO NOTHING RETURNING id; audit/emit only when a row lands.
- Tests: integration test asserts one audit and one outbox row on first capture, and no additional rows on re-ensure.
- Rollout: no schema or consumer changes. Consumers may optionally read origin: "capture" to distinguish inference from assertion.

<sup>Written for commit 5796b252595c5587de8373e6177ade87968c00f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Audit & Activity**
  - Employment relationships created through capture now include audit history and activity updates.
  - Duplicate or no-op employment captures no longer generate audit records or activity events.
  - Newly detected duplicate candidates are audited with source and confidence details.

- **Reliability**
  - Added integration coverage to verify accurate audit and activity records for initial and repeated captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->