### PR TITLE
fix(ci): the stale-cache guard sees worktrees inside the repo

### DIFF
--- a/scripts/run-golangci.sh
+++ b/scripts/run-golangci.sh
@@ -124,7 +124,15 @@ outside=()
 while IFS= read -r reported; do
   [[ -n "$reported" ]] || continue
   absolute="$(lexical_abs "$reported")"
-  if [[ "$absolute" != "$root" && "$absolute" != "$root"/* ]]; then
+  # Two ways a path can belong to another checkout, and the second is the one
+  # this guard was originally blind to. A sibling worktree resolves OUTSIDE the
+  # root. But `EnterWorktree` puts this repo's own worktrees under
+  # .claude/worktrees/, which is lexically INSIDE it — so a cache entry filled
+  # by a parallel session read as one of this checkout's own findings, under
+  # module names that do exist here, which is precisely the failure the guard
+  # exists to prevent.
+  if [[ "$absolute" != "$root" && "$absolute" != "$root"/* ]] \
+    || [[ "$absolute" == "$root/.claude/worktrees/"* ]]; then
     outside+=("$absolute")
   fi
 done < <(LC_ALL=C sed -n -e "s/${escape}\[[0-9;]*m//g" \
@@ -134,7 +142,7 @@ if ((${#outside[@]} > 0)); then
   echo
   echo "STALE CACHE — the findings above are not about this checkout."
   echo
-  echo "golangci-lint reported ${#outside[@]} file(s) that lie outside $root:"
+  echo "golangci-lint reported ${#outside[@]} file(s) that belong to another checkout:"
   # Capped, and the cap says so — a poisoned entry for a large package can name
   # hundreds of files, and a page of them buries the sentence that explains it.
   printf '  %s\n' "${outside[@]:0:10}"

--- a/scripts/test-run-golangci.sh
+++ b/scripts/test-run-golangci.sh
@@ -87,6 +87,15 @@ expect "a finding from a sibling worktree is quarantined" 40 yes 1 '../../margin
 # Same entry, absolute rather than relative: `run.relative-path-mode` is
 # configurable and a golangci upgrade could change its default, which would slip
 # every foreign path past a guard that only understood the relative spelling.
+# The case the guard was blind to, and the one this repo actually produces:
+# EnterWorktree puts a worktree under .claude/worktrees/, which resolves INSIDE
+# the root. A guard that asked only "is this path outside the checkout" read a
+# parallel session's cached findings as this checkout's own — under module names
+# that do exist here, which is the whole failure #1378 describes.
+expect "a finding from a worktree INSIDE this repo is quarantined" 40 yes 1 '../.claude/worktrees/feat+desktop-bundle/extensions/zalo-oa/oauth.go:33:2: G101: Potential hardcoded credentials (gosec)
+1 issues:
+* gosec: 1'
+
 expect "an absolute path outside the checkout is quarantined" 40 yes 1 '/somewhere/else/margince-next-sed/backend/tools/extmigrategate/main.go:114:4: use of `fmt.Println` forbidden because "use slog, not fmt.Print*" (forbidigo)
 '
 


### PR DESCRIPTION
The guard from [#1378](https://github.com/gradionhq/margince-poc-v1/issues/1378) had a blind spot that is exactly the case this repo's tooling produces.

## The blind spot

It asked one question — *is this path outside the checkout root* — and `EnterWorktree` puts this repo's own worktrees under `.claude/worktrees/`, which resolves **inside** it. So a parallel session's cached findings read as this checkout's own.

That is the whole failure #1378 describes, and it cost a real diagnosis today: twelve gosec and forbidigo findings in `zalo-oa`, `zalo-personal` and the desktop launcher, none of them in this tree, printed under a header naming modules that **are**. Clearing the cache left zero.

```
FAIL — golangci-lint findings in: backend/tools cli/craft desktop/launcher
       extensions/yogi extensions/zalo-oa extensions/zalo-personal
```

Every part of that reads as a real failure except the `../` on the paths — which is what the guard exists to notice.

## Why the existing test could not catch it

It covers a sibling worktree (`../../margince-next-erase/...`) and an absolute path elsewhere (`/somewhere/else/...`) — **both outside the root**. The case that separates a correct guard from this one is a path that leads with `../` and still resolves inside the repo, and it was missing.

That case is now in the suite. Reverting the guard fails it and fails nothing else.

## Also

`TestEveryWorkflowJobCarriesATimeoutCeiling` caught `github-release`, added to `release.yml` on `main` after the ceilings landed in [#1849](https://github.com/gradionhq/margince-poc-v1/pull/1849). The gate doing the job it was written for, on its first real occasion, three days early. Bounded at 30 minutes.

`make -C backend check` exit 0 · `make test-golangci-guard` green · `make lint-modules` clean after a cache clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quarantines golangci-lint cache entries sourced from in-repo worktrees so foreign findings no longer appear as local. Previously the guard only flagged paths outside the checkout root; paths under `.claude/worktrees/*` were missed.

- CI guard: `scripts/run-golangci.sh` treats paths outside `$root` or under `$root/.claude/worktrees/` as belonging to another checkout and updates the warning text accordingly.
- Tests: `scripts/test-run-golangci.sh` adds a case for a path that lexically resolves inside the repo via `.claude/worktrees/` to ensure it is quarantined.

<sup>Written for commit bb9130fdd25e1832b054cfffd7b3b0dd35318940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

