### PR TITLE
fix(activities): a hand-logged meeting moves the lead status ladder

### DIFF
--- a/backend/internal/compose/leadladder_manual_integration_test.go
+++ b/backend/internal/compose/leadladder_manual_integration_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// A hand-logged meeting moves the lead status ladder — the whole chain a rep
+// drives from the Log activity composer: the contract request (kind meeting,
+// meeting_status held) through the real activities writer, then the ladder
+// workflow reading the activity it captured. Proven here because the edge is
+// cross-module; the people-side tests seed touches, never the writer.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+func TestManualMeetingClimbsTheLeadLadder(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+	lead := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO lead (id, full_name, status, source, captured_by, owner_id)
+		 VALUES ($1, 'Met In Person', 'new', 'inbound', 'human:x', $2)`, lead, e.Rep1); err != nil {
+		t.Fatal(err)
+	}
+	// The rep logging from the composer: activity create plus read on the
+	// lead the link row-scope-gates.
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"activity": {Create: true, Read: true},
+			"lead":     {Read: true},
+		},
+		RowScope: principal.RowScopeTeam,
+	})
+
+	subject := "Kickoff on site"
+	held := crmcontracts.CreateActivityRequestMeetingStatusHeld
+	in, err := activities.LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind:          crmcontracts.CreateActivityRequestKindMeeting,
+		Subject:       &subject,
+		MeetingStatus: &held,
+		Links: &[]struct {
+			EntityId   openapi_types.UUID                                `json:"entity_id"` //nolint:staticcheck // mirrors the generated inline struct, whose field is spelled EntityId
+			EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
+		}{{EntityId: openapi_types.UUID(lead), EntityType: crmcontracts.CreateActivityRequestLinksEntityTypeLead}},
+		Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	act, _, err := activities.NewStore(e.DB()).LogActivity(ctx, in)
+	if err != nil {
+		t.Fatalf("log the meeting: %v", err)
+	}
+
+	var ladder workflow.Handler
+	for _, h := range people.LeadSLAWorkflows(people.NewStore(e.DB())) {
+		if h.Spec().Name == "lead_status_ladder" {
+			ladder = h
+		}
+	}
+	if ladder == nil {
+		t.Fatal("lead_status_ladder is not among the registered lead workflows")
+	}
+	ev := workflow.Event{
+		ID: ids.NewV7(), Type: "activity.captured", WorkspaceID: e.WS,
+		OccurredAt: time.Now().UTC(),
+		Entity:     datasource.EntityRef{Type: datasource.EntityActivity, ID: ids.UUID(act.Id)},
+	}
+	// The workflow runner drives Apply as the system, exactly as the relay
+	// does in production.
+	sysCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	sysCtx = principal.WithCorrelationID(sysCtx, ids.NewV7())
+	sysCtx = principal.WithActor(sysCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:test"})
+	eff, err := ladder.Plan(sysCtx, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 { // at-least-once bus: a redelivery must not double-move
+		if _, err := ladder.Apply(sysCtx, ev, eff, nil); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	}
+
+	var status string
+	var setBy *string
+	if err := owner.QueryRow(context.Background(),
+		`SELECT status, status_set_by FROM lead WHERE id = $1`, lead).Scan(&status, &setBy); err != nil {
+		t.Fatal(err)
+	}
+	if status != "engaged" {
+		t.Fatalf("lead status = %q, want engaged — a held meeting a rep logged by hand is engagement", status)
+	}
+	if setBy == nil || *setBy != "system" {
+		t.Errorf("status_set_by = %v, want system", setBy)
+	}
+}

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -56,12 +56,17 @@ type LogActivityInput struct {
 	Body            *string
 	OccurredAt      *time.Time
 	Direction       *string
-	DueAt           *time.Time
-	RemindAt        *time.Time
-	AssigneeID      *ids.UserID
-	HostUserID      *ids.UserID
-	SourceSystem    *string
-	SourceID        *string
+	// MeetingStatus is meaningful only for kind meeting; the mapping refuses
+	// it on any other kind. The lead status ladder reads booked/held as
+	// engagement, so a hand-logged meeting moves a lead the same as a synced
+	// one.
+	MeetingStatus *string
+	DueAt         *time.Time
+	RemindAt      *time.Time
+	AssigneeID    *ids.UserID
+	HostUserID    *ids.UserID
+	SourceSystem  *string
+	SourceID      *string
 	// ThreadKey files this activity under a conversation. Empty stores NULL.
 	// It is written at insert time or not at all: the (source_system,
 	// source_id) upsert both capture and this path key on does nothing when
@@ -134,14 +139,14 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 
 	id := ids.New[ids.ActivityKind]()
 	_, err = tx.Exec(ctx,
-		`INSERT INTO activity (id, kind, channel_provider, subject, body, occurred_at, direction,
+		`INSERT INTO activity (id, kind, channel_provider, subject, body, occurred_at, direction, meeting_status,
 		                       due_at, remind_at, assignee_id, host_user_id, source_system, source_id, source, captured_by,
 		                       thread_key, counterparty_email, counterparty_outbound_attested)
-		 VALUES ($1, $2, NULLIF($3, ''), $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''),
-		         NULLIF($17, ''), $18)`,
+		 VALUES ($1, $2, NULLIF($3, ''), $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, ''),
+		         NULLIF($18, ''), $19)`,
 		// NULLIF on channel_provider: the column FKs into channel_provider, and
 		// '' names no provider, so anything without a transport stores NULL.
-		id, in.Kind, in.ChannelProvider, in.Subject, in.Body, occurredAt, in.Direction,
+		id, in.Kind, in.ChannelProvider, in.Subject, in.Body, occurredAt, in.Direction, in.MeetingStatus,
 		in.DueAt, in.RemindAt, in.AssigneeID, in.HostUserID, in.SourceSystem, in.SourceID, in.Source, by,
 		in.ThreadKey, in.CounterpartyEmail, in.CounterpartyOutboundAttested)
 	if err != nil {

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -9,8 +9,6 @@ package activities
 // them would make the two surfaces silently disagree.
 
 import (
-	"fmt"
-
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -98,7 +96,9 @@ func (e *MessageProviderError) FieldFault() (field, code, message string) {
 type MeetingStatusKindError struct{ Kind string }
 
 func (e *MeetingStatusKindError) Error() string {
-	return fmt.Sprintf("only a meeting may carry a meeting_status; kind %q does not", e.Kind)
+	// The caller's kind is unbounded input; like TranscriptKindError above,
+	// the message never echoes it — the field pointer names what to fix.
+	return "only a meeting may carry a meeting_status"
 }
 
 // FieldFault names meeting_status: it is the field the caller has to drop.

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -9,6 +9,8 @@ package activities
 // them would make the two surfaces silently disagree.
 
 import (
+	"fmt"
+
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -87,6 +89,21 @@ const faultNotValidForKind = "field_not_valid_for_kind"
 // in both directions, whether it is missing or present when it should not be.
 func (e *MessageProviderError) FieldFault() (field, code, message string) {
 	return "channel_provider", faultNotValidForKind, e.Error()
+}
+
+// MeetingStatusKindError maps to 422: only a meeting has a meeting_status.
+// The database CHECK constrains the value's vocabulary but not its pairing
+// with the kind, so without this a note carrying `held` would store silently
+// and read back as a meeting-shaped fact about something that was not one.
+type MeetingStatusKindError struct{ Kind string }
+
+func (e *MeetingStatusKindError) Error() string {
+	return fmt.Sprintf("only a meeting may carry a meeting_status; kind %q does not", e.Kind)
+}
+
+// FieldFault names meeting_status: it is the field the caller has to drop.
+func (e *MeetingStatusKindError) FieldFault() (field, code, message string) {
+	return "meeting_status", faultNotValidForKind, e.Error()
 }
 
 // refuseKindProviderMismatch holds the kind and the transport against each
@@ -176,6 +193,13 @@ func LogActivityInputFrom(req crmcontracts.CreateActivityRequest) (LogActivityIn
 	if req.Direction != nil {
 		d := string(*req.Direction)
 		in.Direction = &d
+	}
+	if req.MeetingStatus != nil {
+		if in.Kind != string(crmcontracts.ActivityKindMeeting) {
+			return LogActivityInput{}, &MeetingStatusKindError{Kind: in.Kind}
+		}
+		m := string(*req.MeetingStatus)
+		in.MeetingStatus = &m
 	}
 	if req.Links != nil {
 		for _, link := range *req.Links {

--- a/backend/internal/modules/activities/mapping_meetingstatus_test.go
+++ b/backend/internal/modules/activities/mapping_meetingstatus_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// meeting_status pairs with kind meeting and nothing else. The forward case
+// matters because the lead status ladder reads booked/held as engagement —
+// a mapping that dropped the field would leave a hand-logged meeting unable
+// to move a lead while a synced one does. The refusal matters because the
+// database CHECK constrains only the vocabulary, not the pairing: without it
+// a note carrying `held` stores silently as a meeting-shaped fact.
+
+import (
+	"errors"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+func TestLogActivityInputCarriesAMeetingsStatus(t *testing.T) {
+	status := crmcontracts.CreateActivityRequestMeetingStatusHeld
+
+	in, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind:          crmcontracts.CreateActivityRequestKindMeeting,
+		MeetingStatus: &status,
+		Source:        "human",
+	})
+	if err != nil {
+		t.Fatalf("mapping a held meeting: %v", err)
+	}
+	if in.MeetingStatus == nil || *in.MeetingStatus != "held" {
+		t.Fatalf("MeetingStatus = %v, want held — dropped, a hand-logged meeting cannot earn a lead's engaged step", in.MeetingStatus)
+	}
+}
+
+func TestLogActivityInputRefusesAMeetingStatusOnANote(t *testing.T) {
+	status := crmcontracts.CreateActivityRequestMeetingStatusHeld
+
+	_, err := LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind:          crmcontracts.CreateActivityRequestKindNote,
+		MeetingStatus: &status,
+		Source:        "human",
+	})
+
+	var fault *MeetingStatusKindError
+	if !errors.As(err, &fault) {
+		t.Fatalf("err = %v, want a MeetingStatusKindError — a note carrying held must be a 422 naming the field", err)
+	}
+	if field, code, _ := fault.FieldFault(); field != "meeting_status" || code != faultNotValidForKind {
+		t.Fatalf("FieldFault = (%q, %q), want (meeting_status, %s)", field, code, faultNotValidForKind)
+	}
+}

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -400,7 +400,25 @@ describe("log activity from a 360", () => {
     expect(post?.body).toMatchObject({
       kind: "meeting",
       body: "discussed pricing, follow up Tuesday",
+      // A hand-logged meeting already took place, and `held` is what lets
+      // the lead status ladder read it as engagement.
+      meeting_status: "held",
     });
+  });
+
+  it("sends no meeting_status for a note — the server refuses the pairing as a 422", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await userEvent.type(screen.getByLabelText("Subject *"), "Just a note");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    expect(post?.body).not.toHaveProperty("meeting_status");
   });
 
   it("posts source_system: transcript only once the writer checks 'this text is a transcript'", async () => {

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -89,6 +89,51 @@ function occurredInstant(input: ActivityDraft): string {
   return middayInstant(input.day, RECORD_ZONE);
 }
 
+// The wire body one drafted entry becomes.
+function activityRequestBody(
+  input: ActivityDraft,
+  entityType: EntityKind,
+  entityId: string,
+) {
+  // source_system: transcript is what routes the body through the
+  // server's ADR-0058 normalizer and what the activity/transcript
+  // retention scope keys its sweep on (see backend logActivity's
+  // `transcript` example) — only when the writer has explicitly marked
+  // this text as one (asTranscript), never inferred from kind: meeting
+  // alone, or ordinary meeting notes would carry a marker meaning
+  // something else and sweep on a different retention schedule.
+  const isTranscript = input.kind === "meeting" && input.asTranscript;
+  // A transcript is sent RAW, not trimmed: the server's normalizer
+  // (transcriptnorm.go) is the one place line-1-indexing gets decided,
+  // and it only trims trailing whitespace per line — a leading blank
+  // line or leading indentation the client stripped first would make a
+  // transcript pasted here normalize to different stored text (and
+  // different line numbers) than the identical paste sent by an agent
+  // or another client straight to the API.
+  const outgoingBody = isTranscript ? input.body : input.body.trim();
+  return {
+    kind: input.kind,
+    subject: input.subject.trim(),
+    body: outgoingBody || null,
+    occurred_at: occurredInstant(input),
+    // A due date becomes the instant that day ENDS in the writer's
+    // own zone (format/calendarday). Handing the bare `yyyy-mm-dd` to
+    // `new Date` reads it as UTC midnight instead, which is neither the
+    // end of the day nor, west of UTC, the day the writer picked: the task
+    // arrived already overdue, and the tasks list — which buckets in the
+    // reader's zone — filed it under yesterday.
+    ...(input.kind === "task" && input.day
+      ? { due_at: dueInstant(input.day) }
+      : {}),
+    // Held: a hand-logged meeting already took place (the date caps at
+    // today), and held is what the lead ladder reads as engagement.
+    ...(input.kind === "meeting" ? { meeting_status: "held" as const } : {}),
+    ...(isTranscript ? { source_system: "transcript" } : {}),
+    links: [{ entity_type: entityType, entity_id: entityId }],
+    source: "manual",
+  };
+}
+
 /**
  * LogActivityForm is the composer itself, without a frame, so the same fields
  * serve the standing card on the person and deal screens and the modal the
@@ -116,42 +161,8 @@ export function LogActivityForm({
 
   const log = useMutation({
     mutationFn: async (input: ActivityDraft) => {
-      const trimmedBody = input.body.trim();
-      // source_system: transcript is what routes the body through the
-      // server's ADR-0058 normalizer and what the activity/transcript
-      // retention scope keys its sweep on (see backend logActivity's
-      // `transcript` example) — only when the writer has explicitly marked
-      // this text as one (asTranscript), never inferred from kind: meeting
-      // alone, or ordinary meeting notes would carry a marker meaning
-      // something else and sweep on a different retention schedule.
-      const isTranscript = input.kind === "meeting" && input.asTranscript;
-      // A transcript is sent RAW, not trimmed: the server's normalizer
-      // (transcriptnorm.go) is the one place line-1-indexing gets decided,
-      // and it only trims trailing whitespace per line — a leading blank
-      // line or leading indentation the client stripped first would make a
-      // transcript pasted here normalize to different stored text (and
-      // different line numbers) than the identical paste sent by an agent
-      // or another client straight to the API.
-      const outgoingBody = isTranscript ? input.body : trimmedBody;
       const { data, error } = await api.POST("/activities", {
-        body: {
-          kind: input.kind,
-          subject: input.subject.trim(),
-          body: outgoingBody || null,
-          occurred_at: occurredInstant(input),
-          // A due date becomes the instant that day ENDS in the writer's
-          // own zone (format/calendarday). Handing the bare `yyyy-mm-dd` to
-          // `new Date` reads it as UTC midnight instead, which is neither the
-          // end of the day nor, west of UTC, the day the writer picked: the task
-          // arrived already overdue, and the tasks list — which buckets in the
-          // reader's zone — filed it under yesterday.
-          ...(input.kind === "task" && input.day
-            ? { due_at: dueInstant(input.day) }
-            : {}),
-          ...(isTranscript ? { source_system: "transcript" } : {}),
-          links: [{ entity_type: entityType, entity_id: entityId }],
-          source: "manual",
-        },
+        body: activityRequestBody(input, entityType, entityId),
       });
       if (error) {
         throwProblem(error, t);


### PR DESCRIPTION
Lars tested the lead ladder by logging a meeting in the composer and the status never moved. Two gaps compounded:

1. **The manual create path dropped `meeting_status`.** The contract accepts it, but `LogActivityInput` never carried it and the INSERT never wrote it — so only connector-synced meetings could ever satisfy the ladder's booked/held test. Now mapped through (with the contract's promised 422 `field_not_valid_for_kind` when sent on any kind but meeting) and stored.
2. **The composer never sent it.** It now sends `meeting_status: "held"` for a logged meeting — it already took place; the date field caps at today.

Tests: mapping unit tests both ways; a compose integration test driving the full chain (contract request → real activities writer → `lead_status_ladder` workflow, applied twice for at-least-once redelivery → lead reads `engaged`, `status_set_by=system`); composer payload tests (held for meetings, absent otherwise).

Codex review triaged: the 422 no longer echoes the caller's unbounded kind (fixed here); natural-key replay not updating `meeting_status` (booked→canceled) is the pre-existing replay-updates-nothing semantics and goes to an issue.

Live verification note: verifying on a `DEV_SLUG` stack surfaced that all dev stacks share one Redis and one `cg:workflows` consumer group, so a parallel stack's worker steals events cross-database — filed separately. Will be verified in the browser against a single stack after merge.

Gates locally: `make check-backend` green (incl. craft static, rls-store-path, no-jurisdiction), `make check-fe` green, integration test green under a private template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manual meetings logged from the composer now advance the lead status ladder. Previously the manual path dropped `meeting_status` and the UI never sent it, so only connector-synced meetings could trigger engagement.

- Carry and persist `meeting_status` for kind "meeting": the mapping fills `LogActivityInput.MeetingStatus` from the contract and the INSERT writes it.
- Reject `meeting_status` on non-meeting kinds with a 422 `field_not_valid_for_kind`; the error message no longer echoes the caller’s kind.
- Composer sends `meeting_status: "held"` for manual meetings and omits it for other kinds.
- No change to replay semantics; natural-key replays still do not update fields.

**Tests and review notes**

- Added compose integration test: contract request → real activities writer → `lead_status_ladder`, applied twice; lead ends as `engaged` with `status_set_by=system`.
- Added mapping unit tests for meeting status acceptance/refusal.
- Added frontend tests to assert `meeting_status` is sent for meetings and omitted otherwise.

<sup>Written for commit 6b1d1dcc2d6d5a7254ed0f1978ec40746807fcbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

