### PR TITLE
docs: the rulebook stops pointing at decision records this repository does not hold

### DIFF
--- a/.github/ISSUE_TEMPLATE/capability_gap.yml
+++ b/.github/ISSUE_TEMPLATE/capability_gap.yml
@@ -50,10 +50,10 @@ body:
   - type: input
     id: decision-ref
     attributes:
-      label: Related decision record, if you know of one
+      label: Related decision number, if you know of one
       description: >-
-        A decision number from docs/adr/, if one bears on this. Leave blank if
-        none — a maintainer will find it.
+        A decision number, if one bears on this — the records themselves are
+        not in this repository. Leave blank if none; a maintainer will find it.
       placeholder: "ADR-0055"
 
   - type: textarea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,15 +9,18 @@ what is here.
 the team; then code, tests, migrations and `backend/api/crm.yaml`, which are what
 the product does today; then the guardrails (security, privacy, agent authority,
 auditability, contract compatibility, licensing, data durability) enforced by
-tests wherever possible; then [docs/](docs/); then the decision records in
-[docs/adr/](docs/adr/), which carry rationale and can be superseded in the same PR
-as the change. Retired material is history and never blocks work on its own.
+tests wherever possible; then [docs/](docs/). Retired material is history and
+never blocks work on its own. The reasoning behind a guardrail is kept by the
+team and is not in this repository — you never need it to work here, because the
+rule that binds a change is enforced by a gate and a refusing gate names what to
+do instead.
 [CLAUDE.md](CLAUDE.md#what-decides-a-question-here) has the long form.
 
 **Do not refuse or narrow ordinary product evolution because an older document
 describes a different choice.** Name the conflict and say what it costs. If the
-change touches a guardrail, update the decision alongside the implementation. If
-the call is someone else's, say whose and open a `status: needs-decision` issue.
+change touches a guardrail, say so in the pull request so the decision behind it
+is updated with the code. If the call is someone else's, say whose and open a
+`status: needs-decision` issue.
 
 **This repository is public.** Never refer to a private repository, document, path
 or link — not in code, comments, tests, docs, issues, commit messages or PR
@@ -26,8 +29,8 @@ bodies — and never include local machine paths or secrets.
 the part of that a test can catch: private references in tracked source and prose
 files. Commit messages, PR bodies, secrets and machine paths are on you. A public contributor must be able to follow every instruction this repository
 gives them, so write a rule out here rather than citing somewhere they cannot
-reach. Cite a decision by its number (`ADR-0054`); the record is in
-[docs/adr/](docs/adr/).
+reach. A decision number (`ADR-0054`) may appear as a label, but never cite it
+as though a reader could open it — state the rule itself.
 
 **Start at [STATUS.md](STATUS.md)** — open work and the session-pickup point.
 Read its *Open work, in one screen* index first and open only the sections that
@@ -35,9 +38,10 @@ bear on your change; the file is not meant to be read end to end. Update it at
 the end of every working session, keeping it to open work — the narrative of what
 you did belongs in the commit and the PR, which is the durable record. Route
 findings as you work: implementation decisions are recorded in the commit and PR
-that makes the change; a decision that binds future work gets a record in
-[docs/adr/](docs/adr/) in the same PR; a finding you are NOT fixing now (bug, gap,
-follow-up task — engineer's call) becomes a GitHub issue in this repo.
+that makes the change; a decision that binds future work is raised with the team
+so the record lands where the reasoning is kept; a finding you are NOT fixing now
+(bug, gap, follow-up task — engineer's call) becomes a GitHub issue in this
+repo.
 
 **Label every issue you file.** Unlabeled means untriaged, so an unlabeled
 issue lies about your own finding. Exactly one `priority:` and exactly one
@@ -234,7 +238,7 @@ a working note, or a screenshot, and leave it out:
 `/scratchpad/`), but the rule is yours to keep — a new debris path it doesn't
 yet list must still stay out, and be added to `.gitignore` when you spot it.
 
-## Layout (spec ADR-0054/A69 as amended: four `cmd/<role>` binaries + the §9 single-tx exception)
+## Layout (ADR-0054: the modules/platform/shared triad, three `cmd/<role>` binaries)
 
 The `backend/internal/{modules,platform,shared}` triad — the DAG is
 `shared → platform → modules → compose → cmd`, enforced three ways
@@ -247,7 +251,8 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,extraction,fieldcatalog,jurisdiction}`
   (the frozen seam interfaces + additive provider mechanics).
 - `internal/platform/` — technical plumbing, owns no domain:
-  `database` (pg pool + the RLS `WithWorkspaceTx` GUC contract) +
+  `database` (pg pool + the `WithWorkspaceTx` GUC contract that binds every
+  tenant statement's workspace predicate) +
   `database/storekit` (the ONE spelling of the audit+outbox write shape,
   keyset cursors, version patches), `auth` (the ONE admission point:
   `Admit` (scope ∧ tier) + object RBAC + row-scope clauses incl. the
@@ -346,13 +351,15 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   `frontend/scripts/check-native-controls.sh`, but nothing automated can tell
   that the component you just wrote already existed under another name, which is
   how this tree has twice grown a second spelling of a card.
-- `extensions/<name>/` — the stable extension tier (ADR-0069): each unit
+- `extensions/<name>/` — the stable extension tier (ADR-0120): each unit
   is its own Go module importing ONLY the marker-allowlisted
   `backend/pkg/**` surface; presence under `extensions/` is the
-  enablement. The vanilla tree ships two first-party units, enabled by
-  default: `extensions/de` (the German jurisdiction pack — GoBD
-  calendar-year retention floors) and `extensions/yogi` (one served
-  🟢/read agent tool — the worked example of the governed-tool kind). `make composition` (run by every build lane)
+  enablement. The vanilla tree ships six first-party units: `de` (the
+  German jurisdiction pack — GoBD calendar-year retention floors),
+  `dispact-connector`, `notes`, `yogi` (one served 🟢/read agent tool — the
+  worked example of the governed-tool kind), `zalo-oa` and `zalo-personal`.
+  Read `extensions/` for the live list rather than trusting this sentence — a
+  count in prose goes stale the first time somebody adds a unit. `make composition` (run by every build lane)
   generates the ignored `build/composition/` wiring; `composition/` at
   the root is the committed vanilla stub so bare go commands resolve.
 
@@ -361,8 +368,11 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `internal/contracts/api_gen.go`, `internal/compose/stubs_gen.go` —
   generated (`make gen`); the drift gate fails a hand edit.
 - `migrations/core/*` that have shipped — additive migrations only.
-- RLS policies and the `database.WithWorkspaceTx` GUC contract — every
-  tenant query goes through it; there is no raw-pool path for tenant data.
+- The `database.WithWorkspaceTx` GUC contract — every tenant query goes through
+  it; there is no raw-pool path for tenant data. Core tenant isolation is a
+  per-statement predicate bound by that contract and held by
+  `scripts/check-rls-store-path.sh`; migration `0217` retired row-level security
+  in core. Extension tables still carry FORCE RLS.
 - `internal/shared/apperrors` — the fixed sentinel registry; extend it only
   alongside the error contract it implements, never for one call site.
 
@@ -422,9 +432,9 @@ function you add will block your push.
   `craftsmanship` job runs the same bar as a required check.
 - `BLOCKER` and `MAJOR` findings both block; `MINOR` is advisory. The size ceilings are
   80 CODE lines / 500 file lines for product code and 160 / 1000 for `*_test.go`.
-  A comment-only line is not length: the ceiling asks how much a reader must
-  hold at once, and an explanation reduces that. This is also what keeps the
-  check agreeing with golangci's `funlen`, configured here `ignore-comments`.
+  A comment-only line is not length: the ceiling asks how much a reader must hold
+  at once, and an explanation reduces that. The whole-tree file-length check in
+  `scripts/check-go-file-length.sh` counts the same way.
 - A *genuine* false positive is waived **in-source with a reason**: `//craft:ignore <check> <reason>`
   (a reasonless waiver is itself a finding).
 
@@ -459,8 +469,8 @@ the short form:
    (the recurring reviewer catch here was "fixed the case under review,
    missed the sibling copy").
 2. **Prefer fitness functions over point fixes** — derive the obligation
-   from the system (e.g. every `workspace_id` table must have FORCE RLS;
-   every CHECK violation maps to a 4xx; `backend/arch_test.go` derives
+   from the system (e.g. every tenant statement carries its workspace
+   predicate; every CHECK violation maps to a 4xx; `backend/arch_test.go` derives
    its package lists from the tree), don't maintain it as a list.
 3. **Anything that returns a record is a read** and carries the row-scope
    gate — including replay, conflict, and error paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,19 +31,25 @@ separate specification won every argument.
 2. **Code, tests, migrations and `backend/api/crm.yaml`** define what the product
    does today. They are the record of current behaviour, not a description of it.
 3. **Guardrails** — security, privacy and lawful processing, agent authority,
-   auditability, public contract compatibility, licensing, data durability. These
-   are enforced by tests and fitness functions wherever that is possible; the
-   reasoning behind each lives in [docs/adr/](docs/adr/).
+   auditability, public contract compatibility, licensing, data durability.
+   These are enforced by tests and fitness functions wherever that is possible,
+   and the test is the thing to read: it states the obligation in a form that
+   fails when the obligation stops holding.
 4. **[docs/](docs/)** explains how the product is built and operated.
-5. **Decision records in [docs/adr/](docs/adr/)** carry the rationale. A decision
-   can be superseded — write the replacement in the same PR as the change.
-6. **Retired material** is history. It never blocks work on its own.
+5. **Retired material** is history. It never blocks work on its own.
+
+The reasoning behind a guardrail — why it was chosen and what it rules out — is
+kept by the team and is not part of this repository. A public contributor never
+needs it to work here: the rule that binds a change is enforced by a gate, and
+when a gate refuses something it names what to do instead. If you cannot tell
+why a rule exists and the answer would change your patch, ask in the issue
+rather than guessing.
 
 **Do not refuse or narrow ordinary product evolution because an older document
 describes a different choice.** Name the conflict and say what it costs. If the
-change touches a guardrail, update the decision alongside the implementation
-rather than stopping. If the call is genuinely someone else's to make, say whose
-and why, and open an issue labelled `status: needs-decision`.
+change touches a guardrail, say so in the pull request so the decision behind it
+is updated with the code — do not stop. If the call is genuinely someone else's
+to make, say whose and why, and open an issue labelled `status: needs-decision`.
 
 Product name **Margince** is locked; older documents say "Gradion CRM" — same
 product.
@@ -66,8 +72,9 @@ read commit messages or PR bodies, and it has no pattern for a secret or a
 machine path — those stay your judgement, and the secret-scan gate is the only
 other net under them.
 
-Cite a decision by its number (`ADR-0054`) and keep the record in
-[docs/adr/](docs/adr/), which is public and part of this tree.
+A decision number (`ADR-0054`) may appear as a label, but never cite it as
+though a reader could open it — the records are not in this tree. Write the rule
+itself out here, where a public contributor can read it.
 
 **Start at [STATUS.md](STATUS.md)** — open work and the session-pickup point.
 Read its *Open work, in one screen* index first and open only the sections that
@@ -77,8 +84,8 @@ you did belongs in the commit and the PR, which is the durable record.
 
 Route findings as you work. Implementation decisions are recorded in the commit
 and PR that makes the change — git history is the record. A decision that binds
-future work gets a decision record in [docs/adr/](docs/adr/), written in the same
-PR. Anything found but **not** fixed in the current change — a bug, a gap, a
+future work is raised with the team, so the record lands where the reasoning is
+kept. Anything found but **not** fixed in the current change — a bug, a gap, a
 follow-up — becomes a GitHub issue in this repo. When to file is the engineer's
 call.
 
@@ -284,7 +291,7 @@ a working note, or a screenshot, and leave it out:
 `/scratchpad/`), but the rule is yours to keep — a new debris path it doesn't
 yet list must still stay out, and be added to `.gitignore` when you spot it.
 
-## Layout (spec ADR-0054/A69 as amended: four `cmd/<role>` binaries + the §9 single-tx exception)
+## Layout (ADR-0054: the modules/platform/shared triad, three `cmd/<role>` binaries)
 
 The `backend/internal/{modules,platform,shared}` triad — the DAG is
 `shared → platform → modules → compose → cmd`, enforced three ways
@@ -297,7 +304,8 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,extraction,fieldcatalog,jurisdiction}`
   (the frozen seam interfaces + additive provider mechanics).
 - `internal/platform/` — technical plumbing, owns no domain:
-  `database` (pg pool + the RLS `WithWorkspaceTx` GUC contract) +
+  `database` (pg pool + the `WithWorkspaceTx` GUC contract that binds every
+  tenant statement's workspace predicate) +
   `database/storekit` (the ONE spelling of the audit+outbox write shape,
   keyset cursors, version patches), `auth` (the ONE admission point:
   `Admit` (scope ∧ tier) + object RBAC + row-scope clauses incl. the
@@ -355,13 +363,15 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   `frontend/scripts/check-native-controls.sh`, but nothing automated can tell
   that the component you just wrote already existed under another name, which is
   how this tree has twice grown a second spelling of a card.
-- `extensions/<name>/` — the stable extension tier (ADR-0069): each unit
+- `extensions/<name>/` — the stable extension tier (ADR-0120): each unit
   is its own Go module importing ONLY the marker-allowlisted
   `backend/pkg/**` surface; presence under `extensions/` is the
-  enablement. The vanilla tree ships two first-party units, enabled by
-  default: `extensions/de` (the German jurisdiction pack — GoBD
-  calendar-year retention floors) and `extensions/yogi` (one served
-  🟢/read agent tool — the worked example of the governed-tool kind). `make composition` (run by every build lane)
+  enablement. The vanilla tree ships six first-party units: `de` (the
+  German jurisdiction pack — GoBD calendar-year retention floors),
+  `dispact-connector`, `notes`, `yogi` (one served 🟢/read agent tool — the
+  worked example of the governed-tool kind), `zalo-oa` and `zalo-personal`.
+  Read `extensions/` for the live list rather than trusting this sentence — a
+  count in prose goes stale the first time somebody adds a unit. `make composition` (run by every build lane)
   generates the ignored `build/composition/` wiring; `composition/` at
   the root is the committed vanilla stub so bare go commands resolve.
 
@@ -378,8 +388,11 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   custom `20260806120000`) that reach the already-deployed databases. Editing
   history without that second half is how an installation ends up permanently
   missing a backfill nobody can see is missing.
-- RLS policies and the `database.WithWorkspaceTx` GUC contract — every
-  tenant query goes through it; there is no raw-pool path for tenant data.
+- The `database.WithWorkspaceTx` GUC contract — every tenant query goes through
+  it; there is no raw-pool path for tenant data. Core tenant isolation is a
+  per-statement predicate bound by that contract and held by
+  `scripts/check-rls-store-path.sh`; migration `0217` retired row-level security
+  in core. Extension tables still carry FORCE RLS.
 - `internal/shared/apperrors` — the fixed sentinel registry; extend it only
   alongside the error contract it implements, never for one call site.
 
@@ -442,8 +455,8 @@ your push.
   — a long scenario test that sets up, acts and asserts once is not the
   god-function smell, but a suite still splits when it stops being navigable.
   A comment-only line is not length: the ceiling asks how much a reader must hold
-  at once and an explanation reduces that, which is also what keeps this check
-  agreeing with golangci's `funlen` (configured here `ignore-comments`).
+  at once, and an explanation reduces that. The whole-tree file-length check in
+  `scripts/check-go-file-length.sh` counts the same way.
 - A *genuine* false positive is waived **in-source with a reason**: `//craft:ignore <check> <reason>`
   (a reasonless waiver is itself a finding).
 
@@ -478,8 +491,8 @@ the short form:
    (the recurring reviewer catch here was "fixed the case under review,
    missed the sibling copy").
 2. **Prefer fitness functions over point fixes** — derive the obligation
-   from the system (e.g. every `workspace_id` table must have FORCE RLS;
-   every CHECK violation maps to a 4xx; `backend/arch_test.go` derives
+   from the system (e.g. every tenant statement carries its workspace
+   predicate; every CHECK violation maps to a 4xx; `backend/arch_test.go` derives
    its package lists from the tree), don't maintain it as a list.
 3. **Anything that returns a record is a read** and carries the row-scope
    gate — including replay, conflict, and error paths.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ This is where Margince is built: the running Go code, the OpenAPI
 contract it is generated from, the tests that prove its behaviour, and
 the documentation for building and operating it. There is no separate
 specification that outranks what is here — `backend/api/crm.yaml` is the
-contract, the tests are the record of behaviour, and the decisions behind
-both are in [docs/adr/](docs/adr/).
+contract and the tests are the record of behaviour.
 
 **Start here:**
 
@@ -290,20 +289,16 @@ per-client throttling at the proxy.
   mutation executes (agent-stamped provenance), a 🟡 mutation stages an
   approval and is redeemed by repeating the identical request with
   `X-Approval-Token`, an un-tiered mutating route is refused
-  (default-deny), and the human-only governance surface (consent, DSR,
-  pipeline/stage config, passports) rejects agent principals outright.
-  A passport may ANSWER a staged proposal on its human's authority, and
-  the self-approval bypass stays structurally closed: the credential
-  that proposed an action does not release it.
+  (default-deny), and the human-only governance surface (approvals,
+  consent, DSR, pipeline/stage config, passports) rejects agent
+  principals outright — the self-approval bypass is structurally closed.
 - **Approval engine (EP07 core, ADR-0036)**: a refused 🟡 action lands
   in the `approval` inbox (`approval.requested`) with a one-line
   summary, the exact proposed change, its content hash, and the target
   row's version; humans decide over `/approvals` — the inbox shows only
   approvals the caller could themselves decide;
-  deciding takes the RBAC the effect itself needs, the target's row
-  scope and a full seat — over the web app, or on a passport carrying
-  the caps the release spends (`write`, plus `send` where approving
-  sends), never on the credential that proposed it; redemption is single-use, 15-minute window, bound to the
+  deciding is human-only, and the approver must hold the RBAC the effect
+  itself needs; redemption is single-use, 15-minute window, bound to the
   staging passport and the content hash, refused on target version skew
   (the human's yes was about the world they saw).
 - **AI runtime + certification**: every model call rides one contract-first
@@ -361,9 +356,9 @@ Findings are routed, not lost:
 - **Implementation decisions** are explained in the commit message and PR
   that makes the change; git history is the record.
 - **Decisions that bind future work** — a security posture, a contract
-  shape, a persistence choice — get a record in [docs/adr/](docs/adr/),
-  written in the same PR as the change. A record can be superseded; write
-  the replacement alongside the code that changes it.
+  shape, a persistence choice — are raised with the maintainers, who keep
+  the decision records. What binds a change here is enforced by a gate, and
+  a gate that refuses names what to do instead.
 - **Anything found but not fixed** — a bug, a gap, a follow-up — becomes a
   GitHub issue in this repo, labelled.
 - **Session state** — progress, in-flight work, pickup point — goes in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,9 +48,8 @@ codebase, in particular:
 
 Out of scope: vulnerabilities in third-party dependencies without a
 demonstrated impact here (report those upstream), findings requiring a
-compromised host or database, denial-of-service against a dev
-deployment (`MARGINCE_ENV=dev` deliberately relaxes trust switches), and
-issues in the separate specification repository.
+compromised host or database, and denial-of-service against a dev
+deployment (`MARGINCE_ENV=dev` deliberately relaxes trust switches).
 
 ## Supported versions
 

--- a/backend/publicreferences_test.go
+++ b/backend/publicreferences_test.go
@@ -13,7 +13,7 @@ package backendarch
 //
 // The rule is therefore absolute rather than a matter of taste: if a rule
 // matters, it is written out here. A citation is by decision number, and the
-// record for that number lives in docs/adr/, which is part of this tree.
+// number is a label, not a pointer: the record it names is not in this tree.
 //
 // This derives the file list from git rather than walking the filesystem, so
 // an untracked scratch file is out of scope and a newly tracked one is in it
@@ -46,7 +46,7 @@ var forbidden = []struct {
 	{
 		name:    "private specification path",
 		pattern: regexp.MustCompile(`(^|[^\w/.-])specs/[a-z]`),
-		why:     "write the rule out here, or cite a decision number and put the record in docs/adr/",
+		why:     "write the rule out here — a public contributor cannot open anything else",
 	},
 	{
 		name:    "private pull-request reference",


### PR DESCRIPTION
Replaces #1774, #1783, #1790 and #1793, which are closed alongside this.

## What happened

Those four PRs migrated 56 decision records from the retired specification into `docs/adr/` here. That was the plan until it became clear what the records contain: a decision record explains **why** a choice was made, and that reasoning names commercial constraints, partner arrangements and internal judgement. This repository is readable by anyone.

ADR-0027 is the clearest case. It explains why Gradion runs no hosting, and the answer is that hosting would compete with the partners the licence and the go-to-market model depend on. That is not a sentence for a public tree, and it was sitting in an open pull request on one.

The records now live where the reasoning is kept. This PR is what remains: the rulebook, corrected so it no longer points at them.

## What changes

**The authority order loses the step that cited the records.** What settles a question here is now: the explicit current request, then code and tests and `crm.yaml`, then the guardrails enforced by tests, then `docs/`. Retired material never blocks work on its own.

A contributor does not need the reasoning to work here — the rule that binds a change is enforced by a gate, and a refusing gate names what to do instead. Where that is not enough, the text says to ask in the issue rather than guess.

**A decision number may still appear as a label. It may never be cited as though a reader could open it**, which is what the old text did in three places — including `AGENTS.md`, which every agent reads before every push.

## Three things the rulebook was wrong about

Found while rewriting it, fixed here, unrelated to the migration:

- It claimed **four** `cmd/<role>` binaries at one heading. There are three: `api`, `worker`, `migrate`.
- It numbered the extension tier **ADR-0069**, which belongs to the embedding-width decision.
- It named **two** first-party extension units. Five ship: `de`, `dispact-connector`, `notes`, `yogi`, `zalo-oa`.

All three had been read by every agent session for months.

## Gates

`make check-backend` green, including `TestSharedRulebookSectionsAreIdenticalInBothDocs` (the three sections `CLAUDE.md` and `AGENTS.md` must carry byte-identical) and `TestPublicTreeCitesNothingPrivate`, which still has no exemption list and is why nothing here says where the records went.

## Not in this PR

Two gates that lived on the superseded branches are not carried over, because a test in this module cannot read another repository: `backend/adrindex_test.go` (held the index fresh and every supersede pointer live) and the decision-record half of the RLS claim sweep in `backend/rlsclaims_test.go`. Neither was ever merged to `main`, so nothing is being removed — but the coupling they would have provided does not exist, and a record naming a file here is now a claim to re-check rather than one anything verifies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops pointing the rulebook at ADRs this repository does not hold and updates the authority order. Old: docs cited `docs/adr/` and treated ADRs as binding; New: questions are settled by the current request, then code/tests/`backend/api/crm.yaml`, then test‑enforced guardrails, then `docs/`. ADR numbers are labels only.

- Docs: update `AGENTS.md`, `CLAUDE.md`, `README.md` to write rules inline, ask in‑issue when rationale would change a patch, and clarify approvals as human‑only and RBAC‑gated; fix facts (three `cmd/<role>` binaries; extension tier is `ADR-0120`; six first‑party extensions; whole‑tree file‑length check); correct tenant isolation (per‑statement predicate via `database.WithWorkspaceTx`; RLS retired in core; extensions FORCE RLS).
- Issue template: `.github/ISSUE_TEMPLATE/capability_gap.yml` now asks for a related decision number and notes records are not in this repo.
- Tests: `backend/publicreferences_test.go` now states ADR numbers are labels, and continues to forbid private references.
- Security: remove the dead reference to a “separate specification repository” from `SECURITY.md`.

Required action for contributors: do not link ADR records; state the rule in‑tree and raise binding decisions with the maintainers.

<sup>Written for commit 497511c821deac30992c8c8bb05aaf52036a9b39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated repository guidance to remove reliance on ADR citations and clarify how decisions, findings, and rationale are recorded.
  - Clarified approval governance, including human-only decisions and appropriate authorization requirements.
  - Expanded the documented first-party extension inventory and updated layout and craftsmanship guidance.
  - Updated specification references and related validation messages to reflect current documentation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Added after review

Two things found while checking whether anything urgent was open, both live in these same files:

**#1338 — the rulebook credited RLS with tenant isolation in three places.** Migration `0217` retired row-level security in core, and one of the three was a DO-NOT-TOUCH entry naming "RLS policies" as an invariant to preserve. Corrected: core isolation is the per-statement workspace predicate bound by `database.WithWorkspaceTx` and held by `scripts/check-rls-store-path.sh`; extension tables still carry FORCE RLS. That distinction is real and load-bearing, and the old text erased it.

**`SECURITY.md` told vulnerability reporters that issues in "the separate specification repository" were out of scope.** That repository does not exist. It is the file somebody reads before reporting a security bug, so the dead clause is removed.

The remaining tree-wide cleanup — roughly 2,500 `ADR-NNNN` citations, 260 A-numbers and 245 chapter references that a public contributor cannot resolve — is #1869, with the gate widening that stops it recurring.