### PR TITLE
refactor(authz): the approval token stops carrying a workspace claim nothing read

### DIFF
--- a/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/oauth_surface_integration_test.go
@@ -6,7 +6,10 @@
 package agentaccess
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -90,8 +93,38 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 		t.Fatalf("claims not effect-bound: %+v", claims)
 	}
 
-	// One flipped payload byte is fatal.
+	// The token carries NO workspace claim, and a token minted with one still
+	// verifies. Both halves are the point of retiring it (ADR-0091 §1): the
+	// claim was never read, so dropping it removes no control — and an
+	// unrecognised field is ignored on decode, so tokens issued before the
+	// change are not invalidated by it. A reader who re-adds "ws" for safety
+	// would be adding a field nothing checks, which is what this refuses.
 	parts := strings.Split(*approved.ApprovalToken, ".")
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decoding the token payload: %v", err)
+	}
+	if bytes.Contains(payload, []byte(`"ws"`)) {
+		t.Errorf("the approval token carries a \"ws\" claim: %s\n"+
+			"VerifyApprovalToken does not read it, so it binds the effect to no tenant "+
+			"while looking like it does", payload)
+	}
+	withStaleClaim, err := json.Marshal(map[string]any{
+		"jti": approvalID, "ws": wsID.String(), "kind": "archive_record",
+		"diff_hash": claims.DiffHash, "exp": claims.ExpiresAt,
+	})
+	if err != nil {
+		t.Fatalf("building the pre-retirement payload: %v", err)
+	}
+	var reparsed approvals.ApprovalTokenClaims
+	if err := json.Unmarshal(withStaleClaim, &reparsed); err != nil {
+		t.Fatalf("a token minted before the claim was retired no longer decodes: %v", err)
+	}
+	if reparsed.ApprovalID.String() != approvalID {
+		t.Errorf("the pre-retirement payload decoded to approval %s, want %s", reparsed.ApprovalID, approvalID)
+	}
+
+	// One flipped payload byte is fatal.
 	tampered := parts[0] + "." + flipLastChar(parts[1]) + "." + parts[2]
 	if _, err := svc.VerifyApprovalToken(wsCtx, tampered); !errors.Is(err, apperrors.ErrApprovalTokenInvalid) {
 		t.Fatalf("tampered token → %v, want ErrApprovalTokenInvalid", err)

--- a/backend/internal/modules/approvals/token_jws.go
+++ b/backend/internal/modules/approvals/token_jws.go
@@ -30,12 +30,19 @@ import (
 
 // ApprovalTokenClaims is the effect binding (ADR-0036): exactly one
 // approval, exactly one tool + diff, dead at the approval's own TTL.
+//
+// It carries NO workspace. It used to ("ws"), and ADR-0091 §1 retires that
+// claim — but the honest reason to drop it is that VerifyApprovalToken never
+// read it. The claim was minted into every token and checked by nothing, so it
+// bound no effect to any tenant and its removal takes away no control. What
+// actually binds the token is jti: the approval row it names is fetched and its
+// status re-read on redemption, and that row lives in the one installation this
+// binary serves (A107/ADR-0061).
 type ApprovalTokenClaims struct {
-	ApprovalID  ids.ApprovalID  `json:"jti"`
-	WorkspaceID ids.UUID        `json:"ws"`
-	Kind        string          `json:"kind"`
-	DiffHash    string          `json:"diff_hash"`
-	PassportID  *ids.PassportID `json:"passport_id,omitempty"`
+	ApprovalID ids.ApprovalID  `json:"jti"`
+	Kind       string          `json:"kind"`
+	DiffHash   string          `json:"diff_hash"`
+	PassportID *ids.PassportID `json:"passport_id,omitempty"`
 	// TargetType + TargetID are the polymorphic reference to the approved
 	// action's target; the id stays untyped because the pair is the
 	// discriminated reference, not one entity's typed id.
@@ -54,8 +61,11 @@ type jwsHeader struct {
 // Called by the approve handler so the deciding human's response
 // carries the token the agent will redeem.
 func (s *Service) MintApprovalToken(ctx context.Context, approvalID ids.ApprovalID) (string, error) {
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
+	// The workspace is no longer a CLAIM — see ApprovalTokenClaims — but the
+	// check stays: minting an effect-binding token outside a workspace context
+	// is a wiring fault, and it is better named here than left to surface as
+	// whatever the first unbound read does.
+	if _, ok := principal.WorkspaceID(ctx); !ok {
 		return "", errors.New("crmapprovals: minting outside workspace context")
 	}
 	var token string
@@ -69,7 +79,6 @@ func (s *Service) MintApprovalToken(ctx context.Context, approvalID ids.Approval
 		}
 		claims := ApprovalTokenClaims{
 			ApprovalID:    a.ID,
-			WorkspaceID:   wsID,
 			Kind:          a.Kind,
 			DiffHash:      a.DiffHash,
 			PassportID:    a.PassportID,


### PR DESCRIPTION
First half of #1766, per the decision recorded there: retire the `"ws"` claim
before `app_user` and `session` lose their column.

ADR-0091 §1 lists this claim as its own removal — but the reason to drop it is
not that the ADR says so. **`VerifyApprovalToken` never read it.** The claim was
minted into every approval token and checked by nothing, so it bound no effect
to any tenant while looking like it did.

What actually binds the token is `jti`: the approval row it names is fetched and
its status re-read on redemption, and that row lives in the one installation
this binary serves (A107/ADR-0061).

## Old tokens are not invalidated

An unrecognised field is ignored on decode, so a payload still carrying `"ws"`
verifies and decodes to the same approval. **Asserted directly rather than
reasoned about** — "old tokens still work" is cheap to claim and expensive to be
wrong about, and a token that stops verifying mid-flight is an approval a human
already gave that the agent can no longer redeem.

## The test refuses the claim's return, not just its absence

Somebody re-adding `"ws"` for safety would be adding a field nothing checks —
which is precisely the state this removes. Verified by re-adding it and watching
the assertion fire.

`MintApprovalToken` keeps its workspace check and discards the value: minting an
effect-binding token outside a workspace context is a wiring fault, better named
there than left to surface as whatever the first unbound read does.

## Verification

- `make check-backend` — exit 0
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — 0 blocker, 0 major, 0 minor

This unblocks the last two identity tables: `Identity.WorkspaceID` had no
consumer left but this claim.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the workspace "ws" claim from approval JWS tokens. The verifier never read this claim, so it provided no tenancy control; tokens stay effect-bound via `jti`.

- In `approvals`, `ApprovalTokenClaims` drops `WorkspaceID`. `MintApprovalToken` still requires a workspace in context but no longer embeds it.
- Verification is unchanged. Tokens minted before this change (with a `ws` field) still verify and decode to the same approval; tests assert absence of `ws`, backward compatibility, and prevent reintroduction.
- Unblocks removing `Identity.WorkspaceID` and the workspace columns on `app_user` and `session` per ADR-0091.

<sup>Written for commit 3d2d0122d2cf73053005ef88dcf405cb67b9da36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

