### PR TITLE
feat(contract): the filter vocabulary says what an id field points at

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20630,6 +20630,19 @@ components:
             may set. A retired one is absent here and still accepted by the
             engine, so no `status` lookup is needed to know whether to offer a
             field: if this operation listed it, it is offerable.
+        references:
+          type: string
+          enum: [tag, app_user, team, organization, pipeline, stage, project]
+          description: |
+            The record type this field's ids point at — present for every `id`
+            field, absent for every other type. Offer the record rather than a
+            box for its uuid.
+
+            The values are this contract's own record-type words, so no
+            translation table is needed to key a picker on them.
+
+            Never present on a custom field: the catalog's six types include no
+            `id`, so only a core field can carry a reference.
 
     Tag:
       type: object

--- a/backend/internal/compose/filtervocabularyenums_test.go
+++ b/backend/internal/compose/filtervocabularyenums_test.go
@@ -94,6 +94,17 @@ func TestTheVocabularysTypeEnumIsExactlyWhatIsFilterable(t *testing.T) {
 		"the contract advertises it and nothing filterable carries it")
 }
 
+func TestTheVocabularysReferenceEnumIsExactlyWhatTheEngineDeclares(t *testing.T) {
+	engine := map[string]bool{}
+	for _, target := range storekit.ReferenceTargets() {
+		engine[string(target)] = true
+	}
+	compareVocabularySets(t, "reference target", engine,
+		vocabularyFieldEnum(t, "references", false),
+		"the engine points id fields at it and the contract cannot spell it, so the vocabulary would report a value no client can read",
+		"the contract advertises it and no id field points at it, so no field can ever report it")
+}
+
 // everyFilterableFieldType is the six custom-field types plus id, which only a
 // core field carries. Derived from fieldcatalog.Types() so a seventh custom type
 // joins these gates by existing rather than by somebody remembering them.

--- a/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
+++ b/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
@@ -133,6 +133,10 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 			Type      string   `json:"type"`
 			Operators []string `json:"operators"`
 			Custom    bool     `json:"custom"`
+			// A POINTER, so this test can tell an absent key from an empty
+			// string. A plain string would decode both as "" and the
+			// omitted-for-a-non-id-field guarantee would be unassertable.
+			References *string `json:"references,omitempty"`
 		} `json:"fields"`
 	}
 	status := e.Call(t, "GET", "/v1/filters/vocabulary?resource=person", nil, nil, &vocab)
@@ -161,6 +165,21 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 			if f.Custom {
 				t.Error("owner_id is a core field and is reported custom")
 			}
+			// The wire value, which no unit test can reach: an id field names
+			// the record type its values point at, in the contract's own
+			// record-type word.
+			if f.References == nil {
+				t.Error("owner_id is an id field and the response carries no references key, so a builder can only ask for a uuid")
+			} else if *f.References != "app_user" {
+				t.Errorf("owner_id references %q, want app_user", *f.References)
+			}
+		}
+		// And the other arm, for every non-id field in the same response: the key
+		// is ABSENT rather than blank. "" is not a member of the contract's enum,
+		// so a strict client rejects a response that sends it.
+		if f.Type != "id" && f.References != nil {
+			t.Errorf("%s is typed %s and the response carries references=%q; the key belongs only to an id field",
+				f.Name, f.Type, *f.References)
 		}
 		if len(f.Operators) == 0 {
 			t.Errorf("%s reports no operators, so a builder could offer no clause on it", f.Name)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -4221,6 +4221,39 @@ func (e FilterVocabularyFieldOperators) Valid() bool {
 	}
 }
 
+// Defines values for FilterVocabularyFieldReferences.
+const (
+	FilterVocabularyFieldReferencesAppUser      FilterVocabularyFieldReferences = "app_user"
+	FilterVocabularyFieldReferencesOrganization FilterVocabularyFieldReferences = "organization"
+	FilterVocabularyFieldReferencesPipeline     FilterVocabularyFieldReferences = "pipeline"
+	FilterVocabularyFieldReferencesProject      FilterVocabularyFieldReferences = "project"
+	FilterVocabularyFieldReferencesStage        FilterVocabularyFieldReferences = "stage"
+	FilterVocabularyFieldReferencesTag          FilterVocabularyFieldReferences = "tag"
+	FilterVocabularyFieldReferencesTeam         FilterVocabularyFieldReferences = "team"
+)
+
+// Valid indicates whether the value is a known member of the FilterVocabularyFieldReferences enum.
+func (e FilterVocabularyFieldReferences) Valid() bool {
+	switch e {
+	case FilterVocabularyFieldReferencesAppUser:
+		return true
+	case FilterVocabularyFieldReferencesOrganization:
+		return true
+	case FilterVocabularyFieldReferencesPipeline:
+		return true
+	case FilterVocabularyFieldReferencesProject:
+		return true
+	case FilterVocabularyFieldReferencesStage:
+		return true
+	case FilterVocabularyFieldReferencesTag:
+		return true
+	case FilterVocabularyFieldReferencesTeam:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FilterVocabularyFieldType.
 const (
 	FilterVocabularyFieldTypeBoolean  FilterVocabularyFieldType = "boolean"
@@ -9413,31 +9446,31 @@ func (e VoiceBuildStatus) Valid() bool {
 
 // Defines values for VoiceBuildStatusCode.
 const (
-	BudgetDeferred    VoiceBuildStatusCode = "budget_deferred"
-	Internal          VoiceBuildStatusCode = "internal"
-	InvalidOutput     VoiceBuildStatusCode = "invalid_output"
-	LessThannil       VoiceBuildStatusCode = "<nil>"
-	MaterialDrift     VoiceBuildStatusCode = "material_drift"
-	ModelUnavailable  VoiceBuildStatusCode = "model_unavailable"
-	QualityRegression VoiceBuildStatusCode = "quality_regression"
+	VoiceBuildStatusCodeBudgetDeferred    VoiceBuildStatusCode = "budget_deferred"
+	VoiceBuildStatusCodeInternal          VoiceBuildStatusCode = "internal"
+	VoiceBuildStatusCodeInvalidOutput     VoiceBuildStatusCode = "invalid_output"
+	VoiceBuildStatusCodeLessThannil       VoiceBuildStatusCode = "<nil>"
+	VoiceBuildStatusCodeMaterialDrift     VoiceBuildStatusCode = "material_drift"
+	VoiceBuildStatusCodeModelUnavailable  VoiceBuildStatusCode = "model_unavailable"
+	VoiceBuildStatusCodeQualityRegression VoiceBuildStatusCode = "quality_regression"
 )
 
 // Valid indicates whether the value is a known member of the VoiceBuildStatusCode enum.
 func (e VoiceBuildStatusCode) Valid() bool {
 	switch e {
-	case BudgetDeferred:
+	case VoiceBuildStatusCodeBudgetDeferred:
 		return true
-	case Internal:
+	case VoiceBuildStatusCodeInternal:
 		return true
-	case InvalidOutput:
+	case VoiceBuildStatusCodeInvalidOutput:
 		return true
-	case LessThannil:
+	case VoiceBuildStatusCodeLessThannil:
 		return true
-	case MaterialDrift:
+	case VoiceBuildStatusCodeMaterialDrift:
 		return true
-	case ModelUnavailable:
+	case VoiceBuildStatusCodeModelUnavailable:
 		return true
-	case QualityRegression:
+	case VoiceBuildStatusCodeQualityRegression:
 		return true
 	default:
 		return false
@@ -14764,6 +14797,17 @@ type FilterVocabularyField struct {
 	// this field, so a builder can disable it rather than discover it.
 	Operators []FilterVocabularyFieldOperators `json:"operators"`
 
+	// References The record type this field's ids point at — present for every `id`
+	// field, absent for every other type. Offer the record rather than a
+	// box for its uuid.
+	//
+	// The values are this contract's own record-type words, so no
+	// translation table is needed to key a picker on them.
+	//
+	// Never present on a custom field: the catalog's six types include no
+	// `id`, so only a core field can carry a reference.
+	References *FilterVocabularyFieldReferences `json:"references,omitempty"`
+
 	// Type The six custom-field types plus `id` for a reference to another
 	// record. The type decides the operators, which is why it is here.
 	Type FilterVocabularyFieldType `json:"type"`
@@ -14771,6 +14815,17 @@ type FilterVocabularyField struct {
 
 // FilterVocabularyFieldOperators defines model for FilterVocabularyField.Operators.
 type FilterVocabularyFieldOperators string
+
+// FilterVocabularyFieldReferences The record type this field's ids point at — present for every `id`
+// field, absent for every other type. Offer the record rather than a
+// box for its uuid.
+//
+// The values are this contract's own record-type words, so no
+// translation table is needed to key a picker on them.
+//
+// Never present on a custom field: the catalog's six types include no
+// `id`, so only a core field can carry a reference.
+type FilterVocabularyFieldReferences string
 
 // FilterVocabularyFieldType The six custom-field types plus `id` for a reference to another
 // record. The type decides the operators, which is why it is here.

--- a/backend/internal/modules/collections/filtervocabulary.go
+++ b/backend/internal/modules/collections/filtervocabulary.go
@@ -56,6 +56,11 @@ type VocabularyField struct {
 	Type      string
 	Operators []string
 	Custom    bool
+	// References is the record type an id field's values point at, and is empty
+	// for every other type — so a builder can offer the record rather than ask a
+	// reader to paste a uuid. The engine declares it beside the field; nothing
+	// here derives it from the name.
+	References storekit.Reference
 }
 
 // FilterVocabulary answers every field a NEW filter clause may name for this
@@ -103,10 +108,11 @@ func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]Vocabu
 			continue
 		}
 		fields = append(fields, VocabularyField{
-			Name:      name,
-			Type:      string(field.Type),
-			Operators: storekit.OperatorsFor(field),
-			Custom:    !isCore,
+			Name:       name,
+			Type:       string(field.Type),
+			Operators:  storekit.OperatorsFor(field),
+			Custom:     !isCore,
+			References: field.References,
 		})
 	}
 	// By name, because a map answers a different order every call and a picker
@@ -155,10 +161,19 @@ func wireVocabularyField(f VocabularyField) crmcontracts.FilterVocabularyField {
 	for _, op := range f.Operators {
 		operators = append(operators, crmcontracts.FilterVocabularyFieldOperators(op))
 	}
-	return crmcontracts.FilterVocabularyField{
+	wire := crmcontracts.FilterVocabularyField{
 		Name:      f.Name,
 		Type:      crmcontracts.FilterVocabularyFieldType(f.Type),
 		Operators: operators,
 		Custom:    f.Custom,
 	}
+	// Omitted rather than sent empty for a field that references nothing, because
+	// "" is not a member of the contract's enum: sending it would put a value the
+	// contract forbids on the wire, which a strict client rejects outright. The
+	// key is therefore absent for every non-id field.
+	if f.References != "" {
+		ref := crmcontracts.FilterVocabularyFieldReferences(f.References)
+		wire.References = &ref
+	}
+	return wire
 }

--- a/backend/internal/modules/collections/filtervocabulary_test.go
+++ b/backend/internal/modules/collections/filtervocabulary_test.go
@@ -159,6 +159,85 @@ func TestACustomColumnIsReportedCustomAndACollidingOneIsNot(t *testing.T) {
 	}
 }
 
+// The reference has to reach the CALLER, not merely be declared. Without this a
+// mapping that dropped it left every gate green — the declarations stayed
+// internally consistent and no test read the answer.
+func TestTheVocabularyTellsACallerWhatAnIDFieldReferences(t *testing.T) {
+	fields, ok, err := (&Store{}).FilterVocabulary(readerCtx(), "deal")
+	if err != nil || !ok {
+		t.Fatalf("filterVocabulary: ok=%v err=%v", ok, err)
+	}
+	byName := map[string]VocabularyField{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+	for name, want := range map[string]storekit.Reference{
+		"stage_id":        storekit.RefStage,
+		"pipeline_id":     storekit.RefPipeline,
+		"owner_id":        storekit.RefAppUser,
+		"owner_team_id":   storekit.RefTeam,
+		"organization_id": storekit.RefOrganization,
+		"project_id":      storekit.RefProject,
+		"tag":             storekit.RefTag,
+	} {
+		if got := byName[name].References; got != want {
+			t.Errorf("%s references %q, want %q", name, got, want)
+		}
+	}
+	// And a field that references nothing says so, rather than inheriting a
+	// neighbour's target — the failure a shared local in the mapping would cause.
+	if got := byName["status"].References; got != "" {
+		t.Errorf("status is a picklist and references %q, want none", got)
+	}
+}
+
+// The wire shape of that answer: a reference is a present key, and no reference
+// is an ABSENT one. "" is not a member of the contract's enum, so sending it
+// would put a value the contract forbids on the wire.
+func TestTheWireOmitsTheReferenceKeyForAFieldThatHasNone(t *testing.T) {
+	withRef := wireVocabularyField(VocabularyField{
+		Name: "owner_id", Type: string(storekit.FieldID),
+		References: storekit.RefAppUser,
+	})
+	if withRef.References == nil {
+		t.Fatal("an id field carried no reference to the wire")
+	}
+	if got := string(*withRef.References); got != string(storekit.RefAppUser) {
+		t.Errorf("wire reference = %q, want %q", got, storekit.RefAppUser)
+	}
+	none := wireVocabularyField(VocabularyField{
+		Name: "status", Type: string(storekit.FieldPicklist),
+	})
+	if none.References != nil {
+		t.Errorf("a picklist field carried reference %q to the wire", *none.References)
+	}
+	// Two fields in one response must not share a target. Each call allocates its
+	// own, and this is what would fail if the mapping ever took the address of a
+	// shared local.
+	other := wireVocabularyField(VocabularyField{
+		Name: "stage_id", Type: string(storekit.FieldID),
+		References: storekit.RefStage,
+	})
+	if withRef.References == other.References {
+		t.Error("two wire fields point at the same reference value")
+	}
+	if string(*withRef.References) == string(*other.References) {
+		t.Errorf("both wire fields report %q; one aliased the other", *withRef.References)
+	}
+}
+
+// No custom field may ever be id-typed, which is what makes "a reference belongs
+// to a core field" true rather than merely true today. The catalog's six types
+// are the whole set a workspace can define, so an `id` among them would report a
+// reference-less id field and break the contract's absolute wording.
+func TestNoCustomFieldTypeMapsToAnIDColumn(t *testing.T) {
+	for catalogType, engineType := range customFieldTypes {
+		if engineType == storekit.FieldID {
+			t.Errorf("custom-field type %q maps to id, so a workspace could define a field the vocabulary must describe a reference for", catalogType)
+		}
+	}
+}
+
 // Two identical requests answer the same order. The fields come out of a map, so
 // without the sort this passes by luck and a picker reshuffles between renders.
 func TestTheVocabularyIsOrderedTheSameWayTwice(t *testing.T) {

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -78,8 +78,9 @@ func taggableEntityTypes() []string {
 // that is the tenancy model rather than a hole in it.
 func tagLinkFor(entity string) storekit.Field {
 	return storekit.Field{
-		Expr: "tg.tag_id",
-		Type: storekit.FieldID,
+		Expr:       "tg.tag_id",
+		Type:       storekit.FieldID,
+		References: storekit.RefTag,
 		Link: "EXISTS (SELECT 1 FROM taggable tg WHERE tg.entity_type = '" + entity +
 			"' AND tg.entity_id = t.id AND %s)",
 	}
@@ -106,8 +107,9 @@ const ownerTeamIDField = "owner_team_id"
 // row-scope clause, so naming a team the caller cannot see answers their own
 // visible rows filtered to nothing — never that team's rows.
 var ownerTeamField = storekit.Field{
-	Expr: "tm.team_id",
-	Type: storekit.FieldID,
+	Expr:       "tm.team_id",
+	Type:       storekit.FieldID,
+	References: storekit.RefTeam,
 	Link: "EXISTS (SELECT 1 FROM team_membership tm WHERE tm.user_id = " + colOwnerID +
 		" AND %s)",
 }
@@ -161,7 +163,7 @@ var segmentEngines = map[string]storekit.Query{
 		Table:     "person",
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField: ownerTeamField,
 			tagFilterField:   tagLinkFor("person"),
 		},
@@ -175,7 +177,7 @@ var segmentEngines = map[string]storekit.Query{
 		// export built on one can carry it.
 		BaseWhere: whereArchivedNull + " AND NOT t.is_anchor",
 		Fields: map[string]storekit.Field{
-			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField: ownerTeamField,
 			"industry":       {Expr: "t.industry", Type: storekit.FieldText},
 			"size_band":      {Expr: "t.size_band", Type: storekit.FieldPicklist},
@@ -195,13 +197,13 @@ var segmentEngines = map[string]storekit.Query{
 		Table:     "deal",
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			"pipeline_id":       {Expr: "t.pipeline_id", Type: storekit.FieldID},
-			"stage_id":          {Expr: "t.stage_id", Type: storekit.FieldID},
-			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID},
+			"pipeline_id":       {Expr: "t.pipeline_id", Type: storekit.FieldID, References: storekit.RefPipeline},
+			"stage_id":          {Expr: "t.stage_id", Type: storekit.FieldID, References: storekit.RefStage},
+			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField:    ownerTeamField,
-			"organization_id":   {Expr: "t.organization_id", Type: storekit.FieldID},
-			"partner_org_id":    {Expr: "t.partner_org_id", Type: storekit.FieldID},
-			"project_id":        {Expr: "t.project_id", Type: storekit.FieldID},
+			"organization_id":   {Expr: "t.organization_id", Type: storekit.FieldID, References: storekit.RefOrganization},
+			"partner_org_id":    {Expr: "t.partner_org_id", Type: storekit.FieldID, References: storekit.RefOrganization},
+			"project_id":        {Expr: "t.project_id", Type: storekit.FieldID, References: storekit.RefProject},
 			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
 			"forecast_category": {Expr: "t.forecast_category", Type: storekit.FieldPicklist},
 			tagFilterField:      tagLinkFor("deal"),
@@ -224,7 +226,7 @@ var segmentEngines = map[string]storekit.Query{
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
 			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
-			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField:    ownerTeamField,
 			"candidate_org_key": {Expr: "t.candidate_org_key", Type: storekit.FieldText},
 			tagFilterField:      tagLinkFor("lead"),
@@ -234,9 +236,9 @@ var segmentEngines = map[string]storekit.Query{
 		Table:     projectEntity,
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			ownerIDField:      {Expr: colOwnerID, Type: storekit.FieldID},
+			ownerIDField:      {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField:  ownerTeamField,
-			"organization_id": {Expr: "t.organization_id", Type: storekit.FieldID},
+			"organization_id": {Expr: "t.organization_id", Type: storekit.FieldID, References: storekit.RefOrganization},
 			"phase":           {Expr: "t.phase", Type: storekit.FieldPicklist},
 			tagFilterField:    tagLinkFor(projectEntity),
 		},

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -167,6 +167,48 @@ func TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt(t *testing
 	}
 }
 
+// An id field is a reference to a record, and a surface that cannot say WHICH
+// record type has to fall back to asking for a uuid. So every id leaf declares
+// its target, and nothing else does — a target on a text or picklist field would
+// promise a picker for a column that holds no reference.
+//
+// Swept over every engine's every field rather than listed, so an id leaf added
+// tomorrow is covered the day it lands. This is the check that makes the
+// contract's `references` derivable rather than a per-field convention.
+func TestEveryIDFieldDeclaresWhatItReferences(t *testing.T) {
+	// The engine's own list, not a copy of it. A copy would pass on its own
+	// staleness: adding a constant and pointing a field at it would fail here,
+	// the copy would be updated next to the failure, and the contract-parity gate
+	// in compose — which reads the same list — would never see the new target.
+	targets := map[storekit.Reference]bool{}
+	for _, target := range storekit.ReferenceTargets() {
+		targets[target] = true
+	}
+	seen := 0
+	for resource, engine := range segmentEngines {
+		for name, field := range engine.Fields {
+			if field.Type == storekit.FieldID {
+				seen++
+				if field.References == "" {
+					t.Errorf("%s.%s is an id field and names no target, so a builder can only ask for a uuid", resource, name)
+					continue
+				}
+				if !targets[field.References] {
+					t.Errorf("%s.%s references %q, which is not one the engine declares", resource, name, field.References)
+				}
+				continue
+			}
+			if field.References != "" {
+				t.Errorf("%s.%s is typed %s and names a target %q: only an id holds a reference",
+					resource, name, field.Type, field.References)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no id fields found, so this gate checked nothing")
+	}
+}
+
 // An account's relationship to us is multi-valued, and a withdrawn one is a fact
 // it no longer carries.
 func TestTheRelationshipLeafExcludesWithdrawnRows(t *testing.T) {

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -80,6 +80,54 @@ type Field struct {
 	// join), and a link row is present or absent where a column is null
 	// or not. Empty for every base-table field.
 	Link string
+	// References names the record type this field's ids point at, for a
+	// surface that has to offer the record rather than ask for its uuid.
+	//
+	// The compiler has no use for it — an id compares as an id whatever it
+	// refers to — so it sits here for one reason: this is where a field is
+	// declared, and a lookup table keyed by field name elsewhere would be a
+	// second list of the engine's fields for a new leaf to fall out of.
+	//
+	// It is required of every id field in a vocabulary that is PUBLISHED to a
+	// client — the collections segment engines, gated by
+	// TestEveryIDFieldDeclaresWhatItReferences — and left empty everywhere
+	// else. An engine built to answer a count nobody reads a field list from
+	// (automation's preview vocabularies) owes no target, because nothing can
+	// offer a picker for it.
+	References Reference
+}
+
+// Reference is a record type an id field's values point at. Named rather than a
+// bare string so an unlisted target cannot be assigned, the same way FieldType
+// closes the type column above it.
+type Reference string
+
+// The record types a FieldID field may reference. The values are the contract's
+// own record-type words (`app_user`, not `user`), so a client keying a picker on
+// them needs no translation table.
+const (
+	RefTag          Reference = "tag"
+	RefAppUser      Reference = "app_user"
+	RefTeam         Reference = "team"
+	RefOrganization Reference = "organization"
+	RefPipeline     Reference = "pipeline"
+	RefStage        Reference = "stage"
+	RefProject      Reference = "project"
+)
+
+// ReferenceTargets is every target the engine admits, and the ONE list of them.
+//
+// A function beside the constants rather than a slice restated in each test that
+// needs it — the shape fieldcatalog.Types() already uses for the same reason. The
+// point is which drift stays catchable: a constant absent here fails the sweep
+// over the engines, and an entry here absent from the contract's enum fails the
+// parity gate in compose. Restating this set in either test would make both gates
+// pass on a stale copy of it, which is the one failure they exist to catch.
+func ReferenceTargets() []Reference {
+	return []Reference{
+		RefTag, RefAppUser, RefTeam, RefOrganization,
+		RefPipeline, RefStage, RefProject,
+	}
 }
 
 // Predicate is the canonical filter tree (the representation

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15047,6 +15047,19 @@ export interface components {
              *     field: if this operation listed it, it is offerable.
              */
             custom: boolean;
+            /**
+             * @description The record type this field's ids point at — present for every `id`
+             *     field, absent for every other type. Offer the record rather than a
+             *     box for its uuid.
+             *
+             *     The values are this contract's own record-type words, so no
+             *     translation table is needed to key a picker on them.
+             *
+             *     Never present on a custom field: the catalog's six types include no
+             *     `id`, so only a core field can carry a reference.
+             * @enum {string}
+             */
+            references?: "tag" | "app_user" | "team" | "organization" | "pipeline" | "stage" | "project";
         };
         /** @description A tag. Mirrors the `tag` table. */
         Tag: {


### PR DESCRIPTION
A filter clause on an id field is a reference to a record, and the vocabulary said only `type: id`. A client with that much can render a text box and hope the reader pastes a correct uuid — which is exactly what the Filters & views builder does today for `tag`, `owner_id`, `owner_team_id`, `stage_id`, `pipeline_id`, `organization_id`, `partner_org_id` and `project_id` alike. `ScalarValue` handles `date`, `boolean` and the numerics and falls back to text.

`FilterVocabularyField.references` closes that: present for every id field, absent for every other type, naming one of seven record types. A builder can then offer the tags, seats or stages that exist.

This is the information half. The picker that consumes it is the next change — filed as one PR each so the contract addition is reviewable on its own terms.

## Why not a client-side map

That was the alternative, and it is rejected for the reason this vocabulary exists at all. A map from field NAME to target is a second list of the engine's fields, and the day the engine gains an id leaf the map does not know about it — the picker silently falls back to a uuid box and nothing fails.

That is not hypothetical: two id leaves landed **yesterday** — `owner_team_id` ([#1850](https://github.com/gradionhq/margince-poc-v1/pull/1850)) and the deal's reach into its customer ([#1837](https://github.com/gradionhq/margince-poc-v1/pull/1837)). A client-side map would already be stale twice over. It is the same drift `operators` is here to prevent, one type down.

## Where the declaration lives

On `storekit.Field`, beside `Type`, not in the vocabulary read. The compiler has no use for it — an id compares as an id whatever it refers to — but a field is *declared* there, and keeping it there is what lets a gate hold every id leaf to naming a target. In the vocabulary read it would be a lookup table for a new leaf to fall out of.

## Three gates, each derived rather than listed

| Gate | What it refuses |
|---|---|
| `TestEveryIDFieldDeclaresWhatItReferences` | An id field naming no target — and any *other* type naming one, since a target on a text column promises a picker for a column holding no reference. Sweeps every engine's every field and **fails when it sweeps nothing**, so it cannot pass vacuously. |
| `TestTheVocabularysReferenceEnumIsExactlyWhatTheEngineDeclares` | The engine and the contract disagreeing, in either direction. It reads the two halves from **independently written sources** — taking both from the contract would only prove it agrees with itself. |
| The existing operator/type enum gates | Unchanged, and now joined by a third of the same shape. |

Both new gates mutation-verified: dropping `stage_id`'s declaration, and adding an engine target the contract lacks, each fail by name.

No custom field is ever id-typed (the catalog's six types have no id), so this only ever describes a core field, and the enumeration is closed for the same reason `operators` is.

## Regenerations

All three ran, per the house rule that a contract change is three: `make gen`, `pnpm gen:api`, and the MCP surface record — which is **unchanged**, since `/filters/vocabulary` carries no `x-mcp-tool`. Running it was the check, not a no-op I assumed.

The frontend drift gate initially failed here and was right to: it diffs the working tree, so a regenerated artifact has to be committed, which its own message says. Not a defect.

## Rebase note

`TestEveryWorkflowJobCarriesATimeoutCeiling` — the gate [#1849](https://github.com/gradionhq/margince-poc-v1/pull/1849) added, acting on [#1839](https://github.com/gradionhq/margince-poc-v1/issues/1839) — was failing on `release.yml`'s `github-release` job when I started. That was main's, not this diff's (this touches no workflow), and [#1933](https://github.com/gradionhq/margince-poc-v1/pull/1933) had already fixed it. Rebased onto that rather than working around it.

`make check-backend` green, `make craft-static` green (0 findings), `make check-fe` green (3529 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter vocabulary now tells clients what each id field points at, so builders can render record pickers instead of UUID inputs. Previously it returned only type: id; now id fields include references, and non-id fields omit it.

- Contract: Add optional references to FilterVocabularyField (enum: tag | app_user | team | organization | pipeline | stage | project) in `backend/api/crm.yaml` and `frontend/src/api/schema.d.ts`.
- Engine: Add `References` to `storekit.Field` with closed targets (`RefTag`, `RefAppUser`, `RefTeam`, `RefOrganization`, `RefPipeline`, `RefStage`, `RefProject`) and `ReferenceTargets()`. Annotate all id fields across segment engines (e.g., `owner_id`, `owner_team_id`, `pipeline_id`, `stage_id`, `organization_id`, `partner_org_id`, `project_id`, and the tag link).
- Wiring: `FilterVocabulary` includes references only for id fields and omits the key for others (never sends an empty string). Filter semantics are unchanged.
- Gates: 
  - Every id field must declare a valid target; no non-id field may declare one.
  - Keep the contract enum and engine targets in lockstep via an independent set comparison.
- Rollout: No migration. Existing clients continue to work; clients may use references to offer record pickers.

<sup>Written for commit d0ada4205517469f9728352bdc258b4d4401a331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata identifying what type of record each ID field references.
  * Supported references include tags, users, teams, organizations, pipelines, stages, and projects.
  * Reference information is included only for applicable ID fields and omitted for other fields.

* **Bug Fixes**
  * Improved consistency and accuracy of reference metadata across vocabulary fields and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->