### PR TITLE
fix(ci): the merge queue gates every main commit, full-tree, behind one required check

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,130 @@
+# The Go build cache has one writer, and it is not a gate.
+#
+# A warm build cache for this repo measures ~550 MB and is worth most of a Go
+# job's wall clock. Until now it was written as a BYPRODUCT of two gating jobs on
+# a push to main — which means it depended on a main push surviving to
+# completion, and at this repository's merge velocity 64% of them were cancelled.
+# The cache was being seeded by accident, rarely.
+#
+# It cannot move to the merge queue. actions/cache scopes an entry to the branch
+# that wrote it plus the default branch, and a merge_group run lives on a
+# throwaway `gh-readonly-queue/main/...` ref: an entry saved there is invisible
+# to every PR lane and dies with the ref. RESTORING works from anywhere — only
+# the write is scoped — so the writer has to run on main, which is what this
+# does.
+#
+# On a SCHEDULE rather than on push. Seeding both flavours means redoing a full
+# `make check-backend` and an integration shard against a live Postgres; at ~80
+# merges a day, running that pair per push would burn the pipeline and mostly
+# self-cancel — the same starvation this whole change exists to remove, merely
+# made harmless. Go's build cache is content-addressed and the key ends in the
+# commit SHA with restore-keys walking back to the newest prior entry, so a
+# three-hour-old entry is substantially warm and never WRONG: it misses the
+# entries whose inputs changed and recompiles those.
+#
+# This workflow gates nothing. A red or cancelled run costs latency on the next
+# lane and nothing else.
+name: cache-warm
+
+on:
+  schedule:
+    # Every three hours. Ten-ish merges of drift against a content-addressed
+    # cache, which is still a warm restore.
+    - cron: "0 */3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One writer at a time. Two concurrent runs would race for the same key and the
+# loser's ~550 MB upload would evict the entry it meant to seed. Never cancel: a
+# cancelled run saves nothing, and the entire point is that a run finishes.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  # The untagged compile every non-integration Go job reads.
+  plain:
+    name: warm plain
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The gate this mirrors diffs against origin/main; a shallow checkout
+          # would silently disarm it and warm a different set of artifacts than
+          # the gate actually compiles.
+          fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Restore the Go build cache
+        id: go-cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
+      - name: Compile what the gate compiles (make check-backend)
+        working-directory: .
+        env:
+          # In CI a missing base ref is a broken checkout, never a skip.
+          CONTRACT_BREAKING_REQUIRE_BASE: "1"
+          MIGRATION_VERSIONS_REQUIRE_BASE: "1"
+        run: make check-backend
+      # !cancelled() rather than success(): a red gate still compiled the tree,
+      # and those artifacts are exactly as reusable as a green run's. This
+      # workflow is not a verdict, so a failure here must still leave the cache
+      # better than it found it.
+      - name: Refresh the shared build cache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.go-cache.outputs.key }}
+
+  # The `-tags=integration -cover -coverpkg=./...` compile the twelve shards
+  # read. ONE shard is enough: every shard compiles substantially the same set,
+  # which is why the lane it mirrors also elects a single writer.
+  integration:
+    name: warm integration
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Restore the Go build cache
+        id: go-cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: integration
+      - name: Start the dev infra stack (compose + app role)
+        run: make db-up
+      - name: Compile and run one shard
+        env:
+          INTEGRATION_SHARD: 1/12
+          INTEGRATION_SHARD_OUT: ${{ runner.temp }}/shard-out
+          # The tests are DB-bound, not CPU-bound: on the 4-core runner the
+          # nproc-derived default leaves the slice mostly waiting on Postgres.
+          INTEGRATION_JOBS: 16
+        run: make test-integration
+      - name: Refresh the shared build cache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.go-cache.outputs.key }}

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -52,6 +52,14 @@ jobs:
   plain:
     name: warm plain
     timeout-minutes: 45
+    # Default branch only, dispatch included. A cache entry is scoped to the
+    # branch that wrote it, so a run dispatched from a feature branch spends ~10
+    # minutes and ~550 MB of the 10 GB quota on an entry no PR lane and no queue
+    # build can read — and it takes the `cancel-in-progress: false` slot ahead of
+    # the scheduled main run that would have written a usable one. The workflow
+    # says above that the writer has to run on main; this is what makes that true
+    # rather than merely intended.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -96,6 +104,8 @@ jobs:
   integration:
     name: warm integration
     timeout-minutes: 45
+    # Default branch only, for the reason spelled out on `plain` above.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,13 +249,22 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
-  # Every commit in a PR carries a Developer Certificate of Origin sign-off.
-  # PR-only: the direct-to-main workflow signs off at push time, and history
-  # predating this gate is not retro-required.
+  # Every commit that merges carries a Developer Certificate of Origin sign-off.
+  #
+  # This runs on the merge queue as well as on the pull request, and the queue is
+  # the one that counts: the merge_group payload carries base_sha/head_sha of the
+  # tree that is about to land, so the sign-off is checked against what actually
+  # merges. The alternative — exempting a pull_request-only job from the aggregate
+  # verdict, which refuses a skip on merge_group — would have reopened the
+  # skip-as-pass hole for the one gate that proves provenance.
+  #
+  # History predating this gate is not retro-required.
   dco:
     name: dco
     timeout-minutes: 20
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: >-
+      github.event_name == 'merge_group'
+      || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -264,11 +273,13 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Every PR commit is signed off (DCO)
+      - name: Every merging commit is signed off (DCO)
         working-directory: .
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # `||` coalesces on falsiness, and the unselected event's payload is
+          # empty — so each var takes whichever event actually fired.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./scripts/check-dco.sh "$BASE_SHA" "$HEAD_SHA"
 
   # The deterministic merge gate: build, vet, lint (baseline + new-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,11 +825,19 @@ jobs:
   # (the same trap the sonarcloud job below is written to avoid). Gated at the JOB
   # level like every other lane here, a path skip reports as passing instead.
   #
-  # PR-only on purpose. On main the identical gate runs inside sbom.yml, where it
-  # is the precondition for signing: a keyless signature lands permanently in a
-  # public transparency log and cannot be retracted, so a policy-failing SBOM must
-  # never reach the sign job. Splitting the two events runs the gate exactly once
-  # per path rather than twice on main.
+  # Runs on the merge queue as well as the pull request. It was pull_request-only
+  # while main was gated by a push, because the identical gate runs inside sbom.yml
+  # on main — where it is the precondition for signing: a keyless signature lands
+  # permanently in a public transparency log and cannot be retracted, so a
+  # policy-failing SBOM must never reach the sign job. Splitting the events ran the
+  # gate once per path instead of twice.
+  #
+  # That split cannot survive the merge queue. The `ci` aggregate refuses a skipped
+  # job on merge_group, so a pull_request-only lane here would fail every queue
+  # entry and stop merging — the same trap `dco` sits in, and the same fix. It is
+  # also the better answer on its own terms: a denied licence should be caught
+  # BEFORE the merge, not by the artifact producer that runs after it. sbom.yml
+  # still gates its own signing path, which is what that copy exists for.
   #
   # `make sbom` first because sbom-check reads the generated document — the gate
   # judges the resolved dependency graph, not the manifests.
@@ -838,9 +846,8 @@ jobs:
     timeout-minutes: 30
     needs: [changes]
     if: >-
-      github.event_name == 'pull_request'
-      && needs.changes.outputs.deps == 'true'
-      && github.event.pull_request.draft == false
+      needs.changes.outputs.deps == 'true'
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1320,12 +1320,23 @@ jobs:
   #   sonarcloud                 — not a required check (merge speed during heavy
   #                                development). Listing it here would make it
   #                                blocking by the back door.
+  #   vuln, live-boot, uat       — advisory today, and deliberately still
+  #                                advisory here. See below.
   #
-  # vuln, live-boot and uat ARE listed, and that makes them blocking for the
-  # first time: they run today but sit outside the required-contexts list, so a
-  # red one does not stop a merge. A job worth running is worth believing. If
-  # either e2e job proves flaky under the queue, stabilise or delete it — do not
-  # quietly drop it from this list.
+  # This list is EXACTLY the nine contexts the ruleset required before the
+  # aggregate replaced them, and that equality is the point: this change moves
+  # where the verdict is computed, not what the verdict covers. Adding a lane and
+  # collapsing the contexts in one step would mean a red merge queue with two
+  # candidate explanations, during the week we are establishing whether the queue
+  # itself works.
+  #
+  # vuln, live-boot and uat are the tempting additions — they run on every
+  # qualifying change and a red one does not stop a merge, which is not a state
+  # worth keeping. The reason to wait is the batching: a flaky job under a merge
+  # queue does not cost one re-run, it fails a batch of up to five and forces a
+  # re-split, and nothing has ever exercised these three under a gate that blocks.
+  # Promote them once the queue has a measured baseline, as their own change, so a
+  # regression has one explanation.
   ci:
     name: ci
     timeout-minutes: 10
@@ -1343,9 +1354,6 @@ jobs:
       - integration
       - frontend
       - license-gate
-      - live-boot
-      - uat
-      - vuln
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # The merge queue builds `main + everything ahead in the queue + this entry` on
+  # a throwaway ref and gates THAT tree, before it lands. This event — not the
+  # push above, which stops gating in a later commit on this branch — is what
+  # makes "main is green" a claim about a tree somebody actually tested.
+  merge_group:
   workflow_dispatch:
 
 # ONE live run per ref, main included: a new push cancels the stale lane instead
@@ -47,7 +52,11 @@ on:
 # `workflow_dispatch` on that commit brings the verdict back.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PR lanes still supersede themselves: a new push obsoletes the review in
+  # flight. A merge_group run must never be cancelled — it IS the merge verdict,
+  # and each queue entry has its own throwaway ref anyway, so the group would not
+  # collide. Saying so explicitly beats relying on that.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:
@@ -75,13 +84,25 @@ jobs:
     permissions:
       contents: read
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
+      # Diff-scoping is honest for author feedback and dishonest as a merge
+      # verdict: on a push, a commit matching no scope skipped every gate and
+      # GitHub reported green. On the merge queue every scope is therefore true
+      # and the lane is full-tree. The classifier still RUNS there — its filter
+      # step is cheap — and its answer is merely overridden, so a reader sees the
+      # real diff in the log next to the reason it was ignored.
+      #
+      # The `== 'true'` on each is load-bearing. paths-filter emits the STRING
+      # `true`/`false`, and `||` in a GitHub expression coalesces on falsiness,
+      # where the non-empty string "false" is TRUTHY. Without the comparison every
+      # output would be the string "false" and read as truthy by every consumer:
+      # every job would run on every event, which looks like it works.
+      backend: ${{ steps.filter.outputs.backend == 'true' || github.event_name == 'merge_group' }}
       # The database-bearing subset of `backend`. See the filter below for why
       # the two differ, and by exactly what.
-      backend_db: ${{ steps.filter.outputs.backend_db }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      e2e: ${{ steps.filter.outputs.e2e }}
-      deps: ${{ steps.filter.outputs.deps }}
+      backend_db: ${{ steps.filter.outputs.backend_db == 'true' || github.event_name == 'merge_group' }}
+      frontend: ${{ steps.filter.outputs.frontend == 'true' || github.event_name == 'merge_group' }}
+      e2e: ${{ steps.filter.outputs.e2e == 'true' || github.event_name == 'merge_group' }}
+      deps: ${{ steps.filter.outputs.deps == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,42 +14,33 @@
 name: ci
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   # The merge queue builds `main + everything ahead in the queue + this entry` on
-  # a throwaway ref and gates THAT tree, before it lands. This event — not the
-  # push above, which stops gating in a later commit on this branch — is what
-  # makes "main is green" a claim about a tree somebody actually tested.
+  # a throwaway ref and gates THAT tree, before it lands. This is the merge
+  # verdict, and it is why there is no `push: [main]` trigger here: a push to main
+  # is the RECORD of a verdict already reached, not an occasion to reach one.
   merge_group:
   workflow_dispatch:
 
-# ONE live run per ref, main included: a new push cancels the stale lane instead
-# of running beside it or queueing behind it. The invariant that buys is that the
-# commit being gated is always main's TIP.
+# ONE live run per pull request; a new push supersedes the review in flight.
 #
-# Gating every main commit — what a group keyed by commit buys — is not
-# affordable at this repository's size. A full-stack merge schedules 28 jobs
-# against an org-wide ceiling of 20 concurrent, so two overlapping merges turn a
-# 9-minute gate into a two-hour one and starve every PR lane behind them. A
-# verdict that lands hours after the merge gates nothing.
+# There is no main-push lane to reason about any more. The merge queue gates the
+# tree before it lands (`merge_group` above), so every commit on main arrives with
+# a verdict already attached. Each queue entry gets its own throwaway ref, so
+# entries never collide in this group, and cancel-in-progress narrows to pull
+# requests so a merge verdict can never be cancelled.
 #
-# `cancel-in-progress: false` is not the conservative setting it reads as, which
-# is the trap worth stating where the next reader will look: it protects the run
-# already RUNNING, and a group holds ONE pending run, so an arriving merge
-# cancels the pending one and takes its place. The superseded merge is reported
-# `cancelled` with zero jobs — indistinguishable from a green skip on every
-# dashboard — while the tip still waits out a lane gating an older tree.
-# `queue: max` lifts that pending limit to 100 and would gate every commit, but
-# it cannot be combined with cancellation, and it puts the tip's verdict behind
-# every lane ahead of it: the latency this setting exists to remove.
-#
-# main is a linear history of squash merges, so the tip's tree contains every
-# merge below it and "main is green" stays a true statement about all of them.
-# The price is per-commit attribution: a bisect over main cannot assume every
-# commit was gated, and a red lane can be superseded before anyone reads it —
-# `workflow_dispatch` on that commit brings the verdict back.
+# What this replaces, and why it could not stay: a group keyed on `github.ref`
+# with cancellation across ALL events meant a push to main cancelled the RUNNING
+# main lane. At this repository's merge velocity 64% of main pushes were
+# cancelled, and the survivors were mostly classifier skips averaging 4.5 minutes
+# against a real lane's 16 — so roughly one main commit in twenty-five was ever
+# gated, and "main is green" was a statement about almost nothing. The argument
+# that used to live here traded per-commit gating away to keep the tip's verdict
+# fast, on the grounds that 28 jobs against a 20-concurrent ceiling made the
+# alternative unaffordable. The ceiling moved, and the invariant it bought —
+# main's tip is always the gated commit — is contradicted by the run history.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # PR lanes still supersede themselves: a new push obsoletes the review in
@@ -381,20 +372,6 @@ jobs:
           CONTRACT_BREAKING_REQUIRE_BASE: "1"
           MIGRATION_VERSIONS_REQUIRE_BASE: "1"
         run: make check-backend
-      # Refresh the shared cache from main only. On a PR this step does not run,
-      # so the twelve shards and this job never race to write the same key and a
-      # PR can never poison what the next PR restores. `!cancelled()` rather than
-      # success(): a red lint or a failed test still compiled the tree, and those
-      # artifacts are exactly as reusable as a green run's.
-      - name: Refresh the shared build cache
-        if: >-
-          !cancelled()
-          && github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.go-cache.outputs.key }}
 
   # The composed-build lane (ADR-0069): materialize the walking-skeleton
   # reference extension into extensions/, compose, and run the backend
@@ -669,20 +646,6 @@ jobs:
           path: ${{ runner.temp }}/shard-out
           if-no-files-found: error
           retention-days: 1
-      # ONE shard refreshes the `integration` flavour, and only from main. Every
-      # shard compiles substantially the same set, so a second writer would add
-      # nothing but a race for the same key — and twelve runners each uploading a
-      # ~550 MB cache would evict the entry they were meant to seed.
-      - name: Refresh the shared build cache
-        if: >-
-          !cancelled()
-          && matrix.shard == 1
-          && github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.go-cache.outputs.key }}
 
   # Unit coverage for SonarCloud. The shards run only the integration-tagged
   # packages, but the unit-only packages need a `-cover` pass of their own —
@@ -927,22 +890,24 @@ jobs:
     # PR the scan proceeds without it, because new code there is the diff and
     # a diff that skipped an area has no lines in it for that area to cover.
     #
-    # That reasoning does NOT survive the move to a push. main's new-code
-    # period is `previous_version`, so its new code is every line added since
-    # the last release marker — weeks of Go — and a push REPLACES main's
-    # stored analysis rather than adding a second one. The scanner's Zero
-    # Coverage Sensor scores every executable line it holds no report for as
-    # uncovered, so a push that skipped the Go coverage producer publishes
-    # those weeks at 0% and the quality gate reads red until some later push
-    # happens to rescan them. A docs-only merge skips every producer, which
-    # makes it the common way in. Measuring nothing is not a measurement of
-    # zero, so such a push does not scan and main keeps its last real reading.
+    # The last clause below — `event_name == 'pull_request' || integration
+    # succeeded` — is what stops a partial run from publishing an analysis that
+    # reads as a measurement. The scanner's Zero Coverage Sensor scores every
+    # executable line it holds no report for as UNCOVERED, so a scan that ran
+    # without the Go coverage producer publishes that code at 0% rather than
+    # declining to answer. Measuring nothing is not a measurement of zero.
     #
-    # `integration` alone stands for the Go coverage, and the backend
-    # classifier scope starts every backend producer together — so a run that
-    # has it has the profile that dominates main's new code. A frontend-only
-    # push therefore waits for the next backend one rather than publishing
-    # main with no Go coverage at all.
+    # On a pull request that cannot happen in a way that matters: new code is the
+    # diff, and a diff that skipped an area has no lines in it for that area to
+    # cover. Off a pull request it can, so `integration` — which alone stands for
+    # the Go coverage, and which the backend classifier scope starts together with
+    # every other backend producer — must genuinely have SUCCEEDED, not merely
+    # not-failed.
+    #
+    # On merge_group the classifier is overridden and every producer runs, so the
+    # clause is satisfied whenever the lane is green. It is kept rather than
+    # simplified away because it is the thing that would catch a future event, or
+    # a future skip, that reintroduces a partial scan.
     #
     # deterministic-gates is gated directly, not just transitively. Now that
     # integration runs in parallel with the build gate rather than behind it, a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1343,8 +1343,9 @@ jobs:
   # vuln, live-boot and uat are the tempting additions — they run on every
   # qualifying change and a red one does not stop a merge, which is not a state
   # worth keeping. The reason to wait is the batching: a flaky job under a merge
-  # queue does not cost one re-run, it fails a batch of up to five and forces a
-  # re-split, and nothing has ever exercised these three under a gate that blocks.
+  # queue does not cost one re-run, it fails the whole group it was checked in and
+  # every entry in that group is re-queued, and nothing has ever exercised these
+  # three under a gate that blocks.
   # Promote them once the queue has a measured baseline, as their own change, so a
   # regression has one explanation.
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1312,3 +1312,62 @@ jobs:
           pnpm exec playwright install --with-deps chromium
       - name: Screen-acceptance UAT (build → preview → AC + axe)
         run: make frontend-e2e
+
+  # ONE required context stands for the whole lane.
+  #
+  # Nine separately-required contexts were satisfiable by a run that did nothing:
+  # GitHub reads a skipped required check as a passing one, and the classifier
+  # skips whole jobs. This job is the only required context now, and
+  # scripts/ci-verdict.sh is where "a skip is not a pass on the merge queue" is
+  # written down and unit-tested (make test-ci-verdict).
+  #
+  # WHAT THE needs: LIST DELIBERATELY OMITS:
+  #   changes                    — the classifier produces no verdict.
+  #   fe-quality/-unit/-bundle   — absorbed by the `frontend` fan-in.
+  #   integration-shards,
+  #   integration-unit-coverage  — absorbed by the `integration` fan-in, which
+  #                                already asserts on their results.
+  #   sonarcloud                 — not a required check (merge speed during heavy
+  #                                development). Listing it here would make it
+  #                                blocking by the back door.
+  #
+  # vuln, live-boot and uat ARE listed, and that makes them blocking for the
+  # first time: they run today but sit outside the required-contexts list, so a
+  # red one does not stop a merge. A job worth running is worth believing. If
+  # either e2e job proves flaky under the queue, stabilise or delete it — do not
+  # quietly drop it from this list.
+  ci:
+    name: ci
+    timeout-minutes: 10
+    # always(), so the verdict is reached when an upstream job fails rather than
+    # being skipped along with it — a skipped aggregate is a green required check,
+    # which is the whole failure mode this job exists to end.
+    if: always()
+    needs:
+      - dco
+      - deterministic-gates
+      - craftsmanship
+      - craft-residue
+      - secret-scan
+      - extension-reference
+      - integration
+      - frontend
+      - license-gate
+      - live-boot
+      - uat
+      - vuln
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verdict
+        env:
+          CI_VERDICT_NEEDS: ${{ toJSON(needs) }}
+          CI_VERDICT_EVENT: ${{ github.event_name }}
+        run: ./scripts/ci-verdict.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,7 +924,11 @@ jobs:
     # Analysis" check over a broken build (result == 'failure' fails this
     # condition, so the scan is skipped); the PR is already red, so nothing that
     # wasn't already blocked is blocked.
-    needs: [deterministic-gates, integration, frontend, extension-reference]
+    # `ci` is in needs for the merge_group case ONLY, and it is not a cycle: the
+    # aggregate deliberately omits sonarcloud from its own needs, so nothing waits
+    # on this job to reach a verdict — the queue merges on `ci` alone and this scan
+    # may finish after the merge.
+    needs: [ci, deterministic-gates, integration, frontend, extension-reference]
     if: >-
       !cancelled()
       && (needs.deterministic-gates.result == 'success' || needs.deterministic-gates.result == 'skipped')
@@ -933,6 +937,7 @@ jobs:
       && (needs.extension-reference.result == 'success' || needs.extension-reference.result == 'skipped')
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
       && (github.event_name == 'pull_request' || needs.integration.result == 'success')
+      && (github.event_name != 'merge_group' || needs.ci.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -985,9 +990,14 @@ jobs:
       # keep reporting the last real verdict indefinitely, which is a green that
       # measures nothing — the exact failure this pipeline change exists to end.
       #
-      # Safe because this job runs only on a green lane, and a green batch merges
-      # (the queue's HEADGREEN strategy merges the green prefix), so a tree
-      # published as main is a tree that became main.
+      # What makes it safe is the `needs.ci.result == 'success'` clause above, and
+      # nothing weaker would: this job's other conditions cover only its COVERAGE
+      # producers, so without that clause a merge_group build whose secret-scan,
+      # license-gate, craft-residue or dco failed would still publish. That tree
+      # does not merge — and it would have replaced the stored analysis every
+      # scheduled check reads for main, describing a tree main never became.
+      # Requiring the aggregate verdict is what makes "published as main" mean
+      # "became main".
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -965,9 +965,27 @@ jobs:
         with:
           name: fe-coverage
           path: frontend/coverage
+      # A merge_group run publishes as `main`, and that is not a fiction: the
+      # queue builds `main + the queued entries`, which is byte-for-byte the tree
+      # main becomes when the batch merges. Measuring it here is the same
+      # measurement the old push-to-main scan took, one step earlier.
+      #
+      # Without this override the scanner reads GITHUB_REF and files the analysis
+      # under `gh-readonly-queue/main/pr-N-<sha>` — a branch that is deleted
+      # minutes later. Nothing would ever update main again, and main's stored
+      # analysis does not disappear when it stops being refreshed: it FREEZES. The
+      # nightly `quality-gate` job in scheduled.yml reads `?branch=main` and would
+      # keep reporting the last real verdict indefinitely, which is a green that
+      # measures nothing — the exact failure this pipeline change exists to end.
+      #
+      # Safe because this job runs only on a green lane, and a green batch merges
+      # (the queue's HEADGREEN strategy merges the green prefix), so a tree
+      # published as main is a tree that became main.
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        with:
+          args: ${{ github.event_name == 'merge_group' && '-Dsonar.branch.name=main' || '' }}
       - name: No token yet — scan skipped
         if: ${{ env.SONAR_TOKEN == '' }}
         run: echo "SONAR_TOKEN not set; skipping CI scan (Automatic Analysis still active). Add the secret to activate."

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SEED_DSN ?= postgres://margince_owner:dev@localhost:15432/margince
 # every company renders as a placeholder initial.
 MINIO_PORT ?= 29000
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report secret-scan test-secret-scan test-dev-dsn test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict secret-scan test-secret-scan test-dev-dsn test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -74,7 +74,7 @@ ai-routing-local:
 ## #1639 is about: a backend-only author never runs the lane that would
 ## otherwise catch a stranded frontend schema. On a pull request CI covers the
 ## same ground from the other side, through fe-quality's fe-drift.
-check-backend: check-craft-doc craft-test test-golangci-guard test-scheduled-report check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze
+check-backend: check-craft-doc craft-test test-golangci-guard test-scheduled-report test-ci-verdict check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -548,6 +548,15 @@ test-dev-dsn:
 ## lane runs the reporter only on a red day — an edit to it lands on a green one.
 test-scheduled-report:
 	@./scripts/test-scheduled-report.sh
+
+## test-ci-verdict — prove the single required check still refuses to read a
+## skipped job as a passing one on the merge queue. GitHub counts a skipped
+## required check as passing, so that rule is the only reason nine required
+## contexts could safely collapse into one; a regression in it would show up as
+## a green `ci` over a lane that ran nothing, which is indistinguishable from
+## the real thing on every dashboard.
+test-ci-verdict:
+	@./scripts/test-ci-verdict.sh
 
 ## check-image-pins — every `uses:` in .github/workflows/ AND every container
 ## `image:` (workflow service containers + infra/docker-compose.dev.yml) is

--- a/backend/aggregategatereach_test.go
+++ b/backend/aggregategatereach_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Every job the `ci` aggregate depends on can actually RUN on the merge queue.
+//
+// `ci` is the single required status check, and scripts/ci-verdict.sh refuses any
+// result other than `success` on `merge_group` — because GitHub counts a skipped
+// required check as a passing one, which is how a lane that ran nothing reported
+// green. The cost of that strictness is a coupling that is easy to break from the
+// other side: a job whose `if:` requires `github.event_name == 'pull_request'` is
+// SKIPPED on the queue, the aggregate refuses the skip, and every queue entry
+// fails. The symptom is not a red test — it is merging stopping repository-wide,
+// with the cause several files away from the edit that caused it.
+//
+// This is a fitness test rather than a fixed list because the mistake has already
+// been made twice in one change: `dco` and `license-gate` were both
+// pull_request-only, and finding the second by hand after fixing the first is
+// exactly the "fixed the case under review, missed the sibling copy" pattern the
+// engineering rules name. Deriving the obligation from the workflow means the
+// third one fails here instead of in production.
+//
+// WHAT THIS CATCHES: a job in the aggregate's `needs:` whose condition cannot be
+// satisfied on `merge_group`.
+//
+// WHAT THIS DOES NOT CATCH, deliberately: whether a reachable job is CORRECTLY
+// scoped there. Judging that means evaluating GitHub's expression language
+// against a synthetic event payload, which is a second implementation of the
+// thing under test. The failure this guards is total (nothing merges); the one it
+// does not is a design question a reviewer can see.
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// aggregateWorkflow is the merge gate, and aggregateJob is the one job in it
+// whose `needs:` list defines the required check.
+const (
+	aggregateWorkflow = workflowDir + "/ci.yml"
+	aggregateJob      = "ci"
+)
+
+// prOnlyGuard is the conjunct that makes a job unreachable on the queue.
+// mergeGroupEscape is what makes such a condition reachable again — either an
+// explicit `merge_group` alternative, or the negated spelling
+// (`event_name != 'pull_request'`) that every correctly-written lane here uses.
+const (
+	prOnlyGuard      = "github.event_name == 'pull_request'"
+	mergeGroupEscape = "merge_group"
+	negatedGuard     = "github.event_name != 'pull_request'"
+)
+
+type aggregateJobs struct {
+	Jobs map[string]struct {
+		Needs []string `yaml:"needs"`
+		If    string   `yaml:"if"`
+	} `yaml:"jobs"`
+}
+
+func TestEveryAggregatedJobCanRunOnTheMergeQueue(t *testing.T) {
+	raw, err := os.ReadFile(aggregateWorkflow) // #nosec G304 -- a fixed repo-relative path
+	if err != nil {
+		t.Fatalf("reading %s: %v", aggregateWorkflow, err)
+	}
+	var wf aggregateJobs
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("%s: %v", aggregateWorkflow, err)
+	}
+
+	agg, ok := wf.Jobs[aggregateJob]
+	if !ok {
+		t.Fatalf("%s declares no %q job — either the single required check was renamed, in which case "+
+			"branch protection needs the new name, or it was deleted and nothing aggregates the lane",
+			filepath.Base(aggregateWorkflow), aggregateJob)
+	}
+	// A gate that judged zero jobs would pass exactly like a clean tree.
+	if len(agg.Needs) == 0 {
+		t.Fatalf("job %q lists no needs; this gate would pass vacuously and the required check "+
+			"would stand for nothing", aggregateJob)
+	}
+
+	for _, name := range slices.Sorted(slices.Values(agg.Needs)) {
+		job, ok := wf.Jobs[name]
+		if !ok {
+			t.Errorf("job %q needs %q, which does not exist in %s — the aggregate would never run",
+				aggregateJob, name, filepath.Base(aggregateWorkflow))
+			continue
+		}
+		cond := normalizeCondition(job.If)
+		if !strings.Contains(cond, prOnlyGuard) {
+			continue
+		}
+		if strings.Contains(cond, mergeGroupEscape) || strings.Contains(cond, negatedGuard) {
+			continue
+		}
+		t.Errorf("job %q requires %s with no merge_group alternative, so it is SKIPPED on the queue — "+
+			"and %q refuses a skip there, which stops every merge. Either admit merge_group "+
+			"(`github.event_name != 'pull_request' || ...`, as the other lanes do, taking any PR-only "+
+			"payload field from the merge_group event instead), or drop the job from %q's needs.",
+			name, prOnlyGuard, aggregateJob, aggregateJob)
+	}
+
+	// The aggregate itself must not be conditioned away: a skipped aggregate is a
+	// GREEN required check, which is the failure the whole design exists to end.
+	if got := normalizeCondition(agg.If); got != "always()" {
+		t.Errorf("job %q has if: %q, want %q — an aggregate that is skipped alongside a failed "+
+			"upstream job reports a green required check", aggregateJob, got, "always()")
+	}
+
+	// Verify the gate is reading real conditions, not empty strings from a schema
+	// change. Every lane in this pipeline is conditioned; none being so means the
+	// decode silently stopped working.
+	if !slices.ContainsFunc(agg.Needs, func(n string) bool { return wf.Jobs[n].If != "" }) {
+		t.Errorf("no job in %q's needs carries an `if:` — the decode has stopped seeing conditions, "+
+			"so this gate was about to pass without judging anything", aggregateJob)
+	}
+}
+
+// normalizeCondition collapses the whitespace a YAML folded block (`if: >-`)
+// introduces, so a condition means the same thing to this gate however it is
+// wrapped in the workflow.
+func normalizeCondition(cond string) string {
+	return strings.Join(strings.Fields(cond), " ")
+}

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -13,11 +13,13 @@ checks — so a migration that forgets `FORCE RLS`, an erasure that misses a PII
 table, a denied dependency license, a swallowed error, or a UI regression fails
 the merge instead of shipping.
 
-One lane runs but deliberately does **not** block: the SonarCloud scan. It was
-traded off the required set for merge speed during heavy development, and it is
-re-checked daily on `main` by `scheduled.yml` — see below for why a non-blocking
-gate needs that backstop to stay honest. `vuln`, `uat` and `live-boot` used to be
-advisory too; they are now inside the `ci` aggregate and therefore block.
+Two lanes run but deliberately do **not** block: `vuln` and the SonarCloud scan.
+Both were traded off the required set for merge speed during heavy development,
+and both are re-checked daily on `main` by `scheduled.yml` — see below for why a
+non-blocking gate needs that backstop to stay honest. `uat` and `live-boot` are
+likewise advisory. Promoting the three of them is deliberate future work rather
+than an oversight; the reason it is not bundled with the merge queue is in
+[The `ci` aggregate](#the-ci-aggregate-is-the-only-required-context).
 
 ## Triggers
 
@@ -74,11 +76,20 @@ commit in twenty-five was ever gated, and a docs-only merge landing after a
 breaking one matched no scope, skipped every job, and reported green. `main` went
 red twice with the breakage masked exactly that way.
 
-Both premises are now void: the concurrency ceiling moved, and a merge queue
-gates before the merge rather than racing after it. A skipped required check also
-counts as *passing* on GitHub, which is why the nine separately-required contexts
-collapsed into one `ci` job that refuses a skip — see
-[The jobs](#the-jobs).
+Both premises are void, and neither needed a bigger runner budget to void.
+
+The invariant is contradicted outright by the numbers above. And the slot argument
+was an argument against *racing* a lane after the merge — which a queue does not
+do: it gates before the merge, and it **batches**, so five entries share one lane
+rather than each claiming their own. The 20-concurrent ceiling is unchanged; what
+changed is that `release.yml` and `sbom.yml` stopped drawing ~448 runs a week from
+it (both are dispatch-only now), which is where the room for a queue lane came
+from. If queue depth grows anyway, `max_entries_to_merge` is a ruleset knob that
+costs nothing to turn.
+
+A skipped required check also counts as *passing* on GitHub, which is why the nine
+separately-required contexts collapsed into one `ci` job that refuses a skip — see
+[The `ci` aggregate](#the-ci-aggregate-is-the-only-required-context).
 
 ## Run only the checks a change can affect
 
@@ -219,16 +230,28 @@ and the queue lane covers the remainder.
 upstream job reports a **green** required check, which is the same failure wearing
 a different hat.
 
-Three jobs became blocking when they entered this list — `vuln`, `live-boot` and
-`uat`. They ran before but sat outside the required set, so a red one did not stop
-a merge. If one proves flaky under the queue, stabilise or delete it; do not
-quietly drop it from `needs`.
+**`needs` is exactly the nine contexts the ruleset required before the aggregate
+replaced them**, and that equality is the point: this change moved where the
+verdict is computed, not what it covers. Widening the gate in the same step would
+mean a red merge queue with two candidate explanations, during the week the queue
+itself is on trial.
 
-Seven jobs are deliberately **not** in `needs`: `changes` (produces no verdict),
-`fe-quality`/`fe-unit`/`fe-bundle` and `integration-shards`/
-`integration-unit-coverage` (absorbed by their fan-ins, which already assert on
-them), and `sonarcloud` (non-blocking by decision — listing it here would make it
-required by the back door).
+Ten jobs are deliberately **not** in `needs`:
+
+- `changes` — the classifier produces no verdict.
+- `fe-quality`, `fe-unit`, `fe-bundle` — absorbed by the `frontend` fan-in.
+- `integration-shards`, `integration-unit-coverage` — absorbed by the
+  `integration` fan-in, which already asserts on their results.
+- `sonarcloud` — non-blocking by decision; listing it here would make it required
+  by the back door.
+- `vuln`, `live-boot`, `uat` — advisory, and left that way **on purpose**. They
+  are the obvious additions: each runs on every qualifying change and a red one
+  does not stop a merge, which is not a state worth keeping. What argues for
+  waiting is the batching. A flaky job under a merge queue does not cost one
+  re-run; it fails a batch of up to five and forces a re-split, and nothing has
+  ever exercised these three under a gate that blocks. Promote them once the queue
+  has a measured baseline, as their own change, so a regression has exactly one
+  explanation.
 
 ## The shared Go build cache
 
@@ -316,7 +339,7 @@ third-party actions it calls, which would otherwise ride in unread.
 | `integration shard (k/12)` | `make test-integration` with `INTEGRATION_SHARD=k/12`: a deterministic per-test round-robin slice of the whole integration lane. Slices are count-based, not duration-based; the heavy e2e tail lands on whichever shard draws it, and `INTEGRATION_JOBS=16` (the tests wait on Postgres, not cores) lets that shard chew through its slice instead of running minutes over its siblings. Boots the dev compose stack (`make db-up`: digest-pinned Postgres 16 (pgvector) + Redis 7 + MinIO + the app role — one stack definition, no hand-mirrored GH services); each shard builds its own migrated `margince_test` template and clones per package. Uploads its slice manifests + binary coverage pods |
 | `integration unit coverage` | The unit `-cover` pass over every package, binary coverage pods only. Needed because the shards run just the integration-tagged packages, and without it SonarCloud would see the unit-only packages at a false ~0% new-code coverage. No services (the test-lanes gate guarantees untagged tests open no real DB) |
 | `integration` | The fan-in the `ci` aggregate reads — it stands for the whole sharded lane, so the aggregate needs one entry rather than twelve. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |
-| `vuln` | `make vuln` (govulncheck over all packages). Now **blocking**, via the `ci` aggregate. A vulnerable dependency a PR *introduces* is reported before merge; what it cannot report is a vulnerability disclosed after one, which is why `scheduled.yml` runs it daily on `main` as well |
+| `vuln` | `make vuln` (govulncheck over all packages). **Advisory** — outside the `ci` aggregate, so a red one does not stop a merge. It still runs on every backend change, so a vulnerable dependency a PR *introduces* is reported before merge; what it cannot report is a vulnerability disclosed after one, which is why `scheduled.yml` runs it daily on `main` as well |
 | `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. Runs on `merge_group` as well as `pull_request`, and it is the **only** automatic run of this policy — `sbom.yml` is dispatch-only, so the copy of the gate inside it fires just before a signing run. The merge-queue run is what makes that sufficient, and makes it a stronger claim than it was: `main` receives a dependency change only through a queue build this job passed, so the policy is judged against the tree that lands rather than a PR head that may not match it |
 | `fe-quality` | `make fe-quality` — the design-system script gates, the contract type-drift check, Biome, the composed-SPA typecheck (ADR-0069) and the unit screens' own vitest suites. The only frontend job carrying a Go toolchain: the composed lane needs `gen-composition` output, which nothing else produces |
 | `fe-unit` | `make fe-unit FE_COVERAGE=1` — the vitest suite, instrumented so the run that decides the verdict also writes the lcov. Emits `fe-coverage`, after `frontend/scripts/check-lcov-paths.sh` has proved every path in it resolves from the repo root (see below). Not sharded: the v8 provider's branch records cannot be merged across shards without skewing condition coverage — issue #966 has the measurements and the fix |

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -13,60 +13,94 @@ checks — so a migration that forgets `FORCE RLS`, an erasure that misses a PII
 table, a denied dependency license, a swallowed error, or a UI regression fails
 the merge instead of shipping.
 
-Two lanes run but deliberately do **not** block: `vuln` and the SonarCloud scan.
-Both were traded off the required set for merge speed during heavy development,
-and both are re-checked daily on `main` by `scheduled.yml` — see below for why a
-non-blocking gate needs that backstop to stay honest. `uat` and `live-boot` are
-likewise advisory.
+One lane runs but deliberately does **not** block: the SonarCloud scan. It was
+traded off the required set for merge speed during heavy development, and it is
+re-checked daily on `main` by `scheduled.yml` — see below for why a non-blocking
+gate needs that backstop to stay honest. `vuln`, `uat` and `live-boot` used to be
+advisory too; they are now inside the `ci` aggregate and therefore block.
 
 ## Triggers
 
 - `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_review`)
-- `push` to `main`
+- `merge_group` — **the merge gate**
 - `workflow_dispatch` (manual)
 
-One live run per ref, `main` included (`concurrency` group keyed on
-`github.ref`, `cancel-in-progress: true`): a new push cancels the stale lane, so
-the commit under gate is always the ref's tip. `release.yml` and `sbom.yml` no
-longer contend for that budget at all — both are **manual dispatch only**, so
-neither is triggered by a merge. They keep their JOB-scoped groups for the case
-of two deliberate dispatches, where cancellation must reach the expensive
-generation halves and never the step that publishes or signs — see
-[The other workflows](#the-other-workflows).
-`scheduled.yml` groups without cancelling; nothing supersedes a daily run.
+There is no `push` to `main` trigger. A push to `main` is the *record* of a
+verdict already reached, because the merge queue gated that exact tree before it
+landed.
 
-Gating every `main` commit — a group keyed by commit — is what this replaced,
-and the slot budget is the reason, not a smaller appetite for coverage. A
-full-stack merge schedules 28 jobs against an org-wide ceiling of 20 concurrent
-jobs, so two overlapping merges stretched a 9-minute gate past two hours and
-starved every PR lane behind them. A verdict that lands hours after the merge
-gates nothing.
+### The merge queue is what gates
 
-`cancel-in-progress: false` is not the conservative choice here, which is the
-trap worth remembering. It protects a run that is already *running*, and a group
-holds **one** pending run: an arriving run cancels the pending one and takes its
-place, so while every `main` push shared one group the *intermediate* merges were
-the ones dropped — reported `cancelled`, zero jobs, indistinguishable from a
-green skip on any dashboard — while the tip still waited out a lane gating an
-older tree. `Release` shows the mechanism plainly in its own history: with run
-463 still running, run 464 sat pending from 02:52:53 and was cancelled at
-**02:55:24** — the second run 465 arrived, which then ran to success. `queue: max` lifts the pending limit to 100 and would gate every commit,
-but it cannot be combined with cancellation and it puts the tip's verdict behind
-every lane ahead of it — the latency this setting exists to remove.
+A `merge_group` run builds `main` + everything ahead of it in the queue + the
+entry under test, on a throwaway `gh-readonly-queue/main/...` ref, and gates
+**that** tree. Two properties follow, and they are the whole point:
 
-What tip-only gating gives up is per-commit attribution. `main` is a linear
-history of squash merges, so the tip's tree contains every merge below it and
-"`main` is green" stays a true statement about all of them — but a bisect cannot
-assume every commit was gated, and a red lane can be superseded before anyone
-reads it. A `workflow_dispatch` on that commit brings the verdict back, and the
-daily `backend lane (main)` in `scheduled.yml` stays the backstop for a tree
-nothing is being merged into.
+- **Full tree, always.** The change classifier is overridden on `merge_group`
+  (every scope reports `true`), so no job can be skipped there.
+- **Every commit, not just the tip.** The tree that is measured is the tree that
+  merges.
+
+The queue merges in **batches** — up to five entries per build, with the green
+prefix of a failing batch still merging (`HEADGREEN`). Serialising one PR per
+~20-minute lane would cap merges at three an hour against a demonstrated rate of
+70–82 a day; batching is what makes per-commit gating affordable at all.
+
+`concurrency` is keyed on `github.ref` with `cancel-in-progress` narrowed to
+`pull_request`: a new push supersedes the review in flight, and a merge verdict
+can never be cancelled. Each queue entry has its own ref, so entries never
+collide in that group.
+
+`release.yml` and `sbom.yml` do not contend for the runner budget at all — both
+are **manual dispatch only**, so neither is triggered by a merge. They keep their
+JOB-scoped groups for the case of two deliberate dispatches, where cancellation
+must reach the expensive generation halves and never the step that publishes or
+signs — see [The other workflows](#the-other-workflows). `scheduled.yml` groups
+without cancelling; nothing supersedes a daily run. `cache-warm.yml` groups
+without cancelling for a different reason: a cancelled run saves no cache, so
+finishing is the entire point.
+
+### What this replaced, and why it had to go
+
+`main` pushes used to be gated, sharing one concurrency group with
+`cancel-in-progress: true`. The stated invariant was that the commit under gate
+is always the ref's tip, traded against a slot budget: a full-stack merge
+schedules 28 jobs against an org-wide ceiling of 20 concurrent, so overlapping
+merges stretched a 9-minute gate past two hours.
+
+The run history contradicted the invariant. Across the last 25 pushes to `main`,
+**16 were cancelled** and the survivors averaged **4.5 minutes** against a real
+lane's 16 — the fast ones were classifier skips, not verdicts. Roughly one `main`
+commit in twenty-five was ever gated, and a docs-only merge landing after a
+breaking one matched no scope, skipped every job, and reported green. `main` went
+red twice with the breakage masked exactly that way.
+
+Both premises are now void: the concurrency ceiling moved, and a merge queue
+gates before the merge rather than racing after it. A skipped required check also
+counts as *passing* on GitHub, which is why the nine separately-required contexts
+collapsed into one `ci` job that refuses a skip — see
+[The jobs](#the-jobs).
 
 ## Run only the checks a change can affect
 
 The first job, **`changes`**, classifies the diff (dorny/paths-filter,
 SHA-pinned) into five scopes; every downstream job gates on the relevant
-output. A required job skipped this way still counts as passing.
+output.
+
+**This applies to `pull_request` only.** On `merge_group` every scope is forced
+`true`, so the queue lane is full-tree and nothing can be skipped there. The
+distinction is the load-bearing one in this document: diff-scoping is honest as
+*author feedback* and dishonest as a *merge verdict*. A PR-side skip is safe
+precisely because the queue lane covers the ground it skipped — which is why the
+override lives in the `changes` job's outputs, where it cannot be forgotten, and
+not in each consumer's `if:`.
+
+The classifier still *runs* on `merge_group`; only its answer is overridden. A
+reader therefore sees the real diff in the log next to the reason it was ignored.
+
+Note the `== 'true'` on each output expression. paths-filter emits the **string**
+`true`/`false`, and GitHub's `||` coalesces on falsiness, where the non-empty
+string `"false"` is truthy — without the comparison every scope would read as
+true on every event.
 
 `backend` and `backend_db` are the same set apart from the two agent
 rulebooks. They are split because one flag was driving two unrelated things:
@@ -87,13 +121,19 @@ would report a documentation PR as a broken integration lane.
 
 Consequences:
 
-- A **docs-only PR** matches no scope → every code gate skips. That includes
-  the prose under `infra/` — this file documents the classifier, it is not an
-  input to any gate, so the two `!(*.md)` extglobs keep an edit to it from
-  booting the twelve-shard integration fleet. Each is written as one positive
-  pattern because the action ORs its patterns: a separate `!infra/**/*.md`
-  entry would match every path outside `infra/` and fire the filter on
-  everything.
+- A **docs-only PR** matches no scope → every code gate skips **on the PR**, and
+  runs in full when the PR reaches the queue. That includes the prose under
+  `infra/` — this file documents the classifier, it is not an input to any gate,
+  so the two `!(*.md)` extglobs keep an edit to it from booting the twelve-shard
+  integration fleet on the PR side. Each is written as one positive pattern
+  because the action ORs its patterns: a separate `!infra/**/*.md` entry would
+  match every path outside `infra/` and fire the filter on everything.
+
+  This is the case that used to be dangerous. A docs-only commit landing on
+  `main` after a breaking one matched no scope, skipped every gate, and reported
+  green — `main` went red twice with the breakage masked exactly that way. The
+  queue closes it: the docs-only entry is gated against the full tree it is
+  merging into.
 - A **Dockerfile-only PR** (the root `Dockerfile`, `.dockerignore`,
   `docker-bake.hcl`) also matches no scope, and **nothing else builds the role
   images either**. `ci.yml` dropped its `docker images (api + web + worker)` job
@@ -136,14 +176,18 @@ changes ──┬─> deterministic-gates ──> craftsmanship
           ├─> integration-unit-coverage ────┘                          │
           ├─> extension-reference ──────────────────────────────────┐  │
           ├─> vuln                                                  │  │
-          ├─> license gate  (PR-only, `deps` scope)                 │  │
+          ├─> license gate  (`deps` scope)                          │  │
           ├─> frontend ──> uat                                      │  │
           ├─> live-boot                                             │  │
           v                                                         v  v
  deterministic-gates + integration + extension-reference + frontend ──> sonarcloud
-  dco  (PR-only, independent)
+  dco            (independent — runs on merge_group too)
   craft-residue  (every non-draft change, independent)
   secret-scan    (every non-draft change, independent — + the image-pin gate)
+
+  ci  ── the ONE required context. needs: dco, deterministic-gates,
+         craftsmanship, craft-residue, secret-scan, extension-reference,
+         integration, frontend, license-gate, live-boot, uat, vuln
 ```
 
 Two deliberate shapes here. The Playwright `uat` lane is **fail-fast**: it
@@ -155,7 +199,36 @@ build is still caught by `deterministic-gates` itself. And the lane is
 **sharded**: twelve matrix runners each execute a deterministic per-test slice
 (package-level splitting would floor at the heaviest package,
 `compose/integration`), and the `integration` fan-in reassembles them into the
-one required check.
+single result the `ci` aggregate reads.
+
+### The `ci` aggregate is the only required context
+
+Branch protection requires exactly one check: **`ci`**. It reaches a verdict from
+`needs.*.result` through [`scripts/ci-verdict.sh`](../scripts/ci-verdict.sh),
+which is unit-tested by `make test-ci-verdict` and wired into `check-backend`.
+
+The rule it exists to enforce: **a skipped job is not a passing one on
+`merge_group`.** GitHub counts a skipped *required* check as passing, so nine
+separately-required contexts were satisfiable by a run that did nothing — the
+classifier skipped the jobs, and branch protection read the skips as green. The
+aggregate refuses any result other than `success` on `merge_group`; on
+`pull_request` it admits `skipped`, because there the classifier is doing its job
+and the queue lane covers the remainder.
+
+`if: always()`, deliberately: an aggregate that is skipped alongside a failed
+upstream job reports a **green** required check, which is the same failure wearing
+a different hat.
+
+Three jobs became blocking when they entered this list — `vuln`, `live-boot` and
+`uat`. They ran before but sat outside the required set, so a red one did not stop
+a merge. If one proves flaky under the queue, stabilise or delete it; do not
+quietly drop it from `needs`.
+
+Seven jobs are deliberately **not** in `needs`: `changes` (produces no verdict),
+`fe-quality`/`fe-unit`/`fe-bundle` and `integration-shards`/
+`integration-unit-coverage` (absorbed by their fan-ins, which already assert on
+them), and `sonarcloud` (non-blocking by decision — listing it here would make it
+required by the back door).
 
 ## The shared Go build cache
 
@@ -179,27 +252,50 @@ package builds themselves and only the dependency builds underneath are common:
 
 | Flavour | Written by | Read by |
 |---|---|---|
-| `plain` | `deterministic-gates` | `deterministic-gates`, `extension-reference`, `integration unit coverage`, `live-boot`, `vuln` |
-| `integration` | `integration shard (1/12)` | all twelve shards |
+| `plain` | `cache-warm.yml` job `plain` | `deterministic-gates`, `extension-reference`, `integration unit coverage`, `live-boot`, `vuln` |
+| `integration` | `cache-warm.yml` job `integration` | all twelve shards |
 
-Three properties worth keeping:
+### The writer lives in `cache-warm.yml`, on a schedule
 
-- **Only `main` writes.** Both refresh steps are gated on
-  `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so a PR
-  restores and never saves. That is what stops twelve shards racing to upload
-  the same ~550 MB key, and what stops one PR's cache from reaching the next.
-- **Exactly one writer per flavour.** Every shard compiles substantially the
-  same set, so a second writer would add nothing but contention — hence the
-  `matrix.shard == 1` guard.
-- **The key falls back twice.** `…-<deps-hash>-<sha>` → `…-<deps-hash>-` →
-  `…-`. Dropping the dependency hash on the last hop is deliberate: Go's build
-  cache is content-addressed, so a stale restore is never *wrong*, it only
-  misses the entries whose inputs changed. After a dependency bump a
-  mostly-warm cache still beats a cold one.
+`ci.yml` only ever **restores**. The writing lives in
+[`.github/workflows/cache-warm.yml`](../.github/workflows/cache-warm.yml), which
+runs on `main` every three hours plus `workflow_dispatch`, and **gates nothing** —
+a red or cancelled run there costs latency on the next lane and nothing else.
 
-The refresh steps use `!cancelled()` rather than `success()`: a red lint or a
-failed test still compiled the tree, and those artifacts are exactly as
-reusable as a green run's.
+Three constraints shaped that, and each rules out an alternative that looks
+simpler:
+
+- **The writer cannot live on the merge queue.** `actions/cache` scopes an entry
+  to the branch that wrote it plus the default branch, and a `merge_group` run
+  lives on a throwaway `gh-readonly-queue/main/...` ref — an entry saved there is
+  invisible to every PR lane and dies with the ref. *Restoring* is unscoped
+  (default-branch entries are readable from any branch), so only the write has to
+  be on `main`.
+- **The writer cannot be per-push.** Seeding a flavour is a byproduct of
+  compiling: the `plain` job runs a full `make check-backend`, the `integration`
+  job runs a shard against a live Postgres. At ~80 merges a day that pair would
+  run ~80 times and mostly self-cancel — the same starvation the merge queue
+  removed, merely made harmless.
+- **A stale entry is not a wrong entry.** Go's build cache is content-addressed
+  and the key falls back twice: `…-<deps-hash>-<sha>` → `…-<deps-hash>-` → `…-`.
+  Dropping the dependency hash on the last hop is deliberate — a stale restore
+  only misses the entries whose inputs changed, so a three-hour-old cache is
+  substantially warm and a post-dependency-bump cache still beats a cold one.
+
+What this replaced: both refresh steps used to ride inside gating jobs, gated on
+`github.event_name == 'push' && github.ref == 'refs/heads/main'`. The cache was
+therefore seeded only when a `main` push survived to completion — and 64% of them
+were cancelled, so it was being seeded by accident, rarely.
+
+**Exactly one writer per flavour** still holds, and for the original reason: every
+shard compiles substantially the same set, so a second writer would add nothing
+but a race for the same key, and twelve runners each uploading ~550 MB would evict
+the entry they meant to seed. `cache-warm.yml` runs one job per flavour and takes
+`concurrency: cancel-in-progress: false`, because a cancelled run saves nothing
+and the entire point is that a run finishes.
+
+The refresh steps use `!cancelled()` rather than `success()`: a red gate still
+compiled the tree, and those artifacts are exactly as reusable as a green run's.
 
 `scripts/check-image-pins.sh` scans `.github/actions/` alongside the workflows.
 The `./path` allowance waves a local action through on the grounds that the
@@ -210,8 +306,8 @@ third-party actions it calls, which would otherwise ride in unread.
 
 | Job | What it enforces |
 |---|---|
-| `changes` | The scope classifier above (always runs first, on non-draft) |
-| `dco` | Every PR commit carries a Developer Certificate of Origin sign-off (`scripts/check-dco.sh`). PR-only |
+| `changes` | The scope classifier above (always runs first, on non-draft; its answer is overridden on `merge_group`) |
+| `dco` | Every merging commit carries a Developer Certificate of Origin sign-off (`scripts/check-dco.sh`). Runs on `merge_group` as well as `pull_request`, taking its base/head SHAs from whichever event fired — the queue's are the ones that count, since that is the tree that lands. It cannot be `pull_request`-only: the `ci` aggregate refuses a skip on `merge_group`, so a PR-only job there would stop merging outright, and exempting it would have reopened the skip-as-pass hole for the one gate that proves provenance |
 | `deterministic-gates` | `make check-backend`: build, vet, lint (baseline + new-code strict), arch-lint, unit + root fitness tests (incl. `audit_log` enum coherence + the contract `$ref` pre-flight), generated-drift, and the script gates (craft-doc floor, image pins, contract-breaking, test-lanes, file-length, RLS store-path, jurisdiction isolation, and the `backend/pkg` published-surface freeze). Fetches full history so the diff-scoped gates have a base ref |
 | `extension-reference` | The composed-build lane (ADR-0069): proves the **empty** extension set still composes byte-identically to the committed `composition/` stub, then enables the reference fixture and runs the backend build + unit lane + `check-composition` against the composed workspace, plus every enabled unit's own module lane. Emits its own coverage profile — extension units are separate Go modules, unreachable by the shard profiles |
 | `craftsmanship` | `make craft-static` — strict: BLOCKER **and** MAJOR findings fail it, MINOR is advisory. Runs **after** `deterministic-gates` — a red build is never judged on style |
@@ -219,13 +315,13 @@ third-party actions it calls, which would otherwise ride in unread.
 | `secret-scan` | `make secret-scan` — gitleaks over a clean `git archive HEAD` export, policy in `.gitleaks.toml`. Scans the **committed** tree, never the working tree: gitleaks does not honour `.gitignore`, so an in-place scan reads sibling worktrees and local `.env` files and reaches a different verdict per machine. The job has no install step: `scripts/gitleaks-pin.sh` fetches the version- **and** checksum-pinned binary itself, so CI and a laptop resolve the same scanner through the same code — a scan's verdict is a function of its rule set, so a different version would be a different gate. The official gitleaks action is not used: it needs a paid licence key for organization repositories. Findings print redacted — CI logs on a public repo are public. Followed immediately by `make test-secret-scan`, which plants a token in each exempted file and requires the scan to fail anyway: an allowlist that grew too broad reports "no leaks found" exactly like a clean tree. Then `make test-api-entrypoint`, which is the same class of check one layer out: the container entrypoint must write the bootstrap admin credential only onto an unprovisioned installation, retire one an earlier boot left, and refuse to start when it cannot tell which it is — ADR-0061 §2 consumes bootstrap values exactly once, and a credential written to a live installation is as invisible as an over-broad allowlist. It stubs `margince-migrate`/`margince-api` on `PATH`, so it needs no container and no database. Then `make test-dev-dsn`, in this job for the same reason: a dev stack that ignored `MARGINCE_DSN` looked exactly like one that honoured it, and a slugged stack that took its database name from a supplied DSN looks isolated while sharing the base database. Pure shell, no Docker. Ends with `make check-image-pins` (pure bash and grep, no toolchain), which lives here rather than in the classifier-gated backend lane because it reads the whole workflow directory — see the classifier exceptions above. `make check-backend` keeps running it too, so a laptop `make check` reproduces this verdict |
 | `integration shard (k/12)` | `make test-integration` with `INTEGRATION_SHARD=k/12`: a deterministic per-test round-robin slice of the whole integration lane. Slices are count-based, not duration-based; the heavy e2e tail lands on whichever shard draws it, and `INTEGRATION_JOBS=16` (the tests wait on Postgres, not cores) lets that shard chew through its slice instead of running minutes over its siblings. Boots the dev compose stack (`make db-up`: digest-pinned Postgres 16 (pgvector) + Redis 7 + MinIO + the app role — one stack definition, no hand-mirrored GH services); each shard builds its own migrated `margince_test` template and clones per package. Uploads its slice manifests + binary coverage pods |
 | `integration unit coverage` | The unit `-cover` pass over every package, binary coverage pods only. Needed because the shards run just the integration-tagged packages, and without it SonarCloud would see the unit-only packages at a false ~0% new-code coverage. No services (the test-lanes gate guarantees untagged tests open no real DB) |
-| `integration` | The fan-in — and the required check, under the same name the single-runner lane carried, so branch protection is unchanged. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |
-| `vuln` | `make vuln` (govulncheck over all packages). **Advisory** — not a required context. It still runs on every backend PR, so a vulnerable dependency a PR *introduces* is reported before merge; what it cannot report is a vulnerability disclosed after one, which is why `scheduled.yml` runs it daily on `main` as well |
-| `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. PR-only, and now the **only** automatic run of this policy: `sbom.yml` is dispatch-only, so the copy of the gate inside it fires just before a signing run. That is sufficient because `main` can only receive a dependency change through a PR this job passed |
+| `integration` | The fan-in the `ci` aggregate reads — it stands for the whole sharded lane, so the aggregate needs one entry rather than twelve. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |
+| `vuln` | `make vuln` (govulncheck over all packages). Now **blocking**, via the `ci` aggregate. A vulnerable dependency a PR *introduces* is reported before merge; what it cannot report is a vulnerability disclosed after one, which is why `scheduled.yml` runs it daily on `main` as well |
+| `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. Runs on `merge_group` as well as `pull_request`, and it is the **only** automatic run of this policy — `sbom.yml` is dispatch-only, so the copy of the gate inside it fires just before a signing run. The merge-queue run is what makes that sufficient, and makes it a stronger claim than it was: `main` receives a dependency change only through a queue build this job passed, so the policy is judged against the tree that lands rather than a PR head that may not match it |
 | `fe-quality` | `make fe-quality` — the design-system script gates, the contract type-drift check, Biome, the composed-SPA typecheck (ADR-0069) and the unit screens' own vitest suites. The only frontend job carrying a Go toolchain: the composed lane needs `gen-composition` output, which nothing else produces |
 | `fe-unit` | `make fe-unit FE_COVERAGE=1` — the vitest suite, instrumented so the run that decides the verdict also writes the lcov. Emits `fe-coverage`, after `frontend/scripts/check-lcov-paths.sh` has proved every path in it resolves from the repo root (see below). Not sharded: the v8 provider's branch records cannot be merged across shards without skewing condition coverage — issue #966 has the measurements and the fix |
 | `fe-bundle` | `make fe-bundle` — the Vite production build plus the Storybook catalog build (stories must compile & register) |
-| `frontend` | The fan-in — and the required check, under the same name the single-runner lane carried, so branch protection is unchanged. Asserts all three jobs above succeeded: a failed lane must turn this check **red, not skipped**, because GitHub counts a skipped required check as passing. The three run concurrently because they share no state; serially the lane was ~340s, of which vitest alone was ~207s, so the greps and the type gates sat behind a test run that could tell them nothing |
+| `frontend` | The fan-in the `ci` aggregate reads, standing for all three SPA jobs. Asserts all three succeeded: a failed lane must turn this fan-in **red, not skipped**, because a skip is what the aggregate reads as "this area was legitimately out of scope". The three run concurrently because they share no state; serially the lane was ~340s, of which vitest alone was ~207s, so the greps and the type gates sat behind a test run that could tell them nothing |
 | `uat` | `make frontend-e2e`: the AC-`<screen>`-N screen-acceptance criteria as named Playwright tests + axe WCAG 2.2 AA + the 390px no-horizontal-scroll sweep + the PERF-1 record-open budget. Mocks the API at the network edge, so it is self-contained |
 | `live-boot` | The README quickstart run literally: compose up → migrate → api → `seed-dev` → `verify-boot`. Keeps the API-driven seed and the boot proof honest — the integration shards never boot the api or run the seed script, so those would rot invisibly without this job |
 | `sonarcloud` | The CI-based scan (below) |
@@ -255,16 +351,34 @@ Wiring details:
   upstream (an area-scoped skip produced no artifact; the scan proceeds
   without it), but a real `failure` of `deterministic-gates` skips the scan so
   it never posts a green check over a broken build.
-- On a **push** the scan additionally requires `integration` to have
-  succeeded. A push replaces main's stored analysis, main's new-code period is
-  `previous_version` (weeks of Go, not this commit's diff), and the scanner's
-  Zero Coverage Sensor scores every executable line it has no report for as
-  uncovered — so a push carrying no Go coverage would publish those weeks at
-  0% and turn the quality gate red until a later push rescanned them. A
-  docs-only merge skips every coverage producer and is the common way in. Such
-  a push now skips the scan instead, and main keeps its last real reading. On a
-  pull request the rule does not apply: new code there is the diff, and a diff
-  that skipped an area has no lines of that area to cover.
+- **Off a pull request the scan additionally requires `integration` to have
+  genuinely succeeded**, not merely not-failed. The scanner's Zero Coverage
+  Sensor scores every executable line it holds no report for as *uncovered*, so
+  a scan without the Go coverage producer publishes that code at 0% rather than
+  declining to answer — and measuring nothing is not a measurement of zero. On a
+  pull request the rule does not bite: new code there is the diff, and a diff
+  that skipped an area has no lines of that area to cover. On `merge_group` the
+  classifier is overridden and every producer runs, so the clause is satisfied
+  whenever the lane is green; it is kept rather than simplified away because it
+  is what would catch a future event, or a future skip, that reintroduces a
+  partial scan.
+- **A `merge_group` scan publishes as `main`** (`-Dsonar.branch.name=main`), and
+  that is not a fiction: the queue builds `main` + the queued entries, which is
+  byte-for-byte the tree `main` becomes when the batch merges. It is the same
+  measurement the old push-to-`main` scan took, one step earlier and once per
+  batch.
+
+  Without the override the scanner reads `GITHUB_REF` and files the analysis
+  under `gh-readonly-queue/main/pr-N-<sha>` — a branch deleted minutes later —
+  and nothing would ever update `main` again. A stored analysis does not vanish
+  when it stops being refreshed; it **freezes**. The nightly `quality-gate` job
+  in `scheduled.yml` reads `?branch=main` and would keep reporting that stale
+  verdict indefinitely. Its own comment says a *missing* analysis "reads
+  identically to green on every dashboard"; a frozen one reads the same way.
+
+  Safe because the job runs only on a green lane, and a green batch merges (the
+  queue's `HEADGREEN` strategy merges the green prefix), so a tree published as
+  `main` is a tree that became `main`.
 - **A report's paths are read from the repo root, not from the directory that
   wrote it.** The scanner resolves every `SF:` entry in an lcov against its own
   base directory; vitest's root is `frontend/`, so the default report named
@@ -293,7 +407,17 @@ Wiring details:
 
 ## The other workflows
 
-`ci.yml` is the merge gate. Five workflows sit beside it, deliberately outside it:
+`ci.yml` is the merge gate. Six workflows sit beside it, deliberately outside it:
+
+- **`cache-warm.yml`** — the Go build cache's only writer, on `main` every three
+  hours plus manual dispatch. **Gates nothing**: a red or cancelled run costs
+  latency on the next lane and nothing else. It exists as a separate workflow
+  because the two things a `main` push used to do — reach a verdict, and seed the
+  cache — have different homes now: the verdict moved to the merge queue, and the
+  cache cannot follow it there (`actions/cache` scopes a write to the writing
+  branch plus the default branch, and a queue ref is throwaway). See
+  [The shared Go build cache](#the-shared-go-build-cache) for why it is scheduled
+  rather than per-push.
 
 - **`scheduled.yml`** — daily on `main`, the checks whose answer changes when
   nothing is being merged. `ci.yml` asks "is this diff sound?" and runs because a
@@ -302,10 +426,15 @@ Wiring details:
   daily, so a per-PR scan proves the day it merged and nothing since. The
   **SonarCloud quality gate** is read through the API (not re-scanned) because it
   is no longer a required PR check — a gate nobody is blocked by is a gate nobody
-  reads. And the **backend lane** re-runs unconditionally, because `main`'s
-  last-known-green is not evidence `main` is green: a docs-only commit landing
-  after a breaking one matches no classifier scope, so every gate skips and the
-  run reports green over a broken tree. That has happened more than once.
+  reads; the analysis it reads is published by the `merge_group` scan, per batch.
+  And the **backend lane** re-runs unconditionally — the reason it was written is
+  that `main`'s last-known-green was not evidence `main` was green, because a
+  docs-only commit landing after a breaking one matched no classifier scope, so
+  every gate skipped and the run reported green over a broken tree. That happened
+  more than once. **The merge queue closes that hole, which makes this job
+  redundant on paper** — it is kept deliberately as the one instrument that does
+  not trust the queue. If it goes red while every `merge_group` build was green,
+  the queue has a hole and this is how anyone finds out.
   Findings become **issues** (`scripts/scheduled-report.sh`), one open issue per
   check keyed on an exact title, because a red scheduled run notifies nobody and
   these checks exist precisely for the case where nothing prompts a human to look.
@@ -325,8 +454,9 @@ Wiring details:
   20-concurrent ceiling the PR gates queue in, and with no releases yet they
   published bundles and burned irretractable Rekor signatures for trees no
   consumer would fetch. **No license enforcement was lost** — the `license gate`
-  job in `ci.yml` (above) is job-gated on the `deps` scope and `main` only
-  receives a dependency change through a PR that passed it. Not itself a required
+  job in `ci.yml` (above) is job-gated on the `deps` scope, and it now runs on the
+  merge queue as well as the pull request, so `main` receives a dependency change
+  only through a queue build that gate passed. Not itself a required
   check; the mechanics are in
   [docs/reference/supply-chain.md](../docs/reference/supply-chain.md).
   Cancellation is scoped to the **`sbom` job**, not the workflow: a newer run

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -42,10 +42,35 @@ entry under test, on a throwaway `gh-readonly-queue/main/...` ref, and gates
 - **Every commit, not just the tip.** The tree that is measured is the tree that
   merges.
 
-The queue merges in **batches** — up to five entries per build, with the green
-prefix of a failing batch still merging (`HEADGREEN`). Serialising one PR per
-~20-minute lane would cap merges at three an hour against a demonstrated rate of
-70–82 a day; batching is what makes per-commit gating affordable at all.
+The queue merges in **batches**, because serialising one PR per ~20-minute lane
+would cap merges at three an hour against a demonstrated rate of 70–82 a day.
+Batching is what makes per-commit gating affordable at all.
+
+Two separate limits govern that, and they are easy to conflate:
+
+| Ruleset setting | Configured | What it bounds |
+|---|---|---|
+| `max_entries_to_merge` | **2** | how many entries may merge together as one group |
+| `max_entries_to_build` | **2** | how many queued entries may request checks at once |
+| `min_entries_to_merge` / `…_wait_minutes` | 1 / 2 | a lone entry still merges after a 2-minute wait |
+| `grouping_strategy` | `HEADGREEN` | **which commits get checked** — see below |
+| `check_response_timeout_minutes` | 60 | clears the 22-minute p90 with margin |
+| `merge_method` | `SQUASH` | preserves `required_linear_history` |
+
+`grouping_strategy` is not about partial merging. `HEADGREEN` checks only the
+merge group's **head** commit — the combined changes of every entry in the group —
+while `ALLGREEN` checks each entry's intermediate commit individually. The trade
+is cost against attribution: `ALLGREEN` tells you *which* entry broke the batch
+but multiplies the 28-job lane by the group size, which a 20-concurrent ceiling
+cannot absorb. `HEADGREEN` pays one lane per group and leaves GitHub to work out
+which entry to eject when the group fails. **Neither strategy merges a passing
+prefix of a failing group.**
+
+`max_entries_to_merge` starts at **2** rather than higher on purpose: a batched
+queue multiplies the cost of a flaky job by the group size, and
+[#1494](https://github.com/gradionhq/margince-poc-v1/issues/1494) is open against
+exactly that noise. It is a live ruleset knob — raise it once the queue has a
+measured baseline.
 
 `concurrency` is keyed on `github.ref` with `cancel-in-progress` narrowed to
 `pull_request`: a new push supersedes the review in flight, and a merge verdict
@@ -80,8 +105,9 @@ Both premises are void, and neither needed a bigger runner budget to void.
 
 The invariant is contradicted outright by the numbers above. And the slot argument
 was an argument against *racing* a lane after the merge — which a queue does not
-do: it gates before the merge, and it **batches**, so five entries share one lane
-rather than each claiming their own. The 20-concurrent ceiling is unchanged; what
+do: it gates before the merge, and it **batches**, so a group of entries shares
+one lane rather than each claiming their own. The 20-concurrent ceiling is
+unchanged; what
 changed is that `release.yml` and `sbom.yml` stopped drawing ~448 runs a week from
 it (both are dispatch-only now), which is where the room for a queue lane came
 from. If queue depth grows anyway, `max_entries_to_merge` is a ruleset knob that
@@ -198,7 +224,8 @@ changes ──┬─> deterministic-gates ──> craftsmanship
 
   ci  ── the ONE required context. needs: dco, deterministic-gates,
          craftsmanship, craft-residue, secret-scan, extension-reference,
-         integration, frontend, license-gate, live-boot, uat, vuln
+         integration, frontend, license-gate   (nine — vuln, live-boot and uat
+         stay advisory and are NOT in the fan-in)
 ```
 
 Two deliberate shapes here. The Playwright `uat` lane is **fail-fast**: it
@@ -248,8 +275,9 @@ Ten jobs are deliberately **not** in `needs`:
   are the obvious additions: each runs on every qualifying change and a red one
   does not stop a merge, which is not a state worth keeping. What argues for
   waiting is the batching. A flaky job under a merge queue does not cost one
-  re-run; it fails a batch of up to five and forces a re-split, and nothing has
-  ever exercised these three under a gate that blocks. Promote them once the queue
+  re-run; it fails the whole group it was checked in and every entry in that group
+  is re-queued, and nothing has ever exercised these three under a gate that
+  blocks. Promote them once the queue
   has a measured baseline, as their own change, so a regression has exactly one
   explanation.
 

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -399,9 +399,15 @@ Wiring details:
   verdict indefinitely. Its own comment says a *missing* analysis "reads
   identically to green on every dashboard"; a frozen one reads the same way.
 
-  Safe because the job runs only on a green lane, and a green batch merges (the
-  queue's `HEADGREEN` strategy merges the green prefix), so a tree published as
-  `main` is a tree that became `main`.
+  **Publication waits for the `ci` aggregate verdict**, and nothing weaker would
+  do. This job's other conditions cover only its *coverage producers*, so without
+  that clause a `merge_group` build whose `secret-scan`, `license-gate`,
+  `craft-residue` or `dco` failed would still publish — a tree that does not
+  merge, replacing the stored analysis every scheduled check reads for `main`.
+  Requiring `needs.ci.result == 'success'` on `merge_group` is what makes
+  "published as `main`" mean "became `main`". Nothing waits on this job in turn:
+  the aggregate deliberately omits `sonarcloud` from its own `needs`, so the queue
+  merges on `ci` alone and the scan may finish after the merge.
 - **A report's paths are read from the repo root, not from the directory that
   wrote it.** The scanner resolves every `SF:` entry in an lcov against its own
   base directory; vitest's root is `frontend/`, so the default report named

--- a/scripts/ci-verdict.sh
+++ b/scripts/ci-verdict.sh
@@ -26,12 +26,12 @@ set -euo pipefail
 needs_json="${CI_VERDICT_NEEDS:-}"
 event="${CI_VERDICT_EVENT:-}"
 
-if [ -z "$event" ]; then
+if [[ -z "$event" ]]; then
 	echo "FAIL: CI_VERDICT_EVENT is empty, so the verdict cannot tell whether a skip is admissible. Pass \${{ github.event_name }}." >&2
 	exit 1
 fi
 
-if [ -z "$needs_json" ]; then
+if [[ -z "$needs_json" ]]; then
 	echo "FAIL: CI_VERDICT_NEEDS is empty — there are no job results to judge. Pass \${{ toJSON(needs) }}. A verdict over zero jobs is not a pass." >&2
 	exit 1
 fi
@@ -41,7 +41,7 @@ fi
 results="$(printf '%s' "$needs_json" | jq -r 'to_entries[] | "\(.key)\t\(.value.result)"')"
 count="$(printf '%s\n' "$results" | grep -c . || true)"
 
-if [ "$count" -eq 0 ]; then
+if [[ "$count" -eq 0 ]]; then
 	echo "FAIL: parsed zero job results out of CI_VERDICT_NEEDS — the aggregate's needs: list is empty or the payload changed shape, so this gate was about to pass without judging anything." >&2
 	exit 1
 fi
@@ -53,11 +53,11 @@ esac
 
 failures=0
 while IFS=$'\t' read -r job result; do
-	[ -n "$job" ] || continue
+	[[ -n "$job" ]] || continue
 	case " $admissible " in
 	*" $result "*) continue ;;
 	esac
-	if [ "$result" = skipped ]; then
+	if [[ "$result" == "skipped" ]]; then
 		echo "FAIL: $job was SKIPPED, and on $event every job must run. A skipped gate is indistinguishable from a passing one — run it, or take it out of the aggregate's needs: list." >&2
 	else
 		echo "FAIL: $job reported '$result'." >&2
@@ -65,7 +65,7 @@ while IFS=$'\t' read -r job result; do
 	failures=$((failures + 1))
 done <<<"$results"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures of $count job(s) did not pass on $event." >&2
 	exit 1
 fi

--- a/scripts/ci-verdict.sh
+++ b/scripts/ci-verdict.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# ci-verdict.sh — one required check stands for the whole lane, and a SKIPPED job
+# is not a passing one when the queue is what is asking.
+#
+# GitHub counts a skipped required check as PASSING. The diff classifier skips
+# whole jobs, so a commit matching no scope reported green having run nothing —
+# and that is how a broken tree twice got recorded as gated on main. Collapsing
+# nine required contexts into one job would inherit that hole unless the
+# aggregate refuses a skip, so this refuses it.
+#
+# WHAT THIS CATCHES: on `merge_group`, where the verdict IS the merge gate, any
+# job that did not SUCCEED — skipped, failed, cancelled alike. Nothing merges on
+# unproven ground.
+#
+# WHAT THIS ADMITS, deliberately: a skip on a pull request. There the classifier
+# is doing its job — diff-scoping is honest for author feedback — and the
+# merge_group run is what covers the ground a PR lane skipped. Refusing skips on
+# both events would mean every docs PR booting twelve Postgres shards, which is
+# the cost that produced the classifier in the first place.
+#
+# Reads CI_VERDICT_NEEDS (a `toJSON(needs)` object) and CI_VERDICT_EVENT
+# (github.event_name). Env rather than argv: the JSON is multi-line, and quoting
+# it through a shell argument is how a gate ends up judging an empty string.
+set -euo pipefail
+
+needs_json="${CI_VERDICT_NEEDS:-}"
+event="${CI_VERDICT_EVENT:-}"
+
+if [ -z "$event" ]; then
+	echo "FAIL: CI_VERDICT_EVENT is empty, so the verdict cannot tell whether a skip is admissible. Pass \${{ github.event_name }}." >&2
+	exit 1
+fi
+
+if [ -z "$needs_json" ]; then
+	echo "FAIL: CI_VERDICT_NEEDS is empty — there are no job results to judge. Pass \${{ toJSON(needs) }}. A verdict over zero jobs is not a pass." >&2
+	exit 1
+fi
+
+# Derived from the object rather than a list maintained here, so a job added to
+# the aggregate's `needs:` is judged the day it is added.
+results="$(printf '%s' "$needs_json" | jq -r 'to_entries[] | "\(.key)\t\(.value.result)"')"
+count="$(printf '%s\n' "$results" | grep -c . || true)"
+
+if [ "$count" -eq 0 ]; then
+	echo "FAIL: parsed zero job results out of CI_VERDICT_NEEDS — the aggregate's needs: list is empty or the payload changed shape, so this gate was about to pass without judging anything." >&2
+	exit 1
+fi
+
+case "$event" in
+merge_group) admissible="success" ;;
+*) admissible="success skipped" ;;
+esac
+
+failures=0
+while IFS=$'\t' read -r job result; do
+	[ -n "$job" ] || continue
+	case " $admissible " in
+	*" $result "*) continue ;;
+	esac
+	if [ "$result" = skipped ]; then
+		echo "FAIL: $job was SKIPPED, and on $event every job must run. A skipped gate is indistinguishable from a passing one — run it, or take it out of the aggregate's needs: list." >&2
+	else
+		echo "FAIL: $job reported '$result'." >&2
+	fi
+	failures=$((failures + 1))
+done <<<"$results"
+
+if [ "$failures" -ne 0 ]; then
+	echo "FAIL: $failures of $count job(s) did not pass on $event." >&2
+	exit 1
+fi
+
+echo "OK: all $count job(s) passed on $event"

--- a/scripts/test-ci-verdict.sh
+++ b/scripts/test-ci-verdict.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# test-ci-verdict.sh — prove the single required check refuses a skip on the
+# merge queue and admits one on a pull request.
+#
+# This runs beside the verdict for the reason `test-scheduled-report.sh` runs
+# beside the reporter: the verdict can only be observed exiting 0, and "the check
+# was green" is precisely the signal that was already untrustworthy. The case
+# that matters most is the one that must FAIL — a skipped job on `merge_group` —
+# because GitHub counts a skipped required check as a passing one, and that is
+# the hole this script exists to close. A verdict that admitted a skip there
+# would look identical to a working one on every dashboard.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verdict="$root/scripts/ci-verdict.sh"
+failures=0
+
+# case_is <name> <event> <needs-json> <expected-exit> [substring the output must carry]
+case_is() {
+	local name="$1" event="$2" needs="$3" want="$4" must_say="${5:-}"
+	local out status=0
+	out="$(CI_VERDICT_EVENT="$event" CI_VERDICT_NEEDS="$needs" "$verdict" 2>&1)" || status=$?
+	if [ "$status" -ne "$want" ]; then
+		echo "FAIL: $name — expected exit $want, got $status" >&2
+		printf '%s\n' "$out" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	if [ -n "$must_say" ] && ! printf '%s' "$out" | grep -qF -- "$must_say"; then
+		echo "FAIL: $name — exited $want but never named '$must_say'" >&2
+		printf '%s\n' "$out" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	echo "ok: $name"
+}
+
+all_green='{"dco":{"result":"success"},"integration":{"result":"success"}}'
+one_skip='{"dco":{"result":"success"},"integration":{"result":"skipped"}}'
+one_fail='{"dco":{"result":"success"},"integration":{"result":"failure"}}'
+one_cancel='{"dco":{"result":"success"},"integration":{"result":"cancelled"}}'
+
+case_is "queue, all green" merge_group "$all_green" 0
+case_is "pr, all green" pull_request "$all_green" 0
+
+# The whole point. A skip is a verdict about nothing.
+case_is "queue rejects a skip" merge_group "$one_skip" 1 "integration"
+case_is "pr admits a skip" pull_request "$one_skip" 0
+
+case_is "queue rejects a failure" merge_group "$one_fail" 1 "integration"
+case_is "pr rejects a failure" pull_request "$one_fail" 1 "integration"
+
+# A cancelled job proved nothing either, on either event.
+case_is "queue rejects a cancellation" merge_group "$one_cancel" 1 "integration"
+case_is "pr rejects a cancellation" pull_request "$one_cancel" 1 "integration"
+
+# A verdict over zero jobs is the failure mode this repo already guards against
+# in check-ci-doc-parity.sh: it passes while comparing nothing.
+case_is "empty needs fails" merge_group "" 1 "CI_VERDICT_NEEDS"
+case_is "empty object fails" merge_group '{}' 1 "zero job results"
+case_is "empty event fails" "" "$all_green" 1 "CI_VERDICT_EVENT"
+
+if [ "$failures" -ne 0 ]; then
+	echo "FAIL: $failures case(s) failed" >&2
+	exit 1
+fi
+echo "OK: ci-verdict holds the line on skips"

--- a/scripts/test-ci-verdict.sh
+++ b/scripts/test-ci-verdict.sh
@@ -20,13 +20,13 @@ case_is() {
 	local name="$1" event="$2" needs="$3" want="$4" must_say="${5:-}"
 	local out status=0
 	out="$(CI_VERDICT_EVENT="$event" CI_VERDICT_NEEDS="$needs" "$verdict" 2>&1)" || status=$?
-	if [ "$status" -ne "$want" ]; then
+	if [[ "$status" -ne "$want" ]]; then
 		echo "FAIL: $name — expected exit $want, got $status" >&2
 		printf '%s\n' "$out" >&2
 		failures=$((failures + 1))
 		return
 	fi
-	if [ -n "$must_say" ] && ! printf '%s' "$out" | grep -qF -- "$must_say"; then
+	if [[ -n "$must_say" ]] && ! printf '%s' "$out" | grep -qF -- "$must_say"; then
 		echo "FAIL: $name — exited $want but never named '$must_say'" >&2
 		printf '%s\n' "$out" >&2
 		failures=$((failures + 1))
@@ -34,6 +34,23 @@ case_is() {
 	fi
 	echo "ok: $name"
 }
+
+# The job whose result each fixture varies — and therefore the one a failing
+# verdict has to NAME. Asserting on the name is what proves the verdict points at
+# the offender instead of merely exiting non-zero: nine legible checks were
+# replaced by one, so "something failed" is not an acceptable answer.
+probe_job=integration
+readonly probe_job
+
+# case_is treats an empty expectation as "assert nothing", which the cases that
+# pass no fifth argument rely on — so an empty probe_job would turn five name
+# assertions into silent no-ops and the suite would still report OK. Same rule
+# the gates themselves follow: a check that can pass while comparing nothing
+# fails instead.
+if [[ -z "$probe_job" ]]; then
+	echo "FAIL: probe_job is empty, so every name assertion below would assert nothing" >&2
+	exit 1
+fi
 
 all_green='{"dco":{"result":"success"},"integration":{"result":"success"}}'
 one_skip='{"dco":{"result":"success"},"integration":{"result":"skipped"}}'
@@ -44,15 +61,15 @@ case_is "queue, all green" merge_group "$all_green" 0
 case_is "pr, all green" pull_request "$all_green" 0
 
 # The whole point. A skip is a verdict about nothing.
-case_is "queue rejects a skip" merge_group "$one_skip" 1 "integration"
+case_is "queue rejects a skip" merge_group "$one_skip" 1 "$probe_job"
 case_is "pr admits a skip" pull_request "$one_skip" 0
 
-case_is "queue rejects a failure" merge_group "$one_fail" 1 "integration"
-case_is "pr rejects a failure" pull_request "$one_fail" 1 "integration"
+case_is "queue rejects a failure" merge_group "$one_fail" 1 "$probe_job"
+case_is "pr rejects a failure" pull_request "$one_fail" 1 "$probe_job"
 
 # A cancelled job proved nothing either, on either event.
-case_is "queue rejects a cancellation" merge_group "$one_cancel" 1 "integration"
-case_is "pr rejects a cancellation" pull_request "$one_cancel" 1 "integration"
+case_is "queue rejects a cancellation" merge_group "$one_cancel" 1 "$probe_job"
+case_is "pr rejects a cancellation" pull_request "$one_cancel" 1 "$probe_job"
 
 # A verdict over zero jobs is the failure mode this repo already guards against
 # in check-ci-doc-parity.sh: it passes while comparing nothing.
@@ -60,7 +77,7 @@ case_is "empty needs fails" merge_group "" 1 "CI_VERDICT_NEEDS"
 case_is "empty object fails" merge_group '{}' 1 "zero job results"
 case_is "empty event fails" "" "$all_green" 1 "CI_VERDICT_EVENT"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures case(s) failed" >&2
 	exit 1
 fi


### PR DESCRIPTION
## Why

`main` is not gated, and the pipeline reports that it is.

Measured across the last 25 pushes to `main`:

| | |
|---|---|
| Cancelled | **16 / 25 (64%)** |
| "Success" p50 duration | **4.5 min** — against a real PR lane's 16 min, i.e. classifier skips |
| Pushes reaching a full verdict | **~1 in 25** |

Two mechanisms produce that, and both are load-bearing today:

1. **Cancellation.** `concurrency` keyed on `github.ref` with
   `cancel-in-progress: true` means a push to `main` cancels the *running* `main`
   lane. At 70–82 merges/day against a ~16–22 min lane, the lane rarely reaches a
   verdict.
2. **Diff scoping.** On a push the classifier diffs against the previous commit,
   so a docs-only merge matches no scope, every gate skips, and GitHub reports
   green. `scheduled.yml` already says this out loud: *"main has gone red twice
   with the breakage MASKED … main's last-known-green is therefore not evidence
   main is green."*

And a skipped **required** check counts as *passing* on GitHub, so the fake green
launders all the way through branch protection.

## What changes

A batched **merge queue** becomes the merge gate. `merge_group` runs build
`main + queued entries` and gate **that** tree, full, before it lands.

- **The classifier is overridden on `merge_group`** (one line per output; all 14
  downstream `if:` conditions unchanged). Diff-scoping survives where it is honest
  — fast author feedback on a PR — and is structurally impossible where it is not.
  The full-tree queue lane is what *makes* the PR-side skips safe.
- **Nine required contexts collapse into one `ci` job** whose verdict comes from
  `scripts/ci-verdict.sh`, which refuses any result other than `success` on
  `merge_group`. That rule is the only reason the collapse is safe, so it is
  unit-tested (`make test-ci-verdict`, wired into `check-backend`) and
  mutation-checked.
- **`push: [main]` stops gating.** The queue already gated that exact tree. What
  the push run secretly also did — seed the Go build cache — moves to
  `cache-warm.yml`.
- **`dco` and `license-gate` now run on `merge_group`.** Both were
  `pull_request`-only; the aggregate refuses a skip there, so either would have
  stopped merging repository-wide. `dco` takes the `merge_group` payload's
  base/head SHAs, which is *stronger* than before — sign-off is checked against
  the tree that actually merges.
- **`backend/aggregategatereach_test.go`** derives that invariant instead of
  auditing it: every job in `ci`'s `needs` must be satisfiable on `merge_group`.
  I made this mistake twice in one change (`dco`, then `license-gate`), which is
  precisely the "fixed the case under review, missed the sibling copy" pattern
  CLAUDE.md names — so it is a fitness function, not a third point fix.

### Two things found while building it

- **SonarCloud's `main` analysis would have been orphaned.** Nothing else
  publishes it, and a `merge_group` run files under
  `gh-readonly-queue/main/pr-N-<sha>` — deleted minutes later. A stored analysis
  does not vanish when it stops being refreshed; it **freezes**, and
  `scheduled.yml`'s `quality-gate` reads `?branch=main` and would report that
  stale verdict indefinitely. Fixed by publishing the `merge_group` scan as
  `main`, which is not a fiction: that tree is byte-for-byte the `main` it
  becomes.
- **`cache-warm.yml` is scheduled, not per-push.** Seeding a flavour is a
  byproduct of compiling (a full `make check-backend`; a shard against live
  Postgres). Per-push at ~80 merges/day would run that pair ~80× and mostly
  self-cancel — the same starvation this PR removes, merely made harmless. The
  cache is content-addressed with `restore-keys`, so a 3-hour-old entry is warm
  and never *wrong*.

## Conflicts with an existing decision — please read

**This reverses https://github.com/gradionhq/margince-poc-v1/pull/1797**
("main's tip is the commit that gets gated, not every merge"), merged
2026-08-19. Naming it here rather than silently overwriting it, per CLAUDE.md.

#1797 reasoned honestly, and both of its premises are now void:

- It traded per-commit gating away on a **slot budget** — 28 jobs against an
  org-wide ceiling of 20 concurrent. That was an argument against *racing* a lane
  after each merge, which a queue does not do: it gates before the merge and
  **batches**, so five entries share one lane instead of each claiming their own.
  The ceiling itself is unchanged — no plan upgrade is assumed here. The room came
  from https://github.com/gradionhq/margince-poc-v1/pull/1968 taking `release.yml`
  and `sbom.yml` dispatch-only, ~448 runs a week off the same budget. If queue
  depth grows anyway, `max_entries_to_merge` is a ruleset knob that costs nothing.
- It claimed the invariant *"the commit being gated is always main's TIP."* The
  run history contradicts it: 64% cancelled, and most survivors were classifier
  skips.

## Scope: deliberately like-for-like

`ci`'s `needs` is **exactly the nine contexts the ruleset requires today** —
verified programmatically: no gaps, no extras. This change moves *where* the
verdict is computed, not what it covers.

`vuln`, `live-boot` and `uat` stay **advisory**. They were in an earlier revision
of this branch and came back out. Each runs on every qualifying change and a red
one does not stop a merge, which is not a state worth keeping — but a flaky job
under a *batched* queue does not cost one re-run, it fails a batch of up to five
and forces a re-split, and nothing has ever exercised these three under a gate
that blocks. Widening the gate in the same step would give a red queue two
candidate explanations during the week the queue itself is on trial. Promoting
them is its own change, once there is a measured baseline.

## This PR does not enable the queue

**The ruleset flip is a separate manual step, after this merges.** Order matters:
enabling the queue before `merge_group` is on `main` means every entry waits for a
`ci` context no workflow produces, times out, and is ejected — with no obvious
cause.

Until the flip, `ci` runs as a **non-required** check beside the nine that still
gate, which is the point: its verdict can be compared against theirs before
anything depends on it.

The flip then does three things:

1. `main-required-status-checks`: nine contexts → `ci`.
2. `main-required-ai-reviewers`: **drop CodeRabbit.** Required checks are one list
   applied to both `pull_request` and `merge_group`; CodeRabbit reports only on the
   former, so a queue entry would wait forever. It keeps commenting on every PR
   and stops being a merge blocker.
3. Add the merge-queue rule: `SQUASH` (preserves `required_linear_history`),
   `max_entries_to_merge: 5`, `max_entries_to_build: 2`,
   `grouping_strategy: HEADGREEN`, `check_response_timeout_minutes: 60`.

Both rulesets are backed up to disk before being touched; rollback is a `PUT` of
the saved payload plus deleting the queue rule.

## Verification

Local: `make check` green, including the new `test-ci-verdict` and
`aggregategatereach` gates, `craft-static` (0 findings), `ci-doc-parity`, and
`check-image-pins`.

Both new gates are mutation-checked — the timeout gate names the new `ci` job when
its ceiling is removed, and the reachability gate names `license-gate` when its
`pull_request`-only condition is restored.

After the flip, the acceptance test is the failure the current pipeline permits:
queue a knowingly-broken backend PR together with a docs-only PR in one batch. The
batch must go red, and **the docs-only PR must not merge green on its own.**

`scheduled.yml`'s `backend-lane` is kept deliberately, though the queue makes it
redundant on paper: it is the one check that does not trust the queue. If it goes
red while every `merge_group` build was green, the queue has a hole.

## Follow-ups (issues, not this PR)

- `renovate.json` sets `platformAutomerge: false` because GitHub's async
  auto-merge ignored ruleset `bypass_actors`. A merge queue changes that calculus.
- The ~22 min lane is now the queue's **cycle time**, so every minute cut is
  throughput. `ci.yml` states outright that the twelve shards each compile
  substantially the whole tree.
- Stage 2: split `ci.yml` into reusable lane workflows and move its prose into
  `infra/ci-pipeline.md`. Note that `scripts/check-ci-doc-parity.sh` hardcodes
  `.github/workflows/ci.yml` with anchor `"filters: |"`, so moving the classifier
  to `pr.yml` breaks that gate **by design** — the script must move with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated build-cache warming on scheduled or manually triggered runs.
  - Added consolidated CI status reporting for merge-queue validation.

- **Bug Fixes**
  - Improved handling of cancelled and skipped checks during validation.
  - Ensured queued changes receive required compliance, license, and quality checks.

- **Documentation**
  - Updated CI and release workflow documentation to reflect merge-queue processing, cache behavior, scheduled checks, and analysis requirements.

- **Tests**
  - Added coverage for CI verdict reporting and merge-gate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->