### PR TITLE
refactor(search): the derived corpus drops its tenant column

### DIFF
--- a/backend/internal/compose/integration/binding_integration_test.go
+++ b/backend/internal/compose/integration/binding_integration_test.go
@@ -65,9 +65,9 @@ func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
 	// entity has an embedding row, just not a current one, so it must
 	// still count as pending (the swap case, distinct from "no row at all").
 	if _, err := e.Owner.Exec(ctx, `
-		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-		VALUES ($1, 'person', $2, 0, 'stale-hash', 'fake/old@1024', '[1,2,3]'::vector)`,
-		e.WS, personID); err != nil {
+		INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+		VALUES ('person', $1, 0, 'stale-hash', 'fake/old@1024', '[1,2,3]'::vector)`,
+		personID); err != nil {
 		t.Fatalf("seeding the stale-identity row: %v", err)
 	}
 
@@ -329,9 +329,9 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	// Already covered at the current identity: must not count as pending.
 	coveredID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Already Covered', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
-		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-		VALUES ($1, 'person', $2, 0, 'covered-hash', $3, '[1,2,3]'::vector)`,
-		e.WS, coveredID, identity); err != nil {
+		INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+		VALUES ('person', $1, 0, 'covered-hash', $2, '[1,2,3]'::vector)`,
+		coveredID, identity); err != nil {
 		t.Fatalf("seeding the already-covered row: %v", err)
 	}
 

--- a/backend/internal/compose/integration/embedding_integration_test.go
+++ b/backend/internal/compose/integration/embedding_integration_test.go
@@ -385,15 +385,15 @@ func TestSimilarEntitiesFiltersIdentityAndDoesNotCrossDimCrash(t *testing.T) {
 	// Task 6's migration made possible, and Task 7's read-side filter
 	// must survive.
 	if _, err := e.Owner.Exec(ctx, `
-		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-		VALUES ($1, 'person', $2, 0, 'hash-three', 'm@3', '[1,2,3]'::vector)`,
-		e.WS, threeDim); err != nil {
+		INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+		VALUES ('person', $1, 0, 'hash-three', 'm@3', '[1,2,3]'::vector)`,
+		threeDim); err != nil {
 		t.Fatalf("seeding the 3-dim row: %v", err)
 	}
 	if _, err := e.Owner.Exec(ctx, `
-		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-		VALUES ($1, 'person', $2, 0, 'hash-two', 'm@2', '[1,2]'::vector)`,
-		e.WS, twoDim); err != nil {
+		INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+		VALUES ('person', $1, 0, 'hash-two', 'm@2', '[1,2]'::vector)`,
+		twoDim); err != nil {
 		t.Fatalf("seeding the 2-dim row: %v", err)
 	}
 

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -165,9 +165,9 @@ func seedStaleEmbeddingRow(t *testing.T, e *apptest.AppEnv, wsID string) {
 		t.Fatalf("seeding the stale-row person: %v", err)
 	}
 	if _, err := e.Owner.Exec(ctx, `
-		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-		VALUES ($1, 'person', $2, 0, 'stale-hash', 'fake/stale-identity@1024', '[1,2,3]'::vector)`,
-		wsID, personID); err != nil {
+		INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+		VALUES ('person', $1, 0, 'stale-hash', 'fake/stale-identity@1024', '[1,2,3]'::vector)`,
+		personID); err != nil {
 		t.Fatalf("seeding the stale embedding row: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/erasure_integration_test.go
+++ b/backend/internal/compose/integration/erasure_integration_test.go
@@ -48,7 +48,6 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 	personID := ids.NewV7()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		ctx := context.Background()
-		wsClause := `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO person (id, full_name, first_name, title, source, captured_by)
 			 VALUES ($1, 'Selma Subject', 'Selma', 'CFO', 'manual', 'human:x')`, personID); err != nil {
@@ -88,8 +87,8 @@ func seedSubject(t *testing.T, e *Env) ids.UUID {
 		// model filter; a mixed-width store must still erase fully).
 		vector := "[" + strings.TrimSuffix(strings.Repeat("0.1,", 1023), ",") + ",0.1]"
 		_, err := tx.Exec(ctx,
-			`INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-			 VALUES (`+wsClause+`, 'person', $1, 0, 'h', 'gemini/gemini-embedding-001@1024', $2::vector)`, personID, vector)
+			`INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+			 VALUES ('person', $1, 0, 'h', 'gemini/gemini-embedding-001@1024', $2::vector)`, personID, vector)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -482,9 +482,9 @@ func TestOrganization360ContactRoutesSeparateUntriedFromCold(t *testing.T) {
 	// One colleague has a real two-way exchange with the first contact. The
 	// second has none at all, which is the state under test.
 	e.WsExec(t, `INSERT INTO graph_interaction_edge
-			(workspace_id, user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
-		VALUES ($1, $2, $3, $4, 20, 10, 10)`,
-		e.WS, e.Rep1, reached, org360Clock.Add(-24*time.Hour))
+			(user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
+		VALUES ($1, $2, $3, 20, 10, 10)`,
+		e.Rep1, reached, org360Clock.Add(-24*time.Hour))
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -539,9 +539,9 @@ func TestOrganization360ContactRoutesNameThreeAndCountTheRest(t *testing.T) {
 			VALUES ($1, $2, $3, $4, 'active')`,
 			user, e.WS, fmt.Sprintf("colleague%d@acme.test", i), fmt.Sprintf("Colleague %d", i))
 		e.WsExec(t, `INSERT INTO graph_interaction_edge
-				(workspace_id, user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
-			VALUES ($1, $2, $3, $4, $5, $6, $6)`,
-			e.WS, user, contact, org360Clock.Add(-24*time.Hour), (i+1)*2, i+1)
+				(user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
+			VALUES ($1, $2, $3, $4, $5, $5)`,
+			user, contact, org360Clock.Add(-24*time.Hour), (i+1)*2, i+1)
 	}
 
 	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
@@ -585,9 +585,9 @@ func TestOrganization360OmitsRoutesWithoutTheActivityGrant(t *testing.T) {
 	e.WsExec(t, `INSERT INTO relationship (kind, person_id, organization_id, source, captured_by)
 		VALUES ('employment', $1, $2, 'manual', 'human:x')`, person, org)
 	e.WsExec(t, `INSERT INTO graph_interaction_edge
-			(workspace_id, user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
-		VALUES ($1, $2, $3, $4, 20, 10, 10)`,
-		e.WS, e.Rep1, person, org360Clock.Add(-24*time.Hour))
+			(user_id, person_id, last_at, count_90d, in_count_90d, out_count_90d)
+		VALUES ($1, $2, $3, 20, 10, 10)`,
+		e.Rep1, person, org360Clock.Add(-24*time.Hour))
 
 	// With the grant, the route is there — otherwise the case below could pass
 	// because the fixture produced no route at all.

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -198,9 +198,9 @@ func TestReembedIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
 	}
 	personID := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Drift Person', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
-		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-		VALUES ($1, 'person', $2, 0, 'stale-hash', $3, '[1,2,3]'::vector)`,
-		e.WS, personID, staleRowIdentity); err != nil {
+		INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+		VALUES ('person', $1, 0, 'stale-hash', $2, '[1,2,3]'::vector)`,
+		personID, staleRowIdentity); err != nil {
 		t.Fatalf("seeding the stale-identity row: %v", err)
 	}
 

--- a/backend/internal/compose/networktools_integration_test.go
+++ b/backend/internal/compose/networktools_integration_test.go
@@ -40,11 +40,6 @@ func employAt(t *testing.T, e *integration.Env, person, org ids.UUID) {
 	}, "recording employment")
 }
 
-// wsGUC is the workspace the RLS GUC already binds. Every seed here writes
-// through WithWorkspaceTx for that reason: a raw pool exec has no GUC and the
-// policy refuses it.
-const wsGUC = `NULLIF(current_setting('app.workspace_id', true), '')::uuid`
-
 // seedAsAdmin runs one fixture write inside a workspace-bound transaction.
 func seedAsAdmin(t *testing.T, e *integration.Env, fn func(context.Context, pgx.Tx) error, what string) {
 	t.Helper()
@@ -173,9 +168,9 @@ func seedInteractionEdge(t *testing.T, e *integration.Env, user, person ids.UUID
 	seedAsAdmin(t, e, func(ctx context.Context, tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO graph_interaction_edge
-			    (workspace_id, user_id, person_id, last_at, count_90d, in_count_90d,
+			    (user_id, person_id, last_at, count_90d, in_count_90d,
 			     out_count_90d, count_total, computed_at)
-			VALUES (`+wsGUC+`, $1, $2, now(), 6, 3, 3, 6, now())`, user, person)
+			VALUES ($1, $2, now(), 6, 3, 3, 6, now())`, user, person)
 		return err
 	}, "seeding the interaction edge")
 }

--- a/backend/internal/modules/search/embedding.go
+++ b/backend/internal/modules/search/embedding.go
@@ -114,8 +114,8 @@ func (s *Store) UpsertEmbedding(ctx context.Context, entityType string, entityID
 		// restriction commits before this statement runs or it does not; either
 		// way this statement sees the row as it is now.
 		tag, err := tx.Exec(ctx, `
-			INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
-			SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 0, $3, $4, $5::vector
+			INSERT INTO embedding (entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
+			SELECT $1, $2, 0, $3, $4, $5::vector
 			 WHERE NOT EXISTS (SELECT 1 FROM activity a WHERE $1 = 'activity' AND a.id = $2 AND a.restricted_at IS NOT NULL)
 			ON CONFLICT (entity_type, entity_id, chunk_ix)
 			DO UPDATE SET chunk_hash = EXCLUDED.chunk_hash, model = EXCLUDED.model,

--- a/backend/internal/modules/search/graphedge.go
+++ b/backend/internal/modules/search/graphedge.go
@@ -230,10 +230,9 @@ func recomputePairs(ctx context.Context, tx pgx.Tx, pairs []pair) error {
 		     GROUP BY t.user_id, t.person_id
 		)
 		INSERT INTO graph_interaction_edge AS e
-		    (workspace_id, user_id, person_id, last_at, last_inbound_at, last_outbound_at,
+		    (user_id, person_id, last_at, last_inbound_at, last_outbound_at,
 		     count_90d, in_count_90d, out_count_90d, count_total, computed_at)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		       f.user_id, f.person_id, f.last_at, f.last_inbound_at, f.last_outbound_at,
+		SELECT f.user_id, f.person_id, f.last_at, f.last_inbound_at, f.last_outbound_at,
 		       f.count_90d, f.in_90d, f.out_90d, f.count_total, now()
 		  FROM folded f
 		ON CONFLICT (user_id, person_id) DO UPDATE SET
@@ -412,10 +411,9 @@ func RebuildEdges(ctx context.Context, tx pgx.Tx) error {
 	}
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO graph_interaction_edge
-		    (workspace_id, user_id, person_id, last_at, last_inbound_at, last_outbound_at,
+		    (user_id, person_id, last_at, last_inbound_at, last_outbound_at,
 		     count_90d, in_count_90d, out_count_90d, count_total, computed_at)
-		SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		       up.user_id, pp.person_id,
+		SELECT up.user_id, pp.person_id,
 		       max(a.occurred_at),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),

--- a/backend/migrations/core/1787213222_embedding_drops_the_tenant_column.down.sql
+++ b/backend/migrations/core/1787213222_embedding_drops_the_tenant_column.down.sql
@@ -1,0 +1,34 @@
+-- Reverse of the phase D drop on embedding and graph_interaction_edge.
+--
+-- The column comes back bound to the installation's OWN workspace, which is the
+-- only workspace a single-organization installation has (ADR-0061). It is not a
+-- reconstruction of what each row used to hold: the records these two tables
+-- derive from lost their workspace in earlier slices, so there is no per-row
+-- fact left to read one from. Restoring the shape is what a down migration owes
+-- here; restoring a value nothing records would be inventing one.
+--
+-- An installation whose workspace table is empty has no corpus either — both
+-- tables derive from records — so the subquery is only reached with a row to
+-- find.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE embedding ADD COLUMN workspace_id uuid;
+UPDATE embedding SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+ALTER TABLE embedding
+  ALTER COLUMN workspace_id SET NOT NULL,
+  ADD CONSTRAINT embedding_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE graph_interaction_edge ADD COLUMN workspace_id uuid;
+UPDATE graph_interaction_edge SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+ALTER TABLE graph_interaction_edge
+  ALTER COLUMN workspace_id SET NOT NULL,
+  ADD CONSTRAINT graph_interaction_edge_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_graph_edge_person_wide ON graph_interaction_edge (workspace_id, person_id, last_at DESC);
+CREATE INDEX idx_graph_edge_user_wide   ON graph_interaction_edge (workspace_id, user_id, last_at DESC);
+DROP INDEX idx_graph_edge_person;
+DROP INDEX idx_graph_edge_user;
+ALTER INDEX idx_graph_edge_person_wide RENAME TO idx_graph_edge_person;
+ALTER INDEX idx_graph_edge_user_wide   RENAME TO idx_graph_edge_user;

--- a/backend/migrations/core/1787213222_embedding_drops_the_tenant_column.up.sql
+++ b/backend/migrations/core/1787213222_embedding_drops_the_tenant_column.up.sql
@@ -1,0 +1,30 @@
+-- ADR-0091 §8 phase D: the derived corpus drops its tenant column.
+--
+-- embedding and graph_interaction_edge are both DERIVED from records that no
+-- longer carry a workspace. Every entity an embedding covers lost the column in
+-- an earlier slice, and a graph edge is folded from activities that did too, so
+-- the value on these two rows was a copy of a fact its source no longer states.
+--
+-- These were the last two tables waiting on the re-embed fan-out: a pass used
+-- to be scoped per workspace, and the run tracked which ones it still owed. One
+-- pass rebuilds the whole corpus now, so nothing reads the column at all.
+--
+-- SET LOCAL lock_timeout: each ALTER takes an ACCESS EXCLUSIVE lock, and an
+-- unbounded wait would queue behind one open transaction for as long as it
+-- lives — on embedding, behind any reindex in flight.
+SET LOCAL lock_timeout = '3s';
+
+-- The two edge indexes lead with the column, so they must be replaced rather
+-- than left to fall with it: DROP COLUMN drops a multi-column index outright,
+-- and the person and user lookups the graph is read by would go with it. Built
+-- first, so no read is served without one.
+CREATE INDEX idx_graph_edge_person_narrow ON graph_interaction_edge (person_id, last_at DESC);
+CREATE INDEX idx_graph_edge_user_narrow   ON graph_interaction_edge (user_id, last_at DESC);
+DROP INDEX idx_graph_edge_person;
+DROP INDEX idx_graph_edge_user;
+ALTER INDEX idx_graph_edge_person_narrow RENAME TO idx_graph_edge_person;
+ALTER INDEX idx_graph_edge_user_narrow   RENAME TO idx_graph_edge_user;
+
+-- The workspace foreign key on each table falls with the column.
+ALTER TABLE embedding DROP COLUMN workspace_id;
+ALTER TABLE graph_interaction_edge DROP COLUMN workspace_id;


### PR DESCRIPTION
ADR-0091 §8 phase D — the two tables that were waiting on the re-embed fan-out
(#1941). **8 remaining tables become 6**, counted from the migrated schema:
`app_user`, `audit_log`, `role`, `role_assignment`, `session`, `system_log`.

## Why these two were safe to drop

`embedding` and `graph_interaction_edge` are both **derived**. Every entity an
embedding covers lost its workspace in an earlier slice, and a graph edge is
folded from activities that did too — so the value on these rows was a copy of
a fact its source no longer states. #1941 collapsed the fan-out (one pass
rebuilds the whole corpus, nothing scopes it), so nothing reads the column.

Checked before writing: **no custom migration names either column.** That is
the ordering finding STATUS.md carries — `custom` runs after all of `core`, so
a custom migration naming a core column must survive that column being dropped.

## The index detail

The two edge indexes **lead with the column**, so they are replaced rather than
left to fall with it: `DROP COLUMN` drops a multi-column index outright, and
the person and user lookups the graph is read by would go with it. The narrow
pair is built before the wide pair is dropped, so no read is served without one.

## What changed

- Three writers stop naming it: the embedding upsert, and both graph-edge folds
  (incremental and full rebuild).
- The fixtures that hand-seeded a corpus follow. Two GUC-clause constants in
  those fixtures had no other user and went with the column.
- The down half restores the shape bound to the installation's own workspace
  (ADR-0061), **not** a per-row reconstruction — the source records lost their
  workspace in earlier slices, so there is no fact left to read one from, and
  inventing one would be worse than restoring the shape.

## Verification

- `make check-backend` — green
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` — green
- `make migration-versions` — green
- migration lane exercises apply → reverse → reapply against a real database
- remaining `workspace_id` columns verified by querying `pg_attribute` on the
  migrated schema, not by counting this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the tenant column from the derived corpus. embedding and graph_interaction_edge no longer store workspace_id. Previously both tables copied workspace_id and indexes led with it; now the column is removed, indexes key on person/user and last_at, and writers stop naming the column. This removes a stale copy of a fact upstream no longer records and matches the re-embed run that is no longer workspace-scoped.

- Migration and rollout
  - Replace the two edge indexes with person/user-first variants, then drop the workspace-led pair; drop workspace_id and its FKs on both tables.
  - Update writers: the embedding upsert and both graph-edge folds (incremental and full rebuild) no longer pass workspace_id.
  - Update tests/fixtures to seed without workspace_id; remove unused RLS GUC constants tied to that column.
  - Down migration restores workspace_id set to the installation’s workspace and recreates the wide indexes and FKs.
  - Action: run core migrations before deploying; remove any custom SQL that references embedding.workspace_id or graph_interaction_edge.workspace_id.

<sup>Written for commit 80e2c078b9f5c14d578eabb6fc6b65d5c3cfb5f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

