### PR TITLE
feat(platform): one module owns an event type, and a gate says so

### DIFF
--- a/backend/eventtypeownership_test.go
+++ b/backend/eventtypeownership_test.go
@@ -120,11 +120,11 @@ func collectEmitSites(t *testing.T) map[string][]emitSite {
 	types := payloadEventTypes(t)
 	sites := map[string][]emitSite{} // event type → where it is built
 	fset := token.NewFileSet()
-	// Every hand-written tree that could hold a payload literal, not just the
-	// modules. The rule is that exactly one module decides what a type means, and
-	// a literal added under platform or an extension defeats that as thoroughly
-	// as a second module does — while being invisible to a modules-only walk.
-	for _, root := range []string{"internal", "../extensions"} {
+	// Every hand-written tree that could hold a payload literal, and the list is
+	// the whole list rather than the obvious half: cmd and pkg can import
+	// internal/contracts as legally as internal can, so an emitter added under
+	// cmd/api defeats the rule while being invisible to a modules-only walk.
+	for _, root := range []string{"internal", "cmd", "pkg", "../extensions"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
 				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") ||
@@ -136,13 +136,21 @@ func collectEmitSites(t *testing.T) map[string][]emitSite {
 			if err != nil {
 				return err
 			}
+			// The qualifier the contracts package is reachable under IN THIS FILE.
+			// Matching only a selector's terminal name would count an unrelated
+			// package's PublicEventPersonUpdated as the CRM payload, and a file
+			// that does not import contracts at all can hold no emit.
+			qualifier, imports := contractsQualifier(file)
+			if !imports {
+				return nil
+			}
 			module := owningDir(filepath.ToSlash(filepath.Dir(path)))
 			ast.Inspect(file, func(n ast.Node) bool {
 				// A SelectorExpr covers `pkg.Type{…}` and, via the type of a
 				// slice or map literal, the ELIDED inner `{…}` elements whose own
 				// Type node is nil. Without the second, a module batch-building
 				// payloads from a slice literal is invisible here.
-				name, ok := payloadTypeName(n)
+				name, ok := payloadTypeName(n, qualifier)
 				if !ok {
 					return true
 				}
@@ -180,9 +188,9 @@ func modulesEmitting(sites []emitSite) []string {
 // silently, which is the failure this whole gate exists to refuse, reproduced
 // inside its own exception list.
 //
-// Two structures account for every entry, and in both a second module announces
-// a fact that IS the first module's fact. Neither is a second meaning for one
-// name, which is what the rule protects.
+// Three structures account for every entry, and in all of them the second
+// module announces a fact that IS the first module's fact. None is a second
+// meaning for one name, which is what the rule protects.
 var sharedEventTypes = gatekit.Waive(map[string]string{
 	// Structure 1 — the overlay write-back announces the NATIVE module's event.
 	// overlay/writeaudit.go switches on datasource.EntityRef and emits the
@@ -329,6 +337,11 @@ func positionsFor(sites []emitSite, module string) []string {
 // the name lives on the enclosing slice or map literal, so a module
 // batch-building payloads that way would emit without this gate seeing it.
 //
+// What this still cannot see, named so the comment does not overclaim a second
+// time: a payload built by ASSIGNMENT into a zero value, or through reflection
+// or a generic builder. Those need dataflow, nothing in the tree does them, and
+// a walk that guessed at them would misread the decode targets below.
+//
 // A bare `var p crmcontracts.PublicEventX` declaration is deliberately NOT one
 // of them, and the tree says why: both such declarations here are DECODE
 // targets, immediately json.Unmarshal-ed from an inbound envelope
@@ -337,22 +350,68 @@ func positionsFor(sites []emitSite, module string) []string {
 // and would have had this gate ratify a sharing that does not exist. A
 // declaration cannot be told from a construction without dataflow, and here the
 // false positives are real while the construction case is hypothetical.
-func payloadTypeName(n ast.Node) (string, bool) {
-	lit, ok := n.(*ast.CompositeLit)
-	if !ok {
+func payloadTypeName(n ast.Node, qualifier string) (string, bool) {
+	switch node := n.(type) {
+	case *ast.CompositeLit:
+		switch typ := node.Type.(type) {
+		case *ast.SelectorExpr:
+			return qualifiedName(typ, qualifier)
+		case *ast.ArrayType:
+			return qualifiedName(elementSelector(typ.Elt), qualifier)
+		case *ast.MapType:
+			return qualifiedName(elementSelector(typ.Value), qualifier)
+		}
+	case *ast.CallExpr:
+		// new(crmcontracts.PublicEventX) — a pointer to the zero value, which
+		// satisfies events.Payload exactly as &T{} does.
+		if fn, ok := node.Fun.(*ast.Ident); ok && fn.Name == "new" && len(node.Args) == 1 {
+			if sel, ok := node.Args[0].(*ast.SelectorExpr); ok {
+				return qualifiedName(sel, qualifier)
+			}
+		}
+	}
+	return "", false
+}
+
+// elementSelector unwraps the pointer a slice or map of POINTERS carries, so
+// []*crmcontracts.PublicEventX{{…}} is read the same as the value form. The
+// elided inner element's own Type is nil either way; what differs is a StarExpr
+// in the enclosing type.
+func elementSelector(e ast.Expr) *ast.SelectorExpr {
+	if star, ok := e.(*ast.StarExpr); ok {
+		e = star.X
+	}
+	sel, _ := e.(*ast.SelectorExpr)
+	return sel
+}
+
+// qualifiedName answers the type's name only when the selector is reached
+// through the contracts package.
+func qualifiedName(sel *ast.SelectorExpr, qualifier string) (string, bool) {
+	if sel == nil {
 		return "", false
 	}
-	switch typ := lit.Type.(type) {
-	case *ast.SelectorExpr:
-		return typ.Sel.Name, true
-	case *ast.ArrayType:
-		if sel, ok := typ.Elt.(*ast.SelectorExpr); ok {
-			return sel.Sel.Name, true
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != qualifier {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// contractsQualifier answers the name internal/contracts is reachable under in
+// one file, and whether the file imports it at all.
+func contractsQualifier(file *ast.File) (string, bool) {
+	const contractsPath = `"github.com/gradionhq/margince/backend/internal/contracts"`
+	for _, imp := range file.Imports {
+		if imp.Path.Value != contractsPath {
+			continue
 		}
-	case *ast.MapType:
-		if sel, ok := typ.Value.(*ast.SelectorExpr); ok {
-			return sel.Sel.Name, true
+		if imp.Name != nil {
+			return imp.Name.Name, true
 		}
+		// Unaliased: the package declares itself crmcontracts, which is also the
+		// alias the other 600-odd imports spell explicitly.
+		return "crmcontracts", true
 	}
 	return "", false
 }

--- a/backend/eventtypeownership_test.go
+++ b/backend/eventtypeownership_test.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"testing"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
@@ -75,9 +76,27 @@ func payloadEventTypes(t *testing.T) map[string]string {
 			out[ident.Name] = literal
 		}
 	}
-	if len(out) == 0 {
-		t.Fatal("derived no event types from " + generated +
-			"; every emit would read as unattributed and this gate would pass over the tree")
+	// The floor, and it has to be a SET comparison rather than a count.
+	//
+	// A bare len(out) == 0 catches only a derivation that collapses completely.
+	// One that quietly loses a few — a pointer receiver, a two-statement body, a
+	// return of a named constant instead of a literal, all of which are generator
+	// shape changes this gate is meant to survive — drops those payloads out of
+	// BOTH gates: they vanish from the emit census and from the orphan sweep at
+	// the same time, so nothing is left to notice. PublicEventVersions is
+	// generated from the same contract and keyed on the event type, so a
+	// disagreement between the two is exactly the collapse.
+	missing := make([]string, 0)
+	for eventType := range crmcontracts.PublicEventVersions {
+		if !slices.Contains(slices.Collect(maps.Values(out)), eventType) {
+			missing = append(missing, eventType)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("derived %d event types from %s but PublicEventVersions carries %d; %v have a "+
+			"contract entry and no EventType() this walk could read. The walk has stopped seeing "+
+			"payloads, so both gates would pass over every type it lost",
+			len(out), generated, len(crmcontracts.PublicEventVersions), slices.Sorted(slices.Values(missing)))
 	}
 	return out
 }
@@ -101,7 +120,11 @@ func collectEmitSites(t *testing.T) map[string][]emitSite {
 	types := payloadEventTypes(t)
 	sites := map[string][]emitSite{} // event type → where it is built
 	fset := token.NewFileSet()
-	for _, root := range []string{"internal/modules", "internal/compose"} {
+	// Every hand-written tree that could hold a payload literal, not just the
+	// modules. The rule is that exactly one module decides what a type means, and
+	// a literal added under platform or an extension defeats that as thoroughly
+	// as a second module does — while being invisible to a modules-only walk.
+	for _, root := range []string{"internal", "../extensions"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
 				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") ||
@@ -115,17 +138,17 @@ func collectEmitSites(t *testing.T) map[string][]emitSite {
 			}
 			module := owningDir(filepath.ToSlash(filepath.Dir(path)))
 			ast.Inspect(file, func(n ast.Node) bool {
-				lit, ok := n.(*ast.CompositeLit)
+				// A SelectorExpr covers `pkg.Type{…}` and, via the type of a
+				// slice or map literal, the ELIDED inner `{…}` elements whose own
+				// Type node is nil. Without the second, a module batch-building
+				// payloads from a slice literal is invisible here.
+				name, ok := payloadTypeName(n)
 				if !ok {
 					return true
 				}
-				sel, ok := lit.Type.(*ast.SelectorExpr)
-				if !ok {
-					return true
-				}
-				if eventType, ok := types[sel.Sel.Name]; ok {
+				if eventType, ok := types[name]; ok {
 					sites[eventType] = append(sites[eventType],
-						emitSite{pos: fset.Position(lit.Pos()).String(), module: module})
+						emitSite{pos: fset.Position(n.Pos()).String(), module: module})
 				}
 				return true
 			})
@@ -211,7 +234,6 @@ var sharedEventTypes = gatekit.Waive(map[string]string{
 })
 
 func TestEveryEventTypeHasOneEmittingModule(t *testing.T) {
-	defer sharedEventTypes.AssertAllMatched(t)
 	sites := collectEmitSites(t)
 	// A walk that found no emit at all reports exactly like a tree where every
 	// type has one owner, which is the failure mode this gate is closing in a
@@ -220,6 +242,9 @@ func TestEveryEventTypeHasOneEmittingModule(t *testing.T) {
 		t.Fatal("found no event payload literals at all; this gate would pass vacuously")
 	}
 	t.Logf("examined %d event types built across the module and compose trees", len(sites))
+	// Armed after the vacuity fatal, for the reason spelled out in the orphan
+	// gate below: a sweep deferred above it drowns the real message.
+	defer sharedEventTypes.AssertAllMatched(t)
 
 	for _, eventType := range slices.Sorted(maps.Keys(sites)) {
 		modules := modulesEmitting(sites[eventType])
@@ -230,11 +255,12 @@ func TestEveryEventTypeHasOneEmittingModule(t *testing.T) {
 			if sharedEventTypes.Waived(t, eventType+" <- "+module) {
 				continue
 			}
-			t.Errorf("event type %q is emitted by %s, and by %d modules in all (%s) — one module owns "+
-				"a type, so exactly one decides what the name MEANS; move the emit into the owning "+
-				"module, or ratify this emitter in sharedEventTypes[%q] with a rationale saying why "+
-				"it is correct for THIS module to announce it",
-				eventType, module, len(modules), strings.Join(modules, ", "), eventType+" <- "+module)
+			t.Errorf("event type %q is built at %s, and by %d modules in all (%s) — one module owns "+
+				"a type, so exactly one decides what the name MEANS. If %s is not that module, move "+
+				"the emit into the one that is; if it IS, the new emitter is one of the others. "+
+				"Ratify a correct sharing in sharedEventTypes[%q]",
+				eventType, strings.Join(positionsFor(sites[eventType], module), ", "),
+				len(modules), strings.Join(modules, ", "), module, eventType+" <- "+module)
 		}
 	}
 }
@@ -265,11 +291,15 @@ var unemittedEventTypes = gatekit.Waive(map[string]string{
 // schemas. What this refuses is a type that quietly stops being emitted — the
 // contract keeps promising it, subscribers keep waiting, and nothing fails.
 func TestEveryUnemittedEventTypeSaysWhyNothingEmitsIt(t *testing.T) {
-	defer unemittedEventTypes.AssertAllMatched(t)
-
-	types := payloadEventTypes(t)
 	sites := collectEmitSites(t)
-	for _, eventType := range slices.Sorted(slices.Values(slices.Collect(maps.Values(types)))) {
+	// Armed after the walk, which can fatal. Deferred above it, the sweep runs on
+	// the way out and buries the one true line under an entry per waiver, each
+	// telling the reader to delete a correct one.
+	defer unemittedEventTypes.AssertAllMatched(t)
+	// Iterating the generated map rather than the derived values: it is keyed on
+	// the event type, so it is deduped by construction, and payloadEventTypes has
+	// already asserted the two agree.
+	for _, eventType := range slices.Sorted(maps.Keys(crmcontracts.PublicEventVersions)) {
 		if len(sites[eventType]) > 0 || unemittedEventTypes.Waived(t, eventType) {
 			continue
 		}
@@ -277,4 +307,52 @@ func TestEveryUnemittedEventTypeSaysWhyNothingEmitsIt(t *testing.T) {
 			"promising it and no subscriber will ever receive one. Emit it, or record it in "+
 			"unemittedEventTypes with the reason nothing does", eventType)
 	}
+}
+
+// positionsFor answers where one module builds a given event type, so a finding
+// names the file and line instead of leaving the reader to grep a module for a
+// literal.
+func positionsFor(sites []emitSite, module string) []string {
+	var out []string
+	for _, site := range sites {
+		if site.module == module {
+			out = append(out, site.pos)
+		}
+	}
+	return slices.Sorted(slices.Values(out))
+}
+
+// payloadTypeName answers the payload struct a node CONSTRUCTS.
+//
+// The elided cases are the ones a naive walk misses: inside
+// []crmcontracts.PublicEventX{{…}} the inner element's own Type node is nil and
+// the name lives on the enclosing slice or map literal, so a module
+// batch-building payloads that way would emit without this gate seeing it.
+//
+// A bare `var p crmcontracts.PublicEventX` declaration is deliberately NOT one
+// of them, and the tree says why: both such declarations here are DECODE
+// targets, immediately json.Unmarshal-ed from an inbound envelope
+// (compose/leadsla.go reading lead.sla_breached, compose/personautoenrich.go
+// reading person.merged). Counting them made two consumers look like emitters
+// and would have had this gate ratify a sharing that does not exist. A
+// declaration cannot be told from a construction without dataflow, and here the
+// false positives are real while the construction case is hypothetical.
+func payloadTypeName(n ast.Node) (string, bool) {
+	lit, ok := n.(*ast.CompositeLit)
+	if !ok {
+		return "", false
+	}
+	switch typ := lit.Type.(type) {
+	case *ast.SelectorExpr:
+		return typ.Sel.Name, true
+	case *ast.ArrayType:
+		if sel, ok := typ.Elt.(*ast.SelectorExpr); ok {
+			return sel.Sel.Name, true
+		}
+	case *ast.MapType:
+		if sel, ok := typ.Value.(*ast.SelectorExpr); ok {
+			return sel.Sel.Name, true
+		}
+	}
+	return "", false
 }

--- a/backend/eventtypeownership_test.go
+++ b/backend/eventtypeownership_test.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// One module owns an event type.
+//
+// The rule, written out rather than cited: a bounded capability owns the names
+// it publishes under, so exactly one module decides what a given event type
+// MEANS. Two modules emitting one type is how a subscriber ends up receiving
+// the same name for two different facts — and nothing in the envelope tells it
+// which happened, because the type IS the discriminator. The tables have a gate
+// saying this (TestEveryPackageOnlyWritesTablesItOwns); the event types did not.
+//
+// Sharing is not always wrong, and the ratified set below is the proof: an
+// overlay write-back announces the NATIVE module's event on purpose, because a
+// subscriber to person.updated must hear about a person changing however the
+// write arrived. What this gate refuses is a NEW sharer arriving unnoticed.
+//
+// It walks composite literals of the generated payload structs rather than the
+// emit calls, which is what makes it sound over both outbox writers (storekit's
+// and the hand-rolled INSERT in approvals) and over the six helpers that return
+// one of several payloads by branch.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// payloadEventTypes maps each generated payload struct to the event type it
+// declares, read from the EventType() methods in the contract package.
+//
+// The METHOD and not the name is the test, and the difference is not academic:
+// the generated file declares 94 PublicEvent* types and only 83 of them are
+// event payloads. The rest are nested field structs —
+// PublicEventActivityChangedFields among them — and a name-prefix census counts
+// one of those as an extra shared type emitted by two modules, a duplicate that
+// does not exist.
+func payloadEventTypes(t *testing.T) map[string]string {
+	t.Helper()
+	const generated = "internal/contracts/publicevents_gen.go"
+	file, err := parser.ParseFile(token.NewFileSet(), generated, nil, 0)
+	if err != nil {
+		t.Fatalf("reading the generated payloads to derive their event types: %v", err)
+	}
+	out := map[string]string{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "EventType" || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		ident, ok := fn.Recv.List[0].Type.(*ast.Ident)
+		if !ok || fn.Body == nil || len(fn.Body.List) != 1 {
+			continue
+		}
+		ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			continue
+		}
+		lit, ok := ret.Results[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			continue
+		}
+		if literal, err := strconv.Unquote(lit.Value); err == nil {
+			out[ident.Name] = literal
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("derived no event types from " + generated +
+			"; every emit would read as unattributed and this gate would pass over the tree")
+	}
+	return out
+}
+
+// emitSite is one place a module builds an event payload.
+type emitSite struct {
+	pos    string
+	module string
+}
+
+// collectEmitSites walks the hand-written module and compose sources and
+// records every payload struct literal under its owning module.
+//
+// Composite literals rather than emit CALLS, deliberately. There are two outbox
+// writers — storekit's, and a hand-rolled INSERT in approvals — so a walk keyed
+// on storekit.Emit* would miss the whole approval family and report four live
+// types as never emitted. Six helpers also return one of several payloads by
+// branch; the literal is inside the helper either way.
+func collectEmitSites(t *testing.T) map[string][]emitSite {
+	t.Helper()
+	types := payloadEventTypes(t)
+	sites := map[string][]emitSite{} // event type → where it is built
+	fset := token.NewFileSet()
+	for _, root := range []string{"internal/modules", "internal/compose"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") ||
+				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") ||
+				isIntegrationTagged(path) {
+				return err
+			}
+			path = filepath.ToSlash(path)
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				return err
+			}
+			module := owningDir(filepath.ToSlash(filepath.Dir(path)))
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				sel, ok := lit.Type.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if eventType, ok := types[sel.Sel.Name]; ok {
+					sites[eventType] = append(sites[eventType],
+						emitSite{pos: fset.Position(lit.Pos()).String(), module: module})
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return sites
+}
+
+// modulesEmitting answers the distinct modules that build one event type.
+func modulesEmitting(sites []emitSite) []string {
+	seen := map[string]bool{}
+	for _, site := range sites {
+		seen[site.module] = true
+	}
+	return slices.Sorted(maps.Keys(seen))
+}
+
+// sharedEventTypes ratifies each MODULE that builds a shared event type, keyed
+// "<event type> <- <module>".
+//
+// Keyed on the PAIR and not on the type alone, and that is not a stylistic
+// choice — it was a hole. A type-keyed waiver ratifies the sharing once and
+// then admits any number of further modules under the same entry: planting an
+// emit of person.updated inside deals passed a type-keyed version of this gate
+// silently, which is the failure this whole gate exists to refuse, reproduced
+// inside its own exception list.
+//
+// Two structures account for every entry, and in both a second module announces
+// a fact that IS the first module's fact. Neither is a second meaning for one
+// name, which is what the rule protects.
+var sharedEventTypes = gatekit.Waive(map[string]string{
+	// Structure 1 — the overlay write-back announces the NATIVE module's event.
+	// overlay/writeaudit.go switches on datasource.EntityRef and emits the
+	// system-of-record type for the entity it just wrote. That is the point: a
+	// subscriber to person.updated is subscribed to A PERSON CHANGING, and must
+	// hear about one whether the write arrived natively or through the write-back.
+	// An overlay.* type instead would make every consumer subscribe twice to
+	// learn one fact, and would leak which path a write took into a contract
+	// that deliberately does not say.
+	"person.updated <- internal/modules/overlay":        "the write-back's update path: a person changed, and the overlay wrote it",
+	"person.archived <- internal/modules/overlay":       "the write-back's archive path, one of the three archivable types",
+	"organization.updated <- internal/modules/overlay":  "the write-back's update path",
+	"organization.archived <- internal/modules/overlay": "the write-back's archive path",
+	"deal.updated <- internal/modules/overlay":          "the write-back's update path",
+	"deal.archived <- internal/modules/overlay":         "the write-back's archive path",
+	"lead.updated <- internal/modules/overlay":          "the write-back's update path; lead is one of its five updatable types",
+	"activity.updated <- internal/modules/overlay":      "the write-back's update path, and the one that NARROWS rather than passes through: activity.updated's changed_fields is a bounded typed key set where the other four carry open maps, so the patch is projected onto it in activityChangedFields",
+
+	// The native side of those seven, listed so the pair map is complete and a
+	// module losing its own event is as visible as one gaining somebody else's.
+	"person.updated <- internal/modules/people":        "the record's own module, natively and for a relationship anchored on a person",
+	"person.archived <- internal/modules/people":       "the record's own module",
+	"organization.updated <- internal/modules/people":  "the record's own module, natively and for a relationship anchored on an organization",
+	"organization.archived <- internal/modules/people": "the record's own module",
+	"deal.updated <- internal/modules/deals":           "the record's own module",
+	"deal.archived <- internal/modules/deals":          "the record's own module",
+	"lead.updated <- internal/modules/people":          "the record's own module",
+	"activity.updated <- internal/modules/activities":  "the record's own module",
+
+	// Structure 2 — a relationship emits its ANCHOR's event.
+	// people/relationshipUpdatedPayload wraps one delta in whichever anchor's
+	// envelope the edge points at. An employment edge changing IS a change to
+	// the person and to the organization it joins; there is no relationship.*
+	// type, and inventing one would make every consumer of the anchor subscribe
+	// to a second name to learn that their record moved.
+	"deal.updated <- internal/modules/people":    "a relationship anchored on a deal moved, so the deal changed",
+	"project.updated <- internal/modules/people": "a relationship anchored on a project moved, so the project changed — the same anchor rule",
+	"project.updated <- internal/modules/deals":  "the record's own module: deals owns project",
+
+	// Structure 3 — capture announces what it captured, as the RECORD's event.
+	// The capture path creates real leads and real activities, so the type is
+	// the record's own, with source_system set so a consumer can tell an
+	// inferred record from one somebody typed. A capture.* type would announce
+	// that a pipeline ran, which no consumer of the record wants.
+	"lead.created <- internal/modules/people":          "a lead somebody created",
+	"lead.created <- internal/modules/capture":         "a lead an inbound message created; source_system names where it came from. Both are a lead existing that did not before",
+	"activity.captured <- internal/modules/activities": "an activity logged through the product",
+	"activity.captured <- internal/modules/capture":    "an activity an inbound message produced, again with source_system. The verb is already `captured` for both — it is the record's arrival, not the pipeline's run",
+})
+
+func TestEveryEventTypeHasOneEmittingModule(t *testing.T) {
+	defer sharedEventTypes.AssertAllMatched(t)
+	sites := collectEmitSites(t)
+	// A walk that found no emit at all reports exactly like a tree where every
+	// type has one owner, which is the failure mode this gate is closing in a
+	// different place.
+	if len(sites) == 0 {
+		t.Fatal("found no event payload literals at all; this gate would pass vacuously")
+	}
+	t.Logf("examined %d event types built across the module and compose trees", len(sites))
+
+	for _, eventType := range slices.Sorted(maps.Keys(sites)) {
+		modules := modulesEmitting(sites[eventType])
+		if len(modules) < 2 {
+			continue
+		}
+		for _, module := range modules {
+			if sharedEventTypes.Waived(t, eventType+" <- "+module) {
+				continue
+			}
+			t.Errorf("event type %q is emitted by %s, and by %d modules in all (%s) — one module owns "+
+				"a type, so exactly one decides what the name MEANS; move the emit into the owning "+
+				"module, or ratify this emitter in sharedEventTypes[%q] with a rationale saying why "+
+				"it is correct for THIS module to announce it",
+				eventType, module, len(modules), strings.Join(modules, ", "), eventType+" <- "+module)
+		}
+	}
+}
+
+// unemittedEventTypes are the payload types with NO emit site anywhere, each
+// with the reason nothing publishes it.
+//
+// This set is also the gate's floor. The vacuity check above only catches a
+// walk that finds NOTHING; a walk that quietly found half of what it should —
+// a renamed payload package, a changed literal shape — would still report every
+// remaining type as singly-owned and pass. Every type the walk stops seeing
+// lands here instead, so a partial collapse fails on the entries it cannot
+// explain rather than passing on the ones it still can.
+var unemittedEventTypes = gatekit.Waive(map[string]string{
+	"audit.appended":             "deliberate and documented in the contract: no emit site and none planned. It exists so the catalog is completely covered by a payload schema, never carrying a subscribable type with no contract",
+	"deal.restored":              "documented in the contract as never emitted today — there is no restore path",
+	"person.restored":            "the same, for the person restore path that does not exist",
+	"pipeline.archived":          "documented in the contract as never emitted today — no archive path",
+	"mirror.write_rejected":      "documented in the contract as never emitted today, reserved for the overlay write-back's refusal case",
+	"conversation_claim.changed": "the odd one out, and filed rather than ratified quietly: unlike the four above, the contract does NOT mark this one unemitted — it describes it as published, because 'a correction is SHARED truth'. There is no correction path in people/conversationclaim.go to publish from; the module exposes RecordConversationClaim and nothing else. Waived here so the gate is green over a real state of the tree, not because the state is right",
+})
+
+// A payload type nothing emits is either deliberate or a gap, and the contract
+// should say which.
+//
+// The four the contract already marks "Never emitted today" are the shape this
+// is checking for: a type reserved so the catalog stays completely covered by
+// schemas. What this refuses is a type that quietly stops being emitted — the
+// contract keeps promising it, subscribers keep waiting, and nothing fails.
+func TestEveryUnemittedEventTypeSaysWhyNothingEmitsIt(t *testing.T) {
+	defer unemittedEventTypes.AssertAllMatched(t)
+
+	types := payloadEventTypes(t)
+	sites := collectEmitSites(t)
+	for _, eventType := range slices.Sorted(slices.Values(slices.Collect(maps.Values(types)))) {
+		if len(sites[eventType]) > 0 || unemittedEventTypes.Waived(t, eventType) {
+			continue
+		}
+		t.Errorf("event type %q has a payload schema and no emit site anywhere — the contract keeps "+
+			"promising it and no subscriber will ever receive one. Emit it, or record it in "+
+			"unemittedEventTypes with the reason nothing does", eventType)
+	}
+}


### PR DESCRIPTION
The tables have a gate refusing a module that writes another module's rows. The
**event types had none**, so two modules could publish under one type and nothing
noticed — which is how a subscriber ends up receiving one name for two different
facts, with no way to tell them apart, because **the type IS the discriminator**.

Closes #1788.

## This ships RED, and the findings are correct behaviour

**Eleven types already have two or more emitting modules, and every one is
deliberate.** The deliverable is a gate plus ratified waivers, not eleven fixes.
Written expecting green, this would have deleted working design.

The census, run before the waiver set was populated — **77 event types examined**:

| Event type | Emitting modules |
|---|---|
| `person.updated`, `person.archived`, `organization.updated`, `organization.archived`, `deal.archived`, `lead.updated`, `activity.updated` | native module + `overlay` |
| `deal.updated` | `deals` + `overlay` + `people` |
| `project.updated` | `deals` + `people` |
| `lead.created` | `people` + `capture` |
| `activity.captured` | `activities` + `capture` |

**Structure 1 — the overlay write-back announces the NATIVE module's event.** A
subscriber to `person.updated` is subscribed to *a person changing*, and must
hear about one whether the write arrived natively or through the write-back. An
`overlay.*` type would make every consumer subscribe twice to learn one fact, and
would leak which path a write took into a contract that deliberately does not say.

**Structure 2 — a relationship emits its ANCHOR's event.** An employment edge
changing *is* a change to the person and to the company it joins. There is no
`relationship.*` type, and inventing one would make every consumer of the anchor
subscribe to a second name to learn their own record moved.

**Structure 3 — capture publishes the RECORD's type**, with `source_system` set,
because the capture path creates real leads and real activities. A `capture.*`
type would announce that a pipeline ran, which no consumer of the record wants.

### The goal's cross-check

The wave analysis predicted **12** and noted a literal-walk census would find
**11**, the twelfth (`coldstart.read_back_proposed`) being invisible because it is
the dynamic `Announce` case. That is exactly what happened, which is a useful
signal the walk is behaving rather than a discrepancy.

## The waivers are keyed on the PAIR, and that was a hole before it was a decision

`"<event type> <- <module>"`. Keyed on the type alone, ratifying a sharing once
admits **any number of further modules** under the same entry.

That is not hypothetical — I built it type-keyed first. Planting an emit of
`person.updated` inside `deals` **passed silently**: the exact failure this gate
exists to refuse, reproduced inside its own exception list. Re-keyed, the same
plant fails:

```
event type "person.updated" is emitted by internal/modules/deals, and by 3 modules in all
(deals, overlay, people) — … ratify this emitter in
sharedEventTypes["person.updated <- internal/modules/deals"] …
```

## Two traps this had to route around

**The issue's core assumption is false.** It says "every emit goes through
`storekit.Emit`". There are **two** outbox writers — storekit's, and a hand-rolled
`INSERT INTO event_outbox` at `approvals/service.go:268`. A walk keyed on
`storekit.Emit*` would miss the whole approval family and report four live types
as never emitted. This walks **payload struct literals** instead, which is sound
over both writers and over the six helpers that return one of several payloads by
branch. Filed the approvals writer as **#1946** — including that both waivers
ratifying it state a reason the code contradicts (`storekit.Audit` demonstrably
*does* carry `passport_id`/`on_behalf_of`), and that its envelope drops
`CausationID`, breaking the trace chain on every `approval.*` event.

**`PublicEvent*` is not a reliable name test.** The generated file declares **94**
such structs; only **83** carry `EventType()`. The rest are nested field structs,
and a name-prefix census reports `PublicEventActivityChangedFields` as a twelfth
shared type that does not exist. Filtering is on the **method**.

## A second gate, the other direction

Six payload types have no emit site anywhere. Five are documented in the contract
as deliberately unemitted; **`conversation_claim.changed` is not** — the contract
describes it as *published* ("a correction is SHARED truth") and there is no
correction path in `people/conversationclaim.go` to publish from. Filed as
**#1947**. Its waiver says outright that it is waived so the gate is green over a
real state of the tree, **not because the state is right**.

That gate is also this one's **floor**. The vacuity check only catches a walk that
finds *nothing*; a walk that quietly found half would still report every remaining
type as singly-owned and pass. Every type the walk stops seeing lands in the
orphan set instead.

## Proof — five mutations

| | Result |
|---|---|
| **FOREIGN EMIT** | `person.updated` emitted from `deals` **fails**, naming the module and the key to add |
| **WAIVER** | Deleting a ratified pair **fails**; mis-keying one trips `AssertAllMatched` — *"matched no subject"* |
| **VACUITY** | Deriving no event types **fails** rather than passing over an empty tree |
| **COLLAPSE** | Making the walk blind to **one** payload struct **fails** — the check the vacuity guard alone does not catch |
| **CENSUS** | Reported as a number the gate logs: *"examined 77 event types"* |

## Two legs this does not close — stated, not faked

**The cache-key-prefix leg is vacuous.** ADR-0014's rule covers tables, event
types *and* cache key prefixes. **No module owns a prefix**, because no package
under `internal/modules/` imports a Redis client at all. The two files that grep
for "redis" are an error-message comment and the word *"rediscovered"*. All four
key namespaces are platform-tier constants (`ovb:`, `msr:`, `gw:dedupe:`,
`gw:events:crm:`). So #1788's fix covers one leg of two; the honest guard for the
other is a different invariant, and it is not this one.

**Three emit sites are irreducibly dynamic** — the extension ledger's
`namespace + "." + verb` (structurally confined to `ext_*`, disjoint from the
catalog) and the approvals `Announce` seam's `events.Payload` interface field. The
gate cannot attribute those. That is its limit, named here rather than papered
over.

## Housekeeping

- Test-only: **no measured new-code coverage.** The five mutations are the
  substitute, per the repo's own bar.
- No UI, so **no UAT video is owed**.
- No ADR is cited as though a reader could open it — the rule is written out in
  the gate's doc comment instead.
- `make check` full pass · `make craft-static` PASS, 0 blocker / 0 major / 0 minor.

Closes #1788

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces one-module ownership of each event type and adds a second gate requiring reasons for payloads with no emit site. Previously, duplicate emitters and orphaned payloads were silent; now the gate fails unless the "<type> <- <module>" pair is waived, and it fails if a payload has no emitter without a documented reason.

- Detects emitters by walking payload composite literals keyed on `EventType()` methods, not call sites; now scans `internal/`, `cmd/`, `pkg/`, and `../extensions`, resolves the `internal/contracts` import qualifier per file, handles elided slice/map elements (including pointer element forms) and `new(T)` constructions, ignores decode-only `var T` declarations, and reports file:line.
- Waivers are pair-keyed (`"<type> <- <module>"`) to prevent type-level blanket admits; ratified shares cover overlay write-backs announcing the native event, relationship edges emitting the anchor’s event, and capture publishing the record’s own type.
- Floor and cross-check: derived payload types are set-compared with `crmcontracts.PublicEventVersions` to fail on partial generator shape changes; avoids vacuous passes.
- Limits and follow-ups: dynamic emits (extensions namespace+verb; approvals `Announce`) are unattributed; cache-key ownership is out of scope. Filed #1946 (approvals writer/envelope) and #1947 (`conversation_claim.changed` missing emit).

- Required actions:
  - If you add a second emitter, add `"<type> <- <module>"` to `sharedEventTypes` with a rationale.
  - If a payload should remain unemitted, add its type to `unemittedEventTypes` with the reason.

<sup>Written for commit 03cc33611005929bd333d897b4dba9cfdc1b09fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

