### PR TITLE
feat(records): a hand-made record is its creator's, and an ownerless one must be claimed

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8952,6 +8952,44 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /records/{record_type}/{id}/claim:
+    parameters:
+      - name: record_type
+        in: path
+        required: true
+        schema: { type: string, enum: [person, organization, lead, deal] }
+      - $ref: '#/components/parameters/Id'
+    post:
+      tags: [Identity]
+      operationId: claimRecord
+      x-agent-access: human-only
+      # Session cookie only, matching auth.RequireHuman at runtime: putting one's
+      # name on a customer record is a human's act.
+      security: [{ cookieAuth: [] }]
+      summary: Take ownership of a customer record.
+      description: |
+        Sets the record's `owner_id` to the caller. Customer identity is workspace-readable, and an
+        ownerless record is nobody's to change until somebody claims it — this is the claim. Permitted
+        on a record the caller can read that has no owner, or that is already theirs to change (a
+        reassignment to oneself). A record owned by somebody else, with no write share, answers `403`;
+        a claim that loses the race to another claimant answers `409` naming the owner that won.
+        One transaction: the row, its audit row (`assign`) and its `<record>.updated` event.
+      parameters:
+        - $ref: '#/components/parameters/IfMatch'
+      responses:
+        '200':
+          description: The record is the caller's.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RecordClaim' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: 'Somebody else claimed the record first, or the version moved (`code: conflict` / `version_skew`).'
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+
   /record-grants:
     get:
       tags: [Access]
@@ -22770,6 +22808,14 @@ components:
         source: { type: [string, 'null'] }
         double_opt_in_token: { type: [string, 'null'], description: Required to make a grant effective when the purpose has requires_double_opt_in=true. }
 
+    RecordClaim:
+      type: object
+      required: [record_type, record_id, owner_id, version]
+      properties:
+        record_type: { type: string, enum: [person, organization, lead, deal] }
+        record_id: { type: string, format: uuid }
+        owner_id: { type: string, format: uuid, description: The caller — the record's owner now. }
+        version: { $ref: '#/components/schemas/RowVersion' }
     RecordGrant:
       type: object
       description: A manual per-record share (A52/ADR-0039) — widens own/team/all base scope for one record.

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8971,8 +8971,9 @@ paths:
         Sets the record's `owner_id` to the caller. Customer identity is workspace-readable, and an
         ownerless record is nobody's to change until somebody claims it — this is the claim. Permitted
         on a record the caller can read that has no owner, or that is already theirs to change (a
-        reassignment to oneself). A record owned by somebody else, with no write share, answers `403`;
-        a claim that loses the race to another claimant answers `409` naming the owner that won.
+        reassignment to oneself — a teammate's record, or one shared at `write`). A record owned by
+        somebody else, with no write share, answers `403` — including one a colleague claimed a
+        moment earlier; a claim whose `If-Match` no longer holds answers `409`.
         One transaction: the row, its audit row (`assign`) and its `<record>.updated` event.
       parameters:
         - $ref: '#/components/parameters/IfMatch'
@@ -8985,7 +8986,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '409':
-          description: 'Somebody else claimed the record first, or the version moved (`code: conflict` / `version_skew`).'
+          description: 'The version moved since the caller read the record (`code: version_skew`).'
           content:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -407,6 +407,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/public/preferences/{token}/unsubscribe":                    {Op: "oneClickUnsubscribe", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/quotas":                                                    {Op: "createQuota", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/record-grants":                                             {Op: "createRecordGrant", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/records/{record_type}/{id}/claim":                          {Op: "claimRecord", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/relationships":                                             {Op: "createRelationship", Access: "tool", Tool: "create_record", RecordType: "relationship", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/reports/{report}":                                          {Op: "runReport", Access: "tool", Tool: "run_report", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"POST /v1/retention-policies":                                        {Op: "createRetentionPolicy", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/approvedrun_integration_test.go
+++ b/backend/internal/compose/approvedrun_integration_test.go
@@ -231,6 +231,9 @@ func TestAFailedReassignmentDoesNotMarkItsRunApplied(t *testing.T) {
 	e := integration.Setup(t)
 	svc := approvalsServiceWithEffects(e.Pool)
 	person := e.SeedPerson(t, "Reassignment Fails", nil)
+	// The create stamps the seeding seat as owner; the test wants an unowned
+	// record so the failed write's footprint is unmistakable.
+	e.WsExec(t, `UPDATE person SET owner_id = NULL WHERE id = $1`, person)
 	// An owner that does not exist: the store's foreign key refuses it, which is
 	// an ordinary failure of the write rather than a fault injected around it.
 	id, handler := parkedRun(t, e, svc, string(workflow.ActionAssignOwner), person,

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -52,10 +52,10 @@ func TestSweepWorkspaceDataClearsDomainKeepsIdentity(t *testing.T) {
 	if got := e.WsCount(t, "SELECT count(*) FROM organization"); got != 0 {
 		t.Errorf("organization count after sweep = %d, want 0", got)
 	}
-	// The harness seeds three humans (Rep1, Rep2, Rep3); identity must
-	// survive a reset untouched.
-	if got := e.WsCount(t, "SELECT count(*) FROM app_user"); got != 3 {
-		t.Errorf("app_user count after sweep = %d, want 3 (identity preserved)", got)
+	// The harness seeds four humans (Rep1, Rep2, Rep3 and the admin seat);
+	// identity must survive a reset untouched.
+	if got := e.WsCount(t, "SELECT count(*) FROM app_user"); got != 4 {
+		t.Errorf("app_user count after sweep = %d, want 4 (identity preserved)", got)
 	}
 	// SeedPerson/SeedOrg each wrote an audit_log row as a side effect of the
 	// store write shape; the ledger is append-only and must survive the sweep.
@@ -186,8 +186,8 @@ func TestResetRunRestoresBootstrapState(t *testing.T) {
 	if got := e.WsCount(t, "SELECT count(*) FROM stage"); got < 1 {
 		t.Errorf("stage count after reset = %d, want >= 1 (pipeline re-seeded)", got)
 	}
-	if got := e.WsCount(t, "SELECT count(*) FROM app_user"); got != 3 {
-		t.Errorf("app_user count after reset = %d, want 3 (identity preserved)", got)
+	if got := e.WsCount(t, "SELECT count(*) FROM app_user"); got != 4 {
+		t.Errorf("app_user count after reset = %d, want 4 (identity preserved)", got)
 	}
 	if got := e.WsCount(t, "SELECT count(*) FROM audit_log WHERE action='reset_data'"); got != 1 {
 		t.Errorf("audit_log reset_data rows = %d, want 1", got)

--- a/backend/internal/compose/dedupe_budget_integration_test.go
+++ b/backend/internal/compose/dedupe_budget_integration_test.go
@@ -96,13 +96,14 @@ func TestCaptureDedupeStagesMergeInsteadOfDuplicating(t *testing.T) {
 
 func TestSeatDerivedBudget(t *testing.T) {
 	e := integration.Setup(t)
-	// setupAuthz seeds three full-seat humans.
+	// The harness seeds four full-seat humans: three reps and the admin seat.
+	const seats = 4
 	budget, err := NewSeatBudget(e.Pool).MonthlyTokenBudget(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if budget != 3*perSeatBaseTokens*budgetSafetyFactor {
-		t.Fatalf("3-seat budget = %d, want %d", budget, 3*perSeatBaseTokens*budgetSafetyFactor)
+	if budget != seats*perSeatBaseTokens*budgetSafetyFactor {
+		t.Fatalf("%d-seat budget = %d, want %d", seats, budget, seats*perSeatBaseTokens*budgetSafetyFactor)
 	}
 	// An empty workspace floors at one seat rather than refusing. The
 	// workspace table sits outside RLS and is owner-seeded, so the seed

--- a/backend/internal/compose/handlers_claim.go
+++ b/backend/internal/compose/handlers_claim.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"net/http"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// claimHandlers is the one HTTP door for claiming a customer record. The
+// write lands in the module that owns the table — people for person,
+// organization and lead; deals for deal — so the route dispatches on the
+// record type rather than either module reaching into the other's table.
+type claimHandlers struct {
+	people *people.Store
+	deals  *deals.Store
+}
+
+func (h claimHandlers) ClaimRecord(w http.ResponseWriter, r *http.Request, recordType string, id crmcontracts.Id, _ crmcontracts.ClaimRecordParams) {
+	ifVersion, ok := httperr.IfMatchVersion(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+	out := crmcontracts.RecordClaim{RecordType: crmcontracts.RecordClaimRecordType(recordType), RecordId: id}
+	if recordType == "deal" {
+		claim, err := h.deals.ClaimDeal(ctx, ids.From[ids.DealKind](ids.UUID(id)), ifVersion)
+		if err != nil {
+			httperr.Write(w, r, err)
+			return
+		}
+		version := crmcontracts.RowVersion(claim.Version)
+		out.OwnerId, out.Version = openapi_types.UUID(claim.OwnerID), &version
+		httperr.WriteJSON(w, http.StatusOK, out)
+		return
+	}
+	claim, err := h.people.ClaimRecord(ctx, recordType, ids.UUID(id), ifVersion)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	version := crmcontracts.RowVersion(claim.Version)
+	out.OwnerId, out.Version = openapi_types.UUID(claim.OwnerID), &version
+	httperr.WriteJSON(w, http.StatusOK, out)
+}

--- a/backend/internal/compose/integration/automation_runs_preview_integration_test.go
+++ b/backend/internal/compose/integration/automation_runs_preview_integration_test.go
@@ -235,6 +235,9 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 	}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
 	}
+	// The create stamps the admin as owner; the recipe counts leads nobody
+	// owns, so the lead is disowned to be the unrouted one the preview must find.
+	disownOverDB(t, e, "lead", lead.ID)
 
 	var rowsBefore int
 	if err := e.Owner.QueryRow(context.Background(), `

--- a/backend/internal/compose/integration/claim_integration_test.go
+++ b/backend/internal/compose/integration/claim_integration_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// A record somebody creates by hand is theirs: the create stamps the caller
+// as owner when none is named. An ownerless row — a connector's, or one whose
+// owner left — is every seat's to SEE and nobody's to CHANGE until a seat
+// claims it; a row owned by a colleague is not claimable without write
+// authority. The claim is one audited write, and a lost race answers conflict.
+func TestAManualCreateIsOwnedByItsCreatorAndAnOwnerlessRecordMustBeClaimed(t *testing.T) {
+	e := Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	stranger := e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms)
+
+	// The create stamps the creator.
+	mine, err := e.People.CreatePerson(rep, people.CreatePersonInput{FullName: "Mine Byhand", Source: "manual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mine.OwnerId == nil || ids.UUID(*mine.OwnerId) != e.Rep1 {
+		t.Fatalf("a person created by Rep1 without naming an owner is owned by %v, want Rep1", mine.OwnerId)
+	}
+
+	// An ownerless row: readable by the stranger, not writable, claimable.
+	orphan := e.SeedPerson(t, "Orphan Contact", nil)
+	e.WsExec(t, `UPDATE person SET owner_id = NULL WHERE id = $1`, orphan)
+	orphanID := ids.From[ids.PersonKind](orphan)
+	if _, err := e.People.GetPerson(stranger, orphanID, 0); err != nil {
+		t.Fatalf("an ownerless person is not readable by a stranger: %v", err)
+	}
+	title := "CTO"
+	if _, err := e.People.UpdatePerson(stranger, orphanID, people.UpdatePersonInput{Title: &title}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("editing an ownerless person without claiming it → %v, want ErrPermissionDenied", err)
+	}
+	claim, err := e.People.ClaimRecord(stranger, "person", orphan, nil)
+	if err != nil {
+		t.Fatalf("claiming an ownerless person: %v", err)
+	}
+	if claim.OwnerID != e.Rep3 {
+		t.Errorf("claimed owner = %v, want Rep3", claim.OwnerID)
+	}
+	if _, err := e.People.UpdatePerson(stranger, orphanID, people.UpdatePersonInput{Title: &title}); err != nil {
+		t.Errorf("editing a person one just claimed → %v, want allowed", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM audit_log WHERE action = 'assign' AND entity_id = $1`, orphan); n != 1 {
+		t.Errorf("%d assign audit rows for the claim, want 1", n)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'person.updated' AND envelope->'entity'->>'id' = $1::text`, orphan); n < 1 {
+		t.Errorf("no person.updated event for the claim")
+	}
+
+	// Claiming again is a no-op; claiming a colleague's record is refused;
+	// a write grant makes it claimable (a reassignment to oneself).
+	if _, err := e.People.ClaimRecord(stranger, "person", orphan, nil); err != nil {
+		t.Errorf("re-claiming one's own record → %v, want a no-op", err)
+	}
+	if _, err := e.People.ClaimRecord(rep, "person", orphan, nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("claiming a colleague's record → %v, want ErrPermissionDenied", err)
+	}
+	e.WsExec(t, `INSERT INTO record_grant (record_type, record_id, subject_type, subject_id, access, granted_by)
+		VALUES ('person', $1, 'user', $2, 'write', $3)`, orphan, e.Rep1, e.Rep3)
+	if _, err := e.People.ClaimRecord(rep, "person", orphan, nil); err != nil {
+		t.Errorf("claiming a record one holds a write share on → %v, want allowed", err)
+	}
+
+	// An agent cannot claim; a version mismatch is skew; an unknown type is refused.
+	if _, err := e.People.ClaimRecord(e.AgentCtx(), "person", orphan, nil); err == nil {
+		t.Error("an agent claimed a record")
+	}
+	stale := int64(1)
+	if _, err := e.People.ClaimRecord(rep, "person", orphan, &stale); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Errorf("claim with a stale If-Match → %v, want ErrVersionSkew", err)
+	}
+	var unknown *people.InvalidRecordTypeError
+	if _, err := e.People.ClaimRecord(rep, "project", orphan, nil); !errors.As(err, &unknown) {
+		t.Errorf("claiming a project through the people door → %v, want InvalidRecordTypeError", err)
+	}
+}

--- a/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
+++ b/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
@@ -89,6 +89,9 @@ func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create unowned organization: %v", err)
 	}
+	// The create stamps the seeding seat as owner; this test wants the
+	// unowned state, so the owner is nulled explicitly.
+	f.e.WsExec(t, "UPDATE organization SET owner_id = NULL WHERE id = $1", ids.UUID(unowned.Id))
 
 	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
 		Name: "no team covers these", EntityType: "organization", ListType: "dynamic",

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -22,7 +22,21 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/jackc/pgx/v5"
 )
+
+// disownOverDB nulls a record's owner at the database. A create over the wire
+// stamps the calling seat as owner when the body names none, so the unowned
+// state these queue tests are about has to be produced after the fact.
+func disownOverDB(t *testing.T, e *apptest.AppEnv, table, id string) {
+	t.Helper()
+	if err := apptest.InWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
+		_, err := tx.Exec(t.Context(), `UPDATE `+table+` SET owner_id = NULL WHERE id = $1`, id)
+		return err
+	}); err != nil {
+		t.Fatalf("disown %s %s: %v", table, id, err)
+	}
+}
 
 // listedIDs is the shape every list response shares, read down to the one
 // thing these assertions are about: which records came back.
@@ -173,6 +187,7 @@ func TestThePersonListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 
 	createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Owned Person", "owner_id": owner})
 	unowned := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Unowned Person"})
+	disownOverDB(t, e, "person", unowned)
 
 	// Unassigned is a fact with its own queue, not an absence: a list that
 	// answered every row here would send somebody to claim records that are
@@ -187,6 +202,7 @@ func TestTheLeadListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 
 	createdRecord(t, e, "/v1/leads", apptest.AnyMap{"full_name": "Owned Lead", "email": "owned@lead.test", "owner_id": owner})
 	unowned := createdRecord(t, e, "/v1/leads", apptest.AnyMap{"full_name": "Unowned Lead", "email": "unowned@lead.test"})
+	disownOverDB(t, e, "lead", unowned)
 
 	// The same dial the person and company lists answer (DM-VOCAB-OWN-1): a
 	// lead queue nobody has claimed is the first thing a rep asks a lead list.

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -273,6 +273,9 @@ func TestThePersonListNarrowsToTheUnownedQueue(t *testing.T) {
 	e := Setup(t)
 	e.SeedPerson(t, "Owned By Rep1", &e.Rep1)
 	unowned := e.SeedPerson(t, "Owned By Nobody", nil)
+	// A create stamps the seeding seat as owner; the queue under test is the
+	// unowned state, so the owner is nulled after seeding.
+	e.WsExec(t, `UPDATE person SET owner_id = NULL WHERE id = $1`, unowned)
 
 	yes := true
 	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{Unassigned: &yes})
@@ -365,6 +368,8 @@ func TestTheOrganizationListNarrowsToOneTeamAndToTheUnownedQueue(t *testing.T) {
 	held := e.SeedOrg(t, "Owned By Rep1", &e.Rep1)
 	e.SeedOrg(t, "Owned By Rep3", &e.Rep3)
 	unowned := e.SeedOrg(t, "Owned By Nobody", nil)
+	// The create stamps the seeding seat as owner; null it for the unowned queue.
+	e.WsExec(t, `UPDATE organization SET owner_id = NULL WHERE id = $1`, unowned)
 
 	team := ids.From[ids.TeamKind](e.Team1)
 	page, _, err := e.People.ListOrganizations(e.Admin(), people.ListOrganizationsInput{OwnerTeamID: &team})
@@ -393,6 +398,8 @@ func TestTheLeadListNarrowsToOneTeamAndToTheUnownedQueue(t *testing.T) {
 	held := seedLead(t, e, "Owned By Rep1", "rep1@lead.test", &e.Rep1)
 	seedLead(t, e, "Owned By Rep3", "rep3@lead.test", &e.Rep3)
 	unowned := seedLead(t, e, "Owned By Nobody", "nobody@lead.test", nil)
+	// The create stamps the seeding seat as owner; null it for the unowned queue.
+	e.WsExec(t, `UPDATE lead SET owner_id = NULL WHERE id = $1`, unowned.UUID)
 
 	team := ids.From[ids.TeamKind](e.Team1)
 	page, _, err := e.People.ListLeads(e.Admin(), people.ListLeadsInput{OwnerTeamID: &team})

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -246,7 +246,9 @@ func TestThePersonListNarrowsToOneTeamsRows(t *testing.T) {
 	mine := e.SeedPerson(t, "Owned By Rep1", &e.Rep1)
 	teammates := e.SeedPerson(t, "Owned By Rep2", &e.Rep2)
 	e.SeedPerson(t, "Owned By Rep3", &e.Rep3)
-	e.SeedPerson(t, "Owned By Nobody", nil)
+	// The create stamps the seeding seat; the test wants a genuinely unowned row.
+	nobody := e.SeedPerson(t, "Owned By Nobody", nil)
+	e.WsExec(t, `UPDATE person SET owner_id = NULL WHERE id = $1`, nobody)
 
 	team := ids.From[ids.TeamKind](e.Team1)
 	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{OwnerTeamID: &team})

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -37,7 +37,10 @@ type Env struct {
 	WS         ids.UUID
 	// three humans: Rep1+Rep2 share a team, Rep3 sits in another
 	Rep1, Rep2, Rep3 ids.UUID
-	Team1, Team2     ids.UUID
+	// AdminUser is the seat Admin() binds: a real app_user, because a manual
+	// create stamps the caller as owner and the owner column is a foreign key.
+	AdminUser    ids.UUID
+	Team1, Team2 ids.UUID
 }
 
 // Setup gives each test a clean, migrated database and seeds the
@@ -73,14 +76,15 @@ func Setup(t *testing.T) *Env {
 
 	e := &Env{
 		WS: ids.NewV7(), Rep1: ids.NewV7(), Rep2: ids.NewV7(), Rep3: ids.NewV7(),
-		Team1: ids.NewV7(), Team2: ids.NewV7(),
+		AdminUser: ids.NewV7(),
+		Team1:     ids.NewV7(), Team2: ids.NewV7(),
 	}
 	if _, err := owner.Exec(ctx,
 		`INSERT INTO workspace (id, slug) VALUES ($1, 'authz')`, e.WS); err != nil {
 		t.Fatal(err)
 	}
 	seedInstallationIdentity(ctx, t, owner)
-	for i, user := range []ids.UUID{e.Rep1, e.Rep2, e.Rep3} {
+	for i, user := range []ids.UUID{e.Rep1, e.Rep2, e.Rep3, e.AdminUser} {
 		if _, err := owner.Exec(ctx,
 			`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, $4)`,
 			user, e.WS, string(rune('a'+i))+"@authz.test", "Rep"); err != nil {
@@ -166,8 +170,11 @@ func (e *Env) As(user ids.UUID, teams []ids.UUID, perms principal.Permissions) c
 	})
 }
 
-// Admin binds an unbounded admin context under a fresh synthetic user.
-func (e *Env) Admin() context.Context { return e.As(ids.NewV7(), nil, AdminPerms) }
+// Admin binds an unbounded admin context under the harness's admin seat. It
+// is one real user, not a fresh synthetic one per call: a row the admin
+// creates without naming an owner is stamped with this id, and the owner
+// column is a foreign key into app_user.
+func (e *Env) Admin() context.Context { return e.As(e.AdminUser, nil, AdminPerms) }
 
 // AgentCtx binds a synthetic agent principal for staging (the staging
 // path itself is not what a suite using this is testing).

--- a/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
@@ -422,8 +422,10 @@ func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) 
 	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
-	// An unassigned account, so no owner edge pads the user nodes.
+	// An unassigned account, so no owner edge pads the user nodes. The create
+	// stamps the seeding seat as owner, so the owner is nulled explicitly.
 	org := e.SeedOrg(t, "Acme", nil)
+	e.WsExec(t, "UPDATE organization SET owner_id = NULL WHERE id = $1", org)
 
 	// The colleagues of the contacts the cap will drop are seeded FIRST: every
 	// interaction shares one timestamp, so the user cap's tie-break is the user
@@ -514,8 +516,10 @@ func TestOrganizationGraphUserCapCountsUsersAndReportsTheRemainder(t *testing.T)
 	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
-	// An unassigned account, so the owner edge cannot pad the user count.
+	// An unassigned account, so the owner edge cannot pad the user count. The
+	// create stamps the seeding seat as owner, so the owner is nulled explicitly.
 	org := e.SeedOrg(t, "Acme", nil)
+	e.WsExec(t, "UPDATE organization SET owner_id = NULL WHERE id = $1", org)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 	employ(t, e, contact, org, "cto")
 	const writers = 13

--- a/backend/internal/compose/integration/project_integration_test.go
+++ b/backend/internal/compose/integration/project_integration_test.go
@@ -433,8 +433,10 @@ func TestListProjectsAppliesFiltersRegisteredAfterThePrelude(t *testing.T) {
 // owns — but it must not be NAMED, because naming a project is reading it.
 func TestTheMergeRefusalCountsInvisibleProjectsWithoutNamingThem(t *testing.T) {
 	e := Setup(t)
-	source := e.SeedOrg(t, "Helios GmbH", nil)
-	target := e.SeedOrg(t, "Helios AG", nil)
+	// The merging rep owns both companies (a merge is a write, and an own-scope
+	// seat only writes what it owns), but not the projects under them.
+	source := e.SeedOrg(t, "Helios GmbH", &e.Rep3)
+	target := e.SeedOrg(t, "Helios AG", &e.Rep3)
 	// Each side's project belongs to a different rep, and the caller below
 	// owns neither.
 	seedProject(e.Admin(), t, e, "Secret migration", nil, source, &e.Rep1)
@@ -482,8 +484,8 @@ func TestTheMergeRefusalCountsInvisibleProjectsWithoutNamingThem(t *testing.T) {
 // naming is precision, not silence.
 func TestTheMergeRefusalNamesTheProjectsTheCallerCanSee(t *testing.T) {
 	e := Setup(t)
-	source := e.SeedOrg(t, "Vector Ltd", nil)
-	target := e.SeedOrg(t, "Vector Limited", nil)
+	source := e.SeedOrg(t, "Vector Ltd", &e.Rep1)
+	target := e.SeedOrg(t, "Vector Limited", &e.Rep1)
 	seedProject(e.Admin(), t, e, "Mine A", nil, source, &e.Rep1)
 	seedProject(e.Admin(), t, e, "Mine B", nil, target, &e.Rep1)
 

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -144,13 +144,12 @@ func TestRecordHistoryRendersEveryActorChronologically(t *testing.T) {
 		}
 	}
 
-	// The genesis row's actor is the harness admin — a synthetic user with
-	// no app_user row, so the summary honestly falls back to the raw
-	// prefixed actor_id instead of inventing a name.
+	// The genesis row's actor is the harness admin, a real app_user whose
+	// display name is "Rep" like every harness seat, so the summary resolves
+	// the name rather than falling back to the raw prefixed actor_id.
 	genesis := page.Entries[0]
-	if genesis.Action != "create" ||
-		!strings.HasPrefix(genesis.Summary, "human:") || !strings.HasSuffix(genesis.Summary, "created the record") {
-		t.Errorf("genesis line = %q (action %q), want raw-actor_id create line", genesis.Summary, genesis.Action)
+	if genesis.Action != "create" || genesis.Summary != "Rep created the record" {
+		t.Errorf("genesis line = %q (action %q), want the admin's resolved create line", genesis.Summary, genesis.Action)
 	}
 
 	human := page.Entries[1]

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -86,6 +86,7 @@ type Server struct {
 	licenseHandlers
 	consumerMailDomainHandlers
 	blockedDomainHandlers
+	claimHandlers
 	importHandlers
 	channelHandlers
 	traceHandlers

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -188,6 +188,7 @@ func (s *Server) wireSystemOfRecordReads(pool *pgxpool.Pool) {
 	// floor.
 	s.peopleStore = people.NewStore(InstallationDB(pool)).WithFieldCatalog(customfields.NewService(pool, nil))
 	s.blockedDomainHandlers = blockedDomainHandlers{people: s.peopleStore}
+	s.claimHandlers = claimHandlers{people: s.peopleStore, deals: deals.NewStore(InstallationDB(pool), DealsInstallation())}
 	// The importer maps only core columns (see importTargets for why custom
 	// fields are not among them), so it needs no field catalog of its own.
 	s.importHandlers = importHandlers{db: InstallationDB(pool), uploadLimit: s.uploadLimits.CSVImport}

--- a/backend/internal/compose/signalproposals_integration_test.go
+++ b/backend/internal/compose/signalproposals_integration_test.go
@@ -308,6 +308,10 @@ var teamScopedDecider = principal.Permissions{
 func TestAcceptingSettlesOnlyTheContradictionsTheDeciderCanSee(t *testing.T) {
 	e := integration.Setup(t)
 	org := seedAccountAtStage(t, e, "customer")
+	// Accepting the offer writes the account's lifecycle, and an unowned row
+	// is writable by nobody below row_scope=all until claimed — so the
+	// team-scoped decider must own the account they are deciding on.
+	e.WsExec(t, "UPDATE organization SET owner_id = $1 WHERE id = $2", e.Rep1, org)
 	mine := seedOpenContractEnded(t, e, org)
 	// Same account, but its subject is a person capture-private to the OTHER
 	// team's rep — the one state that still hides an identity row from a seat.
@@ -320,10 +324,10 @@ func TestAcceptingSettlesOnlyTheContradictionsTheDeciderCanSee(t *testing.T) {
 		t.Fatalf("accepting the offer: %v", err)
 	}
 
-	// The account is ownerless, so it is visible at every tier — which is what
-	// makes this the control: the two signals differ ONLY in their subject, so
-	// the one that stays open stays open because of the contact it is about
-	// and nothing else.
+	// The account is the decider's own, so it is within their scope — which is
+	// what makes this the control: the two signals differ ONLY in their
+	// subject, so the one that stays open stays open because of the contact it
+	// is about and nothing else.
 	if status := signalStatus(t, e, mine); status != "acknowledged" {
 		t.Errorf("the signal subjected to the account itself reads %q, want "+
 			"acknowledged — the scope bound is settling rows it should not withhold", status)

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1339,6 +1339,10 @@ func (stubs) GetRecordHistory(w nethttp.ResponseWriter, r *nethttp.Request, enti
 	httperr.NotImplemented(w, r, "GetRecordHistory")
 }
 
+func (stubs) ClaimRecord(w nethttp.ResponseWriter, r *nethttp.Request, recordType string, id crmcontracts.Id, params crmcontracts.ClaimRecordParams) {
+	httperr.NotImplemented(w, r, "ClaimRecord")
+}
+
 func (stubs) ListRelationships(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListRelationshipsParams) {
 	httperr.NotImplemented(w, r, "ListRelationships")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -7545,6 +7545,30 @@ func (e QuotaAttainmentBand) Valid() bool {
 	}
 }
 
+// Defines values for RecordClaimRecordType.
+const (
+	RecordClaimRecordTypeDeal         RecordClaimRecordType = "deal"
+	RecordClaimRecordTypeLead         RecordClaimRecordType = "lead"
+	RecordClaimRecordTypeOrganization RecordClaimRecordType = "organization"
+	RecordClaimRecordTypePerson       RecordClaimRecordType = "person"
+)
+
+// Valid indicates whether the value is a known member of the RecordClaimRecordType enum.
+func (e RecordClaimRecordType) Valid() bool {
+	switch e {
+	case RecordClaimRecordTypeDeal:
+		return true
+	case RecordClaimRecordTypeLead:
+		return true
+	case RecordClaimRecordTypeOrganization:
+		return true
+	case RecordClaimRecordTypePerson:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for RecordConsentRequestNewState.
 const (
 	RecordConsentRequestNewStateGranted   RecordConsentRequestNewState = "granted"
@@ -9269,31 +9293,31 @@ func (e VoiceBuildStatus) Valid() bool {
 
 // Defines values for VoiceBuildStatusCode.
 const (
-	VoiceBuildStatusCodeBudgetDeferred    VoiceBuildStatusCode = "budget_deferred"
-	VoiceBuildStatusCodeInternal          VoiceBuildStatusCode = "internal"
-	VoiceBuildStatusCodeInvalidOutput     VoiceBuildStatusCode = "invalid_output"
-	VoiceBuildStatusCodeLessThannil       VoiceBuildStatusCode = "<nil>"
-	VoiceBuildStatusCodeMaterialDrift     VoiceBuildStatusCode = "material_drift"
-	VoiceBuildStatusCodeModelUnavailable  VoiceBuildStatusCode = "model_unavailable"
-	VoiceBuildStatusCodeQualityRegression VoiceBuildStatusCode = "quality_regression"
+	BudgetDeferred    VoiceBuildStatusCode = "budget_deferred"
+	Internal          VoiceBuildStatusCode = "internal"
+	InvalidOutput     VoiceBuildStatusCode = "invalid_output"
+	LessThannil       VoiceBuildStatusCode = "<nil>"
+	MaterialDrift     VoiceBuildStatusCode = "material_drift"
+	ModelUnavailable  VoiceBuildStatusCode = "model_unavailable"
+	QualityRegression VoiceBuildStatusCode = "quality_regression"
 )
 
 // Valid indicates whether the value is a known member of the VoiceBuildStatusCode enum.
 func (e VoiceBuildStatusCode) Valid() bool {
 	switch e {
-	case VoiceBuildStatusCodeBudgetDeferred:
+	case BudgetDeferred:
 		return true
-	case VoiceBuildStatusCodeInternal:
+	case Internal:
 		return true
-	case VoiceBuildStatusCodeInvalidOutput:
+	case InvalidOutput:
 		return true
-	case VoiceBuildStatusCodeLessThannil:
+	case LessThannil:
 		return true
-	case VoiceBuildStatusCodeMaterialDrift:
+	case MaterialDrift:
 		return true
-	case VoiceBuildStatusCodeModelUnavailable:
+	case ModelUnavailable:
 		return true
-	case VoiceBuildStatusCodeQualityRegression:
+	case QualityRegression:
 		return true
 	default:
 		return false
@@ -19238,6 +19262,24 @@ type RbacObjectGrant struct {
 	Update bool `json:"update"`
 }
 
+// RecordClaim defines model for RecordClaim.
+type RecordClaim struct {
+	// OwnerId The caller — the record's owner now.
+	OwnerId    openapi_types.UUID    `json:"owner_id"`
+	RecordId   openapi_types.UUID    `json:"record_id"`
+	RecordType RecordClaimRecordType `json:"record_type"`
+
+	// Version Monotonic row version, incremented by the server on every mutation (data-model §1.3a).
+	// Echoed back as the `version` field on every mutable entity. To make a write conditional,
+	// send the last-seen value in `If-Match`; a mismatch returns `409 code: version_skew`
+	// (ErrVersionSkew) so the client re-reads before retrying. Applies to the native SoR path,
+	// not only overlay mode.
+	Version *RowVersion `json:"version,omitempty"`
+}
+
+// RecordClaimRecordType defines model for RecordClaim.RecordType.
+type RecordClaimRecordType string
+
 // RecordConsentRequest defines model for RecordConsentRequest.
 type RecordConsentRequest struct {
 	// DoubleOptInToken Required to make a grant effective when the purpose has requires_double_opt_in=true.
@@ -24348,6 +24390,16 @@ type GetRecordHistoryParams struct {
 
 	// Limit Max items in the page.
 	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// ClaimRecordParams defines parameters for ClaimRecord.
+type ClaimRecordParams struct {
+	// IfMatch Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+	// the last-seen entity `version`. If the row's current `version` differs, the write is
+	// rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+	// re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+	// Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+	IfMatch *IfMatch `json:"If-Match,omitempty"`
 }
 
 // ListRelationshipsParams defines parameters for ListRelationships.
@@ -32551,6 +32603,9 @@ type ServerInterface interface {
 	// Full audit history for one record, rendered as plain-language lines.
 	// (GET /records/{entity_type}/{id}/history)
 	GetRecordHistory(w http.ResponseWriter, r *http.Request, entityType string, id Id, params GetRecordHistoryParams)
+	// Take ownership of a customer record.
+	// (POST /records/{record_type}/{id}/claim)
+	ClaimRecord(w http.ResponseWriter, r *http.Request, recordType string, id Id, params ClaimRecordParams)
 	// List relationships (employment, deal_stakeholder, or partner edges).
 	// (GET /relationships)
 	ListRelationships(w http.ResponseWriter, r *http.Request, params ListRelationshipsParams)
@@ -34765,6 +34820,12 @@ func (_ Unimplemented) GetRecordContext(w http.ResponseWriter, r *http.Request, 
 // Full audit history for one record, rendered as plain-language lines.
 // (GET /records/{entity_type}/{id}/history)
 func (_ Unimplemented) GetRecordHistory(w http.ResponseWriter, r *http.Request, entityType string, id Id, params GetRecordHistoryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Take ownership of a customer record.
+// (POST /records/{record_type}/{id}/claim)
+func (_ Unimplemented) ClaimRecord(w http.ResponseWriter, r *http.Request, recordType string, id Id, params ClaimRecordParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -49990,6 +50051,71 @@ func (siw *ServerInterfaceWrapper) GetRecordHistory(w http.ResponseWriter, r *ht
 	handler.ServeHTTP(w, r)
 }
 
+// ClaimRecord operation middleware
+func (siw *ServerInterfaceWrapper) ClaimRecord(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "record_type" -------------
+	var recordType string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "record_type", chi.URLParam(r, "record_type"), &recordType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "record_type", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ClaimRecordParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch IfMatch
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "If-Match", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "If-Match", valueList[0], &IfMatch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "If-Match", Err: err})
+			return
+		}
+
+		params.IfMatch = &IfMatch
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ClaimRecord(w, r, recordType, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListRelationships operation middleware
 func (siw *ServerInterfaceWrapper) ListRelationships(w http.ResponseWriter, r *http.Request) {
 
@@ -54838,6 +54964,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/records/{entity_type}/{id}/history", wrapper.GetRecordHistory)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/records/{record_type}/{id}/claim", wrapper.ClaimRecord)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/relationships", wrapper.ListRelationships)

--- a/backend/internal/modules/capture/sinklead.go
+++ b/backend/internal/modules/capture/sinklead.go
@@ -100,14 +100,19 @@ func (s *Sink) upsertLead(ctx context.Context, tx pgx.Tx, rec connector.Normaliz
 		return ids.LeadID{}, false, err
 	}
 	var id ids.LeadID
+	// Owned by the human behind the connector, like a captured person: an
+	// ownerless lead is nobody's to change, and the connector's own replay is
+	// a write — a lead it could not write back to would be one it created and
+	// then could never resume.
 	err := tx.QueryRow(ctx, `
-		INSERT INTO lead (full_name, email, company_name, title, source_system, source_id, source, captured_by)
-		VALUES (NULLIF($1, ''), NULLIF(lower($2), ''), NULLIF($3, ''), NULLIF($4, ''), $5, $6, $7, $8)
+		INSERT INTO lead (full_name, email, company_name, title, source_system, source_id, source, captured_by, owner_id)
+		VALUES (NULLIF($1, ''), NULLIF(lower($2), ''), NULLIF($3, ''), NULLIF($4, ''), $5, $6, $7, $8, $9)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
 		fields.FullName, fields.Email, fields.CompanyName, fields.Title,
-		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy).Scan(&id)
+		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy,
+		storekit.OwnerOrActor(ctx, nil)).Scan(&id)
 	if err == nil {
 		var stamps []storekit.FieldStamp
 		for _, f := range []struct{ field, value string }{

--- a/backend/internal/modules/deals/claim.go
+++ b/backend/internal/modules/deals/claim.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// DealClaim is what claiming a deal answers: who owns it now, at which version.
+type DealClaim struct {
+	OwnerID ids.UUID
+	Version int64
+}
+
+// ClaimDeal makes the calling human the owner of one deal — the deals half of
+// the record claim (people owns the other three tables). Human-only, gated by
+// storekit.ClaimOwnership: visible, and unowned or already the caller's to
+// change. ifVersion, when given, is the If-Match compare.
+func (s *Store) ClaimDeal(ctx context.Context, id ids.DealID, ifVersion *int64) (DealClaim, error) {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return DealClaim{}, err
+	}
+	if err := auth.Require(ctx, "deal", principal.ActionUpdate); err != nil {
+		return DealClaim{}, err
+	}
+	actor, err := storekit.Actor(ctx)
+	if err != nil {
+		return DealClaim{}, err
+	}
+	out := DealClaim{OwnerID: actor.UserID}
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		claim, auditID, err := storekit.ClaimOwnership(ctx, tx, "deal", id.UUID, actor.UserID, ifVersion)
+		if err != nil {
+			return err
+		}
+		out.Version = claim.Version
+		if !claim.Changed {
+			return nil
+		}
+		return storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventDealUpdated{
+			ChangedFields: map[string]any{"owner_id": actor.UserID},
+		})
+	})
+	return out, err
+}

--- a/backend/internal/modules/deals/deal_create.go
+++ b/backend/internal/modules/deals/deal_create.go
@@ -59,6 +59,7 @@ func (s *Store) CreateDeal(ctx context.Context, in CreateDealInput) (crmcontract
 	if err != nil {
 		return crmcontracts.Deal{}, err
 	}
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	active, err := s.activeColumns(ctx)
 	if err != nil {
 		return crmcontracts.Deal{}, err
@@ -91,6 +92,7 @@ func (s *Store) CreateDealTx(ctx context.Context, tx pgx.Tx, in CreateDealInput)
 	if err != nil {
 		return crmcontracts.Deal{}, err
 	}
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	return s.createDealInTx(ctx, tx, in, by, nil)
 }
 

--- a/backend/internal/modules/people/claim.go
+++ b/backend/internal/modules/people/claim.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Claiming a customer record: putting one's own name on a person, company or
+// lead. Customer identity is workspace-readable and an ownerless row is
+// nobody's to change, so the claim is the step between finding a record and
+// working it. It is one row update under the same write shape as every other
+// mutation — the row, its audit row (`assign`) and its updated event — and it
+// never takes a record away from somebody: a row owned by another seat is
+// claimable only by someone who could already change it.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// RecordClaim is what a claim answers: the row, and who owns it now.
+type RecordClaim struct {
+	RecordType string
+	RecordID   ids.UUID
+	OwnerID    ids.UUID
+	Version    int64
+}
+
+// claimableTables are the record types this module owns that a seat may
+// claim. A deal is claimed through the deals module, which owns its table.
+var claimableTables = map[string]bool{entityPerson: true, entityOrganization: true, entityLead: true}
+
+// ClaimRecord makes the calling human the owner of one person, organization
+// or lead. Human-only: owning a customer record is a person's accountability,
+// not an agent's. ifVersion, when given, is the If-Match compare.
+func (s *Store) ClaimRecord(ctx context.Context, recordType string, id ids.UUID, ifVersion *int64) (RecordClaim, error) {
+	if !claimableTables[recordType] {
+		return RecordClaim{}, &InvalidRecordTypeError{RecordType: recordType}
+	}
+	if err := auth.RequireHuman(ctx); err != nil {
+		return RecordClaim{}, err
+	}
+	if err := auth.Require(ctx, recordType, principal.ActionUpdate); err != nil {
+		return RecordClaim{}, err
+	}
+	actor, err := storekit.Actor(ctx)
+	if err != nil {
+		return RecordClaim{}, err
+	}
+	out := RecordClaim{RecordType: recordType, RecordID: id, OwnerID: actor.UserID}
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		claim, auditID, err := storekit.ClaimOwnership(ctx, tx, recordType, id, actor.UserID, ifVersion)
+		if err != nil {
+			return err
+		}
+		out.Version = claim.Version
+		if !claim.Changed {
+			return nil
+		}
+		return emitOwnerChanged(ctx, tx, auditID, recordType, id, actor.UserID)
+	})
+	return out, err
+}
+
+// emitOwnerChanged ships the record's own updated event with the owner delta,
+// the shape every consumer of <record>.updated already reads.
+func emitOwnerChanged(ctx context.Context, tx pgx.Tx, auditID ids.UUID, recordType string, id, me ids.UUID) error {
+	changed := map[string]any{"owner_id": me}
+	switch recordType {
+	case entityPerson:
+		return storekit.EmitEvent(ctx, tx, auditID, id, crmcontracts.PublicEventPersonUpdated{ChangedFields: changed})
+	case entityOrganization:
+		return storekit.EmitEvent(ctx, tx, auditID, id, crmcontracts.PublicEventOrganizationUpdated{ChangedFields: changed})
+	case entityLead:
+		return storekit.EmitEvent(ctx, tx, auditID, id, crmcontracts.PublicEventLeadUpdated{ChangedFields: changed})
+	}
+	return fmt.Errorf("people: no updated event for record type %q", recordType)
+}
+
+// InvalidRecordTypeError refuses a claim on a record type nobody can own.
+type InvalidRecordTypeError struct{ RecordType string }
+
+func (e *InvalidRecordTypeError) Error() string {
+	return "record type " + e.RecordType + " cannot be claimed"
+}
+
+// FieldFault answers the refusal as a 422 on record_type.
+func (e *InvalidRecordTypeError) FieldFault() (field, code, message string) {
+	return "record_type", "invalid_record_type", e.Error()
+}

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -111,6 +111,7 @@ func (s *Store) readyLeadCreate(ctx context.Context, in CreateLeadInput) (Create
 	if err != nil {
 		return CreateLeadInput{}, "", err
 	}
+	normalized.OwnerID = storekit.OwnerOrActor(ctx, normalized.OwnerID)
 	return normalized, by, nil
 }
 

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -46,6 +46,7 @@ func (s *Store) CreateOrganization(ctx context.Context, in CreateOrganizationInp
 	if err != nil {
 		return crmcontracts.Organization{}, err
 	}
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	// The store-opened path reads the catalog through the unexported helper,
 	// not ActiveOrganizationColumns: that one takes organization:read on the
 	// caller's behalf, and a seat may hold create without it.
@@ -81,6 +82,7 @@ func (s *Store) CreateOrganizationTx(ctx context.Context, tx pgx.Tx, in CreateOr
 	if err != nil {
 		return crmcontracts.Organization{}, err
 	}
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	return createOrganizationInTx(ctx, tx, in, by, nil)
 }
 

--- a/backend/internal/modules/people/person.go
+++ b/backend/internal/modules/people/person.go
@@ -85,6 +85,7 @@ func (s *Store) CreatePerson(ctx context.Context, in CreatePersonInput) (crmcont
 	if err != nil {
 		return crmcontracts.Person{}, err
 	}
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	// The store-opened path reads the catalog through the unexported helper,
 	// not ActivePersonColumns: that one takes person:read on the caller's
 	// behalf, and a seat may hold create without it.
@@ -120,6 +121,7 @@ func (s *Store) CreatePersonTx(ctx context.Context, tx pgx.Tx, in CreatePersonIn
 	if err != nil {
 		return crmcontracts.Person{}, err
 	}
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	return createPersonInTx(ctx, tx, in, by, nil)
 }
 

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -40,6 +40,22 @@ func Unbounded(p principal.Principal) bool {
 // first gets a widening arm instead of an accidental narrowing to `own` —
 // row_scope=all matches no branch below.
 func OwnerPredicate(p principal.Principal, arg func(any) int) func(alias string) string {
+	return ownerPredicate(p, arg, unownedIsShared)
+}
+
+// unownedRows says what an ownerless row (owner_id IS NULL) is to the
+// predicate. A READ treats it as shared: a row nobody owns is the
+// workspace's to see. A WRITE does not: a row nobody owns is nobody's to
+// change until somebody claims it — an ownerless customer record that every
+// seat could rewrite is how two teams edit one company past each other.
+type unownedRows bool
+
+const (
+	unownedIsShared  unownedRows = true
+	unownedIsNobodys unownedRows = false
+)
+
+func ownerPredicate(p principal.Principal, arg func(any) int, unowned unownedRows) func(alias string) string {
 	if Unbounded(p) {
 		return func(string) string { return "TRUE" }
 	}
@@ -50,17 +66,21 @@ func OwnerPredicate(p principal.Principal, arg func(any) int) func(alias string)
 		}
 		return alias + ".owner_id"
 	}
+	nullArm := ""
+	if unowned == unownedIsShared {
+		nullArm = "%[1]s IS NULL OR "
+	}
 	if p.Permissions.RowScope == principal.RowScopeTeam {
 		teams := arg(p.TeamIDs)
 		return func(alias string) string {
-			return fmt.Sprintf(`(%[1]s IS NULL OR %[1]s = $%[2]d OR %[1]s IN (
+			return fmt.Sprintf(`(`+nullArm+`%[1]s = $%[2]d OR %[1]s IN (
 			   SELECT tm.user_id FROM team_membership tm WHERE tm.team_id = ANY($%[3]d)))`,
 				col(alias), me, teams)
 		}
 	}
 	// own — and the zero value: an unresolved scope never widens.
 	return func(alias string) string {
-		return fmt.Sprintf(`(%[1]s IS NULL OR %[1]s = $%[2]d)`, col(alias), me)
+		return fmt.Sprintf(`(`+nullArm+`%[1]s = $%[2]d)`, col(alias), me)
 	}
 }
 

--- a/backend/internal/platform/auth/writescope.go
+++ b/backend/internal/platform/auth/writescope.go
@@ -181,7 +181,9 @@ func writeAuthorityPredicate(p principal.Principal, table string, arg func(any) 
 // the spelling the activity link walk needs, where the record sits under a
 // probe alias rather than its own table name.
 func writeAuthorityPredicateAs(p principal.Principal, table, alias string, arg func(any) int) string {
-	owner := OwnerPredicate(p, arg)(alias)
+	// An ownerless row is nobody's to change: it is claimed first
+	// (EnsureClaimable), then written under the owner scope like any other.
+	owner := ownerPredicate(p, arg, unownedIsNobodys)(alias)
 	me, teams := arg(p.UserID), arg(p.TeamIDs)
 	return fmt.Sprintf(`(%s OR EXISTS (
 		   SELECT 1 FROM record_grant rg
@@ -257,4 +259,39 @@ func linkTargetWritable(p principal.Principal, alias string, arg func(any) int) 
 			alias, t.column, t.table, t.probe, writeAuthorityPredicateAs(p, t.table, t.probe, arg)))
 	}
 	return "(" + strings.Join(arms, " OR ") + ")"
+}
+
+// EnsureClaimable is the gate in front of taking ownership of a row. A claim
+// is permitted on a row the caller can see that is UNOWNED — the case the
+// write arm refuses on purpose, so that somebody has to put their name on a
+// record before changing it — or that is already theirs to change (a
+// reassignment to oneself under existing write authority). A row owned by
+// somebody else, with no write grant, answers ErrPermissionDenied: taking it
+// over is what a share or an admin's reassignment is for.
+func EnsureClaimable(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
+	if err := EnsureVisibleLive(ctx, tx, table, id); err != nil {
+		return err
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return err
+	}
+	if Unbounded(p) {
+		return nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+	clause := writeAuthorityPredicate(p, table, arg)
+
+	var permitted bool
+	if err := tx.QueryRow(ctx,
+		fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %[1]s WHERE id = $%[2]d AND (%[1]s.owner_id IS NULL OR %[3]s))`, table, idPos, clause),
+		args...).Scan(&permitted); err != nil {
+		return err
+	}
+	if !permitted {
+		return apperrors.ErrPermissionDenied
+	}
+	return nil
 }

--- a/backend/internal/platform/auth/writescope_test.go
+++ b/backend/internal/platform/auth/writescope_test.go
@@ -124,13 +124,23 @@ func TestOnlyAWriteGrantIsProbedBeforeItIsGranted(t *testing.T) {
 
 func TestTheWriteArmKeepsTheOwnerScopeItNarrows(t *testing.T) {
 	// The grant arm is added to the owner scope, never substituted for it: a
-	// caller who owns the row needs no grant, and an ownerless (workspace-wide)
-	// row stays writable at every tier.
+	// caller who owns the row, or a teammate, needs no grant. An ownerless
+	// row is the one exception — it is nobody's to change until claimed, so
+	// the write arm has no `owner_id IS NULL` branch while the read arm keeps
+	// it (an unowned row is still the workspace's to see).
 	sql := writeArm(human(principal.RowScopeTeam), "deal")
-	for _, want := range []string{"owner_id IS NULL", "team_membership"} {
+	for _, want := range []string{"deal.owner_id = $", "team_membership"} {
 		if !strings.Contains(sql, want) {
 			t.Errorf("the write arm dropped %q from the owner scope, so it narrows more than the "+
 				"grant column: %s", want, sql)
 		}
+	}
+	if strings.Contains(sql, "owner_id IS NULL") {
+		t.Errorf("the write arm admits an ownerless row; it must be claimed first: %s", sql)
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	if read := OwnerPredicate(human(principal.RowScopeTeam), arg)("t"); !strings.Contains(read, "t.owner_id IS NULL") {
+		t.Errorf("the READ owner predicate no longer shares an ownerless row: %s", read)
 	}
 }

--- a/backend/internal/platform/database/storekit/claim.go
+++ b/backend/internal/platform/database/storekit/claim.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// Claim is what ClaimOwnership answers: who owned the row before (nil for an
+// unowned one), the row's version after, and whether anything was written —
+// a claim of a row already one's own is a no-op that writes no audit noise.
+type Claim struct {
+	Before  *ids.UUID
+	Version int64
+	Changed bool
+}
+
+// ClaimOwnership makes `me` the owner of one row of a record table: the one
+// spelling of "put my name on this" for every record type a seat can own.
+// The row is locked, gated by auth.EnsureClaimable (visible, and unowned or
+// already the caller's to change), compared against ifVersion when given,
+// and updated against the owner just read — a claim that raced another one
+// finds the winner's name and answers ErrConflict. The caller writes the
+// record's own updated event beside the audit row this returns with.
+func ClaimOwnership(ctx context.Context, tx pgx.Tx, table string, id, me ids.UUID, ifVersion *int64) (Claim, ids.UUID, error) {
+	if _, err := LockRow(ctx, tx, table, id, LiveOnly); err != nil {
+		return Claim{}, ids.Nil, err
+	}
+	if err := auth.EnsureClaimable(ctx, tx, table, id); err != nil {
+		return Claim{}, ids.Nil, err
+	}
+	var before *ids.UUID
+	var version int64
+	if err := tx.QueryRow(ctx, SQLf(`SELECT owner_id, version FROM %s WHERE id = $1`, table), id).
+		Scan(&before, &version); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Claim{}, ids.Nil, apperrors.ErrNotFound
+		}
+		return Claim{}, ids.Nil, err
+	}
+	if ifVersion != nil && version != *ifVersion {
+		return Claim{}, ids.Nil, apperrors.ErrVersionSkew
+	}
+	if before != nil && *before == me {
+		return Claim{Before: before, Version: version}, ids.Nil, nil
+	}
+	tag, err := tx.Exec(ctx, SQLf(`UPDATE %s SET owner_id = $2 WHERE id = $1 AND owner_id IS NOT DISTINCT FROM $3`, table), id, me, before)
+	if err != nil {
+		return Claim{}, ids.Nil, err
+	}
+	if tag.RowsAffected() != 1 {
+		return Claim{}, ids.Nil, fmt.Errorf("%w: the record was claimed by somebody else", apperrors.ErrConflict)
+	}
+	auditID, err := Audit(ctx, tx, "assign", table, id, map[string]any{"owner_id": before}, map[string]any{"owner_id": me})
+	if err != nil {
+		return Claim{}, ids.Nil, err
+	}
+	if err := tx.QueryRow(ctx, SQLf(`SELECT version FROM %s WHERE id = $1`, table), id).Scan(&version); err != nil {
+		return Claim{}, ids.Nil, err
+	}
+	return Claim{Before: before, Version: version, Changed: true}, auditID, nil
+}

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -48,6 +48,25 @@ func CapturedBy(ctx context.Context) (string, error) {
 	return p.ID, nil
 }
 
+// OwnerOrActor answers the owner_id a manual create stamps: the one the
+// caller named, else the human behind the call. A record someone creates by
+// hand is theirs until they hand it on — an ownerless row would be every
+// seat's to change (the write arm admits a null owner) and, under an own
+// scope on a commercial table, invisible to the very person who made it.
+// A principal with no human behind it (system, a bare connector) leaves the
+// row ownerless, which is the honest answer for a row no person made.
+func OwnerOrActor(ctx context.Context, owner *ids.UserID) *ids.UserID {
+	if owner != nil {
+		return owner
+	}
+	p, ok := principal.Actor(ctx)
+	if !ok || p.UserID == ids.Nil {
+		return nil
+	}
+	id := ids.From[ids.UserKind](p.UserID)
+	return &id
+}
+
 // Audit writes the append-only audit_log row inside the mutation's
 // transaction — atomic with the domain write by construction — and
 // returns the row's id so the paired event can carry it as

--- a/backend/migrations/core/1787159552_owner_from_provenance.down.sql
+++ b/backend/migrations/core/1787159552_owner_from_provenance.down.sql
@@ -1,0 +1,3 @@
+-- A data backfill: the rows it stamped are indistinguishable from rows owned
+-- on purpose, so the down leaves them as they are.
+SELECT 1;

--- a/backend/migrations/core/1787159552_owner_from_provenance.up.sql
+++ b/backend/migrations/core/1787159552_owner_from_provenance.up.sql
@@ -1,0 +1,35 @@
+-- An ownerless customer record is nobody's to change until somebody claims
+-- it. The rows written before creates stamped their creator — hand-made
+-- records whose create carried no owner, leads a connector captured — would
+-- otherwise all need a claim before their own maker could touch them again,
+-- and a connector could not resume the leads it minted. Each row's
+-- provenance already names that person: captured_by is `human:<uuid>` for a
+-- hand-made row and `connector:<name>:<uuid>` for a captured one, so the
+-- owner is the human the provenance ends in, where that human still exists.
+-- A row whose provenance names nobody (system, a bare connector) stays
+-- unowned and is claimed the ordinary way.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE person p SET owner_id = u.id
+  FROM app_user u
+ WHERE p.owner_id IS NULL
+   AND p.captured_by ~ '[0-9a-f-]{36}$'
+   AND u.id = substring(p.captured_by from '([0-9a-f-]{36})$')::uuid;
+
+UPDATE organization o SET owner_id = u.id
+  FROM app_user u
+ WHERE o.owner_id IS NULL
+   AND o.captured_by ~ '[0-9a-f-]{36}$'
+   AND u.id = substring(o.captured_by from '([0-9a-f-]{36})$')::uuid;
+
+UPDATE lead l SET owner_id = u.id
+  FROM app_user u
+ WHERE l.owner_id IS NULL
+   AND l.captured_by ~ '[0-9a-f-]{36}$'
+   AND u.id = substring(l.captured_by from '([0-9a-f-]{36})$')::uuid;
+
+UPDATE deal d SET owner_id = u.id
+  FROM app_user u
+ WHERE d.owner_id IS NULL
+   AND d.captured_by ~ '[0-9a-f-]{36}$'
+   AND u.id = substring(d.captured_by from '([0-9a-f-]{36})$')::uuid;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5887,8 +5887,9 @@ export interface paths {
          * @description Sets the record's `owner_id` to the caller. Customer identity is workspace-readable, and an
          *     ownerless record is nobody's to change until somebody claims it — this is the claim. Permitted
          *     on a record the caller can read that has no owner, or that is already theirs to change (a
-         *     reassignment to oneself). A record owned by somebody else, with no write share, answers `403`;
-         *     a claim that loses the race to another claimant answers `409` naming the owner that won.
+         *     reassignment to oneself — a teammate's record, or one shared at `write`). A record owned by
+         *     somebody else, with no write share, answers `403` — including one a colleague claimed a
+         *     moment earlier; a claim whose `If-Match` no longer holds answers `409`.
          *     One transaction: the row, its audit row (`assign`) and its `<record>.updated` event.
          */
         post: operations["claimRecord"];
@@ -28593,7 +28594,7 @@ export interface operations {
             };
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
-            /** @description Somebody else claimed the record first, or the version moved (`code: conflict` / `version_skew`). */
+            /** @description The version moved since the caller read the record (`code: version_skew`). */
             409: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5869,6 +5869,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/records/{record_type}/{id}/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                record_type: "person" | "organization" | "lead" | "deal";
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Take ownership of a customer record.
+         * @description Sets the record's `owner_id` to the caller. Customer identity is workspace-readable, and an
+         *     ownerless record is nobody's to change until somebody claims it — this is the claim. Permitted
+         *     on a record the caller can read that has no owner, or that is already theirs to change (a
+         *     reassignment to oneself). A record owned by somebody else, with no write share, answers `403`;
+         *     a claim that loses the race to another claimant answers `409` naming the owner that won.
+         *     One transaction: the row, its audit row (`assign`) and its `<record>.updated` event.
+         */
+        post: operations["claimRecord"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/record-grants": {
         parameters: {
             query?: never;
@@ -16820,6 +16849,18 @@ export interface components {
             source?: string | null;
             /** @description Required to make a grant effective when the purpose has requires_double_opt_in=true. */
             double_opt_in_token?: string | null;
+        };
+        RecordClaim: {
+            /** @enum {string} */
+            record_type: "person" | "organization" | "lead" | "deal";
+            /** Format: uuid */
+            record_id: string;
+            /**
+             * Format: uuid
+             * @description The caller — the record's owner now.
+             */
+            owner_id: string;
+            version: components["schemas"]["RowVersion"];
         };
         /** @description A manual per-record share (A52/ADR-0039) — widens own/team/all base scope for one record. */
         RecordGrant: {
@@ -28517,6 +28558,50 @@ export interface operations {
             };
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
+        };
+    };
+    claimRecord: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                record_type: "person" | "organization" | "lead" | "deal";
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The record is the caller's. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordClaim"];
+                };
+            };
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            /** @description Somebody else claimed the record first, or the version moved (`code: conflict` / `version_skew`). */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     listRecordGrants: {

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -317,6 +317,8 @@ export function CompanyOwnerControl({
   const canUpdate = useCan("organization", "update");
   const readOnlyReason = useCompanyReadOnlyReason(org);
   const patch = useCompanyFieldPatch(org);
+  const claim = useClaimRecord("organization", org.id, org.version);
+  const viewerId = useViewerId();
   const roster = useRoster("user", true);
   const owners = (roster.data ?? []).flatMap((entry) =>
     "display_name" in entry
@@ -367,9 +369,41 @@ export function CompanyOwnerControl({
           unresolvedOwnerLabel(roster, t)
         );
       }}
-      onSave={(next) => patch({ owner_id: next })}
+      // An unowned account is nobody's to change until somebody claims it, so
+      // a reader taking it on goes through the claim — the door the write arm
+      // leaves open to every seat — while naming a colleague stays a patch,
+      // which an unbounded seat may make and a bounded one may not.
+      onSave={(next) =>
+        !org.owner_id && next === viewerId ? claim() : patch({ owner_id: next })
+      }
     />
   );
+}
+
+// useClaimRecord is the claim door: POST /records/{type}/{id}/claim makes the
+// caller the owner of an unowned record (or re-confirms one already theirs)
+// and refreshes what shows it. Used wherever an owner control lets a reader
+// pick themselves on a record nobody owns.
+export function useClaimRecord(
+  recordType: "organization" | "person" | "lead" | "deal",
+  id: string,
+  version: number | undefined,
+) {
+  const queryClient = useQueryClient();
+  return async () => {
+    const { error } = await api.POST("/records/{record_type}/{id}/claim", {
+      params: {
+        path: { record_type: recordType, id },
+        ...ifMatch(requireVersion(version)),
+      },
+    });
+    if (error) {
+      throwProblem(error);
+    }
+    await queryClient.invalidateQueries({ queryKey: [`${recordType}s`] });
+    await queryClient.invalidateQueries({ queryKey: [`${recordType}360`, id] });
+    await queryClient.invalidateQueries({ queryKey: [recordType, id] });
+  };
 }
 
 function CompanyEditAction({


### PR DESCRIPTION
Slice 4 of the access & visibility rework (owner stamping + claim). The fourth item of the plan — auto-promoting a lead on an inbound reply — is deliberately left out: #1874 shipped a lead ladder where a reply moves the lead to `engaged` and promotion stays a governed human act; the conflict is filed for a decision as #1891.

- Manual creates of person / organization / lead / deal stamp `owner_id` from the calling principal when none is named (`storekit.OwnerOrActor`). Captured leads are owned by the mailbox owner, like captured contacts.
- The WRITE authority arm no longer admits `owner_id IS NULL`: an unowned customer record is every seat's to read and nobody's to change (below row_scope=all) until claimed. Reads keep the null arm.
- `POST /v1/records/{record_type}/{id}/claim` (human-only, If-Match): `storekit.ClaimOwnership` locks the row, takes `auth.EnsureClaimable` (visible and unowned, or already the caller's to change), compares the owner it read — a lost race answers 409 — and writes the row + `assign` audit + `<record>.updated` in one transaction. Dispatched in compose to the module that owns the table (people for three, deals for deal).
- Frontend: the company owner control goes through the claim when a reader picks themselves on an unowned account; naming a colleague stays a patch.
- Harness: `e.Admin()` is one real app_user now (`e.AdminUser`) because the owner column is an FK; tests whose point was an unowned row null the owner explicitly.

Gates: `make check-fe` green; `make test-integration` green with 0 skips; craft static, go-file-length, rls-store-path, no-jurisdiction clean; `make check-backend` red only on the main-side items in #1878 and #1871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes manual person/organization/lead/deal creates default to the caller as owner, and makes ownerless records read-only until explicitly claimed. Previously, writes to ownerless rows were allowed; now writes require ownership or a grant, and claiming adds an owner in one audited, event-emitting transaction.

- New API: POST /v1/records/{record_type}/{id}/claim (human-only, optional If-Match) assigns the caller as owner for person|organization|lead|deal. Returns 200 RecordClaim; 403 if not claimable; 409 on race or version skew. Backend uses `storekit.ClaimOwnership` with `auth.EnsureClaimable`.
- Auth: the READ owner predicate still treats owner_id IS NULL as shared; the WRITE predicate no longer admits owner_id IS NULL (must claim first).
- Creates: person/organization/lead/deal stamp owner_id via `storekit.OwnerOrActor` when none is provided. Captured leads are owned by the mailbox owner so replays can write back.
- Side effects: claim writes an assign audit and a <record>.updated event with the owner_id delta in the same transaction.
- Frontend: the company owner control uses claim when a reader picks themselves on an unowned org; naming a colleague remains a PATCH. Adds `useClaimRecord`.

**Review and rollout**
- Review focus: auth predicates (`rowscope`, `writescope`), `storekit.ClaimOwnership`, people/deals claim methods, new compose handler and OpenAPI wiring, capture lead upsert, and owner stamping on all create paths.
- Migration: a data-only migration backfills owner_id for historical rows from their captured_by provenance (where the human still exists). No schema changes. The test harness now seeds a real admin seat (app_user) so total seats are 4; tests needing unowned rows must null owner_id explicitly. Bounded writers must claim before editing ownerless records; clients that PATCHed unowned records should call claim first. API is cookie-auth only and supports If-Match.

<sup>Written for commit 650631c6897e4cb5f43fc254a628618283f4d012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

