### PR TITLE
fix(ai): a data reset spares the model binding

### DIFF
--- a/backend/internal/modules/ai/settingsentry.go
+++ b/backend/internal/modules/ai/settingsentry.go
@@ -62,14 +62,18 @@ func Definitions() []settings.Definition {
 	return []settings.Definition{Routing}
 }
 
-// validateStoredRouting holds a stored binding to the same bar the file
-// always had, so a write through the settings surface cannot land a config the
-// file loader would have refused at boot.
+// validateStoredRouting holds a stored binding to the same bar the file always
+// had, so a write through the settings surface cannot land a config the file
+// loader would have refused at boot.
 //
-// The zero config is the one exception: it is how "no models are bound" is
-// spelled, and refusing it would make the registered default invalid.
+// The ZERO config is the one exception, and only the zero one: it is how "no
+// models are bound" is spelled and it is the registered default, which has to
+// validate. A document that sets a profile and binds no tiers is NOT that — the
+// file loader refuses it ("no tiers bound"), and accepting it here would store
+// something an operator wrote, that reads as configured, and that routes
+// nothing. Silently doing nothing is the failure this surface exists to end.
 func validateStoredRouting(cfg RoutingConfig) error {
-	if cfg.Unconfigured() {
+	if cfg.zero() {
 		return nil
 	}
 	// Bounds first, because validate() reads a defaulted width and cannot tell
@@ -86,5 +90,20 @@ func validateStoredRouting(cfg RoutingConfig) error {
 //
 // Tiers is what decides it: a config carrying a profile and no tiers routes
 // nothing, and treating that as configured would build a Router that refuses
-// every call it is handed.
+// every call it is handed. This is the RUNTIME question — "is there anything to
+// serve" — which is a different question from whether a document may be stored;
+// see zero.
 func (cfg RoutingConfig) Unconfigured() bool { return len(cfg.Tiers) == 0 }
+
+// zero reports whether nothing at all was set, which is the only document the
+// validator exempts from the file loader's bar.
+//
+// Deliberately narrower than Unconfigured. Both mean "serves nothing", but a
+// document that names a profile is one somebody WROTE, and storing it
+// unexamined would accept a half-bound binding that reads as configured and
+// routes nothing.
+func (cfg RoutingConfig) zero() bool {
+	e := cfg.Embeddings
+	return cfg.Profile == "" && len(cfg.Tiers) == 0 &&
+		e.Provider == "" && e.Model == "" && e.BaseURL == "" && len(e.Input) == 0 && e.Dimensions == 0
+}

--- a/backend/internal/modules/ai/settingsentry.go
+++ b/backend/internal/modules/ai/settingsentry.go
@@ -41,13 +41,21 @@ const RoutingKey = "ai.routing"
 // binding: an installation that has bound no models runs with its AI lanes
 // absent, exactly as one with no routing file did. A default that named
 // vendors would send an installation's text somewhere nobody chose.
+//
+// It SURVIVES a data reset, for the reason AsInstallationIdentity names: it is
+// a value bootstrap takes from the deployment configuration, like the
+// installation's name and currency. A reset wipes an installation's data, not
+// the decision about which vendor may process it — and wiping it would be
+// quiet, because a dev stack re-seeds the binding from its routing file on the
+// next boot while a production installation, which has no file, would simply
+// come back with its AI lanes gone.
 var Routing = settings.Define[RoutingConfig](
 	RoutingKey,
 	routingSettingsObject,
 	"update",
 	RoutingConfig{},
 	validateStoredRouting,
-)
+).AsInstallationIdentity()
 
 // Definitions is the ai module's contribution to the settings registry.
 func Definitions() []settings.Definition {

--- a/backend/internal/modules/ai/settingsentry_test.go
+++ b/backend/internal/modules/ai/settingsentry_test.go
@@ -43,14 +43,18 @@ func TestTheRegisteredDefaultBindsNothing(t *testing.T) {
 // registered default — refusing it would make every unset installation fail its
 // own catalog. Everything else is held to the bar the file loader applies.
 func TestValidationAcceptsUnconfiguredAndRefusesAHalfBinding(t *testing.T) {
+	// The zero document is the registered default, so refusing it would make
+	// every unset installation fail its own catalog.
 	if err := Routing.ValidateJSON([]byte(`{}`)); err != nil {
 		t.Errorf("the unconfigured binding was refused: %v", err)
 	}
-	// A profile with no tiers routes nothing. Accepting it would build a Router
-	// that refuses every call it is handed, which reads as an outage rather
-	// than as the misconfiguration it is.
-	if err := Routing.ValidateJSON([]byte(`{"profile":"eu_hosted","tiers":{}}`)); err != nil {
-		t.Errorf("a profile with no tiers must read as unconfigured, not as invalid: %v", err)
+	// A profile with no tiers is REFUSED, and the exemption above is narrower
+	// than it looks for that reason. Both documents serve nothing, but this one
+	// somebody wrote — storing it would accept a binding that reads as
+	// configured, routes nothing, and reports no fault. The file loader refuses
+	// it ("no tiers bound"), and a stored binding is held to the same bar.
+	if err := Routing.ValidateJSON([]byte(`{"profile":"eu_hosted","tiers":{}}`)); err == nil {
+		t.Error("a profile binding no tiers was stored; it reads as configured and routes nothing")
 	}
 	if err := Routing.ValidateJSON([]byte(`{"profile":"nowhere","tiers":{"premium":{"provider":"gemini","model":"m"}}}`)); err == nil {
 		t.Error("an unknown profile was accepted; a stored binding must meet the bar the file loader applies")

--- a/backend/internal/modules/ai/settingsentry_test.go
+++ b/backend/internal/modules/ai/settingsentry_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+// A data reset wipes an installation's DATA, not the decision about which
+// vendor may process it.
+//
+// This one fails quietly in exactly the environment nobody tests in. A dev
+// stack re-seeds the binding from its routing file on the next boot, so a reset
+// looks harmless there; a production installation has no file, so the same
+// reset leaves it with no binding and its AI lanes simply gone — discovered
+// whenever someone next opens a surface that needs a model, not at the reset.
+func TestTheRoutingBindingSurvivesADataReset(t *testing.T) {
+	if !Routing.SurvivesDataReset() {
+		t.Error("a data reset would delete ai.routing; the model binding is what bootstrap took from the " +
+			"deployment configuration, like the installation's name and currency, and a reset spares those")
+	}
+}
+
+// The registered default must be "unconfigured" and never a working binding. A
+// default that named vendors would send an installation's text somewhere nobody
+// chose — and it would do it on the read of an UNSET setting, which is the
+// state every installation is in before anyone binds a model.
+func TestTheRegisteredDefaultBindsNothing(t *testing.T) {
+	raw, err := Routing.DefaultJSON()
+	if err != nil {
+		t.Fatalf("the registered default does not encode: %v", err)
+	}
+	for _, vendor := range []string{"gemini", "anthropic", "openai", "ollama", "vllm"} {
+		if strings.Contains(string(raw), vendor) {
+			t.Errorf("the registered default names %q; an unset binding must bind nothing: %s", vendor, raw)
+		}
+	}
+}
+
+// The zero config is the one value the validator must accept, because it IS the
+// registered default — refusing it would make every unset installation fail its
+// own catalog. Everything else is held to the bar the file loader applies.
+func TestValidationAcceptsUnconfiguredAndRefusesAHalfBinding(t *testing.T) {
+	if err := Routing.ValidateJSON([]byte(`{}`)); err != nil {
+		t.Errorf("the unconfigured binding was refused: %v", err)
+	}
+	// A profile with no tiers routes nothing. Accepting it would build a Router
+	// that refuses every call it is handed, which reads as an outage rather
+	// than as the misconfiguration it is.
+	if err := Routing.ValidateJSON([]byte(`{"profile":"eu_hosted","tiers":{}}`)); err != nil {
+		t.Errorf("a profile with no tiers must read as unconfigured, not as invalid: %v", err)
+	}
+	if err := Routing.ValidateJSON([]byte(`{"profile":"nowhere","tiers":{"premium":{"provider":"gemini","model":"m"}}}`)); err == nil {
+		t.Error("an unknown profile was accepted; a stored binding must meet the bar the file loader applies")
+	}
+}


### PR DESCRIPTION
A defect [#1845](https://github.com/gradionhq/margince-poc-v1/pull/1845) introduced two hours ago, found while scoping increment 3 of [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780).

## The bug

Making routing a `setting` without marking it installation identity means `settings.ResetConfig` **deletes it**. "Reset data" wipes which vendor the installation is bound to, along with the data it was meant to wipe.

`AsInstallationIdentity` states the criterion exactly: *"the values bootstrap takes from the deployment configuration"*. The binding is seeded from the routing file the same way the name, currency and zone are seeded from `margince.yaml`. A reset wipes an installation's **data**, not the decision about which vendor may process it.

## Why it would have shipped

It fails in the one environment nobody would catch it in.

| | after a data reset |
|---|---|
| dev stack | re-seeds the binding from `ai-routing.yaml` on the next boot — looks harmless |
| production | has no file, so it comes back with **no binding and its AI lanes gone** |

And it surfaces whenever somebody next opens a surface that needs a model, with nothing connecting the failure back to the reset that caused it.

## Two more properties the move left unpinned

Both concern the state every installation is in *before* anyone binds a model:

- **The registered default must name no vendor.** It is what a read of an unset setting returns, and a default naming one would send an installation's text somewhere nobody chose.
- **The validator must accept the unconfigured binding.** Refusing it would make every unset installation fail its own catalog — while a half-bound one (a profile with no tiers) must still read as unconfigured rather than invalid, since accepting it would build a Router that refuses every call and reads as an outage.

## Mutation-checked

| Mutation | Result |
|---|---|
| drop the exemption (the bug exactly as merged) | fails, naming the reset |
| give the default a real tier | fails, naming the vendor |

`make -C backend check` exit 0 · `make craft-static` PASS.

Refs [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks `ai.routing` as an installation identity so a data reset no longer deletes the model binding. Old: `settings.ResetConfig` removed it (dev re-seeded; prod lost lanes); new: the binding survives resets in all environments.

- Applies `.AsInstallationIdentity()` to `Routing` and adds a reset-survival test.
- Validation only exempts the zero document `{}`; rejects a profile with no tiers and unknown profiles; the registered default binds nothing.
- No migration required; after a reset, installations retain their existing binding.

<sup>Written for commit 8348b5fc88b960d92d554792ef79111fabb3cdab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI routing configuration now persists through data resets.
  * Unconfigured routing settings remain valid without selecting a vendor.
  * Invalid or unknown routing profiles are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->