### PR TITLE
fix(records): a query plan's statements carry a time budget

### DIFF
--- a/backend/internal/compose/filterpreview.go
+++ b/backend/internal/compose/filterpreview.go
@@ -36,6 +36,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -55,13 +56,11 @@ import (
 const (
 	filterPreviewDefaultRows = 25
 	filterPreviewMaxRows     = 100
-	// previewStatementTimeoutMS bounds each statement in a preview. Generous for
-	// an indexable filter and short enough that an expensive one cannot hold a
-	// pool connection: a glance that takes five seconds has already failed at
-	// being a glance. A literal rather than a bind, because SET LOCAL takes no
-	// parameters — which is safe only because it is a constant here and never a
-	// caller's value.
-	previewStatementTimeoutMS = "5000"
+	// previewStatementBudget bounds each statement in a preview. Generous for an
+	// indexable filter and short enough that an expensive one cannot hold a pool
+	// connection: a glance that takes five seconds has already failed at being a
+	// glance.
+	previewStatementBudget = 5 * time.Second
 )
 
 // filterPreviewHandlers shadows the generated PreviewFilter stub.
@@ -152,8 +151,8 @@ func (h filterPreviewHandlers) preview(
 		// expensive to count is refused in bounded time instead of holding a pool
 		// connection for as long as it takes, which is the difference between one
 		// slow request and a server that stops answering.
-		if _, err := tx.Exec(ctx, "SET LOCAL statement_timeout = "+previewStatementTimeoutMS); err != nil {
-			return fmt.Errorf("bound the preview statement: %w", err)
+		if err := database.BoundStatement(ctx, tx, previewStatementBudget); err != nil {
+			return err
 		}
 		count, err := engine.CountMatching(ctx, tx, pred)
 		if err != nil {

--- a/backend/internal/compose/integration/querybudget_integration_test.go
+++ b/backend/internal/compose/integration/querybudget_integration_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What a query plan is allowed to COST (#1847).
+//
+// A plan's page limit bounds the rows it returns and not the rows it visits: a
+// traversal compiles to a LATERAL join re-executed once per outer candidate
+// row, so a hop that admits almost nobody makes the statement walk the whole
+// outer table before it can fill a single page. The ceiling that bounds that is
+// proven here rather than in a unit test, because a SET LOCAL only bounds
+// anything on a real statement in a real transaction — and because the same
+// corpus has to show the ceiling does NOT cut a legitimate plan short.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/search"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// budgetVolumeRows is how many outer rows the plan below must visit before it
+// can answer.
+//
+// Measured rather than guessed: this corpus answers the plan in ~50 ms, so the
+// one-millisecond budget the first test arms is fifty times short of finishing
+// and the production budget is a hundred times more than enough. Both tests
+// rest on that one gap, so it is stated once.
+const budgetVolumeRows = 20000
+
+// budgetVolumePlan walks every seeded person and probes the employment edge for
+// each of them: the hop's own predicate matches the one seeded company, while
+// the EDGE reaches only one person. A hop that admitted everybody would let the
+// outer scan stop at the page limit after a dozen rows and prove nothing about
+// what a plan can cost.
+const budgetVolumePlan = `{"version": "v1", "target": "person",
+	"traverse": {"relation": "organizations",
+	             "where": [{"field": "address.city", "op": "eq", "value": "Volumeburg"}]}}`
+
+// rankedVolumePlan ranks every seeded person, so the ranking lane has the whole
+// corpus to score before the exact lane sees a candidate.
+const rankedVolumePlan = `{"version": "v1", "target": "person", "similar_to": "Volume"}`
+
+// seedBudgetVolume builds the corpus both tests run the same plan over: one
+// company in one city, many people, and exactly ONE employment edge between
+// them. It answers the person that edge reaches, which is the whole right
+// answer to the plan.
+func (q *queryEnv) seedBudgetVolume(t *testing.T) ids.UUID {
+	t.Helper()
+	ctx := q.admin()
+	org := q.SeedID(t, `INSERT INTO organization (id, display_name, address_city, source, captured_by)
+		VALUES ($1, 'Volume GmbH', 'Volumeburg', 'manual', 'human:x')`)
+	if _, err := q.Owner.Exec(ctx, `INSERT INTO person (full_name, source, captured_by)
+		SELECT 'Volume Person ' || i, 'manual', 'human:x' FROM generate_series(1, $1) AS i`,
+		budgetVolumeRows); err != nil {
+		t.Fatalf("seeding %d people: %v", budgetVolumeRows, err)
+	}
+	var employee ids.UUID
+	if err := q.Owner.QueryRow(ctx, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
+		SELECT 'employment', id, $1, 'manual', 'human:x' FROM person ORDER BY id LIMIT 1
+		RETURNING person_id`, org).Scan(&employee); err != nil {
+		t.Fatalf("seeding the one employment edge: %v", err)
+	}
+	// Without fresh statistics the planner sizes these tables from whatever the
+	// last analyze saw, which on a just-reset database is nothing — and the plan
+	// it picks is what decides the cost under test.
+	if _, err := q.Owner.Exec(ctx, `ANALYZE person, organization, relationship`); err != nil {
+		t.Fatalf("analyzing the seeded volume: %v", err)
+	}
+	return employee
+}
+
+// A plan that cannot finish inside its budget is abandoned and says so, rather
+// than holding a backend for as long as the statement takes. query_workspace is
+// a read any passport may issue, so a handful of concurrent expensive plans is
+// the whole connection pool.
+//
+// The verdict has to be partial_degraded and NOT complete_exact. Both come back
+// with no rows, and the difference between them is the difference between
+// "narrow your question" and "this workspace holds nobody".
+func TestQueryPlanThatOutlastsItsBudgetIsAbandonedRatherThanServed(t *testing.T) {
+	q := setupQuery(t)
+	q.seedBudgetVolume(t)
+	q.executor = search.NewQueryExecutorWithBudget(q.Store, nil, search.NewColumnCatalog(q.DB()), time.Millisecond)
+
+	result := q.run(q.admin(), t, budgetVolumePlan)
+
+	if len(result.Rows) != 0 {
+		t.Fatalf("an abandoned statement answered %d rows, which are only whatever the planner reached first",
+			len(result.Rows))
+	}
+	if result.Coverage != search.CoveragePartialDegraded {
+		t.Fatalf("coverage is %q", result.Coverage)
+	}
+	if len(result.Notes) != 1 || result.Notes[0].Code != search.CodePlanExceededBudget {
+		t.Fatalf("notes are %+v", result.Notes)
+	}
+	// The note is the only thing standing between an empty page and a wrong
+	// conclusion, so it has to say what to do about it.
+	if result.Notes[0].Detail == "" {
+		t.Error("the note tells the caller nothing they can act on")
+	}
+}
+
+// The SAME plan over the SAME corpus answers completely under the production
+// budget. Without this the test above would pass just as well against a ceiling
+// set so low that nothing is ever answered, which is the failure mode a timeout
+// invites: a bound tight enough to be safe and useless.
+func TestQueryPlanWithinItsBudgetAnswersCompletely(t *testing.T) {
+	q := setupQuery(t)
+	employee := q.seedBudgetVolume(t)
+
+	result := q.run(q.admin(), t, budgetVolumePlan)
+
+	if len(result.Rows) != 1 || result.Rows[0].ID != employee {
+		t.Fatalf("the plan answered %d rows; the one employed person is the whole answer", len(result.Rows))
+	}
+	if result.Coverage != search.CoverageCompleteExact {
+		t.Fatalf("coverage is %q, so a plan that ran whole is reporting that it did not", result.Coverage)
+	}
+	if len(result.Notes) != 0 {
+		t.Errorf("a complete answer carries notes: %+v", result.Notes)
+	}
+}
+
+// The RANKING lane is bounded too, which is a different transaction from the
+// one above.
+//
+// A similar_to plan ranks before it filters, and that ranking opens its own
+// transaction inside the store — so a ceiling armed only on the exact lane's
+// statement would leave every ranked plan as unbounded as it was before anyone
+// thought about the cost. This is the same defect one lane to the left, and it
+// is reachable through the same 🟢 read.
+func TestARankedQueryPlanIsBoundedInTheRankingLaneToo(t *testing.T) {
+	q := setupQuery(t)
+	q.seedBudgetVolume(t)
+	q.executor = search.NewQueryExecutorWithBudget(q.Store, nil, search.NewColumnCatalog(q.DB()), time.Millisecond)
+
+	result := q.run(q.admin(), t, rankedVolumePlan)
+
+	if len(result.Rows) != 0 {
+		t.Fatalf("an abandoned ranking answered %d rows", len(result.Rows))
+	}
+	if result.Coverage != search.CoveragePartialDegraded {
+		t.Fatalf("coverage is %q", result.Coverage)
+	}
+	if len(result.Notes) != 1 || result.Notes[0].Code != search.CodePlanExceededBudget {
+		t.Fatalf("notes are %+v", result.Notes)
+	}
+
+	// The control, on the same corpus: under the production budget this lane
+	// ranks the whole corpus in ~115ms and answers a page. Without it the
+	// assertions above would hold just as well against a ranking lane that is
+	// broken rather than bounded.
+	q.executor = search.NewQueryExecutor(q.Store, nil, search.NewColumnCatalog(q.DB()))
+	answered := q.run(q.admin(), t, rankedVolumePlan)
+	if len(answered.Rows) == 0 {
+		t.Fatal("the same ranked plan answers nothing under the production budget")
+	}
+	// No embedder is wired here, so the one note it does carry is the lane
+	// saying it ranked lexically — never the budget.
+	for _, note := range answered.Notes {
+		if note.Code == search.CodePlanExceededBudget {
+			t.Errorf("a plan inside its budget reported exceeding it: %+v", note)
+		}
+	}
+}

--- a/backend/internal/modules/search/querybudget.go
+++ b/backend/internal/modules/search/querybudget.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// What a plan is allowed to COST, and what it answers when it costs more.
+//
+// The page limit bounds the rows a plan RETURNS and not the rows it visits: a
+// traversal compiles to a LATERAL join re-executed once per outer candidate
+// row, and a predicate that matches almost nothing still makes the planner walk
+// the table to prove it. So the ceiling is a time budget, spent by whichever of
+// the plan's two transactions gets there first, and running out of it is an
+// answer rather than a fault.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+)
+
+// CodePlanExceededBudget is the note a plan carries when the statement ran out
+// of time and was abandoned, so the answer has NO rows rather than a short page
+// of them.
+//
+// A plan can cost far more than its page suggests — a traversal is a nested
+// loop, and a predicate that matches almost nothing still walks the table to
+// prove it — so a caller told only that the answer is partial would read the
+// empty page as an empty workspace.
+const CodePlanExceededBudget = "plan_exceeded_time_budget"
+
+// planStatementBudget is how long one plan may hold a connection.
+//
+// It matches the filter preview's ceiling, which is the tree's only other one,
+// and for the same reason: an agent still waiting after five seconds has
+// already lost the turn it asked the question in. An indexed plan with a page
+// limit answers an SMB-sized corpus in milliseconds, so this bounds the plans
+// that cannot be answered at all rather than the ones that are merely large.
+const planStatementBudget = 5 * time.Second
+
+// NewQueryExecutorWithBudget is the same executor with an explicit ceiling, for
+// the tests that have to prove the ceiling is really armed on real statements.
+//
+// It parameterizes the production executor rather than standing in for it: what
+// a test chooses is the number, and the bounded handle, the classification and
+// the answer it produces are the ones a caller gets. The budget is fixed at
+// construction because compose builds ONE executor that every request shares —
+// a setter on it would be a ceiling one request could change under another.
+//
+// A zero budget means unbounded, because a duration's zero value cannot be told
+// apart from one nobody set. Nothing guards against passing it: NewQueryExecutor
+// is the only caller that is not a test, and it passes the constant.
+func NewQueryExecutorWithBudget(store *Store, embedder Embedder, columns ColumnReader,
+	budget time.Duration,
+) *QueryExecutor {
+	// The budget is bound to the store's HANDLE, so it reaches every
+	// transaction answering this plan opens — the ranking lane as well as the
+	// exact one. Bounding the statement in answerRows alone would have left
+	// a similar_to plan's ranking as unbounded as it was before, which is the
+	// same defect one lane to the left.
+	return &QueryExecutor{store: store.bounded(budget), embedder: embedder, columns: columns, budget: budget}
+}
+
+// abandoned is the answer a plan gets when it ran out of its budget, and it is
+// the same answer whichever lane spent it.
+//
+// No rows, because a cancelled statement had found only whatever the planner
+// happened to reach first — an arbitrary subset dressed as a page. The note is
+// then the only thing between an empty answer and a wrong conclusion, so it
+// says what to narrow rather than that something went wrong.
+//
+// Whatever notes the answer had already collected are kept: a ranking that
+// degraded before the budget ran out still degraded, and the caller reading two
+// notes learns both things that happened to their plan.
+func (e *QueryExecutor) abandoned(plan ValidatedPlan, result QueryResult) QueryResult {
+	result.Rows = nil
+	result.Notes = append(result.Notes, QueryNote{
+		Code: CodePlanExceededBudget,
+		Detail: fmt.Sprintf("this plan did not finish within %s and was abandoned, so no rows are returned; "+
+			"narrow it — predicate a field the records are indexed on, or ask without the traversal",
+			e.budget),
+	})
+	result.Coverage = coverageOf(plan, answerShape{abandoned: true})
+	return result
+}
+
+// budgetSpent tells this plan's own ceiling apart from every other reason a
+// statement stops before answering.
+//
+// Postgres raises the same 57014 for a spent statement_timeout, an operator
+// cancelling the backend, and the client going away, so the SQLSTATE alone
+// cannot carry this judgement. The one that must not be misread is the caller:
+// A CANCELLED REQUEST IS NOT A DEGRADED ANSWER — reporting their own vanished
+// deadline as this plan being too slow describes their timeout as a property of
+// the workspace, and there is nobody left to read the answer anyway. The live
+// context separates that case, which is why the classification lives here, with
+// the caller that holds one.
+//
+// An operator cancelling the backend under a live request reads as a spent
+// budget, and is left that way: both mean the statement was stopped before it
+// answered, and narrowing the plan is the caller's move either way.
+func budgetSpent(ctx context.Context, err error) bool {
+	return storekit.IsQueryCanceled(err) && ctx.Err() == nil
+}

--- a/backend/internal/modules/search/querybudget_test.go
+++ b/backend/internal/modules/search/querybudget_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// Postgres raises ONE SQLSTATE for every reason a statement stops early, so the
+// spent-budget answer and the vanished-caller error are told apart by the
+// context and nothing else. Getting this backwards reports a caller's own
+// timeout as this installation's plan being too slow — and answers a degraded
+// page to somebody who is no longer there to read it.
+func TestASpentBudgetIsToldApartFromACallerWhoLeft(t *testing.T) {
+	t.Parallel()
+	canceled := &pgconn.PgError{Code: "57014", Message: "canceling statement due to statement timeout"}
+
+	if !budgetSpent(context.Background(), canceled) {
+		t.Error("a cancelled statement under a live request was not read as the budget being spent")
+	}
+
+	gone, abandon := context.WithCancel(context.Background())
+	abandon()
+	if budgetSpent(gone, canceled) {
+		t.Error("a caller who left was reported as this plan exceeding its budget")
+	}
+
+	unrelated := &pgconn.PgError{Code: "23505", Message: "duplicate key value violates unique constraint"}
+	if budgetSpent(context.Background(), unrelated) {
+		t.Error("an unrelated SQLSTATE was read as the budget being spent")
+	}
+}
+
+// An abandoned statement returns no rows, and the one thing it must never do is
+// claim they are all of them: complete_exact is the only verdict a caller may
+// count with, and an empty page carrying it says the workspace holds nothing.
+func TestAnAbandonedAnswerIsNeverReportedAsComplete(t *testing.T) {
+	t.Parallel()
+	exact := validatedPlanDoc(readerFor(entityDeal), t, `{"version": "v1", "target": "deal"}`)
+	if got := coverageOf(exact, answerShape{abandoned: true}); got != CoveragePartialDegraded {
+		t.Errorf("an abandoned exact plan answered coverage %q", got)
+	}
+	ranked := validatedPlanDoc(readerFor(entityDeal), t, `{"version": "v1", "target": "deal", "similar_to": "roofing"}`)
+	if got := coverageOf(ranked, answerShape{abandoned: true}); got != CoveragePartialDegraded {
+		t.Errorf("an abandoned ranked plan answered coverage %q", got)
+	}
+	// The verdict is still reachable when nothing went wrong, which is what
+	// makes the two above worth asserting.
+	if got := coverageOf(exact, answerShape{}); got != CoverageCompleteExact {
+		t.Errorf("a whole exact answer reported coverage %q", got)
+	}
+}
+
+// The executor bounds a COPY of the store it is handed, never the caller's.
+//
+// That is what keeps the contract /search endpoint out of this: it shares the
+// same store type, and a constructor that bounded the handle in place would
+// have given every unrelated caller of that store this executor's ceiling.
+func TestTheExecutorBoundsItsOwnStoreAndNotTheCallersOne(t *testing.T) {
+	t.Parallel()
+	handle := database.Bind(nil, func(context.Context) (ids.WorkspaceID, error) { return ids.WorkspaceID{}, nil })
+	store := NewStore(handle)
+
+	e := NewQueryExecutorWithBudget(store, nil, nil, time.Millisecond)
+
+	if e.budget != time.Millisecond {
+		t.Errorf("the executor's budget is %s", e.budget)
+	}
+	if e.store == store {
+		t.Error("the executor kept the caller's store, so bounding it bounded theirs too")
+	}
+	if e.store.db == store.db {
+		t.Error("the executor shares the caller's handle, so the ceiling reaches every other user of it")
+	}
+	// And the production constructor arms one at all — an executor built the
+	// way compose builds it must not run unbounded.
+	if NewQueryExecutor(store, nil, nil).budget != planStatementBudget {
+		t.Error("the composed executor carries no budget")
+	}
+}

--- a/backend/internal/modules/search/queryexec.go
+++ b/backend/internal/modules/search/queryexec.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -51,6 +52,8 @@ const (
 	// cursor member, so the rest cannot be asked for — which makes truncation
 	// a degradation rather than pagination.
 	CodeResultTruncated = "result_truncated_at_limit"
+	// The fourth note code, CodePlanExceededBudget, is declared in
+	// querybudget.go beside the ceiling it reports on.
 )
 
 // QueryResult is one answered plan.
@@ -104,6 +107,7 @@ type QueryExecutor struct {
 	store    *Store
 	embedder Embedder
 	columns  ColumnReader
+	budget   time.Duration
 }
 
 // NewQueryExecutor builds the executor over this module's own store, its
@@ -111,8 +115,10 @@ type QueryExecutor struct {
 // vocabulary's nil pass-through widens what may be asked, and a widened
 // vocabulary is exactly what must not be executed against a table nobody
 // checked.
+//
+// It arms the plan-statement ceiling; querybudget.go is what that means.
 func NewQueryExecutor(store *Store, embedder Embedder, columns ColumnReader) *QueryExecutor {
-	return &QueryExecutor{store: store, embedder: embedder, columns: columns}
+	return NewQueryExecutorWithBudget(store, embedder, columns, planStatementBudget)
 }
 
 // Execute answers the plan.
@@ -137,6 +143,9 @@ func (e *QueryExecutor) Execute(ctx context.Context, plan ValidatedPlan) (QueryR
 	}
 	ranked, degraded, err := e.rankCandidates(ctx, plan)
 	if err != nil {
+		if budgetSpent(ctx, err) {
+			return e.abandoned(plan, result), nil
+		}
 		return QueryResult{}, err
 	}
 	if degraded {
@@ -152,9 +161,12 @@ func (e *QueryExecutor) Execute(ctx context.Context, plan ValidatedPlan) (QueryR
 		result.Coverage = coverageOf(plan, answerShape{degraded: degraded})
 		return result, nil
 	}
-	rows, err := e.answerRows(ctx, plan, binding)
+	rows, abandoned, err := e.answerRows(ctx, plan, binding)
 	if err != nil {
 		return QueryResult{}, err
+	}
+	if abandoned {
+		return e.abandoned(plan, result), nil
 	}
 	truncated := plan.Plan.SimilarTo == "" && len(rows) > plan.Limit
 	if truncated {
@@ -202,11 +214,25 @@ func (e *QueryExecutor) bindPlan(ctx context.Context, plan ValidatedPlan) (planB
 // rows rather than an error: object RBAC can change under a plan, and a caller
 // who lost the grant mid-flight learns the same thing an empty workspace tells
 // them.
-func (e *QueryExecutor) answerRows(ctx context.Context, plan ValidatedPlan, binding planBinding) ([]QueryRow, error) {
+//
+// The statement runs under this executor's time budget, which its store's
+// handle carries, because nothing else here bounds what a plan costs. The page
+// limit bounds the rows RETURNED and not the rows visited: a traversal compiles
+// to a LATERAL join re-executed once per outer candidate row, so a hop
+// predicate that matches almost nothing makes the planner walk the whole outer
+// table before it can fill a single page. Without the ceiling the only
+// remaining bound is how long a caller will hold a pool connection, and
+// query_workspace is a read any passport may issue.
+//
+// abandoned reports the budget being spent, which is an ANSWER rather than a
+// fault — see Execute.
+func (e *QueryExecutor) answerRows(ctx context.Context, plan ValidatedPlan, binding planBinding) (
+	answered []QueryRow, abandoned bool, err error,
+) {
 	compiler := &planCompiler{}
 	sql, admitted, err := compiler.compileStatement(ctx, plan, binding)
 	if err != nil || !admitted {
-		return nil, err
+		return nil, false, err
 	}
 	var rows []QueryRow
 	err = e.store.db.Tx(ctx, func(tx pgx.Tx) error {
@@ -219,9 +245,12 @@ func (e *QueryExecutor) answerRows(ctx context.Context, plan ValidatedPlan, bind
 		return err
 	})
 	if err != nil {
-		return nil, err
+		if budgetSpent(ctx, err) {
+			return nil, true, nil
+		}
+		return nil, false, err
 	}
-	return rows, nil
+	return rows, false, nil
 }
 
 // scanPlanRows materializes the answer, carrying the hop row as the evidence
@@ -355,16 +384,11 @@ type answerShape struct {
 	truncated bool
 	// degraded: a lane could not run as asked.
 	degraded bool
+	// abandoned: the statement ran out of its time budget, so there are no
+	// rows at all rather than a short page of them.
+	abandoned bool
 }
 
-// coverageOf decides the verdict. Degradation dominates ranking and ranking
-// dominates completeness, so the only answer that ever claims to be complete
-// is one that ran exactly, whole, and undegraded.
-//
-// Truncation is a verdict on the EXACT lane only. A ranked answer is a top-N
-// by construction — that is what ranked_semantic says — so counting its bound
-// as a degradation would leave the verdict unreachable and tell a caller
-// nothing they did not ask for.
 // CoverageClasses is the CLOSED set coverageOf can answer with.
 //
 // It is exported so the surface that publishes these words can be held to
@@ -377,9 +401,19 @@ func CoverageClasses() []string {
 	return []string{CoverageCompleteExact, CoverageRankedSemantic, CoveragePartialDegraded}
 }
 
+// coverageOf decides the verdict. Degradation dominates ranking and ranking
+// dominates completeness, so the only answer that ever claims to be complete
+// is one that ran exactly, whole, and undegraded. An abandoned statement is
+// the same verdict from the other end — it never ran whole at all — which is
+// why it needs no class of its own.
+//
+// Truncation is a verdict on the EXACT lane only. A ranked answer is a top-N
+// by construction — that is what ranked_semantic says — so counting its bound
+// as a degradation would leave the verdict unreachable and tell a caller
+// nothing they did not ask for.
 func coverageOf(plan ValidatedPlan, shape answerShape) string {
 	switch {
-	case shape.degraded || shape.truncated:
+	case shape.degraded || shape.truncated || shape.abandoned:
 		return CoveragePartialDegraded
 	case plan.Plan.SimilarTo != "":
 		return CoverageRankedSemantic

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -29,6 +30,16 @@ type Store struct {
 // workspace it serves.
 func NewStore(db *database.DB) *Store {
 	return &Store{db: db}
+}
+
+// bounded is this store with a time ceiling on every statement it runs.
+//
+// The ceiling rides the HANDLE, so it reaches the lanes this store opens for
+// itself: answering one query plan takes a ranking transaction and an exact
+// one, and a ceiling armed at a single call site would leave the other lane as
+// unbounded as it was before anybody thought about it.
+func (s *Store) bounded(budget time.Duration) *Store {
+	return &Store{db: s.db.Bounded(budget)}
 }
 
 // forWorkspace is this store re-bound to one tenant of the fleet enumeration.

--- a/backend/internal/platform/database/db.go
+++ b/backend/internal/platform/database/db.go
@@ -6,6 +6,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -32,6 +33,28 @@ import (
 type DB struct {
 	pool      *pgxpool.Pool
 	workspace func(context.Context) (ids.WorkspaceID, error)
+	// budget bounds every statement this handle's transactions run, and is zero
+	// on a handle nobody bounded — see Bounded.
+	budget time.Duration
+}
+
+// Bounded is this handle with a time ceiling on every statement its
+// transactions run.
+//
+// It binds the budget to the HANDLE rather than to a call site because the
+// paths that need one do not run a single statement: answering an agent's query
+// plan takes a ranking lane and an exact lane, each opening its own
+// transaction, and a ceiling added per call site is a ceiling the next lane
+// silently does without. A store built on a bounded handle cannot grow an
+// unbounded query.
+//
+// ZERO is the one value that cannot be a ceiling: it is the field's zero value
+// on every handle nobody bounded, so it has to mean unbounded. Every other
+// value is armed, which is what keeps a NEGATIVE budget from disappearing —
+// BoundStatement refuses it on the first transaction rather than leaving a
+// handle that quietly runs without the ceiling it was asked for.
+func (d *DB) Bounded(budget time.Duration) *DB {
+	return &DB{pool: d.pool, workspace: d.workspace, budget: budget}
 }
 
 // Bind returns a handle that resolves its workspace through resolve.
@@ -93,6 +116,15 @@ func (d *DB) Tx(ctx context.Context, fn func(pgx.Tx) error) error {
 	if err != nil {
 		return fmt.Errorf("pg: resolving the installation's workspace: %w", err)
 	}
+	if d.budget != 0 {
+		bounded := fn
+		fn = func(tx pgx.Tx) error {
+			if err := BoundStatement(ctx, tx, d.budget); err != nil {
+				return err
+			}
+			return bounded(tx)
+		}
+	}
 	return withBoundTx(ctx, d.pool, ws, fn)
 }
 
@@ -106,5 +138,11 @@ func (d *DB) Tx(ctx context.Context, fn func(pgx.Tx) error) error {
 // enumerate — so a new caller here is a sign the work belongs on the job
 // fan-out, which hands each pass the tenant it runs for.
 func (d *DB) ForWorkspace(ws ids.WorkspaceID) *DB {
-	return BindTo(d.pool, ws)
+	// The budget rides along: a pass that re-binds a bounded handle to another
+	// tenant is running the same statements against the same tables, and a
+	// ceiling that fell off at the re-bind would be one nobody could see was
+	// missing.
+	pinned := BindTo(d.pool, ws)
+	pinned.budget = d.budget
+	return pinned
 }

--- a/backend/internal/platform/database/db.go
+++ b/backend/internal/platform/database/db.go
@@ -54,6 +54,15 @@ type DB struct {
 // BoundStatement refuses it on the first transaction rather than leaving a
 // handle that quietly runs without the ceiling it was asked for.
 func (d *DB) Bounded(budget time.Duration) *DB {
+	// Nil-safe for the reason Pool and Tx are: CONSTRUCTION reaches this. A
+	// store built from an un-injected handle is a real thing in this tree — the
+	// unit tests that assert a gate answering before any query build one — and
+	// bounding it must fail where it is USED, with the sentinel those tests key
+	// on, rather than panicking where it is wired. A handle that runs no
+	// statements has nothing to bound anyway.
+	if d == nil {
+		return nil
+	}
 	return &DB{pool: d.pool, workspace: d.workspace, budget: budget}
 }
 

--- a/backend/internal/platform/database/statementbudget.go
+++ b/backend/internal/platform/database/statementbudget.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// BoundStatement gives every statement that follows it in tx a wall-clock
+// ceiling. It is the ONE spelling of "this statement has a budget", for the
+// same reason this package owns the workspace GUC: a store that builds its own
+// timeout is a store whose ceiling nobody can find by grepping for one name.
+//
+// It exists for the paths where the CALLER writes the predicate — a saved
+// filter's tree, an agent's query plan. Those cannot be bounded by a page
+// limit, because the limit bounds the rows returned and not the rows visited: a
+// predicate that matches almost nothing still makes the planner walk the table
+// to prove it. Without a ceiling the only bound left is how long the caller is
+// willing to hold a pool connection, which is not a bound at all.
+//
+// Parameterized set_config, never a string-built SET LOCAL — the same rule the
+// workspace binding above follows, and it holds here even though no budget is a
+// caller's value, because the next budget to be threaded through might be.
+func BoundStatement(ctx context.Context, tx pgx.Tx, budget time.Duration) error {
+	// Postgres reads statement_timeout = 0 as "no timeout", so a budget that
+	// rounds to zero milliseconds would silently UNBOUND the statement this call
+	// exists to bound — the one outcome worse than never having called it. A
+	// sub-millisecond budget is therefore honoured as the shortest ceiling
+	// Postgres can express, and a non-positive one is a programming error rather
+	// than a request for no ceiling.
+	if budget <= 0 {
+		return fmt.Errorf("pg: a statement budget of %s bounds nothing; "+
+			"pass the caller's own ceiling, and note that Postgres reads zero as no timeout", budget)
+	}
+	milliseconds := strconv.FormatInt(max(budget.Milliseconds(), 1), 10)
+	if _, err := tx.Exec(ctx,
+		`SELECT set_config('statement_timeout', $1, true)`, milliseconds); err != nil {
+		return fmt.Errorf("pg: bounding the statement to %s: %w", budget, err)
+	}
+	return nil
+}

--- a/backend/internal/platform/database/statementbudget_test.go
+++ b/backend/internal/platform/database/statementbudget_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// recordingTx captures the statements a budget issues. The embedded interface
+// is nil deliberately: a call to anything but Exec is a call this helper was
+// never asked to stand in for, and panicking says so louder than a zero value.
+type recordingTx struct {
+	pgx.Tx
+	issued []string
+}
+
+func (r *recordingTx) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	r.issued = append(r.issued, fmt.Sprintf("%s %v", sql, args))
+	return pgconn.CommandTag{}, nil
+}
+
+// The budget reaches Postgres in the unit Postgres reads it in. statement_timeout
+// with no unit is milliseconds, and a duration rendered as anything else would
+// bound the statement to the wrong order of magnitude. It rides set_config
+// rather than a built SET LOCAL, so the value is a bound parameter.
+func TestAStatementBudgetIsBoundInMilliseconds(t *testing.T) {
+	t.Parallel()
+	tx := &recordingTx{}
+	if err := BoundStatement(context.Background(), tx, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if len(tx.issued) != 1 || tx.issued[0] != `SELECT set_config('statement_timeout', $1, true) [5000]` {
+		t.Fatalf("the statements issued were %q", tx.issued)
+	}
+}
+
+// A budget too short to express in milliseconds is the trap this rounds away
+// from: Postgres reads statement_timeout = 0 as NO timeout, so truncating a
+// sub-millisecond budget would unbound the statement the call was made to bound
+// — the one outcome worse than never calling it.
+func TestABudgetShorterThanAMillisecondStillBoundsTheStatement(t *testing.T) {
+	t.Parallel()
+	tx := &recordingTx{}
+	if err := BoundStatement(context.Background(), tx, 500*time.Microsecond); err != nil {
+		t.Fatal(err)
+	}
+	if len(tx.issued) != 1 || tx.issued[0] != `SELECT set_config('statement_timeout', $1, true) [1]` {
+		t.Fatalf("the statements issued were %q", tx.issued)
+	}
+}
+
+// Zero is not "no ceiling wanted", it is a caller who computed one wrong. It is
+// refused rather than passed through, because passing it through is silently
+// indistinguishable from the unbounded path.
+func TestANonPositiveBudgetIsRefusedAndIssuesNothing(t *testing.T) {
+	t.Parallel()
+	for _, budget := range []time.Duration{0, -time.Second} {
+		tx := &recordingTx{}
+		err := BoundStatement(context.Background(), tx, budget)
+		if err == nil {
+			t.Fatalf("a budget of %s was accepted", budget)
+		}
+		if len(tx.issued) != 0 {
+			t.Errorf("a refused budget of %s still issued %q", budget, tx.issued)
+		}
+	}
+}
+
+// A bounded handle re-bound to another tenant keeps its ceiling. The fleet
+// passes that re-bind run the same statements against the same tables, and a
+// budget that fell off at the re-bind would be one nobody could see was
+// missing.
+func TestABoundedHandleKeepsItsCeilingWhenReboundToAnotherTenant(t *testing.T) {
+	t.Parallel()
+	bounded := Bind(nil, func(context.Context) (ids.WorkspaceID, error) { return ids.WorkspaceID{}, nil }).
+		Bounded(5 * time.Second)
+
+	if got := bounded.ForWorkspace(ids.WorkspaceID{}).budget; got != 5*time.Second {
+		t.Errorf("the re-bound handle's budget is %s", got)
+	}
+	// An unbounded handle stays unbounded, so the ceiling is something a caller
+	// asks for rather than something re-binding hands out.
+	plain := Bind(nil, func(context.Context) (ids.WorkspaceID, error) { return ids.WorkspaceID{}, nil })
+	if got := plain.ForWorkspace(ids.WorkspaceID{}).budget; got != 0 {
+		t.Errorf("an unbounded handle grew a budget of %s", got)
+	}
+}

--- a/backend/internal/platform/database/statementbudget_test.go
+++ b/backend/internal/platform/database/statementbudget_test.go
@@ -5,7 +5,9 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,11 +23,14 @@ import (
 type recordingTx struct {
 	pgx.Tx
 	issued []string
+	// refuse is what Exec answers, for the caller that has to prove a database
+	// refusing the ceiling does not read as a ceiling that was set.
+	refuse error
 }
 
 func (r *recordingTx) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	r.issued = append(r.issued, fmt.Sprintf("%s %v", sql, args))
-	return pgconn.CommandTag{}, nil
+	return pgconn.CommandTag{}, r.refuse
 }
 
 // The budget reaches Postgres in the unit Postgres reads it in. statement_timeout
@@ -92,5 +97,43 @@ func TestABoundedHandleKeepsItsCeilingWhenReboundToAnotherTenant(t *testing.T) {
 	plain := Bind(nil, func(context.Context) (ids.WorkspaceID, error) { return ids.WorkspaceID{}, nil })
 	if got := plain.ForWorkspace(ids.WorkspaceID{}).budget; got != 0 {
 		t.Errorf("an unbounded handle grew a budget of %s", got)
+	}
+}
+
+// A database that refuses the ceiling must not leave the caller believing there
+// is one. The error says which budget failed, because "bounding the statement"
+// with no number leaves an operator reading it no way to tell a misconfigured
+// ceiling from an unreachable database.
+func TestAStatementThatCannotBeBoundFailsRatherThanRunningUnbounded(t *testing.T) {
+	t.Parallel()
+	refused := errors.New("connection reset")
+	tx := &recordingTx{refuse: refused}
+
+	err := BoundStatement(context.Background(), tx, 5*time.Second)
+
+	if !errors.Is(err, refused) {
+		t.Fatalf("the refusal did not reach the caller: %v", err)
+	}
+	if !strings.Contains(err.Error(), "5s") {
+		t.Errorf("the error does not name the budget it failed to set: %v", err)
+	}
+}
+
+// Bounding an un-injected handle must not panic where it is WIRED. A store
+// built without a database is how this tree asserts a gate that answers before
+// any query runs, and those tests key on the sentinel below — so the bounded
+// path owes them the same answer the unbounded one gives.
+func TestBoundingAnUninjectedHandleStillAnswersTheSentinel(t *testing.T) {
+	t.Parallel()
+	var unwired *DB
+
+	bounded := unwired.Bounded(5 * time.Second)
+
+	err := bounded.Tx(context.Background(), func(pgx.Tx) error {
+		t.Fatal("a transaction body ran on a handle with no database")
+		return nil
+	})
+	if !errors.Is(err, ErrNoWorkspace) {
+		t.Fatalf("a bounded un-injected handle answered %v, not the no-workspace sentinel", err)
 	}
 }

--- a/backend/internal/platform/database/storekit/sqlstate.go
+++ b/backend/internal/platform/database/storekit/sqlstate.go
@@ -16,6 +16,7 @@ const (
 	pgForeignKeyViolation = "23503"
 	pgCheckViolation      = "23514"
 	pgExclusionViolation  = "23P01"
+	pgQueryCanceled       = "57014"
 )
 
 // pgViolation names the violated constraint when err is the given
@@ -89,4 +90,17 @@ func ExclusionViolation(err error) (constraint string, ok bool) {
 // business-rule breach is never a server fault.
 func CheckViolation(err error) (constraint string, ok bool) {
 	return pgViolation(err, pgCheckViolation)
+}
+
+// IsQueryCanceled detects the 57014 a statement raises when it stops before
+// answering: a spent statement_timeout, an operator's pg_cancel_backend, or
+// the client going away.
+//
+// It deliberately does NOT say which of the three, because the SQLSTATE does
+// not. A caller that means to report a spent budget owes the second half of
+// that judgement itself — a cancelled request is not a degraded one, and only
+// the caller holds the context that tells them apart.
+func IsQueryCanceled(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgQueryCanceled
 }


### PR DESCRIPTION
Closes #1847.

## The defect

A plan's page limit bounds the rows it **returns**, not the rows it **visits**. A traversal compiles to a `JOIN LATERAL … LIMIT 1` re-executed once per outer candidate row, so a hop that admits almost nobody makes the planner walk the whole outer table before it can fill a single page — measured on the issue at **74.8 s** for `organization → deals` over a 60k/40k/60k corpus. Nothing on that path had a ceiling of any kind; `compose/filterpreview.go` was the only `statement_timeout` in the tree.

`query_workspace` is 🟢 `TierAutoExecute` / `ScopeRead`, so any passport can issue it and a handful of concurrent expensive plans is the whole connection pool. Answers stay correct and correctly scoped — the property at risk is availability.

## Two corrections to the issue as filed

**1. It is not a hop concern.** A hop-free exact plan with substring predicates over the largest tables costs the same, so the budget rides the **statement**. Bounding only the traversal would get this re-filed the first time somebody types a wide `where`.

**2. Answering one plan opens TWO transactions, and the second one is worse.** `rankCandidates` ranks through `Store.Search` before the exact lane's statement is ever compiled. That lane scores with `ts_rank_cd` over a `'simple'`-configuration tsvector, so a common token matches nearly every row of every admitted branch and the score `ORDER BY` cannot be served by the GIN index. A ceiling armed on the plan statement alone would have left every `similar_to` plan exactly as unbounded as before — the same defect one lane to the left.

So the budget binds to the **handle**, not to a call site: `database.DB.Bounded(budget)`, the executor runs on a bounded copy of its store, and every transaction answering the plan inherits it — including a lane nobody has added yet. `ForWorkspace` carries the budget along for the same reason: one that fell off at a re-bind is one nobody could see was missing.

## What the answer looks like

A spent budget is an **answer**, not a fault: `partial_degraded` plus a note saying what to narrow, which is the shape this executor already gives an unavailable predicate. **No new coverage class and no contract change** — `CoverageClasses()` is untouched.

A cancelled request is **not** a degraded one. Postgres raises one SQLSTATE (57014) for a spent timeout, an operator's cancel, and a client hanging up, so the live context is what separates the caller's own vanished deadline; reporting that as this plan being too slow would describe their timeout as a property of the workspace. `fuse.go` already draws that line for the embed lane. An operator cancel reads as a spent budget and is left that way, which the comment states rather than implies.

`BoundStatement` is the one spelling of the ceiling, beside the workspace GUC and for the same reason. It has two callers the day it lands — the filter preview's own inline literal became the second. It rides parameterized `set_config` rather than a built `SET LOCAL` (the rule the line above it already states), and it refuses a non-positive budget: Postgres reads `0` as *no timeout*, so rounding a sub-millisecond budget down would silently unbound the statement the call exists to bound.

## Gates

Over one 20k-row corpus, **both lanes, each with its own control**:

| Test | Asserts |
|---|---|
| exact lane at 1 ms | abandoned: `partial_degraded` + `plan_exceeded_time_budget`, no rows |
| exact lane at 5 s | `complete_exact`, the one right row, no notes |
| ranking lane at 1 ms | abandoned in the ranking transaction |
| ranking lane at 5 s | answers a page (~115 ms measured) |

The controls are what keep either half from passing against a ceiling set so low nothing is ever answered. Unit tests cover the ms rendering, the sub-millisecond floor, the non-positive refusal, the 57014-vs-cancelled-caller split, and that the executor bounds a **copy** of the store — which is what keeps `/search` out of this.

## The issue's proposed regression gate is NOT here, and cannot be

The description asks for a `pg_stat_user_tables` sequential-scan count. That cannot be written soundly for this path: the plan executes on a **pool** connection and `pg_stat_force_next_flush()` only flushes the *calling* backend. Measured — four consecutive runs left both the `seq_scan` and `idx_scan` deltas at exactly **0** while a control count on the test's own connection moved the counter immediately. The precedent it points at (`sequentialScansOf` in `lastactivity_integration_test.go`) works only because it issues the measured statement on the connection it then reads. Reaching around the executor to run the plan's SQL from the test would be CLAUDE.md rule 6. [Reported on the issue.](https://github.com/gradionhq/margince-poc-v1/issues/1847#issuecomment-5351149395)

## Deliberately out of scope

Only the executor's own copy of the store is bounded, so the contract `/search` operation and the `search_context` retriever keep today's failure mode. Bounding a published operation is a product decision rather than a patch — **#1926** carries it with three options and a recommendation.

## Local verification

`make check-backend` green. `craft static --strict` clean on all ten files; `check-go-file-length` clean with 0 waivers (`queryexec.go` crossed the 500-LOC cap during this work, so the budget concept moved into its own `querybudget.go` rather than taking a waiver). The three new integration tests pass repeatedly when run on their own.

**The full `make test-integration` lane is not green locally, and not because of this change**: a second session is running its own integration lane from a sibling worktree against the same Postgres, which produced `could not clone margince_test … being accessed by other users` and 600 s timeouts in `TestTheRepairMigrationsHealADatabaseThatAlreadyRecordedTheLostBackfill` and `TestOfferPdfHTTP_DownloadWhenTheBlobIsGoneReturns404` — neither test related to this diff. CI's lane runs on clean infrastructure; I am watching it as the authoritative verdict and will re-run locally on a quiet machine before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds every query-plan statement to a time budget to protect pool availability and return actionable partial answers. Previously only filter preview had a timeout and page limits bounded returned rows, not visited rows; now both ranking and exact lanes inherit a handle-bound budget, and spending it yields a partial result with guidance.

- `database.DB.Bounded(budget)` attaches a per-statement ceiling to a handle; `ForWorkspace` preserves it and is now nil-safe for uninjected handles. Default is 5s.
- `database.BoundStatement(ctx, tx, budget)` enforces the ceiling via parameterized `set_config('statement_timeout', ...)`; refuses non‑positive budgets, floors sub‑ms to 1ms, and surfaces errors that name the budget.
- `QueryExecutor` uses a bounded copy of the store via `NewQueryExecutorWithBudget`; both lanes run under the budget. SQLSTATE 57014 is classified with `storekit.IsQueryCanceled` plus request context: a spent budget returns `CoveragePartialDegraded` with note code `plan_exceeded_time_budget`, while a caller-cancel is not reported as degraded. `CoverageClasses()` is unchanged.
- Filter preview now uses `BoundStatement` with the same 5s ceiling.
- Tests cover 1ms abandonment vs success under the production budget for both lanes, cancellation vs timeout split, bounded store as a copy (public `/search` unaffected), nil-handle behavior, and ms rendering/sub-ms floor.

<sup>Written for commit 038866b6302095d09c4be2a270b5a59a6082b5d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added time budgets for search queries, including exact-match and ranking searches.
  - Queries that exceed the limit now return no results with a clear degraded-coverage notice and guidance to narrow the search.
  - Caller-cancelled requests remain distinguishable from queries that exceed their time budget.

- **Bug Fixes**
  - Preview and workspace-bound database operations now consistently enforce configured statement limits.

- **Tests**
  - Added coverage for budget enforcement, cancellation handling, bounded transactions, and complete results for queries finished within the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->