### PR TITLE
fix(people): a lead created without an owner stays unassigned (#1907)

### DIFF
--- a/backend/internal/compose/leadqualifydeal.go
+++ b/backend/internal/compose/leadqualifydeal.go
@@ -31,7 +31,10 @@ func (o leadDealOpener) OpenDealForLead(ctx context.Context, tx pgx.Tx, in peopl
 	}
 	deal, err := o.deals.CreateDealTx(ctx, tx, deals.CreateDealInput{
 		Name: in.Name, AmountMinor: in.AmountMinor, Currency: in.Currency,
-		PipelineID: pipelineID, StageID: stageID, OwnerID: in.OwnerID, Source: in.Source,
+		PipelineID: pipelineID, StageID: stageID, Source: in.Source,
+		// The deal inherits the LEAD's owner exactly — an unassigned lead
+		// qualifies into an unassigned deal, not the promoting actor's.
+		OwnerID: in.OwnerID, OwnerExact: true,
 	})
 	if err != nil {
 		return ids.Nil, err

--- a/backend/internal/compose/leadqualifydeal_integration_test.go
+++ b/backend/internal/compose/leadqualifydeal_integration_test.go
@@ -10,6 +10,7 @@ package compose
 // deals store refuses rolls the whole promotion back.
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -193,4 +194,72 @@ func TestQualifyRollsBackWhenTheDealIsRefused(t *testing.T) {
 	if _, err := unwired.QualifyLead(admin, leadID, people.PromoteLeadInput{Trigger: "human_qualify", Deal: &people.QualifyDealInput{}}); !errors.As(err, &notWired) {
 		t.Errorf("unwired qualify-with-deal err = %v, want DealOpenerNotWiredError", err)
 	}
+}
+
+// Ownership rides the qualify exactly: an unassigned lead becomes an
+// unassigned contact AND an unassigned deal — never the promoting actor's —
+// and an owned lead's deal inherits that owner. The deal half is the
+// OwnerExact seam; without it CreateDealTx's actor fallback silently gave
+// the queue's deal to whoever clicked Qualify.
+func TestQualifyInheritsTheLeadOwnerExactly(t *testing.T) {
+	e := integration.Setup(t)
+	admin := e.Admin()
+	owner := integration.OwnerConn(t)
+	dealsStore := deals.NewStore(e.DB(), DealsInstallation())
+	if err := dealsStore.SeedDefaults(admin); err != nil {
+		t.Fatalf("seed default pipeline: %v", err)
+	}
+	peopleStore := people.NewStore(e.DB()).WithDealOpener(leadDealOpener{deals: dealsStore})
+
+	assertOwners := func(t *testing.T, out people.PromoteOutcome, want *ids.UUID) {
+		t.Helper()
+		var personOwner, dealOwner *ids.UUID
+		if err := owner.QueryRow(context.Background(),
+			`SELECT owner_id FROM person WHERE id = $1`, ids.UUID(out.Person.Id)).Scan(&personOwner); err != nil {
+			t.Fatal(err)
+		}
+		if err := owner.QueryRow(context.Background(),
+			`SELECT owner_id FROM deal WHERE id = $1`, *out.DealID).Scan(&dealOwner); err != nil {
+			t.Fatal(err)
+		}
+		for name, got := range map[string]*ids.UUID{"person": personOwner, "deal": dealOwner} {
+			if (got == nil) != (want == nil) || (got != nil && *got != *want) {
+				t.Errorf("%s owner = %v, want %v", name, got, want)
+			}
+		}
+	}
+
+	queueEmail := "queue-qualify@example.test"
+	queued, _, err := peopleStore.CreateLead(admin, people.CreateLeadInput{Email: &queueEmail, Source: "manual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	queuedOut, err := peopleStore.QualifyLead(admin, ids.From[ids.LeadKind](ids.UUID(queued.Id)), people.PromoteLeadInput{
+		Trigger: "human_qualify", Deal: &people.QualifyDealInput{},
+	})
+	if err != nil {
+		t.Fatalf("qualify the unassigned lead: %v", err)
+	}
+	if queuedOut.DealID == nil {
+		t.Fatal("qualify answered no deal id")
+	}
+	assertOwners(t, queuedOut, nil)
+
+	repOwner := ids.From[ids.UserKind](e.Rep1)
+	ownedEmail := "owned-qualify@example.test"
+	owned, _, err := peopleStore.CreateLead(admin, people.CreateLeadInput{Email: &ownedEmail, Source: "manual", OwnerID: &repOwner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownedOut, err := peopleStore.QualifyLead(admin, ids.From[ids.LeadKind](ids.UUID(owned.Id)), people.PromoteLeadInput{
+		Trigger: "human_qualify", Deal: &people.QualifyDealInput{},
+	})
+	if err != nil {
+		t.Fatalf("qualify the owned lead: %v", err)
+	}
+	if ownedOut.DealID == nil {
+		t.Fatal("qualify answered no deal id")
+	}
+	rep := e.Rep1
+	assertOwners(t, ownedOut, &rep)
 }

--- a/backend/internal/modules/deals/deal_create.go
+++ b/backend/internal/modules/deals/deal_create.go
@@ -39,8 +39,14 @@ type CreateDealInput struct {
 	OrganizationID *ids.OrganizationID
 	ProjectID      *ids.ProjectID
 	OwnerID        *ids.UserID
-	ExpectedClose  *time.Time
-	Source         string
+	// OwnerExact states that OwnerID — nil included — IS the decided owner,
+	// so the actor fallback below must not run. The lead-qualify seam sets
+	// it: the deal inherits the LEAD's owner, and an unassigned lead
+	// qualifies into an unassigned deal rather than one silently owned by
+	// whoever clicked Qualify.
+	OwnerExact    bool
+	ExpectedClose *time.Time
+	Source        string
 	// CustomFields carries the request body's extra top-level keys
 	// (additionalProperties); only active cf_* catalog columns land,
 	// drop-on-mismatch (storekit customcolumns).
@@ -59,7 +65,9 @@ func (s *Store) CreateDeal(ctx context.Context, in CreateDealInput) (crmcontract
 	if err != nil {
 		return crmcontracts.Deal{}, err
 	}
-	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
+	if !in.OwnerExact {
+		in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
+	}
 	active, err := s.activeColumns(ctx)
 	if err != nil {
 		return crmcontracts.Deal{}, err
@@ -92,7 +100,9 @@ func (s *Store) CreateDealTx(ctx context.Context, tx pgx.Tx, in CreateDealInput)
 	if err != nil {
 		return crmcontracts.Deal{}, err
 	}
-	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
+	if !in.OwnerExact {
+		in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
+	}
 	return s.createDealInTx(ctx, tx, in, by, nil)
 }
 

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -111,7 +111,13 @@ func (s *Store) readyLeadCreate(ctx context.Context, in CreateLeadInput) (Create
 	if err != nil {
 		return CreateLeadInput{}, "", err
 	}
-	normalized.OwnerID = storekit.OwnerOrActor(ctx, normalized.OwnerID)
+	// The owner is exactly what the caller named — deliberately NOT
+	// storekit.OwnerOrActor, which every other manual create runs. A lead is
+	// the funnel's queue entity: it arrives unassigned unless somebody names
+	// an owner, routing (leadrouting.go) is what assigns it, and the claim
+	// verb plus the Unassigned list dial exist for the ownerless state. The
+	// UI's create form still defaults its owner picker to the creating rep,
+	// so a rep's own lead stays theirs by an explicit choice, not a fallback.
 	return normalized, by, nil
 }
 

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -111,13 +111,21 @@ func (s *Store) readyLeadCreate(ctx context.Context, in CreateLeadInput) (Create
 	if err != nil {
 		return CreateLeadInput{}, "", err
 	}
-	// The owner is exactly what the caller named — deliberately NOT
+	// The owner is exactly what a HUMAN caller named — deliberately not
 	// storekit.OwnerOrActor, which every other manual create runs. A lead is
 	// the funnel's queue entity: it arrives unassigned unless somebody names
 	// an owner, routing (leadrouting.go) is what assigns it, and the claim
 	// verb plus the Unassigned list dial exist for the ownerless state. The
 	// UI's create form still defaults its owner picker to the creating rep,
 	// so a rep's own lead stays theirs by an explicit choice, not a fallback.
+	//
+	// An AGENT's create keeps the on-behalf-of fallback: EnsureWritable
+	// refuses ownerless rows and the claim verb is human-only, so a NULL
+	// owner would strand the very lead the agent just filed — it could never
+	// update, qualify or disqualify it again. The queue is a human choice.
+	if p, ok := principal.Actor(ctx); ok && p.Type == principal.PrincipalAgent {
+		normalized.OwnerID = storekit.OwnerOrActor(ctx, normalized.OwnerID)
+	}
 	return normalized, by, nil
 }
 

--- a/backend/internal/modules/people/leadowner_integration_test.go
+++ b/backend/internal/modules/people/leadowner_integration_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// A lead's owner is exactly what the create names — no actor fallback. The
+// funnel's queue state is real: an omitted owner stays NULL for routing or a
+// claim, and a named owner is stored as named. Persons/orgs/deals keep the
+// storekit.OwnerOrActor default; this pair pins the lead exception so a
+// refactor "unifying" the creates cannot quietly bring the fallback back.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestCreateLeadWithoutOwnerStaysUnassigned(t *testing.T) {
+	e := setupPromoteConsent(t)
+
+	created, wasCreated, err := e.store.CreateLead(e.ctx, CreateLeadInput{
+		FullName: strPtr("Queue Lead"), Source: "manual",
+	})
+	if err != nil || !wasCreated {
+		t.Fatalf("create lead: created=%v err=%v", wasCreated, err)
+	}
+	if created.OwnerId != nil {
+		t.Fatalf("owner_id = %v, want NULL — an omitted owner is the queue, not the caller", created.OwnerId)
+	}
+
+	ownerID := ids.From[ids.UserKind](e.user)
+	owned, wasCreated, err := e.store.CreateLead(e.ctx, CreateLeadInput{
+		FullName: strPtr("Chosen Lead"), Source: "manual", OwnerID: &ownerID,
+	})
+	if err != nil || !wasCreated {
+		t.Fatalf("create owned lead: created=%v err=%v", wasCreated, err)
+	}
+	if owned.OwnerId == nil || ids.UUID(*owned.OwnerId) != e.user {
+		t.Fatalf("owner_id = %v, want the named owner %s", owned.OwnerId, e.user)
+	}
+}

--- a/backend/internal/modules/people/leadowner_integration_test.go
+++ b/backend/internal/modules/people/leadowner_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 func TestCreateLeadWithoutOwnerStaysUnassigned(t *testing.T) {
@@ -39,5 +40,31 @@ func TestCreateLeadWithoutOwnerStaysUnassigned(t *testing.T) {
 	}
 	if owned.OwnerId == nil || ids.UUID(*owned.OwnerId) != e.user {
 		t.Fatalf("owner_id = %v, want the named owner %s", owned.OwnerId, e.user)
+	}
+}
+
+// An agent's create keeps the on-behalf-of fallback: the claim verb is
+// human-only and ownerless rows refuse writes, so a NULL owner would strand
+// the very lead the agent just filed.
+func TestAgentCreateLeadKeepsTheOnBehalfOwner(t *testing.T) {
+	e := setupPromoteConsent(t)
+	agentCtx := principal.WithActor(e.ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:sdr", UserID: e.user,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"lead": {Create: true, Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	created, wasCreated, err := e.store.CreateLead(agentCtx, CreateLeadInput{
+		FullName: strPtr("Agent Filed"), Source: "manual",
+	})
+	if err != nil || !wasCreated {
+		t.Fatalf("agent create lead: created=%v err=%v", wasCreated, err)
+	}
+	if created.OwnerId == nil || ids.UUID(*created.OwnerId) != e.user {
+		t.Fatalf("owner_id = %v, want the granting human %s — an agent's lead must stay workable by that agent", created.OwnerId, e.user)
 	}
 }

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -90,11 +90,20 @@ export function mapLeadBody(values: Record<string, string>): CreateLeadRequest {
     linkedin_url: values.linkedin_url?.trim() || undefined,
     title: values.title?.trim() || undefined,
     company_name: values.company_name?.trim() || undefined,
-    owner_id: values.owner_id?.trim() || undefined,
+    owner_id:
+      values.owner_id === UNASSIGNED_OWNER
+        ? undefined
+        : values.owner_id?.trim() || undefined,
     status: "new",
     source: values.source?.trim() || "manual",
   };
 }
+
+// The owner picker's "nobody yet" choice. A sentinel rather than the empty
+// string because the field is required — the writer chooses the queue, they
+// do not skip the question. The server reads an omitted owner_id as exactly
+// that: an unassigned lead for routing or a claim to pick up.
+export const UNASSIGNED_OWNER = "unassigned";
 
 const leadCreateFields: CreateField[] = [
   { key: "full_name", label: "create.fullName", required: true },
@@ -225,6 +234,7 @@ function LeadsWorkbench({
   const sources = useLeadSources();
   const ownerOptions = [
     { value: viewerId, label: t("lead.assignToMe") },
+    { value: UNASSIGNED_OWNER, label: t("lead.unassigned") },
     ...(roster.data ?? [])
       .filter((entry) => !("is_agent" in entry && entry.is_agent))
       .filter((entry) => entry.id !== viewerId)


### PR DESCRIPTION
Closes #1907.

**Create:** `POST /v1/leads` no longer routes an omitted `owner_id` through `storekit.OwnerOrActor` — the lead stores exactly the owner the caller named, NULL included. A lead is the funnel's queue entity: the `Unassigned` list dial, the claim verb and routing all model the ownerless state, and the write side can now produce it. Persons, organizations and deals keep the fallback; an integration test pins the lead exception in both directions.

**Two review findings fixed in-branch:**
- **Agents keep the on-behalf-of owner.** Ownerless rows refuse writes and the claim verb is human-only, so an agent's create falling to NULL would strand the very lead the agent just filed. The queue is a human choice.
- **Qualify inherits the lead's owner exactly.** The qualify seam creates the deal with a new `OwnerExact` input, so an unassigned lead qualifies into an unassigned contact AND deal — previously `CreateDealTx`'s actor fallback silently gave the queue's deal to whoever clicked Qualify. Integration test asserts both the NULL and the owned inheritance.

**UI:** the create form's required owner picker (still defaulting to "Assign to me") gains an **Unassigned** option that files the lead into the queue.

Not addressed here (as the issue notes): `PATCH /leads/{id}` still cannot un-assign an owned lead — `omitempty` cannot carry an explicit null. The claim verb covers the other direction; un-assigning needs a contract-level tri-state decision.

Gates locally: `make check-backend`, `make check-fe`, craft static, rls-store-path, no-jurisdiction, and the people + compose qualify integration lanes — all green. Browser verification on a single stack follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Leads created without an owner now stay unassigned instead of defaulting to the caller. Qualify inherits the lead’s owner exactly to the new deal; agent-filed leads still fall back to the granting user to remain writable.

- POST /v1/leads: omitted `owner_id` previously fell back to the actor via `storekit.OwnerOrActor`; it now persists as NULL (unassigned). If your client expects auto-assignment, send `owner_id`.
- Qualify: the deal inherits the lead owner exactly. `deals.CreateDealInput` gains `OwnerExact`; the qualify path sets it so an unassigned lead produces an unassigned contact and deal.
- Agents: when the principal is an agent, lead create keeps the on-behalf-of fallback to avoid stranding ownerless rows.
- UI: the owner picker keeps “Assign to me” by default and adds an “Unassigned” option using `UNASSIGNED_OWNER`, which maps to an omitted `owner_id`.
- Tests: added integration coverage to pin the lead exception and the qualify owner inheritance.

<sup>Written for commit d2dde1697fb8dfea3205e01a453fa3fe33e637c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

