### PR TITLE
fix(authz): a deal read does not name a record its reader cannot open

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18592,9 +18592,9 @@ components:
         fx_rate_date: { type: [string, 'null'], format: date }
         pipeline_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent''s own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).' }
         stage_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null stage FK; must belong to pipeline_id. Overlay mode: NULL (see pipeline_id; the incumbent dealstage id rides `raw`, OVA-MAP-6).' }
-        organization_id: { type: [string, 'null'], format: uuid, description: Primary org; never a raw lead. }
-        partner_org_id: { type: [string, 'null'], format: uuid, description: 'Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row.' }
-        project_id: { type: [string, 'null'], format: uuid, description: 'The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422.' }
+        organization_id: { type: [string, 'null'], format: uuid, description: 'Primary org; never a raw lead. Null when the caller may not read that organization, in which case `masked_fields` names it.' }
+        partner_org_id: { type: [string, 'null'], format: uuid, description: 'Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row. Null when the caller may not read that organization, in which case `masked_fields` names it.' }
+        project_id: { type: [string, 'null'], format: uuid, description: 'The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422. Null when the caller may not read that project, in which case `masked_fields` names it.' }
         owner_id: { type: [string, 'null'], format: uuid }
         status: { type: string, enum: [open, won, lost], default: open }
         lost_reason: { type: [string, 'null'], description: Required when status=lost. }

--- a/backend/internal/compose/integration/dealreferences_integration_test.go
+++ b/backend/internal/compose/integration/dealreferences_integration_test.go
@@ -18,6 +18,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // dealReferenceFixture is one deal pointing at a hidden organization pair and
@@ -26,11 +27,13 @@ type dealReferenceFixture struct {
 	hiddenRefs ids.DealID
 	hiddenProj ids.DealID
 	openOrg    ids.UUID
+	privateOrg ids.UUID
+	wonStage   ids.StageID
 }
 
 func seedDealReferenceFixture(t *testing.T, e *Env) dealReferenceFixture {
 	t.Helper()
-	pipeline, open, _ := DealFixture(t, e)
+	pipeline, open, won := DealFixture(t, e)
 	admin := e.Admin()
 
 	// Seeded workspace-visible so the admin's link write passes its own
@@ -63,7 +66,10 @@ func seedDealReferenceFixture(t *testing.T, e *Env) dealReferenceFixture {
 	}); err != nil {
 		t.Fatalf("linking the deal to its project: %v", err)
 	}
-	return dealReferenceFixture{hiddenRefs: hiddenRefs, hiddenProj: hiddenProj, openOrg: openOrg}
+	return dealReferenceFixture{
+		hiddenRefs: hiddenRefs, hiddenProj: hiddenProj,
+		openOrg: openOrg, privateOrg: privateOrg, wonStage: won,
+	}
 }
 
 func TestADealDoesNotNameRecordsItsReaderCannotRead(t *testing.T) {
@@ -156,5 +162,93 @@ func assertMaskNames(t *testing.T, d crmcontracts.Deal, want ...string) {
 	}
 	if len(got) != len(want) {
 		t.Errorf("masked_fields = %v, want exactly %v", *d.MaskedFields, want)
+	}
+}
+
+// A mutation RESPONSE is a read. Every entry point that hands a deal back must
+// withhold the same references the GET does, or a no-op PATCH becomes the
+// second door onto the id the GET just refused — and the "it lifts on write
+// authority" argument the amount mask makes is not available here: being
+// allowed to change the DEAL says nothing about being allowed to read the
+// ORGANIZATION it names.
+//
+// A table over the entry points rather than one case each, so a sixth deal
+// mutation is a compile-time addition to this list, not a silent omission.
+func TestEveryDealMutationResponseWithholdsTheSameReferences(t *testing.T) {
+	e := Setup(t)
+	fx := seedDealReferenceFixture(t, e)
+
+	perms := AccountRepPerms
+	perms.Objects = map[string]principal.ObjectGrant{
+		"deal":                  {Create: true, Read: true, Update: true, Delete: true},
+		"organization":          {Read: true},
+		"pipeline":              {Read: true},
+		"installation_settings": {Read: true},
+	}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	renamed := "Meridian renewal, retitled"
+	// A won deal owes a contract or a reason there is none; this suite is about
+	// the response's references, not that rule, so it satisfies it and moves on.
+	wonWithout := "imported"
+	cases := []struct {
+		name string
+		call func() (crmcontracts.Deal, error)
+	}{
+		{"a patch that changes nothing still echoes the row", func() (crmcontracts.Deal, error) {
+			return e.Deals.UpdateDeal(rep, fx.hiddenRefs, deals.UpdateDealInput{})
+		}},
+		{"a patch that changes something", func() (crmcontracts.Deal, error) {
+			return e.Deals.UpdateDeal(rep, fx.hiddenRefs, deals.UpdateDealInput{Name: &renamed})
+		}},
+		{"advancing the deal", func() (crmcontracts.Deal, error) {
+			return e.Deals.AdvanceDeal(rep, fx.hiddenRefs, deals.AdvanceDealInput{ToStageID: fx.wonStage, WonWithoutContractReason: &wonWithout})
+		}},
+		{"archiving the deal", func() (crmcontracts.Deal, error) {
+			return e.Deals.ArchiveDeal(rep, fx.hiddenRefs)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.call()
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if got.OrganizationId != nil || got.PartnerOrgId != nil {
+				t.Errorf("%s handed back org %v partner %v, want both withheld",
+					tc.name, got.OrganizationId, got.PartnerOrgId)
+			}
+			assertMaskNames(t, got, "organization_id", "partner_org_id")
+		})
+	}
+}
+
+// Filtering by an id is asking whether it is there, so the list must not
+// confirm through its filter what its projection withholds. The answer is the
+// empty page a company with no deals gives — never a 404, which would itself
+// say the organization is real.
+func TestFilteringByAnUnreadableReferenceAnswersTheEmptyPage(t *testing.T) {
+	e := Setup(t)
+	fx := seedDealReferenceFixture(t, e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	hiddenOrg := ids.From[ids.OrganizationKind](fx.privateOrg)
+	page, _, err := e.Deals.ListDeals(rep, deals.ListDealsInput{OrganizationID: &hiddenOrg})
+	if err != nil {
+		t.Fatalf("filtering by an organization the caller cannot read: %v", err)
+	}
+	if len(page) != 0 {
+		t.Errorf("the filter returned %d deal(s), want none — an unnarrowed filter confirms the binding the read withholds", len(page))
+	}
+
+	// The same filter for a company the reader CAN open still works, or the
+	// fix would have closed the oracle by breaking the feature.
+	openOrg := ids.From[ids.OrganizationKind](fx.openOrg)
+	visible, _, err := e.Deals.ListDeals(rep, deals.ListDealsInput{OrganizationID: &openOrg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(visible) != 1 || ids.UUID(visible[0].Id) != fx.hiddenProj.UUID {
+		t.Errorf("filtering by a readable company returned %d deal(s), want the one deal on it", len(visible))
 	}
 }

--- a/backend/internal/compose/integration/dealreferences_integration_test.go
+++ b/backend/internal/compose/integration/dealreferences_integration_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A deal is customer identity: every seat of the workspace reads every deal.
+// The records it POINTS AT are not — an organization can be capture-private to
+// the colleague who captured it, and a project keeps its own own/team scope. So
+// the deal's references are withheld from a reader who could not open them, and
+// named in masked_fields, exactly as the write path already refuses to SET a
+// reference the caller cannot see (auth.EnsureLinkTarget).
+
+import (
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// dealReferenceFixture is one deal pointing at a hidden organization pair and
+// one pointing at an out-of-scope project, both linked through the real writer.
+type dealReferenceFixture struct {
+	hiddenRefs ids.DealID
+	hiddenProj ids.DealID
+	openOrg    ids.UUID
+}
+
+func seedDealReferenceFixture(t *testing.T, e *Env) dealReferenceFixture {
+	t.Helper()
+	pipeline, open, _ := DealFixture(t, e)
+	admin := e.Admin()
+
+	// Seeded workspace-visible so the admin's link write passes its own
+	// EnsureLinkTarget gate; capture privacy lands afterwards, which is the
+	// order a connector-captured contact reaches this state in anyway.
+	privateOrg := e.SeedOrg(t, "Meridian Labs", &e.Rep3)
+	partnerOrg := e.SeedOrg(t, "Northgate Partners", &e.Rep3)
+	openOrg := e.SeedOrg(t, "Kestrel Foods", nil)
+
+	hiddenRefs := ids.From[ids.DealKind](e.SeedDeal(t, "Meridian renewal", pipeline, open, &e.Rep1))
+	privateOrgID, partnerOrgID := orgIDOf(privateOrg), orgIDOf(partnerOrg)
+	if _, err := e.Deals.UpdateDeal(admin, hiddenRefs, deals.UpdateDealInput{
+		OrganizationID:        &privateOrgID,
+		PartnerOrganizationID: &partnerOrgID,
+	}); err != nil {
+		t.Fatalf("linking the deal to its organizations: %v", err)
+	}
+	e.MakeCapturePrivate(t, "organization", privateOrg, e.Rep3)
+	e.MakeCapturePrivate(t, "organization", partnerOrg, e.Rep3)
+
+	// The project is Team2's; a deal and its project must name the same
+	// company, so the anchor org stays workspace-visible and only the project
+	// is out of Rep1's reach.
+	project := seedProject(admin, t, e, "Kestrel rollout", strPtr("KES-1"), openOrg, &e.Rep3)
+	hiddenProj := ids.From[ids.DealKind](e.SeedDeal(t, "Kestrel expansion", pipeline, open, &e.Rep1))
+	openOrgID := orgIDOf(openOrg)
+	if _, err := e.Deals.UpdateDeal(admin, hiddenProj, deals.UpdateDealInput{
+		OrganizationID: &openOrgID,
+		ProjectID:      &project.ID,
+	}); err != nil {
+		t.Fatalf("linking the deal to its project: %v", err)
+	}
+	return dealReferenceFixture{hiddenRefs: hiddenRefs, hiddenProj: hiddenProj, openOrg: openOrg}
+}
+
+func TestADealDoesNotNameRecordsItsReaderCannotRead(t *testing.T) {
+	e := Setup(t)
+	fx := seedDealReferenceFixture(t, e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	// The reader can open neither organization, so neither id is handed back.
+	got, err := e.Deals.GetDeal(rep, fx.hiddenRefs, 0)
+	if err != nil {
+		t.Fatalf("a rep reading a deal whose organizations are private: %v", err)
+	}
+	if got.OrganizationId != nil {
+		t.Errorf("organization_id = %v, want withheld: it names a capture-private organization the reader cannot open", got.OrganizationId)
+	}
+	if got.PartnerOrgId != nil {
+		t.Errorf("partner_org_id = %v, want withheld", got.PartnerOrgId)
+	}
+	assertMaskNames(t, got, "organization_id", "partner_org_id")
+
+	// The project is out of the reader's row scope; its anchor company is not.
+	proj, err := e.Deals.GetDeal(rep, fx.hiddenProj, 0)
+	if err != nil {
+		t.Fatalf("a rep reading a deal whose project is another team's: %v", err)
+	}
+	if proj.ProjectId != nil {
+		t.Errorf("project_id = %v, want withheld: the project is outside the reader's row scope", proj.ProjectId)
+	}
+	if proj.OrganizationId == nil || ids.UUID(*proj.OrganizationId) != fx.openOrg {
+		t.Errorf("organization_id = %v, want the workspace-visible company the reader CAN open", proj.OrganizationId)
+	}
+	assertMaskNames(t, proj, "project_id")
+
+	// A reader who can see all three still receives all three.
+	full, err := e.Deals.GetDeal(e.Admin(), fx.hiddenProj, 0)
+	if err != nil || full.ProjectId == nil || full.OrganizationId == nil || full.MaskedFields != nil {
+		t.Errorf("the admin's read = org %v project %v masked %v (%v), want every reference", full.OrganizationId, full.ProjectId, full.MaskedFields, err)
+	}
+}
+
+// TestTheDealListWithholdsTheSameReferencesAsTheGet proves the page path, not
+// only the single-row one: a list is where an existence oracle is cheapest.
+func TestTheDealListWithholdsTheSameReferencesAsTheGet(t *testing.T) {
+	e := Setup(t)
+	fx := seedDealReferenceFixture(t, e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	page, _, err := e.Deals.ListDeals(rep, deals.ListDealsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[ids.UUID]bool{}
+	for i := range page {
+		d := page[i]
+		seen[ids.UUID(d.Id)] = true
+		switch ids.UUID(d.Id) {
+		case fx.hiddenRefs.UUID:
+			if d.OrganizationId != nil || d.PartnerOrgId != nil {
+				t.Errorf("the list handed out a private organization: org %v partner %v", d.OrganizationId, d.PartnerOrgId)
+			}
+			assertMaskNames(t, d, "organization_id", "partner_org_id")
+		case fx.hiddenProj.UUID:
+			if d.ProjectId != nil {
+				t.Errorf("the list handed out another team's project: %v", d.ProjectId)
+			}
+		}
+	}
+	if !seen[fx.hiddenRefs.UUID] || !seen[fx.hiddenProj.UUID] {
+		t.Errorf("the list shows %v, want both deals — withholding a reference must not drop the row", seen)
+	}
+}
+
+// assertMaskNames checks masked_fields carries exactly the given names: a null
+// a reader cannot distinguish from an empty field is the half-fix this whole
+// seam exists to avoid.
+func assertMaskNames(t *testing.T, d crmcontracts.Deal, want ...string) {
+	t.Helper()
+	if d.MaskedFields == nil {
+		t.Errorf("masked_fields is absent, want %v named — a withheld null must say it was withheld", want)
+		return
+	}
+	got := map[string]bool{}
+	for _, f := range *d.MaskedFields {
+		got[f] = true
+	}
+	for _, f := range want {
+		if !got[f] {
+			t.Errorf("masked_fields = %v, want it to name %s", *d.MaskedFields, f)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("masked_fields = %v, want exactly %v", *d.MaskedFields, want)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14384,17 +14384,17 @@ type Deal struct {
 	MaskedFields *[]string `json:"masked_fields,omitempty"`
 	Name         string    `json:"name"`
 
-	// OrganizationId Primary org; never a raw lead.
+	// OrganizationId Primary org; never a raw lead. Null when the caller may not read that organization, in which case `masked_fields` names it.
 	OrganizationId *openapi_types.UUID `json:"organization_id,omitempty"`
 	OwnerId        *openapi_types.UUID `json:"owner_id,omitempty"`
 
-	// PartnerOrgId Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row.
+	// PartnerOrgId Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row. Null when the caller may not read that organization, in which case `masked_fields` names it.
 	PartnerOrgId *openapi_types.UUID `json:"partner_org_id,omitempty"`
 
 	// PipelineId Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent's own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).
 	PipelineId *openapi_types.UUID `json:"pipeline_id"`
 
-	// ProjectId The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422.
+	// ProjectId The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422. Null when the caller may not read that project, in which case `masked_fields` names it.
 	ProjectId *openapi_types.UUID     `json:"project_id,omitempty"`
 	Raw       *map[string]interface{} `json:"raw,omitempty"`
 	Source    string                  `json:"source"`

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -349,7 +349,7 @@ func (s *Store) ArchiveDeal(ctx context.Context, id ids.DealID) (crmcontracts.De
 		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventDealArchived{}); err != nil {
 			return fmt.Errorf("emit deal.archived: %w", err)
 		}
-		if out, err = readDeal(ctx, tx, id, storekit.IncludeArchived, active); err != nil {
+		if out, err = readDealForCaller(ctx, tx, id, storekit.IncludeArchived, active); err != nil {
 			return fmt.Errorf("read archived deal: %w", err)
 		}
 		return nil

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -154,7 +154,7 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 				return fmt.Errorf("stamp won deal's correspondence: %w", err)
 			}
 		}
-		if out, err = readDeal(ctx, tx, id, storekit.LiveOnly, active); err != nil {
+		if out, err = readDealForCaller(ctx, tx, id, storekit.LiveOnly, active); err != nil {
 			return fmt.Errorf("read advanced deal: %w", err)
 		}
 		return nil

--- a/backend/internal/modules/deals/deal_create.go
+++ b/backend/internal/modules/deals/deal_create.go
@@ -201,7 +201,7 @@ func (s *Store) createDealInTx(ctx context.Context, tx pgx.Tx, in CreateDealInpu
 	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventDealCreated{Name: in.Name}); err != nil {
 		return crmcontracts.Deal{}, fmt.Errorf("emit deal.created: %w", err)
 	}
-	out, err := readDeal(ctx, tx, id, storekit.LiveOnly, active)
+	out, err := readDealForCaller(ctx, tx, id, storekit.LiveOnly, active)
 	if err != nil {
 		return crmcontracts.Deal{}, fmt.Errorf("read created deal: %w", err)
 	}

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -36,18 +36,28 @@ func (s *Store) GetDeal(ctx context.Context, id ids.DealID, archived storekit.Ar
 		if err := auth.EnsureVisible(ctx, tx, "deal", id.UUID); err != nil {
 			return err
 		}
-		out, err = readDeal(ctx, tx, id, archived, active)
-		if err != nil {
-			return err
-		}
-		one := []crmcontracts.Deal{out}
-		if err := maskDeals(ctx, tx, one); err != nil {
-			return err
-		}
-		out = one[0]
-		return nil
+		out, err = readDealForCaller(ctx, tx, id, archived, active)
+		return err
 	})
 	return out, err
+}
+
+// readDealForCaller reads one deal and masks it — the spelling EVERY entry
+// point that hands a deal back uses, a mutation response included. A response
+// is a read: the row a PATCH echoes is the same row a GET withholds from, and
+// the reference withholding cannot ride on write authority the way a role mask
+// does — being allowed to change the DEAL says nothing about being allowed to
+// read the ORGANIZATION it names.
+//
+// readDeal itself stays unmasked on purpose. The update path builds its
+// before-image from it, and an audit diff taken against a withheld null would
+// record a change nobody made.
+func readDealForCaller(ctx context.Context, tx pgx.Tx, id ids.DealID, archived storekit.ArchivedFilter, active []fieldcatalog.Column) (crmcontracts.Deal, error) {
+	d, err := readDeal(ctx, tx, id, archived, active)
+	if err != nil {
+		return crmcontracts.Deal{}, err
+	}
+	return maskDealForCaller(ctx, tx, d)
 }
 
 type ListDealsInput struct {
@@ -104,7 +114,10 @@ func (s *Store) ListDeals(ctx context.Context, in ListDealsInput) ([]crmcontract
 	if err != nil {
 		return nil, storekit.Page{}, err
 	}
-	where := appendDealFilters(pre.where, in, pre.arg)
+	where, err := appendDealFilters(ctx, pre.where, in, pre.arg)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
 
 	return runListPage(ctx, s, pre, "deal", dealColumns, active, where, scanDealPage,
 		func(d crmcontracts.Deal) (time.Time, ids.UUID) { return d.CreatedAt, ids.UUID(d.Id) },
@@ -140,7 +153,7 @@ func scanDealPage(rows pgx.Rows, active []fieldcatalog.Column, sorted *storekit.
 // visibility, full-text query, the column equality filters, and the
 // stalled predicate — into WHERE clauses (the cf_ filters and the keyset
 // cursor, which depends on the validated sort, stay in ListDeals).
-func appendDealFilters(where []string, in ListDealsInput, arg func(any) int) []string {
+func appendDealFilters(ctx context.Context, where []string, in ListDealsInput, arg func(any) int) ([]string, error) {
 	if !in.IncludeArchived {
 		where = append(where, "archived_at IS NULL")
 	}
@@ -156,14 +169,22 @@ func appendDealFilters(where []string, in ListDealsInput, arg func(any) int) []s
 	if in.OwnerID != nil {
 		where = append(where, storekit.SQLf("owner_id = $%d", arg(*in.OwnerID)))
 	}
-	if in.OrganizationID != nil {
-		where = append(where, storekit.SQLf("organization_id = $%d", arg(*in.OrganizationID)))
-	}
-	if in.ProjectID != nil {
-		where = append(where, storekit.SQLf("project_id = $%d", arg(*in.ProjectID)))
-	}
-	if in.PartnerOrgID != nil {
-		where = append(where, storekit.SQLf("partner_org_id = $%d", arg(*in.PartnerOrgID)))
+	for _, ref := range []struct {
+		column, table string
+		id            *ids.UUID
+	}{
+		{filterOrganizationID, "organization", uuidOfFilter(in.OrganizationID)},
+		{filterProjectID, "project", uuidOfFilter(in.ProjectID)},
+		{filterPartnerOrgID, "organization", uuidOfFilter(in.PartnerOrgID)},
+	} {
+		if ref.id == nil {
+			continue
+		}
+		clause, err := referenceFilterClause(ctx, ref.column, ref.table, *ref.id, arg)
+		if err != nil {
+			return nil, err
+		}
+		where = append(where, clause)
 	}
 	if in.PartnerSourced != nil {
 		if *in.PartnerSourced {
@@ -182,7 +203,44 @@ func appendDealFilters(where []string, in ListDealsInput, arg func(any) int) []s
 			where = append(where, "NOT "+StalledSQL(""))
 		}
 	}
-	return where
+	return where, nil
+}
+
+// uuidOfFilter widens one optional typed filter id to the untyped UUID the
+// reference table above walks. It is deliberately the only widening here: the
+// phantom kind is what stops a project id being probed against organization.
+func uuidOfFilter[K ids.EntityKind](id *ids.ID[K]) *ids.UUID {
+	if id == nil {
+		return nil
+	}
+	return &id.UUID
+}
+
+// referenceFilterClause narrows a filter on a column that NAMES another record
+// to the rows whose target the caller may read.
+//
+// Filtering by an id is asking whether it is there. A bare
+// `organization_id = $1` answers that question for an organization the caller
+// cannot open — the same existence oracle the projection now withholds — so
+// the arm carries the target's own visibility predicate. An empty page is the
+// honest answer, and it is indistinguishable from a visible company that has
+// no deals, which is what existence-hiding wants.
+//
+// An empty scope clause means a caller who reads every row of that table;
+// there is nothing to narrow and the EXISTS would only confirm what the
+// composite foreign key already guarantees.
+func referenceFilterClause(ctx context.Context, column, table string, id ids.UUID, arg func(any) int) (string, error) {
+	pos := arg(id)
+	scope, err := auth.ScopeClauseFor(ctx, table, "ref", arg)
+	if err != nil {
+		return "", err
+	}
+	clause := storekit.SQLf("%s = $%d", column, pos)
+	if scope == "" {
+		return clause, nil
+	}
+	return clause + storekit.SQLf(
+		" AND EXISTS (SELECT 1 FROM %s ref WHERE ref.id = $%d AND %s)", table, pos, scope), nil
 }
 
 const dealColumns = `id, name, amount_minor, currency, pipeline_id, stage_id,

--- a/backend/internal/modules/deals/deal_read_test.go
+++ b/backend/internal/modules/deals/deal_read_test.go
@@ -4,13 +4,26 @@
 package deals
 
 import (
+	"context"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
+
+// systemFilterCtx is the caller for whom no reference filter needs narrowing:
+// the system principal reads every organization and project, so
+// referenceFilterClause renders the bare equality these cases are about.
+// TestAReferenceFilterIsNarrowedToTargetsTheCallerReads covers the other side.
+func systemFilterCtx() context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:test",
+	})
+}
 
 // The partner attribution filters on the deals list: partner_org_id is a
 // column equality match, partner_sourced is attribution PRESENCE — true
@@ -30,7 +43,7 @@ func TestAppendDealFiltersPartnerAttribution(t *testing.T) {
 			name:        "partner_org_id is an equality match",
 			in:          ListDealsInput{PartnerOrgID: &partnerOrg},
 			wantClauses: []string{"archived_at IS NULL", "partner_org_id = $1"},
-			wantArgs:    []any{partnerOrg},
+			wantArgs:    []any{partnerOrg.UUID},
 		},
 		{
 			name:        "partner_sourced true selects attributed deals",
@@ -48,14 +61,17 @@ func TestAppendDealFiltersPartnerAttribution(t *testing.T) {
 			name:        "both partner filters compose",
 			in:          ListDealsInput{PartnerOrgID: &partnerOrg, PartnerSourced: &sourced},
 			wantClauses: []string{"archived_at IS NULL", "partner_org_id = $1", "partner_org_id IS NOT NULL"},
-			wantArgs:    []any{partnerOrg},
+			wantArgs:    []any{partnerOrg.UUID},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var args []any
 			arg := func(v any) int { args = append(args, v); return len(args) }
-			got := appendDealFilters(nil, tc.in, arg)
+			got, err := appendDealFilters(systemFilterCtx(), nil, tc.in, arg)
+			if err != nil {
+				t.Fatalf("appendDealFilters: %v", err)
+			}
 			if !slices.Equal(got, tc.wantClauses) {
 				t.Fatalf("clauses = %q, want %q", got, tc.wantClauses)
 			}
@@ -79,7 +95,10 @@ func TestAppendDealFiltersPartnerBeforeCursorKeepsPlaceholderOrder(t *testing.T)
 	cursor := storekit.EncodeCursor(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), ids.NewV7())
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
-	got := appendDealFilters(nil, ListDealsInput{PartnerOrgID: &partnerOrg}, arg)
+	got, err := appendDealFilters(systemFilterCtx(), nil, ListDealsInput{PartnerOrgID: &partnerOrg}, arg)
+	if err != nil {
+		t.Fatalf("appendDealFilters: %v", err)
+	}
 	var defaultSort *storekit.ListSort
 	clause, err := defaultSort.KeysetClause(cursor, arg)
 	if err != nil {
@@ -92,5 +111,46 @@ func TestAppendDealFiltersPartnerBeforeCursorKeepsPlaceholderOrder(t *testing.T)
 	}
 	if len(args) != 3 {
 		t.Fatalf("expected 3 bound args (org + cursor pair), got %d: %v", len(args), args)
+	}
+}
+
+// Filtering by an id is asking whether it is there. A bounded caller's filter
+// on a reference therefore carries the target's own visibility predicate, so
+// `?organization_id=<an org I cannot open>` cannot confirm the binding the
+// projection withholds — it returns the empty page a company with no deals
+// returns.
+func TestAReferenceFilterIsNarrowedToTargetsTheCallerReads(t *testing.T) {
+	org := ids.New[ids.OrganizationKind]()
+	project := ids.New[ids.ProjectKind]()
+	bounded := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:test",
+		UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects:  map[string]principal.ObjectGrant{"deal": {Read: true}},
+			RowScope: principal.RowScopeOwn,
+		},
+	})
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	got, err := appendDealFilters(bounded, nil,
+		ListDealsInput{OrganizationID: &org, ProjectID: &project, PartnerOrgID: &org}, arg)
+	if err != nil {
+		t.Fatalf("appendDealFilters: %v", err)
+	}
+	for _, want := range []string{
+		"EXISTS (SELECT 1 FROM organization ref WHERE ref.id = $1",
+		"EXISTS (SELECT 1 FROM project ref WHERE ref.id = $",
+	} {
+		if !slices.ContainsFunc(got, func(c string) bool { return strings.Contains(c, want) }) {
+			t.Errorf("clauses = %q, want one carrying %q — an unnarrowed filter is an existence oracle", got, want)
+		}
+	}
+	// partner_org_id is the third arm and points at the same table; it must be
+	// narrowed too, or the oracle simply moves one column across.
+	if !slices.ContainsFunc(got, func(c string) bool {
+		return strings.HasPrefix(c, filterPartnerOrgID+" = $") && strings.Contains(c, "FROM organization ref")
+	}) {
+		t.Errorf("clauses = %q, want the partner arm narrowed as well", got)
 	}
 }

--- a/backend/internal/modules/deals/deal_update.go
+++ b/backend/internal/modules/deals/deal_update.go
@@ -107,7 +107,10 @@ func (s *Store) updateDealInTx(ctx context.Context, tx pgx.Tx,
 	}
 	storekit.SetCustomFieldPatch(p, active, in.CustomFields, current.AdditionalProperties)
 	if p.Empty() {
-		return current, nil
+		// Nothing changed, but the echo is still a read: `current` came from
+		// the unmasked readDeal above, which the before-image needs and the
+		// caller must not have.
+		return maskDealForCaller(ctx, tx, current)
 	}
 
 	if err := s.applyMoneyInvariants(ctx, tx, current, in, p); err != nil {
@@ -123,7 +126,7 @@ func (s *Store) updateDealInTx(ctx context.Context, tx pgx.Tx,
 	if err := recordDealUpdate(ctx, tx, id, current, in, p); err != nil {
 		return crmcontracts.Deal{}, err
 	}
-	out, err := readDeal(ctx, tx, id, storekit.LiveOnly, active)
+	out, err := readDealForCaller(ctx, tx, id, storekit.LiveOnly, active)
 	if err != nil {
 		return crmcontracts.Deal{}, fmt.Errorf("read updated deal: %w", err)
 	}

--- a/backend/internal/modules/deals/fieldmask.go
+++ b/backend/internal/modules/deals/fieldmask.go
@@ -10,9 +10,11 @@ package deals
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -29,12 +31,67 @@ var dealMaskableFields = map[string]func(*crmcontracts.Deal){
 	// would read as a priced deal with its figure missing.
 	"amount_minor": func(d *crmcontracts.Deal) { d.AmountMinor, d.Currency = nil, nil },
 	"currency":     func(d *crmcontracts.Deal) { d.Currency = nil },
+	// The three references. They are withheld by the same mechanism as a role
+	// mask because the reader needs the same thing from them: a null they can
+	// tell from an empty field. Which rows they are withheld ON is a different
+	// question, answered per row by unreadableReferences.
+	filterOrganizationID: func(d *crmcontracts.Deal) { d.OrganizationId = nil },
+	filterProjectID:      func(d *crmcontracts.Deal) { d.ProjectId = nil },
+	filterPartnerOrgID:   func(d *crmcontracts.Deal) { d.PartnerOrgId = nil },
 }
 
-// maskDeals withholds, per row, the fields the caller's role masks. One
-// statement answers which rows of the page the caller could change; the
-// masks conditioned on write authority lift on those.
+// withheldFields is the ordered set of columns withheld from ONE row. Ordered
+// because masked_fields goes on the wire, and a client diffing two reads of
+// the same deal should not see the list reshuffle under it.
+type withheldFields []string
+
+func (w *withheldFields) add(field string) {
+	if !slices.Contains(*w, field) {
+		*w = append(*w, field)
+	}
+}
+
+// applyTo withholds every named field from the row and records the names on
+// it. A name with no withhold func in dealMaskableFields is dropped rather
+// than reported: naming a field in masked_fields while still sending its value
+// is a worse answer than either half alone.
+func (w withheldFields) applyTo(d *crmcontracts.Deal) {
+	named := make([]string, 0, len(w))
+	for _, field := range w {
+		withhold, known := dealMaskableFields[field]
+		if !known {
+			continue
+		}
+		withhold(d)
+		named = append(named, field)
+	}
+	if len(named) > 0 {
+		d.MaskedFields = &named
+	}
+}
+
+// maskDeals withholds, per row, what this reader may not have: the columns
+// their ROLE masks, and the references naming a record they could not open.
+// Both end the same way — the field goes out null and masked_fields names it —
+// so both are collected per row and applied once.
 func maskDeals(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal) error {
+	withheld := make([]withheldFields, len(deals))
+	if err := roleMaskedFields(ctx, tx, deals, withheld); err != nil {
+		return err
+	}
+	if err := unreadableReferences(ctx, tx, deals, withheld); err != nil {
+		return err
+	}
+	for i := range deals {
+		withheld[i].applyTo(&deals[i])
+	}
+	return nil
+}
+
+// roleMaskedFields collects the columns the caller's role withholds on each
+// row. One statement answers which rows of the page the caller could change;
+// the masks conditioned on write authority lift on those.
+func roleMaskedFields(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal, withheld []withheldFields) error {
 	p, err := storekit.Actor(ctx)
 	if err != nil {
 		return err
@@ -52,22 +109,62 @@ func maskDeals(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal) error 
 		return err
 	}
 	for i := range deals {
-		deal := &deals[i]
-		masked := auth.MaskedFields(p, "deal", writable[ids.UUID(deal.Id)])
-		if len(masked) == 0 {
-			continue
+		for _, field := range auth.MaskedFields(p, "deal", writable[ids.UUID(deals[i].Id)]) {
+			withheld[i].add(field)
 		}
-		named := make([]string, 0, len(masked))
-		for _, field := range masked {
-			withhold, known := dealMaskableFields[field]
-			if !known {
-				continue
+	}
+	return nil
+}
+
+// unreadableReferences withholds a deal's links to records the caller could
+// not open. Every seat of the workspace reads every deal — a deal is customer
+// identity — but the records it POINTS AT are not: an organization can be
+// capture-private to the colleague who captured it, and a project keeps its own
+// own/team row scope. Handing the id back regardless would make the deal an
+// existence oracle over rows the reader's own organization and project reads
+// would refuse.
+//
+// The write path has enforced exactly this rule all along: applyDealLinkPatches
+// gates all three references with auth.EnsureLinkTarget before setting them.
+// The system already agrees you may not NAME an organization you cannot see;
+// this is the half that never asked when handing one back.
+//
+// ONE statement per referenced table for the whole page, never a probe per row.
+func unreadableReferences(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal, withheld []withheldFields) error {
+	orgIDs := make([]ids.UUID, 0, 2*len(deals))
+	projectIDs := make([]ids.UUID, 0, len(deals))
+	for _, d := range deals {
+		// partner_org_id points at the same table as organization_id, so one
+		// organization query answers both arms.
+		for _, ref := range []*openapi_types.UUID{d.OrganizationId, d.PartnerOrgId} {
+			if ref != nil {
+				orgIDs = append(orgIDs, ids.UUID(*ref))
 			}
-			withhold(deal)
-			named = append(named, field)
 		}
-		if len(named) > 0 {
-			deal.MaskedFields = &named
+		if d.ProjectId != nil {
+			projectIDs = append(projectIDs, ids.UUID(*d.ProjectId))
+		}
+	}
+	// VisibleSubset answers an empty list without a round trip, so a page that
+	// names no organization or no project pays for neither.
+	visibleOrgs, err := auth.VisibleSubset(ctx, tx, "organization", orgIDs)
+	if err != nil {
+		return err
+	}
+	visibleProjects, err := auth.VisibleSubset(ctx, tx, "project", projectIDs)
+	if err != nil {
+		return err
+	}
+	for i := range deals {
+		d := deals[i]
+		if d.OrganizationId != nil && !visibleOrgs[ids.UUID(*d.OrganizationId)] {
+			withheld[i].add(filterOrganizationID)
+		}
+		if d.PartnerOrgId != nil && !visibleOrgs[ids.UUID(*d.PartnerOrgId)] {
+			withheld[i].add(filterPartnerOrgID)
+		}
+		if d.ProjectId != nil && !visibleProjects[ids.UUID(*d.ProjectId)] {
+			withheld[i].add(filterProjectID)
 		}
 	}
 	return nil

--- a/backend/internal/modules/deals/fieldmask.go
+++ b/backend/internal/modules/deals/fieldmask.go
@@ -70,6 +70,15 @@ func (w withheldFields) applyTo(d *crmcontracts.Deal) {
 	}
 }
 
+// maskDealForCaller applies the read masks to ONE row about to leave the store.
+func maskDealForCaller(ctx context.Context, tx pgx.Tx, d crmcontracts.Deal) (crmcontracts.Deal, error) {
+	one := []crmcontracts.Deal{d}
+	if err := maskDeals(ctx, tx, one); err != nil {
+		return crmcontracts.Deal{}, err
+	}
+	return one[0], nil
+}
+
 // maskDeals withholds, per row, what this reader may not have: the columns
 // their ROLE masks, and the references naming a record they could not open.
 // Both end the same way — the field goes out null and masked_fields names it —

--- a/backend/internal/modules/deals/listfilters.go
+++ b/backend/internal/modules/deals/listfilters.go
@@ -14,9 +14,10 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
-// The filter names this module answers, spelled once each. They are wire names
-// — a caller's query parameter — which is why they are not the column
-// constants they happen to match today.
+// The wire field names this module answers, spelled once each: a caller's
+// query parameter on a list, and the same name where a read reports the field
+// withheld (fieldmask.go). They are wire names, which is why they are not the
+// column constants they happen to match today.
 const (
 	filterOrganizationID = "organization_id"
 	filterOwnerID        = "owner_id"

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -427,9 +427,12 @@ func VisibleSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.UU
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	idsPos := arg(rowIDs)
+	// The clause is rendered into its own variable first: it registers
+	// parameters through arg, and Go does not fix the order in which a call's
+	// operands are evaluated against `args` passed to the same call.
+	clause := VisiblePredicate(p, table, arg)("")
 	rows, err := tx.Query(ctx,
-		fmt.Sprintf(`SELECT id FROM %[1]s WHERE id = ANY($%[2]d) AND %[3]s`,
-			table, idsPos, VisiblePredicate(p, table, arg)("")), args...)
+		fmt.Sprintf(`SELECT id FROM %[1]s WHERE id = ANY($%[2]d) AND %[3]s`, table, idsPos, clause), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -388,3 +388,58 @@ func EnsureVisible(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) er
 	}
 	return nil
 }
+
+// VisibleSubset answers, in ONE statement, which of the given rows of a
+// row-scoped table the caller may SEE — the question EnsureVisible asks of one
+// row, asked of a whole page at once. It is the read-only twin of
+// WritableSubset (fieldmask.go) and exists for the same reason: a projection
+// that carries references to OTHER records must withhold the ones its reader
+// could not open, and a probe per reference is a round trip per row.
+//
+// Absent from the answer means withheld, and a row that does not exist is
+// absent too — which is what existence-hiding wants a caller to be unable to
+// tell apart.
+//
+// It asks EnsureVisible's question, not EnsureVisibleLive's: an archived
+// record is still readable through the archived filter, so naming one is not a
+// disclosure. A caller that must not name a soft-deleted row wants the strict
+// probe per row and its ErrNotFound.
+func VisibleSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.UUID) (map[ids.UUID]bool, error) {
+	if !ownerScopedTables[table] {
+		return nil, fmt.Errorf("auth: %q is not a row-scoped table", table)
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[ids.UUID]bool, len(rowIDs))
+	// The caller reads this table with no predicate at all. EnsureVisible
+	// returns nil for each of these without issuing a query, and so does this.
+	if UnboundedFor(p, table) {
+		for _, id := range rowIDs {
+			out[id] = true
+		}
+		return out, nil
+	}
+	if len(rowIDs) == 0 {
+		return out, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(rowIDs)
+	rows, err := tx.Query(ctx,
+		fmt.Sprintf(`SELECT id FROM %[1]s WHERE id = ANY($%[2]d) AND %[3]s`,
+			table, idsPos, VisiblePredicate(p, table, arg)("")), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12938,17 +12938,17 @@ export interface components {
             stage_id: string | null;
             /**
              * Format: uuid
-             * @description Primary org; never a raw lead.
+             * @description Primary org; never a raw lead. Null when the caller may not read that organization, in which case `masked_fields` names it.
              */
             organization_id?: string | null;
             /**
              * Format: uuid
-             * @description Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row.
+             * @description Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row. Null when the caller may not read that organization, in which case `masked_fields` names it.
              */
             partner_org_id?: string | null;
             /**
              * Format: uuid
-             * @description The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422.
+             * @description The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422. Null when the caller may not read that project, in which case `masked_fields` names it.
              */
             project_id?: string | null;
             /** Format: uuid */


### PR DESCRIPTION
Closes #1876.

## The claim this PR makes

**A deal read served by the deals module — `GetDeal`, `ListDeals`, and all four mutation responses — no longer hands back the id of an organization or project its reader could not open**, and the list's reference filters no longer confirm what the projection withholds. The reference goes out `null` and `masked_fields` names it, so a reader tells *withheld* from *nobody entered one*.

⚠️ **Scope, stated up front so nobody reads more into this than it delivers.** The same three columns are still disclosed by six read paths OUTSIDE this module — filtered/bundle export, prebuilt reports (`open-deals-per-company` groups by `organization_id` by default), `query_workspace`'s direct field predicate, offer reads (`buyer_org_id`, and `buyer_snapshot` carries the organization's NAME), direct contract reads, and the open question of whether a missing object grant should withhold too. Found by Codex review on this PR and tracked in **#2004**. They live in five modules with five visibility models; a module never imports a sibling, so each belongs in its own change.

## The strongest fact, which the issue omits

`deal_read.go:36` holds the file's only `auth.Ensure*` call:

```go
if err := auth.EnsureVisible(ctx, tx, "deal", id.UUID); err != nil {
```

**It is inert for every human seat.** `deal` is an `identityTable` (`auth/tableclass.go:28-30`) and is not `ownerPrivate` (`rowscope.go:107`), so `UnboundedFor` returns true for any human, `ScopeClauseFor` returns `""`, and `EnsureVisible` returns `nil` at `rowscope.go:376-378` **without issuing a query**. `GetDeal` performed no row check of any kind, on the deal or on anything it names.

## Why nulling is the right answer, and where the rule already lived

The write path has enforced exactly this rule all along — `applyDealLinkPatches` gates all three references with `auth.EnsureLinkTarget` before setting them (`deal.go:138,147,154`). **The system already agreed you may not NAME an organization you cannot see; it just never asked when handing one back.**

Prior art, followed rather than re-invented: `capture/tracestore.go:343-350` ("returning the id would make this surface an existence oracle over rows the timeline itself would refuse") and `compose/pipelinetrace/ladder.go:88-110`.

Contract-legal without a schema change: all three are already optional and `type: [string, 'null']` in `crm.yaml`. Their descriptions now say null can mean withheld.

## Evidence

**RED**, on unmodified `origin/main` with only the new test file added:

```
--- FAIL: TestADealDoesNotNameRecordsItsReaderCannotRead
    organization_id = 01a01e45-8641-…455, want withheld: it names a
      capture-private organization the reader cannot open
    partner_org_id = 01a01e45-8646-…41e, want withheld
    masked_fields is absent, want [organization_id partner_org_id] named
--- FAIL: TestTheDealListWithholdsTheSameReferencesAsTheGet
    the list handed out another team's project: 01a01e45-8697-…8a8
```

The FKs are set **through the real writer** (`UpdateDeal`), not hand-inserted. Capture privacy lands *after* the link write, because the admin's own `EnsureLinkTarget` would otherwise refuse to set a reference it cannot see — which is itself the write-side rule working.

**CONTROL** — `make check` printed PASS over the defect (`ok github.com/gradionhq/margince/backend`, contract drift OK, 165 ok/OK legs). That is the scope-escape evidence: the deterministic gate is structurally blind to this, and #1984 says why.

**GREEN** — both tests pass; `TestARepReadsEveryDealButNotAnotherTeamsAmount` still passes on the same seam; full integration lane `OK: integration passed with 0 skips (41 packages)`; `make check` green; `make craft-static` 0 findings.

**MUTATION** — deleting the three entries from `dealMaskableFields` takes the new test red on all five assertions. `fieldmask.go:26` states a mask naming an unlisted column is inert, so the registration is the load-bearing half, and this proves it rather than asserting it.

## The one real risk, named

A withheld null is indistinguishable from an intentional clear on write-back. The patch path is safe as written — `applyDealLinkPatches` only calls `p.Set` when `in.X != nil` — but a client round-tripping a full read into a PATCH with explicit nulls would clear the FK. `masked_fields` is the existing mitigation, and `amount_minor` has carried the same exposure since it shipped.

## Cost

One statement per referenced table per page, never a probe per row (`auth.VisibleSubset`, the read-only twin of `WritableSubset`). A page naming no organization and no project pays for neither. An admin pays one organization query — capture privacy does not yield to `row_scope=all`, by founder decision — and zero for projects, which short-circuit on `UnboundedFor`.

## Not fixed here, filed instead

- **#2004** — tracker: the six readers outside the deals module that still project these references (Codex review, round 2).

- **#1983** — the same defect on `project_read.go` and `contracts/store.go`. `Contract.organization_id` and `Project.organization_id` are `required` and non-nullable, so the remedy that worked for deals is contract-illegal there. Filed `status: needs-decision` with three options and a recommendation.
- **#1984** — widening `composerowscope_test.go` over `internal/modules`. It would **not** have caught this, for three reasons verified against source: `reachesRowScope` never consults `site.table`; the greedy `fkColumn` regex yields `partner_org` for `partner_org_id` and drops it silently, as it does every role-named FK; and the resulting failure would be a shape accident satisfiable by a deal-scope probe that fixes nothing.

## Reviewer, please look hardest at

- **the reader I may have forgotten** — someone who passes the deal gate and must fail the reference gate in a path other than `GetDeal`/`ListDeals`. `readDeal` is deliberately left unmasked because the update path's before-image depends on it (`deal.go:141,150,156`); is there a third caller?
- **`masked_fields` as two readings of one value** — it now carries role masks and reference withholding in one list. A client cannot tell which is which. Is that the right contract?
- **`VisibleSubset` asks `EnsureVisible`'s question, not `EnsureVisibleLive`'s** — an archived organization is still named. The reasoning is that archived records are readable through the archived filter, so it is not a disclosure. Disagree if you see a path where it is.

## Coverage · UAT

Backend only, no UI: no UAT video owed (the goal file says so explicitly). New code is exercised by the integration lane, which CI reconciles into the Sonar coverage report.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents deal reads and mutation responses from leaking `organization_id`, `partner_org_id`, or `project_id` the caller cannot open. Previously these ids were returned unconditionally; now they return null and `masked_fields` names each withheld field. Filters on these ids now honor target visibility to avoid existence oracles and return an empty page when the target is unreadable.

- Adds `auth.VisibleSubset` and extends masking to include unreadable references alongside role-based masks, applied once per row; one query per referenced table per page.
- Routes all caller-facing returns through `readDealForCaller` so GET, LIST, and every mutation response withhold the same fields.
- Narrows `organization_id`, `project_id`, and `partner_org_id` filters with the target’s visibility predicate; `?organization_id=<unreadable>` yields an empty page, not a 404.
- Documents null-as-withheld in `crm.yaml`; regenerates `api_gen.go` and frontend typings; adds unit/integration tests for GET, LIST, all mutations, and filters.
- Client impact: these ids may now be null where they were previously present; rely on `masked_fields` to distinguish withheld from empty. No data migration required.

<sup>Written for commit 39ba4790ffaaea5eea45b8c9e81261dd9a1d9c3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Deal responses now hide organization, partner organization, and project references that the viewer cannot access.
  * Hidden references are identified in `masked_fields`, while the deal itself remains visible.
  * Filtering by inaccessible references now returns an empty result without revealing whether records exist.

* **Consistency**
  * Visibility masking is applied consistently across deal lists, details, creation, updates, advancement, and archiving.
  * Documentation now clarifies reference-access and masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
