### PR TITLE
fix(ci): a release is a decision, not a side effect of every merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,30 @@
 name: Release
 
-# Draft a margince-constellation release for every build that lands on main.
-# The release lives in the constellation dist service at test.margince.com, not
-# on GitHub — a constellation release is a server deployment (role images, an
-# incremental patch, SBOMs) and GitHub hosts none of that.
+# Draft a margince-constellation release, on manual dispatch only. The release
+# lives in the constellation dist service at test.margince.com, not on GitHub —
+# a constellation release is a server deployment (role images, an incremental
+# patch, SBOMs) and GitHub hosts none of that.
 #
-# ONE exception, and only on a manual dispatch: the desktop bundles. Those are
-# something a person downloads and runs on their own machine, so they are
-# attached to a GitHub release under the same version, and that release page is
-# where they are browsed and fetched. See the jobs at the bottom of this file.
+# This ran on every push to main: about 400 runs a week, roughly 10 runner-
+# minutes each on arm64, and three jobs drawn from the same org-wide ceiling of
+# 20 concurrent runners the PR gates queue in. ci.yml already explains what that
+# ceiling costs — a full-stack merge schedules 28 jobs against it, so overlapping
+# lanes turn a 9-minute gate into a much longer one and starve the PR lanes
+# behind them. Releasing on every commit spent that budget on a version nobody
+# asked for: the repository is under heavy development and has no real releases
+# yet, which is what the epoch-pinned 1970.* version says out loud. A release is
+# now a decision somebody makes, which is the only cadence a dispatch can have.
+#
+# The desktop bundles now sit behind the `desktop` dispatch input, default OFF.
+# They used to be separated from an ordinary release by the trigger itself — a
+# push got the dist release, a dispatch additionally got the bundles — and with
+# the push trigger gone that distinction would have collapsed, making every
+# release compile Postgres from source twice for a 170 MB pair of assets nobody
+# asked for. The input keeps the cheap dist-only release as the default and makes
+# the bundles the deliberate act they were before. Those are something a person
+# downloads and runs on their own machine, so they are attached to a GitHub
+# release under the same version, and that release page is where they are browsed
+# and fetched. See the jobs at the bottom of this file.
 #
 # The flow, in order: draft the release versioned 1970.<build> (the build is
 # this workflow's run number, fitting the constellation YYYY.edition version
@@ -29,29 +45,37 @@ name: Release
 # publisher token (the MARGINCE_DIST_PUBLISHER_TOKEN secret — only CI holds
 # it) against the dist service URL below.
 #
-# The patch range is the push's before..after — exactly what the push added.
-# On a branch creation (all-zeros github.event.before) or a force-push (a
-# before the fetched history no longer reaches) there is no ancestor to diff
-# from, so the release drafts without a patch. On a manual dispatch there is
-# no push range, so it falls back to the parent commit (HEAD~1..HEAD).
+# A dispatch carries no push range, so the patch range is HEAD~1..HEAD — the
+# parent commit only, however many commits landed since the last release. That
+# is a known gap, not a property worth relying on: the base belongs at the last
+# PUBLISHED release, which is
+# https://github.com/gradionhq/margince-poc-v1/issues/1798. Until that lands, a
+# dispatched release's patch describes one commit, and a consumer applying
+# patches in order cannot use this stream to move forward. Nothing consumes it
+# today, which is why this is recorded rather than blocking. The step below keeps
+# reading github.event.before so that restoring a push trigger is a one-line
+# change; under a dispatch it is always empty and the fallback always applies.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      desktop:
+        description: "Also build the macOS + Windows desktop bundles and attach them to a GitHub release"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 # Cancellation is scoped per JOB below rather than to the whole workflow, because
 # the two halves of this flow want opposite treatment. Drafting and baking are
-# superseded work — a newer merge should not wait out a full docker bake for a
-# commit nobody will consume — while publishing is a mutation of the dist service
-# and must never be interrupted part-way, so it carries a group that serializes
-# instead of one that cancels.
+# superseded work — a second dispatch should not wait out a full docker bake for
+# a commit nobody will consume — while publishing is a mutation of the dist
+# service and must never be interrupted part-way, so it carries a group that
+# serializes instead of one that cancels.
 #
-# A release therefore describes the push that triggered it, not every commit
-# below it: the patch range is that push's before..after, and a commit whose lane
-# was superseded gets no release of its own.
+# The groups matter far less now that a dispatch is the only trigger: two runs
+# overlap only when somebody starts a second one deliberately. They are kept
+# because that case still exists and the reasoning above still holds for it.
 
 env:
   # The release-management CLI image, published :latest from constellation's
@@ -69,7 +93,7 @@ jobs:
   draft:
     name: Draft release
     timeout-minutes: 30
-    # Superseded by a newer merge on the same ref: the tip is the commit worth
+    # Superseded by a newer run on the same ref: the tip is the commit worth
     # drafting.
     concurrency:
       group: ${{ github.workflow }}-draft-${{ github.ref }}
@@ -341,12 +365,18 @@ jobs:
   # ---------------------------------------------------------------------------
   # The downloadable desktop bundles, and the GitHub release that holds them.
   #
-  # MANUAL DISPATCH ONLY. Everything above runs on every push to main; these
-  # three do not, because a macOS and a Windows bundle each compile Postgres from
-  # source and neither answers a new question on an ordinary merge. Cutting a
-  # downloadable build is a decision someone makes, so it is a button someone
-  # presses — and until they press it, no release accumulates a 170 MB pair of
-  # assets nobody asked for.
+  # GATED ON THE `desktop` DISPATCH INPUT, default OFF. A macOS and a Windows
+  # bundle each compile Postgres from source, so these are much the most
+  # expensive jobs in the file and produce a 170 MB pair of assets. What used to
+  # separate them from an ordinary release was the trigger — a push got the dist
+  # release, a dispatch also got the bundles — and that separation had to move
+  # somewhere when the push trigger went away, or every release would pay for
+  # them. `github.event_name == 'workflow_dispatch'` would now be true always,
+  # which is why it is not the guard any more.
+  #
+  # All three share the one input deliberately: github-release needs both build
+  # jobs, and a skipped `needs` skips it too, so the GitHub release appears
+  # exactly when the bundles it would hold do.
   #
   # Both lanes are REUSED, not copied: desktop-macos.yml and desktop-windows.yml
   # are the same workflows the pull-request check runs, called here through
@@ -355,7 +385,7 @@ jobs:
   # from the bundle CI blessed — the worst place to find it.
   desktop-macos:
     name: Build the macOS bundle
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.desktop
     needs: [draft]
     uses: ./.github/workflows/desktop-macos.yml
     permissions:
@@ -368,7 +398,7 @@ jobs:
 
   desktop-windows:
     name: Build the Windows bundle
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.desktop
     needs: [draft]
     uses: ./.github/workflows/desktop-windows.yml
     permissions:
@@ -388,7 +418,7 @@ jobs:
   # 1970.* build must not present itself as the latest release of the product.
   github-release:
     name: Publish the GitHub release
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.desktop
     needs: [draft, desktop-macos, desktop-windows]
     runs-on: ubuntu-24.04-arm
     # Transfer work, not build work: the bundles were already produced inside

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,53 +1,35 @@
 name: SBOM
 
-# Regenerate the source-tree SBOM whenever a dependency set (Go or Node) or the
-# SBOM pipeline itself (Makefile targets, syft/grant policy, this workflow)
-# changes. syft/grant/cosign run through digest-pinned Docker images (see the
-# Makefile), so the runner needs only Docker — pre-installed on ubuntu-latest.
-# main only. The PR-side license gate moved to ci.yml's `license gate` job, which
-# is gated at the JOB level and so reports a path skip as passing — a required
-# context has to post on every ready PR, and a workflow-level `paths:` filter
-# produces no check run at all when it does not match. What stays here is the
-# artifact work nobody waits on: generation, the gate that guards signing, and
-# signing itself.
+# Regenerate, license-gate and sign the source-tree SBOMs. Manual dispatch only.
+# syft/grant/cosign run through digest-pinned Docker images (see the Makefile),
+# so the runner needs only Docker — pre-installed on ubuntu-latest.
 #
-# `**/pnpm-lock.yaml`, not `pnpm-lock.yaml`: a lockfile-only dependency change is
-# the shape Renovate raises most often, and exactly where new transitive packages
-# and their licenses arrive, so it must trigger this workflow. The glob was
-# written when the only lockfile was frontend/pnpm-lock.yaml and the unglobbed
-# pattern matched nothing; the pnpm workspace root has since moved to the
-# repository root, and `**/` matches zero segments, so the same pattern covers
-# /pnpm-lock.yaml without an edit.
+# This used to run on every dependency-set change that landed on main, about 48
+# runs a week. Those runs drew on the same org-wide ceiling of 20 concurrent
+# runners that the PR gates queue in, and a starved lane there delays a verdict
+# somebody is waiting on. Nothing consumed the output at that cadence: this
+# repository has no releases yet, so each run published bundles for a tree no
+# consumer would ever fetch and signed it into the public Rekor log, where a
+# keyless signature is permanent and cannot be retracted.
+#
+# Dropping the push trigger costs no license enforcement. The gate that decides
+# whether a dependency may land at all is `license gate` in ci.yml, job-gated on
+# the `deps` scope, and main only ever receives a dependency change through a PR
+# that passed it. What stops happening on main is artifact publication and
+# signing — both of which describe a release, and are one dispatch away when
+# there is one to describe.
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - "go.work"
-      - "go.work.sum"
-      - "**/go.mod"
-      - "**/go.sum"
-      - "**/pnpm-lock.yaml"
-      - "**/package.json"
-      - "Makefile"
-      - ".syft.yaml"
-      - ".grant.yaml"
-      - "sbom-schemas/**"
-      - ".github/workflows/sbom.yml"
-      # Composite actions are cataloged as packages by the scan, so adding one
-      # changes what the license gate judges — and main must be re-scanned when it
-      # does. Its absence is why .github/actions/go-build-cache landed unscanned.
-      - ".github/actions/**"
 
 # contents: read is the floor for every job. The OIDC minting credential
 # (id-token: write) is NOT granted here — only the isolated sign job requests it,
-# so PR-controlled generation code can never mint a signing token.
+# so branch-controlled generation code can never mint a signing token.
 permissions:
   contents: read
 
 jobs:
   # The cancellable half. An SBOM describes a tree and only the ref's newest tree
-  # is consumed, so a newer push supersedes the lane still cataloguing an older
+  # is consumed, so a newer run supersedes the lane still cataloguing an older
   # one — and the group sits on this JOB rather than on the workflow so that
   # cancellation can never reach `sign` below. Cancelling generation stops
   # signing before it starts (`sign` needs this job), which is the safe
@@ -83,24 +65,25 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-  # Keyless signing is isolated from generation so PR-controlled build code never
-  # runs while id-token: write is in scope. Only main's SBOMs are signed: keyless
-  # cosign signatures land permanently in the public Rekor log and cannot be
-  # retracted, so a PR preview or a feature-branch dispatch must never produce
-  # one. `needs: sbom` means the license gate has already passed, so a
-  # policy-failing SBOM never reaches this job.
-  # It carries NO concurrency group either, so no later push can interrupt it: the
+  # Keyless signing is isolated from generation so branch-controlled build code
+  # never runs while id-token: write is in scope. Only main's SBOMs are signed:
+  # keyless cosign signatures land permanently in the public Rekor log and cannot
+  # be retracted, so a feature-branch dispatch must never produce one — which is
+  # the whole of the guard now that a dispatch is the only way in.
+  # `needs: sbom` means the license gate has already passed, so a policy-failing
+  # SBOM never reaches this job.
+  # It carries NO concurrency group either, so no later run can interrupt it: the
   # signature reaches Rekor before the bundles are uploaded, and a lane cut
   # between the two would leave a signature standing for a tree whose bundles
   # nobody can fetch. Superseding therefore only ever takes effect BEFORE signing
   # begins — while `sbom` is still pending or running, which is where the wasted
   # work is anyway. Once generation is done this job runs to completion whatever
-  # else lands on the ref behind it.
+  # else arrives on the ref behind it.
   sign:
     name: sign
     timeout-minutes: 30
     needs: sbom
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/reference/supply-chain.md
+++ b/docs/reference/supply-chain.md
@@ -15,7 +15,9 @@ git archive HEAD ─▶ syft ─▶ 3 SBOM docs ─▶ normalize ─▶ parity �
 The SBOM lane covers the whole repo (backend + frontend + extensions), so its
 targets live in the **root** `Makefile` rather than being delegated to
 `backend/`. It is **not** part of `make check`: CI runs it as its own workflow,
-`.github/workflows/sbom.yml`, triggered by dependency-set and pipeline changes.
+`.github/workflows/sbom.yml`, on manual dispatch only. The dependency-license
+policy still runs automatically on every PR that touches a dependency — as the
+`license gate` job in `ci.yml`, not here.
 
 Everything here describes the **source tree**, not a container image: the scan
 input is the committed content of `HEAD`.
@@ -232,37 +234,37 @@ nor a writable home. So the invocation adds `-u $(id -u):$(id -g)` and
 
 ## CI — `.github/workflows/sbom.yml`
 
-Regenerates the SBOM when a dependency set or the pipeline itself changes. There
-is no `pull_request` trigger, so the automatic path is **`main`** — a manual
-dispatch still runs the `sbom` job on any ref, and only `sign` is guarded to
-`main`. The runner needs only Docker, which `ubuntu-latest` pre-installs.
+Regenerates, license-gates and signs the SBOMs. **Manual dispatch only** — there
+is no automatic trigger at all. The runner needs only Docker, which
+`ubuntu-latest` pre-installs.
 
 | Trigger | Condition |
 |---|---|
 | `workflow_dispatch` | manual, any ref (but see the `sign` job's own guard) |
-| `push` | branch `main`, filtered to the paths below |
 
-Path filter: `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`,
-`**/pnpm-lock.yaml`, `**/package.json`, `Makefile`, `.syft.yaml`, `.grant.yaml`,
-`sbom-schemas/**`, `.github/workflows/sbom.yml`, `.github/actions/**`.
+There is no path filter, because there is no filtered trigger to apply it to.
 
-`**/pnpm-lock.yaml` is globbed deliberately. It was written that way when the
-only lockfile in the tree was `frontend/pnpm-lock.yaml`, which the unglobbed
-`pnpm-lock.yaml` did not match — and a lockfile-only dependency change, the shape
-Renovate raises most often and precisely where new transitive packages and their
-licenses arrive, never triggered this workflow at all. The pnpm workspace root
-has since moved to the repository root, so the lockfile is `/pnpm-lock.yaml` and
-the unglobbed pattern would now match it. The glob stays regardless: `**/`
-matches zero segments, so it covers the root lockfile as well as any future one,
-and a pattern that does not have to move when the workspace does is one fewer
-thing to get wrong.
+**Why the `main` push trigger went away.** It fired on every dependency-set
+change that landed, about 48 runs a week, each drawing on the same org-wide
+ceiling of 20 concurrent runners that the PR gates queue in — where a starved
+lane delays a verdict somebody is waiting on. Nothing consumed the output at that
+cadence: this repository has no releases yet, so every run published bundles for
+a tree no consumer would fetch and signed it into the public Rekor log, where a
+keyless signature is permanent and cannot be retracted. Generating and signing
+an artifact stream nobody reads is the cost without the benefit.
 
-**There is no `pull_request` trigger.** The PR-side license gate is the
-`license gate` job in `ci.yml`, gated at the job level on the `deps` scope. A
-workflow-level `paths:` filter produces no check run when it does not match, and
-a required context that never posts blocks a merge forever — so a gate that must
-be required cannot live behind one. Splitting the two paths also means the policy
-runs exactly once per event rather than twice on `main`. See
+**No license enforcement was lost with it.** The gate that decides whether a
+dependency may land is `license gate` in `ci.yml`, job-gated on the `deps` scope,
+and `main` only ever receives a dependency change through a PR that passed it.
+What stopped happening on `main` is artifact publication and signing — both of
+which describe a release, and are one dispatch away when there is one to
+describe.
+
+The license gate lives in `ci.yml` rather than here for a reason worth keeping
+even now that this workflow has no filter of its own: a workflow-level `paths:`
+filter produces no check run when it does not match, and a required context that
+never posts blocks a merge forever — so a gate that must be required cannot live
+behind one. Job-level gating reports a path skip as passing instead. See
 [infra/ci-pipeline.md](../../infra/ci-pipeline.md).
 
 Workflow-level `permissions: contents: read` is the floor for every job. The

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -27,10 +27,12 @@ likewise advisory.
 
 One live run per ref, `main` included (`concurrency` group keyed on
 `github.ref`, `cancel-in-progress: true`): a new push cancels the stale lane, so
-the commit under gate is always the ref's tip. `release.yml` and `sbom.yml` are
-superseded the same way, but scope their groups to the JOB rather than the
-workflow, so cancellation reaches the expensive generation halves and never the
-step that publishes or signs — see [The other workflows](#the-other-workflows).
+the commit under gate is always the ref's tip. `release.yml` and `sbom.yml` no
+longer contend for that budget at all — both are **manual dispatch only**, so
+neither is triggered by a merge. They keep their JOB-scoped groups for the case
+of two deliberate dispatches, where cancellation must reach the expensive
+generation halves and never the step that publishes or signs — see
+[The other workflows](#the-other-workflows).
 `scheduled.yml` groups without cancelling; nothing supersedes a daily run.
 
 Gating every `main` commit — a group keyed by commit — is what this replaced,
@@ -93,13 +95,16 @@ Consequences:
   entry would match every path outside `infra/` and fire the filter on
   everything.
 - A **Dockerfile-only PR** (the root `Dockerfile`, `.dockerignore`,
-  `docker-bake.hcl`) also matches no scope. The role images are built, pushed
-  and digest-pinned into the release by `release.yml` on every push to `main`
-  — that build is the gate now, so an image break surfaces in the release run
-  rather than the merge gate. Stated plainly because it is a real trade: a
-  Dockerfile change merges without any image being built, and the first thing
-  to notice is the release. `ci.yml` no longer carries a job for it, and the
-  `docker images (api + web + worker)` context is no longer required.
+  `docker-bake.hcl`) also matches no scope, and **nothing else builds the role
+  images either**. `ci.yml` dropped its `docker images (api + web + worker)` job
+  on the reasoning that `release.yml` baked the images on every push to `main`,
+  so a break surfaced within a commit. That reasoning expired when `release.yml`
+  became dispatch-only: the images are now built only when somebody cuts a
+  release, so a broken `Dockerfile` can sit on `main` indefinitely and the person
+  who finds it is whoever tries to release next. Stated plainly because it is a
+  real regression in coverage, not a trade that still balances — restoring a
+  build-only, push-nothing image job scoped to those three paths is
+  https://github.com/gradionhq/margince-poc-v1/issues/1965.
 - A **backend-only PR** skips the frontend + UAT lanes; a **frontend-only PR**
   skips the Go build/gate + the integration lane — except for
   `frontend/src/mcp-apps/forbidden.json`, which is authored under `frontend/`
@@ -108,8 +113,10 @@ Consequences:
 - A **CI PR still runs the full backend lane** when it touches `ci.yml`, the
   `Makefile`, or `scripts/**`: those change what a gate *does*, so the gates
   re-run to prove they still pass under the new definition. `release.yml` and
-  `sbom.yml` are outside the scope — neither runs a backend gate, and each
-  proves itself when it runs.
+  `sbom.yml` are outside the scope — neither runs a backend gate. Note that
+  neither proves itself on a schedule either, now that both are dispatch-only: a
+  change that breaks one is discovered by the next person to dispatch it, so a PR
+  touching either is worth dispatching from its own branch before merging.
 - **Draft PRs run nothing** until marked ready (`draft == false` guards every
   job) — the swarm pushes many WIP commits.
 - `craft-residue` and `secret-scan` are the deliberate exceptions: both run on
@@ -214,7 +221,7 @@ third-party actions it calls, which would otherwise ride in unread.
 | `integration unit coverage` | The unit `-cover` pass over every package, binary coverage pods only. Needed because the shards run just the integration-tagged packages, and without it SonarCloud would see the unit-only packages at a false ~0% new-code coverage. No services (the test-lanes gate guarantees untagged tests open no real DB) |
 | `integration` | The fan-in — and the required check, under the same name the single-runner lane carried, so branch protection is unchanged. Asserts every shard + the unit pass succeeded (a failed shard must turn this check red, not skipped), then `scripts/test-integration-reconcile.sh` proves the slices add up: every shard present, identical discovery, union complete + disjoint. Merges all coverage pods into `coverage.out`, uploads `go-coverage` |
 | `vuln` | `make vuln` (govulncheck over all packages). **Advisory** — not a required context. It still runs on every backend PR, so a vulnerable dependency a PR *introduces* is reported before merge; what it cannot report is a vulnerability disclosed after one, which is why `scheduled.yml` runs it daily on `main` as well |
-| `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. PR-only — on `main` the same gate runs inside `sbom.yml`, where it is the precondition for signing, so each path runs it exactly once |
+| `license gate` | `make sbom` then `make sbom-check` — the dependency-license policy (`grant`, policy in `.grant.yaml`) over the resolved dependency graph, not the manifests. Lives here rather than in `sbom.yml` because it is a **gate** and that workflow is an artifact producer: `sbom.yml` filters at the workflow level, so on a PR touching no dependency it produces no check run at all, and a required context that never posts blocks the merge forever. Job-level gating makes a path skip report as passing instead. PR-only, and now the **only** automatic run of this policy: `sbom.yml` is dispatch-only, so the copy of the gate inside it fires just before a signing run. That is sufficient because `main` can only receive a dependency change through a PR this job passed |
 | `fe-quality` | `make fe-quality` — the design-system script gates, the contract type-drift check, Biome, the composed-SPA typecheck (ADR-0069) and the unit screens' own vitest suites. The only frontend job carrying a Go toolchain: the composed lane needs `gen-composition` output, which nothing else produces |
 | `fe-unit` | `make fe-unit FE_COVERAGE=1` — the vitest suite, instrumented so the run that decides the verdict also writes the lcov. Emits `fe-coverage`, after `frontend/scripts/check-lcov-paths.sh` has proved every path in it resolves from the repo root (see below). Not sharded: the v8 provider's branch records cannot be merged across shards without skewing condition coverage — issue #966 has the measurements and the fix |
 | `fe-bundle` | `make fe-bundle` — the Vite production build plus the Storybook catalog build (stories must compile & register) |
@@ -305,33 +312,49 @@ Wiring details:
   The reporting job is the sole holder of `issues: write` and runs no build code —
   the same permission isolation `sbom.yml` uses for signing.
 
-- **`sbom.yml`** — **no `pull_request` trigger**, so its automatic path is `main`
-  (a manual dispatch still runs the `sbom` job on any ref; only `sign` is guarded
-  to `main`). Regenerates the source-tree SBOMs whenever a
-  dependency set or the SBOM pipeline itself changes, license-gates them, and signs
-  them from a separate job that is the sole holder of `id-token: write`. Signing is
-  isolated from all PR-controlled code because a keyless signature lands permanently
-  in a public transparency log and cannot be retracted, so a PR preview must never
-  produce one — and the license gate stays on this path because `sign`'s `needs:
-  sbom` is what keeps a policy-failing SBOM from reaching it. The PR-side gate is
-  the `license gate` job in `ci.yml` (above), so each event path runs the policy
-  exactly once. Not itself a required check; the mechanics are in
+- **`sbom.yml`** — **manual dispatch only; no automatic trigger at all** (the
+  `sbom` job runs on any ref, `sign` only on `main`). Regenerates the source-tree
+  SBOMs, license-gates them, and signs them from a separate job that is the sole
+  holder of `id-token: write`. Signing is isolated from all branch-controlled code
+  because a keyless signature lands permanently in a public transparency log and
+  cannot be retracted, so a feature branch must never produce one — and the
+  license gate stays on this path because `sign`'s `needs: sbom` is what keeps a
+  policy-failing SBOM from reaching it.
+  It previously ran on a path-filtered push to `main`, about 48 runs a week. That
+  was dropped for the same reason as `release.yml` below: the runs drew on the
+  20-concurrent ceiling the PR gates queue in, and with no releases yet they
+  published bundles and burned irretractable Rekor signatures for trees no
+  consumer would fetch. **No license enforcement was lost** — the `license gate`
+  job in `ci.yml` (above) is job-gated on the `deps` scope and `main` only
+  receives a dependency change through a PR that passed it. Not itself a required
+  check; the mechanics are in
   [docs/reference/supply-chain.md](../docs/reference/supply-chain.md).
-  Cancellation is scoped to the **`sbom` job**, not the workflow: a newer push
+  Cancellation is scoped to the **`sbom` job**, not the workflow: a newer run
   supersedes a lane still cataloguing an older tree, but `sign` carries no group
   and cannot be interrupted — it writes to Rekor before the bundles upload, and a
   lane cut between the two would leave a permanent signature for a tree whose
   bundles nobody can fetch. Superseding therefore only takes effect *before*
-  signing begins — while `sbom` is pending or running. A push arriving after
-  generation finished does not stop the signature it has already earned.
-- **`release.yml`** — on a push to `main`, cuts a margince-constellation
+  signing begins — while `sbom` is pending or running.
+- **`release.yml`** — **manual dispatch only**, cuts a margince-constellation
   release versioned `1970.<build>` (the year pinned to the epoch while the
   flow is a PoC, so these releases order below any real dated release; the
   build is the workflow run number) in the dist service of the constellation
   deployment at test.margince.com. A constellation release is a server
   deployment, which GitHub does not host, so this is not a GitHub release —
-  with one exception, the desktop bundles, below. The release-management CLI cuts the
-  incremental patch over the push's range and uploads it with `draft-release`
+  with one exception, the desktop bundles, below.
+  It used to run on **every push to `main`**: about 400 runs a week, ~10
+  runner-minutes each on arm64, three jobs apiece drawn from the same
+  20-concurrent org ceiling the PR gates queue in — a full-stack merge already
+  schedules 28 jobs against it. Releasing per commit spent that budget on
+  versions nobody asked for, which the epoch-pinned `1970.*` scheme says out
+  loud: the repository is under heavy development and has no real releases yet.
+  A release is now a decision somebody makes. Two consequences are recorded
+  where they bite rather than here — the role images lose their only build
+  (the Dockerfile-only bullet above,
+  https://github.com/gradionhq/margince-poc-v1/issues/1965) and the patch range
+  degenerates to one commit (below).
+  The release-management CLI cuts the
+  incremental patch and uploads it with `draft-release`
   together with the three source-tree SBOMs regenerated at the release commit
   (`make sbom` — the dist service verifies the SBOMs attest every file the
   patch produces, so the possibly-lagging committed `sboms/` are never
@@ -354,31 +377,30 @@ Wiring details:
   registry publisher via the `MARGINCE_AUTH_PUBLISHER_TOKEN` secret), added to
   the draft as digest-pinned references with `add-artifacts`, and the release
   is published with `publish-release`. The dist uploads authenticate with the
-  dist publisher token (the `MARGINCE_DIST_PUBLISHER_TOKEN` secret). The two
-  degenerate patch cases go opposite ways: a branch creation (all-zeros
-  `before`) or a force-push (a `before` the fetched history no longer reaches)
-  has no ancestor to diff from, so the release drafts **without a patch** and
-  **stays an unpublished draft** (the dist completeness gate requires the
-  patch), while a **manual dispatch** carries no push range at all and falls
-  back to the parent commit (`HEAD~1..HEAD`). Merges that land close together
-  release only the tip: `draft` and `docker-image` each carry a cancelling group
-  so a bake for a superseded commit stops, while `publish` carries a group that
-  **serializes instead of cancelling** — a publish that has started always
-  finishes, and a publish still pending when a newer one arrives gives up its
-  place. That is mutual exclusion, not ordering: nothing on this path rejects a
-  stale version, so a re-run or a dispatch of an older commit can still publish
-  after a newer one
-  ([#1810](https://github.com/gradionhq/margince-poc-v1/issues/1810)). The patch
-  range is what makes that consequential:
-  each push's range starts at the ref's previous tip, so when commit *N*'s lane
-  is cancelled the next release's patch runs *N..N+1* and the files *N* changed
-  appear in no published patch at all. A consumer applying patches in order is
-  therefore one increment short. Deriving the base from the last **published**
-  release instead of the push's `before` is what closes that
-  ([#1798](https://github.com/gradionhq/margince-poc-v1/issues/1798)). Not a
-  gate — it never blocks a merge.
+  dist publisher token (the `MARGINCE_DIST_PUBLISHER_TOKEN` secret).
+  **The patch range is now always `HEAD~1..HEAD`.** A dispatch carries no push
+  range, so the base falls back to the parent commit — meaning a dispatched
+  release's patch describes **one commit**, however many landed since the last
+  release, and a consumer applying patches in order cannot use this stream to
+  move forward at all. That is strictly worse than it was under the push trigger,
+  where the range at least spanned the push; it is recorded rather than blocking
+  because nothing consumes the stream today. Deriving the base from the last
+  **published** release is what fixes it, and is the prerequisite for any
+  automatic trigger ever coming back
+  ([#1798](https://github.com/gradionhq/margince-poc-v1/issues/1798)).
+  Concurrency still matters only for two deliberate dispatches: `draft` and
+  `docker-image` each carry a cancelling group so a superseded bake stops, while
+  `publish` carries a group that **serializes instead of cancelling** — a publish
+  that has started always finishes, and a publish still pending when a newer one
+  arrives gives up its place. That is mutual exclusion, not ordering: nothing on
+  this path rejects a stale version, so a re-run or a dispatch of an older commit
+  can still publish after a newer one
+  ([#1810](https://github.com/gradionhq/margince-poc-v1/issues/1810)) — a
+  sharper edge now that dispatching an arbitrary ref is the only way in.
+  Not a gate — it never blocks a merge.
 
-  **On a manual dispatch only**, three further jobs attach the desktop bundles
+  **When the `desktop` dispatch input is set** (a checkbox on the Run-workflow
+  form, default **off**), three further jobs attach the desktop bundles
   to a **GitHub** release under the same `1970.<build>` version, which is the
   page a person browses to download a build: `desktop-macos` and
   `desktop-windows` are *called*, not copied — the same reusable workflows the
@@ -389,9 +411,13 @@ Wiring details:
   product's latest). It carries the only `contents: write` in the workflow. It
   needs `draft` and the two build jobs but deliberately **not** `publish`: the
   dist completeness gate is about the patch and the SBOMs, so a dist-side
-  failure must not withhold bundles that already built correctly. Ordinary
-  merges to `main` skip all three — each bundle compiles Postgres from source,
-  and a merge answers no new question about it.
+  failure must not withhold bundles that already built correctly.
+  The input exists because the trigger used to carry this distinction — a push
+  got the dist release, a dispatch also got the bundles — and with the push
+  trigger gone, `github.event_name == 'workflow_dispatch'` is true on every run,
+  so it would have made every release compile Postgres from source twice. Default
+  off keeps a dist-only release cheap; all three jobs share the one input so the
+  GitHub release appears exactly when the bundles it would hold do.
 - **`desktop-macos.yml` / `desktop-windows.yml`** — build the self-contained
   desktop folder for their own platform, which is the only platform it can be
   built on: pgvector has no build system but `nmake` against MSVC, the event bus

--- a/scripts/check-ci-doc-parity.sh
+++ b/scripts/check-ci-doc-parity.sh
@@ -72,7 +72,13 @@ check() {
 }
 
 check .github/workflows/ci.yml "filters: |" infra/ci-pipeline.md
-check .github/workflows/sbom.yml "    paths:" docs/reference/supply-chain.md
+# sbom.yml is not checked: it is dispatch-only and filters on no paths at all, so
+# there is nothing to hold against its document. Restoring a push trigger there
+# means restoring the line
+#   check .github/workflows/sbom.yml "    paths:" docs/reference/supply-chain.md
+# at the same time. Nothing here enforces that — a filter added back without the
+# line goes unchecked and this gate still reports OK, which is the one way this
+# file can now mislead. Spelled out rather than left implicit for that reason.
 
 if [ "$fail" -eq 0 ]; then
   echo "OK: every filtered path is documented"


### PR DESCRIPTION
`Release` and `SBOM` no longer run on a merge. Both are `workflow_dispatch` only.

## Why

| Workflow | Before | Runs / week | After |
|---|---|---|---|
| `Release` | every push to `main` | ~400 (293 published, 87 cancelled) | dispatch only |
| `SBOM` | path-filtered push to `main` | ~48 | dispatch only |

`Release` cost about 10 arm64 runner-minutes per run across three jobs. The
concurrency cost is the bigger half: `ci.yml` records an **org-wide ceiling of 20
concurrent runners**, and that a full-stack merge already schedules 28 jobs
against it — so every merge had its release lanes competing with the PR gates
somebody is actually waiting on.

Nothing consumed either stream at that cadence. This repository is under heavy
development and has no releases yet, which is what the epoch-pinned `1970.*`
version says out loud: those 293 published releases a week described versions
nobody asked for, and each `SBOM` run burned an irretractable public Rekor
signature on a tree no consumer would ever fetch.

## No license enforcement is lost

The gate that decides whether a dependency may land is `license gate` in
`ci.yml`, job-gated on the `deps` scope — PR-only, and `main` can only receive a
dependency change through a PR that passed it. What stops happening on `main` is
artifact publication and signing, both of which describe a release and are one
dispatch away when there is one.

The `**/pnpm-lock.yaml` glob rationale deleted from `sbom.yml` survives in full
at `ci.yml:193-200`, and the `.github/actions/**` "landed unscanned" lesson at
`ci.yml:225`, both on the `deps` scope that now carries the only automatic path.
Nothing was dropped on the floor.

## Two consequences, handled rather than left implicit

**The desktop bundles would have started building on every release.** They were
separated from an ordinary release by the *trigger*
(`if: github.event_name == 'workflow_dispatch'`), which is now true on every run.
Left alone, each release would compile Postgres from source twice for a 170 MB
asset pair. They move behind a `desktop` dispatch input, **default off**. All
three jobs share the one input so the GitHub release appears exactly when the
bundles it would hold do.

Resulting job graph — default dispatch: `draft → docker-image → publish`, and the
three desktop jobs only with the box ticked.

**Nothing builds the role images any more.** `ci.yml` dropped its
`docker images (api + web + worker)` job on the explicit reasoning that
`release.yml` baked them on every push, so a break surfaced within a commit. That
reasoning expired here. Filed as #1965 and recorded in `infra/ci-pipeline.md` as
a coverage regression, not a trade that still balances.

## One thing that gets worse

The patch range is now always `HEAD~1..HEAD` — a dispatch carries no push range,
so a dispatched release's patch describes **one commit** however many landed
since the last release. That is strictly worse than the push range it replaces.
Recorded rather than blocking because nothing consumes the stream today; #1798
(base from the last **published** release) is what fixes it, and is the
prerequisite for any automatic trigger ever coming back. Documented at both the
workflow and the pipeline doc rather than left for the next reader to trip over.

## Gate coupling

`scripts/check-ci-doc-parity.sh` loses its `sbom.yml` check. That gate extracts
the workflow's `paths:` block and **hard-fails** when the anchor matches nothing
("this gate was about to pass without comparing anything"), so a dispatch-only
`sbom.yml` breaks it. The exact line to restore alongside any future push trigger
is named in place — including the honest note that nothing enforces the
restoration, which is the one way that file can now mislead.

## Verification

- `make ci-doc-parity check-image-pins make-target-parity test-scheduled-report` — green
- `make craft-residue` — clean
- `TestPublicTreeCitesNothingPrivate`, `TestSharedRulebookSectionsAreIdenticalInBothDocs` — pass
- All six workflow YAMLs parse; job graph and the `desktop` input asserted structurally

Docs-and-CI only — no Go, no product code, no contract change.

Refs #1965, #1798

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running releases and SBOMs on every merge; both `release.yml` and `sbom.yml` are now manual (`workflow_dispatch`) only to reduce CI contention and avoid publishing unused artifacts. Previously `release.yml` ran on every push to `main` and `sbom.yml` on path-filtered pushes; now they run only when explicitly dispatched.

**Reviewer notes**
- `release.yml`: adds a `desktop` boolean input (default false) to gate macOS/Windows bundles and the GitHub release; a dist-only release remains the default.
- Patch range under a dispatch is now `HEAD~1..HEAD` (one commit); recorded gap until deriving from the last published release is implemented in #1798.
- Role images are no longer built on merge; coverage regression tracked in #1965.
- No license enforcement lost: dependency policy remains the `license gate` job in `ci.yml` (PR-only).
- `sbom.yml`: manual only; sign job still restricted to `main`; no path filters.
- `scripts/check-ci-doc-parity.sh`: removes the `sbom.yml` paths check; inline note shows the exact line to restore if a push trigger returns.
- Documentation updated in `infra/ci-pipeline.md` and `docs/reference/supply-chain.md`.

**Post-merge operations**
- Use “Run workflow” to cut a release; check the `desktop` input to include desktop bundles.
- For changes to `release.yml` or `sbom.yml`, manually dispatch from the branch before merging to validate behavior.
- Dockerfile-only changes won’t build images until a release is dispatched; dispatch as needed while #1965 is open.

<sup>Written for commit e6d1bc252fa36f38cf139827a63722155017e207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

