### PR TITLE
feat(capture): mail sharing is a workspace setting, on by default

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7019,7 +7019,7 @@ paths:
             examples:
               oauth:
                 summary: OAuth provider — server returns the authorize_url to redirect to
-                value: { share_acknowledged: true, redirect_uri: 'https://app.example.com/activation' }
+                value: { redirect_uri: 'https://app.example.com/activation' }
       responses:
         '200':
           description: OAuth redirect target (OAuth providers).
@@ -14037,8 +14037,16 @@ components:
       description: |
         The workspace-shared capture posture (ADR-0072/A118, CAP-PARAM-7). Read by every role,
         changed only by admin/ops.
-      required: [auto_enrich]
+      required: [auto_enrich, mail_sharing]
       properties:
+        mail_sharing:
+          type: boolean
+          description: |
+            The workspace's mail-sharing posture, ON by default: a captured email is readable by
+            every colleague who can see the contact. Switched OFF, every email captured FROM THEN ON
+            is held to its participants and the capturing mailbox owner — already-captured mail keeps
+            the audience it has. Turning it off makes shared pipeline work hard; the setting exists
+            for installations that accept that cost.
         auto_enrich:
           type: boolean
           description: |
@@ -14049,6 +14057,7 @@ components:
       description: A sparse capture-settings patch (admin/ops).
       properties:
         auto_enrich: { type: boolean, description: Toggle captured-organization auto-enrichment. }
+        mail_sharing: { type: boolean, description: 'Toggle the workspace mail-sharing posture; affects mail captured from now on.' }
 
     BlockedDomain:
       type: object
@@ -14250,13 +14259,11 @@ components:
       properties:
         share_acknowledged:
           type: boolean
+          deprecated: true
           description: |
-            The connecting human's one-time acknowledgment that what this connector captures
-            becomes readable to colleagues who can see the contact (they can limit individual
-            messages afterwards, and exclude addresses or domains up front). Required `true`
-            for every capture provider — the connect refuses with 422 `sharing_not_acknowledged`
-            without it — and recorded on the connection as `share_acknowledged_at` before the
-            first pull.
+            Accepted and ignored. Mail sharing is a workspace setting (`CaptureSettings.mail_sharing`,
+            ON by default, admin-switchable) rather than a per-connect acknowledgment; this field
+            remains only so a client that still sends it keeps working.
         redirect_uri: { type: string, format: uri, description: 'App page to return to after OAuth consent (OAuth providers).' }
         return_to:
           type: string

--- a/backend/internal/compose/backfilltransport_integration_test.go
+++ b/backend/internal/compose/backfilltransport_integration_test.go
@@ -183,10 +183,10 @@ func setupBackfillWire(t *testing.T) *backfillWireEnv {
 			RowScope: principal.RowScopeTeam,
 		},
 	})
-	if _, err := registry.Connect(human, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(human, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect gmail: %v", err)
 	}
-	if _, err := registry.Connect(human, "graph", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(human, "graph", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect graph: %v", err)
 	}
 	inserter, err := jobs.NewInserter(e.Pool, quiet)

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -226,7 +226,6 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 	// return_to is silently dropped and a malformed chunked body skips
 	// rejection entirely.
 	returnTo := returnToOnboarding
-	shareAck := false
 	if r.ContentLength != 0 {
 		var req crmcontracts.ConnectConnectorRequest
 		if !httperr.Decode(w, r, &req) {
@@ -235,16 +234,6 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 		if req.ReturnTo != nil && string(*req.ReturnTo) == returnToSettings {
 			returnTo = returnToSettings
 		}
-		shareAck = req.ShareAcknowledged != nil && *req.ShareAcknowledged
-	}
-	// Connecting a mailbox shares its captured correspondence with every
-	// colleague who can see the contact, and that default is a stated choice:
-	// the connect does not even mint an authorize URL until the human has
-	// acknowledged it. The flag rides the signed state to the callback, and
-	// Registry.Connect — the one write point — refuses a grant without it.
-	if !shareAck {
-		httperr.Write(w, r, sharingNotAcknowledged())
-		return
 	}
 	// CSRF: a random nonce goes into both a SameSite=Lax cookie and the signed
 	// state; the callback requires them to match, so a victim can't complete an
@@ -262,8 +251,7 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 	state := h.signer.sign(
 		connectState{
 			Workspace: ws, User: actor.UserID, Provider: string(provider),
-			Nonce: nonce, ReturnTo: returnTo, ShareAck: shareAck,
-			Version: stateVersionNamespacedCSRF,
+			Nonce: nonce, ReturnTo: returnTo, Version: stateVersionNamespacedCSRF,
 		},
 		time.Now().Add(connectStateTTL),
 	)
@@ -315,18 +303,6 @@ func (h connectorHandlers) ConnectorOAuthCallback(w http.ResponseWriter, r *http
 		return
 	}
 
-	// A state without the sharing acknowledgment cannot complete a connect —
-	// Registry.Connect would refuse it anyway — so refuse BEFORE the code
-	// exchange: an exchanged authorization code is a real provider credential,
-	// and minting one only to discard it unrevoked is strictly worse than not
-	// spending it. Reached only by states minted before the checkbox existed
-	// (the connect endpoint refuses to mint an unacknowledged state).
-	if !st.ShareAck {
-		slog.WarnContext(ctx, "connector callback: state carries no sharing acknowledgment", "provider", string(provider))
-		http.Redirect(w, r, h.landingURL(outcomeError, returnTo, string(provider)), http.StatusFound)
-		return
-	}
-
 	runCtx := grantorContext(ctx, st)
 	// The grant needs LIVE authority, resolved before the code is spent: an
 	// exchanged authorization code is a real provider credential, and one
@@ -347,7 +323,7 @@ func (h connectorHandlers) ConnectorOAuthCallback(w http.ResponseWriter, r *http
 		return
 	}
 
-	if _, err := h.registry.Connect(runCtx, string(provider), auth, st.ShareAck); err != nil {
+	if _, err := h.registry.Connect(runCtx, string(provider), auth); err != nil {
 		slog.ErrorContext(ctx, "connector callback: persisting connection", "err", err, "provider", string(provider))
 		http.Redirect(w, r, h.landingURL(outcomeError, returnTo, string(provider)), http.StatusFound)
 		return

--- a/backend/internal/compose/connectors_csrf_test.go
+++ b/backend/internal/compose/connectors_csrf_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -74,8 +73,7 @@ func TestConcurrentGmailAndGraphConsentDoNotClobberEachOther(t *testing.T) {
 	start := func(t *testing.T, provider string) string {
 		t.Helper()
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/v1/connectors/"+provider+"/connect",
-			strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
+		req := httptest.NewRequest(http.MethodPost, "/v1/connectors/"+provider+"/connect", nil).WithContext(humanCtx())
 		h.ConnectConnector(rec, req, crmcontracts.CaptureProvider(provider))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("%s connect status = %d, want 200 (body %s)", provider, rec.Code, rec.Body)
@@ -132,16 +130,11 @@ func TestCallbackAcceptsAConsentStartedBeforeTheCookieWasNamespaced(t *testing.T
 	// un-suffixed cookie. It must still complete.
 	h := graphWiredHandlers()
 	h.oauth = refusingOAuth{}
-	// ShareAck rides along: a REAL pre-namespacing state would also lack the
-	// sharing acknowledgment and be refused for that before the exchange (the
-	// case directly below) — what this test holds is the version/cookie
-	// fallback in consumeCSRFNonce, which outlives that refusal.
 	state := h.signer.sign(connectState{
 		Workspace: ids.MustParse("11111111-1111-1111-1111-111111111111"),
 		User:      ids.MustParse("22222222-2222-2222-2222-222222222222"),
 		Provider:  providerGmail,
 		Nonce:     "legacy-nonce",
-		ShareAck:  true,
 	}, time.Now().Add(connectStateTTL))
 
 	code := "the-code"

--- a/backend/internal/compose/connectors_imap.go
+++ b/backend/internal/compose/connectors_imap.go
@@ -25,18 +25,6 @@ const providerIMAP = "imap"
 
 const codeConnectorStoreFailed = "connector_store_failed"
 
-// sharingNotAcknowledged is the refusal every capture connect answers until
-// the human has ticked the mail-sharing acknowledgment (one sentence, one
-// checkbox): what the connector captures becomes readable to colleagues who
-// can see the contact.
-func sharingNotAcknowledged() *httperr.DetailedError {
-	return &httperr.DetailedError{
-		Status: http.StatusUnprocessableEntity,
-		Code:   "sharing_not_acknowledged",
-		Detail: "Connecting a capture source needs share_acknowledged: true — captured correspondence becomes readable to colleagues who can see the contact.",
-	}
-}
-
 // connectIMAP establishes a STANDING imap connection: the credentials are
 // probed (dial + login, session closed), sealed to the vault by
 // Registry.Connect, and the background sweep takes over — the same lifecycle
@@ -70,10 +58,6 @@ func (h connectorHandlers) connectIMAP(w http.ResponseWriter, r *http.Request) {
 	// never conflated with the credential check below.
 	var req crmcontracts.ConnectConnectorRequest
 	if !httperr.Decode(w, r, &req) {
-		return
-	}
-	if req.ShareAcknowledged == nil || !*req.ShareAcknowledged {
-		httperr.Write(w, r, sharingNotAcknowledged())
 		return
 	}
 	if req.Imap == nil || req.Imap.Secret == nil || req.Imap.Host == "" || req.Imap.Username == "" {
@@ -129,7 +113,7 @@ func (h connectorHandlers) connectIMAP(w http.ResponseWriter, r *http.Request) {
 // persistIMAPConnection stores the sealed bundle and answers with the
 // connected row — the connect's terminal half.
 func (h connectorHandlers) persistIMAPConnection(w http.ResponseWriter, r *http.Request, auth connector.Auth) {
-	if _, err := h.registry.Connect(r.Context(), providerIMAP, auth, true); err != nil {
+	if _, err := h.registry.Connect(r.Context(), providerIMAP, auth); err != nil {
 		if errors.Is(err, apperrors.ErrScopeExceeded) {
 			// Defense-in-depth: connectIMAP grants the descriptor's scopes from
 			// the human's authority, so a human cannot normally trip this. Kept

--- a/backend/internal/compose/connectors_test.go
+++ b/backend/internal/compose/connectors_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -54,7 +53,7 @@ func gmailAuthCodeURLForTest(t *testing.T) string {
 	t.Helper()
 	h := wiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", nil).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gmail")
 
@@ -88,7 +87,7 @@ func humanCtx() context.Context {
 func TestConnectConnectorReturnsSignedAuthorizeURL(t *testing.T) {
 	h := wiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", nil).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gmail")
 
@@ -117,34 +116,6 @@ func TestConnectConnectorReturnsSignedAuthorizeURL(t *testing.T) {
 	if st.Provider != "gmail" || st.User != ids.MustParse("22222222-2222-2222-2222-222222222222") {
 		t.Errorf("state = %+v, want gmail + the acting user", st)
 	}
-	if !st.ShareAck {
-		t.Error("the signed state dropped the sharing acknowledgment — the callback's grant would refuse")
-	}
-}
-
-// Connecting a mailbox shares its captured correspondence with colleagues, so
-// the connect refuses to even mint an authorize URL until the human has said
-// yes to that — a nil body and an explicit false are the same withholding.
-func TestConnectConnectorRefusesWithoutTheSharingAcknowledgment(t *testing.T) {
-	h := wiredHandlers()
-	for name, body := range map[string]io.Reader{
-		"no body":        nil,
-		"explicit false": strings.NewReader(`{"share_acknowledged":false}`),
-	} {
-		t.Run(name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", body).WithContext(humanCtx())
-
-			h.ConnectConnector(rec, req, "gmail")
-
-			if rec.Code != http.StatusUnprocessableEntity {
-				t.Fatalf("status = %d, want 422 (body %s)", rec.Code, rec.Body)
-			}
-			if !strings.Contains(rec.Body.String(), "sharing_not_acknowledged") {
-				t.Fatalf("body = %s, want the sharing_not_acknowledged code", rec.Body)
-			}
-		})
-	}
 }
 
 // Google will not add a scope to an existing refresh token, so both permissions
@@ -164,7 +135,7 @@ func TestGmailConsentRequestsReadAndSendScopes(t *testing.T) {
 func TestConnectConnectorReturnsSignedAuthorizeURLForGcal(t *testing.T) {
 	h := wiredHandlers()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gcal/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gcal/connect", nil).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gcal")
 
@@ -228,7 +199,7 @@ func TestConnectConnectorRejectsUnsupportedProvider(t *testing.T) {
 func TestConnectConnectorNotImplementedWhenUnwired(t *testing.T) {
 	var h connectorHandlers // zero value: no oauth/registry
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", strings.NewReader(`{"share_acknowledged":true}`)).WithContext(humanCtx())
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/gmail/connect", nil).WithContext(humanCtx())
 
 	h.ConnectConnector(rec, req, "gmail")
 

--- a/backend/internal/compose/connectors_wiring_test.go
+++ b/backend/internal/compose/connectors_wiring_test.go
@@ -103,7 +103,6 @@ func TestCallbackRequiresMatchingCSRFCookie(t *testing.T) {
 		User:      ids.MustParse("22222222-2222-2222-2222-222222222222"),
 		Provider:  "gmail",
 		Nonce:     nonce,
-		ShareAck:  true,
 		Version:   stateVersionNamespacedCSRF,
 	}, time.Now().Add(time.Hour))
 	code := "the-code"
@@ -131,29 +130,6 @@ func TestCallbackRequiresMatchingCSRFCookie(t *testing.T) {
 		t.Fatal("a matching nonce cookie should let the flow reach the token exchange")
 	}
 
-	// (c) A state without the sharing acknowledgment — only mintable before
-	// the checkbox existed — is refused BEFORE the exchange: an exchanged
-	// authorization code is a real provider credential, and Registry.Connect
-	// would refuse the grant anyway, leaving that credential minted for
-	// nothing and unrevoked.
-	unacked := signer.sign(connectState{
-		Workspace: ids.MustParse("11111111-1111-1111-1111-111111111111"),
-		User:      ids.MustParse("22222222-2222-2222-2222-222222222222"),
-		Provider:  "gmail",
-		Nonce:     nonce,
-		Version:   stateVersionNamespacedCSRF,
-	}, time.Now().Add(time.Hour))
-	oauth.exchanged = false
-	req = httptest.NewRequest(http.MethodGet, "/cb", nil)
-	req.AddCookie(&http.Cookie{Name: csrfCookieName("gmail"), Value: nonce, HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
-	rec = httptest.NewRecorder()
-	h.ConnectorOAuthCallback(rec, req, "gmail", crmcontracts.ConnectorOAuthCallbackParams{Code: &code, State: unacked})
-	if oauth.exchanged {
-		t.Fatal("the token exchange ran for a state carrying no sharing acknowledgment")
-	}
-	if loc := rec.Header().Get("Location"); loc != "https://app.test/#/onboarding/connect/error/gmail" {
-		t.Errorf("unacknowledged-state Location = %q, want the error landing", loc)
-	}
 }
 
 func TestGmailConfigGating(t *testing.T) {

--- a/backend/internal/compose/connectorstate.go
+++ b/backend/internal/compose/connectorstate.go
@@ -45,11 +45,6 @@ type connectState struct {
 	// landingURL, never a URL — it rides the signed payload so it cannot be
 	// tampered with after the redirect leaves us.
 	ReturnTo string
-	// ShareAck records that the human ticked the mail-sharing acknowledgment
-	// when they started the connect. It rides the signed state because the
-	// callback has no session to re-ask, and the grant refuses without it —
-	// so a state minted before the checkbox existed cannot complete a connect.
-	ShareAck bool
 }
 
 // wireState is the JSON form actually signed — ids.UUID as strings, plus the
@@ -60,7 +55,6 @@ type wireState struct {
 	Provider  string `json:"p"`
 	Nonce     string `json:"n"`
 	ReturnTo  string `json:"rt,omitempty"`
-	ShareAck  bool   `json:"sa,omitempty"`
 	Version   int    `json:"v,omitempty"`
 	Exp       int64  `json:"exp"` // unix seconds
 }
@@ -79,7 +73,6 @@ func (s stateSigner) sign(st connectState, exp time.Time) string {
 		Provider:  st.Provider,
 		Nonce:     st.Nonce,
 		ReturnTo:  st.ReturnTo,
-		ShareAck:  st.ShareAck,
 		Version:   st.Version,
 		Exp:       exp.Unix(),
 	})
@@ -122,7 +115,7 @@ func (s stateSigner) verify(token string, now time.Time) (connectState, error) {
 	}
 	return connectState{
 		Workspace: ws, User: user, Provider: w.Provider,
-		Nonce: w.Nonce, ReturnTo: w.ReturnTo, ShareAck: w.ShareAck, Version: w.Version,
+		Nonce: w.Nonce, ReturnTo: w.ReturnTo, Version: w.Version,
 	}, nil
 }
 

--- a/backend/internal/compose/handlers_capture_settings.go
+++ b/backend/internal/compose/handlers_capture_settings.go
@@ -51,7 +51,7 @@ func (h captureSettingsHandlers) UpdateCaptureSettings(w http.ResponseWriter, r 
 		httperr.Write(w, r, httperr.Validation("body", "invalid_json", "request body is not valid JSON"))
 		return
 	}
-	settings, err := h.store.Update(r.Context(), req.AutoEnrich)
+	settings, err := h.store.Update(r.Context(), req.AutoEnrich, req.MailSharing)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
@@ -61,5 +61,5 @@ func (h captureSettingsHandlers) UpdateCaptureSettings(w http.ResponseWriter, r 
 
 // toContractCaptureSettings maps the stored posture onto the wire shape.
 func toContractCaptureSettings(s capture.Settings) crmcontracts.CaptureSettings {
-	return crmcontracts.CaptureSettings{AutoEnrich: s.AutoEnrich}
+	return crmcontracts.CaptureSettings{AutoEnrich: s.AutoEnrich, MailSharing: s.MailSharing}
 }

--- a/backend/internal/compose/imapconnect_standing_integration_test.go
+++ b/backend/internal/compose/imapconnect_standing_integration_test.go
@@ -117,12 +117,6 @@ func TestStandingIMAPConnectTransport(t *testing.T) {
 	mux := crmcontracts.HandlerFromMuxWithBaseURL(srv, chi.NewRouter(), "/v1")
 	post := func(t *testing.T, ctx context.Context, body map[string]any) *httptest.ResponseRecorder {
 		t.Helper()
-		// Every case in this suite is about its own gate; the mail-sharing
-		// acknowledgment is given here once (its refusal has its own suite,
-		// imapconnect_standing_refusals_test.go).
-		if _, set := body["share_acknowledged"]; !set {
-			body["share_acknowledged"] = true
-		}
 		payload, err := json.Marshal(body)
 		if err != nil {
 			t.Fatal(err)

--- a/backend/internal/compose/imapconnect_standing_refusals_test.go
+++ b/backend/internal/compose/imapconnect_standing_refusals_test.go
@@ -31,8 +31,7 @@ import (
 // imapConnectBody is the typed wire fixture for the connect request — the
 // fields stay compile-time aligned with the contract's imap block.
 type imapConnectBody struct {
-	ShareAcknowledged bool           `json:"share_acknowledged"`
-	Imap              *imapCredsBody `json:"imap,omitempty"`
+	Imap *imapCredsBody `json:"imap,omitempty"`
 }
 
 type imapCredsBody struct {
@@ -82,7 +81,7 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 			return nil, imap.ErrLoginRejected
 		},
 	}
-	creds := imapConnectBody{ShareAcknowledged: true, Imap: &imapCredsBody{
+	creds := imapConnectBody{Imap: &imapCredsBody{
 		Host: "mail.example", Port: 993, Username: "a@b.example", Secret: "s",
 	}}
 
@@ -98,7 +97,7 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 		// OAuth callback does), so a real human is NOT scope-refused. An empty
 		// body reaches the credential check (422) — proving the request passed
 		// the scope gate, and without any dial.
-		rec := postIMAPConnect(imapConnectCtx(t /* no scopes, like a real session */), t, h, imapConnectBody{ShareAcknowledged: true})
+		rec := postIMAPConnect(imapConnectCtx(t /* no scopes, like a real session */), t, h, imapConnectBody{})
 		if rec.Code != http.StatusUnprocessableEntity {
 			t.Fatalf("status = %d, want 422 (passed the scope gate, missing creds)", rec.Code)
 		}
@@ -111,24 +110,8 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 	authed := imapConnectCtx(t)
 
 	t.Run("a missing credential block is 422", func(t *testing.T) {
-		if rec := postIMAPConnect(authed, t, h, imapConnectBody{ShareAcknowledged: true}); rec.Code != http.StatusUnprocessableEntity {
+		if rec := postIMAPConnect(authed, t, h, imapConnectBody{}); rec.Code != http.StatusUnprocessableEntity {
 			t.Fatalf("status = %d, want 422", rec.Code)
-		}
-	})
-
-	t.Run("withholding the sharing acknowledgment is 422 before any probe", func(t *testing.T) {
-		unacked := creds
-		unacked.ShareAcknowledged = false
-		probeCallsBefore := probeCalls
-		rec := postIMAPConnect(authed, t, h, unacked)
-		if rec.Code != http.StatusUnprocessableEntity {
-			t.Fatalf("status = %d, want 422", rec.Code)
-		}
-		if !strings.Contains(rec.Body.String(), "sharing_not_acknowledged") {
-			t.Fatalf("body = %s, want the sharing_not_acknowledged code", rec.Body.String())
-		}
-		if probeCalls != probeCallsBefore {
-			t.Fatal("the credentials were probed although the sharing acknowledgment was withheld")
 		}
 	})
 
@@ -154,7 +137,7 @@ func TestStandingIMAPConnectRefusals(t *testing.T) {
 func TestStandingIMAPConnectFailureMapping(t *testing.T) {
 	// A realistic signed-in human session carries no passport scopes.
 	authed := imapConnectCtx(t)
-	creds := imapConnectBody{ShareAcknowledged: true, Imap: &imapCredsBody{
+	creds := imapConnectBody{Imap: &imapCredsBody{
 		Host: "mail.example", Port: 993, Username: "a@b.example", Secret: "s",
 	}}
 

--- a/backend/internal/compose/integration/capture/capture_account_rebind_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_account_rebind_integration_test.go
@@ -62,7 +62,7 @@ func startImportReconnectingMidPage(t *testing.T, e *integration.SearchEnv, acco
 	fake := &accountBoundConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}}
 	registry.Register(fake)
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(account), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(account)); err != nil {
 		t.Fatalf("connecting %s: %v", account, err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 25, enqueueNothing)
@@ -70,7 +70,7 @@ func startImportReconnectingMidPage(t *testing.T, e *integration.SearchEnv, acco
 		t.Fatalf("StartBackfill: %v", err)
 	}
 	fake.duringPage = func() {
-		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(reconnectAs), true); err != nil {
+		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth(reconnectAs)); err != nil {
 			t.Errorf("mid-page reconnect as %s: %v", reconnectAs, err)
 		}
 	}
@@ -130,7 +130,7 @@ func readConnectionAccount(t *testing.T, e *integration.SearchEnv, connID ids.UU
 func connectAndSync(t *testing.T, registry *capturemod.Registry, e *integration.SearchEnv, account string) ids.UUID {
 	t.Helper()
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth(account), true)
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth(account))
 	if err != nil {
 		t.Fatalf("connecting %s: %v", account, err)
 	}
@@ -152,7 +152,7 @@ func TestReconnectingADifferentAccountDropsTheFirstAccountsWatermark(t *testing.
 	connID := connectAndSync(t, registry, e, "first@example.com")
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com")); err != nil {
 		t.Fatalf("reconnecting as a different account: %v", err)
 	}
 
@@ -174,7 +174,7 @@ func TestReconnectingTheSameAccountKeepsItsWatermark(t *testing.T) {
 	connID := connectAndSync(t, registry, e, "same@example.com")
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("same@example.com"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("same@example.com")); err != nil {
 		t.Fatalf("re-granting the same account: %v", err)
 	}
 
@@ -202,7 +202,7 @@ func TestANewAccountMayImportANarrowerWindowThanTheOldOne(t *testing.T) {
 		t.Fatalf("paging the first import to completion: done=%v err=%v", done, err)
 	}
 
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("second@example.com")); err != nil {
 		t.Fatalf("reconnecting as a different account: %v", err)
 	}
 

--- a/backend/internal/compose/integration/capture/capture_authority_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_authority_integration_test.go
@@ -39,7 +39,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 		`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, e.Rep1); err != nil {
 		t.Fatal(err)
 	}
-	_, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	_, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("grant from a deactivated human → %v, want ErrNotFound", err)
 	}
@@ -60,7 +60,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 		`UPDATE app_user SET status = 'active' WHERE id = $1`, e.Rep1); err != nil {
 		t.Fatal(err)
 	}
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatalf("grant from a live human: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/capture_backfill_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_integration_test.go
@@ -108,7 +108,7 @@ func TestBackfillLifecycle(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -229,7 +229,7 @@ func TestBackfillStepFaultsAreTerminal(t *testing.T) {
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -290,7 +290,7 @@ func TestStartBackfillRollsBackWhenTheJobCannotBeScheduled(t *testing.T) {
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)

--- a/backend/internal/compose/integration/capture/capture_backfill_progress_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_progress_integration_test.go
@@ -80,7 +80,7 @@ func startReportingBackfill(t *testing.T, e *integration.SearchEnv, prov *report
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e)).WithProgressPacing(pacing)
 	registry.Register(prov)
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 20, enqueueNothing)

--- a/backend/internal/compose/integration/capture/capture_backfill_retry_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_retry_integration_test.go
@@ -68,7 +68,7 @@ func startFlakyBackfill(t *testing.T, e *integration.SearchEnv, faults []error) 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&flakyConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}, faults: faults})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 25, enqueueNothing)
@@ -148,7 +148,7 @@ func TestABackfillPageWhoseJobContextDiedNeverWedgesTheRun(t *testing.T) {
 	registry.Register(fake)
 	rep := ids.From[ids.UserKind](e.Rep1)
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", rep, 6, 25, enqueueNothing)

--- a/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_backfill_yield_integration_test.go
@@ -122,7 +122,7 @@ func TestBackfillCountsOnlyTheCounterpartiesItsOwnPagesCreated(t *testing.T) {
 	})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -186,7 +186,7 @@ func TestBackfillYieldsAreVisibleWhileThePageRuns(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -289,7 +289,7 @@ func TestBackfillYieldsSurviveATransientFault(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -352,7 +352,7 @@ func TestBackfillYieldsSurviveACancelUnderTheRunningPage(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -403,7 +403,7 @@ func TestBackfillYieldsAreCreditedOnceAtTheRetryCeiling(t *testing.T) {
 	registry.Register(prov)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	rep := ids.From[ids.UserKind](e.Rep1)

--- a/backend/internal/compose/integration/capture/capture_env_test.go
+++ b/backend/internal/compose/integration/capture/capture_env_test.go
@@ -198,7 +198,7 @@ func newCaptureEnv(t *testing.T) captureEnv {
 	seedCaptureRole(t, e)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/capture_fence_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_fence_integration_test.go
@@ -83,7 +83,7 @@ func TestASyncDisconnectedMidFlightCommitsNothing(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestABackfillPageDisconnectedMidFlightCommitsNothing(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	run, err := registry.StartBackfill(grantCtx, "gmail", ids.From[ids.UserKind](e.Rep1), 6, 25, enqueueNothing)

--- a/backend/internal/compose/integration/capture/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_integration_test.go
@@ -45,6 +45,9 @@ type mailFake struct {
 	linkTo    ids.UUID
 	scopes    []principal.Scope
 	syncCount int
+	// emitSecondMessage adds a second, distinct email to the sync — for the
+	// suites that need mail captured BEFORE and AFTER a posture change.
+	emitSecondMessage bool
 }
 
 func (m *mailFake) Descriptor() connector.Descriptor {
@@ -85,6 +88,16 @@ func (m *mailFake) Sync(ctx context.Context, _ connector.Auth, cursor connector.
 			Fields:     capturemod.LeadFields{FullName: "Lead Sender", Email: "sender@graph.test", CompanyName: "Mailfake GmbH"},
 			Source:     "graph", CapturedBy: "connector:graph",
 		},
+	}
+	if m.emitSecondMessage {
+		records = append(records, connector.NormalizedRecord{
+			EntityType: datasource.EntityActivity,
+			NaturalKey: connector.NaturalKey{SourceSystem: "graph", SourceID: "msg-2"},
+			Fields:     capturemod.ActivityFields{Kind: "email", Subject: "Second thoughts", Body: "one more question", OccurredAt: fixedCaptureTime, Direction: "inbound"},
+			Links:      []datasource.EntityRef{{Type: datasource.EntityPerson, ID: m.linkTo}},
+			Source:     "graph", CapturedBy: "connector:graph",
+			Raw: []byte(`{"provider":"graph","message_id":"msg-2"}`),
+		})
 	}
 	for _, rec := range records {
 		if _, err := sink.Upsert(ctx, rec); err != nil {
@@ -136,7 +149,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +222,7 @@ func TestCaptureScopeIntersectionRefusesOverScopedConnector(t *testing.T) {
 	registry.Register(&mailFake{scopes: []principal.Scope{principal.ScopeRead, principal.ScopeSend}})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	_, err := registry.Connect(grantCtx, "graph", nil, true)
+	_, err := registry.Connect(grantCtx, "graph", nil)
 	if !errors.Is(err, apperrors.ErrScopeExceeded) {
 		t.Fatalf("over-scoped connector grant → %v, want ErrScopeExceeded", err)
 	}
@@ -228,7 +241,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 	registry.Register(&mailFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +258,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 	}
 
 	// Reconnect the same provider for the same human.
-	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true); err != nil {
+	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("token")); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 	views, err := registry.Connections(grantCtx)
@@ -275,7 +288,7 @@ func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", nil, true)
+	connID, err := registry.Connect(grantCtx, "graph", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/capture_lifecycle_audit_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_lifecycle_audit_integration_test.go
@@ -66,7 +66,7 @@ func TestReconnectDeletesSupersededCredentialWhenTheCallerHangsUp(t *testing.T) 
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("first-token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("first-token"))
 	if err != nil {
 		t.Fatalf("first connect: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestReconnectDeletesSupersededCredentialWhenTheCallerHangsUp(t *testing.T) 
 	reqCtx, cancel := context.WithCancel(humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead}))
 	defer cancel()
 	hangUp.hangUp = cancel
-	if _, err := registry.Connect(reqCtx, "graph", connector.Auth("second-token"), true); err != nil {
+	if _, err := registry.Connect(reqCtx, "graph", connector.Auth("second-token")); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestDisconnectDeletesTheCredentialWhenTheCallerHangsUp(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestConnectAndDisconnectLeaveAnAttributableAuditRow(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestARetriedDisconnectDoesNotReAuditTheWithdrawal(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestAConnectThatFailsLeavesNoAuditRow(t *testing.T) {
 	refuseSyncStateUpdates(t, e)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true); err == nil {
+	if _, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token")); err == nil {
 		t.Fatal("connect must fail while the sync-state update is refused")
 	}
 

--- a/backend/internal/compose/integration/capture/capture_mailsharing_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_mailsharing_integration_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// The workspace mail-sharing posture (capture.mail_sharing, ON by default):
+// switched OFF, an email captured from then on is born participants-only —
+// held to the people on the message and the capturing mailbox owner — while
+// already-captured mail keeps the audience it has. The setting moves the
+// default for NEW mail; it rewrites no history.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	capturemod "github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+func TestMailSharingOffHoldsNewMailToItsParticipants(t *testing.T) {
+	e := integration.SetupSearch(t)
+	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Inbox Sender', 'manual', 'human:x')`)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	fake := &mailFake{linkTo: personID}
+	registry.Register(fake)
+	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	audienceOf := func(sourceID string) string {
+		t.Helper()
+		var audience string
+		if err := e.Owner.QueryRow(context.Background(),
+			`SELECT audience FROM activity WHERE source_system = 'graph' AND source_id = $1`, sourceID).Scan(&audience); err != nil {
+			t.Fatal(err)
+		}
+		return audience
+	}
+
+	// The default: sharing ON, the captured email is workspace-readable.
+	if err := registry.SyncOnce(grantCtx, connID); err != nil {
+		t.Fatal(err)
+	}
+	if got := audienceOf("msg-1"); got != "workspace" {
+		t.Fatalf("under the default posture the captured email's audience = %q, want workspace", got)
+	}
+
+	// An admin switches sharing off through the real settings store.
+	adminCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	adminCtx = principal.WithActor(adminCtx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"capture_settings": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	store := capturemod.NewSettings(compose.NewSettingsStore(e.Pool))
+	off := false
+	if _, err := store.Update(adminCtx, nil, &off); err != nil {
+		t.Fatalf("switching mail sharing off: %v", err)
+	}
+
+	// The next captured email is born participants-only; the first keeps
+	// the audience it was captured under.
+	fake.emitSecondMessage = true
+	if err := registry.SyncOnce(grantCtx, connID); err != nil {
+		t.Fatal(err)
+	}
+	if got := audienceOf("msg-2"); got != "participants" {
+		t.Errorf("with sharing off the new email's audience = %q, want participants", got)
+	}
+	if got := audienceOf("msg-1"); got != "workspace" {
+		t.Errorf("switching sharing off rewrote already-captured mail to %q — the setting must move the default only", got)
+	}
+}

--- a/backend/internal/compose/integration/capture/capture_provider_scopes_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_provider_scopes_integration_test.go
@@ -41,7 +41,7 @@ func TestConnectPersistsTheProviderGrantedScopes(t *testing.T) {
 	registry.Register(&grantingFake{granted: granted})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestAConnectorThatCannotReportItsGrantRecordsNoClaim(t *testing.T) {
 	registry.Register(&mailFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_scope_integration_test.go
@@ -98,7 +98,7 @@ func TestCaptureStagesAMergeForALeadCollidingWithAnotherTeamsLead(t *testing.T) 
 	registry, stager := newScopeCaptureRegistry(t, e, fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t 
 	registry, _ := newScopeCaptureRegistry(t, e, fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/capture_settings_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_settings_integration_test.go
@@ -78,7 +78,7 @@ func TestCaptureSettingsStore(t *testing.T) {
 	}
 
 	// A rep (read-only) cannot toggle it.
-	if _, err := store.Update(rep, boolPtr(false)); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := store.Update(rep, boolPtr(false), nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Fatalf("rep update err = %v, want permission denied", err)
 	}
 	if auditCount() != 0 {
@@ -86,7 +86,7 @@ func TestCaptureSettingsStore(t *testing.T) {
 	}
 
 	// Admin turns it off — one audit row, the new value returned and readable.
-	updated, err := store.Update(admin, boolPtr(false))
+	updated, err := store.Update(admin, boolPtr(false), nil)
 	if err != nil {
 		t.Fatalf("admin update: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestCaptureSettingsStore(t *testing.T) {
 	}
 
 	// An idempotent update (same value) is a no-op: no second audit row.
-	if _, err := store.Update(admin, boolPtr(false)); err != nil {
+	if _, err := store.Update(admin, boolPtr(false), nil); err != nil {
 		t.Fatalf("idempotent update: %v", err)
 	}
 	if auditCount() != 1 {
@@ -109,7 +109,7 @@ func TestCaptureSettingsStore(t *testing.T) {
 	}
 
 	// A nil patch leaves it unchanged and writes nothing.
-	if _, err := store.Update(admin, nil); err != nil {
+	if _, err := store.Update(admin, nil, nil); err != nil {
 		t.Fatalf("empty patch: %v", err)
 	}
 	if auditCount() != 1 {

--- a/backend/internal/compose/integration/capture/capture_syncstate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_syncstate_integration_test.go
@@ -92,7 +92,7 @@ func TestSyncFailureNeverKillsAConnection(t *testing.T) {
 	registry.Register(moody)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestSyncFailureNeverKillsAConnection(t *testing.T) {
 		}
 
 		// Reconnect (the OAuth callback path) un-parks it with a clean ladder.
-		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("fresh"), true); err != nil {
+		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("fresh")); err != nil {
 			t.Fatalf("reconnect: %v", err)
 		}
 		status, row = readSyncState(t, e, connID)

--- a/backend/internal/compose/integration/capture/fieldprovenance_integration_test.go
+++ b/backend/internal/compose/integration/capture/fieldprovenance_integration_test.go
@@ -35,7 +35,7 @@ func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("token"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture/gcal_connector_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_connector_integration_test.go
@@ -98,7 +98,7 @@ func TestGcalConnectorSyncsExternalMeetingAndSkipsInternal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gcal", auth, true)
+	connID, err := registry.Connect(grantCtx, "gcal", auth)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gmail_connector_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_connector_integration_test.go
@@ -95,7 +95,7 @@ func TestGmailConnectorSyncsAnActivity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gmail", auth, true)
+	connID, err := registry.Connect(grantCtx, "gmail", auth)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_push_integration_test.go
@@ -55,7 +55,7 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&moodyConnector{name: "gmail"})
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"), true)
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gmail_watch_integration_test.go
+++ b/backend/internal/compose/integration/capture/gmail_watch_integration_test.go
@@ -55,7 +55,7 @@ func TestGmailWatchRegistersRenewsAndLeavesCursor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gmail", auth, true)
+	connID, err := registry.Connect(grantCtx, "gmail", auth)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestGmailWatchJobRenewsOnSchedule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
-	connID, err := registry.Connect(grantCtx, "gmail", auth, true)
+	connID, err := registry.Connect(grantCtx, "gmail", auth)
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
@@ -85,7 +85,7 @@ func TestConnectSealsCredentialInVaultNotOnTheRow(t *testing.T) {
 	registry.Register(&authAssertingFake{})
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestSyncResolvesCredentialFromVault(t *testing.T) {
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
-	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"), true)
+	connID, err := registry.Connect(grantCtx, "graph", connector.Auth("granted-token"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12527,6 +12527,13 @@ type CaptureSettings struct {
 	// AutoEnrich When true, every surviving auto-created organization gets a governed web deep-read
 	// under a daily spend cap. Default is ON (the testing posture).
 	AutoEnrich bool `json:"auto_enrich"`
+
+	// MailSharing The workspace's mail-sharing posture, ON by default: a captured email is readable by
+	// every colleague who can see the contact. Switched OFF, every email captured FROM THEN ON
+	// is held to its participants and the capturing mailbox owner — already-captured mail keeps
+	// the audience it has. Turning it off makes shared pipeline work hard; the setting exists
+	// for installations that accept that cost.
+	MailSharing bool `json:"mail_sharing"`
 }
 
 // CaptureTraceEntry defines model for CaptureTraceEntry.
@@ -13264,12 +13271,10 @@ type ConnectConnectorRequest struct {
 	// open-redirect surface. Ignored by credential providers, which never redirect.
 	ReturnTo *ConnectConnectorRequestReturnTo `json:"return_to,omitempty"`
 
-	// ShareAcknowledged The connecting human's one-time acknowledgment that what this connector captures
-	// becomes readable to colleagues who can see the contact (they can limit individual
-	// messages afterwards, and exclude addresses or domains up front). Required `true`
-	// for every capture provider — the connect refuses with 422 `sharing_not_acknowledged`
-	// without it — and recorded on the connection as `share_acknowledged_at` before the
-	// first pull.
+	// ShareAcknowledged Accepted and ignored. Mail sharing is a workspace setting (`CaptureSettings.mail_sharing`,
+	// ON by default, admin-switchable) rather than a per-connect acknowledgment; this field
+	// remains only so a client that still sends it keeps working.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	ShareAcknowledged *bool `json:"share_acknowledged,omitempty"`
 }
 
@@ -20768,6 +20773,9 @@ type UpdateAutomationRequestStatus string
 type UpdateCaptureSettingsRequest struct {
 	// AutoEnrich Toggle captured-organization auto-enrichment.
 	AutoEnrich *bool `json:"auto_enrich,omitempty"`
+
+	// MailSharing Toggle the workspace mail-sharing posture; affects mail captured from now on.
+	MailSharing *bool `json:"mail_sharing,omitempty"`
 }
 
 // UpdateContractRequest Partial. Status is absent by design — it moves through changeContractStatus.

--- a/backend/internal/modules/capture/registry_disconnect_integration_test.go
+++ b/backend/internal/modules/capture/registry_disconnect_integration_test.go
@@ -193,7 +193,7 @@ func newCaptureRegistryFixture(t *testing.T) (context.Context, *capture.Registry
 // secret exists before disconnect), not the code under test.
 func connectFixtureConnection(ctx context.Context, t *testing.T, reg *capture.Registry) keyvault.Ref {
 	t.Helper()
-	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token"), true); err != nil {
+	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token")); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	var status string
@@ -221,34 +221,21 @@ func queryConnectionRow(ctx context.Context, t *testing.T, status *string, crede
 		Scan(status, credentialRef, auth)
 }
 
-// The grant is where the mail-sharing acknowledgment becomes a recorded fact:
-// a connect stamps share_acknowledged_at before the first pull, and a grant
-// arriving WITHOUT the acknowledgment is refused at the registry — the single
-// write point — so an unacknowledged connection cannot exist however a
-// transport misbehaves.
-func TestConnectRecordsTheSharingAcknowledgmentAndRefusesWithoutIt(t *testing.T) {
+// share_acknowledged_at records when a grant connected under the workspace
+// mail-sharing regime (the setting capture.mail_sharing, ON by default) —
+// the column is stamped by every connect, so a connection's row always says
+// since when its mail has been flowing under that regime.
+func TestConnectStampsWhenTheSharingRegimeBoundTheGrant(t *testing.T) {
 	ctx, reg, _, _ := newCaptureRegistryFixture(t)
-
-	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token"), false); err == nil {
-		t.Fatal("Connect accepted a grant without the mail-sharing acknowledgment")
-	}
-	owner, _ := setupCaptureDB(t)
-	var count int
-	if err := owner.QueryRow(ctx, `SELECT count(*) FROM capture_connection`).Scan(&count); err != nil {
-		t.Fatalf("counting connections: %v", err)
-	}
-	if count != 0 {
-		t.Fatalf("the refused grant left %d connection rows", count)
-	}
-
 	connectFixtureConnection(ctx, t, reg)
+	owner, _ := setupCaptureDB(t)
 	var ackedAt *time.Time
 	if err := owner.QueryRow(ctx,
 		`SELECT share_acknowledged_at FROM capture_connection WHERE provider = 'gmail'`).Scan(&ackedAt); err != nil {
-		t.Fatalf("reading back the acknowledgment stamp: %v", err)
+		t.Fatalf("reading back the stamp: %v", err)
 	}
 	if ackedAt == nil {
-		t.Fatal("Connect committed the row with share_acknowledged_at NULL — the acknowledgment was not recorded")
+		t.Fatal("Connect committed the row with share_acknowledged_at NULL")
 	}
 }
 
@@ -384,7 +371,7 @@ func TestReconnectDeletesThePriorSecret(t *testing.T) {
 		t.Fatalf("precondition: the first secret should exist: %v", err)
 	}
 
-	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token-2"), true); err != nil {
+	if _, err := reg.Connect(ctx, "gmail", connector.Auth("fixture-token-2")); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 
@@ -469,7 +456,7 @@ func TestDisconnectPhase3DoesNotClobberAConcurrentReconnect(t *testing.T) {
 	// exactly like a second request would land on the same process.
 	reg3 := capture.NewRegistry(database.BindTo(poolFromFixture(t), ws), nil, fixtureAuthority{}, vault)
 	reg3.Register(fixtureConnector{})
-	if _, err := reg3.Connect(ctx, "gmail", connector.Auth("fixture-token-reconnect"), true); err != nil {
+	if _, err := reg3.Connect(ctx, "gmail", connector.Auth("fixture-token-reconnect")); err != nil {
 		t.Fatalf("concurrent reconnect: %v", err)
 	}
 	var secondRef *string

--- a/backend/internal/modules/capture/registry_grant.go
+++ b/backend/internal/modules/capture/registry_grant.go
@@ -24,25 +24,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
-// Connect grants one connector under the CALLING human's authority. Three
-// guards run here, all at grant time rather than discovered at 3am
-// mid-sync: the granting human must still resolve as live authority, a
-// connector demanding scopes they do not hold is refused, and a grant
-// without the mail-sharing acknowledgment is refused — captured
-// correspondence is workspace-readable by default, and that default is a
-// stated choice recorded on the row (share_acknowledged_at) before the
-// first pull. The transports collect the acknowledgment (422 without it);
-// this refusal is the single write point holding the invariant that an
-// unacknowledged connection cannot exist.
+// Connect grants one connector under the CALLING human's authority. Two
+// guards run here, both at grant time rather than discovered at 3am
+// mid-sync: the granting human must still resolve as live authority, and
+// a connector demanding scopes they do not hold is refused. Mail sharing
+// is a workspace SETTING (capture.mail_sharing, ON by default) rather
+// than a per-connect acknowledgment; share_acknowledged_at records when
+// this grant connected under that regime.
 //
 // note: the returned id (and the connectionID threaded through SyncOnce and
 // the sync-state recording) names a capture_connection row, which the kernel
 // does not model as a first-class entity — no kind exists for it, so it stays
 // ids.UUID rather than inventing one.
-func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth, shareAcknowledged bool) (ids.UUID, error) {
-	if !shareAcknowledged {
-		return ids.Nil, errors.New("capture: a connector grant needs the mail-sharing acknowledgment — the transport asks for it before calling here")
-	}
+func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth) (ids.UUID, error) {
 	c, err := r.connector(name)
 	if err != nil {
 		return ids.Nil, err

--- a/backend/internal/modules/capture/settings.go
+++ b/backend/internal/modules/capture/settings.go
@@ -21,7 +21,8 @@ import (
 
 // Settings is the workspace-shared capture posture (the wire shape).
 type Settings struct {
-	AutoEnrich bool
+	AutoEnrich  bool
+	MailSharing bool
 }
 
 // SettingsStore is the store over the workspace capture posture.
@@ -36,11 +37,15 @@ func NewSettings(s *settings.Store) *SettingsStore { return &SettingsStore{setti
 // entry (`capture_settings`, read granted to every role), so there is no
 // second gate to keep in step here.
 func (s *SettingsStore) Get(ctx context.Context) (Settings, error) {
-	on, err := settings.Get(ctx, s.settings, AutoEnrich)
+	autoEnrich, err := settings.Get(ctx, s.settings, AutoEnrich)
 	if err != nil {
 		return Settings{}, fmt.Errorf("capture: reading settings: %w", err)
 	}
-	return Settings{AutoEnrich: on}, nil
+	mailSharing, err := settings.Get(ctx, s.settings, MailSharing)
+	if err != nil {
+		return Settings{}, fmt.Errorf("capture: reading settings: %w", err)
+	}
+	return Settings{AutoEnrich: autoEnrich, MailSharing: mailSharing}, nil
 }
 
 // Update applies a sparse capture-settings patch (admin/ops). A nil field is
@@ -57,15 +62,19 @@ func (s *SettingsStore) Get(ctx context.Context) (Settings, error) {
 // read gets a 403 on an empty patch, because the response comes from Get. No
 // seeded role has that combination — `capture_settings` grants read to every
 // role — so this stays a note rather than a branch.
-func (s *SettingsStore) Update(ctx context.Context, autoEnrich *bool) (Settings, error) {
+func (s *SettingsStore) Update(ctx context.Context, autoEnrich, mailSharing *bool) (Settings, error) {
 	if err := auth.Require(ctx, captureSettingsObject, principal.ActionUpdate); err != nil {
 		return Settings{}, err
 	}
-	if autoEnrich == nil {
-		return s.Get(ctx)
+	if autoEnrich != nil {
+		if err := settings.Set(ctx, s.settings, AutoEnrich, *autoEnrich); err != nil {
+			return Settings{}, err
+		}
 	}
-	if err := settings.Set(ctx, s.settings, AutoEnrich, *autoEnrich); err != nil {
-		return Settings{}, err
+	if mailSharing != nil {
+		if err := settings.Set(ctx, s.settings, MailSharing, *mailSharing); err != nil {
+			return Settings{}, err
+		}
 	}
-	return Settings{AutoEnrich: *autoEnrich}, nil
+	return s.Get(ctx)
 }

--- a/backend/internal/modules/capture/settingsentry.go
+++ b/backend/internal/modules/capture/settingsentry.go
@@ -40,10 +40,28 @@ var AutoEnrich = settings.Define[bool](
 	nil, // every bool is a valid posture; a validator here would be ceremony
 )
 
+// MailSharing is the workspace mail-sharing posture: ON, a captured email is
+// readable by every colleague who can see the contact; OFF, every email
+// captured FROM THEN ON is held to its participants and the capturing mailbox
+// owner (the sink stamps audience='participants' at insert). Already-captured
+// mail keeps the audience it has — the setting moves the default, it rewrites
+// no history.
+//
+// Default true: sharing is the point of a CRM, and the off position exists
+// for installations that accept how much harder it makes shared pipeline
+// work — the settings surface says so in as many words.
+var MailSharing = settings.Define[bool](
+	"capture.mail_sharing",
+	captureSettingsObject,
+	"update",
+	true,
+	nil, // every bool is a valid posture; a validator here would be ceremony
+)
+
 // Definitions is capture's contribution to the settings registry. Compose
 // concatenates each module's list; a module that declares no settings has no
 // such function, so this is opt-in rather than an interface every module must
 // satisfy.
 func Definitions() []settings.Definition {
-	return []settings.Definition{AutoEnrich}
+	return []settings.Definition{AutoEnrich, MailSharing}
 }

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -323,10 +323,14 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		return ids.ActivityID{}, false, err
 	}
 	occurredAt := fields.OccurredAt
+	audience, err := capturedAudience(ctx, tx, fields.Kind)
+	if err != nil {
+		return ids.ActivityID{}, false, err
+	}
 	var id ids.ActivityID
-	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested)
-		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14)
+	err = tx.QueryRow(ctx, `
+		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience)
+		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
@@ -349,7 +353,8 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		// a noise REDACTION needs before it destroys content (migration 0137).
 		// Stamped per message, so a newsletter blast is destroyable while a
 		// personal mail from the same address is only ever hidden.
-		rec.Counterparty.ListUnsubscribe).Scan(&id)
+		rec.Counterparty.ListUnsubscribe,
+		audience).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/internal/modules/capture/sinkaudience.go
+++ b/backend/internal/modules/capture/sinkaudience.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
@@ -44,3 +45,25 @@ func limitLinkLessAudience(ctx context.Context, tx pgx.Tx, id ids.ActivityID, re
 // audienceParticipants is the activity audience a link-less captured message
 // is held in (platform/auth ActivityContentClause names the arms).
 const audienceParticipants = "participants"
+
+// capturedAudience answers the audience a freshly captured activity is born
+// with. Mail sharing ON (the default) births an email workspace-readable —
+// the point of capturing into a shared CRM. Switched OFF, an email is held to
+// its participants and the capturing mailbox owner from the moment it lands;
+// the setting moves the default for NEW mail only, and non-mail kinds
+// (meetings, channel messages) keep the workspace default either way.
+func capturedAudience(ctx context.Context, tx pgx.Tx, kind string) (string, error) {
+	if kind != "email" {
+		return audienceWorkspace, nil
+	}
+	sharing, err := settings.ApplyTx(ctx, tx, MailSharing)
+	if err != nil {
+		return "", fmt.Errorf("capture: reading the mail-sharing posture: %w", err)
+	}
+	if sharing {
+		return audienceWorkspace, nil
+	}
+	return audienceParticipants, nil
+}
+
+const audienceWorkspace = "workspace"

--- a/backend/internal/modules/capture/syncpacing_integration_test.go
+++ b/backend/internal/modules/capture/syncpacing_integration_test.go
@@ -66,7 +66,7 @@ func (c rateLimitedConnector) Sync(context.Context, connector.Auth, connector.Cu
 // about production: the row it schedules against is the row production writes.
 func syncOnceOf(ctx context.Context, t *testing.T, reg *capture.Registry, provider string) error {
 	t.Helper()
-	if _, err := reg.Connect(ctx, provider, connector.Auth("fixture-token"), true); err != nil {
+	if _, err := reg.Connect(ctx, provider, connector.Auth("fixture-token")); err != nil {
 		t.Fatalf("Connect(%s): %v", provider, err)
 	}
 	owner, _ := setupCaptureDB(t)

--- a/backend/internal/platform/settings/store.go
+++ b/backend/internal/platform/settings/store.go
@@ -372,3 +372,24 @@ func RequireTx[T any](ctx context.Context, tx pgx.Tx, e *Entry[T]) (T, error) {
 	}
 	return out, nil
 }
+
+// ApplyTx reads a setting inside the caller's transaction WITHOUT the entry's
+// read gate — for MACHINERY applying a workspace posture to its own write
+// (the capture sink stamping a freshly captured row's audience), where the
+// posture must bind whoever the acting principal happens to be: a posture a
+// narrow principal could not read would simply not apply to what they
+// capture, which is the opposite of a control. Never for a surface that
+// ANSWERS the value to a caller — those go through Get/GetTx, whose gate is
+// the only control on the un-RLS'd setting table.
+func ApplyTx[T any](ctx context.Context, tx pgx.Tx, e *Entry[T]) (T, error) {
+	var zero T
+	raw, err := currentJSON(ctx, tx, e)
+	if err != nil {
+		return zero, err
+	}
+	var out T
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return zero, fmt.Errorf("settings: decoding %s: %w", e.Key(), err)
+	}
+	return out, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9034,6 +9034,14 @@ export interface components {
          */
         CaptureSettings: {
             /**
+             * @description The workspace's mail-sharing posture, ON by default: a captured email is readable by
+             *     every colleague who can see the contact. Switched OFF, every email captured FROM THEN ON
+             *     is held to its participants and the capturing mailbox owner — already-captured mail keeps
+             *     the audience it has. Turning it off makes shared pipeline work hard; the setting exists
+             *     for installations that accept that cost.
+             */
+            mail_sharing: boolean;
+            /**
              * @description When true, every surviving auto-created organization gets a governed web deep-read
              *     under a daily spend cap. Default is ON (the testing posture).
              */
@@ -9043,6 +9051,8 @@ export interface components {
         UpdateCaptureSettingsRequest: {
             /** @description Toggle captured-organization auto-enrichment. */
             auto_enrich?: boolean;
+            /** @description Toggle the workspace mail-sharing posture; affects mail captured from now on. */
+            mail_sharing?: boolean;
         };
         /**
          * @description One domain carrying a standing admission decision. `suppressed` refuses it a company —
@@ -9250,12 +9260,10 @@ export interface components {
          */
         ConnectConnectorRequest: {
             /**
-             * @description The connecting human's one-time acknowledgment that what this connector captures
-             *     becomes readable to colleagues who can see the contact (they can limit individual
-             *     messages afterwards, and exclude addresses or domains up front). Required `true`
-             *     for every capture provider — the connect refuses with 422 `sharing_not_acknowledged`
-             *     without it — and recorded on the connection as `share_acknowledged_at` before the
-             *     first pull.
+             * @deprecated
+             * @description Accepted and ignored. Mail sharing is a workspace setting (`CaptureSettings.mail_sharing`,
+             *     ON by default, admin-switchable) rather than a per-connect acknowledgment; this field
+             *     remains only so a client that still sends it keeps working.
              */
             share_acknowledged?: boolean;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2892,8 +2892,15 @@ export const de = {
     "Erweiterungen, die diese Installation mit einem gemeinsamen Zugang betreibt. Was du hier einstellst, gilt für alle.",
 
   "connectors.title": "Verbundene Postfächer",
-  "connectors.shareAck":
-    "Erfasste E-Mails werden für Kolleginnen und Kollegen lesbar, die den Kontakt sehen können — einzelne Nachrichten lassen sich nachträglich einschränken, Adressen und Domains vorab ausschließen.",
+  "mailSharing.title": "E-Mail-Freigabe",
+  "mailSharing.sub":
+    "Erfasste E-Mails sind für alle Kolleginnen und Kollegen lesbar, die den Kontakt sehen können. Standardmäßig eingeschaltet — das macht die Pipeline gemeinsam.",
+  "mailSharing.label": "Erfasste E-Mails im Team teilen",
+  "mailSharing.help":
+    "Einzelne Nachrichten lassen sich nachträglich einschränken, Adressen und Domains vorab ausschließen.",
+  "mailSharing.danger":
+    "ACHTUNG: E-Mail-Freigabe ausschalten macht die Nutzung des CRM schwierig. Neue E-Mails sind dann nur noch für die Beteiligten der jeweiligen Nachricht sichtbar.",
+  "mailSharing.save": "Speichern",
   "connectors.sub":
     "Postfächer, die dein CRM automatisch füllen. Trenne eines bei Bedarf — bereits erfasste Datensätze bleiben.",
   "connectors.loading": "Verbindungen werden geladen…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2884,8 +2884,15 @@ export const en = {
   // Connected inboxes (Settings → Connections): the "manage in Settings"
   // surface the onboarding copy promises.
   "connectors.title": "Connected inboxes",
-  "connectors.shareAck":
-    "Captured mail becomes readable to colleagues who can see the contact — individual messages can be limited afterwards, and addresses or domains excluded up front.",
+  "mailSharing.title": "Email sharing",
+  "mailSharing.sub":
+    "Captured mail is readable by every colleague who can see the contact. On by default — it is what makes the pipeline shared.",
+  "mailSharing.label": "Share captured mail with the team",
+  "mailSharing.help":
+    "Individual messages can be limited afterwards, and addresses or domains excluded up front.",
+  "mailSharing.danger":
+    "DANGER: Switching off email sharing will make usage of the CRM difficult. New mail will be visible only to the people on each message.",
+  "mailSharing.save": "Save",
   "connectors.sub":
     "Mailboxes capturing into your CRM. Disconnect any one when you need to — already-captured records stay.",
   "connectors.loading": "Loading your connections…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2865,8 +2865,15 @@ export const vi = {
     "Những tiện ích bản cài đặt này chạy bằng một thông tin đăng nhập dùng chung. Thiết lập ở đây áp dụng cho mọi người.",
 
   "connectors.title": "Hộp thư đã kết nối",
-  "connectors.shareAck":
-    "Email được thu thập sẽ hiển thị với đồng nghiệp có quyền xem liên hệ — có thể giới hạn từng tin nhắn sau đó, và loại trừ địa chỉ hoặc tên miền ngay từ đầu.",
+  "mailSharing.title": "Chia sẻ email",
+  "mailSharing.sub":
+    "Email được thu thập sẽ hiển thị với mọi đồng nghiệp có quyền xem liên hệ. Bật mặc định — đây là điều làm cho pipeline được chia sẻ.",
+  "mailSharing.label": "Chia sẻ email đã thu thập với nhóm",
+  "mailSharing.help":
+    "Có thể giới hạn từng tin nhắn sau đó, và loại trừ địa chỉ hoặc tên miền ngay từ đầu.",
+  "mailSharing.danger":
+    "NGUY HIỂM: Tắt chia sẻ email sẽ khiến việc sử dụng CRM trở nên khó khăn. Email mới chỉ hiển thị với những người trong từng tin nhắn.",
+  "mailSharing.save": "Lưu",
   "connectors.sub":
     "Các hộp thư đang thu thập vào CRM của bạn. Cần thì ngắt kết nối hộp nào cũng được — bản ghi đã thu thập vẫn giữ nguyên.",
   "connectors.loading": "Đang tải các kết nối…",

--- a/frontend/src/screens/connect-panels.test.tsx
+++ b/frontend/src/screens/connect-panels.test.tsx
@@ -60,11 +60,6 @@ it("OAuthConnectPanel posts the given provider and redirects", async () => {
       jsonResponse({ authorize_url: "https://login.microsoftonline/x" }),
   });
   render(<OAuthConnectPanel provider="graph" onDismiss={() => {}} />);
-  // The connect button stays disabled until the one-time sharing
-  // acknowledgment is ticked.
-  await userEvent.click(
-    screen.getByRole("checkbox", { name: en["connectors.shareAck"] }),
-  );
   await userEvent.click(
     screen.getByRole("button", { name: "Allow access to my Microsoft" }),
   );

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -167,10 +167,9 @@ describe("the connected-inboxes card", () => {
   it("opens the inline IMAP form from the empty state instead of bouncing to onboarding", async () => {
     stubApi([]);
     render(<ConnectorsCard />);
-    // The provider buttons stay disabled until the one-time sharing
-    // acknowledgment — the block's only checkbox — is ticked.
-    await userEvent.click(await screen.findByRole("checkbox"));
-    await userEvent.click(screen.getByRole("button", { name: "IMAP mailbox" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "IMAP mailbox" }),
+    );
     expect(
       screen.getByRole("dialog", { name: "Connect an IMAP mailbox" }),
     ).toBeTruthy();
@@ -256,10 +255,7 @@ describe("the connected-inboxes card", () => {
       return requests;
     });
     const body = await connectRequests[0].clone().json();
-    expect(body).toMatchObject({
-      return_to: "settings",
-      share_acknowledged: true,
-    });
+    expect(body).toEqual({ return_to: "settings" });
   });
 
   it("offers the inline IMAP form to reconnect an imap connection instead of an OAuth reconnect", async () => {
@@ -518,19 +514,6 @@ describe("add a connection", () => {
     ).toBeTruthy();
   });
 
-  it("keeps every add-connection button disabled until the sharing acknowledgment is ticked", async () => {
-    stubApi([gmailConnected]);
-    render(<ConnectorsCard />);
-    await screen.findByText("Add a connection");
-    for (const name of ["Google Calendar", "Microsoft", "IMAP mailbox"]) {
-      expect(screen.getByRole("button", { name })).toBeDisabled();
-    }
-    await userEvent.click(screen.getByRole("checkbox"));
-    for (const name of ["Google Calendar", "Microsoft", "IMAP mailbox"]) {
-      expect(screen.getByRole("button", { name })).not.toBeDisabled();
-    }
-  });
-
   it("redirects the browser when an OAuth provider is chosen", async () => {
     const assign = vi.fn();
     vi.stubGlobal("location", { ...globalThis.location, assign });
@@ -539,7 +522,6 @@ describe("add a connection", () => {
     });
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
-    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(
       screen.getByRole("button", { name: "Google Calendar" }),
     );
@@ -552,7 +534,6 @@ describe("add a connection", () => {
     stubApi([gmailConnected], { connect: { status: 501 } });
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
-    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(screen.getByRole("button", { name: "Microsoft" }));
     expect(
       await screen.findByText("Microsoft isn't configured in this deployment."),
@@ -563,7 +544,6 @@ describe("add a connection", () => {
     stubApi([gmailConnected], { connect: { status: 502 } });
     render(<ConnectorsCard />);
     await screen.findByText("Add a connection");
-    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(screen.getByRole("button", { name: "Microsoft" }));
 
     const alert = await screen.findByRole("alert");

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -7,7 +7,6 @@ import { useRoute } from "../app/router";
 import {
   Badge,
   Button,
-  Checkbox,
   EmptyState,
   SectionHeader,
 } from "../design-system/atoms";
@@ -153,20 +152,11 @@ function ConnectorAddPanel({
   pending,
   notConfigured501,
   connectError,
-  shareAck,
-  onShareAck,
   onConnect,
   onImap,
 }: Readonly<{
   addable: Provider[];
   pending: boolean;
-  // The one-time mail-sharing acknowledgment (one sentence, one checkbox):
-  // captured correspondence is workspace-readable by default, and the server
-  // refuses the connect (422 sharing_not_acknowledged) until it is given.
-  // Held by the parent so the OAuth buttons and the IMAP form opener gate on
-  // the same tick.
-  shareAck: boolean;
-  onShareAck: (v: boolean) => void;
   notConfigured501: Provider | null;
   // Why the last connect started from THESE buttons failed, or null. It renders
   // inside this block, under the strip that produced it: a reason reported in a
@@ -182,15 +172,10 @@ function ConnectorAddPanel({
       {(addable.includes("gcal") || addable.includes("gmail")) && (
         <p className="t-small">{t("connectors.googleSeparateNote")}</p>
       )}
-      <Checkbox
-        checked={shareAck}
-        onChange={(e) => onShareAck(e.currentTarget.checked)}
-        label={t("connectors.shareAck")}
-      />
       <div className="connector-add-actions">
         {addable.map((p) =>
           p === "imap" ? (
-            <Button key={p} small disabled={!shareAck} onClick={onImap}>
+            <Button key={p} small onClick={onImap}>
               <Mail aria-hidden /> {t(providerLabel[p])}
             </Button>
           ) : (
@@ -198,7 +183,7 @@ function ConnectorAddPanel({
               key={p}
               small
               variant={p === "gmail" ? "primary" : undefined}
-              disabled={pending || !shareAck}
+              disabled={pending}
               onClick={() => onConnect(p)}
             >
               <Plug aria-hidden /> {t(providerLabel[p])}
@@ -555,7 +540,6 @@ export function ConnectorsCard() {
     null,
   );
   const [imapConnectOpen, setImapConnectOpen] = useState(false);
-  const [shareAck, setShareAck] = useState(false);
   const [notConfigured501, setNotConfigured501] = useState<Provider | null>(
     null,
   );
@@ -571,10 +555,7 @@ export function ConnectorsCard() {
           params: { path: { provider } },
           // Lands the post-consent redirect back on Settings (Task 2's
           // contract field) rather than the default onboarding landing.
-          // share_acknowledged is honest here: the add buttons stay disabled
-          // until the checkbox is ticked, and a RECONNECT re-asserts the
-          // acknowledgment the connection's first connect already recorded.
-          body: { return_to: "settings", share_acknowledged: true },
+          body: { return_to: "settings" },
         },
       );
       // A deployment that never wired this specific provider answers 501
@@ -633,8 +614,6 @@ export function ConnectorsCard() {
     <ConnectorAddPanel
       addable={addable}
       pending={connect.isPending}
-      shareAck={shareAck}
-      onShareAck={setShareAck}
       notConfigured501={notConfigured501}
       connectError={failureOwnedBy(connectFailure, addable)}
       onConnect={(p) => connect.mutate(p)}

--- a/frontend/src/screens/imap-connect-form.tsx
+++ b/frontend/src/screens/imap-connect-form.tsx
@@ -92,9 +92,6 @@ export function ImapConnectForm({
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
         params: { path: { provider: "imap" } },
         body: {
-          // The Settings add panel disables this form's opener until the
-          // mail-sharing checkbox is ticked, so the assertion is honest here.
-          share_acknowledged: true,
           imap: request,
         },
       });

--- a/frontend/src/screens/mail-sharing.test.tsx
+++ b/frontend/src/screens/mail-sharing.test.tsx
@@ -1,0 +1,125 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type GrantSpec, meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { MailSharingCard } from "./mail-sharing";
+
+// The workspace mail-sharing posture (Settings → Connections): every role
+// reads it, only capture_settings:update holders change it, and switching it
+// off is a deliberate act — the danger callout and an explicit Save stand
+// between the flip and the write.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SETTINGS_EDITOR: GrantSpec = { capture_settings: ["update"] };
+
+// backendFor answers /me with the given grants and /capture/settings with the
+// given posture, capturing any PATCH body so the wire shape is assertable.
+function backendFor(allow: GrantSpec, mailSharing = true) {
+  let sharingState = mailSharing;
+  let capturedPatch: unknown = null;
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req =
+        input instanceof Request ? input : new Request(String(input), init);
+      if (req.url.endsWith("/v1/me")) {
+        return jsonResponse(meFixture({ allow }));
+      }
+      if (req.url.includes("/capture/settings")) {
+        if (req.method === "PATCH") {
+          capturedPatch = await req.json();
+          sharingState = (capturedPatch as { mail_sharing: boolean })
+            .mail_sharing;
+        }
+        return jsonResponse({ auto_enrich: true, mail_sharing: sharingState });
+      }
+      throw new Error(`unexpected request: ${req.method} ${req.url}`);
+    },
+  );
+  return { fetchMock, getCapturedPatch: () => capturedPatch };
+}
+
+const render = (ui: ReactNode) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("MailSharingCard", () => {
+  it("renders the stored ON posture with no warning and no Save", async () => {
+    vi.stubGlobal("fetch", backendFor(SETTINGS_EDITOR, true).fetchMock);
+    render(<MailSharingCard />);
+
+    const toggle = await waitFor(() =>
+      screen.getByTestId<HTMLButtonElement>("mail-sharing-toggle"),
+    );
+    expect(toggle.getAttribute("role")).toBe("switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(toggle.disabled).toBe(false);
+    // No unsaved change and nothing to warn about: the stored posture is ON.
+    expect(screen.queryByText(/make usage of the CRM difficult/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+  });
+
+  it("warns on flip-to-off and PATCHes only when Save is pressed", async () => {
+    const backend = backendFor(SETTINGS_EDITOR, true);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<MailSharingCard />);
+
+    const toggle = await waitFor(() =>
+      screen.getByTestId<HTMLButtonElement>("mail-sharing-toggle"),
+    );
+    await userEvent.click(toggle);
+
+    // The flip alone writes nothing — the cost is said out loud and the
+    // change waits for an explicit Save.
+    expect(
+      await screen.findByText(/make usage of the CRM difficult/),
+    ).toBeTruthy();
+    expect(backend.getCapturedPatch()).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(backend.getCapturedPatch()).toEqual({ mail_sharing: false }),
+    );
+    // Saved: the shown posture is the stored posture again, so Save retires.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
+    );
+  });
+
+  it("disables the switch for a role without capture_settings update", async () => {
+    vi.stubGlobal("fetch", backendFor({}, true).fetchMock);
+    render(<MailSharingCard />);
+
+    const toggle = await waitFor(() =>
+      screen.getByTestId<HTMLButtonElement>("mail-sharing-toggle"),
+    );
+    expect(toggle.disabled).toBe(true);
+    expect(screen.getByText(/Only an admin or ops/)).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/mail-sharing.tsx
+++ b/frontend/src/screens/mail-sharing.tsx
@@ -1,0 +1,113 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Mails } from "lucide-react";
+import { useState } from "react";
+import { api } from "../api/client";
+import { useCanWrite } from "../app/capability";
+import { Button } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { Switch } from "../design-system/switch";
+import { useT } from "../i18n";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+// The workspace mail-sharing posture: ON by default, captured mail is
+// readable by every colleague who can see the contact — the thing that makes
+// the pipeline shared. Switching it OFF holds every email captured from then
+// on to its participants, which makes shared CRM work hard, so the change is
+// a deliberate act: a switch plus a Save button plus a warning that says the
+// cost out loud, never a silent instant toggle. Every role sees the posture;
+// only admin/ops may change it (same gating as the auto-enrich card).
+
+function useMailSharing() {
+  return useQuery({
+    queryKey: ["capture-settings"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/capture/settings");
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+export function MailSharingCard() {
+  const t = useT();
+  const canManage = useCanWrite("capture_settings", "update");
+  const query = useMailSharing();
+  const queryClient = useQueryClient();
+  // null = no unsaved change; the switch renders the stored posture.
+  const [pending, setPending] = useState<boolean | null>(null);
+  const save = useMutation({
+    mutationFn: async (mailSharing: boolean) => {
+      const { data, error } = await api.PATCH("/capture/settings", {
+        body: { mail_sharing: mailSharing },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["capture-settings"], data);
+      setPending(null);
+    },
+  });
+
+  return (
+    <Panel title={t("mailSharing.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("mailSharing.sub")}</p>
+        <QueryGate query={query}>
+          {(settings) => {
+            const shown = pending ?? settings.mail_sharing;
+            const dirty = pending !== null && pending !== settings.mail_sharing;
+            return (
+              <>
+                <Switch
+                  testId="mail-sharing-toggle"
+                  label={
+                    <>
+                      <Mails aria-hidden size={16} />
+                      {t("mailSharing.label")}
+                    </>
+                  }
+                  hint={t("mailSharing.help")}
+                  reason={
+                    canManage ? undefined : t("captureSettings.adminOnly")
+                  }
+                  checked={shown}
+                  disabled={!canManage || save.isPending}
+                  onChange={(next) => setPending(next)}
+                />
+                {!shown && (
+                  <Callout tone="danger" live="alert">
+                    {t("mailSharing.danger")}
+                  </Callout>
+                )}
+                {dirty && (
+                  <Button
+                    variant="primary"
+                    disabled={save.isPending}
+                    onClick={() => {
+                      if (pending !== null) {
+                        save.mutate(pending);
+                      }
+                    }}
+                  >
+                    {t("mailSharing.save")}
+                  </Button>
+                )}
+                {save.isError && (
+                  <Callout tone="danger" live="alert">
+                    {problemMessageOf(save.error, t)}
+                  </Callout>
+                )}
+              </>
+            );
+          }}
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/onboarding-connect-panels.test.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.test.tsx
@@ -43,9 +43,6 @@ async function fillValidForm() {
   await userEvent.type(screen.getByLabelText("IMAP host"), "mail.example.org");
   await userEvent.type(screen.getByLabelText("Email"), "lars@example.org");
   await userEvent.type(screen.getByLabelText("App password"), "app-password");
-  // The submit stays disabled until the one-time sharing acknowledgment —
-  // the panel's only checkbox — is ticked.
-  await userEvent.click(screen.getByRole("checkbox"));
 }
 
 afterEach(() => {
@@ -77,7 +74,6 @@ describe("ImapConnectPanel", () => {
     );
     await waitFor(() => expect(calls.length).toBe(1));
     expect(calls[0].body).toMatchObject({
-      share_acknowledged: true,
       imap: {
         host: "mail.example.org",
         port: 993,

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
-import { Button, Checkbox, Disclosure, Field } from "../design-system/atoms";
+import { Button, Disclosure, Field } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
@@ -159,15 +159,11 @@ export function OAuthConnectPanel({
 }>) {
   const t = useT();
   const copy = OAUTH_COPY[provider];
-  // The one-time mail-sharing acknowledgment: the server refuses the connect
-  // (422 sharing_not_acknowledged) until the human has said yes to captured
-  // correspondence being readable to colleagues who can see the contact.
-  const [shareAck, setShareAck] = useState(false);
   const connect = useMutation({
     mutationFn: async () => {
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
         params: { path: { provider } },
-        body: { share_acknowledged: shareAck },
+        body: {},
       });
       if (error) {
         throwProblem(error);
@@ -205,15 +201,10 @@ export function OAuthConnectPanel({
           is wrong with the thing they just pressed. A caution about what a
           button does belongs beside the button, never behind a fold. */}
       <p className="t-small ob-google-unverified">{t(copy.unverified)}</p>
-      <Checkbox
-        checked={shareAck}
-        onChange={(e) => setShareAck(e.currentTarget.checked)}
-        label={t("connectors.shareAck")}
-      />
       <div className="ob-connect-dialog-actions">
         <Button
           variant="primary"
-          disabled={connect.isPending || !shareAck}
+          disabled={connect.isPending}
           onClick={() => connect.mutate()}
         >
           {connect.isPending ? (
@@ -411,7 +402,6 @@ export function ImapConnectPanel({
   const [password, setPassword] = useState("");
   const [mailbox, setMailbox] = useState("INBOX");
   const [max, setMax] = useState("30");
-  const [shareAck, setShareAck] = useState(false);
 
   const parsedPort =
     port.trim() === "" ? Number(IMAP_DEFAULT_PORT) : Number(port);
@@ -421,7 +411,6 @@ export function ImapConnectPanel({
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
         params: { path: { provider: "imap" } },
         body: {
-          share_acknowledged: shareAck,
           imap: {
             host: host.trim(),
             port: parsedPort,
@@ -456,7 +445,6 @@ export function ImapConnectPanel({
 
   const parsedMax = max.trim() === "" ? 30 : Number(max);
   const ready =
-    shareAck &&
     host.trim() !== "" &&
     Number.isInteger(parsedPort) &&
     parsedPort >= 1 &&
@@ -562,12 +550,6 @@ export function ImapConnectPanel({
           <ShieldCheck aria-hidden /> {t("ob.s4.imapHint")}
         </p>
       </Disclosure>
-
-      <Checkbox
-        checked={shareAck}
-        onChange={(e) => setShareAck(e.currentTarget.checked)}
-        label={t("connectors.shareAck")}
-      />
 
       {connect.isError && (
         <ConnectWarn

--- a/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
@@ -167,9 +167,6 @@ it("marks this tab's own attempt before the real redirect fires", async () => {
   vi.stubGlobal("location", { ...globalThis.location, assign });
   renderConnectAct();
   await userEvent.click(screen.getByRole("button", { name: /Microsoft/ }));
-  // The connect button stays disabled until the one-time sharing
-  // acknowledgment — the dialog's only checkbox — is ticked.
-  await userEvent.click(await screen.findByRole("checkbox"));
   await userEvent.click(
     screen.getByRole("button", { name: "Allow access to my Microsoft" }),
   );
@@ -560,13 +557,10 @@ describe("the IMAP dialog", () => {
     expect(screen.getByLabelText("Mailbox")).toBeTruthy();
     // The prototype this dialog adapts shows SMTP host/port and a "Require
     // TLS" checkbox; the real connector contract has neither, so this form
-    // does not invent widgets that would submit nothing. The one checkbox it
-    // does carry is the sharing acknowledgment, not an invented TLS toggle.
+    // does not invent widgets that would submit nothing — it carries no
+    // checkbox at all.
     expect(screen.queryByLabelText(/smtp/i)).toBeNull();
-    expect(screen.getAllByRole("checkbox")).toHaveLength(1);
-    expect(
-      screen.getByRole("checkbox", { name: en["connectors.shareAck"] }),
-    ).toBeInTheDocument();
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
   });
 
   it("closes on 'Not now' without touching the required-step skip", async () => {
@@ -606,7 +600,6 @@ describe("dismissal during an in-flight connect request", () => {
     });
     renderConnectAct();
     await userEvent.click(screen.getByRole("button", { name: /Microsoft/ }));
-    await userEvent.click(await screen.findByRole("checkbox"));
     await userEvent.click(
       screen.getByRole("button", {
         name: "Allow access to my Microsoft",
@@ -637,7 +630,6 @@ describe("dismissal during an in-flight connect request", () => {
     await userEvent.click(screen.getByRole("button", { name: /Any inbox/ }));
     await userEvent.type(screen.getByLabelText("Email"), "me@example.com");
     await userEvent.type(screen.getByLabelText("App password"), "secret");
-    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(
       screen.getByRole("button", { name: "Test and connect" }),
     );
@@ -743,7 +735,6 @@ it("keeps mail provider cards disabled during a roster refetch, not just its fir
   await userEvent.click(screen.getByRole("button", { name: /Any inbox/ }));
   await userEvent.type(screen.getByLabelText("Email"), "me@example.com");
   await userEvent.type(screen.getByLabelText("App password"), "secret");
-  await userEvent.click(screen.getByRole("checkbox"));
   await userEvent.click(
     screen.getByRole("button", { name: "Test and connect" }),
   );

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -111,6 +111,7 @@ import { LicenseCard } from "./license";
 import { LinkedInImportCard } from "./linkedin-import";
 import { LinkedInReachCard } from "./linkedin-reach";
 import { SEARCH_DEBOUNCE_MS } from "./listquery";
+import { MailSharingCard } from "./mail-sharing";
 import { OfferTemplatesAdmin } from "./offertemplates";
 import { OverlayCard } from "./overlay";
 import { MirrorUserMapCard } from "./overlay-usermap";
@@ -330,6 +331,10 @@ function tabContent(id: SettingsTabId): ReactNode {
 function ConnectionsTab() {
   return (
     <>
+      {/* The rule first, then the mailboxes that live under it: sharing is a
+          workspace posture every user works under, not a property of any one
+          connection below. */}
+      <MailSharingCard />
       <ConnectorsCard />
       <LinkedInImportCard />
       {/* No review queue here: a match a human must judge is a proposal, and


### PR DESCRIPTION
Product call by the PO, replacing the per-connect acknowledgment shipped in #1910 the same day: people connect during onboarding, and sharing captured mail is the point of a shared CRM — so the default is ON as a workspace setting, and switching it off is the deliberate act, not switching it on.

**The setting**: `capture.mail_sharing` (settings mechanism, `capture_settings` object, default true, wire field `CaptureSettings.mail_sharing`). Switched OFF, every email captured **from then on** is born `audience='participants'` — held to the people on the message and the capturing mailbox owner. Already-captured mail keeps the audience it has: the setting moves the default, it rewrites no history. Non-mail kinds are untouched.

**The sink** reads the posture inside its own transaction via the new `settings.ApplyTx` — an explicitly-scoped ungated machinery reader, because a workspace posture must bind whoever the acting principal happens to be.

**The ceremony is gone**: no checkbox on any connect surface, no 422, `share_acknowledged` deprecated-and-ignored on the wire, `Registry.Connect` back to its old signature; `share_acknowledged_at` still stamps 'connected under this regime since'.

**The UI**: Settings → Connections opens with the **Email sharing** card — switch + **Save** button (never an instant toggle) + a danger callout whenever the switch shows off: *'DANGER: Switching off email sharing will make usage of the CRM difficult.'* Every role sees the posture; only admin/ops saves it. de/en/vi.

**Proven on real Postgres**: default → captured email workspace-readable; admin switches off through the real store → the next email is born participants-only and the first keeps its audience.

Verified: `make check-backend` and `make check-fe` green; capture module + compose/integration/capture lanes green under a private template; full vitest (3531) green; craft static clean; rls-store-path and no-jurisdiction OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make mail sharing a workspace setting (`capture.mail_sharing`), ON by default, instead of a per-connect acknowledgment. Previously connects required `share_acknowledged` and defaulted captured email to workspace-visible; now the setting governs the default and connects need no checkbox. When OFF, only newly captured emails are born `audience='participants'`; existing mail keeps its audience.

- API/contract:
  - Add `mail_sharing` to `CaptureSettings` and `UpdateCaptureSettingsRequest`.
  - Deprecate `ConnectConnectorRequest.share_acknowledged` (accepted and ignored); 422 refusal removed.
- Backend behavior:
  - `Registry.Connect` drops the acknowledgment parameter and still stamps `share_acknowledged_at` as “connected under this regime since.”
  - The capture sink computes audience at insert using `settings.ApplyTx`; email respects `mail_sharing`, non-mail kinds unchanged.
- UI:
  - Settings → Connections adds an Email sharing card: switch + Save, with a danger callout when OFF. Every role reads; only admin/ops updates. Copy in `en`/`de`/`vi`.
  - All connect surfaces remove the sharing checkbox; IMAP and OAuth flows post without it.
- Required changes:
  - Update internal callers to `Registry.Connect(ctx, name, auth)` (remove the bool).
  - Clients can stop sending `share_acknowledged`; if sent, it is ignored.
  - No data migration: turning sharing OFF affects only future captured mail.

<sup>Written for commit 233709f492f15f8d099c3a9ca38bec2f83691c09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-level email-sharing settings with a default of shared access.
  * Users can disable sharing so newly captured emails are visible only to participants; existing emails remain unchanged.
  * Added localized settings guidance in English, German, and Vietnamese.
* **Changes**
  * Removed the required sharing acknowledgment step from OAuth, IMAP, and onboarding connection flows.
  * Existing per-connection acknowledgment fields are deprecated and ignored.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->