### PR TITLE
feat(frontend): lead sources, disqualification reasons and lead handling are administered in Settings

### DIFF
--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -94,7 +94,7 @@ func (s *Store) ListLeads(ctx context.Context, in ListLeadsInput) ([]crmcontract
 				where = append(where, storekit.SQLf(leadScoreColumn+" >= $%d", arg(*in.MinScore)))
 			}
 			if in.Source != nil {
-				where = append(where, storekit.SQLf(leadSourceColumn+" = $%d", arg(*in.Source)))
+				where = append(where, leadSourceClause(*in.Source, arg))
 			}
 			if in.SLAState != nil {
 				where = append(where, slaStateClause(policy, *in.SLAState, arg))

--- a/backend/internal/modules/people/leadsource.go
+++ b/backend/internal/modules/people/leadsource.go
@@ -71,6 +71,19 @@ func (m SourceIntents) Of(source string) SourceIntent {
 	return SourceIntentNeutral
 }
 
+// leadSourceClause renders the list's source filter. A connector family
+// (`connector:apollo`, as the source list names it) matches every lead the
+// connector wrote, whose values carry the item id after the family; any
+// other value matches exactly. The family's own underscores are escaped so
+// LIKE reads them as letters.
+func leadSourceClause(source string, arg func(any) int) string {
+	if _, isFamily := connectorFamily(source + ":x"); isFamily && strings.Count(source, ":") == 1 {
+		return storekit.SQLf("("+leadSourceColumn+" = $%d OR "+leadSourceColumn+" LIKE replace($%d, '_', '\\_') || ':%%')",
+			arg(source), arg(source))
+	}
+	return storekit.SQLf(leadSourceColumn+" = $%d", arg(source))
+}
+
 // connectorFamily reduces `connector:apollo:a-1` to `connector:apollo`.
 func connectorFamily(source string) (string, bool) {
 	parts := strings.SplitN(source, ":", 3)

--- a/backend/internal/modules/people/leadsource.go
+++ b/backend/internal/modules/people/leadsource.go
@@ -74,11 +74,14 @@ func (m SourceIntents) Of(source string) SourceIntent {
 // leadSourceClause renders the list's source filter. A connector family
 // (`connector:apollo`, as the source list names it) matches every lead the
 // connector wrote, whose values carry the item id after the family; any
-// other value matches exactly. The family's own underscores are escaped so
-// LIKE reads them as letters.
+// other value matches exactly. The family is bound as a parameter and every
+// LIKE metacharacter in it is escaped (backslash first, then % and _), so a
+// caller-supplied `connector:%` names a family literally called "%" and
+// nothing else.
 func leadSourceClause(source string, arg func(any) int) string {
 	if _, isFamily := connectorFamily(source + ":x"); isFamily && strings.Count(source, ":") == 1 {
-		return storekit.SQLf("("+leadSourceColumn+" = $%d OR "+leadSourceColumn+" LIKE replace($%d, '_', '\\_') || ':%%')",
+		return storekit.SQLf("("+leadSourceColumn+" = $%d OR "+leadSourceColumn+
+			` LIKE replace(replace(replace($%d, '\', '\\'), '%%', '\%%'), '_', '\_') || ':%%')`,
 			arg(source), arg(source))
 	}
 	return storekit.SQLf(leadSourceColumn+" = $%d", arg(source))

--- a/backend/internal/modules/people/leadvocabulary_integration_test.go
+++ b/backend/internal/modules/people/leadvocabulary_integration_test.go
@@ -192,6 +192,16 @@ func TestLeadSourceGovernsHumanWritesAndTheScore(t *testing.T) {
 		}
 	}
 
+	// The list filter names the family and finds the connector's leads.
+	family := "connector:apollo"
+	listed, _, err := e.store.ListLeads(e.ctx, ListLeadsInput{Source: &family})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || ids.UUID(listed[0].Id) != ids.UUID(connectorLead.Id) {
+		t.Errorf("source=%s lists %d leads, want the one connector lead still carrying the family", family, len(listed))
+	}
+
 	// The counts are a lead read, and a lead is customer identity: an actor
 	// scoped to their own rows still reads every lead in the workspace, so
 	// owning the leads elsewhere changes nothing about what they count.

--- a/backend/internal/modules/people/leadworkqueue.go
+++ b/backend/internal/modules/people/leadworkqueue.go
@@ -136,7 +136,7 @@ func leadQueueWhere(ctx context.Context, in ListLeadsInput, active []fieldcatalo
 		where = append(where, storekit.SQLf(leadScoreColumn+" >= $%d", arg(*in.MinScore)))
 	}
 	if in.Source != nil {
-		where = append(where, storekit.SQLf(leadSourceColumn+" = $%d", arg(*in.Source)))
+		where = append(where, leadSourceClause(*in.Source, arg))
 	}
 	if in.SLAState != nil {
 		where = append(where, slaStateClause(policy, *in.SLAState, arg))

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1220,6 +1220,58 @@ export const de = {
   "lead.source.import": "Import",
   "lead.source.crawl": "Webrecherche",
   "lead.source.unknown": "Unbekannte Quelle",
+  "lead.sourceFromConnector":
+    "Von einer Integration geschrieben — behält ihre eigene Quelle.",
+  "leadSources.title": "Lead-Quellen",
+  "leadSources.sub":
+    "Woher Leads kommen. Wird im Formular „Neuer Lead“, als Filter und vom Score verwendet.",
+  "leadSources.readOnly": "Nur ein Admin- oder Ops-Sitz ändert diese Liste.",
+  "leadSources.labelFor": "Bezeichnung der Quelle {key}",
+  "leadSources.intentFor": "Gewichtung von {label}",
+  "leadSources.intent": "Gewichtung",
+  "leadSources.intent.high": "Hohes Interesse",
+  "leadSources.intent.neutral": "Neutral",
+  "leadSources.intent.low": "Geringes Interesse",
+  "leadSources.intentHint":
+    "Hoch gibt Punkte auf den Score, Gering zieht ab; eine Änderung greift bei der nächsten Neuberechnung jedes Leads.",
+  "leadSources.leadCount": "{count} Leads",
+  "leadSources.builtIn": "vorgegeben",
+  "leadSources.builtInKept":
+    "Vorgegebene Quellen lassen sich umbenennen und abschalten, nicht entfernen.",
+  "leadSources.inUse":
+    "{count} Leads nutzen diese Quelle — stattdessen abschalten.",
+  "leadSources.deactivateInstead": "stattdessen abschalten",
+  "leadSources.active": "Aktiv",
+  "leadSources.remove": "Entfernen",
+  "leadSources.removeTitle": "Diese Quelle entfernen?",
+  "leadSources.removeBody":
+    "„{label}“ wird von keinem Lead genutzt und verschwindet aus der Liste.",
+  "leadSources.newLabel": "Neue Quelle",
+  "leadSources.newPlaceholder": "Messe",
+  "leadSources.add": "Quelle hinzufügen",
+  "leadSources.discoveredSub":
+    "Aus Integrationen und Importen — Werte, die auf Leads stehen, aber noch nicht in der Liste sind. Hinzufügen gibt ihnen Bezeichnung und Gewichtung.",
+  "leadSources.adopt": "In die Liste aufnehmen",
+  "leadReasons.title": "Disqualifizierungsgründe",
+  "leadReasons.sub":
+    "Was beim Verwerfen eines Leads gewählt wird. Der Grund steht am Lead und ist filterbar.",
+  "leadReasons.labelFor": "Bezeichnung des Grundes {label}",
+  "leadReasons.leadCount": "{count} Leads",
+  "leadReasons.inUse":
+    "{count} Leads tragen diesen Grund — stattdessen abschalten.",
+  "leadReasons.newLabel": "Neuer Grund",
+  "leadReasons.add": "Grund hinzufügen",
+  "leadReasons.removeTitle": "Diesen Grund entfernen?",
+  "leadReasons.removeBody":
+    "„{label}“ wird von keinem Lead genutzt und verschwindet aus der Liste.",
+  "leadHandling.title": "Lead-Bearbeitung",
+  "leadHandling.sub": "Wie diese Installation mit einem neuen Lead umgeht.",
+  "leadHandling.firstResponse": "Ziel für die erste Antwort",
+  "leadHandling.firstResponseHint":
+    "Standardmäßig aus. An: jeder offene Lead trägt eine Antwortfrist, die Liste bekommt die Ansicht „Überfällig“, und überfällige Leads stehen zuerst.",
+  "leadHandling.targetMinutes": "Ziel (Minuten)",
+  "leadHandling.targetHint":
+    "Wie lange ein Lead nach Zuweisung (oder Anlage) auf die erste Antwort warten darf. 15 Minuten bis 7 Tage.",
   "lead.boardCount": "{count} Leads",
   "lead.duplicateFound":
     "Ein Lead mit dieser E-Mail oder diesem LinkedIn-Profil existiert bereits.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1241,7 +1241,7 @@ export const de = {
   "leadSources.inUse":
     "{count} Leads nutzen diese Quelle — stattdessen abschalten.",
   "leadSources.deactivateInstead": "stattdessen abschalten",
-  "leadSources.active": "Aktiv",
+  "leadSources.activeFor": "{label} ist aktiv",
   "leadSources.remove": "Entfernen",
   "leadSources.removeTitle": "Diese Quelle entfernen?",
   "leadSources.removeBody":
@@ -1270,6 +1270,8 @@ export const de = {
   "leadHandling.firstResponseHint":
     "Standardmäßig aus. An: jeder offene Lead trägt eine Antwortfrist, die Liste bekommt die Ansicht „Überfällig“, und überfällige Leads stehen zuerst.",
   "leadHandling.targetMinutes": "Ziel (Minuten)",
+  "leadHandling.targetOutOfRange":
+    "Eine ganze Minutenzahl zwischen 15 und 10080 (7 Tage) eingeben.",
   "leadHandling.targetHint":
     "Wie lange ein Lead nach Zuweisung (oder Anlage) auf die erste Antwort warten darf. 15 Minuten bis 7 Tage.",
   "lead.boardCount": "{count} Leads",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1257,7 +1257,7 @@ export const en = {
     "Built-in sources can be renamed and switched off, not removed.",
   "leadSources.inUse": "{count} leads use this source — switch it off instead.",
   "leadSources.deactivateInstead": "switch off instead",
-  "leadSources.active": "Active",
+  "leadSources.activeFor": "{label} is active",
   "leadSources.remove": "Remove",
   "leadSources.removeTitle": "Remove this source?",
   "leadSources.removeBody":
@@ -1286,6 +1286,8 @@ export const en = {
   "leadHandling.firstResponseHint":
     "Off by default. On, every open lead carries a reply deadline, the list gains the Overdue view, and overdue leads sort first.",
   "leadHandling.targetMinutes": "Target (minutes)",
+  "leadHandling.targetOutOfRange":
+    "Enter a whole number of minutes between 15 and 10080 (7 days).",
   "leadHandling.targetHint":
     "How long a lead may wait for its first reply once it is routed (or created). 15 minutes to 7 days.",
   "lead.boardCount": "{count} leads",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1237,6 +1237,57 @@ export const en = {
   "lead.source.import": "Import",
   "lead.source.crawl": "Web research",
   "lead.source.unknown": "Unknown source",
+  "lead.sourceFromConnector":
+    "Written by a connector — it keeps its own source.",
+  "leadSources.title": "Lead sources",
+  "leadSources.sub":
+    "Where leads come from. Used in the New lead form, as a filter, and by the score.",
+  "leadSources.readOnly": "Only an admin or ops seat changes this list.",
+  "leadSources.labelFor": "Label of source {key}",
+  "leadSources.intentFor": "Intent of {label}",
+  "leadSources.intent": "Intent",
+  "leadSources.intent.high": "High interest",
+  "leadSources.intent.neutral": "Neutral",
+  "leadSources.intent.low": "Low interest",
+  "leadSources.intentHint":
+    "High adds points to the score, Low subtracts; a change applies on each lead's next rescore.",
+  "leadSources.leadCount": "{count} leads",
+  "leadSources.builtIn": "built-in",
+  "leadSources.builtInKept":
+    "Built-in sources can be renamed and switched off, not removed.",
+  "leadSources.inUse": "{count} leads use this source — switch it off instead.",
+  "leadSources.deactivateInstead": "switch off instead",
+  "leadSources.active": "Active",
+  "leadSources.remove": "Remove",
+  "leadSources.removeTitle": "Remove this source?",
+  "leadSources.removeBody":
+    '"{label}" is not used by any lead and will disappear from the list.',
+  "leadSources.newLabel": "New source",
+  "leadSources.newPlaceholder": "Trade show",
+  "leadSources.add": "Add source",
+  "leadSources.discoveredSub":
+    "From integrations and imports — values that live on leads but are not in the list yet. Add one to give it a label and a weight.",
+  "leadSources.adopt": "Add to list",
+  "leadReasons.title": "Disqualification reasons",
+  "leadReasons.sub":
+    "What a rep picks when a lead is dropped. The reason shows on the lead and can be filtered on.",
+  "leadReasons.labelFor": "Label of reason {label}",
+  "leadReasons.leadCount": "{count} leads",
+  "leadReasons.inUse":
+    "{count} leads carry this reason — switch it off instead.",
+  "leadReasons.newLabel": "New reason",
+  "leadReasons.add": "Add reason",
+  "leadReasons.removeTitle": "Remove this reason?",
+  "leadReasons.removeBody":
+    '"{label}" is not used by any lead and will disappear from the list.',
+  "leadHandling.title": "Lead handling",
+  "leadHandling.sub": "How this installation treats a new lead.",
+  "leadHandling.firstResponse": "First-response target",
+  "leadHandling.firstResponseHint":
+    "Off by default. On, every open lead carries a reply deadline, the list gains the Overdue view, and overdue leads sort first.",
+  "leadHandling.targetMinutes": "Target (minutes)",
+  "leadHandling.targetHint":
+    "How long a lead may wait for its first reply once it is routed (or created). 15 minutes to 7 days.",
   "lead.boardCount": "{count} leads",
   "lead.duplicateFound":
     "A lead with this email or LinkedIn profile already exists.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1216,6 +1216,59 @@ export const vi = {
   "lead.source.import": "Nhập dữ liệu",
   "lead.source.crawl": "Nghiên cứu web",
   "lead.source.unknown": "Nguồn không rõ",
+  "lead.sourceFromConnector":
+    "Do một kết nối ghi vào — giữ nguồn riêng của nó.",
+  "leadSources.title": "Nguồn khách hàng tiềm năng",
+  "leadSources.sub":
+    "Khách hàng tiềm năng đến từ đâu. Dùng trong biểu mẫu tạo mới, làm bộ lọc và trong điểm số.",
+  "leadSources.readOnly":
+    "Chỉ tài khoản quản trị hoặc vận hành mới thay đổi danh sách này.",
+  "leadSources.labelFor": "Nhãn của nguồn {key}",
+  "leadSources.intentFor": "Trọng số của {label}",
+  "leadSources.intent": "Trọng số",
+  "leadSources.intent.high": "Quan tâm cao",
+  "leadSources.intent.neutral": "Trung lập",
+  "leadSources.intent.low": "Quan tâm thấp",
+  "leadSources.intentHint":
+    "Cao cộng điểm, Thấp trừ điểm; thay đổi áp dụng ở lần tính lại tiếp theo của mỗi khách hàng tiềm năng.",
+  "leadSources.leadCount": "{count} khách hàng tiềm năng",
+  "leadSources.builtIn": "có sẵn",
+  "leadSources.builtInKept":
+    "Nguồn có sẵn có thể đổi tên và tắt, không xóa được.",
+  "leadSources.inUse":
+    "{count} khách hàng tiềm năng dùng nguồn này — hãy tắt thay vì xóa.",
+  "leadSources.deactivateInstead": "hãy tắt thay vì xóa",
+  "leadSources.active": "Đang bật",
+  "leadSources.remove": "Xóa",
+  "leadSources.removeTitle": "Xóa nguồn này?",
+  "leadSources.removeBody":
+    '"{label}" không được khách hàng tiềm năng nào dùng và sẽ biến mất khỏi danh sách.',
+  "leadSources.newLabel": "Nguồn mới",
+  "leadSources.newPlaceholder": "Hội chợ",
+  "leadSources.add": "Thêm nguồn",
+  "leadSources.discoveredSub":
+    "Từ tích hợp và nhập liệu — giá trị có trên khách hàng tiềm năng nhưng chưa có trong danh sách. Thêm vào để đặt nhãn và trọng số.",
+  "leadSources.adopt": "Thêm vào danh sách",
+  "leadReasons.title": "Lý do loại",
+  "leadReasons.sub":
+    "Điều nhân viên chọn khi bỏ một khách hàng tiềm năng. Lý do hiển thị trên hồ sơ và lọc được.",
+  "leadReasons.labelFor": "Nhãn của lý do {label}",
+  "leadReasons.leadCount": "{count} khách hàng tiềm năng",
+  "leadReasons.inUse":
+    "{count} khách hàng tiềm năng mang lý do này — hãy tắt thay vì xóa.",
+  "leadReasons.newLabel": "Lý do mới",
+  "leadReasons.add": "Thêm lý do",
+  "leadReasons.removeTitle": "Xóa lý do này?",
+  "leadReasons.removeBody":
+    '"{label}" không được khách hàng tiềm năng nào dùng và sẽ biến mất khỏi danh sách.',
+  "leadHandling.title": "Xử lý khách hàng tiềm năng",
+  "leadHandling.sub": "Cách cài đặt này xử lý một khách hàng tiềm năng mới.",
+  "leadHandling.firstResponse": "Mục tiêu phản hồi đầu tiên",
+  "leadHandling.firstResponseHint":
+    "Mặc định tắt. Khi bật, mọi khách hàng tiềm năng đang mở có hạn phản hồi, danh sách có thêm chế độ xem Quá hạn và các mục quá hạn xếp trước.",
+  "leadHandling.targetMinutes": "Mục tiêu (phút)",
+  "leadHandling.targetHint":
+    "Khách hàng tiềm năng được chờ bao lâu cho phản hồi đầu tiên sau khi được phân (hoặc tạo). Từ 15 phút đến 7 ngày.",
   "lead.boardCount": "{count} lead",
   "lead.duplicateFound": "Đã có lead với email hoặc hồ sơ LinkedIn này.",
   "lead.promote": "Chuyển thành contact",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1238,7 +1238,7 @@ export const vi = {
   "leadSources.inUse":
     "{count} khách hàng tiềm năng dùng nguồn này — hãy tắt thay vì xóa.",
   "leadSources.deactivateInstead": "hãy tắt thay vì xóa",
-  "leadSources.active": "Đang bật",
+  "leadSources.activeFor": "{label} đang bật",
   "leadSources.remove": "Xóa",
   "leadSources.removeTitle": "Xóa nguồn này?",
   "leadSources.removeBody":
@@ -1267,6 +1267,8 @@ export const vi = {
   "leadHandling.firstResponseHint":
     "Mặc định tắt. Khi bật, mọi khách hàng tiềm năng đang mở có hạn phản hồi, danh sách có thêm chế độ xem Quá hạn và các mục quá hạn xếp trước.",
   "leadHandling.targetMinutes": "Mục tiêu (phút)",
+  "leadHandling.targetOutOfRange":
+    "Nhập số phút nguyên từ 15 đến 10080 (7 ngày).",
   "leadHandling.targetHint":
     "Khách hàng tiềm năng được chờ bao lâu cho phản hồi đầu tiên sau khi được phân (hoặc tạo). Từ 15 phút đến 7 ngày.",
   "lead.boardCount": "{count} lead",

--- a/frontend/src/screens/leadpresentation.tsx
+++ b/frontend/src/screens/leadpresentation.tsx
@@ -14,6 +14,7 @@ import { formatDateTime } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
+import { sourceLabelFor } from "./leadsources";
 
 type Lead = components["schemas"]["Lead"];
 
@@ -89,29 +90,6 @@ export function FirstResponseLine({ lead }: Readonly<{ lead: Lead }>) {
   );
 }
 
-export const LEAD_SOURCES = [
-  { value: "manual", label: "lead.source.manual" },
-  { value: "inbound", label: "lead.source.inbound" },
-  { value: "webform", label: "lead.source.webform" },
-  { value: "referral", label: "lead.source.referral" },
-  { value: "import", label: "lead.source.import" },
-  { value: "crawl", label: "lead.source.crawl" },
-] as const;
-
-export function sourceLabel(
-  source: string | null | undefined,
-  t: ReturnType<typeof useT>,
-): string {
-  if (!source) return t("lead.shortfall.noSource");
-  const known = LEAD_SOURCES.find((option) => option.value === source);
-  if (known) return t(known.label);
-  const parts = source.split(":").filter(Boolean);
-  const meaningful = parts[0] === "connector" ? parts[1] : parts[0];
-  return meaningful
-    ? meaningful.charAt(0).toUpperCase() + meaningful.slice(1)
-    : t("lead.source.unknown");
-}
-
 const LEAD_BOARD_STAGES = [
   { stage: "new", label: "lead.statusNew" },
   { stage: "contacted", label: "lead.statusContacted" },
@@ -156,7 +134,7 @@ function LeadCard({
         {lead.title && <span>{lead.title}</span>}
       </span>
       <span className="deal-meta">
-        <span>{sourceLabel(lead.source, t)}</span>
+        <span>{sourceLabelFor(lead, undefined, t)}</span>
         <span>
           {lead.next_task_subject ?? t("lead.noNextTask")}
           {lead.open_task_count

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -45,6 +45,32 @@ afterEach(() => {
   window.location.hash = "";
 });
 
+// The six shipped lead sources, as GET /lead-sources serves them on a fresh
+// installation.
+const SHIPPED_LEAD_SOURCES = {
+  data: [
+    ["manual", "Created manually", "neutral"],
+    ["inbound", "Inbound", "high"],
+    ["webform", "Web form", "high"],
+    ["referral", "Referral", "high"],
+    ["import", "Import", "low"],
+    ["crawl", "Web research", "low"],
+  ].map(([key, label, intent], i) => ({
+    id: `src-${key}`,
+    key,
+    label,
+    intent,
+    sort_order: (i + 1) * 10,
+    active: true,
+    system: true,
+    lead_count: 0,
+    version: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  })),
+  discovered: [],
+};
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -794,6 +820,20 @@ function stubFetch(
         sections: [],
       });
     }
+    // The administered vocabularies, as a fresh installation ships them:
+    // the screens read their labels and pick lists off these.
+    if (request.method === "GET" && request.url.endsWith("/v1/lead-sources")) {
+      return jsonResponse(SHIPPED_LEAD_SOURCES);
+    }
+    if (
+      request.method === "GET" &&
+      request.url.endsWith("/v1/leads/settings")
+    ) {
+      return jsonResponse({
+        first_response_enabled: true,
+        first_response_target_minutes: 240,
+      });
+    }
     const answer = await responder(request.url, request.method, request);
     if (request.url.endsWith("/v1/me")) {
       const body: unknown = await answer.clone().json();
@@ -1428,6 +1468,21 @@ function stubFetchWithMe(
         return jsonResponse({
           anchor: { type: "lead", id: "l-1" },
           sections: [],
+        });
+      }
+      if (
+        request.method === "GET" &&
+        request.url.endsWith("/v1/lead-sources")
+      ) {
+        return jsonResponse(SHIPPED_LEAD_SOURCES);
+      }
+      if (
+        request.method === "GET" &&
+        request.url.endsWith("/v1/leads/settings")
+      ) {
+        return jsonResponse({
+          first_response_enabled: true,
+          first_response_target_minutes: 240,
         });
       }
       const answer = await responder(request.url, request.method, request);

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -17,7 +17,7 @@ import {
 } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import { FieldGrid, FieldRow } from "../design-system/fieldgrid";
-import { InlineText } from "../design-system/inlinechoice";
+import { InlineChoice, InlineText } from "../design-system/inlinechoice";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useRecordTimeline } from "../design-system/recordtimeline";
 import { Select } from "../design-system/select";
@@ -44,13 +44,11 @@ import { RecordHistoryTab, useRecordHistory } from "./history";
 import { LeadBulkBar } from "./leadbulk";
 import {
   FirstResponseLine,
-  LEAD_SOURCES,
   LEAD_STATUS_FILTER_OPTIONS,
   LeadBoard,
   SlaBadge,
   StatusBadge,
   scoreTone,
-  sourceLabel,
 } from "./leadpresentation";
 import { LeadManualSignals } from "./leadsignals";
 import {
@@ -81,6 +79,13 @@ type CreateLeadRequest = components["schemas"]["CreateLeadRequest"];
 type UpdateLeadRequest = components["schemas"]["UpdateLeadRequest"];
 type PromoteLeadRequest = components["schemas"]["PromoteLeadRequest"];
 type PromoteTrigger = PromoteLeadRequest["trigger"];
+
+import {
+  sourceFilterOptions,
+  sourceLabelFor,
+  sourcePickOptions,
+  useLeadSources,
+} from "./leadsources";
 
 export { scoreTone } from "./leadpresentation";
 
@@ -308,6 +313,7 @@ function LeadsWorkbench({ viewerId }: Readonly<{ viewerId: string }>) {
   // The board writes status, which the mirror refuses (a lead's lifecycle is
   // not a field write-back), so overlay gets the table and no toggle.
   const [view, setView] = useState<"table" | "board">("table");
+  const sources = useLeadSources();
   const ownerOptions = [
     { value: viewerId, label: t("lead.assignToMe") },
     ...(roster.data ?? [])
@@ -375,10 +381,9 @@ function LeadsWorkbench({ viewerId }: Readonly<{ viewerId: string }>) {
                 label: "lead.source",
                 type: "select",
                 required: true,
-                options: LEAD_SOURCES.map((source) => ({
-                  value: source.value,
-                  label: t(source.label),
-                })),
+                // The active administered list, in the administrator's order;
+                // "Created manually" is the default because it is first.
+                options: sourcePickOptions(sources.data?.data, null, t),
               },
               ...cf.formFields,
             ]}
@@ -462,7 +467,9 @@ function LeadsWorkbench({ viewerId }: Readonly<{ viewerId: string }>) {
             key: "source",
             header: t("lead.source"),
             cell: (lead: Lead) => (
-              <span className="t-caption">{sourceLabel(lead.source, t)}</span>
+              <span className="t-caption">
+                {sourceLabelFor(lead, sources.data?.data, t)}
+              </span>
             ),
           },
           ownerColumn<Lead>(t),
@@ -524,7 +531,7 @@ function LeadsWorkbench({ viewerId }: Readonly<{ viewerId: string }>) {
             key: "source",
             label: "lead.filterSource",
             allLabel: "lead.filterSourceAll",
-            options: LEAD_SOURCES.map((source) => ({ ...source })),
+            options: sourceFilterOptions(sources.data, t),
           },
         ]}
         // The one ownership dial every record list carries (DM-VOCAB-OWN-1):
@@ -1060,6 +1067,8 @@ function LeadIdentityFields({
   readOnlyReason?: string;
 }>) {
   const t = useT();
+  const sources = useLeadSources();
+  const fromConnector = (lead.source ?? "").startsWith("connector:");
   // One write at a time: a second row opened while a save is in flight would
   // carry the If-Match the first write is about to make stale.
   const canEdit = !readOnlyReason && !saving;
@@ -1110,7 +1119,20 @@ function LeadIdentityFields({
             )}
           </FieldRow>
           <FieldRow label={t("lead.source")}>
-            {sourceLabel(lead.source, t)}
+            <InlineChoice
+              label={t("lead.source")}
+              hideLabel
+              value={lead.source ?? ""}
+              options={sourcePickOptions(sources.data?.data, lead.source, t)}
+              // A connector's value stays where the connector put it; the
+              // administered list is what a human may pick from.
+              canEdit={canEdit && !fromConnector}
+              readOnlyReason={
+                fromConnector ? t("lead.sourceFromConnector") : readOnlyReason
+              }
+              render={() => sourceLabelFor(lead, sources.data?.data, t)}
+              onSave={(next) => save({ source: next })}
+            />
           </FieldRow>
           {lead.project_id && (
             <FieldRow label={t("lead.project")}>
@@ -1283,7 +1305,7 @@ function LeadBadges({ lead }: Readonly<{ lead: Lead }>) {
       {lead.score_override_reason && <Badge>{t("lead.overriddenBadge")}</Badge>}
       <StatusBadge status={lead.status} />
       {lead.company_name && <Badge>{lead.company_name}</Badge>}
-      {lead.source && <Badge>{sourceLabel(lead.source, t)}</Badge>}
+      {lead.source && <Badge>{sourceLabelFor(lead, undefined, t)}</Badge>}
       {terminal && <Badge tone={terminal.tone}>{t(terminal.label)}</Badge>}
     </div>
   );

--- a/frontend/src/screens/leadsources.ts
+++ b/frontend/src/screens/leadsources.ts
@@ -151,13 +151,22 @@ export function sourceKeyLabel(
 // the ACTIVE administered sources, in the administrator's order. A lead that
 // already carries a value outside that list (a connector's, a retired one)
 // keeps it as a first, non-removable option so the control never shows a
-// value it cannot name.
+// value it cannot name. While the list has not arrived — or failed — the
+// shipped six stand in, so a required picker is never empty and a lead can
+// still be created with a value the server knows.
 export function sourcePickOptions(
   sources: readonly LeadSource[] | undefined,
   current: string | null | undefined,
   t: ReturnType<typeof useT>,
 ): { value: string; label: string }[] {
-  const active = administeredOf(sources).filter((s) => s.active);
+  const administered = administeredOf(sources);
+  const active =
+    sources === undefined
+      ? Object.entries(SHIPPED_SOURCE_LABELS).map(([key, label]) => ({
+          key,
+          label: t(label),
+        }))
+      : administered.filter((s) => s.active);
   const options = active.map((s) => ({ value: s.key, label: s.label }));
   if (current && !active.some((s) => s.key === current)) {
     options.unshift({
@@ -168,9 +177,9 @@ export function sourcePickOptions(
   return options;
 }
 
-// The filter chip offers everything a lead could carry: every administered
-// source (retired ones included — the leads carrying them still exist) and
-// every discovered value.
+// The filter chip offers the ACTIVE administered sources and every discovered
+// value — the contract's reading of "inactive sources leave the create form
+// and the filter".
 export function sourceFilterOptions(
   list:
     | Readonly<{
@@ -187,7 +196,9 @@ export function sourceFilterOptions(
     ? list.discovered.filter((d) => typeof d?.key === "string")
     : [];
   return [
-    ...data.map((s) => ({ value: s.key, text: s.label })),
+    ...data
+      .filter((s) => s.active)
+      .map((s) => ({ value: s.key, text: s.label })),
     ...discovered.map((d) => ({
       value: d.key,
       text: sourceKeyLabel(d.key, data, t),

--- a/frontend/src/screens/leadsources.ts
+++ b/frontend/src/screens/leadsources.ts
@@ -1,0 +1,196 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import type { useT } from "../i18n";
+import { throwProblem } from "./common";
+
+// The lead vocabularies and lead handling, read from the server: which
+// sources a lead may come from (and what each is worth to the score), the
+// reasons a lead may be closed with, and whether the first-response target
+// is tracked at all. Every lead surface reads these through here so the
+// create form, the filter chip, the detail page and the settings cards
+// cannot disagree about the list.
+
+export type LeadSource = components["schemas"]["LeadSource"];
+export type DiscoveredLeadSource =
+  components["schemas"]["DiscoveredLeadSource"];
+export type LeadSourceIntent = components["schemas"]["LeadSourceIntent"];
+export type LeadDisqualifyReason =
+  components["schemas"]["LeadDisqualifyReason"];
+export type LeadSettings = components["schemas"]["LeadSettings"];
+
+export const LEAD_SOURCES_KEY = ["lead-sources"] as const;
+export const LEAD_DISQUALIFY_REASONS_KEY = ["lead-disqualify-reasons"] as const;
+export const LEAD_SETTINGS_KEY = ["lead-settings"] as const;
+
+export function useLeadSources() {
+  return useQuery({
+    queryKey: LEAD_SOURCES_KEY,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/lead-sources");
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+export function useLeadDisqualifyReasons() {
+  return useQuery({
+    queryKey: LEAD_DISQUALIFY_REASONS_KEY,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/lead-disqualify-reasons",
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data.data;
+    },
+  });
+}
+
+export function useLeadSettings() {
+  return useQuery({
+    queryKey: LEAD_SETTINGS_KEY,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/leads/settings");
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+export function useUpdateLeadSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (
+      body: components["schemas"]["UpdateLeadSettingsRequest"],
+    ) => {
+      const { data, error } = await api.PATCH("/leads/settings", { body });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: LEAD_SETTINGS_KEY });
+      // The list renders the SLA column and the Overdue view off this
+      // setting, so the leads it already holds are stale the moment it flips.
+      void queryClient.invalidateQueries({ queryKey: ["leads"] });
+    },
+  });
+}
+
+// The six shipped keys keep a client-side label so a lead renders sensibly
+// before the list has loaded (and in a test that never serves it); anything
+// the server labels wins over these.
+const SHIPPED_SOURCE_LABELS: Readonly<
+  Record<string, Parameters<ReturnType<typeof useT>>[0]>
+> = {
+  manual: "lead.source.manual",
+  inbound: "lead.source.inbound",
+  webform: "lead.source.webform",
+  referral: "lead.source.referral",
+  import: "lead.source.import",
+  crawl: "lead.source.crawl",
+};
+
+// administeredOf is the absent-body guard every reader of the list shares: a
+// payload that is not the contract's array, or a row without a key, is
+// treated as nothing rather than crashing the render that reads it.
+function administeredOf(
+  sources: readonly LeadSource[] | undefined,
+): LeadSource[] {
+  if (!Array.isArray(sources)) return [];
+  return sources.filter(
+    (s) => typeof s?.key === "string" && typeof s?.label === "string",
+  );
+}
+
+// sourceLabelFor names a stored source value for a reader: the server's own
+// label when the row carries one, else the administered list's, else the
+// shipped label, else a connector value's family ("Apollo") — never the
+// raw `connector:apollo:a-1` token.
+export function sourceLabelFor(
+  lead: Readonly<{ source?: string | null; source_label?: string | null }>,
+  sources: readonly LeadSource[] | undefined,
+  t: ReturnType<typeof useT>,
+): string {
+  if (lead.source_label) return lead.source_label;
+  return sourceKeyLabel(lead.source, sources, t);
+}
+
+export function sourceKeyLabel(
+  source: string | null | undefined,
+  sources: readonly LeadSource[] | undefined,
+  t: ReturnType<typeof useT>,
+): string {
+  if (!source) return t("lead.shortfall.noSource");
+  const known = administeredOf(sources);
+  const administered = known.find((s) => s.key === source);
+  if (administered) return administered.label;
+  const shipped = SHIPPED_SOURCE_LABELS[source];
+  if (shipped) return t(shipped);
+  const parts = source.split(":").filter(Boolean);
+  const family =
+    parts[0] === "connector"
+      ? known.find((s) => s.key === `${parts[0]}:${parts[1]}`)
+      : undefined;
+  if (family) return family.label;
+  const meaningful = parts[0] === "connector" ? parts[1] : parts[0];
+  return meaningful
+    ? meaningful.charAt(0).toUpperCase() + meaningful.slice(1)
+    : t("lead.source.unknown");
+}
+
+// The options a human may pick from when creating or correcting a lead:
+// the ACTIVE administered sources, in the administrator's order. A lead that
+// already carries a value outside that list (a connector's, a retired one)
+// keeps it as a first, non-removable option so the control never shows a
+// value it cannot name.
+export function sourcePickOptions(
+  sources: readonly LeadSource[] | undefined,
+  current: string | null | undefined,
+  t: ReturnType<typeof useT>,
+): { value: string; label: string }[] {
+  const active = administeredOf(sources).filter((s) => s.active);
+  const options = active.map((s) => ({ value: s.key, label: s.label }));
+  if (current && !active.some((s) => s.key === current)) {
+    options.unshift({
+      value: current,
+      label: sourceKeyLabel(current, sources, t),
+    });
+  }
+  return options;
+}
+
+// The filter chip offers everything a lead could carry: every administered
+// source (retired ones included — the leads carrying them still exist) and
+// every discovered value.
+export function sourceFilterOptions(
+  list:
+    | Readonly<{
+        data: readonly LeadSource[];
+        discovered: readonly DiscoveredLeadSource[];
+      }>
+    | undefined,
+  t: ReturnType<typeof useT>,
+): { value: string; text: string }[] {
+  // A body that lost a contract-required array is treated as the empty
+  // list it claims rather than a crash in the render that reads it.
+  const data = administeredOf(list?.data);
+  const discovered = Array.isArray(list?.discovered)
+    ? list.discovered.filter((d) => typeof d?.key === "string")
+    : [];
+  return [
+    ...data.map((s) => ({ value: s.key, text: s.label })),
+    ...discovered.map((d) => ({
+      value: d.key,
+      text: sourceKeyLabel(d.key, data, t),
+    })),
+  ];
+}

--- a/frontend/src/screens/leadvocab.css
+++ b/frontend/src/screens/leadvocab.css
@@ -1,0 +1,61 @@
+/* Settings → Data model: the two lead vocabularies and the lead-handling
+   posture. One list shape for both vocabularies, so a source row and a reason
+   row line up under each other. */
+
+.lead-vocab-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 var(--space-4);
+}
+
+/* A row is one record: label (editable), its key, what it is worth, how many
+   leads carry it, and its flags. It wraps on a narrow column rather than
+   squeezing the label it is about. */
+.lead-vocab-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border-subtle, transparent);
+}
+
+.lead-vocab-row > .lead-vocab-rename {
+  flex: 1 1 180px;
+  width: auto;
+}
+
+.lead-vocab-key {
+  flex: 0 0 auto;
+}
+
+.lead-vocab-count {
+  flex: 0 0 auto;
+  min-width: 6ch;
+}
+
+.lead-vocab-flags {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+/* The add row reads as one line: label, intent, submit. */
+.lead-vocab-add {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
+.lead-vocab-add > .field:first-child {
+  flex: 1 1 200px;
+}
+
+.lead-handling {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 32rem;
+}

--- a/frontend/src/screens/leadvocab.stories.tsx
+++ b/frontend/src/screens/leadvocab.stories.tsx
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  LeadDisqualifyReasonsCard,
+  LeadHandlingCard,
+  LeadSourcesCard,
+} from "./leadvocab";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// Settings › Data model: where leads come from, why they get dropped, and
+// whether the first-response target is tracked. Every role reads the lists;
+// the custom_field write verbs decide who may change them.
+
+function source(
+  key: string,
+  label: string,
+  intent: string,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    id: `src-${key}`,
+    key,
+    label,
+    intent,
+    sort_order: 10,
+    active: true,
+    system: false,
+    lead_count: 0,
+    version: 1,
+    created_at: "2026-08-01T08:00:00Z",
+    updated_at: "2026-08-01T08:00:00Z",
+    ...extra,
+  };
+}
+
+const SOURCES = {
+  data: [
+    source("manual", "Created manually", "neutral", {
+      system: true,
+      lead_count: 12,
+    }),
+    source("inbound", "Inbound", "high", { system: true, lead_count: 31 }),
+    source("webform", "Web form", "high", { system: true, lead_count: 4 }),
+    source("referral", "Referral", "high", { system: true, lead_count: 9 }),
+    source("import", "Import", "low", {
+      system: true,
+      lead_count: 140,
+      active: false,
+    }),
+    source("crawl", "Web research", "low", { system: true, lead_count: 2 }),
+    source("trade_show", "Trade show", "high", { lead_count: 3 }),
+  ],
+  discovered: [{ key: "connector:apollo", lead_count: 27 }],
+};
+
+const REASONS = {
+  data: [
+    ["r1", "Not a good fit", 6],
+    ["r2", "Bad timing", 11],
+    ["r3", "No budget", 2],
+    ["r4", "No decision power", 0],
+    ["r5", "Chose a competitor", 1],
+    ["r6", "No interest", 4],
+    ["r7", "Not reachable", 8],
+    ["r8", "Duplicate or spam", 3],
+  ].map(([id, label, count]) => ({
+    id,
+    label,
+    sort_order: 10,
+    active: true,
+    system: true,
+    lead_count: count,
+    version: 1,
+    created_at: "2026-08-01T08:00:00Z",
+    updated_at: "2026-08-01T08:00:00Z",
+  })),
+};
+
+const ADMIN = { custom_field: ["read", "create", "update", "delete"] } as const;
+const READER = { custom_field: ["read"] } as const;
+
+function story(allow: Parameters<typeof meRoute>[0], slaOn: boolean) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute(allow),
+      "GET /lead-sources": () => jsonResponse(SOURCES),
+      "GET /lead-disqualify-reasons": () => jsonResponse(REASONS),
+      "GET /leads/settings": () =>
+        jsonResponse({
+          first_response_enabled: slaOn,
+          first_response_target_minutes: 240,
+        }),
+    });
+    return (
+      <StoryProviders>
+        <LeadSourcesCard />
+        <LeadDisqualifyReasonsCard />
+        <LeadHandlingCard />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof LeadSourcesCard> = {
+  title: "Settings/Organization/Data model/Lead vocabularies",
+  component: LeadSourcesCard,
+};
+export default meta;
+type Story = StoryObj<typeof LeadSourcesCard>;
+
+export const Admin: Story = { render: story(ADMIN, false) };
+export const AdminWithTargetOn: Story = { render: story(ADMIN, true) };
+export const Reader: Story = { render: story(READER, false) };

--- a/frontend/src/screens/leadvocab.test.tsx
+++ b/frontend/src/screens/leadvocab.test.tsx
@@ -1,0 +1,306 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type GrantSpec, meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import {
+  LeadDisqualifyReasonsCard,
+  LeadHandlingCard,
+  LeadSourcesCard,
+} from "./leadvocab";
+
+// Settings › Data model: the lead vocabularies and the lead-handling posture.
+// Every role reads them; the custom_field write verbs decide who may change
+// them, and the cards disable rather than hide.
+
+const ADMIN: GrantSpec = {
+  custom_field: ["read", "create", "update", "delete"],
+};
+const READER: GrantSpec = { custom_field: ["read"] };
+
+function source(
+  key: string,
+  label: string,
+  extra: Partial<{
+    system: boolean;
+    lead_count: number;
+    active: boolean;
+    intent: string;
+  }> = {},
+) {
+  return {
+    id: `src-${key}`,
+    key,
+    label,
+    intent: "neutral",
+    sort_order: 10,
+    active: true,
+    system: false,
+    lead_count: 0,
+    version: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...extra,
+  };
+}
+
+type Call = { url: string; method: string; body: unknown };
+
+function backend(allow: GrantSpec, calls: Call[] = []) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : null;
+    const url = String(request ? request.url : input);
+    const method = request ? request.method : (init?.method ?? "GET");
+    const raw = request ? await request.text() : String(init?.body ?? "");
+    calls.push({ url, method, body: raw ? JSON.parse(raw) : undefined });
+    let body: unknown;
+    let status = 200;
+    if (url.endsWith("/v1/me")) {
+      body = meFixture({ allow });
+    } else if (url.includes("/lead-sources") && method === "GET") {
+      body = {
+        data: [
+          source("manual", "Created manually", { system: true, lead_count: 3 }),
+          source("trade_show", "Trade show", { intent: "high" }),
+        ],
+        discovered: [{ key: "connector:apollo", lead_count: 7 }],
+      };
+    } else if (url.includes("/lead-sources") && method === "DELETE") {
+      body = null;
+      status = 204;
+    } else if (url.includes("/lead-sources")) {
+      body = source("trade_show", "Messe");
+    } else if (url.includes("/lead-disqualify-reasons") && method === "GET") {
+      body = {
+        data: [
+          { ...source("r1", "Bad timing", { system: true, lead_count: 2 }) },
+          { ...source("r2", "Went quiet") },
+        ],
+      };
+    } else if (url.includes("/lead-disqualify-reasons")) {
+      body = source("r2", "Went quiet");
+    } else if (url.endsWith("/leads/settings")) {
+      body = {
+        first_response_enabled: false,
+        first_response_target_minutes: 240,
+      };
+    }
+    return new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{children}</LocaleProvider>
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("LeadSourcesCard", () => {
+  it("lists the administered sources with their counts, marks built-ins, and offers removal only where the server would allow it", async () => {
+    vi.stubGlobal("fetch", backend(ADMIN));
+    render(
+      <Providers>
+        <LeadSourcesCard />
+      </Providers>,
+    );
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Created manually")).toBeTruthy(),
+    );
+    expect(screen.getByText("built-in")).toBeTruthy();
+    expect(screen.getByText("3 leads")).toBeTruthy();
+    // The built-in, in-use source says "switch off instead"; the unused
+    // custom one gets the Remove button.
+    const manual = screen.getByTestId("lead-source-manual");
+    expect(manual.textContent).toContain("switch off instead");
+    const trade = screen.getByTestId("lead-source-trade_show");
+    expect(within(trade).getByRole("button", { name: "Remove" })).toBeTruthy();
+    expect(within(manual).queryByRole("button", { name: "Remove" })).toBeNull();
+  });
+
+  it("renames on Enter and re-weights through the intent select, one PATCH each", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", backend(ADMIN, calls));
+    render(
+      <Providers>
+        <LeadSourcesCard />
+      </Providers>,
+    );
+    const input = (await screen.findByDisplayValue(
+      "Trade show",
+    )) as HTMLInputElement;
+    await userEvent.clear(input);
+    await userEvent.type(input, "Messe{Enter}");
+    await waitFor(() =>
+      expect(
+        calls.some(
+          (c) =>
+            c.method === "PATCH" &&
+            c.url.endsWith("/lead-sources/src-trade_show") &&
+            JSON.stringify(c.body) === JSON.stringify({ label: "Messe" }),
+        ),
+      ).toBe(true),
+    );
+    // The select is a combobox: open it, pick the option.
+    await userEvent.click(
+      screen.getByRole("combobox", { name: "Intent of Trade show" }),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "Low interest" }));
+    await waitFor(() =>
+      expect(
+        calls.some(
+          (c) =>
+            c.method === "PATCH" &&
+            c.url.endsWith("/lead-sources/src-trade_show") &&
+            JSON.stringify(c.body) === JSON.stringify({ intent: "low" }),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("adds a source with a label and intent, and adopts a discovered connector family", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", backend(ADMIN, calls));
+    render(
+      <Providers>
+        <LeadSourcesCard />
+      </Providers>,
+    );
+    await userEvent.type(
+      await screen.findByTestId("lead-source-new-label"),
+      "Webinar",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add source" }));
+    await waitFor(() =>
+      expect(
+        calls.some(
+          (c) =>
+            c.method === "POST" &&
+            c.url.endsWith("/lead-sources") &&
+            JSON.stringify(c.body) ===
+              JSON.stringify({ label: "Webinar", intent: "neutral" }),
+        ),
+      ).toBe(true),
+    );
+    expect(screen.getByText("7 leads")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Add to list" }));
+    await waitFor(() =>
+      expect(
+        calls.some(
+          (c) =>
+            c.method === "POST" &&
+            c.url.endsWith("/lead-sources") &&
+            (c.body as { key?: string }).key === "connector:apollo",
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("leaves every control inert for a reader and says why", async () => {
+    vi.stubGlobal("fetch", backend(READER));
+    render(
+      <Providers>
+        <LeadSourcesCard />
+      </Providers>,
+    );
+    const input = (await screen.findByDisplayValue(
+      "Trade show",
+    )) as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    expect(
+      screen.getByText("Only an admin or ops seat changes this list."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add source" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+  });
+});
+
+describe("LeadDisqualifyReasonsCard", () => {
+  it("lists the reasons and keeps the built-in, in-use one from removal", async () => {
+    vi.stubGlobal("fetch", backend(ADMIN));
+    render(
+      <Providers>
+        <LeadDisqualifyReasonsCard />
+      </Providers>,
+    );
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Bad timing")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("lead-reason-src-r1").textContent).toContain(
+      "switch off instead",
+    );
+    expect(
+      within(screen.getByTestId("lead-reason-src-r2")).getByRole("button", {
+        name: "Remove",
+      }),
+    ).toBeTruthy();
+  });
+});
+
+describe("LeadHandlingCard", () => {
+  it("shows the target off by default, flips it through one PATCH, and keeps the minutes field inert while off", async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal("fetch", backend(ADMIN, calls));
+    render(
+      <Providers>
+        <LeadHandlingCard />
+      </Providers>,
+    );
+    const toggle = await screen.findByTestId("lead-first-response-switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    const minutes = screen.getByTestId(
+      "lead-first-response-target",
+    ) as HTMLInputElement;
+    expect(minutes.disabled).toBe(true);
+    expect(minutes.value).toBe("240");
+    await userEvent.click(toggle);
+    await waitFor(() =>
+      expect(
+        calls.some(
+          (c) =>
+            c.method === "PATCH" &&
+            c.url.endsWith("/leads/settings") &&
+            JSON.stringify(c.body) ===
+              JSON.stringify({ first_response_enabled: true }),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("refuses the flip for a reader and says why", async () => {
+    vi.stubGlobal("fetch", backend(READER));
+    render(
+      <Providers>
+        <LeadHandlingCard />
+      </Providers>,
+    );
+    const toggle = (await screen.findByTestId(
+      "lead-first-response-switch",
+    )) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(
+      screen.getByText("Only an admin or ops seat changes this list."),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/leadvocab.tsx
+++ b/frontend/src/screens/leadvocab.tsx
@@ -34,6 +34,17 @@ import "./leadvocab.css";
 // controls disable with the reason rather than hide.
 
 const INTENTS = ["high", "neutral", "low"] as const;
+
+// The contract promises the arrays; a body that lost one is treated as the
+// empty list it claims rather than a crash in the render that reads it.
+function rowsOf<Row>(rows: readonly Row[] | null | undefined): readonly Row[] {
+  return Array.isArray(rows) ? rows : [];
+}
+
+// The first-response target's bounds, the same the server enforces
+// (15 minutes to 7 days); checked here so a refusal never leaves the page.
+const TARGET_MIN_MINUTES = 15;
+const TARGET_MAX_MINUTES = 7 * 24 * 60;
 const intentLabel: Record<LeadSourceIntent, MessageKey> = {
   high: "leadSources.intent.high",
   neutral: "leadSources.intent.neutral",
@@ -199,7 +210,7 @@ function LeadSourceRow({
       <span className="lead-vocab-flags">
         {builtIn && <Badge>{t("leadSources.builtIn")}</Badge>}
         <Switch
-          label={t("leadSources.active")}
+          label={t("leadSources.activeFor", { label: source.label })}
           labelHidden
           checked={source.active}
           disabled={!canEdit}
@@ -259,7 +270,7 @@ export function LeadSourcesCard() {
         {(list) => (
           <>
             <ul className="lead-vocab-list" data-testid="lead-source-list">
-              {list.data.map((source) => (
+              {rowsOf(list.data).map((source) => (
                 <LeadSourceRow
                   key={source.id}
                   source={source}
@@ -272,16 +283,18 @@ export function LeadSourcesCard() {
                 />
               ))}
             </ul>
-            {list.discovered.length > 0 && (
+            {rowsOf(list.discovered).length > 0 && (
               <PanelRow>
                 <p className="t-caption">{t("leadSources.discoveredSub")}</p>
                 <ul
                   className="lead-vocab-list"
                   data-testid="lead-source-discovered"
                 >
-                  {list.discovered.map((found) => (
+                  {rowsOf(list.discovered).map((found) => (
                     <li key={found.key} className="lead-vocab-row">
-                      <span>{sourceKeyLabel(found.key, list.data, t)}</span>
+                      <span>
+                        {sourceKeyLabel(found.key, rowsOf(list.data), t)}
+                      </span>
                       <span className="t-mono t-caption lead-vocab-key">
                         {found.key}
                       </span>
@@ -297,7 +310,11 @@ export function LeadSourcesCard() {
                             onClick={() =>
                               create.mutate({
                                 key: found.key,
-                                label: sourceKeyLabel(found.key, list.data, t),
+                                label: sourceKeyLabel(
+                                  found.key,
+                                  rowsOf(list.data),
+                                  t,
+                                ),
                                 intent: "neutral",
                               })
                             }
@@ -462,7 +479,7 @@ export function LeadDisqualifyReasonsCard() {
       <QueryGate query={query}>
         {(reasons) => (
           <ul className="lead-vocab-list" data-testid="lead-reason-list">
-            {reasons.map((reason) => {
+            {rowsOf(reasons).map((reason) => {
               const count = reason.lead_count ?? 0;
               const builtIn = reason.system === true;
               const removable = canRemove && !builtIn && count === 0;
@@ -486,7 +503,9 @@ export function LeadDisqualifyReasonsCard() {
                   <span className="lead-vocab-flags">
                     {builtIn && <Badge>{t("leadSources.builtIn")}</Badge>}
                     <Switch
-                      label={t("leadSources.active")}
+                      label={t("leadSources.activeFor", {
+                        label: reason.label,
+                      })}
                       labelHidden
                       checked={reason.active}
                       disabled={!canEdit}
@@ -586,6 +605,7 @@ export function LeadHandlingCard() {
   const query = useLeadSettings();
   const update = useUpdateLeadSettings();
   const [draft, setDraft] = useState<string | null>(null);
+  const [targetError, setTargetError] = useState<string | null>(null);
   return (
     <Panel title={t("leadHandling.title")}>
       <PanelBody className="form-stack">
@@ -601,16 +621,27 @@ export function LeadHandlingCard() {
               draft ?? String(settings.first_response_target_minutes);
             const commit = () => {
               const minutes = Number(shown);
-              if (
-                !Number.isInteger(minutes) ||
-                minutes === settings.first_response_target_minutes
-              ) {
+              if (minutes === settings.first_response_target_minutes) {
                 setDraft(null);
+                setTargetError(null);
                 return;
               }
+              if (
+                !Number.isInteger(minutes) ||
+                minutes < TARGET_MIN_MINUTES ||
+                minutes > TARGET_MAX_MINUTES
+              ) {
+                // The typed value stays so it can be corrected, and the
+                // field says what it wants.
+                setTargetError(t("leadHandling.targetOutOfRange"));
+                return;
+              }
+              setTargetError(null);
               update.mutate(
                 { first_response_target_minutes: minutes },
-                { onSettled: () => setDraft(null) },
+                // A refused write keeps the draft for the reader to fix; a
+                // landed one clears it so the field reads the stored value.
+                { onSuccess: () => setDraft(null) },
               );
             };
             return (
@@ -629,6 +660,7 @@ export function LeadHandlingCard() {
                 <Field
                   label={t("leadHandling.targetMinutes")}
                   hint={t("leadHandling.targetHint")}
+                  error={targetError ?? undefined}
                 >
                   {(control) => (
                     <TextInput

--- a/frontend/src/screens/leadvocab.tsx
+++ b/frontend/src/screens/leadvocab.tsx
@@ -1,0 +1,658 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { api } from "../api/client";
+import { useCanWrite } from "../app/capability";
+import { isOption } from "../app/options";
+import { Badge, Button, Field, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { Select } from "../design-system/select";
+import { Switch } from "../design-system/switch";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+import {
+  LEAD_DISQUALIFY_REASONS_KEY,
+  LEAD_SOURCES_KEY,
+  type LeadDisqualifyReason,
+  type LeadSource,
+  type LeadSourceIntent,
+  sourceKeyLabel,
+  useLeadDisqualifyReasons,
+  useLeadSettings,
+  useLeadSources,
+  useUpdateLeadSettings,
+} from "./leadsources";
+import "./leadvocab.css";
+
+// Settings › Data model: the two administered lead vocabularies and the
+// lead-handling posture. Every role reads them — the leads list needs the
+// labels and the SLA switch to know what to render — and only a seat holding
+// the custom_field write verbs changes them, the same posture as the
+// custom-field catalog beside them. The server stays the RBAC authority; the
+// controls disable with the reason rather than hide.
+
+const INTENTS = ["high", "neutral", "low"] as const;
+const intentLabel: Record<LeadSourceIntent, MessageKey> = {
+  high: "leadSources.intent.high",
+  neutral: "leadSources.intent.neutral",
+  low: "leadSources.intent.low",
+};
+
+function useSourceMutations() {
+  const queryClient = useQueryClient();
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: LEAD_SOURCES_KEY });
+    // The list and the create form render labels off this list.
+    void queryClient.invalidateQueries({ queryKey: ["leads"] });
+  };
+  const create = useMutation({
+    mutationFn: async (body: {
+      label: string;
+      key?: string;
+      intent: LeadSourceIntent;
+    }) => {
+      const { data, error } = await api.POST("/lead-sources", { body });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: invalidate,
+  });
+  const update = useMutation({
+    mutationFn: async ({
+      id,
+      ...body
+    }: {
+      id: string;
+      label?: string;
+      intent?: LeadSourceIntent;
+      active?: boolean;
+      sort_order?: number;
+    }) => {
+      const { data, error } = await api.PATCH("/lead-sources/{id}", {
+        params: { path: { id } },
+        body,
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: invalidate,
+  });
+  const remove = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await api.DELETE("/lead-sources/{id}", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: invalidate,
+  });
+  return { create, update, remove };
+}
+
+// A label that commits on Enter or blur, and gives the typed text back when
+// the save is refused so the reader can fix it rather than retype it.
+function RenameField({
+  label,
+  value,
+  canEdit,
+  onSave,
+}: Readonly<{
+  label: string;
+  value: string;
+  canEdit: boolean;
+  onSave: (next: string) => void;
+}>) {
+  const [draft, setDraft] = useState(value);
+  const [known, setKnown] = useState(value);
+  if (known !== value) {
+    setKnown(value);
+    setDraft(value);
+  }
+  const commit = () => {
+    const next = draft.trim();
+    if (next !== "" && next !== value) {
+      onSave(next);
+    } else {
+      setDraft(value);
+    }
+  };
+  // The row's own words name the field (the list is the label column), so
+  // the control carries its name for assistive tech only.
+  return (
+    <TextInput
+      aria-label={label}
+      className="lead-vocab-rename"
+      value={draft}
+      disabled={!canEdit}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          commit();
+        }
+        if (e.key === "Escape") {
+          setDraft(value);
+        }
+      }}
+    />
+  );
+}
+
+function LeadSourceRow({
+  source,
+  canEdit,
+  canRemove,
+  onUpdate,
+  onRemove,
+}: Readonly<{
+  source: LeadSource;
+  canEdit: boolean;
+  canRemove: boolean;
+  onUpdate: (patch: {
+    label?: string;
+    intent?: LeadSourceIntent;
+    active?: boolean;
+  }) => void;
+  onRemove: () => void;
+}>) {
+  const t = useT();
+  const count = source.lead_count ?? 0;
+  const builtIn = source.system === true;
+  // Built-ins and in-use sources deactivate instead: the server answers 409
+  // to the delete, so the control says so instead of offering it.
+  const removable = canRemove && !builtIn && count === 0;
+  return (
+    <li className="lead-vocab-row" data-testid={`lead-source-${source.key}`}>
+      <RenameField
+        label={t("leadSources.labelFor", { key: source.key })}
+        value={source.label}
+        canEdit={canEdit}
+        onSave={(label) => onUpdate({ label })}
+      />
+      <span className="t-mono t-caption lead-vocab-key">{source.key}</span>
+      <Select
+        aria-label={t("leadSources.intentFor", { label: source.label })}
+        value={source.intent}
+        disabled={!canEdit}
+        onChange={(value) => {
+          if (isOption(value, INTENTS) && value !== source.intent) {
+            onUpdate({ intent: value });
+          }
+        }}
+        options={INTENTS.map((value) => ({
+          value,
+          label: t(intentLabel[value]),
+        }))}
+      />
+      <span className="t-caption lead-vocab-count">
+        {t("leadSources.leadCount", { count })}
+      </span>
+      <span className="lead-vocab-flags">
+        {builtIn && <Badge>{t("leadSources.builtIn")}</Badge>}
+        <Switch
+          label={t("leadSources.active")}
+          labelHidden
+          checked={source.active}
+          disabled={!canEdit}
+          onChange={(next) => onUpdate({ active: next })}
+        />
+        {removable ? (
+          <Button small variant="danger" onClick={onRemove}>
+            {t("leadSources.remove")}
+          </Button>
+        ) : (
+          canRemove && (
+            <span
+              className="t-caption"
+              title={
+                builtIn
+                  ? t("leadSources.builtInKept")
+                  : t("leadSources.inUse", { count })
+              }
+            >
+              {t("leadSources.deactivateInstead")}
+            </span>
+          )
+        )}
+      </span>
+    </li>
+  );
+}
+
+export function LeadSourcesCard() {
+  const t = useT();
+  const canCreate = useCanWrite("custom_field", "create");
+  const canEdit = useCanWrite("custom_field", "update");
+  const canRemove = useCanWrite("custom_field", "delete");
+  const query = useLeadSources();
+  const { create, update, remove } = useSourceMutations();
+  const [label, setLabel] = useState("");
+  const [intent, setIntent] = useState<LeadSourceIntent>("neutral");
+  const [removing, setRemoving] = useState<LeadSource | null>(null);
+  const denialId = useId();
+  const failure = [create, update, remove].find((m) => m.isError);
+  return (
+    <Panel title={t("leadSources.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("leadSources.sub")}</p>
+        {!canEdit && (
+          <p className="t-small" id={denialId}>
+            {t("leadSources.readOnly")}
+          </p>
+        )}
+        {failure && (
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(failure.error, t)}
+          </Callout>
+        )}
+      </PanelBody>
+      <QueryGate query={query}>
+        {(list) => (
+          <>
+            <ul className="lead-vocab-list" data-testid="lead-source-list">
+              {list.data.map((source) => (
+                <LeadSourceRow
+                  key={source.id}
+                  source={source}
+                  canEdit={canEdit}
+                  canRemove={canRemove}
+                  onUpdate={(patch) =>
+                    update.mutate({ id: source.id, ...patch })
+                  }
+                  onRemove={() => setRemoving(source)}
+                />
+              ))}
+            </ul>
+            {list.discovered.length > 0 && (
+              <PanelRow>
+                <p className="t-caption">{t("leadSources.discoveredSub")}</p>
+                <ul
+                  className="lead-vocab-list"
+                  data-testid="lead-source-discovered"
+                >
+                  {list.discovered.map((found) => (
+                    <li key={found.key} className="lead-vocab-row">
+                      <span>{sourceKeyLabel(found.key, list.data, t)}</span>
+                      <span className="t-mono t-caption lead-vocab-key">
+                        {found.key}
+                      </span>
+                      <span className="t-caption lead-vocab-count">
+                        {t("leadSources.leadCount", {
+                          count: found.lead_count,
+                        })}
+                      </span>
+                      <span className="lead-vocab-flags">
+                        {canCreate && (
+                          <Button
+                            small
+                            onClick={() =>
+                              create.mutate({
+                                key: found.key,
+                                label: sourceKeyLabel(found.key, list.data, t),
+                                intent: "neutral",
+                              })
+                            }
+                          >
+                            {t("leadSources.adopt")}
+                          </Button>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </PanelRow>
+            )}
+          </>
+        )}
+      </QueryGate>
+      {canCreate && (
+        <PanelRow>
+          <form
+            className="lead-vocab-add"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (label.trim() === "") return;
+              create.mutate(
+                { label: label.trim(), intent },
+                { onSuccess: () => setLabel("") },
+              );
+            }}
+          >
+            <Field label={t("leadSources.newLabel")}>
+              {(control) => (
+                <TextInput
+                  {...control}
+                  data-testid="lead-source-new-label"
+                  placeholder={t("leadSources.newPlaceholder")}
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                />
+              )}
+            </Field>
+            <Field label={t("leadSources.intent")}>
+              {(control) => (
+                <Select
+                  {...control}
+                  value={intent}
+                  onChange={(value) => {
+                    if (isOption(value, INTENTS)) setIntent(value);
+                  }}
+                  options={INTENTS.map((value) => ({
+                    value,
+                    label: t(intentLabel[value]),
+                  }))}
+                />
+              )}
+            </Field>
+            <Button type="submit" variant="primary" disabled={create.isPending}>
+              {t("leadSources.add")}
+            </Button>
+          </form>
+          <p className="t-caption">{t("leadSources.intentHint")}</p>
+        </PanelRow>
+      )}
+      <ConfirmModal
+        open={removing !== null}
+        onClose={() => {
+          remove.reset();
+          setRemoving(null);
+        }}
+        title={t("leadSources.removeTitle")}
+        confirmLabel={t("leadSources.remove")}
+        confirmVariant="danger"
+        pending={remove.isPending}
+        error={remove.isError ? problemMessageOf(remove.error, t) : null}
+        onConfirm={() => {
+          if (removing) {
+            remove.mutate(removing.id, { onSuccess: () => setRemoving(null) });
+          }
+        }}
+      >
+        <p className="t-small">
+          {t("leadSources.removeBody", { label: removing?.label ?? "" })}
+        </p>
+      </ConfirmModal>
+    </Panel>
+  );
+}
+
+function useReasonMutations() {
+  const queryClient = useQueryClient();
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: LEAD_DISQUALIFY_REASONS_KEY,
+    });
+  };
+  const create = useMutation({
+    mutationFn: async (body: { label: string }) => {
+      const { data, error } = await api.POST("/lead-disqualify-reasons", {
+        body,
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: invalidate,
+  });
+  const update = useMutation({
+    mutationFn: async ({
+      id,
+      ...body
+    }: {
+      id: string;
+      label?: string;
+      active?: boolean;
+    }) => {
+      const { data, error } = await api.PATCH("/lead-disqualify-reasons/{id}", {
+        params: { path: { id } },
+        body,
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: invalidate,
+  });
+  const remove = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await api.DELETE("/lead-disqualify-reasons/{id}", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: invalidate,
+  });
+  return { create, update, remove };
+}
+
+export function LeadDisqualifyReasonsCard() {
+  const t = useT();
+  const canCreate = useCanWrite("custom_field", "create");
+  const canEdit = useCanWrite("custom_field", "update");
+  const canRemove = useCanWrite("custom_field", "delete");
+  const query = useLeadDisqualifyReasons();
+  const { create, update, remove } = useReasonMutations();
+  const [label, setLabel] = useState("");
+  const [removing, setRemoving] = useState<LeadDisqualifyReason | null>(null);
+  const failure = [create, update, remove].find((m) => m.isError);
+  return (
+    <Panel title={t("leadReasons.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("leadReasons.sub")}</p>
+        {!canEdit && <p className="t-small">{t("leadSources.readOnly")}</p>}
+        {failure && (
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(failure.error, t)}
+          </Callout>
+        )}
+      </PanelBody>
+      <QueryGate query={query}>
+        {(reasons) => (
+          <ul className="lead-vocab-list" data-testid="lead-reason-list">
+            {reasons.map((reason) => {
+              const count = reason.lead_count ?? 0;
+              const builtIn = reason.system === true;
+              const removable = canRemove && !builtIn && count === 0;
+              return (
+                <li
+                  key={reason.id}
+                  className="lead-vocab-row lead-vocab-row-reason"
+                  data-testid={`lead-reason-${reason.id}`}
+                >
+                  <RenameField
+                    label={t("leadReasons.labelFor", { label: reason.label })}
+                    value={reason.label}
+                    canEdit={canEdit}
+                    onSave={(next) =>
+                      update.mutate({ id: reason.id, label: next })
+                    }
+                  />
+                  <span className="t-caption lead-vocab-count">
+                    {t("leadReasons.leadCount", { count })}
+                  </span>
+                  <span className="lead-vocab-flags">
+                    {builtIn && <Badge>{t("leadSources.builtIn")}</Badge>}
+                    <Switch
+                      label={t("leadSources.active")}
+                      labelHidden
+                      checked={reason.active}
+                      disabled={!canEdit}
+                      onChange={(next) =>
+                        update.mutate({ id: reason.id, active: next })
+                      }
+                    />
+                    {removable ? (
+                      <Button
+                        small
+                        variant="danger"
+                        onClick={() => setRemoving(reason)}
+                      >
+                        {t("leadSources.remove")}
+                      </Button>
+                    ) : (
+                      canRemove && (
+                        <span
+                          className="t-caption"
+                          title={
+                            builtIn
+                              ? t("leadSources.builtInKept")
+                              : t("leadReasons.inUse", { count })
+                          }
+                        >
+                          {t("leadSources.deactivateInstead")}
+                        </span>
+                      )
+                    )}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </QueryGate>
+      {canCreate && (
+        <PanelRow>
+          <form
+            className="lead-vocab-add"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (label.trim() === "") return;
+              create.mutate(
+                { label: label.trim() },
+                { onSuccess: () => setLabel("") },
+              );
+            }}
+          >
+            <Field label={t("leadReasons.newLabel")}>
+              {(control) => (
+                <TextInput
+                  {...control}
+                  data-testid="lead-reason-new-label"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                />
+              )}
+            </Field>
+            <Button type="submit" variant="primary" disabled={create.isPending}>
+              {t("leadReasons.add")}
+            </Button>
+          </form>
+        </PanelRow>
+      )}
+      <ConfirmModal
+        open={removing !== null}
+        onClose={() => {
+          remove.reset();
+          setRemoving(null);
+        }}
+        title={t("leadReasons.removeTitle")}
+        confirmLabel={t("leadSources.remove")}
+        confirmVariant="danger"
+        pending={remove.isPending}
+        error={remove.isError ? problemMessageOf(remove.error, t) : null}
+        onConfirm={() => {
+          if (removing) {
+            remove.mutate(removing.id, { onSuccess: () => setRemoving(null) });
+          }
+        }}
+      >
+        <p className="t-small">
+          {t("leadReasons.removeBody", { label: removing?.label ?? "" })}
+        </p>
+      </ConfirmModal>
+    </Panel>
+  );
+}
+
+// The first-response target: off by default, and the number is the
+// installation's own. The switch writes when flipped; the target commits on
+// Enter or blur like a rename, only once the value is a whole number in range.
+export function LeadHandlingCard() {
+  const t = useT();
+  const canEdit = useCanWrite("custom_field", "update");
+  const query = useLeadSettings();
+  const update = useUpdateLeadSettings();
+  const [draft, setDraft] = useState<string | null>(null);
+  return (
+    <Panel title={t("leadHandling.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("leadHandling.sub")}</p>
+        {update.isError && (
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(update.error, t)}
+          </Callout>
+        )}
+        <QueryGate query={query}>
+          {(settings) => {
+            const shown =
+              draft ?? String(settings.first_response_target_minutes);
+            const commit = () => {
+              const minutes = Number(shown);
+              if (
+                !Number.isInteger(minutes) ||
+                minutes === settings.first_response_target_minutes
+              ) {
+                setDraft(null);
+                return;
+              }
+              update.mutate(
+                { first_response_target_minutes: minutes },
+                { onSettled: () => setDraft(null) },
+              );
+            };
+            return (
+              <div className="lead-handling">
+                <Switch
+                  label={t("leadHandling.firstResponse")}
+                  hint={t("leadHandling.firstResponseHint")}
+                  checked={settings.first_response_enabled}
+                  pending={update.isPending}
+                  reason={canEdit ? undefined : t("leadSources.readOnly")}
+                  testId="lead-first-response-switch"
+                  onChange={(next) =>
+                    update.mutate({ first_response_enabled: next })
+                  }
+                />
+                <Field
+                  label={t("leadHandling.targetMinutes")}
+                  hint={t("leadHandling.targetHint")}
+                >
+                  {(control) => (
+                    <TextInput
+                      {...control}
+                      data-testid="lead-first-response-target"
+                      inputMode="numeric"
+                      value={shown}
+                      disabled={!canEdit || !settings.first_response_enabled}
+                      onChange={(e) => setDraft(e.target.value)}
+                      onBlur={commit}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          commit();
+                        }
+                      }}
+                    />
+                  )}
+                </Field>
+              </div>
+            );
+          }}
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -84,13 +84,22 @@ export type ListPage<Row> = {
   page: { next_cursor: string | null; has_more: boolean };
 };
 
+/**
+ * One value a filter chip offers: named by a message key when the vocabulary
+ * is the screen's own, or by the server's text when it is an administered list
+ * (lead sources, for one) the screen only relays.
+ */
+export type FilterOption =
+  | { value: string; label: MessageKey }
+  | { value: string; text: string };
+
 /** A filter chip, declared in the screen's own message keys. */
 export type FilterSpec = {
   key: string;
   label: MessageKey;
   /** The "no filter" entry, which is also how a chosen value is cleared. */
   allLabel: MessageKey;
-  options: { value: string; label: MessageKey }[];
+  options: FilterOption[];
 };
 
 /** A saved view: a named sort + filter preset, shown as a tab. */
@@ -458,7 +467,7 @@ function translateChip(chip: FilterSpec, t: Translate): ListChip {
     allLabel: t(chip.allLabel),
     options: chip.options.map((option) => ({
       value: option.value,
-      label: t(option.label),
+      label: "text" in option ? option.text : t(option.label),
     })),
   };
 }

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -101,6 +101,11 @@ import { ImportCard } from "./import";
 import { InstallationSettingsCard } from "./installation-settings";
 import { ProviderCard } from "./integrations-provider";
 import { JobHealthCard } from "./jobhealth";
+import {
+  LeadDisqualifyReasonsCard,
+  LeadHandlingCard,
+  LeadSourcesCard,
+} from "./leadvocab";
 import { LicenseCard } from "./license";
 import { LinkedInImportCard } from "./linkedin-import";
 import { LinkedInReachCard } from "./linkedin-reach";
@@ -390,6 +395,9 @@ function DataModelTab() {
     <>
       <CustomFieldsAdmin />
       <PipelinesCard />
+      <LeadSourcesCard />
+      <LeadDisqualifyReasonsCard />
+      <LeadHandlingCard />
       <ProductsAdmin />
       <OfferTemplatesAdmin />
     </>


### PR DESCRIPTION
## What changes

Settings › Data model gains three cards after Pipelines (`frontend/src/screens/leadvocab.tsx`):

- **Lead sources** — rename inline (Enter/blur), re-weight via an Intent select (High / Neutral / Low interest), switch on/off, Remove only for a non-built-in source no lead carries (otherwise "switch off instead" with the reason), adopt a value discovered on connector-written leads ("From integrations"), add a new one (key derived server-side).
- **Disqualification reasons** — same shape without intent.
- **Lead handling** — the first-response target switch (off by default) and its minutes (15..10080), written through `PATCH /leads/settings`.

Every role reads the cards; `custom_field` create/update/delete enable the controls, which disable with the reason otherwise.

The leads screens now read the vocabulary from the server (`leadsources.ts`): the New lead form offers the active sources in the administrator's order; list/board/detail show `source_label` (falling back to the shipped labels and a connector family's label); the filter chip offers every administered and discovered value (`FilterOption` gains a `text` form for server-named options); the detail page's Source is an inline choice that PATCHes `source` (connector-written values stay read-only with the reason). The backend list filter `source=connector:<name>` now matches the family through its prefix.

## Verified

`make check-fe` green (3517 tests). `make check-backend` green except the pre-existing `tools/seed-demo` staticcheck finding (#1871). `make craft-static` green. People integration lane for the vocabulary tests green. New tests: `leadvocab.test.tsx` (7), `leads.test.tsx` stubs now serve `/lead-sources` and `/leads/settings`. Stories: `leadvocab.stories.tsx`. Not seen in a browser: the isolated dev stack could not boot (Docker Hub image pull hangs on this machine).

Batman-mode PR: merged on the local gate + Codex review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Administers lead sources, disqualification reasons, and lead handling in Settings, and switches lead UIs to a server-defined vocabulary. Previously the frontend hardcoded six sources and filtered by exact value; now the list comes from the server, filtering supports connector families, and lead handling is configurable.

- Settings › Data model adds three cards: Lead sources (inline rename, intent High/Neutral/Low, on/off, remove only when allowed, adopt discovered connector values, add new), Disqualification reasons (same shape, no intent), and Lead handling (toggle first-response target and minutes via `PATCH /leads/settings`, validated 15–10080; a refused update keeps the typed value). All roles read; seats with `custom_field` write verbs can change them; controls disable with the reason. Cards tolerate missing arrays in responses.
- Leads UI uses server data: the New lead form offers active sources in admin order (falls back to the shipped six until the list arrives); list/board/detail show `source_label` with fallbacks to shipped labels and a connector family; the filter chip offers active administered sources plus discovered values; Source on the detail page is an inline choice that PATCHes `source` (connector-written sources are read-only with a reason).
- Backend list and work queue filters: `source=connector:<family>` matches all leads for that connector family; the family is bound as a parameter and LIKE escapes backslash, percent, and underscore. Exact matches are unchanged.
- Rollout: no migration; shipped defaults come from `GET /lead-sources`. Enabling the first-response target adds the Overdue view and sorts overdue leads first.

<sup>Written for commit 88e06ae6a13c5adbc9265bba8ceca8416fe2f6cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

