### PR TITLE
fix(ci): the release publish job carries a ceiling like every other job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,6 +391,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: [draft, desktop-macos, desktop-windows]
     runs-on: ubuntu-24.04-arm
+    # Two artifact downloads and one release creation. The long work in this
+    # workflow is the desktop builds this job waits on, not the publish.
+    timeout-minutes: 15
     permissions:
       # The only job in this workflow that writes to this repository, and it
       # writes exactly one thing: the release and its tag. Every other job here


### PR DESCRIPTION
`main` is red, and this is the one line that makes it green.

#1849 gave every CI job a wall-clock ceiling and armed `TestEveryWorkflowJobCarriesATimeoutCeiling` to keep it that way. `release.yml`'s `github-release` job did not get one, so the gate that shipped with it fails on `main` — which makes the required check red on **every** open PR, where it reads as that PR's problem rather than the tree's.

Fifteen minutes: the job downloads two artifacts and creates one release. The long work in this workflow is the desktop builds it waits on, and those carry their own 60 and 30.

Verified locally: `go test -run TestEveryWorkflowJobCarriesATimeoutCeiling ./backend` passes on this branch and fails on `main`.

Closes #1932


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 15-minute timeout ceiling to the `github-release` publish job in `release.yml` so all CI jobs have timeouts. Previously this job had no timeout, which broke the timeout gate on main and made required checks red on every PR; now the gate passes and a hung publish stops after 15 minutes.

- Applies only to the manual `workflow_dispatch` publish job; dependent desktop builds already have 60 and 30-minute ceilings.
- No change to successful releases: the job downloads two artifacts and creates one release well within the new limit.

<sup>Written for commit 4a5c21259bd16d0354e42b823775713f4c342d9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

