### PR TITLE
fix(seed-demo): the invisible characters say which ones they are

### DIFF
--- a/backend/tools/seed-demo/address_test.go
+++ b/backend/tools/seed-demo/address_test.go
@@ -71,7 +71,7 @@ func TestParseAddressOnTheShapesTheDatasetHolds(t *testing.T) {
 			// One company's page really does carry a word joiner here, and it
 			// sits exactly where the postcode match has to begin.
 			name:    "an invisible word joiner before the postcode",
-			printed: "Viktoriastraße 3b ⁠ 86150 Augsburg",
+			printed: "Viktoriastraße 3b \u2060 86150 Augsburg",
 			want:    address{Line1: "Viktoriastraße 3b", PostalCode: "86150", City: "Augsburg"},
 		},
 	} {
@@ -198,12 +198,12 @@ func TestParseAddressTakesTheLastPostcodeNotTheFirst(t *testing.T) {
 // Persian and the Indic scripts they control joining and are part of the
 // spelling. Dropping them would corrupt an address rather than clean it.
 func TestCleanPrintedAddressKeepsJoinersThatAreSpelling(t *testing.T) {
-	withZWNJ := "خیابان‌ولیعصر 12"
-	if got := cleanPrintedAddress(withZWNJ); !strings.Contains(got, "‌") {
+	withZWNJ := "خیابان\u200cولیعصر 12"
+	if got := cleanPrintedAddress(withZWNJ); !strings.Contains(got, "\u200c") {
 		t.Errorf("a zero-width non-joiner was stripped from %q -> %q", withZWNJ, got)
 	}
 	// The word joiner one real page prints IS removed.
-	if got := cleanPrintedAddress("Viktoriastraße 3b⁠ 86150"); strings.Contains(got, "⁠") {
+	if got := cleanPrintedAddress("Viktoriastraße 3b\u2060 86150"); strings.Contains(got, "\u2060") {
 		t.Errorf("the word joiner survived: %q", got)
 	}
 }


### PR DESCRIPTION
**`main` is red** and has been since [#1868](https://github.com/gradionhq/margince-poc-v1/pull/1868) merged. Every PR opened against it inherits a failing `deterministic-gates` for a file it did not touch — which is how a red nobody trusts makes every other verdict unreadable.

## The finding

staticcheck ST1018, five times in `backend/tools/seed-demo/address_test.go`: three WORD JOINERs (U+2060) and two ZERO WIDTH NON-JOINERs (U+200C), written **literally** inside string constants.

## Why they are there, and why escaping them is the right fix rather than a suppression

They are deliberate. The suite tests that `cleanPrintedAddress` strips exactly these characters out of an address a company printed in its own legal notice, so the fixtures have to contain them.

Written raw they are **invisible**. The test reads as though it asserts something about `"Viktoriastraße 3b 86150 Augsburg"`, and a reader has no way to see the character the assertion is actually about, tell a WORD JOINER from a ZWNJ, or notice if one were silently deleted by an editor that trims what it cannot render.

Escaped, the values are byte-for-byte identical — the test passes unchanged — and the fixture now states what it is testing.

## Verification

- `go test ./seed-demo/ -count=1` passes. That is the proof the values are unchanged: the assertions are `strings.Contains(got, "‌")`, so a changed value would fail them.
- `make lint-modules` reports no findings in `backend/tools`.

## Noticed while here, not fixed here

`make lint-modules` walks into `.claude/worktrees/`, so it lints whatever other sessions happen to have checked out and its verdict depends on unrelated local state. It reported findings from a sibling worktree's copy of `gen-agentpolicy` on this machine. Filing separately rather than widening this fix — `main` should go green first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes invisible Unicode joiners in `backend/tools/seed-demo/address_test.go` to fix staticcheck failures on `main` and make the fixtures explicit. Previously the tests embedded raw WORD JOINER (U+2060) and ZERO WIDTH NON-JOINER (U+200C); they now use `\u2060` and `\u200c` escapes with identical behavior.

- Replaces U+2060 and U+200C literals in test strings with `\u2060` and `\u200c`; test assertions and outcomes are unchanged.
- Confirms we still keep ZWNJ in Persian addresses and strip WORD JOINER from the German address, as before.
- Unblocks the `deterministic-gates`/`make lint-modules` staticcheck gate that was red on `main`.

<sup>Written for commit 1abb934e4a614e90ed9d5a964a38b36db4328804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

