### PR TITLE
feat(people): a rep's logged note is contact, and the stepper shows the climb

### DIFF
--- a/backend/internal/compose/leadladder_manual_integration_test.go
+++ b/backend/internal/compose/leadladder_manual_integration_test.go
@@ -110,3 +110,77 @@ func TestManualMeetingClimbsTheLeadLadder(t *testing.T) {
 		t.Errorf("status_set_by = %v, want system", setBy)
 	}
 }
+
+// The composer's other touch: a plain note a rep types ("wrote them an
+// intro mail") carries no direction and no meeting status, and still has to
+// earn Contacted — through the same real writer and workflow as the meeting
+// above, because the mapping dropping any of it would strand the lead on New.
+func TestManualNoteMarksTheLeadContacted(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+	lead := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO lead (id, full_name, status, source, captured_by, owner_id)
+		 VALUES ($1, 'Wrote Them First', 'new', 'inbound', 'human:x', $2)`, lead, e.Rep1); err != nil {
+		t.Fatal(err)
+	}
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"activity": {Create: true, Read: true},
+			"lead":     {Read: true},
+		},
+		RowScope: principal.RowScopeTeam,
+	})
+	subject := "Sent the intro mail"
+	in, err := activities.LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind:    crmcontracts.CreateActivityRequestKindNote,
+		Subject: &subject,
+		Links: &[]struct {
+			EntityId   openapi_types.UUID                                `json:"entity_id"` //nolint:staticcheck // mirrors the generated inline struct, whose field is spelled EntityId
+			EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
+		}{{EntityId: openapi_types.UUID(lead), EntityType: crmcontracts.CreateActivityRequestLinksEntityTypeLead}},
+		Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	act, _, err := activities.NewStore(e.DB()).LogActivity(ctx, in)
+	if err != nil {
+		t.Fatalf("log the note: %v", err)
+	}
+
+	var ladder workflow.Handler
+	for _, h := range people.LeadSLAWorkflows(people.NewStore(e.DB())) {
+		if h.Spec().Name == "lead_status_ladder" {
+			ladder = h
+		}
+	}
+	if ladder == nil {
+		t.Fatal("lead_status_ladder is not among the registered lead workflows")
+	}
+	sysCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	sysCtx = principal.WithCorrelationID(sysCtx, ids.NewV7())
+	sysCtx = principal.WithActor(sysCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:test"})
+	ev := workflow.Event{
+		ID: ids.NewV7(), Type: "activity.captured", WorkspaceID: e.WS,
+		OccurredAt: time.Now().UTC(),
+		Entity:     datasource.EntityRef{Type: datasource.EntityActivity, ID: ids.UUID(act.Id)},
+	}
+	eff, err := ladder.Plan(sysCtx, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ladder.Apply(sysCtx, ev, eff, nil); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	var status string
+	if err := owner.QueryRow(context.Background(),
+		`SELECT status FROM lead WHERE id = $1`, lead).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "contacted" {
+		t.Fatalf("lead status = %q, want contacted — a rep's own note is outreach on the record", status)
+	}
+}

--- a/backend/internal/modules/people/leadladder_integration_test.go
+++ b/backend/internal/modules/people/leadladder_integration_test.go
@@ -78,7 +78,8 @@ func TestLadderClimbsFromActivityAndNeverDescends(t *testing.T) {
 }
 
 // Which step a captured activity earns: engagement from an inbound reply or
-// a booked/held meeting, contact from any outbound touch, nothing else.
+// a booked/held meeting, contact from any outbound touch or a note a human
+// logged, nothing else.
 func TestLadderStepForReadsTheTouch(t *testing.T) {
 	cases := []struct {
 		name string
@@ -92,7 +93,9 @@ func TestLadderStepForReadsTheTouch(t *testing.T) {
 		{"cancelled meeting", leadResponseTouch{kind: "meeting", meetingStatus: "cancelled"}, "", false},
 		{"outbound email", leadResponseTouch{direction: "outbound", kind: "email"}, LeadStatusContacted, true},
 		{"outbound call by the system", leadResponseTouch{direction: "outbound", kind: "call", capturedBy: "connector:x"}, LeadStatusContacted, true},
-		{"a note", leadResponseTouch{kind: "note"}, "", false},
+		{"a note a human logged", leadResponseTouch{kind: "note", capturedBy: "human:u1"}, LeadStatusContacted, true},
+		{"a note an agent wrote", leadResponseTouch{kind: "note", capturedBy: "agent:a1"}, "", false},
+		{"a note with no author prefix", leadResponseTouch{kind: "note"}, "", false},
 	}
 	for _, tc := range cases {
 		got, ok := ladderStepFor(tc.t)

--- a/backend/internal/modules/people/leadladder_integration_test.go
+++ b/backend/internal/modules/people/leadladder_integration_test.go
@@ -93,9 +93,9 @@ func TestLadderStepForReadsTheTouch(t *testing.T) {
 		{"cancelled meeting", leadResponseTouch{kind: "meeting", meetingStatus: "cancelled"}, "", false},
 		{"outbound email", leadResponseTouch{direction: "outbound", kind: "email"}, LeadStatusContacted, true},
 		{"outbound call by the system", leadResponseTouch{direction: "outbound", kind: "call", capturedBy: "connector:x"}, LeadStatusContacted, true},
-		{"a note a human logged", leadResponseTouch{kind: "note", capturedBy: "human:u1"}, LeadStatusContacted, true},
-		{"a note an agent wrote", leadResponseTouch{kind: "note", capturedBy: "agent:a1"}, "", false},
-		{"a note with no author prefix", leadResponseTouch{kind: "note"}, "", false},
+		{"a note a human logged", leadResponseTouch{kind: "note", source: "manual", capturedBy: "human:u1"}, LeadStatusContacted, true},
+		{"a note an agent wrote", leadResponseTouch{kind: "note", source: "manual", capturedBy: "agent:a1"}, "", false},
+		{"an imported note under the operator's identity", leadResponseTouch{kind: "note", source: "flip:hubspot:a1", capturedBy: "human:op"}, "", false},
 	}
 	for _, tc := range cases {
 		got, ok := ladderStepFor(tc.t)

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -239,17 +239,24 @@ func (s *Store) RecordLeadFirstResponse(ctx context.Context, leadID ids.LeadID, 
 	return set, err
 }
 
-// isFirstResponseActivity decides whether an outbound activity captured by
-// this actor is a genuine response (formulas §18.1) rather than a
-// cold-outbound auto-touch: a human's outbound always is; an agent's counts
-// only when the lead had already written in — a touch with nothing to
-// respond to is the anti-pollution case §2 names.
-func isFirstResponseActivity(direction, capturedBy string, hadInbound bool) bool {
-	if direction != "outbound" {
-		return false
-	}
-	if strings.HasPrefix(capturedBy, string(principal.PrincipalHuman)+":") {
+// isFirstResponseActivity decides whether a captured activity is a genuine
+// response (formulas §18.1) rather than a cold-outbound auto-touch: a
+// human's outbound always is; an agent's counts only when the lead had
+// already written in — a touch with nothing to respond to is the
+// anti-pollution case §2 names. A note a rep typed into the composer
+// (humanLoggedNote) counts too, and for the same reason it walks the
+// ladder: it records outreach that happened off-system, and a lead the
+// stepper shows as Contacted must not go on to breach the first-response
+// target as if nobody had answered.
+func isFirstResponseActivity(t leadResponseTouch) bool {
+	if humanLoggedNote(t) {
 		return true
 	}
-	return hadInbound
+	if t.direction != "outbound" {
+		return false
+	}
+	if strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":") {
+		return true
+	}
+	return t.hadInbound
 }

--- a/backend/internal/modules/people/leadsla_test.go
+++ b/backend/internal/modules/people/leadsla_test.go
@@ -55,20 +55,23 @@ func TestLeadSLAFieldsFollowTheClock(t *testing.T) {
 
 // What counts as a first response (§18.1): a human's outbound always; an
 // agent's only when the lead had already written in — a cold touch with
-// nothing to respond to is not a response.
+// nothing to respond to is not a response. A note counts exactly when the
+// ladder counts it (humanLoggedNote): typed by a human, source manual.
 func TestIsFirstResponseActivity(t *testing.T) {
 	cases := map[string]struct {
-		direction, by string
-		hadInbound    bool
-		want          bool
+		touch leadResponseTouch
+		want  bool
 	}{
-		"human outbound":                  {"outbound", "human:u1", false, true},
-		"agent reply to an inbound":       {"outbound", "agent:sdr", true, true},
-		"agent cold outbound":             {"outbound", "agent:sdr", false, false},
-		"inbound is the lead's, not ours": {"inbound", "human:u1", false, false},
+		"human outbound":                  {leadResponseTouch{direction: "outbound", capturedBy: "human:u1"}, true},
+		"agent reply to an inbound":       {leadResponseTouch{direction: "outbound", capturedBy: "agent:sdr", hadInbound: true}, true},
+		"agent cold outbound":             {leadResponseTouch{direction: "outbound", capturedBy: "agent:sdr"}, false},
+		"inbound is the lead's, not ours": {leadResponseTouch{direction: "inbound", capturedBy: "human:u1"}, false},
+		"a rep's composer note":           {leadResponseTouch{kind: "note", source: "manual", capturedBy: "human:u1"}, true},
+		"an imported note":                {leadResponseTouch{kind: "note", source: "flip:hubspot:a1", capturedBy: "human:op"}, false},
+		"an agent's note":                 {leadResponseTouch{kind: "note", source: "manual", capturedBy: "agent:sdr"}, false},
 	}
 	for name, tc := range cases {
-		if got := isFirstResponseActivity(tc.direction, tc.by, tc.hadInbound); got != tc.want {
+		if got := isFirstResponseActivity(tc.touch); got != tc.want {
 			t.Errorf("%s: got %t, want %t", name, got, tc.want)
 		}
 	}

--- a/backend/internal/modules/people/leadslaworkflow.go
+++ b/backend/internal/modules/people/leadslaworkflow.go
@@ -59,7 +59,7 @@ func (w leadFirstResponse) Apply(ctx context.Context, ev workflow.Event, eff wor
 	}
 	applied := false
 	for _, t := range touches {
-		if !isFirstResponseActivity(t.direction, t.capturedBy, t.hadInbound) {
+		if !isFirstResponseActivity(t) {
 			continue
 		}
 		set, err := w.store.RecordLeadFirstResponse(ctx, t.lead, t.occurredAt)
@@ -131,17 +131,18 @@ func (leadStatusLadder) IdempotencyKey(ev workflow.Event) string {
 // system-captured outbound with no prior inbound — a cold sequence mail — is
 // still contact: we reached out, whoever pressed send.
 //
-// A note a HUMAN logged is contact too: the composer is how a rep records "I
-// wrote to them" when the mail itself was not captured, and refusing the step
-// would leave a worked lead reading as untouched. Human only — an agent's or
-// import's note asserts no outreach, and a note never reaches engagement,
-// because writing about a lead is not the lead writing back.
+// A note a HUMAN typed into the composer is contact too: it is how a rep
+// records "I wrote to them" when the mail itself was not captured, and
+// refusing the step would leave a worked lead reading as untouched. The
+// source=manual guard keeps every import out — a flip-cutover note arrives
+// stamped with the OPERATOR's human identity (compose/flipwriters.go), and
+// replaying history must not walk today's ladder. A note never reaches
+// engagement: writing about a lead is not the lead writing back.
 func ladderStepFor(t leadResponseTouch) (LeadStatus, bool) {
 	switch {
 	case t.direction == "inbound", t.kind == "meeting" && (t.meetingStatus == "booked" || t.meetingStatus == "held"):
 		return LeadStatusEngaged, true
-	case t.direction == "outbound",
-		t.kind == "note" && strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":"):
+	case t.direction == "outbound", humanLoggedNote(t):
 		return LeadStatusContacted, true
 	}
 	return "", false
@@ -158,6 +159,20 @@ type leadResponseTouch struct {
 	hadInbound    bool
 	kind          string
 	meetingStatus string
+	source        string
+}
+
+// activitySourceManual is the activity `source` the Log composer stamps: the
+// marker that a person typed the entry, where an import or sync stamps its
+// provenance instead.
+const activitySourceManual = "manual"
+
+// humanLoggedNote is the ONE spelling of "a rep typed this note into the
+// composer" — the ladder's contact arm and the first-response rule
+// (isFirstResponseActivity) both read it, so they cannot drift apart.
+func humanLoggedNote(t leadResponseTouch) bool {
+	return t.kind == "note" && t.source == activitySourceManual &&
+		strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":")
 }
 
 // leadResponseTouches answers which leads the activity is linked to, with
@@ -172,7 +187,7 @@ func (s *Store) leadResponseTouches(ctx context.Context, activityID ids.Activity
 			               WHERE li.lead_id = l.lead_id AND ai.direction = 'inbound'
 			                 AND ai.archived_at IS NULL AND `+auth.ActivityAvailableClause("ai")+`
 			                 AND ai.occurred_at < a.occurred_at),
-			       a.kind, coalesce(a.meeting_status, '')
+			       a.kind, coalesce(a.meeting_status, ''), a.source
 			FROM activity_link l JOIN activity a ON a.id = l.activity_id
 			WHERE l.activity_id = $1 AND l.lead_id IS NOT NULL AND a.archived_at IS NULL
 			  AND `+auth.ActivityAvailableClause("a"), activityID)
@@ -182,7 +197,7 @@ func (s *Store) leadResponseTouches(ctx context.Context, activityID ids.Activity
 		defer rows.Close()
 		for rows.Next() {
 			var t leadResponseTouch
-			if err := rows.Scan(&t.lead, &t.direction, &t.capturedBy, &t.occurredAt, &t.hadInbound, &t.kind, &t.meetingStatus); err != nil {
+			if err := rows.Scan(&t.lead, &t.direction, &t.capturedBy, &t.occurredAt, &t.hadInbound, &t.kind, &t.meetingStatus, &t.source); err != nil {
 				return err
 			}
 			out = append(out, t)

--- a/backend/internal/modules/people/leadslaworkflow.go
+++ b/backend/internal/modules/people/leadslaworkflow.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -129,11 +130,18 @@ func (leadStatusLadder) IdempotencyKey(ev workflow.Event) string {
 // booked/held meeting is engagement; any other outbound touch is contact. A
 // system-captured outbound with no prior inbound — a cold sequence mail — is
 // still contact: we reached out, whoever pressed send.
+//
+// A note a HUMAN logged is contact too: the composer is how a rep records "I
+// wrote to them" when the mail itself was not captured, and refusing the step
+// would leave a worked lead reading as untouched. Human only — an agent's or
+// import's note asserts no outreach, and a note never reaches engagement,
+// because writing about a lead is not the lead writing back.
 func ladderStepFor(t leadResponseTouch) (LeadStatus, bool) {
 	switch {
 	case t.direction == "inbound", t.kind == "meeting" && (t.meetingStatus == "booked" || t.meetingStatus == "held"):
 		return LeadStatusEngaged, true
-	case t.direction == "outbound":
+	case t.direction == "outbound",
+		t.kind == "note" && strings.HasPrefix(t.capturedBy, string(principal.PrincipalHuman)+":"):
 		return LeadStatusContacted, true
 	}
 	return "", false

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useEffect, useId, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -1182,6 +1182,36 @@ type LeadTab = (typeof LEAD_TABS)[number];
 // LeadScreen — no new fetches, no behavior change from the pre-tab layout;
 // the promote modal's open/trigger/note state stays lifted in the parent so
 // it survives a tab switch away and back.
+// The status ladder climbs a few seconds AFTER a logged touch: the workflow
+// runs off the outbox, in the worker, not inside the POST. Without a delayed
+// re-read the stepper keeps the old status until a manual reload — which
+// reads as "logging did nothing". Three staggered re-reads cover the
+// relay+workflow latency without polling forever; unmounting cancels them.
+function useLadderRefresh(id: string): () => void {
+  const queryClient = useQueryClient();
+  const timers = useRef<number[]>([]);
+  useEffect(
+    () => () => {
+      for (const timer of timers.current) {
+        window.clearTimeout(timer);
+      }
+    },
+    [],
+  );
+  return () => {
+    for (const delay of [1500, 4000, 8000]) {
+      timers.current.push(
+        window.setTimeout(() => {
+          queryClient.invalidateQueries({ queryKey: ["lead", id] });
+          queryClient.invalidateQueries({
+            queryKey: ["record-history", "lead", id],
+          });
+        }, delay),
+      );
+    }
+  };
+}
+
 function LeadOverviewPane({
   lead,
   id,
@@ -1202,6 +1232,7 @@ function LeadOverviewPane({
   // Qualify turns a mirrored lead into a person — a write the incumbent mirror
   // refuses (unsupported_by_sor), so the verbs are hidden in overlay.
   const overlay = useSorMode() === "overlay";
+  const refreshAfterTouch = useLadderRefresh(id);
   return (
     <>
       {/* A promoted lead's page leads with what the promotion did — the
@@ -1221,7 +1252,11 @@ function LeadOverviewPane({
       {/* The composer follows the facts so opening a lead answers "what
           should I do" before asking the rep to type. */}
       {!lead.archived_at && !overlay && (
-        <LogActivity entityType="lead" entityId={id} />
+        <LogActivity
+          entityType="lead"
+          entityId={id}
+          onLogged={refreshAfterTouch}
+        />
       )}
       <CustomFieldsCard object="lead" record={lead} />
     </>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1203,6 +1203,7 @@ function useLadderRefresh(id: string): () => void {
       timers.current.push(
         window.setTimeout(() => {
           queryClient.invalidateQueries({ queryKey: ["lead", id] });
+          queryClient.invalidateQueries({ queryKey: ["leads"] });
           queryClient.invalidateQueries({
             queryKey: ["record-history", "lead", id],
           });
@@ -1220,6 +1221,7 @@ function LeadOverviewPane({
   onQualify,
   onDisqualify,
   onLifecycleChanged,
+  onTouchLogged,
 }: Readonly<{
   lead: Lead;
   id: string;
@@ -1228,11 +1230,14 @@ function LeadOverviewPane({
   onQualify: () => void;
   onDisqualify: () => void;
   onLifecycleChanged: () => void;
+  // Owned by LeadScreen, ABOVE the tab switch: the refresh timers this
+  // schedules must survive this pane unmounting when the reader flips to
+  // History mid-climb.
+  onTouchLogged: () => void;
 }>) {
   // Qualify turns a mirrored lead into a person — a write the incumbent mirror
   // refuses (unsupported_by_sor), so the verbs are hidden in overlay.
   const overlay = useSorMode() === "overlay";
-  const refreshAfterTouch = useLadderRefresh(id);
   return (
     <>
       {/* A promoted lead's page leads with what the promotion did — the
@@ -1252,11 +1257,7 @@ function LeadOverviewPane({
       {/* The composer follows the facts so opening a lead answers "what
           should I do" before asking the rep to type. */}
       {!lead.archived_at && !overlay && (
-        <LogActivity
-          entityType="lead"
-          entityId={id}
-          onLogged={refreshAfterTouch}
-        />
+        <LogActivity entityType="lead" entityId={id} onLogged={onTouchLogged} />
       )}
       <CustomFieldsCard object="lead" record={lead} />
     </>
@@ -1430,6 +1431,7 @@ function LeadDialogs({
 }
 
 export function LeadScreen({ id }: Readonly<{ id: string }>) {
+  const refreshAfterTouch = useLadderRefresh(id);
   const t = useT();
   const cf = useObjectCustomFields("lead");
   const queryClient = useQueryClient();
@@ -1579,6 +1581,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
                   queryClient.invalidateQueries({ queryKey: ["leads"] });
                   queryClient.invalidateQueries({ queryKey: ["lead", id] });
                 }}
+                onTouchLogged={refreshAfterTouch}
               />
             )}
             <LeadDialogs

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -322,7 +322,12 @@ export function LogActivityForm({
 export function LogActivity({
   entityType,
   entityId,
-}: Readonly<{ entityType: EntityKind; entityId: string }>) {
+  onLogged,
+}: Readonly<{
+  entityType: EntityKind;
+  entityId: string;
+  onLogged?: () => void;
+}>) {
   const t = useT();
   // Logging an activity writes to a mirrored record; in overlay every write
   // answers unsupported_by_sor, so the form would only fail on submit. Guarded
@@ -334,7 +339,11 @@ export function LogActivity({
   }
   return (
     <Card className="card-stack" title={t("log.title")} sub={t("log.sub")}>
-      <LogActivityForm entityType={entityType} entityId={entityId} />
+      <LogActivityForm
+        entityType={entityType}
+        entityId={entityId}
+        onLogged={onLogged}
+      />
     </Card>
   );
 }


### PR DESCRIPTION
Follow-up to #1911, from Lars's testing: "doesn't work" and "why only meeting? a note could be that I wrote an email".

**The lead had actually moved** — his meeting had set it Engaged seconds after logging — but the page never re-reads the lead after a logged touch, so the stepper kept the stale status until a manual reload. And he's right about notes.

1. **A note a rep types into the composer now earns Contacted.** The rule is one function, `humanLoggedNote` (kind note ∧ source manual ∧ captured_by `human:`), read by BOTH the ladder and the first-response check, so a lead shown as Contacted can't still breach the response target as if nobody answered. Imports stay out — a flip-cutover note lands under the operator's identity but with provenance source, never `manual` (review finding). An agent's note earns nothing; a note never reaches Engaged.
2. **The stepper shows the climb without a reload.** `useLadderRefresh` re-reads the lead, the list and the history at 1.5s/4s/8s after a logged touch — owned by `LeadScreen`, above the tab switch, so flipping to History mid-climb doesn't cancel the timers (review finding); cancelled on unmount.

Tests: `ladderStepFor`/`isFirstResponseActivity` tables incl. the imported-note and agent-note refusals; a compose integration test driving a note through the real activities writer → ladder workflow → `contacted`.

Codex review triaged: import-cutover misclassification and SLA non-resolution fixed here; History-tab timer cancellation fixed here; list-query invalidation added.

Gates locally: `make check-backend`, `make check-fe`, craft static, rls-store-path, no-jurisdiction, targeted integration lanes — all green. Browser verification against a single stack follows the merge (the shared-Redis trap #1912 makes a parallel-stack check lie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes a rep’s manual note as Contacted and refreshes the lead stepper after a touch. Previously a note earned nothing and the stepper stayed stale until reload; now a human-logged note advances to Contacted and satisfies first response, and the UI re-reads after 1.5/4/8s.

- Details
  - ladder/SLA: `humanLoggedNote` = kind note ∧ source `manual` ∧ `captured_by` starts with `human:`. It earns Contacted; it never earns Engaged. Agent notes and imported notes (non-`manual` source, even if `captured_by` is a human operator) are ignored. The same rule feeds `isFirstResponseActivity`, so a lead shown as Contacted won’t breach the first-response target.
  - data flow: `leadResponseTouches` now includes `a.source`.
  - UI: `LeadScreen` owns `useLadderRefresh`; it invalidates `["lead", id]`, `["leads"]`, and `["record-history","lead", id]` at 1.5s/4s/8s and cancels on unmount. `LogActivity` accepts `onLogged` and triggers the refresh.
  - tests: expanded table tests for notes (human, agent, imported) and an integration test that drives a manual note through to Contacted.

<sup>Written for commit bc3a61cff642526b4889b8f631819ad790f23055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

