### PR TITLE
fix(frontend): an id filter clause names a record instead of a pasted uuid

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5419,6 +5419,8 @@ export const de = {
     "Die erste Seite der Treffer \u2014 genug, um den Filter zu pr\u00fcfen, nicht die gesamte Auswahl.",
   "filters.noMatches": "Keine Datens\u00e4tze entsprechen diesem Filter.",
   "filters.loadView": "Gespeicherten Filter laden",
+  "filters.pickRecord": "Eintrag wählen",
+  "filters.loadingRecords": "Auswahl wird geladen…",
   "filters.saveList": "Als Liste speichern",
   "filters.saveListTitle": "Diesen Filter als dynamische Liste speichern",
   "filters.listName": "Listenname",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5426,6 +5426,8 @@ export const en = {
     "The first page of matches — enough to check the filter, not the whole selection.",
   "filters.noMatches": "No records match this filter.",
   "filters.loadView": "Load a saved filter",
+  "filters.pickRecord": "Choose one",
+  "filters.loadingRecords": "Loading choices…",
   "filters.saveList": "Save as list",
   "filters.saveListTitle": "Save this filter as a dynamic list",
   "filters.listName": "List name",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5376,6 +5376,8 @@ export const vi = {
   "filters.noMatches":
     "Kh\u00f4ng c\u00f3 b\u1ea3n ghi n\u00e0o kh\u1edbp b\u1ed9 l\u1ecdc n\u00e0y.",
   "filters.loadView": "T\u1ea3i b\u1ed9 l\u1ecdc \u0111\u00e3 l\u01b0u",
+  "filters.pickRecord": "Ch\u1ecdn m\u1ed9t",
+  "filters.loadingRecords": "\u0110ang t\u1ea3i l\u1ef1a ch\u1ecdn\u2026",
   "filters.saveList": "L\u01b0u th\u00e0nh danh s\u00e1ch",
   "filters.saveListTitle":
     "L\u01b0u b\u1ed9 l\u1ecdc n\u00e0y th\u00e0nh danh s\u00e1ch \u0111\u1ed9ng",

--- a/frontend/src/screens/filterbuilder.stories.tsx
+++ b/frontend/src/screens/filterbuilder.stories.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { FilterBuilder } from "./filterbuilder";
+import type { VocabularyField } from "./filterdata";
+import { type Node, newGroup, newLeaf } from "./segmentpredicate";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The predicate builder: a tree of clauses, each offering only what the server's
+// vocabulary admits for the field it names.
+//
+// What these stories document is the VALUE control, because it is the part whose
+// right answer depends on the field. An operand is a record picker, a date, a
+// two-way choice or a box, and picking wrong makes a field either unusable or
+// silently wrong — a uuid box nobody can fill, or a free-text box over a closed
+// set that answers "0 match" to a typo.
+//
+// There is no story for the OPEN listbox: Select portals it outside the story
+// root, so the capture is indistinguishable from the closed state and would
+// document nothing. That interaction is covered in filterbuilder.test.tsx, which
+// can reach the portal.
+const meta: Meta<typeof FilterBuilder> = {
+  title: "Screens/Filter builder",
+  component: FilterBuilder,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+const FIELDS: VocabularyField[] = [
+  {
+    name: "owner_id",
+    type: "id",
+    operators: ["eq", "neq", "in", "exists"],
+    custom: false,
+    references: "app_user",
+  },
+  {
+    // Unbounded: a workspace has as many accounts as customers, so this one
+    // keeps a plain box rather than a dropdown that could never be complete.
+    name: "organization_id",
+    type: "id",
+    operators: ["eq", "neq", "in", "exists"],
+    custom: false,
+    references: "organization",
+  },
+  {
+    name: "full_name",
+    type: "text",
+    operators: ["eq", "neq", "in", "contains", "exists"],
+    custom: false,
+  },
+  {
+    name: "created_at",
+    type: "date",
+    operators: ["eq", "neq", "gt", "gte", "lt", "lte", "exists"],
+    custom: false,
+  },
+  {
+    name: "cf_loyalty_tier",
+    type: "picklist",
+    operators: ["eq", "neq", "in", "exists"],
+    custom: true,
+  },
+];
+
+function routes(): void {
+  installFetchStub({
+    "GET /users": () =>
+      jsonResponse({
+        data: [
+          { id: "u-1", display_name: "Ann Lee" },
+          { id: "u-2", display_name: "Bruno Sá" },
+        ],
+        page: { next_cursor: null, has_more: false },
+      }),
+  });
+}
+
+/** Controlled, because the builder answers edits rather than holding them. */
+function Editing({ start }: Readonly<{ start: Node }>) {
+  const [tree, setTree] = useState<Node>(start);
+  return <FilterBuilder tree={tree} onChange={setTree} fields={FIELDS} />;
+}
+
+function story(start: Node) {
+  return () => {
+    routes();
+    return (
+      <StoryProviders>
+        <Editing start={start} />
+      </StoryProviders>
+    );
+  };
+}
+
+type Story = StoryObj<typeof FilterBuilder>;
+
+export const RecordPicker: Story = {
+  // An id clause names a seat, chosen by name. The stored value is still the id.
+  render: story(newGroup("and", [newLeaf("owner_id", "eq", "u-2")])),
+};
+
+export const UnboundedTargetKeepsABox: Story = {
+  // The documented exception. A dropdown here could never be complete, and a
+  // half-filled one would read as "this account does not exist".
+  render: story(newGroup("and", [newLeaf("organization_id", "eq", "")])),
+};
+
+export const OperatorAnswersTheQuestion: Story = {
+  // `exists` asks the whole question itself, so there is no operand to collect —
+  // the two readings ARE the choice.
+  render: story(newGroup("and", [newLeaf("owner_id", "exists", true)])),
+};
+
+export const NestedGroups: Story = {
+  // ALL over ANY, which is the shape a real filter takes once it has more than
+  // one idea in it.
+  render: story(
+    newGroup("and", [
+      newLeaf("full_name", "contains", "ann"),
+      newGroup("or", [
+        newLeaf("cf_loyalty_tier", "eq", "gold"),
+        newLeaf("created_at", "gt", "2026-01-01"),
+      ]),
+    ]),
+  ),
+};

--- a/frontend/src/screens/filterbuilder.test.tsx
+++ b/frontend/src/screens/filterbuilder.test.tsx
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { FilterBuilder } from "./filterbuilder";
 import type { VocabularyField } from "./filterdata";
@@ -30,6 +31,18 @@ const VOCAB: VocabularyField[] = [
     type: "id",
     operators: ["eq", "neq", "in", "exists"],
     custom: false,
+    // The vocabulary names an id field's target, so the fixture does too — a
+    // stub that omitted it would exercise a response the server cannot send.
+    references: "app_user",
+  },
+  {
+    // An unbounded target: too many accounts to enumerate, so this one keeps the
+    // plain box until the async picker exists.
+    name: "organization_id",
+    type: "id",
+    operators: ["eq", "neq", "in", "exists"],
+    custom: false,
+    references: "organization",
   },
   {
     name: "full_name",
@@ -61,13 +74,41 @@ const VOCAB: VocabularyField[] = [
  *  only that a callback fired. */
 function Harness({ start }: Readonly<{ start: Node }>) {
   const [tree, setTree] = useState<Node>(start);
+  // A fresh client per mount: the record pickers read rosters, and a shared
+  // cache would let one test's options answer another's assertion.
+  const [client] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
   return (
-    <>
+    <QueryClientProvider client={client}>
       <FilterBuilder tree={tree} onChange={setTree} fields={VOCAB} />
       {/* The encoded tree is the thing the server would receive, so the test
           asserts against that rather than against the DOM's rendering of it. */}
       <pre data-testid="wire">{JSON.stringify(encode(tree))}</pre>
-    </>
+    </QueryClientProvider>
+  );
+}
+
+/** The seats a record picker offers. Named, so an assertion reads as a person. */
+function stubSeats() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      const body = url.includes("/users")
+        ? {
+            data: [
+              { id: "u-1", display_name: "Ann Lee" },
+              { id: "u-2", display_name: "Bruno Sá" },
+            ],
+            page: { next_cursor: null, has_more: false },
+          }
+        : { data: [], page: { next_cursor: null, has_more: false } };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
   );
 }
 
@@ -130,6 +171,62 @@ describe("what the builder offers", () => {
     );
 
     expect(screen.queryByText("custom field")).toBeNull();
+  });
+});
+
+describe("an id clause names a record, not a uuid", () => {
+  it("offers the records the vocabulary's target points at", async () => {
+    resetIDsForTest();
+    stubSeats();
+    const user = userEvent.setup();
+    render(
+      <Harness start={newGroup("and", [newLeaf("owner_id", "eq", "")])} />,
+    );
+
+    // The seat is chosen by NAME. Before this, the same clause needed a uuid
+    // typed into a text box, and a typo read as a filter matching nothing.
+    await pickOption(
+      user,
+      await screen.findByRole("combobox", { name: "Value" }),
+      "Bruno Sá",
+    );
+
+    // And the wire still carries the id, which is what the engine compares.
+    expect(wire()).toEqual({
+      and: [{ field: "owner_id", op: "eq", value: "u-2" }],
+    });
+  });
+
+  it("keeps a plain box for a target too large to enumerate", async () => {
+    resetIDsForTest();
+    stubSeats();
+    render(
+      <Harness
+        start={newGroup("and", [newLeaf("organization_id", "eq", "")])}
+      />,
+    );
+
+    // An account list grows with the business, so it is not a dropdown. The box
+    // stays until the async picker exists — a half-filled list would be worse,
+    // since a reader could not tell a missing account from an absent one.
+    expect(await screen.findByLabelText("Value")).toBeTruthy();
+    expect(screen.queryByRole("combobox", { name: "Value" })).toBeNull();
+  });
+
+  it("asks nothing of a reader when the operator already answered", async () => {
+    resetIDsForTest();
+    stubSeats();
+    render(
+      <Harness
+        start={newGroup("and", [newLeaf("owner_id", "exists", true)])}
+      />,
+    );
+
+    // `exists` on an id field is a two-way question the operator itself asked, so
+    // offering a record to compare against would ask for an operand the engine
+    // ignores. The operator arms come first in the control for that reason.
+    expect(screen.queryByRole("combobox", { name: "Value" })).toBeNull();
+    expect(screen.getByRole("button", { name: "has a value" })).toBeTruthy();
   });
 });
 

--- a/frontend/src/screens/filterbuilder.test.tsx
+++ b/frontend/src/screens/filterbuilder.test.tsx
@@ -209,7 +209,7 @@ describe("an id clause names a record, not a uuid", () => {
     // An account list grows with the business, so it is not a dropdown. The box
     // stays until the async picker exists — a half-filled list would be worse,
     // since a reader could not tell a missing account from an absent one.
-    expect(await screen.findByLabelText("Value")).toBeTruthy();
+    expect(await screen.findByRole("textbox", { name: "Value" })).toBeTruthy();
     expect(screen.queryByRole("combobox", { name: "Value" })).toBeNull();
   });
 
@@ -227,6 +227,30 @@ describe("an id clause names a record, not a uuid", () => {
     // ignores. The operator arms come first in the control for that reason.
     expect(screen.queryByRole("combobox", { name: "Value" })).toBeNull();
     expect(screen.getByRole("button", { name: "has a value" })).toBeTruthy();
+  });
+});
+
+describe("when a roster cannot be read", () => {
+  it("falls back to a box so the clause can still be written", async () => {
+    resetIDsForTest();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ title: "Unavailable", status: 503 }), {
+            status: 503,
+            headers: { "Content-Type": "application/problem+json" },
+          }),
+      ),
+    );
+    render(
+      <Harness start={newGroup("and", [newLeaf("owner_id", "eq", "")])} />,
+    );
+
+    // Not an empty dropdown: that would claim this workspace has no seats, and
+    // would leave the reader unable to write the clause at all.
+    expect(await screen.findByRole("textbox", { name: "Value" })).toBeTruthy();
+    expect(screen.queryByRole("combobox", { name: "Value" })).toBeNull();
   });
 });
 

--- a/frontend/src/screens/filterbuilder.tsx
+++ b/frontend/src/screens/filterbuilder.tsx
@@ -428,7 +428,8 @@ function ValueControl({
     return (
       <RecordValue
         reference={references}
-        value={typeof value === "string" ? value : ""}
+        type={type}
+        value={value}
         onChange={onChange}
       />
     );
@@ -450,19 +451,28 @@ function ValueControl({
  */
 function RecordValue({
   reference,
+  type,
   value,
   onChange,
 }: Readonly<{
   reference: Reference | undefined;
-  value: string;
+  type: VocabularyField["type"];
+  value: LeafValue;
   onChange: (next: LeafValue) => void;
 }>) {
   const t = useT();
-  const { options, loading } = useReferenceOptions(reference);
+  const { options, loading, failed } = useReferenceOptions(reference);
+  // A read that failed falls back to the plain box rather than to an empty
+  // dropdown. An empty list would tell the reader this workspace has no such
+  // records — a confident answer to a question that never got one — and would
+  // leave them unable to write the clause at all.
+  if (failed) {
+    return <ScalarValue type={type} value={value} onChange={onChange} />;
+  }
   return (
     <Select
       options={options}
-      value={value}
+      value={typeof value === "string" ? value : ""}
       onChange={onChange}
       disabled={loading}
       placeholder={

--- a/frontend/src/screens/filterbuilder.tsx
+++ b/frontend/src/screens/filterbuilder.tsx
@@ -24,6 +24,11 @@ import type { MessageKey } from "../i18n/en";
 import "./filterbuilder.css";
 import { fieldLabel, groupFields, type VocabularyField } from "./filterdata";
 import {
+  boundedReference,
+  type Reference,
+  useReferenceOptions,
+} from "./filterreference";
+import {
   addToGroup,
   type FilterOp,
   type Group,
@@ -346,6 +351,7 @@ function ClauseRow({
       />
       <ValueControl
         type={chosen?.type ?? "text"}
+        references={chosen?.references}
         op={op}
         value={value}
         onChange={(nextValue) =>
@@ -383,11 +389,14 @@ function ClauseRow({
  */
 function ValueControl({
   type,
+  references,
   op,
   value,
   onChange,
 }: Readonly<{
   type: VocabularyField["type"];
+  /** What an id field's values point at, when the vocabulary named one. */
+  references: Reference | undefined;
   op: FilterOp;
   value: LeafValue;
   onChange: (next: LeafValue) => void;
@@ -415,7 +424,53 @@ function ValueControl({
       />
     );
   }
+  if (boundedReference(references)) {
+    return (
+      <RecordValue
+        reference={references}
+        value={typeof value === "string" ? value : ""}
+        onChange={onChange}
+      />
+    );
+  }
   return <ScalarValue type={type} value={value} onChange={onChange} />;
+}
+
+/**
+ * An id comparison as the RECORD it names, not its uuid.
+ *
+ * Only for a target the options module can enumerate. An organization reference
+ * falls through to the plain box, because a workspace's accounts are as many as
+ * its customers and a dropdown cannot hold them — the async picker that case
+ * needs is its own change, and a half-filled list would be worse than a box.
+ *
+ * A stored id whose record is gone still shows: Select renders its placeholder
+ * for a value matching no option, so the clause reads as needing attention
+ * rather than silently appearing empty.
+ */
+function RecordValue({
+  reference,
+  value,
+  onChange,
+}: Readonly<{
+  reference: Reference | undefined;
+  value: string;
+  onChange: (next: LeafValue) => void;
+}>) {
+  const t = useT();
+  const { options, loading } = useReferenceOptions(reference);
+  return (
+    <Select
+      options={options}
+      value={value}
+      onChange={onChange}
+      disabled={loading}
+      placeholder={
+        loading ? t("filters.loadingRecords") : t("filters.pickRecord")
+      }
+      aria-label={t("filters.value")}
+    />
+  );
 }
 
 /** The two-way choice that `exists` and a boolean field both need. */

--- a/frontend/src/screens/filterreference.test.ts
+++ b/frontend/src/screens/filterreference.test.ts
@@ -1,0 +1,163 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { boundedReference, useReferenceOptions } from "./filterreference";
+
+// Each target reads a different surface and a different display column — a seat
+// is `display_name`, everything else is `name` — so the arms are tested one by
+// one rather than in aggregate. Getting one wrong does not fail loudly: the
+// dropdown renders the right NUMBER of options, each with a blank label, which
+// reads as a broken control rather than as a mapping mistake.
+
+afterEach(cleanup);
+
+/** Every request made, so a test asserts which surface answered the target. */
+function harness(body: unknown) {
+  const seen: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      seen.push(String(input instanceof Request ? input.url : input));
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return { seen, wrapper };
+}
+
+const page = { next_cursor: null, has_more: false };
+
+describe("which surface answers a target", () => {
+  it.each([
+    ["tag", "/tags", { data: [{ id: "t-1", name: "VIP" }], page }, "VIP"],
+    [
+      "app_user",
+      "/users",
+      { data: [{ id: "u-1", display_name: "Ann Lee" }], page },
+      // The one target whose label is NOT `name`. A seat mapped through `name`
+      // would answer an option with no words in it.
+      "Ann Lee",
+    ],
+    ["team", "/teams", { data: [{ id: "tm-1", name: "West" }], page }, "West"],
+    [
+      "pipeline",
+      "/pipelines",
+      { data: [{ id: "p-1", name: "New business" }], page },
+      "New business",
+    ],
+    [
+      "stage",
+      "/stages",
+      { data: [{ id: "s-1", name: "Qualified" }], page },
+      "Qualified",
+    ],
+    [
+      "project",
+      "/projects",
+      { data: [{ id: "pr-1", name: "Rollout" }], page },
+      "Rollout",
+    ],
+  ] as const)(
+    "%s reads %s and labels by the column it has",
+    async (reference, path, body, label) => {
+      const { seen, wrapper } = harness(body);
+      const { result } = renderHook(() => useReferenceOptions(reference), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.options).toHaveLength(1));
+      expect(result.current.options[0]?.label).toBe(label);
+      expect(seen.some((url) => url.includes(path))).toBe(true);
+    },
+  );
+});
+
+describe("a target this module cannot enumerate", () => {
+  it("asks for nothing and offers nothing for an organization", async () => {
+    const { seen, wrapper } = harness({ data: [], page });
+    const { result } = renderHook(() => useReferenceOptions("organization"), {
+      wrapper,
+    });
+
+    // No request at all: an account list grows with the business, so the caller
+    // renders a box instead. Firing the read and discarding it would spend a
+    // request per clause to answer nothing.
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(seen).toHaveLength(0);
+    expect(result.current.options).toEqual([]);
+  });
+
+  it("asks for nothing when the field names no target at all", async () => {
+    const { seen, wrapper } = harness({ data: [], page });
+    const { result } = renderHook(() => useReferenceOptions(undefined), {
+      wrapper,
+    });
+
+    expect(seen).toHaveLength(0);
+    expect(result.current.options).toEqual([]);
+  });
+});
+
+describe("a read that fails", () => {
+  it("reports the failure rather than an empty set", async () => {
+    const seen: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        seen.push(String(input instanceof Request ? input.url : input));
+        return new Response(
+          JSON.stringify({ title: "Unavailable", status: 503 }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/problem+json" },
+          },
+        );
+      }),
+    );
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+
+    const { result } = renderHook(() => useReferenceOptions("tag"), {
+      wrapper,
+    });
+
+    // `failed`, not merely empty. A caller that could only see zero options
+    // would render a dropdown claiming this workspace has no tags — a confident
+    // answer to a question the server never answered.
+    await waitFor(() => expect(result.current.failed).toBe(true));
+    expect(result.current.options).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe("boundedReference", () => {
+  it.each(["tag", "app_user", "team", "pipeline", "stage", "project"] as const)(
+    "%s can be enumerated",
+    (reference) => {
+      expect(boundedReference(reference)).toBe(true);
+    },
+  );
+
+  it("an organization cannot", () => {
+    expect(boundedReference("organization")).toBe(false);
+  });
+
+  it("nor can a field that names no target", () => {
+    expect(boundedReference(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/screens/filterreference.ts
+++ b/frontend/src/screens/filterreference.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The records an id filter clause can point at, as options a reader picks from.
+//
+// The vocabulary now names the target record type per field, so this module is a
+// lookup FROM that name — not from the field's own name. That is the whole
+// difference: a map keyed on `stage_id` would not know about the next id leaf the
+// engine gains, whereas a map keyed on `stage` covers every field that ever
+// points at a stage.
+//
+// One target is deliberately absent. An organization list is unbounded — a
+// workspace has as many accounts as it has customers — so it cannot be
+// enumerated into a dropdown, and the async picker it needs is its own change.
+// `boundedReference` says which targets this module can answer, so the caller
+// falls back to a plain box rather than rendering an empty list.
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { throwProblem } from "./common";
+
+/** The record type an id field points at, as the vocabulary reports it. */
+export type Reference = NonNullable<
+  components["schemas"]["FilterVocabularyField"]["references"]
+>;
+
+/** One option, already carrying the label a reader should see. */
+export type ReferenceOption = Readonly<{ value: string; label: string }>;
+
+/**
+ * Whether this module can enumerate the target.
+ *
+ * Only `organization` cannot: it is the one reference whose set grows with the
+ * business rather than with configuration. Everything else is workspace
+ * configuration — tags, seats, teams, pipelines, stages, projects — and small
+ * enough that one page answers it.
+ */
+export function boundedReference(reference: Reference | undefined): boolean {
+  return reference !== undefined && reference !== "organization";
+}
+
+/**
+ * How many to read from the two targets that page.
+ *
+ * Most of these lists take no limit at all — tags, teams, pipelines and stages
+ * are unpaged because they are configuration a human maintains, and the contract
+ * says so by offering no cursor. Seats and projects do page, and one page of
+ * either is more than a filter builder can usefully show; a workspace past this
+ * many has a problem a dropdown cannot solve.
+ */
+const ROSTER_LIMIT = 200;
+
+/**
+ * The options for one reference target, or an empty list while it loads and for
+ * a target this module does not enumerate.
+ *
+ * Keyed on the target rather than on the field, so two fields pointing at the
+ * same record type share one cache entry and one request — `organization_id` and
+ * `partner_org_id` would, if organizations were bounded, and `owner_id` on five
+ * resources already does.
+ */
+export function useReferenceOptions(reference: Reference | undefined) {
+  const query = useQuery({
+    queryKey: ["filter-reference", reference],
+    enabled: boundedReference(reference),
+    // Configuration changes rarely and a builder reads it on every clause, so a
+    // minute of staleness saves a request per keystroke-adjacent render.
+    staleTime: 60_000,
+    queryFn: async (): Promise<ReferenceOption[]> => readOptions(reference),
+  });
+  return { options: query.data ?? [], loading: query.isPending };
+}
+
+// Each arm reads the surface that owns the record type and answers the display
+// column that record type actually has — `display_name` for a seat, `name` for
+// everything else. Spelled per arm rather than through one generic reader
+// because the response types differ, and a cast to paper over that would be the
+// place a renamed column stopped being noticed.
+async function readOptions(
+  reference: Reference | undefined,
+): Promise<ReferenceOption[]> {
+  switch (reference) {
+    case "tag": {
+      const { data, error } = await api.GET("/tags");
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data.map((tag) => ({ value: tag.id, label: tag.name }));
+    }
+    case "app_user": {
+      const { data, error } = await api.GET("/users", {
+        params: { query: { limit: ROSTER_LIMIT } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data.map((seat) => ({
+        value: seat.id,
+        label: seat.display_name,
+      }));
+    }
+    case "team": {
+      const { data, error } = await api.GET("/teams");
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data.map((team) => ({ value: team.id, label: team.name }));
+    }
+    case "pipeline": {
+      const { data, error } = await api.GET("/pipelines");
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data.map((pipeline) => ({
+        value: pipeline.id,
+        label: pipeline.name,
+      }));
+    }
+    case "stage": {
+      const { data, error } = await api.GET("/stages");
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data.map((stage) => ({ value: stage.id, label: stage.name }));
+    }
+    case "project": {
+      const { data, error } = await api.GET("/projects", {
+        params: { query: { limit: ROSTER_LIMIT } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data.map((project) => ({
+        value: project.id,
+        label: project.name,
+      }));
+    }
+    default:
+      // `organization` and an absent target both land here. The query is
+      // disabled for them, so this is unreachable rather than a silent empty
+      // answer — and it stays exhaustive so a new target added to the contract
+      // arrives here as a compile-visible gap rather than an empty dropdown.
+      return [];
+  }
+}

--- a/frontend/src/screens/filterreference.ts
+++ b/frontend/src/screens/filterreference.ts
@@ -69,7 +69,16 @@ export function useReferenceOptions(reference: Reference | undefined) {
     staleTime: 60_000,
     queryFn: async (): Promise<ReferenceOption[]> => readOptions(reference),
   });
-  return { options: query.data ?? [], loading: query.isPending };
+  return {
+    options: query.data ?? [],
+    loading: query.isPending,
+    // A read that FAILED must not be reported as an empty set. Without this the
+    // caller renders an enabled dropdown with nothing in it, which says "this
+    // workspace has no tags" — a confident answer to a question that was never
+    // answered. The caller falls back to a plain box instead, so a reader can
+    // still write the clause.
+    failed: query.isError,
+  };
 }
 
 // Each arm reads the surface that owns the record type and answers the display


### PR DESCRIPTION
Part of [#1958](https://github.com/gradionhq/margince-poc-v1/issues/1958). The builder rendered one bare text box for every type it had no case for, so `tag`, `owner_id`, `owner_team_id`, `stage_id`, `pipeline_id` and `project_id` all required **pasting a uuid**. [#1939](https://github.com/gradionhq/margince-poc-v1/pull/1939) made the vocabulary say what each id points at; this spends it.

`owner id is Bruno Sá`, not `owner id is u-2`.

## The lookup is keyed on the target, not the field

That is the whole value of the contract change behind it. A map keyed on `stage_id` would not know about the next id leaf the engine gains — and two landed in one day last week. A map keyed on `stage` covers every field that ever points at a stage, and two fields sharing a target share one cache entry and one request.

## The endpoints said something useful

`/tags`, `/teams`, `/pipelines` and `/stages` accept no `limit` at all — the contract offers them no cursor, because they are configuration a human maintains. That is the same property that makes them safe to put in a dropdown. Only `/users` and `/projects` page, and one page of either is already more than a picker can usefully show. So the `bounded` distinction is not my judgement imposed on the API; it is the API's own shape, and I found it by the types refusing the parameter.

## `organization` deliberately keeps a box

A workspace has as many accounts as it has customers, so it cannot be enumerated — and a half-filled dropdown is **worse** than a box, because a reader cannot tell a missing account from an absent one. `boundedReference` makes that boundary a declaration rather than an accident, and the async picker it needs is its own change.

## What is gated

| Behaviour | Why it matters |
|---|---|
| A seat is chosen by name, and the wire still carries its id | the engine compares ids; the human should not have to |
| An unbounded target keeps its box | the documented exception, so it cannot regress into an empty dropdown |
| `exists` on an id field offers no record at all | the operator already asked the whole question, so a picker there would collect an operand the engine ignores — this pins the ordering inside the control |

Mutation-verified: making nothing bounded fails the first.

The test fixture now carries `references` on its id fields, because the server sends it — a stub that omitted it would exercise a response the API cannot produce. That made the builder read rosters, so the harness owes it a query client and a stub, with a fresh client per mount so one test's options cannot answer another's assertion.

## Story

`filterbuilder.tsx` had no story at all — a pre-existing gap `fe-uat` surfaces once the file is touched. Four now: the record picker, the unbounded exception, the operator-answers-it case, and nested groups.

There is deliberately **no** story for the open listbox. `Select` portals it outside the story root, so the capture was indistinguishable from the closed state — a story whose screenshot does not show what it claims is noise. I removed it after looking at the capture rather than trusting that it worked; the interaction is covered in the unit test, which can reach the portal.

## Still open on #1958

The more misleading half: **closed-set values are also typed freehand.** A mistyped `status` compiles, matches nothing, and reads as a settled "0 match". Custom picklists are solvable today through the catalog's `options`; core ones need a decision about where their allowed values come from. Neither is in this change.

`make check-fe` green (3532 tests), `make fe-uat` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ID filter clauses now pick a record by name instead of requiring a pasted UUID. Previously `owner_id`, `owner_team_id`, `tag`, `stage_id`, `pipeline_id`, and `project_id` were free-text; now bounded references render a dropdown while the wire still carries the id. Unbounded targets and failed roster reads fall back to a text box; `exists` on an id field shows no record input.

- Keyed on the reference target (e.g., `app_user`, `stage`) rather than the field name; shared cache and request via `@tanstack/react-query` (staleTime 60s). `/tags`, `/teams`, `/pipelines`, `/stages` are unpaged; `/users` and `/projects` use a 200-item limit.
- Fallbacks: `boundedReference` gates dropdowns; when the options read fails, the control renders a textbox instead of an empty dropdown. Placeholders use `filters.pickRecord` and `filters.loadingRecords`.
- Stories document the record picker, the unbounded exception, the operator-answers-it case, and nested groups. Tests stub fetch, wrap with a per-mount `QueryClientProvider`, and add per-target assertions; fixtures include `references` for id fields.

**Migration**
- Ensure the filter vocabulary sends `references` for id fields; without it, those fields remain a text box.
- Render paths using the builder must have a `@tanstack/react-query` provider available.

<sup>Written for commit 505f7c10f2dc1221b0e885c74bb6a77d77db8262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

