### PR TITLE
feat(reports): a masked amount never reaches an aggregate, an export, or a preview

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -21638,6 +21638,7 @@ components:
           items: { type: object, additionalProperties: true }
           description: Aggregate rows; each carries its own `derivation_url` handle for the exact cell (group keys bound to the row's values).
         total_rows: { type: integer }
+        excluded_by_permission: { type: [integer, 'null'], description: 'Visible rows a field mask withheld from this run — excluded from every aggregate and from the drill-through alike, so the numbers stay reconcilable. Null when no mask applied; 0 means masked but nothing excluded.' }
         generated_at: { type: string, format: date-time }
         derivation_url:
           type: [string, 'null']
@@ -21671,6 +21672,7 @@ components:
           additionalProperties: true
           description: The requested aggregates recomputed over exactly these source rows — equals the explained cell.
         total_rows: { type: integer, description: Source rows matched (rows is capped at the report row limit). }
+        excluded_by_permission: { type: [integer, 'null'], description: 'Visible rows a field mask withheld — the same exclusion the explained report applied, so the drill-through reconciles exactly.' }
         generated_at: { type: string, format: date-time }
 
     # ---- Search ----

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -18,10 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
-
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -304,134 +301,6 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 		plan.aggSelects = append(plan.aggSelects, sel)
 	}
 	return plan, nil
-}
-
-// fetchDerivation executes a compiled plan: the drill-through rows and
-// the aggregate recompute run over the identical WHERE side (validated
-// predicates + the caller's row-scope clause) in one transaction.
-func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec reportSpec, plan derivationPlan, out *derivationOutcome) error {
-	return database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
-		var args []any
-		arg := func(v any) int { args = append(args, v); return len(args) }
-
-		where, err := derivationWhere(ctx, spec, plan, arg)
-		if err != nil {
-			return err
-		}
-		// The identical mask exclusion the report applied (reportmask.go):
-		// the explanation must not out-see the number it explains, and the
-		// withheld count rides the envelope the same way.
-		maskClauses, masked, err := maskExclusionClauses(ctx, spec, arg)
-		if err != nil {
-			return err
-		}
-		if masked {
-			n, err := countMaskExcluded(ctx, tx, spec, where, maskClauses, args)
-			if err != nil {
-				return err
-			}
-			out.ExcludedByPermission = &n
-			where = append(where, maskClauses...)
-		}
-		whereSQL := strings.Join(where, " AND ")
-
-		rowsSQL, rowsArgs, err := bindInstallationZone(ctx, tx, fmt.Sprintf(
-			"SELECT %s FROM %s WHERE %s ORDER BY t.id LIMIT %d",
-			strings.Join(plan.selects, ", "), spec.fromClause(), whereSQL, reportRowLimit), args)
-		if err != nil {
-			return err
-		}
-		pgRows, err := tx.Query(ctx, rowsSQL, rowsArgs...)
-		if err != nil {
-			return fmt.Errorf("derivation %s rows: %w", report, err)
-		}
-		defer pgRows.Close()
-		out.Rows, err = scanDerivationRows(pgRows, plan.columns)
-		if err != nil {
-			return err
-		}
-		pgRows.Close()
-
-		// Recompute the explained aggregates over the identical row set
-		// (count(*) rides along as the honest total behind the capped
-		// rows slice). Values are read positionally, so a caller alias
-		// cannot shadow the total.
-		aggSQL, aggArgs, err := bindInstallationZone(ctx, tx, fmt.Sprintf(
-			"SELECT count(*), %s FROM %s WHERE %s",
-			strings.Join(plan.aggSelects, ", "), spec.fromClause(), whereSQL), args)
-		if err != nil {
-			return err
-		}
-		values := make([]any, len(plan.aggColumns)+1)
-		ptrs := make([]any, len(values))
-		for i := range values {
-			ptrs[i] = &values[i]
-		}
-		if err := tx.QueryRow(ctx, aggSQL, aggArgs...).Scan(ptrs...); err != nil {
-			return fmt.Errorf("derivation %s aggregates: %w", report, err)
-		}
-		total, ok := values[0].(int64)
-		if !ok {
-			return fmt.Errorf("derivation %s: count(*) returned %T, not int64", report, values[0])
-		}
-		out.TotalRows = int(total)
-		for i, name := range plan.aggColumns {
-			out.Aggregates[name] = wireValue(values[i+1])
-		}
-		return nil
-	})
-}
-
-// derivationWhere renders the drill-through's WHERE side: the report's
-// base predicate, the validated equality predicates ("" = SQL NULL), and
-// the caller's row-scope clause (the activity link-walk when the report
-// rides on activities). The identical clause backs both the rows query
-// and the aggregate recompute, so the explanation can never out-see the
-// number it explains.
-func derivationWhere(ctx context.Context, spec reportSpec, plan derivationPlan, arg func(any) int) ([]string, error) {
-	where := []string{spec.baseWhere}
-	for _, p := range plan.preds {
-		if p.isNull {
-			where = append(where, p.expr+" IS NULL")
-		} else {
-			where = append(where, fmt.Sprintf("%s = $%d", p.expr, arg(p.value)))
-		}
-	}
-	var scope string
-	var err error
-	if spec.activityWalk {
-		scope, err = auth.ActivityContentClause(ctx, "t", arg)
-	} else {
-		scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if scope != "" {
-		where = append(where, scope)
-	}
-	return where, nil
-}
-
-// scanDerivationRows materializes the drill-through rows, mapping each
-// column to its wire value positionally.
-func scanDerivationRows(pgRows pgx.Rows, columns []string) ([]map[string]any, error) {
-	var out []map[string]any
-	for pgRows.Next() {
-		values, err := pgRows.Values()
-		if err != nil {
-			return nil, err
-		}
-		row := make(map[string]any, len(columns))
-		for i, col := range columns {
-			row[col] = wireValue(values[i])
-		}
-		out = append(out, row)
-	}
-	if err := pgRows.Err(); err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 // boundPredicate is one field = value binding rendered into the

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -63,14 +63,17 @@ type derivationQuery struct {
 // derivationOutcome is a resolved handle: definition, drill-through
 // rows, and the aggregates recomputed over exactly those rows.
 type derivationOutcome struct {
-	Report      string
-	Definition  string
-	Plan        map[string]any
-	Columns     []string
-	Rows        []map[string]any
-	Aggregates  map[string]any
-	TotalRows   int
-	GeneratedAt time.Time
+	Report     string
+	Definition string
+	Plan       map[string]any
+	Columns    []string
+	Rows       []map[string]any
+	Aggregates map[string]any
+	TotalRows  int
+	// ExcludedByPermission counts the visible rows a field mask withheld —
+	// nil when no mask applied, exactly like the report envelope it explains.
+	ExcludedByPermission *int
+	GeneratedAt          time.Time
 }
 
 // derivationURL mints the handle for one aggregate row (or, with a nil
@@ -314,6 +317,21 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		where, err := derivationWhere(ctx, spec, plan, arg)
 		if err != nil {
 			return err
+		}
+		// The identical mask exclusion the report applied (reportmask.go):
+		// the explanation must not out-see the number it explains, and the
+		// withheld count rides the envelope the same way.
+		maskClauses, masked, err := maskExclusionClauses(ctx, spec, arg)
+		if err != nil {
+			return err
+		}
+		if masked {
+			n, err := countMaskExcluded(ctx, tx, spec, where, maskClauses, args)
+			if err != nil {
+				return err
+			}
+			out.ExcludedByPermission = &n
+			where = append(where, maskClauses...)
 		}
 		whereSQL := strings.Join(where, " AND ")
 

--- a/backend/internal/compose/derivationfetch.go
+++ b/backend/internal/compose/derivationfetch.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The derivation's EXECUTION half: the drill-through rows, the aggregate
+// recompute, and the shared WHERE side that keeps them reading the identical
+// row set. The compile half (plan validation, definition rendering, the
+// handle round-trip) stays in derivation.go.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// fetchDerivation executes a compiled plan: the drill-through rows and
+// the aggregate recompute run over the identical WHERE side (validated
+// predicates + the caller's row-scope clause) in one transaction.
+func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec reportSpec, plan derivationPlan, out *derivationOutcome) error {
+	return database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		var args []any
+		arg := func(v any) int { args = append(args, v); return len(args) }
+
+		where, err := derivationWhere(ctx, spec, plan, arg)
+		if err != nil {
+			return err
+		}
+		// The identical mask exclusion the report applied (reportmask.go):
+		// the explanation must not out-see the number it explains, and the
+		// withheld count rides the envelope the same way.
+		maskClauses, masked, err := maskExclusionClauses(ctx, spec, arg)
+		if err != nil {
+			return err
+		}
+		if masked {
+			n, err := countMaskExcluded(ctx, tx, spec, where, maskClauses, args)
+			if err != nil {
+				return err
+			}
+			out.ExcludedByPermission = &n
+			where = append(where, maskClauses...)
+		}
+		whereSQL := strings.Join(where, " AND ")
+
+		rowsSQL, rowsArgs, err := bindInstallationZone(ctx, tx, fmt.Sprintf(
+			"SELECT %s FROM %s WHERE %s ORDER BY t.id LIMIT %d",
+			strings.Join(plan.selects, ", "), spec.fromClause(), whereSQL, reportRowLimit), args)
+		if err != nil {
+			return err
+		}
+		pgRows, err := tx.Query(ctx, rowsSQL, rowsArgs...)
+		if err != nil {
+			return fmt.Errorf("derivation %s rows: %w", report, err)
+		}
+		defer pgRows.Close()
+		out.Rows, err = scanDerivationRows(pgRows, plan.columns)
+		if err != nil {
+			return err
+		}
+		pgRows.Close()
+
+		// Recompute the explained aggregates over the identical row set
+		// (count(*) rides along as the honest total behind the capped
+		// rows slice). Values are read positionally, so a caller alias
+		// cannot shadow the total.
+		aggSQL, aggArgs, err := bindInstallationZone(ctx, tx, fmt.Sprintf(
+			"SELECT count(*), %s FROM %s WHERE %s",
+			strings.Join(plan.aggSelects, ", "), spec.fromClause(), whereSQL), args)
+		if err != nil {
+			return err
+		}
+		values := make([]any, len(plan.aggColumns)+1)
+		ptrs := make([]any, len(values))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := tx.QueryRow(ctx, aggSQL, aggArgs...).Scan(ptrs...); err != nil {
+			return fmt.Errorf("derivation %s aggregates: %w", report, err)
+		}
+		total, ok := values[0].(int64)
+		if !ok {
+			return fmt.Errorf("derivation %s: count(*) returned %T, not int64", report, values[0])
+		}
+		out.TotalRows = int(total)
+		for i, name := range plan.aggColumns {
+			out.Aggregates[name] = wireValue(values[i+1])
+		}
+		return nil
+	})
+}
+
+// derivationWhere renders the drill-through's WHERE side: the report's
+// base predicate, the validated equality predicates ("" = SQL NULL), and
+// the caller's row-scope clause (the activity link-walk when the report
+// rides on activities). The identical clause backs both the rows query
+// and the aggregate recompute, so the explanation can never out-see the
+// number it explains.
+func derivationWhere(ctx context.Context, spec reportSpec, plan derivationPlan, arg func(any) int) ([]string, error) {
+	where := []string{spec.baseWhere}
+	for _, p := range plan.preds {
+		if p.isNull {
+			where = append(where, p.expr+" IS NULL")
+		} else {
+			where = append(where, fmt.Sprintf("%s = $%d", p.expr, arg(p.value)))
+		}
+	}
+	var scope string
+	var err error
+	if spec.activityWalk {
+		scope, err = auth.ActivityContentClause(ctx, "t", arg)
+	} else {
+		scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return where, nil
+}
+
+// scanDerivationRows materializes the drill-through rows, mapping each
+// column to its wire value positionally.
+func scanDerivationRows(pgRows pgx.Rows, columns []string) ([]map[string]any, error) {
+	var out []map[string]any
+	for pgRows.Next() {
+		values, err := pgRows.Values()
+		if err != nil {
+			return nil, err
+		}
+		row := make(map[string]any, len(columns))
+		for i, col := range columns {
+			row[col] = wireValue(values[i])
+		}
+		out = append(out, row)
+	}
+	if err := pgRows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/compose/filteredexport.go
+++ b/backend/internal/compose/filteredexport.go
@@ -223,8 +223,18 @@ func maskedRowSelects(ctx context.Context, tx pgx.Tx, table string, columns []st
 			conditioned[f] = true
 		}
 	}
+	// Only a conditioned mask naming a REAL column earns the writable-set
+	// bind: a stale mask row naming no column would otherwise register a
+	// parameter no CASE references, which Postgres refuses outright.
+	rendered := false
+	for _, col := range columns {
+		if conditioned[col] {
+			rendered = true
+			break
+		}
+	}
 	writablePos := 0
-	if len(conditioned) > 0 {
+	if rendered {
 		writable, err := auth.WritableSubset(ctx, tx, table, idList)
 		if err != nil {
 			return nil, nil, err

--- a/backend/internal/compose/filteredexport.go
+++ b/backend/internal/compose/filteredexport.go
@@ -41,6 +41,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/collections"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
@@ -174,13 +175,13 @@ func readRowsByID(ctx context.Context, tx pgx.Tx, table string, columns []string
 	if len(idList) == 0 {
 		return nil, nil
 	}
-	selects := make([]string, len(columns))
-	for i, col := range columns {
-		selects[i] = "t." + col
+	selects, args, err := maskedRowSelects(ctx, tx, table, columns, idList)
+	if err != nil {
+		return nil, err
 	}
 	sql := fmt.Sprintf("SELECT %s FROM %s t WHERE t.id = ANY($1) ORDER BY t.id",
 		strings.Join(selects, ", "), table)
-	pgRows, err := tx.Query(ctx, sql, idList)
+	pgRows, err := tx.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("filtered export read %s: %w", table, err)
 	}
@@ -198,6 +199,57 @@ func readRowsByID(ctx context.Context, tx pgx.Tx, table string, columns []string
 		return nil, err
 	}
 	return out, nil
+}
+
+// maskedRowSelects renders the per-column SELECT list with the caller's
+// field masks applied in the statement itself: an always-masked column goes
+// out NULL on every row, a write-authority-conditioned one only on the rows
+// the caller could not change — the identical decision the deal list makes
+// per row, spelled here once for the export and the filter preview, which
+// otherwise print every column of every visible row.
+func maskedRowSelects(ctx context.Context, tx pgx.Tx, table string, columns []string, idList []ids.UUID) ([]string, []any, error) {
+	args := []any{idList}
+	p, err := storekit.Actor(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	alwaysMasked := map[string]bool{}
+	for _, f := range auth.MaskedFields(p, table, true) {
+		alwaysMasked[f] = true
+	}
+	conditioned := map[string]bool{}
+	for _, f := range auth.MaskedFields(p, table, false) {
+		if !alwaysMasked[f] {
+			conditioned[f] = true
+		}
+	}
+	writablePos := 0
+	if len(conditioned) > 0 {
+		writable, err := auth.WritableSubset(ctx, tx, table, idList)
+		if err != nil {
+			return nil, nil, err
+		}
+		writableIDs := make([]ids.UUID, 0, len(writable))
+		for id, ok := range writable {
+			if ok {
+				writableIDs = append(writableIDs, id)
+			}
+		}
+		args = append(args, writableIDs)
+		writablePos = len(args)
+	}
+	selects := make([]string, len(columns))
+	for i, col := range columns {
+		switch {
+		case alwaysMasked[col]:
+			selects[i] = fmt.Sprintf("NULL AS %s", col)
+		case conditioned[col]:
+			selects[i] = fmt.Sprintf("CASE WHEN t.id = ANY($%d) THEN t.%s END AS %s", writablePos, col, col)
+		default:
+			selects[i] = "t." + col
+		}
+	}
+	return selects, args, nil
 }
 
 // renderExport renders one member as the requested open format, reusing the

--- a/backend/internal/compose/imapconnect_standing_integration_test.go
+++ b/backend/internal/compose/imapconnect_standing_integration_test.go
@@ -117,6 +117,12 @@ func TestStandingIMAPConnectTransport(t *testing.T) {
 	mux := crmcontracts.HandlerFromMuxWithBaseURL(srv, chi.NewRouter(), "/v1")
 	post := func(t *testing.T, ctx context.Context, body map[string]any) *httptest.ResponseRecorder {
 		t.Helper()
+		// Every case in this suite is about its own gate; the mail-sharing
+		// acknowledgment is given here once (its refusal has its own suite,
+		// imapconnect_standing_refusals_test.go).
+		if _, set := body["share_acknowledged"]; !set {
+			body["share_acknowledged"] = true
+		}
 		payload, err := json.Marshal(body)
 		if err != nil {
 			t.Fatal(err)

--- a/backend/internal/compose/integration/fieldmask_integration_test.go
+++ b/backend/internal/compose/integration/fieldmask_integration_test.go
@@ -80,3 +80,26 @@ func TestARepReadsEveryDealButNotAnotherTeamsAmount(t *testing.T) {
 		t.Errorf("the admin's read = amount %v masked %v (%v), want the amount", full.AmountMinor, full.MaskedFields, err)
 	}
 }
+
+// The list surface's twin of the report case: a rep whose role lost
+// deal.update owns write authority over NO row, so the mask holds on their
+// own deal too — revoking a verb must never widen what a role reads.
+func TestARevokedUpdateVerbMasksTheRepsOwnAmount(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	mine := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
+	e.WsExec(t, `UPDATE deal SET amount_minor = $2, currency = 'EUR' WHERE id = $1`, mine, int64(250000))
+
+	perms := activityLifecyclePerms
+	perms.Objects = map[string]principal.ObjectGrant{"deal": {Read: true}, "pipeline": {Read: true}}
+	perms.FieldMasks = []principal.FieldMask{{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority}}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	got, err := e.Deals.GetDeal(rep, ids.From[ids.DealKind](mine), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AmountMinor != nil || got.MaskedFields == nil {
+		t.Errorf("own deal without the update verb = amount %v masked %v, want the amount withheld", got.AmountMinor, got.MaskedFields)
+	}
+}

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -481,3 +481,51 @@ func exportCSV(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) [][]string 
 	}
 	return records
 }
+
+// A field mask follows a deal into its export: the CSV row of another team's
+// deal carries an EMPTY amount for a rep whose role masks it, while their own
+// row keeps the figure — the same per-row decision the deal list makes,
+// proven here against the statement the export actually runs.
+func TestFilteredExportWithholdsAMaskedAmount(t *testing.T) {
+	e := SetupSearch(t)
+	f := e.seedFilteredDeals(t)
+	for id, amount := range map[ids.UUID]int64{f.matchOwn: 100000, f.matchOther: 250000} {
+		if _, err := e.Owner.Exec(context.Background(), `UPDATE deal SET amount_minor = $2, currency = 'EUR' WHERE id = $1`, id, amount); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	base := e.AsTeamRep(e.Rep1, e.Team1)
+	actor, _ := principal.Actor(base)
+	actor.Permissions.Objects["deal"] = principal.ObjectGrant{Read: true, Update: true}
+	actor.Permissions.FieldMasks = []principal.FieldMask{
+		{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority},
+	}
+	ctx := principal.WithActor(base, actor)
+
+	result, err := compose.NewFilteredExportWriter(e.Pool).WriteFiltered(
+		ctx, dealEngine(ctx, t, e), commitDeals(), "csv",
+	)
+	if err != nil {
+		t.Fatalf("filtered export: %v", err)
+	}
+	rowIDs := CSVColumn(t, result.Body, "id")
+	amounts := CSVColumn(t, result.Body, "amount_minor")
+	if len(rowIDs) != 2 {
+		t.Fatalf("exported rows = %v, want both matching deals (a deal is readable by every seat)", rowIDs)
+	}
+	for i, id := range rowIDs {
+		switch id {
+		case f.matchOwn.String():
+			if amounts[i] != "100000" {
+				t.Errorf("the rep's own amount = %q, want 100000", amounts[i])
+			}
+		case f.matchOther.String():
+			if amounts[i] != "" {
+				t.Errorf("the other team's amount = %q, want empty — the export printed a masked value", amounts[i])
+			}
+		default:
+			t.Errorf("unexpected row %s", id)
+		}
+	}
+}

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -293,7 +293,7 @@ func reportToolRunner(engine *reportEngine) agents.ReportRunner {
 		if err != nil {
 			return nil, err
 		}
-		return json.Marshal(map[string]any{
+		result := map[string]any{
 			"report":  outcome.Report,
 			"plan":    outcome.Plan,
 			"columns": outcome.Columns,
@@ -304,7 +304,14 @@ func reportToolRunner(engine *reportEngine) agents.ReportRunner {
 			"rows":         outcome.Rows,
 			"total_rows":   len(outcome.Rows),
 			"generated_at": outcome.GeneratedAt,
-		})
+		}
+		// A field mask shrank this run's row set: say so, exactly like the
+		// HTTP envelope does — a reduced total with no signal is the
+		// ambiguity the field exists to prevent, and a model acts on it.
+		if outcome.ExcludedByPermission != nil {
+			result["excluded_by_permission"] = *outcome.ExcludedByPermission
+		}
+		return json.Marshal(result)
 	}
 }
 

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -319,14 +319,18 @@ func (s reportSpec) fromClause() string {
 // Filters/GroupBy/Aggregates carry the EFFECTIVE plan (defaults applied)
 // so the transport can mint derivation handles for exactly what ran.
 type reportOutcome struct {
-	Report      string
-	Plan        map[string]any
-	Filters     map[string]any
-	GroupBy     []string
-	Aggregates  []reportAggregate
-	Columns     []string
-	Rows        []map[string]any
-	GeneratedAt time.Time
+	Report     string
+	Plan       map[string]any
+	Filters    map[string]any
+	GroupBy    []string
+	Aggregates []reportAggregate
+	Columns    []string
+	Rows       []map[string]any
+	// ExcludedByPermission counts the visible rows a field mask withheld from
+	// this run — nil when no mask applied, so the wire can tell "no masking"
+	// from "masked, none excluded".
+	ExcludedByPermission *int
+	GeneratedAt          time.Time
 }
 
 type reportEngine struct {
@@ -358,13 +362,14 @@ func (e *reportEngine) runSpec(ctx context.Context, report string, spec reportSp
 		return reportOutcome{}, err
 	}
 
-	rows, err := e.fetchRows(ctx, report, spec, req, groupBy, selects, columns)
+	rows, excluded, err := e.fetchRows(ctx, report, spec, req, groupBy, selects, columns)
 	if err != nil {
 		return reportOutcome{}, err
 	}
 
 	return reportOutcome{
-		Report: report,
+		ExcludedByPermission: excluded,
+		Report:               report,
 		Plan: map[string]any{
 			"object":     string(spec.entity),
 			"filters":    req.Filters,

--- a/backend/internal/compose/report_fieldmask_integration_test.go
+++ b/backend/internal/compose/report_fieldmask_integration_test.go
@@ -122,3 +122,33 @@ func TestAnAlwaysMaskEmptiesTheAggregateAndSaysSo(t *testing.T) {
 		t.Errorf("excluded_by_permission = %v, want 2 — both visible rows withheld", result.ExcludedByPermission)
 	}
 }
+
+// Write authority is the object's update verb AND the row arm. A rep whose
+// role lost deal.update still OWNS rows; the mask must not lift on them —
+// otherwise revoking the verb would WIDEN what the rep reads out of a sum.
+func TestARevokedUpdateVerbKeepsTheMaskOnTheRepsOwnRows(t *testing.T) {
+	e := setupForecast(t)
+	own := int64(100_000)
+	e.seedOpenDeal(t, "Mine", 20, &e.Rep1, &own, nil)
+
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	rep := principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		TeamIDs: []ids.UUID{e.Team1},
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"deal":                  {Read: true},
+				"installation_settings": {Read: true},
+			},
+			RowScope:   principal.RowScopeTeam,
+			FieldMasks: []principal.FieldMask{{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority}},
+		},
+	})
+	result := e.runReport(rep, t, "open-deals-per-company", sumAmountBody())
+	if len(result.Rows) != 0 {
+		t.Errorf("rows = %v, want none — without the update verb the rep holds write authority over no row", result.Rows)
+	}
+	if result.ExcludedByPermission == nil || *result.ExcludedByPermission != 1 {
+		t.Errorf("excluded_by_permission = %v, want 1", result.ExcludedByPermission)
+	}
+}

--- a/backend/internal/compose/report_fieldmask_integration_test.go
+++ b/backend/internal/compose/report_fieldmask_integration_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// A field mask meeting the report engine: a rep whose role masks another
+// team's deal amount must not read those amounts back out of a SUM, and the
+// drill-through that explains the sum must show exactly the rows inside it.
+// Masked rows are EXCLUDED — from the aggregate and the explanation alike —
+// and the envelope carries the withheld count as excluded_by_permission, so
+// a smaller total reads as governed rather than as missing data.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// maskedDealReader mints a rep on team1 whose role masks deal.amount_minor
+// under the given condition — deal update is granted because the write arm is
+// what lifts an outside_write_authority mask on the rep's own rows.
+func (e *forecastEnv) maskedDealReader(cond principal.MaskCondition) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		TeamIDs: []ids.UUID{e.Team1},
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"deal":                  {Read: true, Update: true},
+				"installation_settings": {Read: true},
+			},
+			RowScope:   principal.RowScopeTeam,
+			FieldMasks: []principal.FieldMask{{Object: "deal", Field: "amount_minor", Condition: cond}},
+		},
+	})
+}
+
+func sumAmountBody() string {
+	return `{"group_by":["currency"],"aggregates":[{"fn":"sum","field":"amount_minor","as":"total"}]}`
+}
+
+func asInt(t *testing.T, v any) int64 {
+	t.Helper()
+	n, ok := v.(json.Number)
+	if !ok {
+		t.Fatalf("value %v (%T) is not a number", v, v)
+	}
+	i, err := n.Int64()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return i
+}
+
+func TestAMaskedAmountNeverReachesAReportAggregate(t *testing.T) {
+	e := setupForecast(t)
+	own := int64(100_000)
+	other := int64(250_000)
+	mine := e.seedOpenDeal(t, "Mine", 20, &e.Rep1, &own, nil)
+	theirs := e.seedOpenDeal(t, "Theirs", 20, &e.Rep3, &other, nil)
+
+	rep := e.maskedDealReader(principal.MaskOutsideWriteAuthority)
+	result := e.runReport(rep, t, "open-deals-per-company", sumAmountBody())
+	if len(result.Rows) != 1 {
+		t.Fatalf("rows = %v, want the one EUR group", result.Rows)
+	}
+	if got := asInt(t, result.Rows[0]["total"]); got != own {
+		t.Errorf("masked rep's sum = %d, want only their own %d — the masked amount leaked into the aggregate", got, own)
+	}
+	if result.ExcludedByPermission == nil || *result.ExcludedByPermission != 1 {
+		t.Errorf("excluded_by_permission = %v, want 1 — the withheld row is counted, never silently dropped", result.ExcludedByPermission)
+	}
+
+	// The drill-through explains the SAME row set: the masked deal is absent
+	// and the recomputed aggregate equals the number it explains.
+	derivation := e.explainReport(rep, t, "open-deals-per-company", result.DerivationURL)
+	if got := asInt(t, derivation.Aggregates["total"]); got != own {
+		t.Errorf("derivation total = %d, want %d — the explanation out-saw the report", got, own)
+	}
+	if derivation.ExcludedByPermission == nil || *derivation.ExcludedByPermission != 1 {
+		t.Errorf("derivation excluded_by_permission = %v, want 1", derivation.ExcludedByPermission)
+	}
+	for _, row := range derivation.Rows {
+		if row["id"] == theirs.String() {
+			t.Errorf("the drill-through printed the masked deal %s", theirs)
+		}
+	}
+	if len(derivation.Rows) != 1 || derivation.Rows[0]["id"] != mine.String() {
+		t.Errorf("drill-through rows = %v, want exactly the rep's own deal %s", derivation.Rows, mine)
+	}
+
+	// An unmasked admin reads the whole workspace, and the envelope says no
+	// mask applied (null, not 0).
+	all := e.runReport(e.Admin(), t, "open-deals-per-company", sumAmountBody())
+	if got := asInt(t, all.Rows[0]["total"]); got != own+other {
+		t.Errorf("admin sum = %d, want %d", got, own+other)
+	}
+	if all.ExcludedByPermission != nil {
+		t.Errorf("admin excluded_by_permission = %v, want absent — no mask applied", *all.ExcludedByPermission)
+	}
+}
+
+func TestAnAlwaysMaskEmptiesTheAggregateAndSaysSo(t *testing.T) {
+	e := setupForecast(t)
+	own := int64(100_000)
+	other := int64(250_000)
+	e.seedOpenDeal(t, "Mine", 20, &e.Rep1, &own, nil)
+	e.seedOpenDeal(t, "Theirs", 20, &e.Rep3, &other, nil)
+
+	rep := e.maskedDealReader(principal.MaskAlways)
+	result := e.runReport(rep, t, "open-deals-per-company", sumAmountBody())
+	if len(result.Rows) != 0 {
+		t.Errorf("rows = %v, want none — every row's amount is withheld", result.Rows)
+	}
+	if result.ExcludedByPermission == nil || *result.ExcludedByPermission != 2 {
+		t.Errorf("excluded_by_permission = %v, want 2 — both visible rows withheld", result.ExcludedByPermission)
+	}
+}

--- a/backend/internal/compose/report_fieldmask_integration_test.go
+++ b/backend/internal/compose/report_fieldmask_integration_test.go
@@ -44,6 +44,7 @@ func sumAmountBody() string {
 	return `{"group_by":["currency"],"aggregates":[{"fn":"sum","field":"amount_minor","as":"total"}]}`
 }
 
+//craft:ignore naked-any the wire rows decode to map[string]any (decodeWire's UseNumber shape); this is the one coercion seam
 func asInt(t *testing.T, v any) int64 {
 	t.Helper()
 	n, ok := v.(json.Number)

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -172,20 +172,22 @@ func (e *forecastEnv) Admin() context.Context {
 }
 
 type reportResultWire struct {
-	Report        string           `json:"report"`
-	Columns       []string         `json:"columns"`
-	Rows          []map[string]any `json:"rows"`
-	TotalRows     int              `json:"total_rows"`
-	DerivationURL string           `json:"derivation_url"`
+	Report               string           `json:"report"`
+	Columns              []string         `json:"columns"`
+	Rows                 []map[string]any `json:"rows"`
+	TotalRows            int              `json:"total_rows"`
+	ExcludedByPermission *int             `json:"excluded_by_permission"`
+	DerivationURL        string           `json:"derivation_url"`
 }
 
 type derivationWire struct {
-	Report     string           `json:"report"`
-	Definition string           `json:"definition"`
-	Columns    []string         `json:"columns"`
-	Rows       []map[string]any `json:"rows"`
-	Aggregates map[string]any   `json:"aggregates"`
-	TotalRows  int              `json:"total_rows"`
+	Report               string           `json:"report"`
+	Definition           string           `json:"definition"`
+	Columns              []string         `json:"columns"`
+	Rows                 []map[string]any `json:"rows"`
+	Aggregates           map[string]any   `json:"aggregates"`
+	TotalRows            int              `json:"total_rows"`
+	ExcludedByPermission *int             `json:"excluded_by_permission"`
 }
 
 //craft:ignore naked-any decodeWire is the one JSON unmarshal seam; the wire structs above give it shape

--- a/backend/internal/compose/reporthandlers.go
+++ b/backend/internal/compose/reporthandlers.go
@@ -47,13 +47,14 @@ func (h reportHandlers) RunReport(w http.ResponseWriter, r *http.Request, report
 	resultURL := derivationURL(outcome.Report, outcome.Filters, nil, outcome.Aggregates, nil)
 	totalRows := len(rows)
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReportResult{
-		Report:        outcome.Report,
-		Plan:          outcome.Plan,
-		Columns:       outcome.Columns,
-		Rows:          rows,
-		TotalRows:     &totalRows,
-		GeneratedAt:   &outcome.GeneratedAt,
-		DerivationUrl: &resultURL,
+		Report:               outcome.Report,
+		Plan:                 outcome.Plan,
+		Columns:              outcome.Columns,
+		Rows:                 rows,
+		TotalRows:            &totalRows,
+		ExcludedByPermission: outcome.ExcludedByPermission,
+		GeneratedAt:          &outcome.GeneratedAt,
+		DerivationUrl:        &resultURL,
 	})
 }
 
@@ -76,13 +77,14 @@ func (h reportHandlers) ExplainReport(w http.ResponseWriter, r *http.Request, re
 	rows := make([]map[string]interface{}, len(outcome.Rows))
 	copy(rows, outcome.Rows)
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReportDerivation{
-		Report:      outcome.Report,
-		Definition:  outcome.Definition,
-		Plan:        outcome.Plan,
-		Columns:     outcome.Columns,
-		Rows:        rows,
-		Aggregates:  &outcome.Aggregates,
-		TotalRows:   &outcome.TotalRows,
-		GeneratedAt: &outcome.GeneratedAt,
+		Report:               outcome.Report,
+		Definition:           outcome.Definition,
+		Plan:                 outcome.Plan,
+		Columns:              outcome.Columns,
+		Rows:                 rows,
+		Aggregates:           &outcome.Aggregates,
+		TotalRows:            &outcome.TotalRows,
+		ExcludedByPermission: outcome.ExcludedByPermission,
+		GeneratedAt:          &outcome.GeneratedAt,
 	})
 }

--- a/backend/internal/compose/reportmask.go
+++ b/backend/internal/compose/reportmask.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Field masks meeting the report engine. A mask withholds a column of a row
+// (deals' amount for a rep outside the owning team, ADR-level rule shipped
+// with the field-mask work); an aggregate over that column would disclose it
+// through the total, and a drill-through would print it. The report engine
+// therefore EXCLUDES masked rows — from the aggregate and from the
+// drill-through alike, so "Explain This Number" keeps reconciling exactly —
+// and reports how many visible rows were withheld as excluded_by_permission,
+// so a smaller number reads as governed, never as missing data.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// maskExclusionClauses renders, per masked column of the spec's entity, the
+// predicate for the rows the caller may still aggregate — "" clauses (no mask
+// for this caller) yield (nil, false). The clauses AND into the query's WHERE;
+// their negation is the excluded_by_permission count's filter.
+func maskExclusionClauses(ctx context.Context, spec reportSpec, arg func(any) int) ([]string, bool, error) {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return nil, false, fmt.Errorf("compose: report mask check without an actor")
+	}
+	seen := map[string]bool{}
+	var clauses []string
+	for _, m := range p.Permissions.FieldMasks {
+		if m.Object != string(spec.entity) || seen[m.Field] {
+			continue
+		}
+		seen[m.Field] = true
+		clause, applies, err := auth.MaskExcludedClause(ctx, string(spec.entity), m.Field, "t", arg)
+		if err != nil {
+			return nil, false, err
+		}
+		if !applies || clause == "" {
+			continue
+		}
+		clauses = append(clauses, clause)
+	}
+	return clauses, len(clauses) > 0, nil
+}
+
+// countMaskExcluded answers how many rows of the report's visible base set the
+// mask withheld: the same FROM and WHERE minus the mask clauses, counting the
+// rows that fail them. Every bind of the main statement is referenced here
+// too, so one args slice serves both.
+func countMaskExcluded(ctx context.Context, tx pgx.Tx, spec reportSpec, baseWhere []string, maskClauses []string, args []any) (int, error) {
+	where := strings.Join(baseWhere, " AND ")
+	sql := fmt.Sprintf("SELECT count(*) FILTER (WHERE NOT (%s)) FROM %s WHERE %s",
+		strings.Join(maskClauses, " AND "), spec.fromClause(), where)
+	sql, args, err := bindInstallationZone(ctx, tx, sql, args)
+	if err != nil {
+		return 0, err
+	}
+	var excluded int64
+	if err := tx.QueryRow(ctx, sql, args...).Scan(&excluded); err != nil {
+		return 0, fmt.Errorf("report mask exclusion count: %w", err)
+	}
+	return int(excluded), nil
+}

--- a/backend/internal/compose/reportsql.go
+++ b/backend/internal/compose/reportsql.go
@@ -31,14 +31,31 @@ const reportRowLimit = 1000
 // fetchRows assembles the WHERE side (validated filters + the caller's
 // row-scope clause), runs the plan inside the workspace-bound
 // transaction, and shapes each row for the wire.
-func (e *reportEngine) fetchRows(ctx context.Context, report string, spec reportSpec, req reportRequest, groupBy, selects, columns []string) ([]map[string]any, error) {
+func (e *reportEngine) fetchRows(ctx context.Context, report string, spec reportSpec, req reportRequest, groupBy, selects, columns []string) ([]map[string]any, *int, error) {
 	var rows []map[string]any
+	var excluded *int
 	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		where, err := buildReportWhere(ctx, spec, req, arg)
 		if err != nil {
 			return err
+		}
+		// Field masks exclude their rows from the whole statement — the
+		// aggregate and the drill-through must keep reading the identical
+		// row set (reportmask.go) — and the withheld count rides the
+		// envelope as excluded_by_permission.
+		maskClauses, masked, err := maskExclusionClauses(ctx, spec, arg)
+		if err != nil {
+			return err
+		}
+		if masked {
+			n, err := countMaskExcluded(ctx, tx, spec, where, maskClauses, args)
+			if err != nil {
+				return err
+			}
+			excluded = &n
+			where = append(where, maskClauses...)
 		}
 		sql, args, err := bindInstallationZone(ctx, tx, reportSQL(spec, selects, where, groupBy), args)
 		if err != nil {
@@ -53,9 +70,9 @@ func (e *reportEngine) fetchRows(ctx context.Context, report string, spec report
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return rows, nil
+	return rows, excluded, nil
 }
 
 // buildReportWhere assembles the WHERE side — the spec's base predicate,

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19724,8 +19724,11 @@ type ReportDerivation struct {
 	Columns    []string                `json:"columns"`
 
 	// Definition Plain-language reading of the exact filter + group + aggregate that produced the number.
-	Definition  string     `json:"definition"`
-	GeneratedAt *time.Time `json:"generated_at,omitempty"`
+	Definition string `json:"definition"`
+
+	// ExcludedByPermission Visible rows a field mask withheld — the same exclusion the explained report applied, so the drill-through reconciles exactly.
+	ExcludedByPermission *int       `json:"excluded_by_permission,omitempty"`
+	GeneratedAt          *time.Time `json:"generated_at,omitempty"`
 
 	// Plan The validated predicate/group/aggregate set that was resolved.
 	Plan   map[string]interface{} `json:"plan"`
@@ -19743,8 +19746,11 @@ type ReportResult struct {
 	Columns []string `json:"columns"`
 
 	// DerivationUrl Handle for "Explain This Number" drill-through to source rows (`GET /reports/{report}/derivation`); the result-level handle explains the whole filtered set, each row's handle the single cell.
-	DerivationUrl *string    `json:"derivation_url,omitempty"`
-	GeneratedAt   *time.Time `json:"generated_at,omitempty"`
+	DerivationUrl *string `json:"derivation_url,omitempty"`
+
+	// ExcludedByPermission Visible rows a field mask withheld from this run — excluded from every aggregate and from the drill-through alike, so the numbers stay reconcilable. Null when no mask applied; 0 means masked but nothing excluded.
+	ExcludedByPermission *int       `json:"excluded_by_permission,omitempty"`
+	GeneratedAt          *time.Time `json:"generated_at,omitempty"`
 
 	// Plan The validated query plan that was executed (shown before/after run).
 	Plan   map[string]interface{} `json:"plan"`

--- a/backend/internal/modules/agents/results.go
+++ b/backend/internal/modules/agents/results.go
@@ -437,6 +437,10 @@ type RunReportResult struct {
 	TotalRows     *int    `json:"total_rows,omitempty"`
 	DerivationURL *string `json:"derivation_url,omitempty"`
 	GeneratedAt   *string `json:"generated_at,omitempty"`
+	// ExcludedByPermission is present when a field mask withheld rows from
+	// this run — the count of visible rows excluded from every aggregate, so
+	// a smaller total reads as governed rather than as missing data.
+	ExcludedByPermission *int `json:"excluded_by_permission,omitempty"`
 }
 
 // marshalResult encodes a typed seam answer for the wire, carrying the seam's

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -4608,6 +4608,9 @@
           "derivation_url": {
             "type": "string"
           },
+          "excluded_by_permission": {
+            "type": "integer"
+          },
           "generated_at": {
             "type": "string"
           },

--- a/backend/internal/platform/auth/fieldmask.go
+++ b/backend/internal/platform/auth/fieldmask.go
@@ -82,6 +82,14 @@ func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.U
 		}
 		return out, nil
 	}
+	// The row arm alone is not write authority: a caller whose role lost the
+	// object's update verb can still OWN a row, and a mask conditioned on
+	// write authority must not lift for them. EnsureWritable never sees this
+	// case because its handlers Require(update) first; this helper is asked
+	// bare, so it asks itself.
+	if !p.Permissions.Allows(table, principal.ActionUpdate) {
+		return out, nil
+	}
 	if len(rowIDs) == 0 {
 		return out, nil
 	}
@@ -132,6 +140,13 @@ func MaskExcludedClause(ctx context.Context, object, field, alias string, arg fu
 		if m.Condition != principal.MaskOutsideWriteAuthority {
 			// MaskAlways (and any future stricter condition this switch does
 			// not know) withholds the column on every row: fail closed.
+			return "FALSE", true, nil
+		}
+		// Write authority is the object's update verb AND the row arm — a
+		// caller whose role lost the verb owns no write authority anywhere,
+		// however many rows the row arm alone would name (the same pair
+		// WritableSubset asks).
+		if !p.Permissions.Allows(object, principal.ActionUpdate) {
 			return "FALSE", true, nil
 		}
 		if clause == "" {

--- a/backend/internal/platform/auth/fieldmask.go
+++ b/backend/internal/platform/auth/fieldmask.go
@@ -107,3 +107,36 @@ func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.U
 	}
 	return out, rows.Err()
 }
+
+// MaskExcludedClause renders the predicate for the rows on which the caller
+// may READ one maskable column — the filter an AGGREGATE over that column
+// applies, so a sum never includes a value the row itself would withhold and
+// the drill-through that explains the sum shows exactly the rows inside it.
+// Returns ("", false) when no mask names the (object, field) pair for this
+// caller; "FALSE" when a mask withholds the column on every row. The alias
+// names the row like the caller's FROM clause does.
+func MaskExcludedClause(ctx context.Context, object, field, alias string, arg func(any) int) (string, bool, error) {
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	if Unbounded(p) {
+		return "", false, nil
+	}
+	clause, masked := "", false
+	for _, m := range p.Permissions.FieldMasks {
+		if m.Object != object || m.Field != field {
+			continue
+		}
+		masked = true
+		if m.Condition != principal.MaskOutsideWriteAuthority {
+			// MaskAlways (and any future stricter condition this switch does
+			// not know) withholds the column on every row: fail closed.
+			return "FALSE", true, nil
+		}
+		if clause == "" {
+			clause = writeAuthorityPredicateAs(p, object, alias, arg)
+		}
+	}
+	return clause, masked, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15746,6 +15746,8 @@ export interface components {
                 [key: string]: unknown;
             }[];
             total_rows?: number;
+            /** @description Visible rows a field mask withheld from this run — excluded from every aggregate and from the drill-through alike, so the numbers stay reconcilable. Null when no mask applied; 0 means masked but nothing excluded. */
+            excluded_by_permission?: number | null;
             /** Format: date-time */
             generated_at?: string;
             /** @description Handle for "Explain This Number" drill-through to source rows (`GET /reports/{report}/derivation`); the result-level handle explains the whole filtered set, each row's handle the single cell. */
@@ -15775,6 +15777,8 @@ export interface components {
             };
             /** @description Source rows matched (rows is capped at the report row limit). */
             total_rows?: number;
+            /** @description Visible rows a field mask withheld — the same exclusion the explained report applied, so the drill-through reconciles exactly. */
+            excluded_by_permission?: number | null;
             /** Format: date-time */
             generated_at?: string;
         };


### PR DESCRIPTION
Part of #1896. The field-mask work (#1895) stopped at the deal read and list; a rep whose role masks another team's amounts could still read them back out of a forecast SUM, a filtered export, or a segment preview.

**Reports + drill-throughs** (`compose/reportmask.go`): masked rows are excluded from the whole statement — the aggregate and its 'Explain This Number' drill-through keep reading the identical row set, so they still reconcile exactly. The envelope carries `excluded_by_permission` on `ReportResult` and `ReportDerivation`: null when no mask applied, an honest count when one did.

**Platform**: `auth.MaskExcludedClause` is the one spelling of 'the rows on which this caller may read one maskable column' — the write arm for an `outside_write_authority` mask, `FALSE` for an always mask.

**Export + preview** (`maskedRowSelects` in `compose/filteredexport.go`): the filtered export and the segment preview null masked columns in the statement itself — an always-masked column goes out NULL on every row, a conditioned one on the rows the caller could not change. The same per-row decision the deal list makes.

**Proven on real Postgres**: a masked rep's sum carries only their own amount with `excluded_by_permission: 1` and a drill-through showing exactly that row; an admin sums everything with the field absent; an always-mask empties the aggregate and says 2; the CSV export prints the rep's own amount and an empty cell for the other team's.

Still open on #1896 (updated there): the org/person 360 pages, briefs and meeting-brief groundings, org rollup, agents' commercial results — surfaces with their own deal SELECTs.

Verified: `make check-backend` and `make check-fe` green; the full compose and compose/integration lanes green under a private template; craft static clean; rls-store-path and no-jurisdiction OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents masked deal amounts from appearing in report aggregates, drill‑throughs, filtered exports, and segment previews. Previously, masked amounts could leak via SUMs/drill‑throughs and exports/previews; now reports exclude masked rows end‑to‑end and exports/previews emit NULL for masked columns, with write authority correctly requiring both update permission and row ownership.

- Reports/drill‑throughs: apply the same mask exclusion to the whole statement; add excluded_by_permission to both result and derivation envelopes. API/types updated in `backend/api/crm.yaml`, `backend/internal/contracts/api_gen.go`, and `frontend/src/api/schema.d.ts`; MCP `run_report` now includes excluded_by_permission.
- Platform/auth: add `auth.MaskExcludedClause` (rows on which the caller may read a maskable column). Fix `WritableSubset` and `MaskExcludedClause` to require the object's update verb AND row arm; `MaskAlways` yields `FALSE`. Ignore conditioned masks that name no real column to avoid unused binds.
- Export/preview: implement per‑column masking in `maskedRowSelects` (always masked → NULL; conditioned → NULL unless the row is writable via `auth.WritableSubset`) so exports/previews match the deal list.
- Refactor: move derivation execution to `backend/internal/compose/derivationfetch.go` with no behavior change.
- Migration: optional UI — display excluded_by_permission; request/response remain backward‑compatible (additive fields only).

<sup>Written for commit b3a607b0194b3ec64f57d5815b29fd46f771b47b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Report aggregates and drill-through results now respect field-level permissions consistently.
  - Filtered exports mask restricted fields, including records outside the viewer’s write authority.
  - Report responses can show how many rows were excluded by permission-based masking.
  - The `run_report` output now supports the optional `excluded_by_permission` count.

- **Bug Fixes**
  - Prevented restricted values from appearing in aggregates, drill-through rows, and filtered exports.
  - Ensured missing update permissions cannot unintentionally reveal masked fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->