### PR TITLE
feat(frontend): the log form's date works for every kind, not only tasks

### DIFF
--- a/frontend/src/format/calendarday.test.ts
+++ b/frontend/src/format/calendarday.test.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { describe, expect, it } from "vitest";
-import { calendarDay, dueInstant } from "./calendarday";
+import { calendarDay, dueInstant, middayInstant } from "./calendarday";
 
 // The zone the machine running this suite happens to be in. Every assertion
 // below is written against it rather than against a fixed offset, because the
@@ -45,5 +45,37 @@ describe("dueInstant", () => {
     expect(dueInstant("2026-07-05")).toMatch(
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
     );
+  });
+});
+
+describe("middayInstant", () => {
+  it("lands at the zone's own noon of the picked day, either side of a DST switch", () => {
+    // Berlin is +01:00 in January and +02:00 in July.
+    expect(middayInstant("2026-01-15", "Europe/Berlin")).toBe(
+      "2026-01-15T11:00:00.000Z",
+    );
+    expect(middayInstant("2026-07-05", "Europe/Berlin")).toBe(
+      "2026-07-05T10:00:00.000Z",
+    );
+  });
+
+  it("keeps the picked day in the record zone AND for writers far west of it", () => {
+    // The scenario that broke writer-local noon: a writer in Honolulu (UTC-10)
+    // backdating an entry a Berlin-rendered timeline then filed under the
+    // NEXT day. Minted at Berlin noon, both zones read the picked day.
+    const at = new Date(middayInstant("2026-07-10", "Europe/Berlin"));
+    expect(calendarDay(at, "Europe/Berlin")).toBe("2026-07-10");
+    expect(calendarDay(at, "Pacific/Honolulu")).toBe("2026-07-10");
+  });
+
+  it("holds for zones on half-hour offsets and across the date line", () => {
+    for (const zone of [
+      "Asia/Kolkata",
+      "Pacific/Kiritimati",
+      "Pacific/Honolulu",
+    ]) {
+      const at = new Date(middayInstant("2026-03-29", zone));
+      expect(calendarDay(at, zone)).toBe("2026-03-29");
+    }
   });
 });

--- a/frontend/src/format/calendarday.ts
+++ b/frontend/src/format/calendarday.ts
@@ -71,3 +71,40 @@ export function calendarDay(at: Date, zone: string): string {
 export function dueInstant(day: string): string {
   return new Date(`${day}T23:59:59`).toISOString();
 }
+
+// The instant that is NOON of a picked calendar day in a named zone — for a
+// backdated entry whose screens render dates in that zone (the record pages'
+// RECORD_ZONE): filing it at the zone's own midday is what keeps it on the
+// picked day both there and in the wall clock of any writer within twelve
+// hours of that zone.
+//
+// Found without a timezone table: read what wall time the zone shows at UTC
+// noon of that day, then shift the instant by the difference from the noon
+// that was wanted. One correction is exact because a zone's offset does not
+// change within the couple of hours the shift moves through — DST switches
+// happen at night, and the target is midday.
+export function middayInstant(day: string, zone: string): string {
+  const utcNoon = new Date(`${day}T12:00:00Z`);
+  const parts = new Map(
+    new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      // h23, not `hour12: false`: some ICU builds resolve the latter to h24,
+      // which prints midnight as "24" and breaks the ISO string below.
+      hourCycle: "h23",
+    })
+      .formatToParts(utcNoon)
+      .map((part) => [part.type, part.value]),
+  );
+  const shown = new Date(
+    `${parts.get("year")}-${parts.get("month")}-${parts.get("day")}T${parts.get("hour")}:${parts.get("minute")}:00Z`,
+  );
+  const wanted = new Date(`${day}T12:00:00Z`);
+  return new Date(
+    utcNoon.getTime() - (shown.getTime() - wanted.getTime()),
+  ).toISOString();
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2021,7 +2021,7 @@ export const de = {
   "log.subject": "Betreff",
   "log.body": "Details",
   "log.dueAt": "Fällig am",
-  "log.dueAtHint": "Nur bei Aufgaben",
+  "log.date": "Datum",
   "log.save": "Erfassen",
   "log.saving": "Wird erfasst…",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2016,7 +2016,7 @@ export const en = {
   "log.transcriptUploadFailed":
     "Could not read that file — try pasting the text instead.",
   "log.dueAt": "Due date",
-  "log.dueAtHint": "Tasks only",
+  "log.date": "Date",
   "log.save": "Log",
   "log.saving": "Logging…",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2000,7 +2000,7 @@ export const vi = {
   "log.subject": "Tiêu đề",
   "log.body": "Nội dung",
   "log.dueAt": "Ngày đến hạn",
-  "log.dueAtHint": "Chỉ áp dụng cho công việc",
+  "log.date": "Ngày",
   "log.save": "Ghi nhận",
   "log.saving": "Đang ghi nhận…",
 

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { calendarDay } from "../format/calendarday";
 import { LocaleProvider } from "../i18n";
+import { RECORD_ZONE } from "./company360";
 import { LogActivity } from "./logactivity";
 import { PersonScreen } from "./people";
 import { groupTask } from "./tasks";
@@ -226,30 +227,83 @@ describe("log activity from a 360", () => {
     );
   });
 
-  it("keeps the due-date input's space for a note and enables it for a task", async () => {
+  it("offers one date box for every kind: prefilled today, relabeled per kind, the day kept across a switch", async () => {
     stubApi({ "POST /activities": createdActivity });
-    render(<LogActivity entityType="organization" entityId="o1" />);
-    // The field stays in place for a note, disabled rather than hidden.
-    // Mounting it on the kind switch moved every control below it down
-    // mid-form.
-    const due = screen.getByLabelText("Due date", { selector: "input" });
-    expect(due.hasAttribute("disabled")).toBe(true);
-    // Reserved means VISIBLE-but-disabled. `hidden` is display:none, which
-    // collapses the row and reintroduces the reflow this test exists to stop.
-    expect(due.closest("div")?.hasAttribute("hidden")).toBe(false);
-    // Read the clock on both sides of the switch: a run that straddles
+    // Read the clock on both sides of the render: a run that straddles
     // midnight would otherwise fail on which "today" the prefill caught.
     const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const dayBeforeSwitch = calendarDay(new Date(), zone);
-    await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
-    const dayAfterSwitch = calendarDay(new Date(), zone);
-    const enabled = screen.getByLabelText<HTMLInputElement>("Due date", {
+    const dayBeforeRender = calendarDay(new Date(), zone);
+    render(<LogActivity entityType="organization" entityId="o1" />);
+    const dayAfterRender = calendarDay(new Date(), zone);
+    // A note's date is the day it happened, live from the start and showing
+    // the today that would otherwise be assumed invisibly at submit.
+    const noteDay = screen.getByLabelText<HTMLInputElement>("Date", {
       selector: "input",
     });
-    expect(enabled.hasAttribute("disabled")).toBe(false);
-    // Becoming a task fills the empty field with the writer's own today —
-    // the date that would otherwise be assumed invisibly at submit.
-    expect([dayBeforeSwitch, dayAfterSwitch]).toContain(enabled.value);
+    expect(noteDay.hasAttribute("disabled")).toBe(false);
+    expect([dayBeforeRender, dayAfterRender]).toContain(noteDay.value);
+    // Becoming a task turns the same box into the due date, keeping the day
+    // the writer picked instead of resetting it under them.
+    fireEvent.change(noteDay, { target: { value: PICKED_DAY } });
+    await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
+    const dueDay = screen.getByLabelText<HTMLInputElement>("Due date", {
+      selector: "input",
+    });
+    expect(dueDay.value).toBe(PICKED_DAY);
+  });
+
+  it("posts a backdated note's occurred_at inside the picked day", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="organization" entityId="o1" />);
+    fireEvent.change(screen.getByLabelText("Date"), {
+      target: { value: PICKED_DAY },
+    });
+    await userEvent.type(screen.getByLabelText("Subject *"), "Call recap");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    if (!post) throw new Error("expected a POST /activities to be captured");
+    if (
+      typeof post.body !== "object" ||
+      post.body === null ||
+      !("occurred_at" in post.body) ||
+      typeof post.body.occurred_at !== "string"
+    ) {
+      throw new Error("expected the note to carry a string occurred_at");
+    }
+    // The instant lands on the day the writer picked in BOTH zones that
+    // matter: the record pages render timelines in RECORD_ZONE, and the
+    // writer reads their own wall clock — and a note never carries a due
+    // date, backdated or not.
+    const occurred = new Date(post.body.occurred_at);
+    expect(calendarDay(occurred, RECORD_ZONE)).toBe(PICKED_DAY);
+    expect(calendarDay(occurred, READER_ZONE)).toBe(PICKED_DAY);
+    expect("due_at" in post.body).toBe(false);
+  });
+
+  it("refuses a future day for a note but not for a task's due date", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="organization" entityId="o1" />);
+    // Nothing has occurred in the future: for a note the input is capped at
+    // today, and a value forced past the cap fails the form's own validation,
+    // so the POST never leaves.
+    const noteDay = screen.getByLabelText<HTMLInputElement>("Date");
+    expect(noteDay.max).toBe(noteDay.value);
+    fireEvent.change(noteDay, { target: { value: "2199-01-01" } });
+    await userEvent.type(screen.getByLabelText("Subject *"), "Time travel");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+      false,
+    );
+    // A due date has no ceiling — tasks are usually for the future.
+    await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
+    expect(screen.getByLabelText<HTMLInputElement>("Due date").max).toBe("");
   });
 
   it("posts a task's due_at as the END of the picked day in the writer's own zone", async () => {

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -12,11 +12,12 @@ import {
   TextInput,
 } from "../design-system/atoms";
 import { Select } from "../design-system/select";
-import { calendarDay, dueInstant } from "../format/calendarday";
+import { calendarDay, dueInstant, middayInstant } from "../format/calendarday";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys, taskWriteKeys } from "./activitykeys";
 import { problemMessageOf, throwProblem, useSorMode } from "./common";
+import { RECORD_ZONE } from "./company360";
 
 // Log a note or task from a 360 (person/company/deal/lead): the contract's
 // logActivity POST, linked to the record being viewed, occurred_at stamped
@@ -29,8 +30,9 @@ type ActivityDraft = {
   kind: "note" | "task" | "meeting";
   subject: string;
   body: string;
-  // yyyy-mm-dd from the date input; only a task carries a due date.
-  dueAt: string;
+  // yyyy-mm-dd from the date input. Its meaning follows the kind: a task's
+  // due date, otherwise the day the note or meeting happened.
+  day: string;
   // A meeting's body is ordinary notes UNLESS this is explicitly checked —
   // otherwise "discussed pricing, follow up Tuesday" typed while logging a
   // meeting would silently carry source_system: transcript, which the
@@ -44,7 +46,7 @@ const EMPTY_DRAFT: ActivityDraft = {
   kind: "note",
   subject: "",
   body: "",
-  dueAt: "",
+  day: "",
   asTranscript: false,
 };
 
@@ -54,14 +56,37 @@ const EMPTY_DRAFT: ActivityDraft = {
 // any future line citation at a timestamp instead of what was said.
 const ACCEPTED_TRANSCRIPT_EXTENSION = ".txt";
 
-// The writer's own calendar day. A task's due date starts here the moment the
-// kind becomes task — the day that WOULD apply is shown in the field instead
-// of being assumed at submit behind an empty box.
+// The writer's own calendar day. The composer's date field starts here — the
+// day that WOULD apply is shown where the writer can change it instead of
+// being assumed at submit behind an empty box.
 function todayDay(): string {
   return calendarDay(
     new Date(),
     Intl.DateTimeFormat().resolvedOptions().timeZone,
   );
+}
+
+function freshDraft(kind: ActivityDraft["kind"] = "note"): ActivityDraft {
+  return { ...EMPTY_DRAFT, kind, day: todayDay() };
+}
+
+// The instant a logged activity carries. The picked day left on today — or,
+// for a note, pushed into the future, which nothing can have occurred in —
+// means the actual moment of logging, so entries logged in sequence keep
+// their timeline order. A backdated day becomes that day's noon in
+// RECORD_ZONE, the zone every record page renders its timeline in, so the
+// entry files under the day the writer picked. A task's picked day is its
+// DUE date instead — the task itself occurred now.
+function occurredInstant(input: ActivityDraft): string {
+  const now = new Date();
+  const today = calendarDay(
+    now,
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+  if (input.kind === "task" || input.day === "" || input.day >= today) {
+    return now.toISOString();
+  }
+  return middayInstant(input.day, RECORD_ZONE);
 }
 
 /**
@@ -85,13 +110,7 @@ export function LogActivityForm({
   const t = useT();
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<ActivityDraft>(() =>
-    initialKind
-      ? {
-          ...EMPTY_DRAFT,
-          kind: initialKind,
-          dueAt: initialKind === "task" ? todayDay() : "",
-        }
-      : EMPTY_DRAFT,
+    freshDraft(initialKind),
   );
   const [fileError, setFileError] = useState<string | null>(null);
 
@@ -119,15 +138,15 @@ export function LogActivityForm({
           kind: input.kind,
           subject: input.subject.trim(),
           body: outgoingBody || null,
-          occurred_at: new Date().toISOString(),
-          // The picked day becomes the instant that day ENDS in the writer's
+          occurred_at: occurredInstant(input),
+          // A due date becomes the instant that day ENDS in the writer's
           // own zone (format/calendarday). Handing the bare `yyyy-mm-dd` to
           // `new Date` reads it as UTC midnight instead, which is neither the
           // end of the day nor, west of UTC, the day the writer picked: the task
           // arrived already overdue, and the tasks list — which buckets in the
           // reader's zone — filed it under yesterday.
-          ...(input.kind === "task" && input.dueAt
-            ? { due_at: dueInstant(input.dueAt) }
+          ...(input.kind === "task" && input.day
+            ? { due_at: dueInstant(input.day) }
             : {}),
           ...(isTranscript ? { source_system: "transcript" } : {}),
           links: [{ entity_type: entityType, entity_id: entityId }],
@@ -147,7 +166,7 @@ export function LogActivityForm({
       for (const queryKey of keys) {
         queryClient.invalidateQueries({ queryKey });
       }
-      setDraft(EMPTY_DRAFT);
+      setDraft(freshDraft());
       onLogged?.();
     },
   });
@@ -175,39 +194,29 @@ export function LogActivityForm({
               ]}
               value={draft.kind}
               onChange={(value) =>
-                setDraft((current) => {
-                  const kind =
-                    value === "task" || value === "meeting" ? value : "note";
-                  // Becoming a task fills the empty due date with today — the
-                  // likeliest answer, standing where the writer can change it.
-                  // A date the writer already picked is never overwritten.
-                  const dueAt =
-                    kind === "task" && current.dueAt === ""
-                      ? todayDay()
-                      : current.dueAt;
-                  return { ...current, kind, dueAt };
+                setField({
+                  kind:
+                    value === "task" || value === "meeting" ? value : "note",
                 })
               }
             />
           )}
         </Field>
-        {/* Only a task carries a due date, but the field stays in place for a
-            note — disabled, not hidden. Mounting it on the kind switch moved
-            every control below it down while the writer was reading them, and
-            `hidden` would do the same thing by another name (it is
-            display:none). Disabled keeps the row's height AND shows the reader
-            that the field exists and why it is not theirs to fill yet. */}
-        <Field
-          label={t("log.dueAt")}
-          hint={draft.kind === "task" ? undefined : t("log.dueAtHint")}
-        >
+        {/* One date box for every kind, prefilled with today, so nothing about
+            the entry's date is assumed invisibly. The picked day carries what
+            the kind needs it to: a task's due date, otherwise the day the
+            note or meeting happened (occurredInstant). */}
+        <Field label={draft.kind === "task" ? t("log.dueAt") : t("log.date")}>
           {(control) => (
             <TextInput
               {...control}
               type="date"
-              value={draft.dueAt}
-              disabled={draft.kind !== "task"}
-              onChange={(event) => setField({ dueAt: event.target.value })}
+              value={draft.day}
+              // A note or meeting cannot have happened in the future, and the
+              // cap makes the picker say so; a due date has no such ceiling.
+              // occurredInstant clamps a typed-in future day the same way.
+              max={draft.kind === "task" ? undefined : todayDay()}
+              onChange={(event) => setField({ day: event.target.value })}
               // A native date input opens its calendar only from the tiny
               // icon; a click on the value just places a caret. Opening on
               // any click is what a writer reaching for "the date" expects.


### PR DESCRIPTION
Follow-up to #1903 — Lars still could not click the date, because the field was a task-only due date, disabled for the default Note kind. This makes the date field mean something for every kind.

- One always-enabled date box, prefilled with the writer's local today, relabeled per kind (**Date** for note/meeting, **Due date** for task).
- For a note or meeting the picked day becomes `occurred_at`: left on today it sends the actual moment of logging (keeps timeline order); a backdated day becomes that day's **noon in RECORD_ZONE** (Europe/Berlin — the zone record timelines render in), via the new `format/calendarday.middayInstant`, so the entry files under the picked day for both the writer and the Berlin-rendered timeline. This addresses the cross-zone finding from review: writer-local noon filed a Honolulu writer's entry under the next Berlin day.
- A note's picker is capped at `max=today` (nothing occurs in the future), and `occurredInstant` clamps a forced future value to now as a second net.
- For a task the picked day stays the due date (end-of-day instant, unchanged), `occurred_at` stays now.
- Clicking anywhere in the field opens the calendar (`showPicker()`), not only the tiny native icon.

Tests: `middayInstant` unit tests incl. DST both sides, Honolulu and date-line zones; composer tests for the prefill, day kept across kind switch, backdated `occurred_at` on the picked day in both RECORD_ZONE and the runner's zone, future-day refusal, and `due_at` unchanged.

Gates locally: `make check-fe` green, `make frontend-e2e` green (92 passed). Verified live on an isolated dev stack: backdating to 2026-08-11 posts `2026-08-11T10:00:00Z` (Berlin noon) and the timeline files it under 11/08/2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the log form’s date handling across kinds and fixes the disabled date on notes. Notes/meetings now set `occurred_at` from the picked day; tasks still use the picked day as `due_at`.

- Date input: always enabled, prefilled with the writer’s local today; labeled “Date” for note/meeting and “Due date” for task; value persists across kind switches; clicking anywhere opens the picker.
- Semantics: notes/meetings — today leaves `occurred_at` as now; a backdated day becomes that day’s noon in `RECORD_ZONE` via `middayInstant`, keeping the picked day in both the timeline zone and the writer’s zone. Tasks — `due_at` remains end-of-day via `dueInstant`; `occurred_at` is now. Notes/meetings cannot pick future dates (`max=today` and clamped in `occurredInstant`).
- Implementation: new `middayInstant(day, zone)` in `frontend/src/format/calendarday.ts` and `occurredInstant` in the composer; i18n adds `log.date` and removes the task-only hint; tests cover DST, half-hour offsets, date-line zones, prefill, kind switch, backdating, future-date refusal for notes, and unchanged task due dates.
- Review focus: timezone math in `frontend/src/format/calendarday.ts`, `RECORD_ZONE` usage, and the date field’s `max` behavior; confirm tasks’ due-date behavior is unchanged.

<sup>Written for commit fc97dde78677c1e3090717ca6a3d6db52f1fd681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

