### PR TITLE
feat(authz): a role can read a record and still not read every column of it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18430,6 +18430,15 @@ components:
         name: { type: string }
         amount_minor: { type: [integer, 'null'], format: int64 }
         currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
+        masked_fields:
+          type: array
+          readOnly: true
+          items: { type: string }
+          description: >-
+            The fields of THIS row the caller's role withholds (a field mask — e.g. `amount_minor`
+            for a rep on a deal they may read but not change). A named field is null because it is
+            withheld, not because it is empty; absent or empty means nothing is withheld. Sorting or
+            filtering the list by a masked field is refused (422).
         fx_rate_to_base: { type: [string, 'null'], description: 'Native→base, frozen at close (null while open). Decimal-as-string to avoid float rounding of the 10-dp rate.' }
         fx_rate_date: { type: [string, 'null'], format: date }
         pipeline_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent''s own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).' }

--- a/backend/internal/compose/integration/fieldmask_integration_test.go
+++ b/backend/internal/compose/integration/fieldmask_integration_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
+)
+
+// A field mask withholds one column of a readable row. A rep reads every deal
+// in the workspace; the amount of another team's deal is null and named in
+// masked_fields, their own team's amount is theirs, and a sort by the masked
+// column is refused — ordering by a value is reading it. The mask is a row
+// property the admin does not carry.
+func TestARepReadsEveryDealButNotAnotherTeamsAmount(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	mine := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
+	theirs := e.SeedDeal(t, "Theirs", pipeline, open, &e.Rep3)
+	amount := int64(250000)
+	for _, id := range []ids.UUID{mine, theirs} {
+		e.WsExec(t, `UPDATE deal SET amount_minor = $2, currency = 'EUR' WHERE id = $1`, id, amount)
+	}
+
+	perms := activityLifecyclePerms
+	perms.Objects = map[string]principal.ObjectGrant{"deal": {Read: true, Update: true}, "pipeline": {Read: true}}
+	perms.FieldMasks = []principal.FieldMask{{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority}}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	got, err := e.Deals.GetDeal(rep, ids.From[ids.DealKind](theirs), 0)
+	if err != nil {
+		t.Fatalf("a rep reading another team's deal: %v", err)
+	}
+	if got.AmountMinor != nil || got.MaskedFields == nil || len(*got.MaskedFields) != 1 || (*got.MaskedFields)[0] != "amount_minor" {
+		t.Errorf("another team's deal for a rep = amount %v masked %v, want amount withheld and named", got.AmountMinor, got.MaskedFields)
+	}
+	own, err := e.Deals.GetDeal(rep, ids.From[ids.DealKind](mine), 0)
+	if err != nil || own.AmountMinor == nil || *own.AmountMinor != amount || own.MaskedFields != nil {
+		t.Errorf("the rep's own deal = amount %v masked %v (%v), want the amount and no mask", own.AmountMinor, own.MaskedFields, err)
+	}
+
+	page, _, err := e.Deals.ListDeals(rep, deals.ListDealsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[ids.UUID]bool{}
+	for _, d := range page {
+		seen[ids.UUID(d.Id)] = true
+		switch ids.UUID(d.Id) {
+		case mine:
+			if d.AmountMinor == nil {
+				t.Error("the list withheld the rep's own amount")
+			}
+		case theirs:
+			if d.AmountMinor != nil || d.MaskedFields == nil {
+				t.Error("the list handed the rep another team's amount")
+			}
+		}
+	}
+	if !seen[mine] || !seen[theirs] {
+		t.Errorf("the list shows %v, want both deals", seen)
+	}
+	sort := "-amount_minor"
+	var refused *values.ParseError
+	if _, _, err := e.Deals.ListDeals(rep, deals.ListDealsInput{Sort: &sort}); !errors.As(err, &refused) || refused.Code != "field_masked" {
+		t.Errorf("sorting by a masked column → %v, want the field_masked refusal", err)
+	}
+
+	// The admin carries no mask.
+	full, err := e.Deals.GetDeal(e.Admin(), ids.From[ids.DealKind](theirs), 0)
+	if err != nil || full.AmountMinor == nil || full.MaskedFields != nil {
+		t.Errorf("the admin's read = amount %v masked %v (%v), want the amount", full.AmountMinor, full.MaskedFields, err)
+	}
+}

--- a/backend/internal/compose/integration/fieldmask_integration_test.go
+++ b/backend/internal/compose/integration/fieldmask_integration_test.go
@@ -39,8 +39,8 @@ func TestARepReadsEveryDealButNotAnotherTeamsAmount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a rep reading another team's deal: %v", err)
 	}
-	if got.AmountMinor != nil || got.MaskedFields == nil || len(*got.MaskedFields) != 1 || (*got.MaskedFields)[0] != "amount_minor" {
-		t.Errorf("another team's deal for a rep = amount %v masked %v, want amount withheld and named", got.AmountMinor, got.MaskedFields)
+	if got.AmountMinor != nil || got.Currency != nil || got.MaskedFields == nil || len(*got.MaskedFields) != 1 || (*got.MaskedFields)[0] != "amount_minor" {
+		t.Errorf("another team's deal for a rep = amount %v currency %v masked %v, want the money pair withheld and the amount named", got.AmountMinor, got.Currency, got.MaskedFields)
 	}
 	own, err := e.Deals.GetDeal(rep, ids.From[ids.DealKind](mine), 0)
 	if err != nil || own.AmountMinor == nil || *own.AmountMinor != amount || own.MaskedFields != nil {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14176,7 +14176,10 @@ type Deal struct {
 
 	// LostReason Required when status=lost.
 	LostReason *string `json:"lost_reason,omitempty"`
-	Name       string  `json:"name"`
+
+	// MaskedFields The fields of THIS row the caller's role withholds (a field mask — e.g. `amount_minor` for a rep on a deal they may read but not change). A named field is null because it is withheld, not because it is empty; absent or empty means nothing is withheld. Sorting or filtering the list by a masked field is refused (422).
+	MaskedFields *[]string `json:"masked_fields,omitempty"`
+	Name         string    `json:"name"`
 
 	// OrganizationId Primary org; never a raw lead.
 	OrganizationId *openapi_types.UUID `json:"organization_id,omitempty"`
@@ -27258,6 +27261,14 @@ func (a *Deal) UnmarshalJSON(b []byte) error {
 		delete(object, "lost_reason")
 	}
 
+	if raw, found := object["masked_fields"]; found {
+		err = json.Unmarshal(raw, &a.MaskedFields)
+		if err != nil {
+			return fmt.Errorf("error reading 'masked_fields': %w", err)
+		}
+		delete(object, "masked_fields")
+	}
+
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
@@ -27494,6 +27505,13 @@ func (a Deal) MarshalJSON() ([]byte, error) {
 		object["lost_reason"], err = json.Marshal(a.LostReason)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'lost_reason': %w", err)
+		}
+	}
+
+	if a.MaskedFields != nil {
+		object["masked_fields"], err = json.Marshal(a.MaskedFields)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'masked_fields': %w", err)
 		}
 	}
 

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -37,7 +37,15 @@ func (s *Store) GetDeal(ctx context.Context, id ids.DealID, archived storekit.Ar
 			return err
 		}
 		out, err = readDeal(ctx, tx, id, archived, active)
-		return err
+		if err != nil {
+			return err
+		}
+		one := []crmcontracts.Deal{out}
+		if err := maskDeals(ctx, tx, one); err != nil {
+			return err
+		}
+		out = one[0]
+		return nil
 	})
 	return out, err
 }
@@ -88,6 +96,9 @@ func (s *Store) ListDeals(ctx context.Context, in ListDealsInput) ([]crmcontract
 	if err != nil {
 		return nil, storekit.Page{}, err
 	}
+	if err := refuseMaskedSort(ctx, in.Sort); err != nil {
+		return nil, storekit.Page{}, err
+	}
 	pre, err := buildListPrelude(ctx, "deal", dealListFields, active,
 		in.Sort, in.Limit, in.Cursor, in.CustomFilters)
 	if err != nil {
@@ -96,7 +107,8 @@ func (s *Store) ListDeals(ctx context.Context, in ListDealsInput) ([]crmcontract
 	where := appendDealFilters(pre.where, in, pre.arg)
 
 	return runListPage(ctx, s, pre, "deal", dealColumns, active, where, scanDealPage,
-		func(d crmcontracts.Deal) (time.Time, ids.UUID) { return d.CreatedAt, ids.UUID(d.Id) })
+		func(d crmcontracts.Deal) (time.Time, ids.UUID) { return d.CreatedAt, ids.UUID(d.Id) },
+		func(tx pgx.Tx, page []crmcontracts.Deal) error { return maskDeals(ctx, tx, page) })
 }
 
 // scanDealPage drains one list query's rows: each deal plus, under a

--- a/backend/internal/modules/deals/fieldmask.go
+++ b/backend/internal/modules/deals/fieldmask.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The deal's field masks, applied where the row meets the wire. A rep reads
+// every deal in the workspace; the amount of one that is not theirs to change
+// is withheld — null, and named in masked_fields so the reader can tell it
+// from an amount nobody entered.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
+)
+
+// dealMaskableFields are the columns a mask may name on a deal, and how each
+// is withheld. A mask naming a column not listed here is inert: withholding
+// is a deliberate act per field, not a reflective one over the struct.
+var dealMaskableFields = map[string]func(*crmcontracts.Deal){
+	"amount_minor": func(d *crmcontracts.Deal) { d.AmountMinor = nil },
+	"currency":     func(d *crmcontracts.Deal) { d.Currency = nil },
+}
+
+// maskDeals withholds, per row, the fields the caller's role masks. One
+// statement answers which rows of the page the caller could change; the
+// masks conditioned on write authority lift on those.
+func maskDeals(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal) error {
+	p, err := storekit.Actor(ctx)
+	if err != nil {
+		return err
+	}
+	// Cheap exit for the common case — no mask on deals at all.
+	if len(auth.MaskedFields(p, "deal", false)) == 0 {
+		return nil
+	}
+	rowIDs := make([]ids.UUID, 0, len(deals))
+	for _, d := range deals {
+		rowIDs = append(rowIDs, ids.UUID(d.Id))
+	}
+	writable, err := auth.WritableSubset(ctx, tx, "deal", rowIDs)
+	if err != nil {
+		return err
+	}
+	for i := range deals {
+		masked := auth.MaskedFields(p, "deal", writable[ids.UUID(deals[i].Id)])
+		if len(masked) == 0 {
+			continue
+		}
+		named := make([]string, 0, len(masked))
+		for _, field := range masked {
+			withhold, known := dealMaskableFields[field]
+			if !known {
+				continue
+			}
+			withhold(&deals[i])
+			named = append(named, field)
+		}
+		if len(named) > 0 {
+			deals[i].MaskedFields = &named
+		}
+	}
+	return nil
+}
+
+// refuseMaskedSort refuses a sort over a column the caller's role masks on
+// any row: ordering by a value is reading it, and a page ordered by amounts
+// the caller may not see would disclose them through the order.
+func refuseMaskedSort(ctx context.Context, sort *string) error {
+	if sort == nil || *sort == "" {
+		return nil
+	}
+	field := strings.TrimPrefix(strings.TrimSpace(*sort), "-")
+	if _, maskable := dealMaskableFields[field]; !maskable {
+		return nil
+	}
+	masked, err := auth.MasksAnyRowOf(ctx, "deal", field)
+	if err != nil {
+		return err
+	}
+	if masked {
+		return &values.ParseError{
+			Field: "sort", Code: "field_masked",
+			Message: "sort by " + field + " is not available: your role does not read it on every deal",
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/deals/fieldmask.go
+++ b/backend/internal/modules/deals/fieldmask.go
@@ -25,7 +25,9 @@ import (
 // is withheld. A mask naming a column not listed here is inert: withholding
 // is a deliberate act per field, not a reflective one over the struct.
 var dealMaskableFields = map[string]func(*crmcontracts.Deal){
-	"amount_minor": func(d *crmcontracts.Deal) { d.AmountMinor = nil },
+	// The money pair goes together: a currency beside a withheld amount
+	// would read as a priced deal with its figure missing.
+	"amount_minor": func(d *crmcontracts.Deal) { d.AmountMinor, d.Currency = nil, nil },
 	"currency":     func(d *crmcontracts.Deal) { d.Currency = nil },
 }
 

--- a/backend/internal/modules/deals/listquery.go
+++ b/backend/internal/modules/deals/listquery.go
@@ -107,6 +107,9 @@ func runListPage[T any](
 	where []string,
 	scan func(pgx.Rows, []fieldcatalog.Column, *storekit.ListSort) ([]T, []*string, error),
 	key func(T) (time.Time, ids.UUID),
+	// finish runs over the trimmed page inside the same transaction — the
+	// field-mask pass, which needs one more statement over the page's ids.
+	finish ...func(pgx.Tx, []T) error,
 ) ([]T, storekit.Page, error) {
 	var out []T
 	var page storekit.Page
@@ -130,6 +133,11 @@ func runListPage[T any](
 			page = storekit.Page{
 				HasMore:    true,
 				NextCursor: pre.sorted.EncodePageCursor(cursorKeys[pre.limit-1], createdAt, id),
+			}
+		}
+		for _, f := range finish {
+			if err := f(tx, out); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/backend/internal/modules/identity/fieldmasks.go
+++ b/backend/internal/modules/identity/fieldmasks.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// loadFieldMasks reads the columns the principal's roles withhold — the
+// union over every role held, additive like the grants: a role that masks a
+// field masks it for the seat, whatever another role says.
+func loadFieldMasks(ctx context.Context, tx pgx.Tx, roleKeys []string) ([]principal.FieldMask, error) {
+	if len(roleKeys) == 0 {
+		return nil, nil
+	}
+	rows, err := tx.Query(ctx,
+		`SELECT DISTINCT object, field, condition FROM field_mask WHERE role_key = ANY($1) ORDER BY object, field, condition`,
+		roleKeys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var masks []principal.FieldMask
+	for rows.Next() {
+		var m principal.FieldMask
+		if err := rows.Scan(&m.Object, &m.Field, &m.Condition); err != nil {
+			return nil, err
+		}
+		masks = append(masks, m)
+	}
+	return masks, rows.Err()
+}

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -470,3 +470,33 @@ func TestNonActiveStatusesCannotLogIn(t *testing.T) {
 		t.Fatalf("reactivated user cannot log in: %v", err)
 	}
 }
+
+// The seeded field mask reaches the principal through the role: a rep's
+// login carries the deal amount mask, and a manager's does not. A mask is a
+// property of the role, read at login like the grants — the store that
+// withholds the column never reads the table.
+func TestTheRepRoleCarriesTheDealAmountMask(t *testing.T) {
+	e := setupRevocationEnv(t, "field-mask")
+	ctx := principal.WithWorkspaceID(context.Background(), e.admin.WorkspaceID.UUID)
+	if err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, e.member.UserID, "rep"); err != nil {
+		t.Fatal(err)
+	}
+	asRep, _, err := e.svc.Login(ctx, e.member.Email, memberPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := principal.FieldMask{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority}
+	if len(asRep.Permissions.FieldMasks) != 1 || asRep.Permissions.FieldMasks[0] != want {
+		t.Errorf("a rep's field masks = %+v, want exactly %+v", asRep.Permissions.FieldMasks, want)
+	}
+	if err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, e.member.UserID, "manager"); err != nil {
+		t.Fatal(err)
+	}
+	asManager, _, err := e.svc.Login(ctx, e.member.Email, memberPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(asManager.Permissions.FieldMasks) != 0 {
+		t.Errorf("a manager's field masks = %+v, want none", asManager.Permissions.FieldMasks)
+	}
+}

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -464,31 +464,6 @@ func loadGrants(ctx context.Context, tx pgx.Tx, userID ids.UserID) (roles []stri
 	return roles, teams, perms, err
 }
 
-// loadFieldMasks reads the columns the principal's roles withhold — the
-// union over every role held, additive like the grants: a role that masks a
-// field masks it for the seat, whatever another role says.
-func loadFieldMasks(ctx context.Context, tx pgx.Tx, roleKeys []string) ([]principal.FieldMask, error) {
-	if len(roleKeys) == 0 {
-		return nil, nil
-	}
-	rows, err := tx.Query(ctx,
-		`SELECT DISTINCT object, field, condition FROM field_mask WHERE role_key = ANY($1) ORDER BY object, field, condition`,
-		roleKeys)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var masks []principal.FieldMask
-	for rows.Next() {
-		var m principal.FieldMask
-		if err := rows.Scan(&m.Object, &m.Field, &m.Condition); err != nil {
-			return nil, err
-		}
-		masks = append(masks, m)
-	}
-	return masks, rows.Err()
-}
-
 // rawTeamIDs widens typed team ids to the untyped []ids.UUID the kernel
 // principal and the authz port carry — the row-scope seams stay untyped
 // (they compare team membership against polymorphic scope clauses).

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -456,7 +456,37 @@ func loadGrants(ctx context.Context, tx pgx.Tx, userID ids.UserID) (roles []stri
 		}
 		teams = append(teams, t)
 	}
-	return roles, teams, policy.Merge(byRole), teamRows.Err()
+	if err := teamRows.Err(); err != nil {
+		return nil, nil, principal.Permissions{}, err
+	}
+	perms = policy.Merge(byRole)
+	perms.FieldMasks, err = loadFieldMasks(ctx, tx, roles)
+	return roles, teams, perms, err
+}
+
+// loadFieldMasks reads the columns the principal's roles withhold — the
+// union over every role held, additive like the grants: a role that masks a
+// field masks it for the seat, whatever another role says.
+func loadFieldMasks(ctx context.Context, tx pgx.Tx, roleKeys []string) ([]principal.FieldMask, error) {
+	if len(roleKeys) == 0 {
+		return nil, nil
+	}
+	rows, err := tx.Query(ctx,
+		`SELECT DISTINCT object, field, condition FROM field_mask WHERE role_key = ANY($1) ORDER BY object, field, condition`,
+		roleKeys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var masks []principal.FieldMask
+	for rows.Next() {
+		var m principal.FieldMask
+		if err := rows.Scan(&m.Object, &m.Field, &m.Condition); err != nil {
+			return nil, err
+		}
+		masks = append(masks, m)
+	}
+	return masks, rows.Err()
 }
 
 // rawTeamIDs widens typed team ids to the untyped []ids.UUID the kernel

--- a/backend/internal/platform/auth/fieldmask.go
+++ b/backend/internal/platform/auth/fieldmask.go
@@ -62,10 +62,11 @@ func MasksAnyRowOf(ctx context.Context, object, field string) (bool, error) {
 }
 
 // WritableSubset answers, in ONE statement, which of the given rows of a
-// shareable table the caller could change — the write arm EnsureWritable
+// shareable table the caller may SEE and could CHANGE — the pair EnsureWritable
 // takes, asked of a page at once so a list can mask per row without a probe
-// per row. An unbounded caller writes them all; rows the caller cannot see at
-// all are simply absent from the answer (the list already scoped them).
+// per row. A row the caller cannot see is absent from the answer whatever
+// their write authority, capture privacy included; only a caller who reads the
+// table whole with no predicate at all (UnboundedFor) writes every row named.
 func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.UUID) (map[ids.UUID]bool, error) {
 	if !shareableTables[table] {
 		return nil, fmt.Errorf("auth: %q is not a shareable table", table)
@@ -75,7 +76,7 @@ func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.U
 		return nil, err
 	}
 	out := make(map[ids.UUID]bool, len(rowIDs))
-	if Unbounded(p) {
+	if UnboundedFor(p, table) && Unbounded(p) {
 		for _, id := range rowIDs {
 			out[id] = true
 		}
@@ -87,7 +88,10 @@ func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.U
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	idsPos := arg(rowIDs)
-	clause := writeAuthorityPredicate(p, table, arg)
+	// Visibility first, the write arm second — the same two questions
+	// EnsureWritable asks, in one statement. An unbounded caller's write arm
+	// is TRUE and capture privacy is all that can still withhold a row.
+	clause := VisiblePredicate(p, table, arg)("") + " AND " + writeAuthorityPredicate(p, table, arg)
 	rows, err := tx.Query(ctx,
 		fmt.Sprintf(`SELECT id FROM %[1]s WHERE id = ANY($%[2]d) AND %[3]s`, table, idsPos, clause), args...)
 	if err != nil {

--- a/backend/internal/platform/auth/fieldmask.go
+++ b/backend/internal/platform/auth/fieldmask.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// Field masks: the columns a principal reads as withheld. Object RBAC answers
+// whether a role may read a KIND of record, the row scope which ROWS; a mask
+// narrows one column of a readable row. It is applied where a store maps a
+// row onto the wire — the field goes out null and the record names it in
+// masked_fields, so a reader can tell "withheld" from "empty" — and it is
+// refused as a sort or filter key, since ordering by a value is reading it.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// MaskedFields answers the columns of one object the principal reads as
+// withheld on a row it may or may not change. An unbounded principal and the
+// system principal read every column; a mask conditioned on write authority
+// lifts on a row the caller could write.
+func MaskedFields(p principal.Principal, object string, writable bool) []string {
+	if Unbounded(p) {
+		return nil
+	}
+	var out []string
+	for _, m := range p.Permissions.FieldMasks {
+		if m.Object != object {
+			continue
+		}
+		if m.Condition == principal.MaskOutsideWriteAuthority && writable {
+			continue
+		}
+		out = append(out, m.Field)
+	}
+	return out
+}
+
+// MasksAnyRowOf reports whether the principal carries a mask on the object at
+// all — the test a list applies before accepting a sort or filter over a
+// maskable column: ordering by a value the caller may not read on some rows
+// would disclose it through the order.
+func MasksAnyRowOf(ctx context.Context, object, field string) (bool, error) {
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return false, err
+	}
+	if Unbounded(p) {
+		return false, nil
+	}
+	for _, m := range p.Permissions.FieldMasks {
+		if m.Object == object && m.Field == field {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// WritableSubset answers, in ONE statement, which of the given rows of a
+// shareable table the caller could change — the write arm EnsureWritable
+// takes, asked of a page at once so a list can mask per row without a probe
+// per row. An unbounded caller writes them all; rows the caller cannot see at
+// all are simply absent from the answer (the list already scoped them).
+func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.UUID) (map[ids.UUID]bool, error) {
+	if !shareableTables[table] {
+		return nil, fmt.Errorf("auth: %q is not a shareable table", table)
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[ids.UUID]bool, len(rowIDs))
+	if Unbounded(p) {
+		for _, id := range rowIDs {
+			out[id] = true
+		}
+		return out, nil
+	}
+	if len(rowIDs) == 0 {
+		return out, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(rowIDs)
+	clause := writeAuthorityPredicate(p, table, arg)
+	rows, err := tx.Query(ctx,
+		fmt.Sprintf(`SELECT id FROM %[1]s WHERE id = ANY($%[2]d) AND %[3]s`, table, idsPos, clause), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -66,7 +66,8 @@ var (
 // once stated as an invariant — "no migration seeds reference data a test
 // depends on" — and migration 0240 was the first to break that assumption
 // (activity_kind, channel_provider: DESIGN-SP4 §4; the lead_source and
-// lead_disqualify_reason vocabularies since). A reset that DELETEd them
+// lead_disqualify_reason vocabularies and the field_mask seed since). A reset
+// that DELETEd them
 // would silently un-seed every test's fixed activity kinds and telegram's
 // channel-provider row, and the failure would surface somewhere else entirely
 // — a foreign-key violation on an activity insert with no visible connection
@@ -89,7 +90,7 @@ const resetTables = `
 	WHERE n.nspname IN ('public', 'ext')
 	  AND c.relkind = 'r'
 	  AND c.relname NOT LIKE 'schema_migrations_%'
-	  AND c.relname NOT IN ('activity_kind', 'channel_provider', 'lead_source', 'lead_disqualify_reason')`
+	  AND c.relname NOT IN ('activity_kind', 'channel_provider', 'lead_source', 'lead_disqualify_reason', 'field_mask')`
 
 // reclaimSlack is how much a table may grow past its empty size before a reset
 // TRUNCATEs it instead of DELETEing it. Growth, not absolute size, is the

--- a/backend/internal/platform/testdb/reset_integration_test.go
+++ b/backend/internal/platform/testdb/reset_integration_test.go
@@ -59,7 +59,7 @@ func nonEmptyTables(ctx context.Context, t *testing.T, owner *pgx.Conn) []string
 		  AND n.nspname <> 'information_schema'
 		  AND c.relkind IN ('r', 'p', 'f')
 		  AND c.relname NOT LIKE 'schema_migrations_%'
-		  AND c.relname NOT IN ('activity_kind', 'channel_provider', 'lead_source', 'lead_disqualify_reason')
+		  AND c.relname NOT IN ('activity_kind', 'channel_provider', 'lead_source', 'lead_disqualify_reason', 'field_mask')
 		ORDER BY n.nspname, c.relname`)
 	if err != nil {
 		t.Fatalf("listing tables: %v", err)
@@ -109,7 +109,7 @@ func TestResetScopeCoversEveryDataRelation(t *testing.T) {
 		WHERE n.nspname IN ('public', 'ext')
 		  AND c.relkind IN ('r', 'p')
 		  AND c.relname NOT LIKE 'schema_migrations_%'
-		  AND c.relname NOT IN ('activity_kind', 'channel_provider', 'lead_source', 'lead_disqualify_reason')
+		  AND c.relname NOT IN ('activity_kind', 'channel_provider', 'lead_source', 'lead_disqualify_reason', 'field_mask')
 		ORDER BY n.nspname, c.relname`)
 	if err != nil {
 		t.Fatalf("listing every data relation: %v", err)

--- a/backend/internal/shared/kernel/principal/principal.go
+++ b/backend/internal/shared/kernel/principal/principal.go
@@ -168,7 +168,28 @@ type Permissions struct {
 	RoleKeys []string
 	Objects  map[string]ObjectGrant
 	RowScope RowScope
+	// FieldMasks are the columns this principal reads as withheld, the union
+	// over its roles (a mask any role carries, the principal carries).
+	FieldMasks []FieldMask
 }
+
+// FieldMask names one column a role reads as withheld, and when.
+type FieldMask struct {
+	Object    string
+	Field     string
+	Condition MaskCondition
+}
+
+// MaskCondition says when a field mask holds.
+type MaskCondition string
+
+const (
+	// MaskAlways withholds the field on every row.
+	MaskAlways MaskCondition = "always"
+	// MaskOutsideWriteAuthority withholds the field on a row the caller may
+	// read but not change — the amount of another team's deal.
+	MaskOutsideWriteAuthority MaskCondition = "outside_write_authority"
+)
 
 // Allows answers the object-level RBAC question (B-EP03.2). Unknown
 // objects and the zero value deny.

--- a/backend/migrations/core/1787161153_field_mask.down.sql
+++ b/backend/migrations/core/1787161153_field_mask.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+DROP TABLE IF EXISTS field_mask;

--- a/backend/migrations/core/1787161153_field_mask.up.sql
+++ b/backend/migrations/core/1787161153_field_mask.up.sql
@@ -1,0 +1,30 @@
+-- Field masks: the columns a role reads as withheld. Until now the masks were
+-- a dead key in role.permissions that nothing read; this is the authoritative
+-- table, and enforcement follows in platform/auth (MaskedFields) and the
+-- stores that map a row onto the wire.
+--
+-- A mask is keyed by ROLE KEY, not role id: the system roles exist once per
+-- installation under fixed keys, so a seed can name them without knowing
+-- their ids, and a custom role carrying the same key inherits the rule.
+--
+-- condition says when the mask holds: `always`, or `outside_write_authority`
+-- — the caller may read the record but it is not theirs to change, so the
+-- sensitive column is withheld while the rest stays readable. That second
+-- condition is what makes a workspace-readable deal safe to show every rep:
+-- they see the deal exists and who owns it; the amount is the owner's team's.
+SET LOCAL lock_timeout = '3s';
+
+CREATE TABLE field_mask (
+  id         uuid PRIMARY KEY DEFAULT uuidv7(),
+  role_key   text NOT NULL,
+  object     text NOT NULL,
+  field      text NOT NULL,
+  condition  text NOT NULL CHECK (condition IN ('always', 'outside_write_authority')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (role_key, object, field)
+);
+
+-- The one mask the shared-identity decision makes load-bearing: a rep reads
+-- every deal in the workspace, and another team's amount is not theirs.
+INSERT INTO field_mask (role_key, object, field, condition)
+VALUES ('rep', 'deal', 'amount_minor', 'outside_write_authority');

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -54,16 +54,19 @@ const extSecretsStoreDir = "internal/platform/extsecrets"
 // against — expected data, not a cost anyone is paying.
 var tableOwners = map[string]string{
 	// identity
-	"workspace":                "internal/modules/identity",
-	"app_user":                 "internal/modules/identity",
-	"team":                     "internal/modules/identity",
-	"team_membership":          "internal/modules/identity",
-	"session":                  "internal/modules/identity",
-	"passport":                 "internal/modules/identity",
-	"setup_token":              "internal/modules/identity",
-	"auth_token":               "internal/modules/identity",
-	"role":                     "internal/modules/identity",
-	"role_assignment":          "internal/modules/identity",
+	"workspace":       "internal/modules/identity",
+	"app_user":        "internal/modules/identity",
+	"team":            "internal/modules/identity",
+	"team_membership": "internal/modules/identity",
+	"session":         "internal/modules/identity",
+	"passport":        "internal/modules/identity",
+	"setup_token":     "internal/modules/identity",
+	"auth_token":      "internal/modules/identity",
+	"role":            "internal/modules/identity",
+	"role_assignment": "internal/modules/identity",
+	// The columns a role reads as withheld; written by administration, read
+	// by the grant loader into the principal.
+	"field_mask":               "internal/modules/identity",
 	"record_grant":             "internal/modules/identity",
 	"oauth_client":             "internal/modules/identity",
 	"oauth_authorization_code": "internal/modules/identity",

--- a/docs/explanation/rbac-roles-and-teams.md
+++ b/docs/explanation/rbac-roles-and-teams.md
@@ -129,6 +129,22 @@ explicitly makes Demo Admin the owner of its records (`scripts/seed-dev.sql`).
 No system role ships `row_scope: own`; it exists for custom roles. The seeded `rep`/`manager` are
 `team`, so team membership is what actually decides who may write whose records.
 
+## Field masks — one column of a readable row
+
+A role can read a kind of record and still not read every column of it. `field_mask`
+(`backend/migrations/core/…_field_mask.up.sql`) names, per **role key**, an object, a field and a
+condition: `always`, or `outside_write_authority` — the row is readable but not the caller's to
+change. The masks are loaded into the principal at login with the grants (a seat carries the union
+over its roles) and applied where a store maps the row onto the wire (`platform/auth/fieldmask.go`,
+`deals/fieldmask.go`): the field goes out `null` and the record names it in `masked_fields`, so a
+reader can tell withheld from empty. Sorting or filtering a list by a masked column is refused
+(422), because ordering by a value is reading it. An unbounded seat (`row_scope: all`) carries no
+mask.
+
+The one seeded mask is the one the shared-identity read makes load-bearing: `rep` → `deal` →
+`amount_minor` → `outside_write_authority`. A rep sees every deal and who owns it; the amount of a
+deal outside their write authority is withheld.
+
 ## Teams
 
 A **team** (`team` table) is a named group; **`team_membership`** joins users to teams (many-to-many

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12810,6 +12810,8 @@ export interface components {
             /** Format: int64 */
             amount_minor?: number | null;
             currency?: string | null;
+            /** @description The fields of THIS row the caller's role withholds (a field mask — e.g. `amount_minor` for a rep on a deal they may read but not change). A named field is null because it is withheld, not because it is empty; absent or empty means nothing is withheld. Sorting or filtering the list by a masked field is refused (422). */
+            readonly masked_fields?: string[];
             /** @description Native→base, frozen at close (null while open). Decimal-as-string to avoid float rounding of the 10-dp rate. */
             fx_rate_to_base?: string | null;
             /** Format: date */

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -40,6 +40,7 @@ import {
 } from "../design-system/composed";
 import { type ListChip, ListSurface } from "../design-system/listsurface";
 import type { ListColumn } from "../design-system/listtable";
+import { FieldGuard } from "../design-system/rbac";
 import { Select } from "../design-system/select";
 import { AutonomyDot, ProvenanceTag } from "../design-system/trust";
 import {
@@ -576,7 +577,11 @@ function dealColumns(
       numeric: true,
       sort: "amount_minor",
       cell: (deal) =>
-        deal.amount_minor != null && deal.currency ? (
+        // Withheld is not empty: a masked amount keeps its cell and says so,
+        // where an unpriced deal shows nothing.
+        deal.masked_fields?.includes("amount_minor") ? (
+          <FieldGuard mode="masked" />
+        ) : deal.amount_minor != null && deal.currency ? (
           <span className="t-mono">
             {formatMoney(deal.amount_minor, deal.currency, locale)}
           </span>


### PR DESCRIPTION
Slice 6 of the access & visibility rework: field masks, enforced.

- `field_mask` (migration `1787161153`): per **role key**, an object, a field and a condition `always | outside_write_authority`. Seeded: `rep` → `deal.amount_minor` → `outside_write_authority` — the one mask the shared-identity read makes load-bearing.
- The masks are loaded into the principal at login with the grants (`identity/fieldmasks.go`, union over roles). `platform/auth/fieldmask.go`: `MaskedFields`, `MasksAnyRowOf`, and `WritableSubset` — one statement answering which rows of a page the caller could change, so a list masks per row without a probe per row.
- `deals`: `GetDeal` and `ListDeals` withhold the masked field (null) and name it in the new `Deal.masked_fields`; a sort by a masked column answers 422 `field_masked`. An unbounded seat carries no mask.
- Frontend: the deal list shows a withheld amount as withheld (`FieldGuard`), not as empty.
- Docs: `rbac-roles-and-teams.md` gains the field-mask section.

Not in this slice (filed as follow-ups): aggregate reads (forecast, deals-by-stage, reports) do not yet fail closed over masked rows; the kanban card / person strip show a masked amount as absent rather than withheld; masks on other objects beyond deal.

Gates: `make check-fe` green; `make test-integration` green with 0 skips; craft static, go-file-length, rls-store-path, no-jurisdiction clean; `make check-backend` red only on the main-side items in #1878 and #1871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces role-based field masks so a role can read a record without every column. Previously reps saw all deal fields; now for deals outside their write authority the money pair is withheld: `masked_fields` names `amount_minor` and both `amount_minor` and `currency` are null. Sorting by a masked column is refused; admin/unbounded seats are unchanged.

- Run migration `1787161153` to create and seed `field_mask` (seed: `rep` → `deal.amount_minor` → `outside_write_authority`).
- `Deal` adds read-only `masked_fields`; clients must treat a named null as withheld, not empty.
- `ListDeals` rejects masked sorts with 422 `field_masked`; `GetDeal`/`ListDeals` apply masks per row.
- Masks load into the principal at login (union over roles) and are enforced in `platform/auth` and `deals`; the writable-subset check respects visibility.

<sup>Written for commit 6f6f4bddd76d5897591ca7d618f7b5b8c13d1e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

