### PR TITLE
fix(ci): the release job that publishes the bundles carries a wall-clock ceiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,6 +391,13 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: [draft, desktop-macos, desktop-windows]
     runs-on: ubuntu-24.04-arm
+    # Transfer work, not build work: the bundles were already produced inside
+    # the desktop lanes' own 90-minute ceilings, and this job only moves them —
+    # two artifact downloads, one re-zip, one release upload. That is the same
+    # shape as `draft` and `publish` above, which carry 30 for the same reason.
+    # If a desktop bundle ever grows past what 30 minutes of artifact transfer
+    # can carry, this moves with the sibling two rather than on its own.
+    timeout-minutes: 30
     permissions:
       # The only job in this workflow that writes to this repository, and it
       # writes exactly one thing: the release and its tag. Every other job here


### PR DESCRIPTION
`TestEveryWorkflowJobCarriesATimeoutCeiling` fails on unmodified `origin/main`
(`c01b006b3`), so `make check` is red on every branch cut from it. Reproduced on
a clean worktree with no local changes:

```
--- FAIL: TestEveryWorkflowJobCarriesATimeoutCeiling (0.00s)
    workflowtimeouts_test.go:90: release.yml: job "github-release" has no timeout-minutes,
    so it inherits GitHub's six-hour default
```

#1849 armed the gate. #1120 added `desktop-macos`, `desktop-windows` and
`github-release` to `release.yml`. The first two only `uses:` a reusable
workflow, which the gate correctly exempts; `github-release` carries real steps
and no ceiling.

## Why 30 and not a rounder number

Not a guess: it is the ceiling the two sibling jobs doing the same shape of work
already carry. `github-release` does not BUILD anything — the bundles were
produced inside `desktop-macos`/`desktop-windows`, each under its own
90-minute ceiling. What is left here is two artifact downloads, one re-zip and
one release upload, which is what `draft` and `publish` do at 30. The comment
next to it says so, including what moves it: if a bundle grows past what 30
minutes of transfer can carry, all three move together.

## Proof

- **RED**, on unmodified `origin/main` in a clean worktree: the failure above.
- **GREEN**, with this one line: `ok github.com/gradionhq/margince/backend`.

## Not fixed here

A workflow-only PR does not obviously look like something a Go test judges, and
whether the change classifier should route `.github/workflows/**` into the lane
that runs this test is the part that stops the next one. Recorded in #1932
rather than guessed at here.

No coverage number: the change is one line of YAML and produces no measured
coverage. The gate itself is the proof, shown red then green above.

Closes #1932

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 30-minute timeout to the `github-release` job in `.github/workflows/release.yml`. Previously it had no ceiling and inherited GitHub’s 6-hour default; now it matches `draft`/`publish`, preventing long hangs and making `TestEveryWorkflowJobCarriesATimeoutCeiling` pass.

**Review notes**
- Adds `timeout-minutes: 30` to `github-release`; rationale comment included in YAML.
- Rationale: the job only transfers artifacts; builds happen in `desktop-macos`/`desktop-windows` under their own 90-minute ceilings.
- Effect: fixes the failing timeout gate on main; release behavior unchanged except the job now times out after 30 minutes instead of 6 hours.
- Tracking: does not address routing of workflow-only PRs into the lane that runs the gate (see #1932).

<sup>Written for commit 38b98ad709b23c59e0b93ecead83d7ccac5fc019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the release process timeout to 30 minutes to support longer-running releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->