### PR TITLE
docs(agents-mcp): main is green again — the published MCP surface docs match what a client is served

### DIFF
--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 43,
     "resources": 8,
-    "tool_catalog_bytes": 124406,
+    "tool_catalog_bytes": 124450,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 31878,
-    "largest_tool_bytes": 4679,
+    "approx_wire_tokens_total": 31889,
+    "largest_tool_bytes": 4723,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
       "description_bytes": 32392,
       "input_schema_bytes": 28804,
-      "output_schema_bytes": 53763,
+      "output_schema_bytes": 53807,
       "description_plus_input_schema_bytes": 61196
     }
   },
@@ -6085,6 +6085,9 @@
                 },
                 "derivation_url": {
                   "type": "string"
+                },
+                "excluded_by_permission": {
+                  "type": "integer"
                 },
                 "generated_at": {
                   "type": "string"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 8 |
 | Tool catalog | 121.5 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 31878 |
+| Approx. wire tokens | 31889 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -93,7 +93,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`relink_activity`](#relink_activity) | Re-associate an activity to a record |  |  | 2.3 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 2.8 KB |
-| [`run_report`](#run_report) | Run a report | yes |  | 4.5 KB |
+| [`run_report`](#run_report) | Run a report | yes |  | 4.6 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.0 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.7 KB |
 | [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.6 KB |
@@ -6645,6 +6645,9 @@ Answer a question about totals, counts or breakdowns — pipeline by stage, deal
         },
         "derivation_url": {
           "type": "string"
+        },
+        "excluded_by_permission": {
+          "type": "integer"
         },
         "generated_at": {
           "type": "string"


### PR DESCRIPTION
#1917 changed the served `run_report` envelope (`excluded_by_permission`) and regenerated `docs/reference/mcp-info.{json,md}`, but its commit staged only `backend/` — the regen never landed, and `TestPublishedMCPSurfaceMatchesWhatAClientIsServed` has been red on main since. This is that regen, byte-identical to what the gate serves (verified locally: the gate passes with these two files and fails without them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates `docs/reference/mcp-info.{json,md}` so the published MCP surface matches what clients receive. Previously the docs were stale, causing `TestPublishedMCPSurfaceMatchesWhatAClientIsServed` to fail; with this regen, the test passes.

- Adds `excluded_by_permission` (integer) to the `run_report` result schema in both files.
- Updates generated metrics (tool_catalog_bytes, approx_wire_tokens_total, largest_tool_bytes, output_schema_bytes); `run_report` now 4.6 KB in the docs.
- Docs-only change; no API or runtime behavior changes. No migration required.

<sup>Written for commit 9f7e49610a896181d3f0d9ebf5ea9e1991800991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

