### PR TITLE
fix(frontend): the log form's due date explains itself and starts on today

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2021,6 +2021,7 @@ export const de = {
   "log.subject": "Betreff",
   "log.body": "Details",
   "log.dueAt": "Fällig am",
+  "log.dueAtHint": "Nur bei Aufgaben",
   "log.save": "Erfassen",
   "log.saving": "Wird erfasst…",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2016,6 +2016,7 @@ export const en = {
   "log.transcriptUploadFailed":
     "Could not read that file — try pasting the text instead.",
   "log.dueAt": "Due date",
+  "log.dueAtHint": "Tasks only",
   "log.save": "Log",
   "log.saving": "Logging…",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2000,6 +2000,7 @@ export const vi = {
   "log.subject": "Tiêu đề",
   "log.body": "Nội dung",
   "log.dueAt": "Ngày đến hạn",
+  "log.dueAtHint": "Chỉ áp dụng cho công việc",
   "log.save": "Ghi nhận",
   "log.saving": "Đang ghi nhận…",
 

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -237,16 +237,19 @@ describe("log activity from a 360", () => {
     // Reserved means VISIBLE-but-disabled. `hidden` is display:none, which
     // collapses the row and reintroduces the reflow this test exists to stop.
     expect(due.closest("div")?.hasAttribute("hidden")).toBe(false);
+    // Read the clock on both sides of the switch: a run that straddles
+    // midnight would otherwise fail on which "today" the prefill caught.
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const dayBeforeSwitch = calendarDay(new Date(), zone);
     await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
+    const dayAfterSwitch = calendarDay(new Date(), zone);
     const enabled = screen.getByLabelText<HTMLInputElement>("Due date", {
       selector: "input",
     });
     expect(enabled.hasAttribute("disabled")).toBe(false);
     // Becoming a task fills the empty field with the writer's own today —
     // the date that would otherwise be assumed invisibly at submit.
-    expect(enabled.value).toBe(
-      calendarDay(new Date(), Intl.DateTimeFormat().resolvedOptions().timeZone),
-    );
+    expect([dayBeforeSwitch, dayAfterSwitch]).toContain(enabled.value);
   });
 
   it("posts a task's due_at as the END of the picked day in the writer's own zone", async () => {

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -238,11 +238,15 @@ describe("log activity from a 360", () => {
     // collapses the row and reintroduces the reflow this test exists to stop.
     expect(due.closest("div")?.hasAttribute("hidden")).toBe(false);
     await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
-    expect(
-      screen
-        .getByLabelText("Due date", { selector: "input" })
-        .hasAttribute("disabled"),
-    ).toBe(false);
+    const enabled = screen.getByLabelText<HTMLInputElement>("Due date", {
+      selector: "input",
+    });
+    expect(enabled.hasAttribute("disabled")).toBe(false);
+    // Becoming a task fills the empty field with the writer's own today —
+    // the date that would otherwise be assumed invisibly at submit.
+    expect(enabled.value).toBe(
+      calendarDay(new Date(), Intl.DateTimeFormat().resolvedOptions().timeZone),
+    );
   });
 
   it("posts a task's due_at as the END of the picked day in the writer's own zone", async () => {
@@ -250,7 +254,9 @@ describe("log activity from a 360", () => {
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="organization" entityId="o1" />);
     await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
-    await userEvent.type(screen.getByLabelText("Due date"), PICKED_DAY);
+    fireEvent.change(screen.getByLabelText("Due date"), {
+      target: { value: PICKED_DAY },
+    });
     await userEvent.type(screen.getByLabelText("Subject *"), "Send proposal");
     await userEvent.click(screen.getByRole("button", { name: "Log" }));
     await waitFor(() =>
@@ -281,7 +287,9 @@ describe("log activity from a 360", () => {
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="organization" entityId="o1" />);
     await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
-    await userEvent.type(screen.getByLabelText("Due date"), PICKED_DAY);
+    fireEvent.change(screen.getByLabelText("Due date"), {
+      target: { value: PICKED_DAY },
+    });
     await userEvent.type(screen.getByLabelText("Subject *"), "Send proposal");
     await userEvent.click(screen.getByRole("button", { name: "Log" }));
     await waitFor(() =>

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
 } from "../design-system/atoms";
 import { Select } from "../design-system/select";
-import { dueInstant } from "../format/calendarday";
+import { calendarDay, dueInstant } from "../format/calendarday";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys, taskWriteKeys } from "./activitykeys";
@@ -54,6 +54,16 @@ const EMPTY_DRAFT: ActivityDraft = {
 // any future line citation at a timestamp instead of what was said.
 const ACCEPTED_TRANSCRIPT_EXTENSION = ".txt";
 
+// The writer's own calendar day. A task's due date starts here the moment the
+// kind becomes task — the day that WOULD apply is shown in the field instead
+// of being assumed at submit behind an empty box.
+function todayDay(): string {
+  return calendarDay(
+    new Date(),
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+}
+
 /**
  * LogActivityForm is the composer itself, without a frame, so the same fields
  * serve the standing card on the person and deal screens and the modal the
@@ -74,8 +84,14 @@ export function LogActivityForm({
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
-  const [draft, setDraft] = useState<ActivityDraft>(
-    initialKind ? { ...EMPTY_DRAFT, kind: initialKind } : EMPTY_DRAFT,
+  const [draft, setDraft] = useState<ActivityDraft>(() =>
+    initialKind
+      ? {
+          ...EMPTY_DRAFT,
+          kind: initialKind,
+          dueAt: initialKind === "task" ? todayDay() : "",
+        }
+      : EMPTY_DRAFT,
   );
   const [fileError, setFileError] = useState<string | null>(null);
 
@@ -159,9 +175,17 @@ export function LogActivityForm({
               ]}
               value={draft.kind}
               onChange={(value) =>
-                setField({
-                  kind:
-                    value === "task" || value === "meeting" ? value : "note",
+                setDraft((current) => {
+                  const kind =
+                    value === "task" || value === "meeting" ? value : "note";
+                  // Becoming a task fills the empty due date with today — the
+                  // likeliest answer, standing where the writer can change it.
+                  // A date the writer already picked is never overwritten.
+                  const dueAt =
+                    kind === "task" && current.dueAt === ""
+                      ? todayDay()
+                      : current.dueAt;
+                  return { ...current, kind, dueAt };
                 })
               }
             />
@@ -173,7 +197,10 @@ export function LogActivityForm({
             `hidden` would do the same thing by another name (it is
             display:none). Disabled keeps the row's height AND shows the reader
             that the field exists and why it is not theirs to fill yet. */}
-        <Field label={t("log.dueAt")}>
+        <Field
+          label={t("log.dueAt")}
+          hint={draft.kind === "task" ? undefined : t("log.dueAtHint")}
+        >
           {(control) => (
             <TextInput
               {...control}
@@ -181,6 +208,10 @@ export function LogActivityForm({
               value={draft.dueAt}
               disabled={draft.kind !== "task"}
               onChange={(event) => setField({ dueAt: event.target.value })}
+              // A native date input opens its calendar only from the tiny
+              // icon; a click on the value just places a caret. Opening on
+              // any click is what a writer reaching for "the date" expects.
+              onClick={(event) => event.currentTarget.showPicker?.()}
             />
           )}
         </Field>


### PR DESCRIPTION
Lars hit this while testing the lead page: clicking the due-date box in the Log activity composer did nothing (it is disabled while the type is Note), and logging a task left the date empty while today was silently assumed.

Three changes in `frontend/src/screens/logactivity.tsx`:

- The disabled due-date field now carries a **Tasks only** hint, so a dead click is explained.
- Switching the type to Task prefills the field with the writer's own today (reader-zone `calendarDay`); a date the writer already picked is never overwritten. `initialKind="task"` callers get the same prefill.
- A click anywhere in the enabled field opens the calendar via `showPicker()` instead of only the tiny native icon.

New i18n key `log.dueAtHint` in en/de/vi. Tests: the enable-test now asserts the prefill; the two due_at tests set the date via `fireEvent.change` since the field is no longer empty.

Gates run locally: `make check-fe` green, `make frontend-e2e` green (92 passed). Verified in the browser on the dev stack: hint shows for a note, switching to Task fills 2026-08-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Log activity form’s due-date UX: Notes now explain the disabled field, Tasks prefill today, and any click on the enabled field opens the date picker. Previously the field gave no hint, tasks left the date empty while submit silently assumed today, and only the icon opened the picker.

- Switching to Task (or `initialKind="task"`) pre-fills the due date with the writer’s today (their calendar day); a picked date is never overwritten.
- Adds i18n key `log.dueAtHint` (“Tasks only”) with strings in en/de/vi.
- The date input calls `showPicker()` on click.
- Tests: prefill assertion tolerates runs that straddle midnight; due date is set via change events.

<sup>Written for commit 8073d22ba390188301751173588fa88fec8b5159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

