### PR TITLE
docs(how-to): set up and run a partner program from the UI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ maps the codebase and links everything below.
 - [write-a-certification-case.md](how-to/write-a-certification-case.md) — bind a site to the production request builder and validator that certify it: the test-first loop, the case interface, the three site kinds, scenario and rubric authoring, scope.
 - [register-a-webhook.md](how-to/register-a-webhook.md) — register an HTTPS endpoint for Standard-Webhooks-signed, retried outbound delivery of contract-generated event payloads (curl or Settings → Integrations), and verify/inspect/replay a delivery.
 - [add-an-extension.md](how-to/add-an-extension.md) — ship a stable-tier extension unit (a jurisdiction pack) under `extensions/`, composed and verified.
+- [set-up-a-partner-program.md](how-to/set-up-a-partner-program.md) — run a partner program from the UI: make a company a partner, what every field means, work the pipeline; no code.
 
 ### Reference — look it up
 - [modules.md](reference/modules.md) — the modules: what each owns, its tables, its HTTP surface.

--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -1,0 +1,110 @@
+# Set up and run a partner program
+
+This guide is for the person who runs the partner program — no code, no API. It shows where
+partners live in the app, how to make a company a partner, what every field on the form means,
+and how to work the pipeline afterwards. The one thing you *cannot* do from the UI — changing
+the value lists themselves — is covered at the end.
+
+## What a partner is in Margince
+
+A partner is not a separate record you create next to a company. It is an **extra layer on a
+company that already exists**: the company keeps its name, domain, people, and timeline, and
+gains partner state on top — a role, a certification status, a margin tier, and a relationship
+stage. Nothing is duplicated, so the same company page shows both its commercial life and its
+partner life.
+
+That also means the first step of any partner setup is simply having the company in Margince.
+If it isn't there yet, add it (or let capture create it from mail traffic) before you continue.
+
+## Make a company a partner
+
+1. Open the company's page (**Companies** → pick the company).
+2. Open its **Partner** tab. A company that isn't a partner yet shows **"Not a partner yet"**
+   and, below it, the **"Make this a partner"** form.
+3. Pick a **Partner role** — this is the only required field — and fill in whatever else you
+   already know.
+4. Save. The company is now a partner: it appears in the partner list, and the Partner tab
+   switches from the setup form to the editable partner record.
+
+Everything on the form can be changed later from the same tab. Becoming a partner is a normal
+governed write like any other: it is recorded in the audit log with who did it and when.
+
+## What the fields mean
+
+**Partner role** *(required)* — what kind of partner they are to us:
+
+| Role | Meaning |
+|---|---|
+| **Hosting** | They run the software for their clients. |
+| **Consulting** | They advise clients and bring us in. |
+| **Strategic** | A broader alliance that doesn't fit the other two. |
+
+Implementation and development work is Gradion's own turf, which is why there is no role for it.
+
+**Certification status** — where they stand in the certification funnel. A new partner starts
+as **Applied**; move them to **Certified** once they pass, and to **Suspended** if the
+certification is revoked. This is a statement about certification only — suspending a partner
+does not archive the company or stop anything else.
+
+**Margin tier** — the commercial tier that sets their margin: **Tier 1 (15%)**,
+**Tier 2 (20%)**, or **Tier 3 (25%)**. Leave it **Not set** until a tier has actually been
+agreed; the field is deliberately optional so the record never claims a deal term that doesn't
+exist yet.
+
+**Relationship stage** — where the *relationship* is, independent of certification. The stages
+read as a funnel:
+
+| Stage | You are here when… |
+|---|---|
+| **Research** | you're still figuring out whether they're worth approaching (the default). |
+| **Identified** | you've decided they're a real prospect. |
+| **Contacted** | you've reached out, no real conversation yet. |
+| **In conversation** | an actual dialogue is running. |
+| **Fit confirmed** | both sides agree there's a fit. |
+| **Agreement pending** | paperwork is in motion. |
+| **Active** | the partnership is live. |
+| **Active — referring** | live *and* actually sending business. |
+| **Dormant** | it was live, but it's gone quiet. |
+| **No fit** | you looked, and it's a no. Keeps the record honest instead of deleting it. |
+
+**Next step / Next step due** — the one concrete thing that moves this relationship forward,
+and when it's due. Treat an empty next step on a partner that isn't Active (or No fit) as a
+smell: it means nobody owns the relationship right now.
+
+**Served segments** — free-form, comma-separated tags for the client segments this partner
+serves (say, `SMB, agencies, e-commerce`). There is no fixed list; use the same words across
+partners so filtering stays useful.
+
+## Work the program day to day
+
+- **The partner list** — from the **Companies** list header, open **Partners**. It is the flat
+  list of every partner, filterable by role and certification status. This is your program
+  overview: who's applied, who's certified, who's suspended.
+- **The company page stays the home** — activities, people, and deals with a partner live on
+  the company page like for any other company. The Partner tab is one more tab there, not a
+  separate world.
+- **A simple weekly loop:** filter the list for **Applied** and push certifications forward;
+  scan for partners whose stage is behind reality and correct it; make sure every in-flight
+  partner has a next step with a due date.
+
+Agents see partners too: the partner list and partner updates are exposed as governed MCP
+tools, so an agent working for you can look partners up and (within its granted scopes) update
+the same fields you edit here — every such write lands in the same audit trail.
+
+## Changing the value lists themselves
+
+The dropdown values — the three roles, the three certification statuses, the three margin
+tiers, the ten stages — are **fixed vocabulary, not admin configuration**. There is no settings
+screen for them, on purpose: they are enforced end to end, in the API contract
+([`backend/api/crm.yaml`](../../backend/api/crm.yaml), the `Partner` schema), as database CHECK
+constraints, and in the form's option lists
+([`frontend/src/screens/partners.tsx`](../../frontend/src/screens/partners.tsx)).
+
+If the program outgrows a list — a fourth role, a different tier structure — that is a small
+code change plus a migration, not a workaround: change the enum in the contract, add a
+migration for the CHECK constraint, run `make gen`, and extend the option list and its labels
+in the frontend. [add-an-endpoint.md](add-an-endpoint.md) walks the contract-change loop;
+[apply-migrations.md](apply-migrations.md) covers the migration half.
+
+For per-partner data that doesn't fit the fixed fields, you don't need any of that: **Settings →
+Custom fields** lets an admin add custom fields without touching code.


### PR DESCRIPTION
A plain-language how-to for the person who runs the partner program — UI only, no code. Covers: what a partner record is (an extension on an existing company), promoting a company on its Partner tab, what every field and dropdown value means (roles, certification statuses, margin tiers, the ten relationship stages), and working the pipeline from the partner list.

It also states plainly that the dropdown vocabularies are fixed (contract enums + DB CHECKs + the form's option lists), that there is no admin settings screen for them, and where a list change lives if the program outgrows them — with a pointer to custom fields for per-partner data that doesn't need any of that.

Indexed in docs/README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UI-only how-to for running the partner program and links it from the docs index. This gives program owners a single source for the partner data model, field definitions, daily workflow, and the fixed dropdown vocabularies, including where list changes live in code.

- Verify roles (Hosting, Consulting, Strategic), certification statuses (Applied, Certified, Suspended), margin tiers (Tier 1–3), and the ten relationship stages match `backend/api/crm.yaml`, DB CHECKs, and the frontend option lists.
- Check UI paths and copy: Company → Partner tab, "Make this a partner" flow, and Companies → Partners list.
- Confirm referenced files and links exist: `backend/api/crm.yaml`, `frontend/src/screens/partners.tsx`, how-to links for contract changes and migrations, and the new entry in `docs/README.md`.
- Ensure the note on agent access via governed MCP tools and audit logging is accurate.
- Confirm guidance on using Settings → Custom fields for per-partner data is correct.

<sup>Written for commit b870bf109aa73eb530ff9848b6afd09fcf3b6f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

