### PR TITLE
feat(seed-demo): companies arrive with the address their own legal notice printed

### DIFF
--- a/backend/tools/seed-demo/address.go
+++ b/backend/tools/seed-demo/address.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -76,16 +77,34 @@ func parseAddress(printed string) address {
 	if printed == "" {
 		return address{}
 	}
-	out := address{Line1: printed}
 	rest, country := splitTrailingCountry(printed)
-	out.Country = country
+	// A value that is nothing BUT a country word describes no address. Sending
+	// the country alone would file a company in Germany with no street, city
+	// or postcode, which reads as an address on every screen that shows one.
+	if strings.TrimSpace(rest) == "" {
+		return address{}
+	}
+	out := address{Line1: printed, Country: country}
 
-	match := dachPostcode.FindStringSubmatchIndex(rest)
-	if match == nil {
+	// The LAST match, not the first. A postcode ends a DACH address, and an
+	// earlier digit run is something else that came before the street — a
+	// suite, a building number, a PO box. Taking the first match read
+	// "Suite 1200 Hauptstrasse 5 80331 München" as postcode 1200 in the city
+	// of Hauptstrasse.
+	all := dachPostcode.FindAllStringSubmatchIndex(rest, -1)
+	if all == nil {
 		out.Line1 = strings.TrimSpace(strings.TrimRight(rest, ","))
 		return out
 	}
-	groups := dachPostcode.FindStringSubmatch(rest)
+	match := all[len(all)-1]
+	groups := make([]string, 0, len(match)/2)
+	for i := 0; i < len(match); i += 2 {
+		if match[i] < 0 {
+			groups = append(groups, "")
+			continue
+		}
+		groups = append(groups, rest[match[i]:match[i+1]])
+	}
 	if out.Country == "" {
 		out.Country = countryPrefixes[strings.ToUpper(groups[1])]
 	}
@@ -110,8 +129,17 @@ func parseAddress(printed string) address {
 func cleanPrintedAddress(printed string) string {
 	printed = strings.Map(func(r rune) rune {
 		switch r {
-		case '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff':
-			return -1 // zero-width and word joiners: rendering hints, not content
+		case '\u200b', '\u2060', '\ufeff':
+			// Zero-width space, word joiner, BOM: rendering hints a CMS emits
+			// mid-line, and one company's page puts a word joiner exactly
+			// where its postcode begins.
+			//
+			// U+200C and U+200D are deliberately NOT here. They look like the
+			// same class of invisible character and are not: in Persian and
+			// the Indic scripts they control joining and are part of the
+			// spelling, so dropping them would corrupt an address rather than
+			// clean it.
+			return -1
 		case '\u00a0', '\u2007', '\u202f':
 			return ' ' // the non-breaking spaces a CMS emits between number and unit
 		}
@@ -188,32 +216,64 @@ func organizationBody(comp company) jsonBody {
 
 // fillOrganizationAddress puts an address on a company already on file.
 //
-// Only ever FILLS: a record that already carries a street is left alone. The
-// dataset is one source among several a real installation has, and overwriting
-// an address somebody corrected by hand would make re-seeding destructive
-// rather than convergent.
+// Only ever FILLS, and only a record with NO address at all. The dataset is one
+// source among several a real installation has, so re-seeding must not be
+// destructive: a record carrying any address part — a city somebody typed, a
+// line2 the crawl never sees — is left exactly as it is. Checking line1 alone
+// would replace all six columns and quietly drop the rest.
 func fillOrganizationAddress(c *client, orgID string, comp company) error {
-	parsed := parseAddress(comp.value("registered_address"))
-	body := addressBody(parsed)
+	body := addressBody(parseAddress(comp.value("registered_address")))
 	if body == nil {
 		return nil
 	}
 	var current struct {
 		Address *struct {
-			Line1 string `json:"line1"`
+			Line1      string `json:"line1"`
+			Line2      string `json:"line2"`
+			City       string `json:"city"`
+			Region     string `json:"region"`
+			PostalCode string `json:"postal_code"`
+			Country    string `json:"country"`
 		} `json:"address"`
 		Version int `json:"version"`
 	}
 	if err := c.get("/v1/organizations/"+orgID, nil, &current); err != nil {
 		return fmt.Errorf("reading %s back: %w", comp.Domain, err)
 	}
-	if current.Address != nil && strings.TrimSpace(current.Address.Line1) != "" {
-		return nil
+	if current.Address != nil {
+		for _, part := range []string{
+			current.Address.Line1, current.Address.Line2, current.Address.City,
+			current.Address.Region, current.Address.PostalCode, current.Address.Country,
+		} {
+			if strings.TrimSpace(part) != "" {
+				return nil
+			}
+		}
 	}
-	if err := c.patch("/v1/organizations/"+orgID, jsonBody{
-		"address": body, "if_version": current.Version,
-	}, nil); err != nil {
+	// The version guard goes in the If-Match header: the body's `if_version`
+	// is accepted and ignored, so a write spelled that way is last-write-wins
+	// and would overwrite an address added between the read above and here.
+	if err := c.patchGuarded("/v1/organizations/"+orgID, current.Version, jsonBody{"address": body}, nil); err != nil {
 		return fmt.Errorf("setting the address on %s: %w", comp.Domain, err)
 	}
 	return nil
+}
+
+func findOrganization(c *client, comp company) (id string, found bool, err error) {
+	var page struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	query := url.Values{"q": {comp.displayName()}, "limit": {"25"}}
+	if err := c.get("/v1/organizations", query, &page); err != nil {
+		return "", false, fmt.Errorf("searching for %s: %w", comp.Domain, err)
+	}
+	for _, row := range page.Data {
+		if strings.EqualFold(row.DisplayName, comp.displayName()) {
+			return row.ID, true, nil
+		}
+	}
+	return "", false, nil
 }

--- a/backend/tools/seed-demo/address.go
+++ b/backend/tools/seed-demo/address.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Splitting a printed address into the parts the organization API takes.
+//
+// The crawl stores what the Impressum printed — one line, as a human reads it
+// — and the contract wants line1, city, postal_code and country separately.
+// Nothing in between does the splitting, so a dataset that HAS 54 addresses
+// filed none of them.
+//
+// This parses the shapes the dataset actually holds rather than addresses in
+// general. Every case below was taken from a real accepted.json, and a value
+// this cannot read is filed whole in line1 rather than guessed at: a company
+// whose street is right and whose city is empty is honest, and one whose city
+// was invented is not.
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// address is the structured form the organization API takes.
+type address struct {
+	Line1      string
+	City       string
+	PostalCode string
+	Country    string // ISO-3166 alpha-2
+}
+
+// empty reports an address with nothing worth writing.
+func (a address) empty() bool {
+	return a.Line1 == "" && a.City == "" && a.PostalCode == "" && a.Country == ""
+}
+
+// dachPostcode finds the postcode-and-city pair that ends a German, Austrian
+// or Swiss address, with the country prefix those countries print in front of
+// the postcode ("D-50668", "A-4030", "CH-6300", "D – 80801").
+//
+// The city runs to the end of the value or to the country word, and may carry
+// the spaces and hyphens a real city name has: "Bad Friedrichshall",
+// "Frankfurt/Main", "Mühldorf am Inn".
+var dachPostcode = regexp.MustCompile(
+	`(?:\b([ADCH]{1,2})\s*[-–]\s*)?\b(\d{4,5})\s+([\p{Lu}][\p{L}\p{M}]*(?:[ /-][\p{L}\p{M}.]+)*)`)
+
+// countryWords maps the country a site prints, in the languages this dataset
+// crawls, onto the ISO code the contract wants. The country is stated by the
+// page or it is absent — never inferred from a postcode, because a postcode
+// range is not a country and guessing one would be exactly the invention the
+// crawl's own gates refuse.
+var countryWords = map[string]string{
+	"deutschland": "DE", "germany": "DE",
+	"österreich": "AT", "oesterreich": "AT", "austria": "AT",
+	"schweiz": "CH", "switzerland": "CH", "suisse": "CH",
+	"usa": "US", "united states": "US",
+	"united kingdom": "GB", "england": "GB",
+	"nederland": "NL", "netherlands": "NL",
+	"españa": "ES", "espana": "ES", "spain": "ES",
+	"france": "FR", "italia": "IT", "italy": "IT",
+	"polska": "PL", "poland": "PL",
+	"việt nam": "VN", "viet nam": "VN", "vietnam": "VN",
+}
+
+// countryPrefixes maps the letter a DACH address prints before its postcode.
+var countryPrefixes = map[string]string{"D": "DE", "A": "AT", "CH": "CH"}
+
+// parseAddress splits one printed address.
+//
+// It never returns an error. An address it cannot read keeps its whole printed
+// form in Line1, which is the honest answer: the company's address is on
+// record and the parts are simply not separated, rather than separated wrongly.
+func parseAddress(printed string) address {
+	printed = cleanPrintedAddress(printed)
+	if printed == "" {
+		return address{}
+	}
+	out := address{Line1: printed}
+	rest, country := splitTrailingCountry(printed)
+	out.Country = country
+
+	match := dachPostcode.FindStringSubmatchIndex(rest)
+	if match == nil {
+		out.Line1 = strings.TrimSpace(strings.TrimRight(rest, ","))
+		return out
+	}
+	groups := dachPostcode.FindStringSubmatch(rest)
+	if out.Country == "" {
+		out.Country = countryPrefixes[strings.ToUpper(groups[1])]
+	}
+	out.PostalCode = groups[2]
+	out.City = strings.TrimSpace(strings.Trim(groups[3], ",."))
+	// Everything before the postcode is the street and whatever the notice
+	// printed with it — a floor, a building name, a care-of line.
+	out.Line1 = strings.TrimSpace(strings.TrimRight(rest[:match[0]], " ,"))
+	if out.Line1 == "" {
+		out.Line1 = printed
+	}
+	return out
+}
+
+// cleanPrintedAddress removes the characters a rendered page leaves in text
+// and no field should carry: the zero-width joiners and word-joiners a CMS
+// emits mid-line, and repeated whitespace.
+//
+// This is real rather than defensive: one company's address arrives as
+// "Viktoriastraße 3b⁠ 86150 Augsburg", and the word joiner sits exactly
+// where the postcode match has to begin.
+func cleanPrintedAddress(printed string) string {
+	printed = strings.Map(func(r rune) rune {
+		switch r {
+		case '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff':
+			return -1 // zero-width and word joiners: rendering hints, not content
+		case '\u00a0', '\u2007', '\u202f':
+			return ' ' // the non-breaking spaces a CMS emits between number and unit
+		}
+		return r
+	}, printed)
+	return strings.Join(strings.Fields(printed), " ")
+}
+
+// splitTrailingCountry lifts the country off the end of the value and returns
+// what remains. Only a country the page NAMED is taken; the rest of the value
+// is untouched.
+func splitTrailingCountry(printed string) (rest, country string) {
+	trimmed := strings.TrimRight(printed, " ,.")
+	lower := strings.ToLower(trimmed)
+	for word, code := range countryWords {
+		if !strings.HasSuffix(lower, word) {
+			continue
+		}
+		cut := len(trimmed) - len(word)
+		// A suffix that is part of a longer word is not the country: only a
+		// boundary before it makes "…, Austria" different from "…Faustria".
+		if cut > 0 && !isAddressBoundary(rune(trimmed[cut-1])) {
+			continue
+		}
+		return strings.TrimSpace(strings.TrimRight(trimmed[:cut], " ,")), code
+	}
+	return trimmed, ""
+}
+
+func isAddressBoundary(r rune) bool {
+	return r == ' ' || r == ',' || r == '.'
+}
+
+// addressBody is the address as the contract takes it, or nil when the read
+// found none. Only the parts that were actually printed are sent: an empty
+// city is left out rather than written as an empty string, so a partial
+// address reads as partial instead of as a city nobody named.
+func addressBody(a address) jsonBody {
+	if a.empty() {
+		return nil
+	}
+	out := jsonBody{}
+	addIfSet(out, "line1", a.Line1)
+	addIfSet(out, "city", a.City)
+	addIfSet(out, "postal_code", a.PostalCode)
+	addIfSet(out, "country", a.Country)
+	return out
+}
+
+// organizationBody is the company as the create contract takes it.
+//
+// Everything here comes from the reviewed site read, so improving the read
+// improves the record rather than leaving two descriptions to keep in step.
+func organizationBody(comp company) jsonBody {
+	body := jsonBody{
+		"display_name": comp.displayName(),
+		"source":       seedSource,
+		"domains":      []jsonBody{{"domain": comp.Domain, "is_primary": true}},
+	}
+	addIfSet(body, "legal_name", comp.value("legal_name"))
+	addIfSet(body, "industry", comp.value("industry"))
+	if description := comp.value("offer_summary"); description != "" {
+		body["description"] = truncate(description, 500)
+	}
+	// The address the company's own legal notice printed. The crawl stores it
+	// as one line, the way a person reads it, and the contract takes it in
+	// parts — so it is split here rather than filed as prose in a field meant
+	// for a street.
+	if addr := addressBody(parseAddress(comp.value("registered_address"))); addr != nil {
+		body["address"] = addr
+	}
+	return body
+}
+
+// fillOrganizationAddress puts an address on a company already on file.
+//
+// Only ever FILLS: a record that already carries a street is left alone. The
+// dataset is one source among several a real installation has, and overwriting
+// an address somebody corrected by hand would make re-seeding destructive
+// rather than convergent.
+func fillOrganizationAddress(c *client, orgID string, comp company) error {
+	parsed := parseAddress(comp.value("registered_address"))
+	body := addressBody(parsed)
+	if body == nil {
+		return nil
+	}
+	var current struct {
+		Address *struct {
+			Line1 string `json:"line1"`
+		} `json:"address"`
+		Version int `json:"version"`
+	}
+	if err := c.get("/v1/organizations/"+orgID, nil, &current); err != nil {
+		return fmt.Errorf("reading %s back: %w", comp.Domain, err)
+	}
+	if current.Address != nil && strings.TrimSpace(current.Address.Line1) != "" {
+		return nil
+	}
+	if err := c.patch("/v1/organizations/"+orgID, jsonBody{
+		"address": body, "if_version": current.Version,
+	}, nil); err != nil {
+		return fmt.Errorf("setting the address on %s: %w", comp.Domain, err)
+	}
+	return nil
+}

--- a/backend/tools/seed-demo/address_test.go
+++ b/backend/tools/seed-demo/address_test.go
@@ -3,7 +3,10 @@
 
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestParseAddressOnTheShapesTheDatasetHolds pins the real cases. Every value
 // here was taken from a company's accepted.json, so a change that breaks one
@@ -146,5 +149,61 @@ func TestAddressBodySendsOnlyWhatWasPrinted(t *testing.T) {
 	}
 	if body["line1"] == "" {
 		t.Error("the printed address was not sent at all")
+	}
+}
+
+// TestParseAddressRefusesACountryOnValueWithNoAddress — a value that is
+// nothing but a country word describes no address, and sending the country
+// alone would file a company in Germany with no street, city or postcode.
+// That reads as an address on every screen that shows one.
+func TestParseAddressRefusesACountryOnValueWithNoAddress(t *testing.T) {
+	for _, printed := range []string{"Germany", "Deutschland", " , Austria ", ""} {
+		got := parseAddress(printed)
+		if !got.empty() {
+			t.Errorf("parseAddress(%q) = %+v, want nothing", printed, got)
+		}
+		if addressBody(got) != nil {
+			t.Errorf("parseAddress(%q) produced a request body", printed)
+		}
+	}
+}
+
+// TestParseAddressTakesTheLastPostcodeNotTheFirst — a postcode ends a DACH
+// address, and an earlier digit run is something that came before the street:
+// a suite, a building number, a PO box. Reading the first match turned
+// "Suite 1200 Hauptstrasse 5 80331 München" into postcode 1200 in a city
+// called Hauptstrasse.
+func TestParseAddressTakesTheLastPostcodeNotTheFirst(t *testing.T) {
+	for _, tc := range []struct {
+		printed string
+		want    address
+	}{
+		{
+			printed: "Suite 1200 Hauptstrasse 5 80331 München",
+			want:    address{Line1: "Suite 1200 Hauptstrasse 5", PostalCode: "80331", City: "München"},
+		},
+		{
+			printed: "Gebäude 4000 Nord Musterweg 2 12345 Ort",
+			want:    address{Line1: "Gebäude 4000 Nord Musterweg 2", PostalCode: "12345", City: "Ort"},
+		},
+	} {
+		if got := parseAddress(tc.printed); got != tc.want {
+			t.Errorf("parseAddress(%q)\n got %+v\nwant %+v", tc.printed, got, tc.want)
+		}
+	}
+}
+
+// TestCleanPrintedAddressKeepsJoinersThatAreSpelling — U+200C and U+200D look
+// like the same class of invisible character as a word joiner and are not: in
+// Persian and the Indic scripts they control joining and are part of the
+// spelling. Dropping them would corrupt an address rather than clean it.
+func TestCleanPrintedAddressKeepsJoinersThatAreSpelling(t *testing.T) {
+	withZWNJ := "خیابان‌ولیعصر 12"
+	if got := cleanPrintedAddress(withZWNJ); !strings.Contains(got, "‌") {
+		t.Errorf("a zero-width non-joiner was stripped from %q -> %q", withZWNJ, got)
+	}
+	// The word joiner one real page prints IS removed.
+	if got := cleanPrintedAddress("Viktoriastraße 3b⁠ 86150"); strings.Contains(got, "⁠") {
+		t.Errorf("the word joiner survived: %q", got)
 	}
 }

--- a/backend/tools/seed-demo/address_test.go
+++ b/backend/tools/seed-demo/address_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import "testing"
+
+// TestParseAddressOnTheShapesTheDatasetHolds pins the real cases. Every value
+// here was taken from a company's accepted.json, so a change that breaks one
+// breaks a company's address rather than a hypothetical.
+func TestParseAddressOnTheShapesTheDatasetHolds(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		printed string
+		want    address
+	}{
+		{
+			name:    "the plain German form",
+			printed: "Adessoplatz 1 44269 Dortmund",
+			want:    address{Line1: "Adessoplatz 1", PostalCode: "44269", City: "Dortmund"},
+		},
+		{
+			name:    "a country prefix with spaced dashes",
+			printed: "Ainmillerstrasse 22 D – 80801 München",
+			want:    address{Line1: "Ainmillerstrasse 22", PostalCode: "80801", City: "München", Country: "DE"},
+		},
+		{
+			name:    "a Swiss four-digit postcode and its prefix",
+			printed: "Bundesplatz 16 CH-6300 Zug Switzerland",
+			want:    address{Line1: "Bundesplatz 16", PostalCode: "6300", City: "Zug", Country: "CH"},
+		},
+		{
+			name:    "an Austrian one",
+			printed: "Passaustrasse 26-28 A-4030 Linz Austria",
+			want:    address{Line1: "Passaustrasse 26-28", PostalCode: "4030", City: "Linz", Country: "AT"},
+		},
+		{
+			name:    "a floor between the street and the postcode",
+			printed: "Charlottenstraße 4 12th Floor 10969 Berlin Germany",
+			want:    address{Line1: "Charlottenstraße 4 12th Floor", PostalCode: "10969", City: "Berlin", Country: "DE"},
+		},
+		{
+			name:    "a city with a slash in its name",
+			printed: "Neue Rothofstrasse 13-19 60313 Frankfurt/Main Germany",
+			want:    address{Line1: "Neue Rothofstrasse 13-19", PostalCode: "60313", City: "Frankfurt/Main", Country: "DE"},
+		},
+		{
+			name:    "a city of three words",
+			printed: "Richard-Wagner-Straße 14c 84453 Mühldorf am Inn",
+			want:    address{Line1: "Richard-Wagner-Straße 14c", PostalCode: "84453", City: "Mühldorf am Inn"},
+		},
+		{
+			name:    "a building name before the street",
+			printed: "Hamburg Business Center Poststraße 33 20354 Hamburg",
+			want:    address{Line1: "Hamburg Business Center Poststraße 33", PostalCode: "20354", City: "Hamburg"},
+		},
+		{
+			name:    "commas between every part",
+			printed: "Domstraße 20, D-50668 Cologne, Germany",
+			want:    address{Line1: "Domstraße 20", PostalCode: "50668", City: "Cologne", Country: "DE"},
+		},
+		{
+			name:    "the German word for the country",
+			printed: "Industriestrasse 50a 8304 Wallisellen Schweiz",
+			want:    address{Line1: "Industriestrasse 50a", PostalCode: "8304", City: "Wallisellen", Country: "CH"},
+		},
+		{
+			// One company's page really does carry a word joiner here, and it
+			// sits exactly where the postcode match has to begin.
+			name:    "an invisible word joiner before the postcode",
+			printed: "Viktoriastraße 3b ⁠ 86150 Augsburg",
+			want:    address{Line1: "Viktoriastraße 3b", PostalCode: "86150", City: "Augsburg"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAddress(tc.printed)
+			if got != tc.want {
+				t.Errorf("parseAddress(%q)\n got %+v\nwant %+v", tc.printed, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseAddressKeepsWhatItCannotSplit is the honest-degradation rule. A
+// company whose street is right and whose city is empty is a partial record;
+// one whose city was invented is a wrong record, and the dataset's whole
+// no-guess posture says which of those is acceptable.
+func TestParseAddressKeepsWhatItCannotSplit(t *testing.T) {
+	for _, tc := range []struct {
+		printed   string
+		wantLine1 string
+		wantCC    string
+	}{
+		{
+			printed:   "354 Oyster Point Boulevard South San Francisco, California, 94080, USA",
+			wantLine1: "354 Oyster Point Boulevard South San Francisco, California, 94080",
+			wantCC:    "US",
+		},
+		{
+			printed:   "55 Baker Street, London, W1U 8EW, United Kingdom",
+			wantLine1: "55 Baker Street, London, W1U 8EW",
+			wantCC:    "GB",
+		},
+	} {
+		got := parseAddress(tc.printed)
+		if got.Line1 != tc.wantLine1 {
+			t.Errorf("line1 = %q, want %q", got.Line1, tc.wantLine1)
+		}
+		if got.Country != tc.wantCC {
+			t.Errorf("country = %q, want %q", got.Country, tc.wantCC)
+		}
+		if got.City != "" || got.PostalCode != "" {
+			t.Errorf("a shape this cannot read must not produce a city or postcode, got %+v", got)
+		}
+	}
+}
+
+// TestParseAddressNeverInventsACountry — the country is stated by the page or
+// it is absent. A postcode range is not a country, and deriving one would be
+// the same guessing the crawl's own gates exist to refuse.
+func TestParseAddressNeverInventsACountry(t *testing.T) {
+	for _, printed := range []string{
+		"Adessoplatz 1 44269 Dortmund",
+		"Wipplingerstraße 23 1010 Wien",
+		"Schönhauser Allee 124 10437 Berlin",
+	} {
+		if got := parseAddress(printed); got.Country != "" {
+			t.Errorf("parseAddress(%q) invented country %q", printed, got.Country)
+		}
+	}
+}
+
+// TestAddressBodySendsOnlyWhatWasPrinted keeps a partial address partial: an
+// absent city is left out of the request rather than sent as an empty string,
+// which the API would store as a city nobody named.
+func TestAddressBodySendsOnlyWhatWasPrinted(t *testing.T) {
+	if body := addressBody(address{}); body != nil {
+		t.Errorf("an empty address produced a body: %v", body)
+	}
+	body := addressBody(parseAddress("55 Baker Street, London, W1U 8EW, United Kingdom"))
+	if _, ok := body["city"]; ok {
+		t.Error("an unparsed city was sent anyway")
+	}
+	if body["country"] != "GB" {
+		t.Errorf("country = %v, want GB", body["country"])
+	}
+	if body["line1"] == "" {
+		t.Error("the printed address was not sent at all")
+	}
+}

--- a/backend/tools/seed-demo/apiclient.go
+++ b/backend/tools/seed-demo/apiclient.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -134,6 +135,26 @@ func (c *client) patch(path string, body jsonBody, out any) error { //craft:igno
 		return fmt.Errorf("building request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	return c.do(req, out)
+}
+
+// patchGuarded is patch with an optimistic-concurrency precondition.
+//
+// The version goes in the If-Match HEADER, which is the only place these
+// endpoints read it. An `if_version` in the body is accepted and IGNORED — a
+// PATCH carrying a version that cannot exist answers 200 and writes anyway —
+// so a guard spelled that way is not a guard at all.
+func (c *client) patchGuarded(path string, version int, body jsonBody, out any) error { //craft:ignore naked-any out is any JSON shape the caller declares; json.Decode's own contract
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encoding request: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPatch, c.base+path, bytes.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-Match", strconv.Itoa(version))
 	return c.do(req, out)
 }
 

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -343,30 +343,17 @@ func ensureOrganization(c *client, comp company, dryRun bool) (id string, existe
 		// eventually-consistent behind an index, and a company created
 		// moments ago is exactly the case it has not caught up with.
 		if existing, ok := conflictingID(err); ok {
+			// The same convergence the found-by-search path gets: this company
+			// IS already on file, so it must still gain what the dataset has
+			// since learned.
+			if err := fillOrganizationAddress(c, existing, comp); err != nil {
+				return "", false, err
+			}
 			return existing, true, nil
 		}
 		return "", false, err
 	}
 	return out.ID, false, nil
-}
-
-func findOrganization(c *client, comp company) (id string, found bool, err error) {
-	var page struct {
-		Data []struct {
-			ID          string `json:"id"`
-			DisplayName string `json:"display_name"`
-		} `json:"data"`
-	}
-	query := url.Values{"q": {comp.displayName()}, "limit": {"25"}}
-	if err := c.get("/v1/organizations", query, &page); err != nil {
-		return "", false, fmt.Errorf("searching for %s: %w", comp.Domain, err)
-	}
-	for _, row := range page.Data {
-		if strings.EqualFold(row.DisplayName, comp.displayName()) {
-			return row.ID, true, nil
-		}
-	}
-	return "", false, nil
 }
 
 // ensurePerson finds someone by their address and creates them if absent.

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -317,27 +317,26 @@ func ensureOrganization(c *client, comp company, dryRun bool) (id string, existe
 	if id, found, err := findOrganization(c, comp); err != nil {
 		return "", false, err
 	} else if found {
+		// A company already on file still gains what the dataset has since
+		// learned. The seeder converges — "improve the crawl and re-seed" is
+		// the supported way to use it — so a field that only ever reached a
+		// CREATE would never arrive at all for the 190 companies already
+		// seeded, which is exactly what happened to the address.
+		if !dryRun {
+			if err := fillOrganizationAddress(c, id, comp); err != nil {
+				return "", false, err
+			}
+		}
 		return id, true, nil
 	}
 	if dryRun {
 		return "", false, nil
 	}
 
-	body := jsonBody{
-		"display_name": comp.displayName(),
-		"source":       seedSource,
-		"domains":      []jsonBody{{"domain": comp.Domain, "is_primary": true}},
-	}
-	addIfSet(body, "legal_name", comp.value("legal_name"))
-	addIfSet(body, "industry", comp.value("industry"))
-	if description := comp.value("offer_summary"); description != "" {
-		body["description"] = truncate(description, 500)
-	}
-
 	var out struct {
 		ID string `json:"id"`
 	}
-	if err := c.post("/v1/organizations", body, &out); err != nil {
+	if err := c.post("/v1/organizations", organizationBody(comp), &out); err != nil {
 		// The duplicate-domain refusal NAMES the record it collided with, so
 		// a second run resolves the company from the server's own answer.
 		// That is more reliable than re-probing: search is


### PR DESCRIPTION
The dataset held **54 registered addresses and the database showed 1**. The
seeder wrote `legal_name`, `industry` and `description` and dropped the address
— not because the API lacked the field (`Organization`,
`CreateOrganizationRequest` and `UpdateOrganizationRequest` all take a
structured address) but because nothing ever sent it.

## The split

The crawl stores an address the way a person reads it —
`Passaustrasse 26-28 A-4030 Linz Austria` — and the contract takes
`line1`/`city`/`postal_code`/`country` separately. `parseAddress` splits it.

**52 of the 54 come out fully split**, checked against every real value rather
than a sample. Cases the tests pin, each from a company's `accepted.json`:

- a floor between street and postcode — `Charlottenstraße 4 12th Floor 10969 Berlin`
- a building name before the street — `Hamburg Business Center Poststraße 33 20354 Hamburg`
- cities of three words (`Mühldorf am Inn`) and with a slash (`Frankfurt/Main`)
- Swiss and Austrian four-digit postcodes with `D-`/`A-`/`CH-` prefixes
- the spaced-dash form — `D – 80801`
- one page that prints a **word joiner exactly where the postcode begins**

## What it will not do is guess

The two it cannot read are a US and a UK address. Both keep their whole printed
form in `line1` and still recover the country, so the record is partial rather
than wrong.

The country comes only from a word the page printed — never derived from a
postcode range, which would be the invention the crawl's own gates refuse.
Three German addresses carry no country word and correctly get none.

## It reaches companies already on file

`ensureOrganization` returns early for a company that exists, so a create-only
fill would never have reached the 190 companies already seeded. The seeder
converges — *improve the crawl and re-seed* is how it is meant to be used — so
`fillOrganizationAddress` patches existing records too, and the duplicate-domain
recovery path fills as well.

It fills **only a record with no address at all**. Any part already set — a city
somebody typed, a `line2` the crawl never sees — and it does nothing, because
re-seeding must not be destructive.

## Codex found five defects; four are fixed here

| defect | fix |
|---|---|
| `if_version` in the PATCH body is **silently ignored** — verified: version 999999 wrote with HTTP 200 | new `client.patchGuarded` sends `If-Match` |
| the existence check read `line1` alone, so a curated city could be replaced | returns early if **any** of six parts is set |
| the postcode was the **first** digit run — `Suite 1200 Hauptstrasse 5 80331 München` parsed as postcode 1200 | takes the last match |
| U+200C/U+200D stripped, which are **spelling** in Persian and Indic scripts | only zero-width space, word joiner and BOM removed |

The fifth is pre-existing and filed as **#1867**: `ownership.go` and
`records.go` spell the version guard the same ineffective way.

I also found one myself before the review landed: a value that is nothing but a
country word produced an address with a country and no street.

## Verified against a live stack

**Addresses went from 1 to 56** — 52 postcodes, 36 countries — with
`verify: OK`, and a second run changed nothing. No re-crawl involved; this is
purely the 54 addresses already in the dataset.

`backend/make check` reports `0 issues` and composition reproducible.
`make craft-static`, `check-gofmt.sh`, `check-go-file-length.sh` pass.

`TestEveryMigrationTakingABlockingLockBoundsHowLongItWaits` fails on `main`
already — `relationship_traversal_indexes` from #1831. Confirmed by stashing
this branch and re-running. No migration files here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds organizations with the registered address from their legal notice. Previously the seeder ignored addresses; now it splits the printed address into `line1`/`city`/`postal_code`/`country` and backfills organizations that have no address.

- Adds `parseAddress` that handles DACH formats (incl. `D-`/`A-`/`CH-` and spaced dashes), takes the last digit run as the postcode, strips only zero‑width space/word‑joiner/BOM, and never guesses a country; US/UK cases stay as `line1` only. Tests pin real dataset shapes.
- Sends only printed parts (`addressBody`) so partial addresses stay partial; refuses values that are just a country word.
- Backfills existing orgs via `fillOrganizationAddress` but only when all address fields are empty; leaves any curated part untouched.
- Guards PATCHes with `If-Match` via `client.patchGuarded`; fixes no-op `if_version` body parameter.
- Uses `organizationBody` for creates; duplicate-domain recovery and search paths both invoke the same fill. `findOrganization` extracted.

**Rollout**
- No migrations. Re-run the demo seeder to backfill addresses; safe and idempotent (second run makes no changes).

<sup>Written for commit 1d56d2169b0c9306a69ede6de596889b89fb5ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

