### PR TITLE
feat(capture): connecting a mailbox states the sharing default before the first pull

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14248,6 +14248,15 @@ components:
         provider (imap) submits `imap` and answers with the created `connection`. Exactly one
         of `authorize_url` or `connection` is returned.
       properties:
+        share_acknowledged:
+          type: boolean
+          description: |
+            The connecting human's one-time acknowledgment that what this connector captures
+            becomes readable to colleagues who can see the contact (they can limit individual
+            messages afterwards, and exclude addresses or domains up front). Required `true`
+            for every capture provider — the connect refuses with 422 `sharing_not_acknowledged`
+            without it — and recorded on the connection as `share_acknowledged_at` before the
+            first pull.
         redirect_uri: { type: string, format: uri, description: 'App page to return to after OAuth consent (OAuth providers).' }
         return_to:
           type: string

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7019,7 +7019,7 @@ paths:
             examples:
               oauth:
                 summary: OAuth provider — server returns the authorize_url to redirect to
-                value: { redirect_uri: 'https://app.example.com/activation' }
+                value: { share_acknowledged: true, redirect_uri: 'https://app.example.com/activation' }
       responses:
         '200':
           description: OAuth redirect target (OAuth providers).

--- a/backend/internal/compose/backfilltransport_integration_test.go
+++ b/backend/internal/compose/backfilltransport_integration_test.go
@@ -183,10 +183,10 @@ func setupBackfillWire(t *testing.T) *backfillWireEnv {
 			RowScope: principal.RowScopeTeam,
 		},
 	})
-	if _, err := registry.Connect(human, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(human, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect gmail: %v", err)
 	}
-	if _, err := registry.Connect(human, "graph", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(human, "graph", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect graph: %v", err)
 	}
 	inserter, err := jobs.NewInserter(e.Pool, quiet)

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -315,6 +315,18 @@ func (h connectorHandlers) ConnectorOAuthCallback(w http.ResponseWriter, r *http
 		return
 	}
 
+	// A state without the sharing acknowledgment cannot complete a connect —
+	// Registry.Connect would refuse it anyway — so refuse BEFORE the code
+	// exchange: an exchanged authorization code is a real provider credential,
+	// and minting one only to discard it unrevoked is strictly worse than not
+	// spending it. Reached only by states minted before the checkbox existed
+	// (the connect endpoint refuses to mint an unacknowledged state).
+	if !st.ShareAck {
+		slog.WarnContext(ctx, "connector callback: state carries no sharing acknowledgment", "provider", string(provider))
+		http.Redirect(w, r, h.landingURL(outcomeError, returnTo, string(provider)), http.StatusFound)
+		return
+	}
+
 	runCtx := grantorContext(ctx, st)
 	// The grant needs LIVE authority, resolved before the code is spent: an
 	// exchanged authorization code is a real provider credential, and one

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -226,6 +226,7 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 	// return_to is silently dropped and a malformed chunked body skips
 	// rejection entirely.
 	returnTo := returnToOnboarding
+	shareAck := false
 	if r.ContentLength != 0 {
 		var req crmcontracts.ConnectConnectorRequest
 		if !httperr.Decode(w, r, &req) {
@@ -234,6 +235,16 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 		if req.ReturnTo != nil && string(*req.ReturnTo) == returnToSettings {
 			returnTo = returnToSettings
 		}
+		shareAck = req.ShareAcknowledged != nil && *req.ShareAcknowledged
+	}
+	// Connecting a mailbox shares its captured correspondence with every
+	// colleague who can see the contact, and that default is a stated choice:
+	// the connect does not even mint an authorize URL until the human has
+	// acknowledged it. The flag rides the signed state to the callback, and
+	// Registry.Connect — the one write point — refuses a grant without it.
+	if !shareAck {
+		httperr.Write(w, r, sharingNotAcknowledged())
+		return
 	}
 	// CSRF: a random nonce goes into both a SameSite=Lax cookie and the signed
 	// state; the callback requires them to match, so a victim can't complete an
@@ -251,7 +262,8 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 	state := h.signer.sign(
 		connectState{
 			Workspace: ws, User: actor.UserID, Provider: string(provider),
-			Nonce: nonce, ReturnTo: returnTo, Version: stateVersionNamespacedCSRF,
+			Nonce: nonce, ReturnTo: returnTo, ShareAck: shareAck,
+			Version: stateVersionNamespacedCSRF,
 		},
 		time.Now().Add(connectStateTTL),
 	)
@@ -323,7 +335,7 @@ func (h connectorHandlers) ConnectorOAuthCallback(w http.ResponseWriter, r *http
 		return
 	}
 
-	if _, err := h.registry.Connect(runCtx, string(provider), auth); err != nil {
+	if _, err := h.registry.Connect(runCtx, string(provider), auth, st.ShareAck); err != nil {
 		slog.ErrorContext(ctx, "connector callback: persisting connection", "err", err, "provider", string(provider))
 		http.Redirect(w, r, h.landingURL(outcomeError, returnTo, string(provider)), http.StatusFound)
 		return

--- a/backend/internal/compose/connectors_csrf_test.go
+++ b/backend/internal/compose/connectors_csrf_test.go
@@ -132,11 +132,16 @@ func TestCallbackAcceptsAConsentStartedBeforeTheCookieWasNamespaced(t *testing.T
 	// un-suffixed cookie. It must still complete.
 	h := graphWiredHandlers()
 	h.oauth = refusingOAuth{}
+	// ShareAck rides along: a REAL pre-namespacing state would also lack the
+	// sharing acknowledgment and be refused for that before the exchange (the
+	// case directly below) — what this test holds is the version/cookie
+	// fallback in consumeCSRFNonce, which outlives that refusal.
 	state := h.signer.sign(connectState{
 		Workspace: ids.MustParse("11111111-1111-1111-1111-111111111111"),
 		User:      ids.MustParse("22222222-2222-2222-2222-222222222222"),
 		Provider:  providerGmail,
 		Nonce:     "legacy-nonce",
+		ShareAck:  true,
 	}, time.Now().Add(connectStateTTL))
 
 	code := "the-code"

--- a/backend/internal/compose/connectors_csrf_test.go
+++ b/backend/internal/compose/connectors_csrf_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,7 +74,8 @@ func TestConcurrentGmailAndGraphConsentDoNotClobberEachOther(t *testing.T) {
 	start := func(t *testing.T, provider string) string {
 		t.Helper()
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/v1/connectors/"+provider+"/connect", nil).WithContext(humanCtx())
+		req := httptest.NewRequest(http.MethodPost, "/v1/connectors/"+provider+"/connect",
+			strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 		h.ConnectConnector(rec, req, crmcontracts.CaptureProvider(provider))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("%s connect status = %d, want 200 (body %s)", provider, rec.Code, rec.Body)

--- a/backend/internal/compose/connectors_graph_test.go
+++ b/backend/internal/compose/connectors_graph_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ func graphWiredHandlers() connectorHandlers {
 func TestConnectGraphReturnsMicrosoftAuthorizeURL(t *testing.T) {
 	h := graphWiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "graph")
 
@@ -67,7 +68,7 @@ func TestConnectGraphReturnsMicrosoftAuthorizeURL(t *testing.T) {
 func TestConnectGraphNotImplementedWhenOnlyGmailWired(t *testing.T) {
 	h := wiredHandlers() // gmail app only
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "graph")
 
@@ -82,7 +83,7 @@ func TestGcalConnectsAlongsideGraph(t *testing.T) {
 	// returns its signed authorize URL.
 	h := graphWiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gcal/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gcal/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gcal")
 

--- a/backend/internal/compose/connectors_imap.go
+++ b/backend/internal/compose/connectors_imap.go
@@ -25,6 +25,18 @@ const providerIMAP = "imap"
 
 const codeConnectorStoreFailed = "connector_store_failed"
 
+// sharingNotAcknowledged is the refusal every capture connect answers until
+// the human has ticked the mail-sharing acknowledgment (one sentence, one
+// checkbox): what the connector captures becomes readable to colleagues who
+// can see the contact.
+func sharingNotAcknowledged() *httperr.DetailedError {
+	return &httperr.DetailedError{
+		Status: http.StatusUnprocessableEntity,
+		Code:   "sharing_not_acknowledged",
+		Detail: "Connecting a capture source needs share_acknowledged: true — captured correspondence becomes readable to colleagues who can see the contact.",
+	}
+}
+
 // connectIMAP establishes a STANDING imap connection: the credentials are
 // probed (dial + login, session closed), sealed to the vault by
 // Registry.Connect, and the background sweep takes over — the same lifecycle
@@ -58,6 +70,10 @@ func (h connectorHandlers) connectIMAP(w http.ResponseWriter, r *http.Request) {
 	// never conflated with the credential check below.
 	var req crmcontracts.ConnectConnectorRequest
 	if !httperr.Decode(w, r, &req) {
+		return
+	}
+	if req.ShareAcknowledged == nil || !*req.ShareAcknowledged {
+		httperr.Write(w, r, sharingNotAcknowledged())
 		return
 	}
 	if req.Imap == nil || req.Imap.Secret == nil || req.Imap.Host == "" || req.Imap.Username == "" {
@@ -113,7 +129,7 @@ func (h connectorHandlers) connectIMAP(w http.ResponseWriter, r *http.Request) {
 // persistIMAPConnection stores the sealed bundle and answers with the
 // connected row — the connect's terminal half.
 func (h connectorHandlers) persistIMAPConnection(w http.ResponseWriter, r *http.Request, auth connector.Auth) {
-	if _, err := h.registry.Connect(r.Context(), providerIMAP, auth); err != nil {
+	if _, err := h.registry.Connect(r.Context(), providerIMAP, auth, true); err != nil {
 		if errors.Is(err, apperrors.ErrScopeExceeded) {
 			// Defense-in-depth: connectIMAP grants the descriptor's scopes from
 			// the human's authority, so a human cannot normally trip this. Kept

--- a/backend/internal/compose/connectors_test.go
+++ b/backend/internal/compose/connectors_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -53,7 +54,7 @@ func gmailAuthCodeURLForTest(t *testing.T) string {
 	t.Helper()
 	h := wiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gmail")
 
@@ -87,7 +88,7 @@ func humanCtx() context.Context {
 func TestConnectConnectorReturnsSignedAuthorizeURL(t *testing.T) {
 	h := wiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gmail")
 
@@ -116,6 +117,34 @@ func TestConnectConnectorReturnsSignedAuthorizeURL(t *testing.T) {
 	if st.Provider != "gmail" || st.User != ids.MustParse("22222222-2222-2222-2222-222222222222") {
 		t.Errorf("state = %+v, want gmail + the acting user", st)
 	}
+	if !st.ShareAck {
+		t.Error("the signed state dropped the sharing acknowledgment — the callback's grant would refuse")
+	}
+}
+
+// Connecting a mailbox shares its captured correspondence with colleagues, so
+// the connect refuses to even mint an authorize URL until the human has said
+// yes to that — a nil body and an explicit false are the same withholding.
+func TestConnectConnectorRefusesWithoutTheSharingAcknowledgment(t *testing.T) {
+	h := wiredHandlers()
+	for name, body := range map[string]io.Reader{
+		"no body":        nil,
+		"explicit false": strings.NewReader(`{"share_acknowledged":false}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", body).WithContext(humanCtx())
+
+			h.ConnectConnector(rec, req, "gmail")
+
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want 422 (body %s)", rec.Code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), "sharing_not_acknowledged") {
+				t.Fatalf("body = %s, want the sharing_not_acknowledged code", rec.Body)
+			}
+		})
+	}
 }
 
 // Google will not add a scope to an existing refresh token, so both permissions
@@ -135,7 +164,7 @@ func TestGmailConsentRequestsReadAndSendScopes(t *testing.T) {
 func TestConnectConnectorReturnsSignedAuthorizeURLForGcal(t *testing.T) {
 	h := wiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gcal/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gcal/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gcal")
 
@@ -199,7 +228,7 @@ func TestConnectConnectorRejectsUnsupportedProvider(t *testing.T) {
 func TestConnectConnectorNotImplementedWhenUnwired(t *testing.T) {
 	var h connectorHandlers // zero value: no oauth/registry
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", nil).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gmail")
 

--- a/backend/internal/compose/connectors_wiring_test.go
+++ b/backend/internal/compose/connectors_wiring_test.go
@@ -103,6 +103,7 @@ func TestCallbackRequiresMatchingCSRFCookie(t *testing.T) {
 		User:      ids.MustParse("22222222-2222-2222-2222-222222222222"),
 		Provider:  "gmail",
 		Nonce:     nonce,
+		ShareAck:  true,
 		Version:   stateVersionNamespacedCSRF,
 	}, time.Now().Add(time.Hour))
 	code := "the-code"
@@ -128,6 +129,30 @@ func TestCallbackRequiresMatchingCSRFCookie(t *testing.T) {
 	h.ConnectorOAuthCallback(httptest.NewRecorder(), req, "gmail", params)
 	if !oauth.exchanged {
 		t.Fatal("a matching nonce cookie should let the flow reach the token exchange")
+	}
+
+	// (c) A state without the sharing acknowledgment — only mintable before
+	// the checkbox existed — is refused BEFORE the exchange: an exchanged
+	// authorization code is a real provider credential, and Registry.Connect
+	// would refuse the grant anyway, leaving that credential minted for
+	// nothing and unrevoked.
+	unacked := signer.sign(connectState{
+		Workspace: ids.MustParse("11111111-1111-1111-1111-111111111111"),
+		User:      ids.MustParse("22222222-2222-2222-2222-222222222222"),
+		Provider:  "gmail",
+		Nonce:     nonce,
+		Version:   stateVersionNamespacedCSRF,
+	}, time.Now().Add(time.Hour))
+	oauth.exchanged = false
+	req = httptest.NewRequest(http.MethodGet, "/cb", nil)
+	req.AddCookie(&http.Cookie{Name: csrfCookieName("gmail"), Value: nonce, HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
+	rec = httptest.NewRecorder()
+	h.ConnectorOAuthCallback(rec, req, "gmail", crmcontracts.ConnectorOAuthCallbackParams{Code: &code, State: unacked})
+	if oauth.exchanged {
+		t.Fatal("the token exchange ran for a state carrying no sharing acknowledgment")
+	}
+	if loc := rec.Header().Get("Location"); loc != "https://app.test/#/onboarding/connect/error/gmail" {
+		t.Errorf("unacknowledged-state Location = %q, want the error landing", loc)
 	}
 }
 

--- a/backend/internal/compose/connectorstate.go
+++ b/backend/internal/compose/connectorstate.go
@@ -45,6 +45,11 @@ type connectState struct {
 	// landingURL, never a URL — it rides the signed payload so it cannot be
 	// tampered with after the redirect leaves us.
 	ReturnTo string
+	// ShareAck records that the human ticked the mail-sharing acknowledgment
+	// when they started the connect. It rides the signed state because the
+	// callback has no session to re-ask, and the grant refuses without it —
+	// so a state minted before the checkbox existed cannot complete a connect.
+	ShareAck bool
 }
 
 // wireState is the JSON form actually signed — ids.UUID as strings, plus the
@@ -55,6 +60,7 @@ type wireState struct {
 	Provider  string `json:"p"`
 	Nonce     string `json:"n"`
 	ReturnTo  string `json:"rt,omitempty"`
+	ShareAck  bool   `json:"sa,omitempty"`
 	Version   int    `json:"v,omitempty"`
 	Exp       int64  `json:"exp"` // unix seconds
 }
@@ -73,6 +79,7 @@ func (s stateSigner) sign(st connectState, exp time.Time) string {
 		Provider:  st.Provider,
 		Nonce:     st.Nonce,
 		ReturnTo:  st.ReturnTo,
+		ShareAck:  st.ShareAck,
 		Version:   st.Version,
 		Exp:       exp.Unix(),
 	})
@@ -115,7 +122,7 @@ func (s stateSigner) verify(token string, now time.Time) (connectState, error) {
 	}
 	return connectState{
 		Workspace: ws, User: user, Provider: w.Provider,
-		Nonce: w.Nonce, ReturnTo: w.ReturnTo, Version: w.Version,
+		Nonce: w.Nonce, ReturnTo: w.ReturnTo, ShareAck: w.ShareAck, Version: w.Version,
 	}, nil
 }
 

--- a/backend/internal/compose/imapconnect_standing_refusals_test.go
+++ b/backend/internal/compose/imapconnect_standing_refusals_test.go
@@ -31,7 +31,8 @@ import (
 // imapConnectBody is the typed wire fixture for the connect request — the
 // fields stay compile-time aligned with the contract's imap block.
 type imapConnectBody struct {
-	Imap *imapCredsBody `json:"imap,omitempty"`
+	ShareAcknowledged bool           `json:"share_acknowledged"`
+	Imap              *imapCredsBody `json:"imap,omitempty"`
 }
 
 type imapCredsBody struct {
@@ -81,7 +82,7 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 			return nil, imap.ErrLoginRejected
 		},
 	}
-	creds := imapConnectBody{Imap: &imapCredsBody{
+	creds := imapConnectBody{ShareAcknowledged: true, Imap: &imapCredsBody{
 		Host: "mail.example", Port: 993, Username: "a@b.example", Secret: "s",
 	}}
 
@@ -97,7 +98,7 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 		// OAuth callback does), so a real human is NOT scope-refused. An empty
 		// body reaches the credential check (422) — proving the request passed
 		// the scope gate, and without any dial.
-		rec := postIMAPConnect(imapConnectCtx(t /* no scopes, like a real session */), t, h, imapConnectBody{})
+		rec := postIMAPConnect(imapConnectCtx(t /* no scopes, like a real session */), t, h, imapConnectBody{ShareAcknowledged: true})
 		if rec.Code != http.StatusUnprocessableEntity {
 			t.Fatalf("status = %d, want 422 (passed the scope gate, missing creds)", rec.Code)
 		}
@@ -110,8 +111,24 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 	authed := imapConnectCtx(t)
 
 	t.Run("a missing credential block is 422", func(t *testing.T) {
-		if rec := postIMAPConnect(authed, t, h, imapConnectBody{}); rec.Code != http.StatusUnprocessableEntity {
+		if rec := postIMAPConnect(authed, t, h, imapConnectBody{ShareAcknowledged: true}); rec.Code != http.StatusUnprocessableEntity {
 			t.Fatalf("status = %d, want 422", rec.Code)
+		}
+	})
+
+	t.Run("withholding the sharing acknowledgment is 422 before any probe", func(t *testing.T) {
+		unacked := creds
+		unacked.ShareAcknowledged = false
+		probeCallsBefore := probeCalls
+		rec := postIMAPConnect(authed, t, h, unacked)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("status = %d, want 422", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "sharing_not_acknowledged") {
+			t.Fatalf("body = %s, want the sharing_not_acknowledged code", rec.Body.String())
+		}
+		if probeCalls != probeCallsBefore {
+			t.Fatal("the credentials were probed although the sharing acknowledgment was withheld")
 		}
 	})
 
@@ -137,7 +154,7 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 func TestStandingIMAPConnectFailureMapping(t *testing.T) {
 	// A realistic signed-in human session carries no passport scopes.
 	authed := imapConnectCtx(t)
-	creds := imapConnectBody{Imap: &imapCredsBody{
+	creds := imapConnectBody{ShareAcknowledged: true, Imap: &imapCredsBody{
 		Host: "mail.example", Port: 993, Username: "a@b.example", Secret: "s",
 	}}
 

--- a/backend/internal/compose/integration/capture/capture_account_rebind_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_account_rebind_integration_test.go
@@ -62,7 +62,7 @@ func startImportReconnectingMidPage(t *testing.T, e *integration.SearchEnv, acco
 	fake := &accountBoundConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}}
 	registry.Register(fake)
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(account)); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(account), true); err != nil {
 		t.Fatalf("connecting %s: %v", account, err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 25, enqueueNothing)
@@ -70,7 +70,7 @@ func startImportReconnectingMidPage(t *testing.T, e *integration.SearchEnv, acco
 		t.Fatalf("StartBackfill: %v", err)
 	}
 	fake.duringPage = func() {
-		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(reconnectAs)); err != nil {
+		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(reconnectAs), true); err != nil {
 			t.Errorf("mid-page reconnect as %s: %v", reconnectAs, err)
 		}
 	}
@@ -130,7 +130,7 @@ func readConnectionAccount(t *testing.T, e *integration.SearchEnv, connID ids.UU
 func connectAndSync(t *testing.T, registry *capturemod.Registry, e *integration.SearchEnv, account string) ids.UUID {
 	t.Helper()
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth(account))
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth(account), true)
 	if err != nil {
 		t.Fatalf("connecting %s: %v", account, err)
 	}
@@ -152,7 +152,7 @@ func TestReconnectingADifferentAccountDropsTheFirstAccountsWatermark(t *testing.
 	connID := connectAndSync(t, registry, e, "first@example.com")
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com"), true); err != nil {
 		t.Fatalf("reconnecting as a different account: %v", err)
 	}
 
@@ -174,7 +174,7 @@ func TestReconnectingTheSameAccountKeepsItsWatermark(t *testing.T) {
 	connID := connectAndSync(t, registry, e, "same@example.com")
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("same@example.com")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("same@example.com"), true); err != nil {
 		t.Fatalf("re-granting the same account: %v", err)
 	}
 
@@ -202,7 +202,7 @@ func TestANewAccountMayImportANarrowerWindowThanTheOldOne(t *testing.T) {
 		t.Fatalf("paging the first import to completion: done=%v err=%v", done, err)
 	}
 
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com"), true); err != nil {
 		t.Fatalf("reconnecting as a different account: %v", err)
 	}
 

--- a/backend/internal/compose/integration/capture/capture_authority_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_authority_integration_test.go
@@ -39,7 +39,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 		`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, e.Rep1); err != nil {
 		t.Fatal(err)
 	}
-	_, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	_, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("grant from a deactivated human → %v, want ErrNotFound", err)
 	}
@@ -60,7 +60,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 		`UPDATE app_user SET status = 'active' WHERE id = $1`, e.Rep1); err != nil {
 		t.Fatal(err)
 	}
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatalf("grant from a live human: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/capture_backfill_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_integration_test.go
@@ -108,7 +108,7 @@ func TestBackfillLifecycle(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -229,7 +229,7 @@ func TestBackfillStepFaultsAreTerminal(t *testing.T) {
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -290,7 +290,7 @@ func TestStartBackfillRollsBackWhenTheJobCannotBeScheduled(t *testing.T) {
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)

--- a/backend/internal/compose/integration/capture/capture_backfill_progress_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_progress_integration_test.go
@@ -80,7 +80,7 @@ func startReportingBackfill(t *testing.T, e *integration.SearchEnv, prov *report
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e)).WithProgressPacing(pacing)
 	registry.Register(prov)
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 20, enqueueNothing)

--- a/backend/internal/compose/integration/capture/capture_backfill_retry_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_retry_integration_test.go
@@ -68,7 +68,7 @@ func startFlakyBackfill(t *testing.T, e *integration.SearchEnv, faults []error) 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&flakyConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}, faults: faults})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 25, enqueueNothing)
@@ -148,7 +148,7 @@ func TestABackfillPageWhoseJobContextDiedNeverWedgesTheRun(t *testing.T) {
 	registry.Register(fake)
 	rep := ids.From[ids.UserKind](e.Rep1)
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", rep, 6, 25, enqueueNothing)

--- a/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
@@ -122,7 +122,7 @@ func TestBackfillCountsOnlyTheCounterpartiesItsOwnPagesCreated(t *testing.T) {
 	})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -186,7 +186,7 @@ func TestBackfillYieldsAreVisibleWhileThePageRuns(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -289,7 +289,7 @@ func TestBackfillYieldsSurviveATransientFault(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -352,7 +352,7 @@ func TestBackfillYieldsSurviveACancelUnderTheRunningPage(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -403,7 +403,7 @@ func TestBackfillYieldsAreCreditedOnceAtTheRetryCeiling(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)

--- a/backend/internal/compose/integration/capture/capture_env_test.go
+++ b/backend/internal/compose/integration/capture/capture_env_test.go
@@ -198,7 +198,7 @@ func newCaptureEnv(t *testing.T) captureEnv {
 	seedCaptureRole(t, e)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/capture_fence_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_fence_integration_test.go
@@ -83,7 +83,7 @@ func TestASyncDisconnectedMidFlightCommitsNothing(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestABackfillPageDisconnectedMidFlightCommitsNothing(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 25, enqueueNothing)

--- a/backend/internal/compose/integration/capture/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_integration_test.go
@@ -136,7 +136,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestCaptureScopeIntersectionRefusesOverScopedConnector(t *testing.T) {
 	registry.Register(&mailFake{scopes: []principal.Scope{principal.ScopeRead, principal.ScopeSend}})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	_, err := registry.Connect(grantCtx, "graph", nil)
+	_, err := registry.Connect(grantCtx, "graph", nil, true)
 	if !errors.Is(err, apperrors.ErrScopeExceeded) {
 		t.Fatalf("over-scoped connector grant → %v, want ErrScopeExceeded", err)
 	}
@@ -228,7 +228,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 	registry.Register(&mailFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 	}
 
 	// Reconnect the same provider for the same human.
-	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("token")); err != nil {
+	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 	views, err := registry.Connections(grantCtx)
@@ -275,7 +275,7 @@ func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", nil)
+	connID, err := registry.Connect(grantCtx, "graph", nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/capture_lifecycle_audit_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_lifecycle_audit_integration_test.go
@@ -66,7 +66,7 @@ func TestReconnectDeletesSupersededCredentialWhenTheCallerHangsUp(t *testing.T) 
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("first-token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("first-token"), true)
 	if err != nil {
 		t.Fatalf("first connect: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestReconnectDeletesSupersededCredentialWhenTheCallerHangsUp(t *testing.T) 
 	reqCtx, cancel := context.WithCancel(humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead}))
 	defer cancel()
 	hangUp.hangUp = cancel
-	if _, err := registry.Connect(reqCtx, "graph", connector.Auth("second-token")); err != nil {
+	if _, err := registry.Connect(reqCtx, "graph", connector.Auth("second-token"), true); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestDisconnectDeletesTheCredentialWhenTheCallerHangsUp(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestConnectAndDisconnectLeaveAnAttributableAuditRow(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestARetriedDisconnectDoesNotReAuditTheWithdrawal(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestAConnectThatFailsLeavesNoAuditRow(t *testing.T) {
 	refuseSyncStateUpdates(t, e)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token")); err == nil {
+	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true); err == nil {
 		t.Fatal("connect must fail while the sync-state update is refused")
 	}
 

--- a/backend/internal/compose/integration/capture/capture_provider_scopes_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_provider_scopes_integration_test.go
@@ -41,7 +41,7 @@ func TestConnectPersistsTheProviderGrantedScopes(t *testing.T) {
 	registry.Register(&grantingFake{granted: granted})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestAConnectorThatCannotReportItsGrantRecordsNoClaim(t *testing.T) {
 	registry.Register(&mailFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_scope_integration_test.go
@@ -98,7 +98,7 @@ func TestCaptureStagesAMergeForALeadCollidingWithAnotherTeamsLead(t *testing.T) 
 	registry, stager := newScopeCaptureRegistry(t, e, fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t 
 	registry, _ := newScopeCaptureRegistry(t, e, fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/capture_syncstate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_syncstate_integration_test.go
@@ -92,7 +92,7 @@ func TestSyncFailureNeverKillsAConnection(t *testing.T) {
 	registry.Register(moody)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestSyncFailureNeverKillsAConnection(t *testing.T) {
 		}
 
 		// Reconnect (the OAuth callback path) un-parks it with a clean ladder.
-		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("fresh")); err != nil {
+		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("fresh"), true); err != nil {
 			t.Fatalf("reconnect: %v", err)
 		}
 		status, row = readSyncState(t, e, connID)

--- a/backend/internal/compose/integration/capture/fieldprovenance_integration_test.go
+++ b/backend/internal/compose/integration/capture/fieldprovenance_integration_test.go
@@ -35,7 +35,7 @@ func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/gcal_connector_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_connector_integration_test.go
@@ -98,7 +98,7 @@ func TestGcalConnectorSyncsExternalMeetingAndSkipsInternal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gcal", auth)
+	connID, err := registry.Connect(grantCtx, "gcal", auth, true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gmail_connector_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_connector_integration_test.go
@@ -95,7 +95,7 @@ func TestGmailConnectorSyncsAnActivity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gmail", auth)
+	connID, err := registry.Connect(grantCtx, "gmail", auth, true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_push_integration_test.go
@@ -55,7 +55,7 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&moodyConnector{name: "gmail"})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gmail_watch_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_watch_integration_test.go
@@ -55,7 +55,7 @@ func TestGmailWatchRegistersRenewsAndLeavesCursor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gmail", auth)
+	connID, err := registry.Connect(grantCtx, "gmail", auth, true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestGmailWatchJobRenewsOnSchedule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gmail", auth)
+	connID, err := registry.Connect(grantCtx, "gmail", auth, true)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
@@ -85,7 +85,7 @@ func TestConnectSealsCredentialInVaultNotOnTheRow(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestSyncResolvesCredentialFromVault(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13263,6 +13263,14 @@ type ConnectConnectorRequest struct {
 	// A closed enum, never a URL — the server maps it to a fixed path, so it carries no
 	// open-redirect surface. Ignored by credential providers, which never redirect.
 	ReturnTo *ConnectConnectorRequestReturnTo `json:"return_to,omitempty"`
+
+	// ShareAcknowledged The connecting human's one-time acknowledgment that what this connector captures
+	// becomes readable to colleagues who can see the contact (they can limit individual
+	// messages afterwards, and exclude addresses or domains up front). Required `true`
+	// for every capture provider — the connect refuses with 422 `sharing_not_acknowledged`
+	// without it — and recorded on the connection as `share_acknowledged_at` before the
+	// first pull.
+	ShareAcknowledged *bool `json:"share_acknowledged,omitempty"`
 }
 
 // ConnectConnectorRequestReturnTo Which surface the post-consent redirect lands on. Absent means `onboarding`.

--- a/backend/internal/modules/capture/registry_disconnect_integration_test.go
+++ b/backend/internal/modules/capture/registry_disconnect_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -192,7 +193,7 @@ func newCaptureRegistryFixture(t *testing.T) (context.Context, *capture.Registry
 // secret exists before disconnect), not the code under test.
 func connectFixtureConnection(ctx context.Context, t *testing.T, reg *capture.Registry) keyvault.Ref {
 	t.Helper()
-	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token")); err != nil {
+	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token"), true); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	var status string
@@ -218,6 +219,37 @@ func queryConnectionRow(ctx context.Context, t *testing.T, status *string, crede
 	return owner.QueryRow(ctx,
 		`SELECT status, credential_ref, auth FROM capture_connection WHERE provider = 'gmail'`).
 		Scan(status, credentialRef, auth)
+}
+
+// The grant is where the mail-sharing acknowledgment becomes a recorded fact:
+// a connect stamps share_acknowledged_at before the first pull, and a grant
+// arriving WITHOUT the acknowledgment is refused at the registry — the single
+// write point — so an unacknowledged connection cannot exist however a
+// transport misbehaves.
+func TestConnectRecordsTheSharingAcknowledgmentAndRefusesWithoutIt(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+
+	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token"), false); err == nil {
+		t.Fatal("Connect accepted a grant without the mail-sharing acknowledgment")
+	}
+	owner, _ := setupCaptureDB(t)
+	var count int
+	if err := owner.QueryRow(ctx, `SELECT count(*) FROM capture_connection`).Scan(&count); err != nil {
+		t.Fatalf("counting connections: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("the refused grant left %d connection rows", count)
+	}
+
+	connectFixtureConnection(ctx, t, reg)
+	var ackedAt *time.Time
+	if err := owner.QueryRow(ctx,
+		`SELECT share_acknowledged_at FROM capture_connection WHERE provider = 'gmail'`).Scan(&ackedAt); err != nil {
+		t.Fatalf("reading back the acknowledgment stamp: %v", err)
+	}
+	if ackedAt == nil {
+		t.Fatal("Connect committed the row with share_acknowledged_at NULL — the acknowledgment was not recorded")
+	}
 }
 
 // Disconnecting must not leave a live credential behind: the row stops being
@@ -352,7 +384,7 @@ func TestReconnectDeletesThePriorSecret(t *testing.T) {
 		t.Fatalf("precondition: the first secret should exist: %v", err)
 	}
 
-	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token-2")); err != nil {
+	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token-2"), true); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 
@@ -437,7 +469,7 @@ func TestDisconnectPhase3DoesNotClobberAConcurrentReconnect(t *testing.T) {
 	// exactly like a second request would land on the same process.
 	reg3 := capture.NewRegistry(database.BindTo(poolFromFixture(t), ws), nil, fixtureAuthority{}, vault)
 	reg3.Register(fixtureConnector{})
-	if _, err := reg3.Connect(ctx, "gmail", connector.Auth("fixture-token-reconnect")); err != nil {
+	if _, err := reg3.Connect(ctx, "gmail", connector.Auth("fixture-token-reconnect"), true); err != nil {
 		t.Fatalf("concurrent reconnect: %v", err)
 	}
 	var secondRef *string

--- a/backend/internal/modules/capture/registry_grant.go
+++ b/backend/internal/modules/capture/registry_grant.go
@@ -24,16 +24,25 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
-// Connect grants one connector under the CALLING human's authority. Two
-// guards run here, both at grant time rather than discovered at 3am
-// mid-sync: the granting human must still resolve as live authority, and
-// a connector demanding scopes they do not hold is refused.
+// Connect grants one connector under the CALLING human's authority. Three
+// guards run here, all at grant time rather than discovered at 3am
+// mid-sync: the granting human must still resolve as live authority, a
+// connector demanding scopes they do not hold is refused, and a grant
+// without the mail-sharing acknowledgment is refused — captured
+// correspondence is workspace-readable by default, and that default is a
+// stated choice recorded on the row (share_acknowledged_at) before the
+// first pull. The transports collect the acknowledgment (422 without it);
+// this refusal is the single write point holding the invariant that an
+// unacknowledged connection cannot exist.
 //
 // note: the returned id (and the connectionID threaded through SyncOnce and
 // the sync-state recording) names a capture_connection row, which the kernel
 // does not model as a first-class entity — no kind exists for it, so it stays
 // ids.UUID rather than inventing one.
-func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth) (ids.UUID, error) {
+func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth, shareAcknowledged bool) (ids.UUID, error) {
+	if !shareAcknowledged {
+		return ids.Nil, errors.New("capture: a connector grant needs the mail-sharing acknowledgment — the transport asks for it before calling here")
+	}
 	c, err := r.connector(name)
 	if err != nil {
 		return ids.Nil, err
@@ -250,10 +259,11 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 	rebound := rebindsAccount(priorLabel, in.accountLabel)
 	var id ids.UUID
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO capture_connection (provider, user_id, scopes, credential_ref, status, account_label, provider_scopes)
-		VALUES ($1, $2, $3, $4, 'connected', $5, $6)
+		INSERT INTO capture_connection (provider, user_id, scopes, credential_ref, status, account_label, provider_scopes, share_acknowledged_at)
+		VALUES ($1, $2, $3, $4, 'connected', $5, $6, now())
 		ON CONFLICT (user_id, provider)
 		DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'connected', archived_at = NULL,
+		              share_acknowledged_at = COALESCE(capture_connection.share_acknowledged_at, now()),
 		              account_label = EXCLUDED.account_label, provider_scopes = EXCLUDED.provider_scopes,
 		              generation = capture_connection.generation + CASE WHEN $7 THEN 1 ELSE 0 END,
 		              sync_cursor = CASE WHEN $7 THEN NULL ELSE capture_connection.sync_cursor END,

--- a/backend/internal/modules/capture/registry_grant.go
+++ b/backend/internal/modules/capture/registry_grant.go
@@ -256,6 +256,11 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 	// the mailbox it was fetched from: bumping the generation here would cancel
 	// the very import the human was told to repair. Disconnect is the other write
 	// that ends a grant, and it bumps the generation itself.
+	// A rebind is also a NEW sharing decision: the acknowledgment recorded on
+	// the row was given for the PREVIOUS mailbox, so the stamp is re-taken from
+	// this grant (which carried its own acknowledgment past Connect's refusal)
+	// rather than inherited across accounts. A same-account reconnect keeps
+	// the original stamp.
 	rebound := rebindsAccount(priorLabel, in.accountLabel)
 	var id ids.UUID
 	if err := tx.QueryRow(ctx, `
@@ -263,7 +268,8 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 		VALUES ($1, $2, $3, $4, 'connected', $5, $6, now())
 		ON CONFLICT (user_id, provider)
 		DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'connected', archived_at = NULL,
-		              share_acknowledged_at = COALESCE(capture_connection.share_acknowledged_at, now()),
+		              share_acknowledged_at = CASE WHEN $7 THEN now()
+		                                           ELSE COALESCE(capture_connection.share_acknowledged_at, now()) END,
 		              account_label = EXCLUDED.account_label, provider_scopes = EXCLUDED.provider_scopes,
 		              generation = capture_connection.generation + CASE WHEN $7 THEN 1 ELSE 0 END,
 		              sync_cursor = CASE WHEN $7 THEN NULL ELSE capture_connection.sync_cursor END,

--- a/backend/internal/modules/capture/syncpacing_integration_test.go
+++ b/backend/internal/modules/capture/syncpacing_integration_test.go
@@ -66,7 +66,7 @@ func (c rateLimitedConnector) Sync(context.Context, connector.Auth, connector.Cu
 // about production: the row it schedules against is the row production writes.
 func syncOnceOf(ctx context.Context, t *testing.T, reg *capture.Registry, provider string) error {
 	t.Helper()
-	if _, err := reg.Connect(ctx, provider, connector.Auth("fixture-token")); err != nil {
+	if _, err := reg.Connect(ctx, provider, connector.Auth("fixture-token"), true); err != nil {
 		t.Fatalf("Connect(%s): %v", provider, err)
 	}
 	owner, _ := setupCaptureDB(t)

--- a/backend/migrations/core/1787182202_capture_share_acknowledgment.down.sql
+++ b/backend/migrations/core/1787182202_capture_share_acknowledgment.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_connection DROP COLUMN share_acknowledged_at;

--- a/backend/migrations/core/1787182202_capture_share_acknowledgment.up.sql
+++ b/backend/migrations/core/1787182202_capture_share_acknowledgment.up.sql
@@ -1,0 +1,13 @@
+-- The mail-sharing acknowledgment: connecting a mailbox shares its captured
+-- correspondence with every colleague who can see the contact, and that
+-- default is a stated choice, not a surprise. The connect flow refuses
+-- without the acknowledgment; the grant stamps it here before the first pull.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_connection ADD COLUMN share_acknowledged_at timestamptz NULL;
+
+-- Connections that predate the acknowledgment keep capturing: their humans
+-- connected under the rules of their day, and parking live mailboxes until
+-- each owner returns to re-consent would silently stop capture workspace-wide.
+-- The stamp records when the sharing default became binding for the row.
+UPDATE capture_connection SET share_acknowledged_at = now();

--- a/backend/tools/seed-demo/comms.go
+++ b/backend/tools/seed-demo/comms.go
@@ -73,8 +73,8 @@ func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error)
 		// row is installation-wide by construction (ADR-0091 §8 phase D).
 		tag, err := conn.Exec(ctx, `
 			INSERT INTO capture_connection
-			       (provider, user_id, scopes, status, account_label, auth)
-			VALUES ('offline_demo', $1::uuid, '{read}', 'connected', $2, $3::bytea)
+			       (provider, user_id, scopes, status, account_label, auth, share_acknowledged_at)
+			VALUES ('offline_demo', $1::uuid, '{read}', 'connected', $2, $3::bytea, now())
 			ON CONFLICT (user_id, provider) DO NOTHING`,
 			userID, user.Email, []byte(userID))
 		if err != nil {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9250,6 +9250,15 @@ export interface components {
          */
         ConnectConnectorRequest: {
             /**
+             * @description The connecting human's one-time acknowledgment that what this connector captures
+             *     becomes readable to colleagues who can see the contact (they can limit individual
+             *     messages afterwards, and exclude addresses or domains up front). Required `true`
+             *     for every capture provider — the connect refuses with 422 `sharing_not_acknowledged`
+             *     without it — and recorded on the connection as `share_acknowledged_at` before the
+             *     first pull.
+             */
+            share_acknowledged?: boolean;
+            /**
              * Format: uri
              * @description App page to return to after OAuth consent (OAuth providers).
              */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2892,6 +2892,8 @@ export const de = {
     "Erweiterungen, die diese Installation mit einem gemeinsamen Zugang betreibt. Was du hier einstellst, gilt für alle.",
 
   "connectors.title": "Verbundene Postfächer",
+  "connectors.shareAck":
+    "Erfasste E-Mails werden für Kolleginnen und Kollegen lesbar, die den Kontakt sehen können — einzelne Nachrichten lassen sich nachträglich einschränken, Adressen und Domains vorab ausschließen.",
   "connectors.sub":
     "Postfächer, die dein CRM automatisch füllen. Trenne eines bei Bedarf — bereits erfasste Datensätze bleiben.",
   "connectors.loading": "Verbindungen werden geladen…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2884,6 +2884,8 @@ export const en = {
   // Connected inboxes (Settings → Connections): the "manage in Settings"
   // surface the onboarding copy promises.
   "connectors.title": "Connected inboxes",
+  "connectors.shareAck":
+    "Captured mail becomes readable to colleagues who can see the contact — individual messages can be limited afterwards, and addresses or domains excluded up front.",
   "connectors.sub":
     "Mailboxes capturing into your CRM. Disconnect any one when you need to — already-captured records stay.",
   "connectors.loading": "Loading your connections…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2865,6 +2865,8 @@ export const vi = {
     "Những tiện ích bản cài đặt này chạy bằng một thông tin đăng nhập dùng chung. Thiết lập ở đây áp dụng cho mọi người.",
 
   "connectors.title": "Hộp thư đã kết nối",
+  "connectors.shareAck":
+    "Email được thu thập sẽ hiển thị với đồng nghiệp có quyền xem liên hệ — có thể giới hạn từng tin nhắn sau đó, và loại trừ địa chỉ hoặc tên miền ngay từ đầu.",
   "connectors.sub":
     "Các hộp thư đang thu thập vào CRM của bạn. Cần thì ngắt kết nối hộp nào cũng được — bản ghi đã thu thập vẫn giữ nguyên.",
   "connectors.loading": "Đang tải các kết nối…",

--- a/frontend/src/screens/connect-panels.test.tsx
+++ b/frontend/src/screens/connect-panels.test.tsx
@@ -60,6 +60,11 @@ it("OAuthConnectPanel posts the given provider and redirects", async () => {
       jsonResponse({ authorize_url: "https://login.microsoftonline/x" }),
   });
   render(<OAuthConnectPanel provider="graph" onDismiss={() => {}} />);
+  // The connect button stays disabled until the one-time sharing
+  // acknowledgment is ticked.
+  await userEvent.click(
+    screen.getByRole("checkbox", { name: en["connectors.shareAck"] }),
+  );
   await userEvent.click(
     screen.getByRole("button", { name: "Allow access to my Microsoft" }),
   );

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -1,4 +1,6 @@
 /** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
@@ -165,9 +167,10 @@ describe("the connected-inboxes card", () => {
   it("opens the inline IMAP form from the empty state instead of bouncing to onboarding", async () => {
     stubApi([]);
     render(<ConnectorsCard />);
-    await userEvent.click(
-      await screen.findByRole("button", { name: "IMAP mailbox" }),
-    );
+    // The provider buttons stay disabled until the one-time sharing
+    // acknowledgment — the block's only checkbox — is ticked.
+    await userEvent.click(await screen.findByRole("checkbox"));
+    await userEvent.click(screen.getByRole("button", { name: "IMAP mailbox" }));
     expect(
       screen.getByRole("dialog", { name: "Connect an IMAP mailbox" }),
     ).toBeTruthy();
@@ -253,7 +256,10 @@ describe("the connected-inboxes card", () => {
       return requests;
     });
     const body = await connectRequests[0].clone().json();
-    expect(body).toMatchObject({ return_to: "settings" });
+    expect(body).toMatchObject({
+      return_to: "settings",
+      share_acknowledged: true,
+    });
   });
 
   it("offers the inline IMAP form to reconnect an imap connection instead of an OAuth reconnect", async () => {
@@ -512,6 +518,19 @@ describe("add a connection", () => {
     ).toBeTruthy();
   });
 
+  it("keeps every add-connection button disabled until the sharing acknowledgment is ticked", async () => {
+    stubApi([gmailConnected]);
+    render(<ConnectorsCard />);
+    await screen.findByText("Add a connection");
+    for (const name of ["Google Calendar", "Microsoft", "IMAP mailbox"]) {
+      expect(screen.getByRole("button", { name })).toBeDisabled();
+    }
+    await userEvent.click(screen.getByRole("checkbox"));
+    for (const name of ["Google Calendar", "Microsoft", "IMAP mailbox"]) {
+      expect(screen.getByRole("button", { name })).not.toBeDisabled();
+    }
+  });
+
   it("redirects the browser when an OAuth provider is chosen", async () => {
     const assign = vi.fn();
     vi.stubGlobal("location", { ...globalThis.location, assign });
@@ -520,6 +539,7 @@ describe("add a connection", () => {
     });
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
+    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(
       screen.getByRole("button", { name: "Google Calendar" }),
     );
@@ -532,6 +552,7 @@ describe("add a connection", () => {
     stubApi([gmailConnected], { connect: { status: 501 } });
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
+    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(screen.getByRole("button", { name: "Microsoft" }));
     expect(
       await screen.findByText("Microsoft isn't configured in this deployment."),
@@ -542,6 +563,7 @@ describe("add a connection", () => {
     stubApi([gmailConnected], { connect: { status: 502 } });
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
+    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(screen.getByRole("button", { name: "Microsoft" }));
 
     const alert = await screen.findByRole("alert");

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -7,6 +7,7 @@ import { useRoute } from "../app/router";
 import {
   Badge,
   Button,
+  Checkbox,
   EmptyState,
   SectionHeader,
 } from "../design-system/atoms";
@@ -152,11 +153,20 @@ function ConnectorAddPanel({
   pending,
   notConfigured501,
   connectError,
+  shareAck,
+  onShareAck,
   onConnect,
   onImap,
 }: Readonly<{
   addable: Provider[];
   pending: boolean;
+  // The one-time mail-sharing acknowledgment (one sentence, one checkbox):
+  // captured correspondence is workspace-readable by default, and the server
+  // refuses the connect (422 sharing_not_acknowledged) until it is given.
+  // Held by the parent so the OAuth buttons and the IMAP form opener gate on
+  // the same tick.
+  shareAck: boolean;
+  onShareAck: (v: boolean) => void;
   notConfigured501: Provider | null;
   // Why the last connect started from THESE buttons failed, or null. It renders
   // inside this block, under the strip that produced it: a reason reported in a
@@ -172,10 +182,15 @@ function ConnectorAddPanel({
       {(addable.includes("gcal") || addable.includes("gmail")) && (
         <p className="t-small">{t("connectors.googleSeparateNote")}</p>
       )}
+      <Checkbox
+        checked={shareAck}
+        onChange={(e) => onShareAck(e.currentTarget.checked)}
+        label={t("connectors.shareAck")}
+      />
       <div className="connector-add-actions">
         {addable.map((p) =>
           p === "imap" ? (
-            <Button key={p} small onClick={onImap}>
+            <Button key={p} small disabled={!shareAck} onClick={onImap}>
               <Mail aria-hidden /> {t(providerLabel[p])}
             </Button>
           ) : (
@@ -183,7 +198,7 @@ function ConnectorAddPanel({
               key={p}
               small
               variant={p === "gmail" ? "primary" : undefined}
-              disabled={pending}
+              disabled={pending || !shareAck}
               onClick={() => onConnect(p)}
             >
               <Plug aria-hidden /> {t(providerLabel[p])}
@@ -540,6 +555,7 @@ export function ConnectorsCard() {
     null,
   );
   const [imapConnectOpen, setImapConnectOpen] = useState(false);
+  const [shareAck, setShareAck] = useState(false);
   const [notConfigured501, setNotConfigured501] = useState<Provider | null>(
     null,
   );
@@ -555,7 +571,10 @@ export function ConnectorsCard() {
           params: { path: { provider } },
           // Lands the post-consent redirect back on Settings (Task 2's
           // contract field) rather than the default onboarding landing.
-          body: { return_to: "settings" },
+          // share_acknowledged is honest here: the add buttons stay disabled
+          // until the checkbox is ticked, and a RECONNECT re-asserts the
+          // acknowledgment the connection's first connect already recorded.
+          body: { return_to: "settings", share_acknowledged: true },
         },
       );
       // A deployment that never wired this specific provider answers 501
@@ -614,6 +633,8 @@ export function ConnectorsCard() {
     <ConnectorAddPanel
       addable={addable}
       pending={connect.isPending}
+      shareAck={shareAck}
+      onShareAck={setShareAck}
       notConfigured501={notConfigured501}
       connectError={failureOwnedBy(connectFailure, addable)}
       onConnect={(p) => connect.mutate(p)}

--- a/frontend/src/screens/imap-connect-form.tsx
+++ b/frontend/src/screens/imap-connect-form.tsx
@@ -94,7 +94,9 @@ export function ImapConnectForm({
         body: {
           // The Settings add panel disables this form's opener until the
           // mail-sharing checkbox is ticked, so the assertion is honest here.
-          share_acknowledged: true, imap: request },
+          share_acknowledged: true,
+          imap: request,
+        },
       });
       if (error) {
         throwProblem(error);

--- a/frontend/src/screens/imap-connect-form.tsx
+++ b/frontend/src/screens/imap-connect-form.tsx
@@ -91,7 +91,10 @@ export function ImapConnectForm({
     mutationFn: async (request: ImapConnectRequest) => {
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
         params: { path: { provider: "imap" } },
-        body: { imap: request },
+        body: {
+          // The Settings add panel disables this form's opener until the
+          // mail-sharing checkbox is ticked, so the assertion is honest here.
+          share_acknowledged: true, imap: request },
       });
       if (error) {
         throwProblem(error);

--- a/frontend/src/screens/onboarding-connect-panels.test.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.test.tsx
@@ -43,6 +43,9 @@ async function fillValidForm() {
   await userEvent.type(screen.getByLabelText("IMAP host"), "mail.example.org");
   await userEvent.type(screen.getByLabelText("Email"), "lars@example.org");
   await userEvent.type(screen.getByLabelText("App password"), "app-password");
+  // The submit stays disabled until the one-time sharing acknowledgment —
+  // the panel's only checkbox — is ticked.
+  await userEvent.click(screen.getByRole("checkbox"));
 }
 
 afterEach(() => {
@@ -74,6 +77,7 @@ describe("ImapConnectPanel", () => {
     );
     await waitFor(() => expect(calls.length).toBe(1));
     expect(calls[0].body).toMatchObject({
+      share_acknowledged: true,
       imap: {
         host: "mail.example.org",
         port: 993,

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
-import { Button, Disclosure, Field } from "../design-system/atoms";
+import { Button, Checkbox, Disclosure, Field } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
@@ -159,11 +159,15 @@ export function OAuthConnectPanel({
 }>) {
   const t = useT();
   const copy = OAUTH_COPY[provider];
+  // The one-time mail-sharing acknowledgment: the server refuses the connect
+  // (422 sharing_not_acknowledged) until the human has said yes to captured
+  // correspondence being readable to colleagues who can see the contact.
+  const [shareAck, setShareAck] = useState(false);
   const connect = useMutation({
     mutationFn: async () => {
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
         params: { path: { provider } },
-        body: {},
+        body: { share_acknowledged: shareAck },
       });
       if (error) {
         throwProblem(error);
@@ -201,10 +205,15 @@ export function OAuthConnectPanel({
           is wrong with the thing they just pressed. A caution about what a
           button does belongs beside the button, never behind a fold. */}
       <p className="t-small ob-google-unverified">{t(copy.unverified)}</p>
+      <Checkbox
+        checked={shareAck}
+        onChange={(e) => setShareAck(e.currentTarget.checked)}
+        label={t("connectors.shareAck")}
+      />
       <div className="ob-connect-dialog-actions">
         <Button
           variant="primary"
-          disabled={connect.isPending}
+          disabled={connect.isPending || !shareAck}
           onClick={() => connect.mutate()}
         >
           {connect.isPending ? (
@@ -402,6 +411,7 @@ export function ImapConnectPanel({
   const [password, setPassword] = useState("");
   const [mailbox, setMailbox] = useState("INBOX");
   const [max, setMax] = useState("30");
+  const [shareAck, setShareAck] = useState(false);
 
   const parsedPort =
     port.trim() === "" ? Number(IMAP_DEFAULT_PORT) : Number(port);
@@ -411,6 +421,7 @@ export function ImapConnectPanel({
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
         params: { path: { provider: "imap" } },
         body: {
+          share_acknowledged: shareAck,
           imap: {
             host: host.trim(),
             port: parsedPort,
@@ -445,6 +456,7 @@ export function ImapConnectPanel({
 
   const parsedMax = max.trim() === "" ? 30 : Number(max);
   const ready =
+    shareAck &&
     host.trim() !== "" &&
     Number.isInteger(parsedPort) &&
     parsedPort >= 1 &&
@@ -550,6 +562,12 @@ export function ImapConnectPanel({
           <ShieldCheck aria-hidden /> {t("ob.s4.imapHint")}
         </p>
       </Disclosure>
+
+      <Checkbox
+        checked={shareAck}
+        onChange={(e) => setShareAck(e.currentTarget.checked)}
+        label={t("connectors.shareAck")}
+      />
 
       {connect.isError && (
         <ConnectWarn

--- a/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
@@ -167,8 +167,11 @@ it("marks this tab's own attempt before the real redirect fires", async () => {
   vi.stubGlobal("location", { ...globalThis.location, assign });
   renderConnectAct();
   await userEvent.click(screen.getByRole("button", { name: /Microsoft/ }));
+  // The connect button stays disabled until the one-time sharing
+  // acknowledgment — the dialog's only checkbox — is ticked.
+  await userEvent.click(await screen.findByRole("checkbox"));
   await userEvent.click(
-    await screen.findByRole("button", { name: "Allow access to my Microsoft" }),
+    screen.getByRole("button", { name: "Allow access to my Microsoft" }),
   );
   await waitFor(() => expect(assign).toHaveBeenCalled());
   expect(sessionStorage.getItem("ob.connect.oauthAttempt")).toBe("graph");
@@ -557,9 +560,13 @@ describe("the IMAP dialog", () => {
     expect(screen.getByLabelText("Mailbox")).toBeTruthy();
     // The prototype this dialog adapts shows SMTP host/port and a "Require
     // TLS" checkbox; the real connector contract has neither, so this form
-    // does not invent widgets that would submit nothing.
+    // does not invent widgets that would submit nothing. The one checkbox it
+    // does carry is the sharing acknowledgment, not an invented TLS toggle.
     expect(screen.queryByLabelText(/smtp/i)).toBeNull();
-    expect(screen.queryByRole("checkbox")).toBeNull();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(1);
+    expect(
+      screen.getByRole("checkbox", { name: en["connectors.shareAck"] }),
+    ).toBeInTheDocument();
   });
 
   it("closes on 'Not now' without touching the required-step skip", async () => {
@@ -599,8 +606,9 @@ describe("dismissal during an in-flight connect request", () => {
     });
     renderConnectAct();
     await userEvent.click(screen.getByRole("button", { name: /Microsoft/ }));
+    await userEvent.click(await screen.findByRole("checkbox"));
     await userEvent.click(
-      await screen.findByRole("button", {
+      screen.getByRole("button", {
         name: "Allow access to my Microsoft",
       }),
     );
@@ -629,6 +637,7 @@ describe("dismissal during an in-flight connect request", () => {
     await userEvent.click(screen.getByRole("button", { name: /Any inbox/ }));
     await userEvent.type(screen.getByLabelText("Email"), "me@example.com");
     await userEvent.type(screen.getByLabelText("App password"), "secret");
+    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(
       screen.getByRole("button", { name: "Test and connect" }),
     );
@@ -734,6 +743,7 @@ it("keeps mail provider cards disabled during a roster refetch, not just its fir
   await userEvent.click(screen.getByRole("button", { name: /Any inbox/ }));
   await userEvent.type(screen.getByLabelText("Email"), "me@example.com");
   await userEvent.type(screen.getByLabelText("App password"), "secret");
+  await userEvent.click(screen.getByRole("checkbox"));
   await userEvent.click(
     screen.getByRole("button", { name: "Test and connect" }),
   );


### PR DESCRIPTION
Closes #1900 (decided 2026-08-20: option 2 — one sentence, one checkbox).

Since the access & visibility rework, mail captured from a connected mailbox is readable by every colleague who can see the contact. The person connecting was never told. Now every capture connect — gmail, gcal, graph, imap — carries a one-time acknowledgment and refuses without it.

**Contract**: `ConnectConnectorRequest.share_acknowledged` must be `true`; otherwise 422 `sharing_not_acknowledged`. The OAuth path refuses before minting an authorize URL and carries the flag through the signed state; IMAP refuses before probing credentials.

**Write point**: `Registry.Connect` refuses an unacknowledged grant, so an unacknowledged connection cannot exist however a transport misbehaves; the row records `share_acknowledged_at` before the first pull, and a reconnect keeps the original stamp (`COALESCE`).

**Migration** `1787182202`: adds the column, backfills existing connections — their capture is already live, and parking mailboxes until each owner re-consents would silently stop capture workspace-wide. The stamp on backfilled rows records when the sharing default became binding, not a retroactive claim of consent.

**Frontend**: the Settings add panel, the onboarding OAuth dialog and both IMAP forms gate their buttons on the checkbox (de/en/vi).

Verified: `make check-backend` and `make check-fe` green; capture integration lane green under a private template incl. the new `TestConnectRecordsTheSharingAcknowledgmentAndRefusesWithoutIt`; Playwright 92 passed; craft static clean; rls-store-path and no-jurisdiction OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an explicit sharing acknowledgment when connecting a mailbox so users know captured mail is readable to colleagues who can see the contact. Previously connects succeeded silently; now every capture provider refuses without it, and OAuth callbacks also refuse legacy states before spending an authorization code.

- API: `ConnectConnectorRequest.share_acknowledged` must be `true` or 422 `sharing_not_acknowledged`. OAuth refuses before minting an authorize URL; IMAP refuses before probing credentials. The flag rides the signed OAuth state; the callback rejects unacknowledged pre-change states before code exchange.
- Persistence: new `share_acknowledged_at` is stamped on grant before the first pull. Same-account reconnect keeps the original stamp; a rebind to a different mailbox re-takes the stamp on the new grant.
- Write point: `Registry.Connect` requires a `shareAcknowledged` boolean and refuses unacknowledged grants, ensuring an unacknowledged connection cannot exist.

- Migration `1787182202`: adds `share_acknowledged_at` and backfills existing connections (no re-consent required; backfill records when the default became binding).
- Client change required: callers of `/v1/connectors/{provider}/connect` must include `{"share_acknowledged": true}`.
- Stale OAuth states minted before this change fail on callback and must be retried.
- Frontend gates all connect buttons/forms on a one-time checkbox with copy in `en/de/vi`.

<sup>Written for commit 40aa5190e5f8bcd2cffede7f63fe4452eb6893c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mail-sharing acknowledgment checkbox when connecting or reconnecting email accounts.
  * Connection actions remain unavailable until acknowledgment is provided.
  * Added clear messaging about email visibility, per-message restrictions, and address/domain exclusions.
  * Recorded the acknowledgment time for newly connected accounts.

* **Bug Fixes**
  * Unacknowledged connection attempts now receive a clear validation error and are not created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->