### PR TITLE
fix(seed-demo): a lead is named like the company it sits at

### DIFF
--- a/backend/tools/seed-demo/generated.go
+++ b/backend/tools/seed-demo/generated.go
@@ -182,10 +182,7 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 	}
 
 	leadRank := leadAssignRank(plan)
-	// Per-culture counters: each pool is walked from its own zero, so a
-	// dataset with four Korean leads uses the first four Korean names rather
-	// than whatever positions the global order happens to land on.
-	nameRank := map[nameLocale]int{}
+	nameRank := leadNameRank(plan)
 
 	for _, domain := range sortedDomains(plan) {
 		p := plan[domain]
@@ -196,9 +193,7 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 		if !ok {
 			continue
 		}
-		culture := nameLocaleFor(domain)
-		first, last := generatedLeadName(domain, nameRank[culture])
-		nameRank[culture]++
+		first, last := generatedLeadName(domain, nameRank[domain])
 		title := generatedLeadTitle(domain)
 		sourceID := "gen-lead-" + domain
 
@@ -405,6 +400,34 @@ func leadIsAssigned(rank int) bool {
 // Leads already on file are never moved, so that left an installation's split
 // depending on the order its runs happened in. The plan is the same on every
 // run, so a rank taken from it is too.
+// leadNameRank ranks each lead-bearing domain WITHIN its own naming culture,
+// so a dataset with four Korean leads uses the first four Korean names.
+//
+// Ranked over the plan rather than counted as the seeding loop walks, for the
+// same reason leadAssignRank is: the loop skips a domain whose organization
+// the installation does not hold, so a `-limit N` run counted a different
+// number of domains ahead of D than a full run did. A lead already on file is
+// never renamed, so that left the NAME depending on the order the runs
+// happened in -- and freed a name for another domain to take, which is how the
+// duplicates this change exists to remove would have come back.
+//
+// The plan is identical on every run and knows nothing about which
+// organizations exist, so a rank taken from it cannot drift.
+func leadNameRank(plan map[string]profile) map[string]int {
+	rank := make(map[string]int, len(plan))
+	perCulture := map[nameLocale]int{}
+	for _, domain := range sortedDomains(plan) {
+		p := plan[domain]
+		if p.Pinned || p.LeadState == "" {
+			continue
+		}
+		culture := nameLocaleFor(domain)
+		rank[domain] = perCulture[culture]
+		perCulture[culture]++
+	}
+	return rank
+}
+
 func leadAssignRank(plan map[string]profile) map[string]int {
 	rank := make(map[string]int, len(plan))
 	n := 0

--- a/backend/tools/seed-demo/generated.go
+++ b/backend/tools/seed-demo/generated.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // profileStageName maps a profile's stage to the workspace pipeline's own
@@ -179,6 +182,10 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 	}
 
 	leadRank := leadAssignRank(plan)
+	// Per-culture counters: each pool is walked from its own zero, so a
+	// dataset with four Korean leads uses the first four Korean names rather
+	// than whatever positions the global order happens to land on.
+	nameRank := map[nameLocale]int{}
 
 	for _, domain := range sortedDomains(plan) {
 		p := plan[domain]
@@ -189,7 +196,9 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 		if !ok {
 			continue
 		}
-		first, last := generatedLeadName(domain)
+		culture := nameLocaleFor(domain)
+		first, last := generatedLeadName(domain, nameRank[culture])
+		nameRank[culture]++
 		title := generatedLeadTitle(domain)
 		sourceID := "gen-lead-" + domain
 
@@ -282,16 +291,27 @@ func leadCreateStatus(want string) string {
 	}
 }
 
-var leadFirstNames = []string{"Jonas", "Mareike", "Tobias", "Svenja", "Kilian", "Annika", "Fabian", "Carla"}
-var leadLastNames = []string{"Wenzel", "Achterberg", "Roth", "Lindqvist", "Sommer", "Baumgart", "Reinhold", "Kessler"}
-var leadTitles = []string{
-	"Head of E-Commerce", "Digital Product Owner", "Leiter IT", "Marketing Manager",
-	"Head of Operations", "Projektleiterin Digitalisierung",
-}
-
-func generatedLeadName(domain string) (string, string) {
-	first := leadFirstNames[hashIndex("leadfirst:"+domain, len(leadFirstNames))]
-	last := leadLastNames[hashIndex("leadlast:"+domain, len(leadLastNames))]
+// generatedLeadName draws a name from the company's own naming culture.
+//
+// Names are assigned by RANK within each culture's pool, not by hashing the
+// domain. Hashing gave the same pair to several companies -- "Tobias Ziegler"
+// landed on four domains and "Kilian Wenzel" on nine before the pools grew --
+// because a hash over 45 domains collides long before it exhausts a 20x20
+// pool. Walking the pool in order makes every name distinct until the pool
+// runs out, and the pools are bigger than the number of leads.
+//
+// The rank comes from the sorted domain list, so it is stable across runs for
+// the same plan, exactly as leadAssignRank is.
+func generatedLeadName(domain string, rank int) (string, string) {
+	pool, ok := leadNamesByLocale[nameLocaleFor(domain)]
+	if !ok {
+		pool = leadNamesByLocale[namesDE]
+	}
+	// Stride the surnames so consecutive leads do not share one: with first
+	// names cycling every len(First) entries, a plain rank would pair rank and
+	// rank+len(First) with the same surname.
+	first := pool.First[rank%len(pool.First)]
+	last := pool.Last[(rank*7+rank/len(pool.First))%len(pool.Last)]
 	return first, last
 }
 
@@ -309,11 +329,58 @@ func generatedLeadName(domain string) (string, string) {
 // jonas.sommer.shopify@example.com, not jonas.sommer.shopify.com@example.com.
 func generatedLeadEmail(first, last, domain string) string {
 	slug := strings.NewReplacer(".", "", "-", "").Replace(domain)
-	return strings.ToLower(first+"."+last+"."+slug) + "@example.com"
+	return foldASCII(first) + "." + foldASCII(last) + "." + strings.ToLower(slug) + "@example.com"
+}
+
+// foldASCII turns a name into the local part a mail system would mint from it:
+// Krüger -> krueger, Nguyễn -> nguyen, Ji-woo -> jiwoo.
+//
+// Necessary because the name pools are no longer German-only. Left unfolded,
+// a Vietnamese lead was handed the address thảo.đỗ@example.com -- an address
+// with combining marks in it, which is not what a mail system produces and not
+// something an address validator has to accept.
+//
+// German umlauts EXPAND rather than dropping their diaeresis, because that is
+// what German mail actually does: juettner@, not juttner@. Everything else
+// decomposes and loses its marks, which covers Vietnamese and the Nordic and
+// Slavic names in the list. This mirrors fold() in the dataset's
+// tools/synth_emails.py, which does the same job for crawled people.
+func foldASCII(name string) string {
+	// D-with-stroke and the Nordic letters are distinct LETTERS, not a base
+	// plus a combining mark, so NFKD leaves them alone and the alnum filter
+	// then drops them: Đỗ became "o" and Yến Đinh became yen.inh. They have to
+	// be mapped by hand.
+	expanded := strings.NewReplacer(
+		"ä", "ae", "ö", "oe", "ü", "ue",
+		"Ä", "Ae", "Ö", "Oe", "Ü", "Ue",
+		"ß", "ss",
+		"đ", "d", "Đ", "D",
+		"ø", "o", "Ø", "O", "å", "aa", "Å", "Aa", "æ", "ae", "Æ", "Ae",
+		"ł", "l", "Ł", "L",
+	).Replace(name)
+
+	decomposed := norm.NFKD.String(expanded)
+	var b strings.Builder
+	b.Grow(len(decomposed))
+	for _, r := range decomposed {
+		if unicode.Is(unicode.Mn, r) {
+			continue // a combining mark: Nguyễn -> Nguyen
+		}
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else if r >= 'A' && r <= 'Z' {
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
 }
 
 func generatedLeadTitle(domain string) string {
-	return leadTitles[hashIndex("leadtitle:"+domain, len(leadTitles))]
+	titles, ok := leadTitlesByLocale[nameLocaleFor(domain)]
+	if !ok {
+		titles = leadTitlesByLocale[namesDE]
+	}
+	return titles[hashIndex("leadtitle:"+domain, len(titles))]
 }
 
 // leadIsAssigned splits the generated leads in half: the assigned ones get

--- a/backend/tools/seed-demo/leadnames.go
+++ b/backend/tools/seed-demo/leadnames.go
@@ -53,10 +53,29 @@ func nameLocaleFor(domain string) nameLocale {
 }
 
 // koreanNameDomains are the Korean companies whose domain does not end in .kr.
+//
+// Read off the crawled dataset rather than guessed: each of these publishes a
+// Korean registered address or a Korean legal name in
+// datasets/v1/siteresults/<domain>/accepted.json — a Busan or Seoul address,
+// or a name in Hangul. A .com or .org tells you nothing about where a company
+// is, and company-locale.json cannot answer it either: it records the language
+// a company's DOCUMENTS are in, and every Korean company in it is marked "en"
+// because Korean sites publish English.
+//
+// Deliberately NOT here: centricsoftware.com, algolia.com and google.com, all
+// of which name a Seoul office somewhere on the site. An office in Korea does
+// not make a company Korean, and naming their leads Park would be the same
+// class of error as calling 감소프트's lead Annika.
 var koreanNameDomains = map[string]bool{
-	"dacell.com":     true,
-	"hongikinfo.com": true,
-	"nidsoft.com":    true,
+	"allincarbon.com": true, // 올인카본, Anyang
+	"boomco.org":      true, // Boomco Communication, Busan
+	"crescai.com":     true, // CRESC AI INC., Ulsan
+	"dacell.com":      true,
+	"enabler-ai.com":  true, // 이네이블러, Seoul
+	"hongikinfo.com":  true,
+	"isaac-eng.com":   true, // ISAAC Engineering, Gunpo-si
+	"nidsoft.com":     true, // NidSoft, Geumcheon-gu Seoul
+	"orca.partners":   true, // ORCA MES, Busan
 }
 
 // The pools are large enough that 45 generated leads do not collide into the

--- a/backend/tools/seed-demo/leadnames.go
+++ b/backend/tools/seed-demo/leadnames.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Who a generated lead is, by name.
+//
+// Separate from generated.go because it is data rather than logic, and because
+// the pools have to be big: a lead list where the same person appears nine
+// times reads as machine-made, and that is exactly what an 8x8 pool produced.
+
+import "strings"
+
+// nameLocale is which naming culture a generated lead is drawn from. It is
+// deliberately NOT docLocale: a Korean company's paper is written in English
+// (the Korean sites publish English, so their contracts do too), but a lead
+// sitting at that company is still called Park, not Achterberg. One is the
+// language of a document, the other is what people are named.
+type nameLocale string
+
+const (
+	namesDE nameLocale = "de"
+	namesVI nameLocale = "vi"
+	namesKO nameLocale = "ko"
+	namesEN nameLocale = "en"
+)
+
+// nameLocaleFor answers which pool a company's people are named from.
+//
+// The Korean domains are listed explicitly because .kr and .co.kr are not the
+// whole set -- an .or.kr is a public body and DACELL sits on a .com -- and
+// because company-locale.json answers a different question. That file says
+// which language the DOCUMENTS are in, and it maps every Korean company to
+// English, which is right for a contract and wrong for a person's name.
+func nameLocaleFor(domain string) nameLocale {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if koreanNameDomains[domain] {
+		return namesKO
+	}
+	switch {
+	case strings.HasSuffix(domain, ".kr"):
+		return namesKO
+	case strings.HasSuffix(domain, ".vn"):
+		return namesVI
+	}
+	if localeFor(domain) == localeVI {
+		return namesVI
+	}
+	if localeFor(domain) == localeEN {
+		return namesEN
+	}
+	return namesDE
+}
+
+// koreanNameDomains are the Korean companies whose domain does not end in .kr.
+var koreanNameDomains = map[string]bool{
+	"dacell.com":     true,
+	"hongikinfo.com": true,
+	"nidsoft.com":    true,
+}
+
+// The pools are large enough that 45 generated leads do not collide into the
+// same handful of people. The previous 8x8 German pool produced "Kilian
+// Wenzel" nine times across the dataset and put a German name on every Korean
+// and Vietnamese company, both of which are visible on the first page of the
+// lead list.
+var leadNamesByLocale = map[nameLocale]struct{ First, Last []string }{
+	namesDE: {
+		First: []string{"Jonas", "Mareike", "Tobias", "Svenja", "Kilian", "Annika", "Fabian", "Carla",
+			"Lennart", "Johanna", "Sebastian", "Franziska", "Matthias", "Katrin", "Philipp", "Nadine",
+			"Christoph", "Verena", "Dominik", "Sabine"},
+		Last: []string{"Wenzel", "Achterberg", "Roth", "Lindqvist", "Sommer", "Baumgart", "Reinhold", "Kessler",
+			"Hoffmann", "Brandt", "Krüger", "Seibert", "Vogler", "Naumann", "Ziegler", "Dreher",
+			"Lehmann", "Osterloh", "Hartwig", "Bergmann"},
+	},
+	namesVI: {
+		First: []string{"Minh", "Lan", "Hùng", "Thảo", "Dũng", "Trang", "Khánh", "Ngọc",
+			"Tuấn", "Hà", "Quang", "Linh", "Sơn", "Mai", "Đức", "Yến",
+			"Nam", "Phương", "Thành", "Vân"},
+		Last: []string{"Nguyễn", "Trần", "Lê", "Phạm", "Hoàng", "Vũ", "Đặng", "Bùi",
+			"Đỗ", "Hồ", "Ngô", "Dương", "Lý", "Phan", "Võ", "Đinh"},
+	},
+	namesKO: {
+		First: []string{"Ji-woo", "Min-jun", "Seo-yeon", "Do-yun", "Ha-eun", "Jun-seo", "Soo-ah", "Tae-hyun",
+			"Eun-ji", "Sang-hoon", "Yu-jin", "Hyun-woo", "Da-eun", "Jae-min", "So-yeong", "Dong-hyun"},
+		Last: []string{"Kim", "Lee", "Park", "Choi", "Jung", "Kang", "Cho", "Yoon",
+			"Jang", "Lim", "Han", "Oh", "Seo", "Shin", "Kwon", "Hwang"},
+	},
+	namesEN: {
+		First: []string{"Emma", "Oliver", "Sophie", "Daniel", "Laura", "Thomas", "Claire", "Adam",
+			"Rachel", "Simon", "Hannah", "Peter", "Alice", "Mark", "Julia", "Steven",
+			"Nina", "Paul", "Ellen", "George"},
+		Last: []string{"Whitfield", "Barrow", "Kingsley", "Harper", "Ellison", "Radcliffe", "Marsden", "Prescott",
+			"Ashworth", "Bramley", "Corrigan", "Danvers", "Everly", "Fairbanks", "Grayson", "Holbrook"},
+	},
+}
+
+var leadTitlesByLocale = map[nameLocale][]string{
+	namesDE: {"Head of E-Commerce", "Digital Product Owner", "Leiter IT", "Marketing Manager",
+		"Head of Operations", "Projektleiterin Digitalisierung", "Leiter Vertrieb", "Bereichsleiter IT"},
+	namesVI: {"Giám đốc Kỹ thuật", "Trưởng phòng Dự án", "Giám đốc Điều hành", "Trưởng phòng Kinh doanh",
+		"Phụ trách CNTT", "Quản lý Sản xuất"},
+	namesKO: {"IT팀장", "사업개발팀장", "기술연구소장", "구매팀장", "영업본부장", "생산관리팀장"},
+	namesEN: {"Head of E-Commerce", "Digital Product Owner", "Head of IT", "Marketing Manager",
+		"Head of Operations", "Director of Digital", "VP Sales", "Head of Procurement"},
+}

--- a/backend/tools/seed-demo/profile_test.go
+++ b/backend/tools/seed-demo/profile_test.go
@@ -378,3 +378,71 @@ func TestFoldASCIIProducesAMailableLocalPart(t *testing.T) {
 		}
 	}
 }
+
+// TestLeadNameRankIsIndependentOfRunHistory is the convergence contract for
+// names, and it is the defect a review caught in the first version of this
+// change: the per-culture counter was advanced inside the seeding loop, AFTER
+// the guard that skips a domain whose organization the installation does not
+// hold.
+//
+// That made a name depend on the order the runs happened in. A `-limit N` run
+// holds a subset of the organizations, so a domain got a different rank than
+// on a full run — and because a lead already on file is never renamed, the
+// name it was given first stuck while the rank it "should" have had was freed
+// for another domain to take. Duplicate names, which is the whole thing this
+// change removes.
+//
+// Ranking over the plan takes the run out of the equation: the plan is the
+// same every time and knows nothing about which organizations exist.
+func TestLeadNameRankIsIndependentOfRunHistory(t *testing.T) {
+	full := leadNameRank(leadPlan("a.de", "b.de", "c.de", "d.de", "e.de", "f.de"))
+
+	for i := 0; i < 3; i++ {
+		again := leadNameRank(leadPlan("a.de", "b.de", "c.de", "d.de", "e.de", "f.de"))
+		for d, r := range full {
+			if again[d] != r {
+				t.Fatalf("%s ranked %d then %d — the same plan must rank the same", d, r, again[d])
+			}
+		}
+	}
+
+	// Ranks are per culture, each starting at zero, so a Korean lead uses the
+	// first Korean name rather than whatever global position it landed on.
+	// Ranks follow SORTED domain order, so condt.co.kr precedes gamsoft.kr.
+	mixed := leadNameRank(leadPlan("a.de", "gamsoft.kr", "b.de", "aubot.vn", "condt.co.kr"))
+	if mixed["condt.co.kr"] != 0 {
+		t.Errorf("first Korean domain ranked %d, want 0", mixed["condt.co.kr"])
+	}
+	if mixed["gamsoft.kr"] != 1 {
+		t.Errorf("second Korean domain ranked %d, want 1", mixed["gamsoft.kr"])
+	}
+	if mixed["aubot.vn"] != 0 {
+		t.Errorf("first Vietnamese domain ranked %d, want 0", mixed["aubot.vn"])
+	}
+	if mixed["a.de"] != 0 || mixed["b.de"] != 1 {
+		t.Errorf("German ranks are %d and %d, want 0 and 1", mixed["a.de"], mixed["b.de"])
+	}
+}
+
+// TestKoreanCompaniesOffDotKrAreNamedKorean pins the second half of the same
+// review: isaac-eng.com is ISAAC Engineering of Gunpo-si and was getting an
+// English name, because the exception list only held three domains.
+//
+// The counter-examples matter as much as the examples. A company with a Seoul
+// office is not a Korean company, and naming its leads Park would be the same
+// mistake in the other direction.
+func TestKoreanCompaniesOffDotKrAreNamedKorean(t *testing.T) {
+	for _, domain := range []string{
+		"isaac-eng.com", "dacell.com", "hongikinfo.com", "nidsoft.com",
+		"allincarbon.com", "boomco.org", "crescai.com", "enabler-ai.com", "orca.partners",
+	} {
+		if got := nameLocaleFor(domain); got != namesKO {
+			t.Errorf("nameLocaleFor(%q) = %q, want %q — it is a Korean company", domain, got, namesKO)
+		}
+	}
+	for _, domain := range []string{"centricsoftware.com", "algolia.com", "google.com"} {
+		if got := nameLocaleFor(domain); got == namesKO {
+			t.Errorf("nameLocaleFor(%q) = korean — an office in Seoul is not a Korean company", domain)
+		}
+	}
+}

--- a/backend/tools/seed-demo/profile_test.go
+++ b/backend/tools/seed-demo/profile_test.go
@@ -312,3 +312,69 @@ func TestLeadAssignRankIsIndependentOfRunHistory(t *testing.T) {
 		}
 	}
 }
+
+// TestNameLocaleForFollowsTheCompany pins which naming culture a company's
+// generated lead is drawn from. The bug this replaces put a German name on a
+// Korean and a Vietnamese company, four rows apart on the first page of the
+// lead list.
+func TestNameLocaleForFollowsTheCompany(t *testing.T) {
+	for domain, want := range map[string]nameLocale{
+		"gamsoft.kr":     namesKO,
+		"condt.co.kr":    namesKO,
+		"utp.or.kr":      namesKO,
+		"dacell.com":     namesKO, // Korean company on a .com
+		"hongikinfo.com": namesKO,
+		"aubot.vn":       namesVI,
+		"i-soft.com.vn":  namesVI,
+	} {
+		if got := nameLocaleFor(domain); got != want {
+			t.Errorf("nameLocaleFor(%q) = %q, want %q", domain, got, want)
+		}
+	}
+}
+
+// TestGeneratedLeadNamesAreDistinct is the other half of the same bug: an 8x8
+// German pool hashed by domain produced "Kilian Wenzel" nine times across 45
+// leads. Names are now assigned by rank, so a pool bigger than the lead count
+// cannot repeat.
+func TestGeneratedLeadNamesAreDistinct(t *testing.T) {
+	for _, culture := range []nameLocale{namesDE, namesVI, namesKO, namesEN} {
+		pool := leadNamesByLocale[culture]
+		seen := map[string]bool{}
+		// One more than any single dataset draws from one culture.
+		for rank := 0; rank < 16; rank++ {
+			first, last := generatedLeadName("example."+string(culture), rank)
+			name := first + " " + last
+			if seen[name] {
+				t.Errorf("%s: %q repeats within the first 16 ranks", culture, name)
+			}
+			seen[name] = true
+		}
+		if len(pool.First) < 16 || len(pool.Last) < 16 {
+			t.Errorf("%s pool is too small to keep 16 leads distinct: %d first, %d last",
+				culture, len(pool.First), len(pool.Last))
+		}
+	}
+}
+
+// TestFoldASCIIProducesAMailableLocalPart pins the folding. Without it a
+// Vietnamese lead was handed thao.đỗ@example.com — combining marks and a
+// D-with-stroke in an address, which no mail system produces.
+func TestFoldASCIIProducesAMailableLocalPart(t *testing.T) {
+	for in, want := range map[string]string{
+		"Nguyễn":  "nguyen",
+		"Đỗ":      "do",
+		"Đặng":    "dang",
+		"Thảo":    "thao",
+		"Krüger":  "krueger",  // German expands rather than dropping the mark
+		"Jüttner": "juettner", // matches the dataset's own synth_emails.py
+		"Weiß":    "weiss",
+		"Ji-woo":  "jiwoo",
+		"Grønn":   "gronn",
+		"Kessler": "kessler",
+	} {
+		if got := foldASCII(in); got != want {
+			t.Errorf("foldASCII(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Two bugs, both visible on the first page of the lead list.

**The same people over and over.** 45 generated leads were drawn from an 8×8 pool of German names by hashing the domain. A hash over 45 domains collides long before it exhausts 64 combinations, so `Kilian Wenzel` appeared nine times, `Tobias Reinhold` eight, `Annika Achterberg` six — four rows of one screen carried the same name.

Names are now assigned by **rank** within each culture's pool, walking it in order rather than hashing into it, and the pools are 16–20 deep on each side. 45 leads produce 45 distinct people. Hashing was tried first with larger pools and combined salts and still repeated a name three times: a hash cannot promise distinctness, a pool walk can.

**A German name on a Korean company.** Every generated lead was German whatever the company was, so 감소프트 had an Annika Achterberg. Names now follow the company's naming culture, and job titles with them (기술연구소장, Trưởng phòng Kinh doanh).

The culture is deliberately **not** read from `company-locale.json` — that file says which language a company's *documents* are in and maps every Korean company to English, which is right for a contract and wrong for a person's name. `nameLocaleFor` uses it for the Vietnamese cases it does answer, and handles Korean from the domain plus the Korean companies sitting on a `.com`.

**Folding**, which the new pools made necessary: the address was built from the raw name, so a Vietnamese lead would have got `thảo.đỗ@example.com`. `foldASCII` mirrors `fold()` in the dataset's `synth_emails.py` — German umlauts expand (`juettner@`, not `juttner@`), everything else decomposes. `Đ` is mapped by hand because it is a distinct letter rather than a base plus a mark, so NFKD left it alone and the alnum filter was silently deleting it (`Yến Đinh` → `yen.inh`).

Pools moved to `leadnames.go` because `generated.go` passed the 500-line cap.

**Verified** against the 45 domains that carry a generated lead: 45 distinct names, 45 distinct addresses, every local part ASCII, every culture matching its company.

`make check-backend` green, all legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates culture-appropriate, distinct demo leads and folds email local parts to ASCII. Previously names were hashed from a small German pool, causing duplicates and culture mismatches; now names and titles follow the company’s naming culture and are assigned by per-culture rank computed over the plan for stability.

- Behavior: names/titles follow `de`, `vi`, `ko`, `en` via `nameLocaleFor`; `leadNameRank` computes a per-culture rank over the plan to keep assignments stable across partial runs; `generatedLeadName(domain, rank)` walks culture-specific pools in order; email locals use `foldASCII` (German umlauts expand; other diacritics are stripped; `Đ/đ`, `Ø/ø`, `Ł/ł` mapped).
- Implementation: added `leadnames.go` with larger name/title pools, locale logic, and an explicit list of Korean companies on non-.kr domains; `generatedLeadEmail` uses `foldASCII`; new dependency `golang.org/x/text/unicode/norm`; tests pin culture mapping, per-culture rank stability, distinctness, and folding.
- Rollout: reseeding changes generated names, titles, and email addresses; update any snapshots relying on prior seed values.

<sup>Written for commit 9e269912bf11fa67e57c722b7fe67c47c8ab4cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

