### PR TITLE
feat(contract): a picklist filter clause picks its value instead of typing it

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -245,8 +245,15 @@ deps:
     # generated routing schema, because "what the editor accepts" and "what
     # boots" is one claim and only the root package may hold both halves —
     # the ai module itself must not gain a JSON Schema dependency for it.
+    # corepicklistcontract_test.go asks collections' SegmentEngine what
+    # values each core picklist offers and holds them to the enums in
+    # api/crm.yaml — the same "only root may hold both halves" shape, and
+    # for the same reason: collections must not gain a YAML dependency to
+    # check a document it does not own. It reads the engine through
+    # storekit's own Field type rather than restating "picklist" as a bare
+    # string, which is the platform edge below.
     # Root carries test files only, so this grants no production edge.
-    mayDependOn: [contracts, compose, ai]
+    mayDependOn: [contracts, compose, ai, collections, platform]
     canUse: [yaml, jsonschema]
   cmd:
     mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, integrations, agreements, commissions, contracts, platform, migrations]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -21237,6 +21237,19 @@ components:
             may set. A retired one is absent here and still accepted by the
             engine, so no `status` lookup is needed to know whether to offer a
             field: if this operation listed it, it is offerable.
+        options:
+          type: array
+          items: { type: string }
+          description: |
+            A picklist field's allowed values, present (non-empty) when
+            `type=picklist` and absent otherwise. Offer these rather than a text
+            box: a value outside the set compiles and matches nothing, so a typo
+            reads as a settled answer instead of a mistake.
+
+            For a workspace-defined field these are the catalog's own `options`
+            for the same column. For a core field they are the values the
+            contract enumerates, minus null — a null in one of those enums is the
+            column's nullability, and `exists` is how a filter asks about that.
         references:
           type: string
           enum: [tag, app_user, team, organization, pipeline, stage, project]

--- a/backend/catalogoptionsreaders_test.go
+++ b/backend/catalogoptionsreaders_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Who may read a custom field's OPTIONS.
+//
+// fieldcatalog.Column carries three things with two different disclosure rules
+// (the port's own doc states them): Name and Type are schema, ambient to any
+// caller who may read a record carrying the column, while Options is catalogue
+// CONTENT — the values an admin authored — and a consumer handing them to a
+// caller needs `custom_field:read`.
+//
+// A Column cannot enforce that. It holds no context, so the obligation lands on
+// each consumer, and an obligation spread across consumers is one a new consumer
+// meets by not knowing about it. That is how this arrived: the filter vocabulary
+// began reporting options and disclosed them to any principal with `list:read`
+// for two pushes before a review noticed.
+//
+// So this gate does exactly one thing, and it is worth saying what it is NOT.
+// It does NOT verify that a reader checks the grant — a fitness function can see
+// which package reads a field, never whether the grant it checked governs the
+// value it returned. What it does is make a new reader VISIBLE: adding one fails
+// here, and the fix is to add the package below, which is a line away from the
+// rule in the port's doc. A gate that claimed the stronger thing would be a name
+// promising more than its body, which is worse than this.
+//
+// Derived structurally rather than by name, in the shape jobregistrationban_test
+// uses: a file cannot hold a Column without importing the port, so the readers
+// are the files that import it AND select `.Options`. The one blind spot is a
+// file that imports the port and separately selects `.Options` on some other
+// type — it would be reported as a reader it is not. That is a false positive
+// resolved by the same edit as a true one, and the alternative is type-checking
+// the whole module to sharpen a two-entry list.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The port whose Column type this is about. Only this module can import it —
+// it is internal, and each extension is its own module — so the walk is
+// backend/ alone rather than the license gate's three trees.
+const fieldcatalogPort = "github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
+
+// gatekit:fixture the reader set this gate asserts, not a waived cost — a
+// package listed here is claimed to gate the read, and an entry no file reaches
+// is reported stale below rather than quietly ratifying nothing.
+//
+// The packages that may read Options, each for a stated reason. Adding one is
+// the point of the gate, not a workaround for it: state why the values reach a
+// caller and which grant that caller had to hold.
+var catalogOptionsReaders = map[string]string{
+	// Owns the column. It writes the jsonb (marshalOptions) and reads it back
+	// (unmarshalOptions), and its own list surface is `custom_field:read`.
+	"internal/modules/customfields": "the catalogue itself",
+	// Reports a picklist's values so a builder can offer them, and gates that
+	// half on `custom_field:read` (customPicklistValuesAreReadable).
+	"internal/modules/collections": "the filter vocabulary",
+}
+
+func TestOnlyTheDeclaredPackagesReadACustomFieldsOptions(t *testing.T) {
+	found := map[string]bool{}
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// path != "." because the root's own name is dotted and skipping it
+			// would take the whole tree, reporting nothing for the most
+			// reassuring possible reason.
+			if path != "." && skipOptionsReaderDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_gen.go") {
+			return nil
+		}
+		if readsCatalogOptions(t, path) {
+			found[filepath.ToSlash(filepath.Dir(path))] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module: %v", err)
+	}
+
+	if len(found) == 0 {
+		t.Fatal("no reader of Column.Options found anywhere, so this gate has stopped reading the code it derives from")
+	}
+	for pkg := range found {
+		if _, declared := catalogOptionsReaders[pkg]; !declared {
+			t.Errorf("%s reads a custom field's Options and is not declared as a reader. Those values are catalogue CONTENT, not schema: a caller may only be told them if they hold custom_field:read (see the disclosure rule on fieldcatalog.Column). If this package gates that read, add it to catalogOptionsReaders with the reason; if it does not, gate it first.", pkg)
+		}
+	}
+	for pkg, why := range catalogOptionsReaders {
+		if !found[pkg] {
+			t.Errorf("catalogOptionsReaders declares %s (%s) and it no longer reads Options — a stale entry makes this gate quietly permissive for whoever inherits the name", pkg, why)
+		}
+	}
+}
+
+// readsCatalogOptions answers whether one file both imports the port and selects
+// `.Options`. Both halves are needed: the import is what makes a Column
+// reachable, and the selector is the read.
+func readsCatalogOptions(t *testing.T, path string) bool {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	imported := false
+	for _, spec := range file.Imports {
+		if strings.Trim(spec.Path.Value, `"`) == fieldcatalogPort {
+			imported = true
+			break
+		}
+	}
+	if !imported {
+		return false
+	}
+	reads := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if selector, ok := n.(*ast.SelectorExpr); ok && selector.Sel.Name == "Options" {
+			reads = true
+		}
+		return !reads
+	})
+	return reads
+}
+
+func skipOptionsReaderDir(name string) bool {
+	return name == "node_modules" || name == "build" || name == "testdata" ||
+		strings.HasPrefix(name, ".")
+}

--- a/backend/corepicklistcontract_test.go
+++ b/backend/corepicklistcontract_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The core picklist value sets against the contract that owns them.
+//
+// A filter builder offers a picklist's values instead of asking a reader to type
+// one, and the sets it offers are declared beside the engine (collections'
+// vocab.go) while the contract enumerates them in api/crm.yaml. Drift between the
+// two is silent and runs both ways: a value the contract dropped stays on offer
+// and selects nothing, and a value it gained is one no builder shows — which is
+// the free-text failure the whole surface exists to remove, arriving one enum
+// member at a time.
+//
+// Here rather than in the module, for the reason the root's other contract gates
+// carry: this walks the authoritative 3.1 document rather than the generated Go,
+// so a contract-only edit cannot slip past it, and collections does not take a
+// YAML dependency to hold a claim about a document it does not own.
+//
+// Reading the document also lets the null be dropped deliberately. oapi-codegen
+// emits a `<nil>` member for a nullable enum (OrganizationSizeBandLessThannil is
+// real), so a set derived from the generated constants would carry a value no
+// human should be offered; a null in the contract is the COLUMN's nullability,
+// and `exists: false` is how a filter asks for empty.
+//
+// The COMPLETENESS half — that every core picklist offers values at all, that a
+// retired one offers none, and that no offered value is empty or `<nil>` — is
+// collections' own TestEveryCorePicklistOffersItsValues. This holds the sets it
+// finds to the document, which is why an empty set is skipped here rather than
+// asserted twice.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gradionhq/margince/backend/internal/modules/collections"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+)
+
+// contractDocument is the OpenAPI document these sets mirror.
+const contractDocument = "api/crm.yaml"
+
+// Where each offered set lives in the contract, keyed `<resource>.<field>`.
+//
+// The property is named separately from the field because the two can differ: an
+// account's relationship is `relationship_types` on the schema (an account may
+// hold several) and `relationship_type` as a filter leaf, which selects accounts
+// that hold AT LEAST the named one.
+//
+// A picklist with no entry here FAILS rather than being skipped, so a core
+// picklist added tomorrow is covered the day it lands — by forcing whoever adds
+// it to say where the contract admits its values.
+var picklistInContract = map[string]struct{ schema, property string }{
+	"organization.lifecycle":         {"Organization", "lifecycle"},
+	"organization.size_band":         {"Organization", "size_band"},
+	"organization.relationship_type": {"Organization", "relationship_types"},
+	"deal.status":                    {"Deal", "status"},
+	"deal.forecast_category":         {"Deal", "forecast_category"},
+	"lead.status":                    {"Lead", "status"},
+	"project.phase":                  {"Project", "phase"},
+	// A deal filters on its customer's account through a link leaf, so two of the
+	// sets above appear a second time under the deal engine. Both entries name the
+	// Organization property they reach, which is the point: a link leaf offering a
+	// different set from the field it reads is exactly the drift this catches.
+	"deal.organization_lifecycle": {"Organization", "lifecycle"},
+	"deal.organization_size_band": {"Organization", "size_band"},
+}
+
+func TestEveryOfferedPicklistMatchesTheContractsValues(t *testing.T) {
+	doc := loadContractDocument(t)
+	compared := 0
+	for _, resource := range vocabularyResources(t, doc) {
+		engine, ok, err := (&collections.Store{}).SegmentEngine(context.Background(), resource)
+		if err != nil {
+			t.Fatalf("segment engine for %s: %v", resource, err)
+		}
+		if !ok {
+			t.Errorf("the contract admits resource %q and no engine serves it", resource)
+			continue
+		}
+		for name, field := range engine.Fields {
+			if field.Type != storekit.FieldPicklist || len(field.Options) == 0 {
+				continue
+			}
+			where, declared := picklistInContract[resource+"."+name]
+			if !declared {
+				t.Errorf("%s.%s offers values and nothing says where the contract admits them, so nothing holds the two together", resource, name)
+				continue
+			}
+			compared++
+			compareValueSets(t, resource+"."+name, field.Options, contractEnum(t, doc, where.schema, where.property))
+		}
+	}
+	if compared == 0 {
+		t.Fatal("no picklist was compared, so this gate checked nothing")
+	}
+}
+
+// compareValueSets reports each direction separately, because the two failures
+// read nothing alike to whoever has to fix them.
+func compareValueSets(t *testing.T, field string, offered []string, admitted map[string]bool) {
+	t.Helper()
+	offers := map[string]bool{}
+	for _, value := range offered {
+		offers[value] = true
+		if !admitted[value] {
+			t.Errorf("%s offers %q and the contract does not admit it, so picking it composes a clause that selects nothing", field, value)
+		}
+	}
+	for value := range admitted {
+		if !offers[value] {
+			t.Errorf("%s: the contract admits %q and the field does not offer it, so a builder cannot compose a clause the engine accepts", field, value)
+		}
+	}
+	if len(admitted) == 0 {
+		t.Errorf("%s: the contract enum read as empty, so this compared nothing", field)
+	}
+}
+
+// vocabularyResources reads the resources GET /filters/vocabulary admits, so a
+// sixth one is swept by existing rather than by being added to a list here.
+func vocabularyResources(t *testing.T, doc map[string]any) []string {
+	t.Helper()
+	operation := descendContract(t, doc, "paths", "/filters/vocabulary", "get")
+	params, ok := operation["parameters"].([]any)
+	if !ok {
+		t.Fatal("GET /filters/vocabulary declares no parameters, so the resource set is unreadable")
+	}
+	for _, raw := range params {
+		param, isMap := raw.(map[string]any)
+		if !isMap || param["name"] != "resource" {
+			continue
+		}
+		schema, isMap := param["schema"].(map[string]any)
+		if !isMap {
+			t.Fatal("the resource parameter carries no schema")
+		}
+		return enumStrings(t, schema, "the resource parameter")
+	}
+	t.Fatal("GET /filters/vocabulary declares no resource parameter")
+	return nil
+}
+
+// contractEnum answers one property's enum, minus null.
+//
+// An array-typed property (relationship_types) keeps its enum on `items`, so both
+// spellings are read: the admitted values are the same set either way, and which
+// one a schema uses is not this gate's business.
+func contractEnum(t *testing.T, doc map[string]any, schema, property string) map[string]bool {
+	t.Helper()
+	node := descendContract(t, doc, "components", "schemas", schema, "properties", property)
+	if _, direct := node["enum"]; !direct {
+		items, isMap := node["items"].(map[string]any)
+		if !isMap {
+			t.Fatalf("%s.%s has neither an enum nor items to read one from", schema, property)
+		}
+		node = items
+	}
+	admitted := map[string]bool{}
+	for _, value := range enumStrings(t, node, schema+"."+property) {
+		admitted[value] = true
+	}
+	return admitted
+}
+
+// enumStrings reads a schema node's enum as strings. A null member is dropped —
+// it is the column's nullability, not a value to offer — and anything else
+// non-string is named rather than skipped, since it would be a contract shape
+// this gate cannot read.
+func enumStrings(t *testing.T, node map[string]any, subject string) []string {
+	t.Helper()
+	raw, ok := node["enum"].([]any)
+	if !ok {
+		t.Fatalf("%s carries no enum", subject)
+	}
+	var values []string
+	for _, member := range raw {
+		text, isText := member.(string)
+		if !isText {
+			if member != nil {
+				t.Errorf("%s enum carries a non-string member %#v", subject, member)
+			}
+			continue
+		}
+		values = append(values, text)
+	}
+	return values
+}
+
+func descendContract(t *testing.T, doc map[string]any, path ...string) map[string]any {
+	t.Helper()
+	node := doc
+	for _, key := range path {
+		next, ok := node[key].(map[string]any)
+		if !ok {
+			t.Fatalf("the contract has no %s under %v", key, path)
+		}
+		node = next
+	}
+	return node
+}
+
+func loadContractDocument(t *testing.T) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(contractDocument)
+	if err != nil {
+		t.Fatalf("reading %s: %v", contractDocument, err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing %s: %v", contractDocument, err)
+	}
+	return doc
+}

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 19
+	wantFixtureAnnotations = 20
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
+++ b/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
@@ -19,6 +19,7 @@ package collections
 
 import (
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
@@ -137,6 +138,10 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 			// string. A plain string would decode both as "" and the
 			// omitted-for-a-non-id-field guarantee would be unassertable.
 			References *string `json:"references,omitempty"`
+			// A pointer for the same reason: an absent key and an empty array are
+			// different answers, and only one of them is right for a field with no
+			// closed set.
+			Options *[]string `json:"options,omitempty"`
 		} `json:"fields"`
 	}
 	status := e.Call(t, "GET", "/v1/filters/vocabulary?resource=person", nil, nil, &vocab)
@@ -161,6 +166,17 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 			if f.Type != "picklist" {
 				t.Errorf("%s type = %q, want the picklist the admin created", column, f.Type)
 			}
+			// The values the admin authored, over the wire and through the real
+			// catalogue write — the one path that proves the jsonb column, the
+			// decode and the response mapping agree. A picklist that arrived
+			// without them is the whole defect: the builder falls back to a free
+			// text box over a closed set.
+			switch {
+			case f.Options == nil:
+				t.Errorf("%s is a picklist and the response carries no options key, so a builder can only ask a reader to type a value", column)
+			case !slices.Equal(*f.Options, []string{"gold", "silver"}):
+				t.Errorf("%s offers %v, want the two values the admin created", column, *f.Options)
+			}
 		case "owner_id":
 			if f.Custom {
 				t.Error("owner_id is a core field and is reported custom")
@@ -180,6 +196,12 @@ func TestTheFilterVocabularyOverHTTPOffersWhatADynamicListAccepts(t *testing.T) 
 		if f.Type != "id" && f.References != nil {
 			t.Errorf("%s is typed %s and the response carries references=%q; the key belongs only to an id field",
 				f.Name, f.Type, *f.References)
+		}
+		// Same shape for the closed set: only a picklist has one, so any other
+		// type carrying an options key promises a picker for a free-text column.
+		if f.Type != "picklist" && f.Options != nil {
+			t.Errorf("%s is typed %s and the response carries options=%v; only a picklist has a closed set",
+				f.Name, f.Type, *f.Options)
 		}
 		if len(f.Operators) == 0 {
 			t.Errorf("%s reports no operators, so a builder could offer no clause on it", f.Name)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15157,6 +15157,17 @@ type FilterVocabularyField struct {
 	// this field, so a builder can disable it rather than discover it.
 	Operators []FilterVocabularyFieldOperators `json:"operators"`
 
+	// Options A picklist field's allowed values, present (non-empty) when
+	// `type=picklist` and absent otherwise. Offer these rather than a text
+	// box: a value outside the set compiles and matches nothing, so a typo
+	// reads as a settled answer instead of a mistake.
+	//
+	// For a workspace-defined field these are the catalog's own `options`
+	// for the same column. For a core field they are the values the
+	// contract enumerates, minus null — a null in one of those enums is the
+	// column's nullability, and `exists` is how a filter asks about that.
+	Options *[]string `json:"options,omitempty"`
+
 	// References The record type this field's ids point at — present for every `id`
 	// field, absent for every other type. Offer the record rather than a
 	// box for its uuid.

--- a/backend/internal/modules/collections/filtervocabulary.go
+++ b/backend/internal/modules/collections/filtervocabulary.go
@@ -79,11 +79,26 @@ type VocabularyField struct {
 // Gated as a read of `list`, the object whose filters this vocabulary describes,
 // with no row-scope clause because it returns no record and no record's contents.
 //
-// The custom half carries a SECOND gate, `custom_field:read`, because that half
-// is the catalogue's data — see offerableCustomColumns. A seeded role holds both
-// grants, but role grants are editable one object at a time (setRoleObjectGrant),
-// so "the seed pairs them" is a fact about a fresh install rather than an
-// invariant, and this operation may not lean on it.
+// One thing here is NOT ambient, and the line runs between schema and content.
+// A cf_* column's NAME and TYPE are schema: the record surfaces already expose
+// them to anyone who may read a record, and a builder that could not see them
+// would offer a field the engine accepts, which is the divergence this whole seam
+// exists to prevent. A custom picklist's VALUES are different — an admin authored
+// them, they are the same content `GET /custom-fields` refuses, and they only
+// began travelling here when the vocabulary started carrying options at all.
+//
+// So the field is listed either way and its values need `custom_field:read`
+// (customPicklistValuesAreReadable). A reader without that grant keeps every
+// field they could filter on and falls back to typing the value, which is the
+// behaviour that stood before options travelled — never a lost capability.
+//
+// CORE options are unaffected: those are the contract's own enums, published in
+// api/crm.yaml, so no grant can be what protects them.
+//
+// The gate is asked rather than inferred from the seed. Every seeded role that
+// holds `list:read` also holds `custom_field:read`, but role grants are edited
+// one object at a time (setRoleObjectGrant), so seed pairing is a fact about a
+// fresh install and not an invariant this operation may lean on.
 func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]VocabularyField, bool, error) {
 	if err := auth.Require(ctx, "list", principal.ActionRead); err != nil {
 		return nil, false, err
@@ -96,6 +111,10 @@ func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]Vocabu
 		return nil, false, nil
 	}
 	offerable, err := s.offerableCustomColumns(ctx, resource)
+	if err != nil {
+		return nil, false, err
+	}
+	valuesReadable, err := customPicklistValuesAreReadable(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -114,19 +133,44 @@ func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]Vocabu
 		if !isCore && !offerable[name] {
 			continue
 		}
+		options := field.Options
+		if !isCore && !valuesReadable {
+			options = nil
+		}
 		fields = append(fields, VocabularyField{
 			Name:       name,
 			Type:       string(field.Type),
 			Operators:  storekit.OperatorsFor(field),
 			Custom:     !isCore,
 			References: field.References,
-			Options:    field.Options,
+			Options:    options,
 		})
 	}
 	// By name, because a map answers a different order every call and a picker
 	// whose fields reshuffle between two identical requests reads as broken.
 	sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
 	return fields, true, nil
+}
+
+// customPicklistValuesAreReadable answers whether this caller may be told the
+// values an admin authored for a custom picklist — the catalogue's own content,
+// governed by the catalogue's own grant, exactly as `GET /custom-fields` governs
+// it.
+//
+// A refusal is an ANSWER here, not a failure: the field is still listed and the
+// builder still composes clauses on it, so a missing grant narrows what the
+// response says rather than whether it succeeds. Any other error is the caller's
+// to see, which is why only the denial is folded into false.
+func customPicklistValuesAreReadable(ctx context.Context) (bool, error) {
+	err := auth.Require(ctx, "custom_field", principal.ActionRead)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return false, nil
+	default:
+		return false, err
+	}
 }
 
 // offerableCustomColumns answers which cf_* columns a new clause may name — the
@@ -143,23 +187,6 @@ func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]Vocabu
 func (s *Store) offerableCustomColumns(ctx context.Context, resource string) (map[string]bool, error) {
 	if s.catalog == nil {
 		return map[string]bool{}, nil
-	}
-	// The catalogue's own grant governs the catalogue's own data, here as on the
-	// surface that owns it. What this vocabulary reports for a custom field is a
-	// column name, a type and — since it began carrying them — the VALUES an admin
-	// authored, which is the same content `GET /custom-fields` refuses without
-	// this grant.
-	//
-	// Withheld as a whole field rather than as a blanked options list, which keeps
-	// the documented subset relation true: everything this operation lists is
-	// something the engine accepts. The engine still ACCEPTS a saved filter naming
-	// a custom field, because retirement and authority are different questions —
-	// only the OFFER is withheld.
-	if err := auth.Require(ctx, "custom_field", principal.ActionRead); err != nil {
-		if errors.Is(err, apperrors.ErrPermissionDenied) {
-			return map[string]bool{}, nil
-		}
-		return nil, err
 	}
 	active, err := s.catalog.ActiveColumns(ctx, resource)
 	if err != nil {

--- a/backend/internal/modules/collections/filtervocabulary.go
+++ b/backend/internal/modules/collections/filtervocabulary.go
@@ -38,12 +38,15 @@ package collections
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -75,11 +78,12 @@ type VocabularyField struct {
 //
 // Gated as a read of `list`, the object whose filters this vocabulary describes,
 // with no row-scope clause because it returns no record and no record's contents.
-// The workspace-private part of the answer is which cf_* columns exist, and that
-// is already ambient to every principal reachable here: every seeded role holding
-// `list:read` also holds `custom_field:read` (core migrations 0064, 0183, 0268),
-// and the catalogue read that grant governs returns strictly more — labels,
-// slugs, status, and the retired rows this operation omits.
+//
+// The custom half carries a SECOND gate, `custom_field:read`, because that half
+// is the catalogue's data — see offerableCustomColumns. A seeded role holds both
+// grants, but role grants are editable one object at a time (setRoleObjectGrant),
+// so "the seed pairs them" is a fact about a fresh install rather than an
+// invariant, and this operation may not lean on it.
 func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]VocabularyField, bool, error) {
 	if err := auth.Require(ctx, "list", principal.ActionRead); err != nil {
 		return nil, false, err
@@ -140,6 +144,23 @@ func (s *Store) offerableCustomColumns(ctx context.Context, resource string) (ma
 	if s.catalog == nil {
 		return map[string]bool{}, nil
 	}
+	// The catalogue's own grant governs the catalogue's own data, here as on the
+	// surface that owns it. What this vocabulary reports for a custom field is a
+	// column name, a type and — since it began carrying them — the VALUES an admin
+	// authored, which is the same content `GET /custom-fields` refuses without
+	// this grant.
+	//
+	// Withheld as a whole field rather than as a blanked options list, which keeps
+	// the documented subset relation true: everything this operation lists is
+	// something the engine accepts. The engine still ACCEPTS a saved filter naming
+	// a custom field, because retirement and authority are different questions —
+	// only the OFFER is withheld.
+	if err := auth.Require(ctx, "custom_field", principal.ActionRead); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return map[string]bool{}, nil
+		}
+		return nil, err
+	}
 	active, err := s.catalog.ActiveColumns(ctx, resource)
 	if err != nil {
 		return nil, fmt.Errorf("read the active custom-field columns for %s: %w", resource, err)
@@ -166,10 +187,10 @@ func wireVocabularyField(f VocabularyField) crmcontracts.FilterVocabularyField {
 		operators = append(operators, crmcontracts.FilterVocabularyFieldOperators(op))
 	}
 	wire := crmcontracts.FilterVocabularyField{
-		Options:   optionsOrNil(f.Options),
 		Name:      f.Name,
 		Type:      crmcontracts.FilterVocabularyFieldType(f.Type),
 		Operators: operators,
+		Options:   optionsOrNil(f.Options),
 		Custom:    f.Custom,
 	}
 	// Omitted rather than sent empty for a field that references nothing, because
@@ -186,9 +207,16 @@ func wireVocabularyField(f VocabularyField) crmcontracts.FilterVocabularyField {
 // optionsOrNil answers nil for a field with no closed set, so the key is absent
 // rather than an empty array. An empty array would say "this picklist admits
 // nothing", which is a different and false statement.
+//
+// A COPY, because a core field's set is a package-level var shared by every
+// request: handing out a pointer into it lets one consumer that sorts or rewrites
+// the slice change what every later caller is told. Its neighbour in this literal
+// already builds a fresh slice per call for the same reason, and being the one
+// member that does not would be the inconsistency somebody eventually trips on.
 func optionsOrNil(options []string) *[]string {
 	if len(options) == 0 {
 		return nil
 	}
-	return &options
+	own := slices.Clone(options)
+	return &own
 }

--- a/backend/internal/modules/collections/filtervocabulary.go
+++ b/backend/internal/modules/collections/filtervocabulary.go
@@ -80,10 +80,21 @@ type VocabularyField struct {
 // with no row-scope clause because it returns no record and no record's contents.
 //
 // One thing here is NOT ambient, and the line runs between schema and content.
-// A cf_* column's NAME and TYPE are schema: the record surfaces already expose
-// them to anyone who may read a record, and a builder that could not see them
-// would offer a field the engine accepts, which is the divergence this whole seam
-// exists to prevent. A custom picklist's VALUES are different — an admin authored
+//
+// A cf_* column's NAME and TYPE are schema, and the reason they are ambient is
+// the EQUIVALENCE this seam exists for, not a claim about other surfaces: a
+// builder composes from what this operation lists, so a field withheld here is
+// one the engine accepts and no human can name. That makes the vocabulary wrong
+// about the product rather than merely quiet.
+//
+// It is worth being exact about what that buys, because the looser argument is
+// tempting and false. Record payloads do NOT already reveal every one of these
+// names — ExtractValues omits a NULL, so a custom column with no value on any
+// record is invisible there and visible here. The equivalence is paid for with
+// that much disclosure, deliberately: the alternative is a builder that cannot
+// filter on a column until somebody happens to fill it in.
+//
+// A custom picklist's VALUES are the other side of the line — an admin authored
 // them, they are the same content `GET /custom-fields` refuses, and they only
 // began travelling here when the vocabulary started carrying options at all.
 //

--- a/backend/internal/modules/collections/filtervocabulary.go
+++ b/backend/internal/modules/collections/filtervocabulary.go
@@ -61,6 +61,9 @@ type VocabularyField struct {
 	// reader to paste a uuid. The engine declares it beside the field; nothing
 	// here derives it from the name.
 	References storekit.Reference
+	// Options is a picklist's allowed values, so a builder offers them instead of
+	// asking a reader to type one. Empty for every other type.
+	Options []string
 }
 
 // FilterVocabulary answers every field a NEW filter clause may name for this
@@ -113,6 +116,7 @@ func (s *Store) FilterVocabulary(ctx context.Context, resource string) ([]Vocabu
 			Operators:  storekit.OperatorsFor(field),
 			Custom:     !isCore,
 			References: field.References,
+			Options:    field.Options,
 		})
 	}
 	// By name, because a map answers a different order every call and a picker
@@ -162,6 +166,7 @@ func wireVocabularyField(f VocabularyField) crmcontracts.FilterVocabularyField {
 		operators = append(operators, crmcontracts.FilterVocabularyFieldOperators(op))
 	}
 	wire := crmcontracts.FilterVocabularyField{
+		Options:   optionsOrNil(f.Options),
 		Name:      f.Name,
 		Type:      crmcontracts.FilterVocabularyFieldType(f.Type),
 		Operators: operators,
@@ -176,4 +181,14 @@ func wireVocabularyField(f VocabularyField) crmcontracts.FilterVocabularyField {
 		wire.References = &ref
 	}
 	return wire
+}
+
+// optionsOrNil answers nil for a field with no closed set, so the key is absent
+// rather than an empty array. An empty array would say "this picklist admits
+// nothing", which is a different and false statement.
+func optionsOrNil(options []string) *[]string {
+	if len(options) == 0 {
+		return nil
+	}
+	return &options
 }

--- a/backend/internal/modules/collections/filtervocabulary_test.go
+++ b/backend/internal/modules/collections/filtervocabulary_test.go
@@ -191,6 +191,54 @@ func TestTheVocabularyTellsACallerWhatAnIDFieldReferences(t *testing.T) {
 	}
 }
 
+// The values have to reach the CALLER. Declaring them and reporting them are
+// different things, and the last time this vocabulary gained a field the gates
+// proved only the former.
+func TestTheVocabularyTellsACallerAPicklistsValues(t *testing.T) {
+	fields, ok, err := (&Store{}).FilterVocabulary(readerCtx(), "deal")
+	if err != nil || !ok {
+		t.Fatalf("filterVocabulary: ok=%v err=%v", ok, err)
+	}
+	byName := map[string]VocabularyField{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+	if got := byName["status"].Options; len(got) != 3 || got[0] != "open" {
+		t.Errorf("status offers %v, want the contract's own three", got)
+	}
+	// A nullable enum's null is the column's nullability, not a value to offer.
+	for _, value := range byName["forecast_category"].Options {
+		if value == "" || value == "<nil>" {
+			t.Errorf("forecast_category offers %q as something a reader could pick", value)
+		}
+	}
+	// And a field with no closed set says so by carrying none.
+	if got := byName["owner_id"].Options; len(got) != 0 {
+		t.Errorf("owner_id is an id field and offers values %v", got)
+	}
+}
+
+// The wire shape: values are a present key for a picklist and an ABSENT one
+// otherwise. An empty array would say "this picklist admits nothing".
+func TestTheWireOmitsTheOptionsKeyForAFieldWithNoClosedSet(t *testing.T) {
+	withOptions := wireVocabularyField(VocabularyField{
+		Name: "status", Type: string(storekit.FieldPicklist),
+		Options: []string{"open", "won"},
+	})
+	if withOptions.Options == nil {
+		t.Fatal("a picklist carried no options to the wire")
+	}
+	if got := *withOptions.Options; len(got) != 2 || got[0] != "open" {
+		t.Errorf("wire options = %v, want the two given", got)
+	}
+	none := wireVocabularyField(VocabularyField{
+		Name: "full_name", Type: string(storekit.FieldText),
+	})
+	if none.Options != nil {
+		t.Errorf("a text field carried options %v to the wire", *none.Options)
+	}
+}
+
 // The wire shape of that answer: a reference is a present key, and no reference
 // is an ABSENT one. "" is not a member of the contract's enum, so sending it
 // would put a value the contract forbids on the wire.

--- a/backend/internal/modules/collections/filtervocabulary_test.go
+++ b/backend/internal/modules/collections/filtervocabulary_test.go
@@ -439,46 +439,77 @@ func TestReadingTheVocabularyNeedsTheListReadGrant(t *testing.T) {
 	}
 }
 
-// The custom half needs the catalogue's own grant, because that half IS the
-// catalogue's data — the column names an admin created and the values they
-// authored, which is what `GET /custom-fields` refuses without it.
+// A custom picklist's VALUES need the catalogue's grant; the field itself does
+// not. That line is where schema stops and content starts: a cf_* column's name
+// and type are already ambient to anyone who may read a record carrying it, and
+// withholding the field would make this operation offer less than the engine
+// accepts — the divergence the whole seam exists to prevent. The values are what
+// an admin authored, and are the same content `GET /custom-fields` refuses.
 //
-// Withheld as whole fields rather than as blanked values, which is what keeps
-// the operation's subset relation true: everything it lists is something the
-// engine accepts. The core half is unaffected, so the reader can still filter.
-func TestTheCustomHalfNeedsTheCustomFieldReadGrant(t *testing.T) {
-	catalog := stubFilterable{cols: map[string][]fieldcatalog.Column{
-		"person": {{Name: "cf_tier", Type: fieldcatalog.TypePicklist, Options: []string{"gold"}}},
-	}}
-	store := (&Store{}).WithFieldCatalog(catalog)
+// So the degradation is deliberate and it is the OLD behaviour: a reader without
+// the grant types the value, exactly as everyone did before options travelled.
+func TestACustomPicklistsValuesNeedTheCatalogueGrant(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {{Name: "cf_tier", Type: fieldcatalog.TypePicklist, Options: []string{"gold", "silver"}}},
+	}})
 
 	blind := grantCtx("list", principal.ObjectGrant{Read: true})
 	withheld, ok, err := store.FilterVocabulary(blind, "person")
 	if err != nil || !ok {
-		t.Fatalf("filterVocabulary without custom_field:read: ok=%v err=%v — the core half is still readable", ok, err)
+		t.Fatalf("filterVocabulary without custom_field:read: ok=%v err=%v — a missing grant narrows the answer, it does not refuse", ok, err)
 	}
-	for _, f := range withheld {
-		if f.Name == "cf_tier" {
-			t.Errorf("a principal without custom_field:read was offered %q with values %v", f.Name, f.Options)
-		}
+	tier, present := fieldNamed(withheld, "cf_tier")
+	if !present {
+		t.Fatal("cf_tier was dropped entirely: the field is schema and the engine still accepts a clause naming it, so omitting it makes this operation advertise less than the engine takes")
 	}
-	if len(withheld) == 0 {
-		t.Fatal("the core half went with it, so this proved nothing about the custom one")
+	if len(tier.Options) != 0 {
+		t.Errorf("a principal without custom_field:read was told cf_tier's values %v", tier.Options)
+	}
+	// Still filterable, which is the point of withholding the values rather than
+	// the field: the operators are what let a builder compose the clause at all.
+	if len(tier.Operators) == 0 {
+		t.Error("cf_tier carries no operators, so withholding its values cost the clause instead of the copy")
 	}
 
-	// The same store, one grant richer, answers with the field — so the assertion
-	// above is about the grant and not about a stub that never worked.
+	// The same store, one grant richer. Without this the assertion above would
+	// also pass against a stub whose options never arrived.
 	granted, _, err := store.FilterVocabulary(readerCtx(), "person")
 	if err != nil {
 		t.Fatalf("filterVocabulary with both grants: %v", err)
 	}
-	offered := false
-	for _, f := range granted {
-		offered = offered || f.Name == "cf_tier"
+	told, _ := fieldNamed(granted, "cf_tier")
+	if len(told.Options) != 2 {
+		t.Errorf("cf_tier offers %v to a principal holding custom_field:read, want both authored values", told.Options)
 	}
-	if !offered {
-		t.Error("cf_tier was withheld from a principal holding custom_field:read")
+}
+
+// A CORE picklist's values are the contract's own enum, published in
+// api/crm.yaml, so no grant is what protects them — and gating them would hide
+// from a reader something they can read in the specification.
+func TestACorePicklistsValuesNeedNoCatalogueGrant(t *testing.T) {
+	blind := grantCtx("list", principal.ObjectGrant{Read: true})
+	fields, ok, err := (&Store{}).FilterVocabulary(blind, "deal")
+	if err != nil || !ok {
+		t.Fatalf("filterVocabulary: ok=%v err=%v", ok, err)
 	}
+	status, present := fieldNamed(fields, "status")
+	if !present {
+		t.Fatal("deal.status is missing from the vocabulary")
+	}
+	if len(status.Options) == 0 {
+		t.Error("deal.status offers no values to a principal without custom_field:read; a contract enum is not the catalogue's content")
+	}
+}
+
+// fieldNamed reads one field out of a vocabulary answer, since the order is by
+// name and a caller looking for one field should not depend on where it lands.
+func fieldNamed(fields []VocabularyField, name string) (VocabularyField, bool) {
+	for _, f := range fields {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return VocabularyField{}, false
 }
 
 // A resource with no engine is distinguishable from one whose vocabulary is

--- a/backend/internal/modules/collections/filtervocabulary_test.go
+++ b/backend/internal/modules/collections/filtervocabulary_test.go
@@ -40,15 +40,26 @@ import (
 // grantCtx binds a human actor holding exactly one object grant, so a test
 // cannot pass on a permission the operation does not require.
 func grantCtx(object string, grant principal.ObjectGrant) context.Context {
+	return readGrantsCtx(map[string]principal.ObjectGrant{object: grant})
+}
+
+func readGrantsCtx(objects map[string]principal.ObjectGrant) context.Context {
 	return principal.WithActor(context.Background(), principal.Principal{
 		Type:        principal.PrincipalHuman,
-		Permissions: principal.Permissions{Objects: map[string]principal.ObjectGrant{object: grant}},
+		Permissions: principal.Permissions{Objects: objects},
 	})
 }
 
-// readerCtx holds `list:read` — the gate FilterVocabulary applies.
+// readerCtx holds BOTH grants FilterVocabulary applies: `list:read` for the
+// operation and `custom_field:read` for its custom half. A seeded role holds
+// both, so this is the ordinary caller — the one-grant cases are their own tests
+// below, and using a one-grant context here would quietly test the withheld
+// answer everywhere.
 func readerCtx() context.Context {
-	return grantCtx("list", principal.ObjectGrant{Read: true})
+	return readGrantsCtx(map[string]principal.ObjectGrant{
+		"list":         {Read: true},
+		"custom_field": {Read: true},
+	})
 }
 
 // everyTypeCatalog seeds one custom column per filterable custom-field type, so
@@ -192,8 +203,9 @@ func TestTheVocabularyTellsACallerWhatAnIDFieldReferences(t *testing.T) {
 }
 
 // The values have to reach the CALLER. Declaring them and reporting them are
-// different things, and the last time this vocabulary gained a field the gates
-// proved only the former.
+// different things: a mapping that dropped the field would keep every
+// declaration-side gate green, because the declarations stay internally
+// consistent when nothing reads the answer.
 func TestTheVocabularyTellsACallerAPicklistsValues(t *testing.T) {
 	fields, ok, err := (&Store{}).FilterVocabulary(readerCtx(), "deal")
 	if err != nil || !ok {
@@ -206,13 +218,10 @@ func TestTheVocabularyTellsACallerAPicklistsValues(t *testing.T) {
 	if got := byName["status"].Options; len(got) != 3 || got[0] != "open" {
 		t.Errorf("status offers %v, want the contract's own three", got)
 	}
-	// A nullable enum's null is the column's nullability, not a value to offer.
-	for _, value := range byName["forecast_category"].Options {
-		if value == "" || value == "<nil>" {
-			t.Errorf("forecast_category offers %q as something a reader could pick", value)
-		}
-	}
-	// And a field with no closed set says so by carrying none.
+	// A field with no closed set says so by carrying none.
+	//
+	// What each set CONTAINS is swept in TestEveryCorePicklistOffersItsValues,
+	// which reaches all seven; this asserts only that the set travels.
 	if got := byName["owner_id"].Options; len(got) != 0 {
 		t.Errorf("owner_id is an id field and offers values %v", got)
 	}
@@ -427,6 +436,48 @@ func TestReadingTheVocabularyNeedsTheListReadGrant(t *testing.T) {
 	}
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("err = %v, want permission denied", err)
+	}
+}
+
+// The custom half needs the catalogue's own grant, because that half IS the
+// catalogue's data — the column names an admin created and the values they
+// authored, which is what `GET /custom-fields` refuses without it.
+//
+// Withheld as whole fields rather than as blanked values, which is what keeps
+// the operation's subset relation true: everything it lists is something the
+// engine accepts. The core half is unaffected, so the reader can still filter.
+func TestTheCustomHalfNeedsTheCustomFieldReadGrant(t *testing.T) {
+	catalog := stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {{Name: "cf_tier", Type: fieldcatalog.TypePicklist, Options: []string{"gold"}}},
+	}}
+	store := (&Store{}).WithFieldCatalog(catalog)
+
+	blind := grantCtx("list", principal.ObjectGrant{Read: true})
+	withheld, ok, err := store.FilterVocabulary(blind, "person")
+	if err != nil || !ok {
+		t.Fatalf("filterVocabulary without custom_field:read: ok=%v err=%v — the core half is still readable", ok, err)
+	}
+	for _, f := range withheld {
+		if f.Name == "cf_tier" {
+			t.Errorf("a principal without custom_field:read was offered %q with values %v", f.Name, f.Options)
+		}
+	}
+	if len(withheld) == 0 {
+		t.Fatal("the core half went with it, so this proved nothing about the custom one")
+	}
+
+	// The same store, one grant richer, answers with the field — so the assertion
+	// above is about the grant and not about a stub that never worked.
+	granted, _, err := store.FilterVocabulary(readerCtx(), "person")
+	if err != nil {
+		t.Fatalf("filterVocabulary with both grants: %v", err)
+	}
+	offered := false
+	for _, f := range granted {
+		offered = offered || f.Name == "cf_tier"
+	}
+	if !offered {
+		t.Error("cf_tier was withheld from a principal holding custom_field:read")
 	}
 }
 

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -178,12 +178,16 @@ func customerField(
 // asking a reader to type one from a closed set. A mistyped value compiles and
 // matches nothing, which reads as a settled answer rather than as a mistake.
 //
-// These MIRROR the contract, which owns them, and
-// TestEveryCorePicklistOffersExactlyTheContractsValues reads the document and
-// fails when the two part company. Written out here rather than assembled from
-// the generated constants for one reason: the generator emits a `<nil>` member
-// for a nullable enum (OrganizationSizeBandLessThannil is real), and a set built
-// from constants would offer "<nil>" as something a human could pick.
+// These MIRROR the contract, which owns them, and the mirror is gated:
+// TestEveryOfferedPicklistMatchesTheContractsValues (backend/, where the other
+// gates that read api/crm.yaml live) reads the document and fails in both
+// directions when the two part company.
+//
+// Written out here rather than assembled from the generated constants because of
+// how the generator spells a NULLABLE enum: it emits a `<nil>` member, so a set
+// built from OrganizationSizeBand's or DealForecastCategory's constants would
+// offer "<nil>" as something a human could pick. Only those two are nullable
+// today, and one is enough — a set is either derived or it is not.
 //
 // A null in a contract enum is the COLUMN's nullability, never a value worth
 // offering — `exists: false` is how a filter asks for empty — so the sets below

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -137,8 +137,9 @@ var ownerTeamField = storekit.Field{
 // value no row carries selects nothing rather than being refused.
 // TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt gates that.
 var relationshipTypeField = storekit.Field{
-	Expr: "rt.relationship_type",
-	Type: storekit.FieldPicklist,
+	Expr:    "rt.relationship_type",
+	Type:    storekit.FieldPicklist,
+	Options: relationshipTypeValues,
 	Link: "EXISTS (SELECT 1 FROM organization_relationship_type rt" +
 		" WHERE rt.organization_id = t.id AND rt.archived_at IS NULL AND %s)",
 }
@@ -165,9 +166,45 @@ const customerLink = "EXISTS (SELECT 1 FROM organization o WHERE o.id = t.organi
 // customerField types one organization column as a deal-side filter leaf. The
 // operators it advertises narrow themselves — OperatorsFor reads Link — so an
 // industry reached this way offers everything text does except `contains`.
-func customerField(column string, fieldType storekit.FieldType) storekit.Field {
-	return storekit.Field{Expr: "o." + column, Type: fieldType, Link: customerLink}
+func customerField(
+	column string, fieldType storekit.FieldType, options ...string,
+) storekit.Field {
+	return storekit.Field{
+		Expr: "o." + column, Type: fieldType, Link: customerLink, Options: options,
+	}
 }
+
+// The allowed values of each core picklist, so a builder offers them instead of
+// asking a reader to type one from a closed set. A mistyped value compiles and
+// matches nothing, which reads as a settled answer rather than as a mistake.
+//
+// These MIRROR the contract, which owns them, and
+// TestEveryCorePicklistOffersExactlyTheContractsValues reads the document and
+// fails when the two part company. Written out here rather than assembled from
+// the generated constants for one reason: the generator emits a `<nil>` member
+// for a nullable enum (OrganizationSizeBandLessThannil is real), and a set built
+// from constants would offer "<nil>" as something a human could pick.
+//
+// A null in a contract enum is the COLUMN's nullability, never a value worth
+// offering — `exists: false` is how a filter asks for empty — so the sets below
+// carry no null and the gate compares against the document minus it.
+var (
+	lifecycleValues = []string{
+		"unknown", "target", "prospect", "opportunity",
+		"customer", "former_customer", "disqualified",
+	}
+	sizeBandValues = []string{
+		"1-10", "11-50", "51-200", "201-500", "501-1000", "1001-5000", "5000+",
+	}
+	relationshipTypeValues = []string{
+		"customer", "partner", "supplier", "investor",
+		"portfolio_company", "competitor", "other",
+	}
+	dealStatusValues   = []string{"open", "won", "lost"}
+	forecastValues     = []string{"commit", "best_case", "pipeline", "omitted"}
+	leadStatusValues   = []string{"new", "contacted", "engaged", "promoted", "disqualified"}
+	projectPhaseValues = []string{"initiative", "pursuing", "delivering", "closed"}
+)
 
 var segmentEngines = map[string]storekit.Query{
 	"person": {
@@ -191,8 +228,8 @@ var segmentEngines = map[string]storekit.Query{
 			ownerIDField:     {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField: ownerTeamField,
 			"industry":       {Expr: "t.industry", Type: storekit.FieldText},
-			"size_band":      {Expr: "t.size_band", Type: storekit.FieldPicklist},
-			"lifecycle":      {Expr: "t.lifecycle", Type: storekit.FieldPicklist},
+			"size_band":      {Expr: "t.size_band", Type: storekit.FieldPicklist, Options: sizeBandValues},
+			"lifecycle":      {Expr: "t.lifecycle", Type: storekit.FieldPicklist, Options: lifecycleValues},
 			// RETIRED with the column (ADR-0079/A124), and kept here for the one
 			// release it survives: a saved segment written against it must keep
 			// evaluating until its author has moved it to lifecycle. Dropping the
@@ -215,8 +252,8 @@ var segmentEngines = map[string]storekit.Query{
 			"organization_id":   {Expr: "t.organization_id", Type: storekit.FieldID, References: storekit.RefOrganization},
 			"partner_org_id":    {Expr: "t.partner_org_id", Type: storekit.FieldID, References: storekit.RefOrganization},
 			"project_id":        {Expr: "t.project_id", Type: storekit.FieldID, References: storekit.RefProject},
-			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
-			"forecast_category": {Expr: "t.forecast_category", Type: storekit.FieldPicklist},
+			"status":            {Expr: "t.status", Type: storekit.FieldPicklist, Options: dealStatusValues},
+			"forecast_category": {Expr: "t.forecast_category", Type: storekit.FieldPicklist, Options: forecastValues},
 			tagFilterField:      tagLinkFor("deal"),
 			// The customer's own attributes, so "the pipeline for manufacturing"
 			// is a filter rather than a spreadsheet. Same columns and same types
@@ -228,15 +265,15 @@ var segmentEngines = map[string]storekit.Query{
 			// written against it keep evaluating — a NEW way to name it would be
 			// a fresh dependency on a column that is going away.
 			"organization_industry":  customerField("industry", storekit.FieldText),
-			"organization_size_band": customerField("size_band", storekit.FieldPicklist),
-			"organization_lifecycle": customerField("lifecycle", storekit.FieldPicklist),
+			"organization_size_band": customerField("size_band", storekit.FieldPicklist, sizeBandValues...),
+			"organization_lifecycle": customerField("lifecycle", storekit.FieldPicklist, lifecycleValues...),
 		},
 	},
 	"lead": {
 		Table:     "lead",
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
+			"status":            {Expr: "t.status", Type: storekit.FieldPicklist, Options: leadStatusValues},
 			ownerIDField:        {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField:    ownerTeamField,
 			"candidate_org_key": {Expr: "t.candidate_org_key", Type: storekit.FieldText},
@@ -250,7 +287,7 @@ var segmentEngines = map[string]storekit.Query{
 			ownerIDField:      {Expr: colOwnerID, Type: storekit.FieldID, References: storekit.RefAppUser},
 			ownerTeamIDField:  ownerTeamField,
 			"organization_id": {Expr: "t.organization_id", Type: storekit.FieldID, References: storekit.RefOrganization},
-			"phase":           {Expr: "t.phase", Type: storekit.FieldPicklist},
+			"phase":           {Expr: "t.phase", Type: storekit.FieldPicklist, Options: projectPhaseValues},
 			tagFilterField:    tagLinkFor(projectEntity),
 		},
 	},
@@ -367,7 +404,14 @@ func customField(column fieldcatalog.Column) (storekit.Field, bool) {
 	if !ok {
 		return storekit.Field{}, false
 	}
-	return storekit.Field{Expr: `t.` + pgx.Identifier{column.Name}.Sanitize(), Type: fieldType}, true
+	return storekit.Field{
+		Expr: `t.` + pgx.Identifier{column.Name}.Sanitize(),
+		Type: fieldType,
+		// Straight from the catalogue, which owns them for the same reason it owns
+		// labels: they are per-workspace admin state. Empty for every non-picklist
+		// type, which is what the column itself reports.
+		Options: column.Options,
+	}, true
 }
 
 // errNotAFilterTree is what a jsonb value that does not decode into the

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -199,6 +199,18 @@ func TestEveryCorePicklistOffersItsValues(t *testing.T) {
 				if len(field.Options) == 0 {
 					t.Errorf("%s.%s is a picklist and offers no values, so a builder can only ask a reader to type one", resource, name)
 				}
+				for _, value := range field.Options {
+					// Two values a reader must never be shown, both of which a set
+					// assembled from the generated constants would carry: the empty
+					// string, and the `<nil>` member oapi-codegen emits for a nullable
+					// enum. A null is the COLUMN's nullability — `exists: false` is how
+					// a filter asks for empty — so neither is a value to pick, and this
+					// is swept over every set because the next nullable enum will not
+					// announce itself.
+					if value == "" || value == "<nil>" {
+						t.Errorf("%s.%s offers %q as something a reader could pick", resource, name, value)
+					}
+				}
 				continue
 			}
 			if len(field.Options) > 0 {

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -9,6 +9,7 @@ package collections
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -71,11 +72,14 @@ func TestEveryEngineWithAnOwnerAlsoFiltersByTeam(t *testing.T) {
 		}
 		checked++
 		// Definitionally identical to the shared leaf, which is the enforceable
-		// invariant: whatever the join is, every engine runs the same one. This
-		// cannot tell a copy from the original — storekit.Field is a comparable
-		// struct of three strings, so an identical literal passes — and catching
-		// the copy itself would be a lint job, not an assertion.
-		if team != ownerTeamField {
+		// invariant: whatever the join is, every engine runs the same one. It
+		// still cannot tell a copy from the original — an identical literal
+		// passes — and catching the copy itself would be a lint job.
+		//
+		// DeepEqual rather than ==, because Field carries a slice now and is no
+		// longer comparable. The language agreeing is convenient: == would have
+		// gone on reading as an identity check while comparing values.
+		if !reflect.DeepEqual(team, ownerTeamField) {
 			t.Errorf("%s's team leaf differs from the shared one: %+v", resource, team)
 		}
 	}
@@ -164,6 +168,66 @@ func TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt(t *testing
 	// "selects nothing" safe rather than merely unhelpful.
 	if strings.Contains(sql, "custmer") {
 		t.Errorf("the operand was inlined into the query text: %q", sql)
+	}
+}
+
+// Every core picklist offers values, and no other type does.
+//
+// A picklist without them is the defect this closes: the builder falls back to a
+// free-text box over a closed set, so a mistyped value compiles, matches nothing,
+// and reads as a settled answer. Swept over the engines rather than listed, so a
+// core picklist added tomorrow is covered the day it lands.
+//
+// A CUSTOM picklist is exempt here and only here: its values live in the
+// catalogue and arrive per workspace, so a static engine cannot carry them —
+// SegmentEngine merges them in, and the merge is tested with its own stub.
+func TestEveryCorePicklistOffersItsValues(t *testing.T) {
+	seen := 0
+	for resource, engine := range segmentEngines {
+		for name, field := range engine.Fields {
+			// The retired field is the one picklist that must NOT offer values: no
+			// surface may offer it for a new clause at all, so offering its values
+			// would contradict retiredCoreFields.
+			if retiredCoreFields[resource][name] {
+				if len(field.Options) > 0 {
+					t.Errorf("%s.%s is retired and still offers values", resource, name)
+				}
+				continue
+			}
+			if field.Type == storekit.FieldPicklist {
+				seen++
+				if len(field.Options) == 0 {
+					t.Errorf("%s.%s is a picklist and offers no values, so a builder can only ask a reader to type one", resource, name)
+				}
+				continue
+			}
+			if len(field.Options) > 0 {
+				t.Errorf("%s.%s is typed %s and offers values; only a picklist has a closed set",
+					resource, name, field.Type)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no core picklists found, so this gate checked nothing")
+	}
+}
+
+// A custom picklist's values come from the catalogue, not from this file.
+func TestACustomPicklistOffersTheCataloguesValues(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {{
+			Name:    "cf_tier",
+			Type:    fieldcatalog.TypePicklist,
+			Options: []string{"gold", "silver"},
+		}},
+	}})
+	engine, ok, err := store.SegmentEngine(context.Background(), "person")
+	if err != nil || !ok {
+		t.Fatalf("segmentEngine: ok=%v err=%v", ok, err)
+	}
+	got := engine.Fields["cf_tier"].Options
+	if len(got) != 2 || got[0] != "gold" || got[1] != "silver" {
+		t.Errorf("cf_tier offers %v, want the catalogue's own options", got)
 	}
 }
 

--- a/backend/internal/modules/customfields/catalogreader.go
+++ b/backend/internal/modules/customfields/catalogreader.go
@@ -68,7 +68,9 @@ func (s *Service) queryColumns(ctx context.Context, whereTail string, args ...an
 	var cols []fieldcatalog.Column
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
-			fmt.Sprintf(`SELECT column_name, type FROM custom_field WHERE object = $1 %s`, whereTail),
+			fmt.Sprintf(
+				`SELECT column_name, type, COALESCE(options, '[]'::jsonb)
+				   FROM custom_field WHERE object = $1 %s`, whereTail),
 			args...)
 		if err != nil {
 			return err
@@ -76,7 +78,10 @@ func (s *Service) queryColumns(ctx context.Context, whereTail string, args ...an
 		defer rows.Close()
 		for rows.Next() {
 			var c fieldcatalog.Column
-			if err := rows.Scan(&c.Name, &c.Type); err != nil {
+			// options is NULL for every non-picklist type, coalesced to an empty
+			// array above so the scan target is one shape rather than a pointer
+			// every caller would have to nil-check.
+			if err := rows.Scan(&c.Name, &c.Type, &c.Options); err != nil {
 				return err
 			}
 			cols = append(cols, c)

--- a/backend/internal/modules/customfields/catalogreader.go
+++ b/backend/internal/modules/customfields/catalogreader.go
@@ -68,6 +68,8 @@ func (s *Service) queryColumns(ctx context.Context, whereTail string, args ...an
 	var cols []fieldcatalog.Column
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
+			// COALESCE because options is NULL for every non-picklist type, and an
+			// empty jsonb array decodes to the empty set a caller means to read.
 			fmt.Sprintf(
 				`SELECT column_name, type, COALESCE(options, '[]'::jsonb)
 				   FROM custom_field WHERE object = $1 %s`, whereTail),
@@ -77,11 +79,19 @@ func (s *Service) queryColumns(ctx context.Context, whereTail string, args ...an
 		}
 		defer rows.Close()
 		for rows.Next() {
-			var c fieldcatalog.Column
-			// options is NULL for every non-picklist type, coalesced to an empty
-			// array above so the scan target is one shape rather than a pointer
-			// every caller would have to nil-check.
-			if err := rows.Scan(&c.Name, &c.Type, &c.Options); err != nil {
+			var (
+				c          fieldcatalog.Column
+				optionsRaw []byte
+			)
+			if err := rows.Scan(&c.Name, &c.Type, &optionsRaw); err != nil {
+				return err
+			}
+			// Decoded through the module's own spelling rather than by scanning
+			// straight into []string: that hands the shape of a malformed column to
+			// pgx's JSON codec, whose error names a driver type, where this names the
+			// column and what it should have held.
+			c.Options, err = unmarshalOptions(optionsRaw)
+			if err != nil {
 				return err
 			}
 			cols = append(cols, c)

--- a/backend/internal/modules/customfields/create.go
+++ b/backend/internal/modules/customfields/create.go
@@ -294,3 +294,22 @@ func marshalOptions(options []string) ([]byte, error) {
 	}
 	return raw, nil
 }
+
+// unmarshalOptions is the one spelling of the decoding, and it exists as a pair
+// with marshalOptions because both catalog reads want the same answer to the same
+// two questions: what a malformed column says to the caller, and what an absent
+// option set decodes to. A second decode written at its own call site answered
+// them differently once already.
+//
+// Empty raw is an empty set, not an error: a non-picklist field stores SQL NULL
+// (optionsJSON), which is the normal shape for most rows rather than a fault.
+func unmarshalOptions(raw []byte) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var options []string
+	if err := json.Unmarshal(raw, &options); err != nil {
+		return nil, fmt.Errorf("customfields: catalog options column is not a JSON string array: %w", err)
+	}
+	return options, nil
+}

--- a/backend/internal/modules/customfields/service.go
+++ b/backend/internal/modules/customfields/service.go
@@ -9,7 +9,6 @@ package customfields
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -178,11 +177,11 @@ func scanCustomField(row pgx.Row) (crmcontracts.CustomField, error) {
 	out.ColumnName = &colName
 	out.Currency = currency
 	out.Version = &version
-	if len(optionsRaw) > 0 {
-		var options []string
-		if err := json.Unmarshal(optionsRaw, &options); err != nil {
-			return crmcontracts.CustomField{}, fmt.Errorf("customfields: catalog options column is not a JSON string array: %w", err)
-		}
+	options, err := unmarshalOptions(optionsRaw)
+	if err != nil {
+		return crmcontracts.CustomField{}, err
+	}
+	if options != nil {
 		out.Options = &options
 	}
 	return out, nil

--- a/backend/internal/modules/privacy/subjectcolumns.go
+++ b/backend/internal/modules/privacy/subjectcolumns.go
@@ -36,7 +36,22 @@ func subjectCustomColumns(ctx context.Context, tx pgx.Tx, object string) ([]fiel
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, pgx.RowToStructByPos[fieldcatalog.Column])
+	defer rows.Close()
+	// Scanned into NAMED fields rather than by position. fieldcatalog.Column
+	// belongs to the port, not to this module, so a positional mapping bound this
+	// two-column SELECT to a struct shape privacy has no say over: the day the
+	// port gained a third field for somebody else's read, this query started
+	// failing on a mismatch it never mentioned. Only the columns erasure and the
+	// Art. 15 export actually use are read.
+	var cols []fieldcatalog.Column
+	for rows.Next() {
+		var c fieldcatalog.Column
+		if err := rows.Scan(&c.Name, &c.Type); err != nil {
+			return nil, err
+		}
+		cols = append(cols, c)
+	}
+	return cols, rows.Err()
 }
 
 // nullColumnAssignments renders the `, "cf_x" = NULL, …` fragment an

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -99,13 +99,16 @@ type Field struct {
 	// OFFER them. Empty for every other type, and empty for a picklist whose
 	// values this engine does not know.
 	//
-	// ADVERTISEMENT only today: compileLeaf does not refuse a value outside the
-	// set. Making it refuse is a live-API behaviour change — a saved segment
-	// holding a value since removed from the set would begin failing at read time
-	// — so that is its own decision, tracked separately. What this field fixes
-	// meanwhile is the surface: a builder that knows the values offers them
-	// instead of asking a reader to type one, which is how a typo became a filter
-	// matching nothing.
+	// ADVERTISEMENT only: compileLeaf does not refuse a value outside the set, and
+	// TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt holds that
+	// so the behaviour is gated rather than assumed. Refusing would be a live-API
+	// change — a saved segment holding a value since removed from its set would
+	// begin failing at read time — which is why the set travels first and the
+	// refusal is a separate call to make.
+	//
+	// What this fixes meanwhile is the surface: a builder that knows the values
+	// offers them instead of asking a reader to type one, which is how a typo
+	// became a filter that matched nothing and read as a settled answer.
 	Options []string
 }
 

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -95,6 +95,18 @@ type Field struct {
 	// (automation's preview vocabularies) owes no target, because nothing can
 	// offer a picker for it.
 	References Reference
+	// Options is a picklist field's allowed values, for a surface that has to
+	// OFFER them. Empty for every other type, and empty for a picklist whose
+	// values this engine does not know.
+	//
+	// ADVERTISEMENT only today: compileLeaf does not refuse a value outside the
+	// set. Making it refuse is a live-API behaviour change — a saved segment
+	// holding a value since removed from the set would begin failing at read time
+	// — so that is its own decision, tracked separately. What this field fixes
+	// meanwhile is the surface: a builder that knows the values offers them
+	// instead of asking a reader to type one, which is how a typo became a filter
+	// matching nothing.
+	Options []string
 }
 
 // Reference is a record type an id field's values point at. Named rather than a

--- a/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
+++ b/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
@@ -61,10 +61,12 @@ func Types() []string {
 // The fields carry DIFFERENT disclosure rules, and this is the one place that
 // says so, because three surfaces read them and each was choosing for itself:
 //
-//   - Name and Type are SCHEMA. Ambient to any caller who may read a record
-//     carrying the column — the record surfaces already expose them, and a
-//     consumer that had to hide them would describe a narrower product than the
-//     engine implements.
+//   - Name and Type are SCHEMA. Ambient to any caller who may read records of
+//     that object, because a consumer that had to hide them would describe a
+//     narrower product than the engine implements — a field nothing may name is
+//     a field a filter cannot use. Note what this does NOT rest on: a record
+//     payload omits a NULL, so a column with no value on any record is not
+//     already visible there. Ambient is a decision, not an observation.
 //   - Options is catalogue CONTENT, authored by an admin. A consumer passing it
 //     to a caller needs `custom_field:read`, the grant that governs the
 //     catalogue surface these values otherwise come from.

--- a/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
+++ b/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
@@ -60,6 +60,15 @@ func Types() []string {
 type Column struct {
 	Name string
 	Type string
+	// Options is a picklist column's allowed values, and is empty for every
+	// other type. It travels with the column because a consumer that has to
+	// OFFER the field needs them — a builder without them can only ask a reader
+	// to type a value from a closed set, which is how a mistyped one becomes a
+	// filter that silently matches nothing.
+	//
+	// The catalogue owns them, as it owns labels: they are per-workspace admin
+	// state, not something the engine or a consumer may derive.
+	Options []string
 }
 
 // Reader answers the active custom-field columns for one core object,

--- a/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
+++ b/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
@@ -57,6 +57,21 @@ func Types() []string {
 // of the Type* constants above). Whether a given Column is active,
 // retired, or both is a question of which method returned it — Reader
 // and FilterableReader below — not of the type itself.
+//
+// The fields carry DIFFERENT disclosure rules, and this is the one place that
+// says so, because three surfaces read them and each was choosing for itself:
+//
+//   - Name and Type are SCHEMA. Ambient to any caller who may read a record
+//     carrying the column — the record surfaces already expose them, and a
+//     consumer that had to hide them would describe a narrower product than the
+//     engine implements.
+//   - Options is catalogue CONTENT, authored by an admin. A consumer passing it
+//     to a caller needs `custom_field:read`, the grant that governs the
+//     catalogue surface these values otherwise come from.
+//
+// Neither of those is a Column's own business to enforce — it holds no context —
+// so the obligation lands on the consumer, which is why it is written where every
+// consumer reads rather than in each of them.
 type Column struct {
 	Name string
 	Type string

--- a/backend/positionalrowscan_test.go
+++ b/backend/positionalrowscan_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A positional row mapping may only target a struct its own package declares.
+//
+// `pgx.RowToStructByPos[T]` binds a SELECT's column ORDER to T's field order, so
+// the query and the struct have to be edited together. That is fine — and is why
+// the pattern is used here — as long as one package owns both. It stops being
+// fine the moment T belongs to somebody else: privacy read the custom-field
+// catalogue as RowToStructByPos[fieldcatalog.Column] with a two-column SELECT,
+// and the day that PORT gained a third field for a different module's read,
+// privacy's erasure and its Art. 15 export both began failing on a mismatch
+// neither file mentions. Nothing in either module changed.
+//
+// Only the integration lane could see it, because the mismatch is a pgx runtime
+// error rather than a compile error, which is what makes it worth a gate: the
+// unit suites, the type checker and the linters were all green.
+//
+// Derived rather than listed: the rule is read off every call in the tree, so a
+// new one is enrolled by existing (review-loop rule 2). The fix at any site is to
+// scan into named fields, which also documents which columns that query needs.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Go trees this walks — every hand-written module, like the license gate's.
+var positionalScanTrees = []string{".", "../extensions", "../fixtures"}
+
+func TestAPositionalRowScanTargetsItsOwnPackagesStruct(t *testing.T) {
+	calls := 0
+	for _, root := range positionalScanTrees {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				// path != root, because the root itself is "." and a dotted name is
+				// exactly what the skip list rejects: skipping it would take the whole
+				// tree with it, and the walk would report no findings for the most
+				// reassuring possible reason.
+				if path != root && skipPositionalScanDir(d.Name()) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			foreign, found := foreignPositionalScans(t, path)
+			calls += found
+			for _, target := range foreign {
+				t.Errorf("%s maps rows positionally into %s, a struct another package declares: the SELECT's column order is then bound to a shape this package does not own, and a field added there breaks this query with a count mismatch that names neither. Scan into named fields instead.",
+					path, target)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	if calls == 0 {
+		t.Fatal("no positional row mapping found anywhere — this test has stopped reading the code it derives from")
+	}
+}
+
+// foreignPositionalScans answers the qualified type arguments of every
+// RowToStructByPos in one file, plus how many such calls it holds at all — the
+// count is what tells a silent pass from a walk that read nothing.
+func foreignPositionalScans(t *testing.T, path string) ([]string, int) {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	var foreign []string
+	found := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		index, ok := n.(*ast.IndexExpr)
+		if !ok || !isPositionalRowMapper(index.X) {
+			return true
+		}
+		found++
+		// A qualified type argument (`pkg.T`) is the whole finding: an unqualified
+		// one names a type this file's own package declares, which is the sanctioned
+		// use. A pointer or slice around it is unwrapped so `[]pkg.T` reads the same.
+		if qualified, ok := unwrapPositionalScanType(index.Index).(*ast.SelectorExpr); ok {
+			foreign = append(foreign, positionalScanTargetName(qualified))
+		}
+		return true
+	})
+	return foreign, found
+}
+
+func isPositionalRowMapper(fn ast.Expr) bool {
+	selector, ok := fn.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "RowToStructByPos"
+}
+
+func unwrapPositionalScanType(expr ast.Expr) ast.Expr {
+	for {
+		switch inner := expr.(type) {
+		case *ast.StarExpr:
+			expr = inner.X
+		case *ast.ArrayType:
+			expr = inner.Elt
+		default:
+			return expr
+		}
+	}
+}
+
+func positionalScanTargetName(selector *ast.SelectorExpr) string {
+	if pkg, ok := selector.X.(*ast.Ident); ok {
+		return pkg.Name + "." + selector.Sel.Name
+	}
+	return selector.Sel.Name
+}
+
+func skipPositionalScanDir(name string) bool {
+	return name == "node_modules" || name == "build" || name == "testdata" ||
+		strings.HasPrefix(name, ".")
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15510,6 +15510,18 @@ export interface components {
              */
             custom: boolean;
             /**
+             * @description A picklist field's allowed values, present (non-empty) when
+             *     `type=picklist` and absent otherwise. Offer these rather than a text
+             *     box: a value outside the set compiles and matches nothing, so a typo
+             *     reads as a settled answer instead of a mistake.
+             *
+             *     For a workspace-defined field these are the catalog's own `options`
+             *     for the same column. For a core field they are the values the
+             *     contract enumerates, minus null — a null in one of those enums is the
+             *     column's nullability, and `exists` is how a filter asks about that.
+             */
+            options?: string[];
+            /**
              * @description The record type this field's ids point at — present for every `id`
              *     field, absent for every other type. Offer the record rather than a
              *     box for its uuid.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5523,6 +5523,7 @@ export const de = {
   "filters.loadView": "Gespeicherten Filter laden",
   "filters.pickRecord": "Eintrag wählen",
   "filters.loadingRecords": "Auswahl wird geladen…",
+  "filters.pickValue": "Wert wählen",
   "filters.saveList": "Als Liste speichern",
   "filters.saveListTitle": "Diesen Filter als dynamische Liste speichern",
   "filters.listName": "Listenname",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5545,6 +5545,7 @@ export const en = {
   "filters.loadView": "Load a saved filter",
   "filters.pickRecord": "Choose one",
   "filters.loadingRecords": "Loading choices…",
+  "filters.pickValue": "Choose a value",
   "filters.saveList": "Save as list",
   "filters.saveListTitle": "Save this filter as a dynamic list",
   "filters.listName": "List name",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5478,6 +5478,7 @@ export const vi = {
   "filters.loadView": "T\u1ea3i b\u1ed9 l\u1ecdc \u0111\u00e3 l\u01b0u",
   "filters.pickRecord": "Ch\u1ecdn m\u1ed9t",
   "filters.loadingRecords": "\u0110ang t\u1ea3i l\u1ef1a ch\u1ecdn\u2026",
+  "filters.pickValue": "Ch\u1ecdn gi\u00e1 tr\u1ecb",
   "filters.saveList": "L\u01b0u th\u00e0nh danh s\u00e1ch",
   "filters.saveListTitle":
     "L\u01b0u b\u1ed9 l\u1ecdc n\u00e0y th\u00e0nh danh s\u00e1ch \u0111\u1ed9ng",

--- a/frontend/src/screens/filterbuilder.test.tsx
+++ b/frontend/src/screens/filterbuilder.test.tsx
@@ -61,6 +61,9 @@ const VOCAB: VocabularyField[] = [
     type: "picklist",
     operators: ["eq", "neq", "in", "exists"],
     custom: true,
+    // The vocabulary carries a picklist's allowed values, so the fixture does —
+    // a stub without them would exercise a response the server cannot send.
+    options: ["gold", "silver", "bronze"],
   },
   {
     name: "cf_deal_score",
@@ -251,6 +254,64 @@ describe("when a roster cannot be read", () => {
     // would leave the reader unable to write the clause at all.
     expect(await screen.findByRole("textbox", { name: "Value" })).toBeTruthy();
     expect(screen.queryByRole("combobox", { name: "Value" })).toBeNull();
+  });
+});
+
+describe("a closed set is picked, not typed", () => {
+  it("offers the values the vocabulary carries", async () => {
+    resetIDsForTest();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        start={newGroup("and", [newLeaf("cf_loyalty_tier", "eq", "")])}
+      />,
+    );
+
+    await pickOption(
+      user,
+      await screen.findByRole("combobox", { name: "Value" }),
+      "silver",
+    );
+
+    expect(wire()).toEqual({
+      and: [{ field: "cf_loyalty_tier", op: "eq", value: "silver" }],
+    });
+  });
+
+  it("gives a reader no way to compose a value the set does not hold", async () => {
+    resetIDsForTest();
+    render(
+      <Harness
+        start={newGroup("and", [newLeaf("cf_loyalty_tier", "eq", "")])}
+      />,
+    );
+
+    // No text box at all for a closed set. That is the whole fix: a free box
+    // over these values let `Gold` through, which compiled, matched nothing, and
+    // reported "0 match" as a settled answer.
+    expect(screen.queryByRole("textbox", { name: "Value" })).toBeNull();
+    const listed = (await screen.findByRole("combobox", { name: "Value" }))
+      .textContent;
+    expect(listed).not.toContain("Gold");
+  });
+
+  it("still types a free-text field", async () => {
+    resetIDsForTest();
+    const user = userEvent.setup();
+    render(
+      <Harness start={newGroup("and", [newLeaf("full_name", "eq", "")])} />,
+    );
+
+    // The other half of the rule: `text` has no closed set, so a box is right
+    // there and turning every field into a dropdown would be the opposite error.
+    await user.type(
+      await screen.findByRole("textbox", { name: "Value" }),
+      "ann",
+    );
+
+    expect(wire()).toEqual({
+      and: [{ field: "full_name", op: "eq", value: "ann" }],
+    });
   });
 });
 

--- a/frontend/src/screens/filterbuilder.tsx
+++ b/frontend/src/screens/filterbuilder.tsx
@@ -352,6 +352,7 @@ function ClauseRow({
       <ValueControl
         type={chosen?.type ?? "text"}
         references={chosen?.references}
+        options={chosen?.options}
         op={op}
         value={value}
         onChange={(nextValue) =>
@@ -390,6 +391,7 @@ function ClauseRow({
 function ValueControl({
   type,
   references,
+  options,
   op,
   value,
   onChange,
@@ -397,6 +399,8 @@ function ValueControl({
   type: VocabularyField["type"];
   /** What an id field's values point at, when the vocabulary named one. */
   references: Reference | undefined;
+  /** A picklist's allowed values, when the vocabulary carried them. */
+  options: readonly string[] | undefined;
   op: FilterOp;
   value: LeafValue;
   onChange: (next: LeafValue) => void;
@@ -431,6 +435,24 @@ function ValueControl({
         type={type}
         value={value}
         onChange={onChange}
+      />
+    );
+  }
+  if (options !== undefined && options.length > 0) {
+    // A closed set is picked, not typed. Typing it invites the failure this whole
+    // surface exists to prevent: a value outside the set compiles, matches
+    // nothing, and reads as a settled answer rather than as a mistake.
+    //
+    // The label IS the value. These are the wire words a workspace admin chose,
+    // or a contract enum; inventing display copy here would be a second
+    // vocabulary for a reader to reconcile against what the record page shows.
+    return (
+      <Select
+        options={options.map((option) => ({ value: option, label: option }))}
+        value={typeof value === "string" ? value : ""}
+        onChange={onChange}
+        placeholder={t("filters.pickValue")}
+        aria-label={t("filters.value")}
       />
     );
   }


### PR DESCRIPTION
The misleading half of [#1958](https://github.com/gradionhq/margince-poc-v1/issues/1958). A picklist field offered a **free-text box over a closed set**, so `Open` instead of `open` compiled, matched nothing, and reported *"0 deals match"* as a settled answer — a wrong answer to a normal question, with no error anywhere.

Affected every closed-set field: `status`, `lifecycle`, `size_band`, `forecast_category`, `phase`, `relationship_type`, and every workspace-defined picklist.

The vocabulary now carries a picklist's allowed values and the builder offers them.

## One mechanism, on purpose

Both kinds of field go through `Field.Options`, because a picker for *some* picklists and a box for others would be more confusing than today's uniform-but-wrong control. Where the values come from differs, and that split is the **existing seam** rather than a new one:

| | Source | Why |
|---|---|---|
| custom field | the catalogue | per-workspace admin state — the same place labels come from, for the reason `filtervocabulary.go` already states |
| core field | declared beside the engine's other facts | the contract enumerates them; they are identical in every installation |

## Two things the generator taught

Both would otherwise have surfaced only as a bad dropdown:

- **oapi-codegen emits a `<nil>` member for a nullable enum.** `OrganizationSizeBandLessThannil` is real. A set assembled from the generated constants would have offered `"<nil>"` as something a human could pick — so the declarations are written out, and a test asserts no reported value is empty or `"<nil>"`.
- **A null in a contract enum is the column's nullability, not a value.** `forecast_category` enumerates `[null, commit, …]`; the offered set drops the null, because `exists: false` is how a filter asks for empty.

## Deliberately not included

**Making the engine refuse an out-of-set value — that is [#1851](https://github.com/gradionhq/margince-poc-v1/issues/1851).** It is a live-API behaviour change: a saved segment holding a value since removed from its set would begin failing at read time, which #1851 itself names as the hazard. `Field.Options` is advertisement only today, and it is precisely what makes closing #1851 cheap once somebody rules on the migration.

I split on that line rather than bundling it, because the surface fix carries no migration risk and the engine fix does.

## Gated four ways, each derived rather than listed

- every core picklist offers values, and **no other type does** — a set on a text column would promise a picker for a column with no closed set;
- the retired `classification` field offers **none**, since no surface may offer it at all;
- a custom picklist reports the catalogue's own options, through the real merge;
- the values reach the **caller**, not merely the declaration — the gate the last vocabulary field went without, and the reason its absence was caught in review.

Mutation-verified both ways: dropping the response mapping fails by name, and removing the picker fails the two behaviour tests.

`fieldcatalog.Column` gains `Options` so the catalogue can carry them; the `custom_field.options` jsonb it reads has been there since core 0063. Adding a slice also made `storekit.Field` non-comparable, which turned one test's `!=` into a compile error — the language agreeing with the review that called that check an identity test in name only. It reads `reflect.DeepEqual` now, and says so.

## A note on the frontend lane

`connected-agents.test.tsx` fails on this branch **and on a clean `origin/main`** — I verified in a detached checkout at `b3f24756` with nothing of mine applied. Three tests cannot find the per-client `Disconnect <client>` button. Filed as [#1974](https://github.com/gradionhq/margince-poc-v1/issues/1974) (`priority: critical`, since a red `check-fe` on main taints every PR's verdict). It is outside this arc so I have not fixed it; flagging so this diff is not blamed for it.

`make check-backend` green, `make craft-static` green (0 findings), and my own suites pass (41 tests across the filter screens).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Picklist filters now offer a dropdown of allowed values instead of a free‑text box, preventing typos that silently matched nothing. Options come from the contract for core fields and from the catalog for custom fields; when options aren’t available or permitted, the UI falls back to typing.

- Contract/API: adds `options?: string[]` to `FilterVocabularyField` with docs; OpenAPI and generated types updated. The wire omits `options` when empty and clones slices.
- Backend: adds `Options []string` to `storekit.Field`. Declares core picklist sets and gates them against the OpenAPI enums (nulls not offered; no `"<nil>"`). Custom picklist options flow from the catalog via `fieldcatalog.Column.Options`; options decoding is centralized. `FilterVocabulary` always lists fields with `list:read` and includes custom picklist values only with `custom_field:read`; core values are always sent. Privacy fixes a catalog read to scan by name. Fit checks: HTTP integration asserts options travel; a reader census for `fieldcatalog.Column.Options`; and a ban on positional row scans into foreign structs.
- Frontend: the filter builder renders a select with “Choose a value” when `options` exist; otherwise it shows a textbox. i18n adds `filters.pickValue`.

**Rollout**
- Backward compatible: the engine still accepts out‑of‑set values; saved filters continue to work; no data migration.
- Permissions: `list:read` lists fields and operators; `custom_field:read` is required to receive custom picklist values; core picklist values are always included.

<sup>Written for commit 7a13a01169e0caad96d46b87d2e7b5a2fb35aab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

