### PR TITLE
refactor(identity): role and role_assignment drop the tenant column

### DIFF
--- a/backend/internal/compose/extingress_integration_test.go
+++ b/backend/internal/compose/extingress_integration_test.go
@@ -117,23 +117,23 @@ func grantCapture(t *testing.T, e *extRuntimeEnv, member ids.UUID) {
 	var roleID ids.UUID
 	if err := owner.QueryRow(context.Background(),
 		`WITH existing AS (
-		     SELECT id FROM role WHERE workspace_id = $1 AND key = 'ingress-probe'
+		     SELECT id FROM role WHERE key = 'ingress-probe'
 		 ), created AS (
-		     INSERT INTO role (workspace_id, key, name, permissions)
-		     SELECT $1, 'ingress-probe', 'Ingress Probe', $2::jsonb
+		     INSERT INTO role (key, name, permissions)
+		     SELECT 'ingress-probe', 'Ingress Probe', $1::jsonb
 		     WHERE NOT EXISTS (SELECT 1 FROM existing)
 		     RETURNING id
 		 )
 		 SELECT id FROM created UNION ALL SELECT id FROM existing`,
-		e.WS, capturePolicy).Scan(&roleID); err != nil {
+		capturePolicy).Scan(&roleID); err != nil {
 		t.Fatalf("seeding the capture role: %v", err)
 	}
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO role_assignment (workspace_id, role_id, user_id)
-		 SELECT $1, $2, $3
+		`INSERT INTO role_assignment (role_id, user_id)
+		 SELECT $1, $2
 		 WHERE NOT EXISTS (
-		     SELECT 1 FROM role_assignment WHERE workspace_id = $1 AND role_id = $2 AND user_id = $3)`,
-		e.WS, roleID, member); err != nil {
+		     SELECT 1 FROM role_assignment WHERE role_id = $1 AND user_id = $2)`,
+		roleID, member); err != nil {
 		t.Fatalf("granting %s the capture role: %v", member, err)
 	}
 }
@@ -145,7 +145,7 @@ func revokeRoles(t *testing.T, e *extRuntimeEnv, member ids.UUID) {
 	t.Helper()
 	owner := integration.OwnerConn(t)
 	if _, err := owner.Exec(context.Background(),
-		`DELETE FROM role_assignment WHERE workspace_id = $1 AND user_id = $2`, e.WS, member); err != nil {
+		`DELETE FROM role_assignment WHERE user_id = $1`, member); err != nil {
 		t.Fatalf("revoking %s's grants: %v", member, err)
 	}
 }

--- a/backend/internal/compose/graphconsumer_integration_test.go
+++ b/backend/internal/compose/graphconsumer_integration_test.go
@@ -459,17 +459,16 @@ func grantReadPeopleRole(t *testing.T, e *integration.Env, user ids.UUID, rowSco
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var roleID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO role (workspace_id, key, name, permissions)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-			        'ghost_owner_' || $1, 'Ghost owner test',
+			INSERT INTO role (key, name, permissions)
+			VALUES ('ghost_owner_' || $1, 'Ghost owner test',
 			        format('{"row_scope":"%s","objects":{"person":{"read":true}}}', $1)::jsonb)
 			ON CONFLICT (key) DO UPDATE SET name = EXCLUDED.name
 			RETURNING id`, rowScope).Scan(&roleID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO role_assignment (workspace_id, user_id, role_id)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)
+			INSERT INTO role_assignment (user_id, role_id)
+			VALUES ($1, $2)
 			ON CONFLICT DO NOTHING`, user, roleID)
 		return err
 	}); err != nil {

--- a/backend/internal/compose/integration/agentcommandoperand_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandoperand_integration_test.go
@@ -64,7 +64,7 @@ func TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing(t *tes
 		stmt(`UPDATE app_user SET password_hash = (SELECT password_hash FROM app_user WHERE email = 'ada@example.com') WHERE id = $1`, rep),
 		// 'rep' is an ordinary human seat: it reads every account except one
 		// whose capture is private to somebody else.
-		stmt(`INSERT INTO role_assignment (workspace_id, role_id, user_id) SELECT $2, r.id, $1 FROM role r WHERE r.key = 'rep'`, rep, wsA),
+		stmt(`INSERT INTO role_assignment (role_id, user_id) SELECT r.id, $1 FROM role r WHERE r.key = 'rep'`, rep),
 	)
 	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "rep@example.com", "password": "correct-horse-battery",

--- a/backend/internal/compose/integration/capture/capture_env_test.go
+++ b/backend/internal/compose/integration/capture/capture_env_test.go
@@ -162,15 +162,15 @@ func seedCaptureRole(t *testing.T, e *integration.SearchEnv) {
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var roleID string
 		if err := tx.QueryRow(context.Background(), `
-			INSERT INTO role (workspace_id, key, name, permissions)
-			VALUES ($1, 'capture_rep', 'Capture Rep',
+			INSERT INTO role (key, name, permissions)
+			VALUES ('capture_rep', 'Capture Rep',
 			        '{"objects":{"activity":{"create":true,"read":true},"person":{"create":true,"read":true},"organization":{"create":true,"read":true}},"row_scope":"all"}'::jsonb)
-			RETURNING id`, e.WS).Scan(&roleID); err != nil {
+			RETURNING id`).Scan(&roleID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(context.Background(),
-			`INSERT INTO role_assignment (workspace_id, role_id, user_id) VALUES ($1, $2, $3)`,
-			e.WS, roleID, e.Rep1)
+			`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
+			roleID, e.Rep1)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/commsattachments_integration_test.go
+++ b/backend/internal/compose/integration/commsattachments_integration_test.go
@@ -51,13 +51,13 @@ func sendWorkerCtx(ws ids.UUID) context.Context {
 func grantOwnScopeRepRole(t *testing.T, e *Env, user ids.UUID) {
 	t.Helper()
 	roleKey := "sendrep-" + user.String()[:8]
-	e.WsExec(t, `INSERT INTO role (workspace_id, key, name, permissions)
-		VALUES ($1, $2, 'Send Rep', $3::jsonb)`,
-		e.WS, roleKey,
+	e.WsExec(t, `INSERT INTO role (key, name, permissions)
+		VALUES ($1, 'Send Rep', $2::jsonb)`,
+		roleKey,
 		`{"objects":{"person":{"read":true}},"row_scope":"own"}`)
-	e.WsExec(t, `INSERT INTO role_assignment (workspace_id, role_id, user_id)
-		SELECT $1, r.id, $2 FROM role r WHERE r.workspace_id = $1 AND r.key = $3`,
-		e.WS, user, roleKey)
+	e.WsExec(t, `INSERT INTO role_assignment (role_id, user_id)
+		SELECT r.id, $1 FROM role r WHERE r.key = $2`,
+		user, roleKey)
 }
 
 // A file its sender can still read transmits. Without this case the refusals

--- a/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
@@ -181,15 +181,15 @@ func seedTaskCreatePermission(t *testing.T, owner *pgx.Conn, ws, user ids.UUID) 
 	t.Helper()
 	var roleID ids.UUID
 	if err := owner.QueryRow(context.Background(),
-		`INSERT INTO role (workspace_id, key, name, permissions)
-		 VALUES ($1, 'reminder_owner', 'Reminder Owner',
+		`INSERT INTO role (key, name, permissions)
+		 VALUES ('reminder_owner', 'Reminder Owner',
 		         '{"objects":{"activity":{"create":true,"read":true}},"row_scope":"own"}'::jsonb)
-		 RETURNING id`, ws).Scan(&roleID); err != nil {
+		 RETURNING id`).Scan(&roleID); err != nil {
 		t.Fatalf("seeding the create_task test role: %v", err)
 	}
 	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO role_assignment (workspace_id, role_id, user_id) VALUES ($1, $2, $3)`,
-		ws, roleID, user); err != nil {
+		`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
+		roleID, user); err != nil {
 		t.Fatalf("assigning the create_task test role: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -105,15 +105,15 @@ func demoteToRep(t *testing.T, e *apptest.AppEnv) {
 		t.Fatalf("admin lookup: %v", err)
 	}
 	if err := tx.QueryRow(ctx,
-		`SELECT id FROM role WHERE workspace_id = $1 AND key = 'rep'`, wsID).Scan(&repRoleID); err != nil {
+		`SELECT id FROM role WHERE key = 'rep'`).Scan(&repRoleID); err != nil {
 		t.Fatalf("rep role lookup: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `DELETE FROM role_assignment WHERE user_id = $1`, userID); err != nil {
 		t.Fatalf("clear role assignment: %v", err)
 	}
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO role_assignment (workspace_id, role_id, user_id) VALUES ($1, $2, $3)`,
-		wsID, repRoleID, userID); err != nil {
+		`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
+		repRoleID, userID); err != nil {
 		t.Fatalf("assign rep role: %v", err)
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -115,9 +115,9 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	seedInWorkspace(
 		t, e, wsB,
 		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'eve@other.example', 'Eve Other')`, eve, wsB),
-		stmt(`INSERT INTO role (workspace_id, key, name) VALUES ($1, 'other-tenant-only', 'Other Tenant Only')`, wsB),
-		stmt(`INSERT INTO role_assignment (workspace_id, role_id, user_id)
-		      SELECT $1, r.id, $2 FROM role r WHERE r.key = 'other-tenant-only'`, wsB, eve),
+		stmt(`INSERT INTO role (key, name) VALUES ('other-tenant-only', 'Other Tenant Only')`),
+		stmt(`INSERT INTO role_assignment (role_id, user_id)
+		      SELECT r.id, $1 FROM role r WHERE r.key = 'other-tenant-only'`, eve),
 	)
 
 	// (e) No session → 401, before we lean on the authenticated reads.
@@ -232,8 +232,8 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 		// the gate under test reads the request principal, so the assertion is
 		// only worth anything from a real non-admin session.
 		stmt(`UPDATE app_user SET password_hash = (SELECT password_hash FROM app_user WHERE email = 'ada@example.com') WHERE id = $1`, rep),
-		stmt(`INSERT INTO role_assignment (workspace_id, role_id, user_id)
-		      SELECT $2, r.id, $1 FROM role r WHERE r.key = 'rep'`, rep, wsA),
+		stmt(`INSERT INTO role_assignment (role_id, user_id)
+		      SELECT r.id, $1 FROM role r WHERE r.key = 'rep'`, rep),
 	)
 
 	// The admin arm first, from the session the bootstrap left: every row

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -608,10 +608,10 @@ func (we *webhookEnv) dropObjectReadFromEveryRole(t *testing.T, object string) {
 			"this one delivered on that grant, and this one is about its absence", object)
 	}
 	rewritten := we.execInWorkspace(t,
-		`UPDATE role SET permissions = jsonb_set(permissions, ARRAY['objects', $2::text],
+		`UPDATE role SET permissions = jsonb_set(permissions, ARRAY['objects', $1::text],
 			'{"create":true,"read":false,"update":true,"delete":true}'::jsonb)
-		 WHERE workspace_id = $1 AND permissions -> 'objects' IS NOT NULL`,
-		we.wsID, object)
+		 WHERE permissions -> 'objects' IS NOT NULL`,
+		object)
 	if rewritten == 0 {
 		t.Fatal("the rewrite matched no role document, so the grants the fan-out reads are the ones it started with")
 	}
@@ -633,8 +633,8 @@ func (we *webhookEnv) rolesGranting(t *testing.T, object, action string) int {
 	we.inWorkspaceTx(t, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM role
-			 WHERE workspace_id = $1 AND permissions -> 'objects' -> $2 ->> $3 = 'true'`,
-			we.wsID, object, action).Scan(&count)
+			 WHERE permissions -> 'objects' -> $1 ->> $2 = 'true'`,
+			object, action).Scan(&count)
 	})
 	return count
 }

--- a/backend/internal/compose/sitelead_integration_test.go
+++ b/backend/internal/compose/sitelead_integration_test.go
@@ -85,15 +85,15 @@ func seedRequesterCanReadPeople(t *testing.T, e *integration.Env, user ids.UUID)
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var roleID ids.UUID
 		if err := tx.QueryRow(ctx,
-			`INSERT INTO role (workspace_id, key, name, permissions)
-			 VALUES ($1, 'site_read_requester', 'Site Read Requester',
+			`INSERT INTO role (key, name, permissions)
+			 VALUES ('site_read_requester', 'Site Read Requester',
 			         '{"objects":{"person":{"read":true},"lead":{"read":true}},"row_scope":"all"}'::jsonb)
-			 RETURNING id`, e.WS).Scan(&roleID); err != nil {
+			 RETURNING id`).Scan(&roleID); err != nil {
 			return err
 		}
 		_, err := tx.Exec(ctx,
-			`INSERT INTO role_assignment (workspace_id, role_id, user_id) VALUES ($1, $2, $3)`,
-			e.WS, roleID, user)
+			`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
+			roleID, user)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/identity/agentseat_integration_test.go
+++ b/backend/internal/modules/identity/agentseat_integration_test.go
@@ -132,8 +132,8 @@ func TestBootstrapMintsAnAgentSeatThatCarriesNoAuthorityOfItsOwn(t *testing.T) {
 
 	var grants int
 	if err := owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM role_assignment WHERE workspace_id = $1 AND user_id = $2`,
-		wsID, seat.id).Scan(&grants); err != nil {
+		`SELECT count(*) FROM role_assignment WHERE user_id = $1`,
+		seat.id).Scan(&grants); err != nil {
 		t.Fatalf("counting the seat's role assignments: %v", err)
 	}
 	if grants != 0 {

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -223,7 +223,7 @@ func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap
 		origin == originConfigured).Scan(&userID); err != nil {
 		return ids.WorkspaceID{}, err
 	}
-	if err := seedSystemRoles(ctx, tx, wsID, userID); err != nil {
+	if err := seedSystemRoles(ctx, tx, userID); err != nil {
 		return ids.WorkspaceID{}, err
 	}
 	if err := seedAgentSeat(ctx, tx, wsID, boot); err != nil {

--- a/backend/internal/modules/identity/roles_integration_test.go
+++ b/backend/internal/modules/identity/roles_integration_test.go
@@ -90,7 +90,7 @@ func TestSettingOneGrantLeavesTheRestOfTheDocumentIntact(t *testing.T) {
 	// would leave one behind.
 	if _, err := e.owner.Exec(context.Background(),
 		`UPDATE role SET permissions = jsonb_set(permissions, '{objects,ext_gone_thing}', '{"read":true}'::jsonb, true)
-		  WHERE workspace_id = $1 AND key = 'rep'`, e.admin.WorkspaceID); err != nil {
+		  WHERE key = 'rep'`); err != nil {
 		t.Fatalf("planting the orphaned grant: %v", err)
 	}
 
@@ -100,8 +100,7 @@ func TestSettingOneGrantLeavesTheRestOfTheDocumentIntact(t *testing.T) {
 
 	var raw []byte
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT permissions FROM role WHERE workspace_id = $1 AND key = 'rep'`,
-		e.admin.WorkspaceID).Scan(&raw); err != nil {
+		`SELECT permissions FROM role WHERE key = 'rep'`).Scan(&raw); err != nil {
 		t.Fatalf("reading the document back: %v", err)
 	}
 	var doc struct {

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -187,15 +187,15 @@ func (in *BootstrapInput) normalize() error {
 // seedSystemRoles lays down the compiled-in role set for a fresh
 // workspace and assigns the admin role to its first user — part of the
 // Bootstrap transaction, so a partial role set can never survive.
-func seedSystemRoles(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, adminUserID ids.UserID) error {
+func seedSystemRoles(ctx context.Context, tx pgx.Tx, adminUserID ids.UserID) error {
 	// note: role is not a first-class entity in the id kind vocabulary, so
 	// its ids stay ids.UUID (kernel gap — no RoleKind to assert).
 	var adminRoleID ids.UUID
 	for _, role := range systemRoles {
 		var roleID ids.UUID
 		err := tx.QueryRow(ctx,
-			`INSERT INTO role (workspace_id, key, name, is_system, permissions) VALUES ($1, $2, $3, true, $4) RETURNING id`,
-			wsID, role.key, role.name, policy.MustDefaultJSON(role.key)).Scan(&roleID)
+			`INSERT INTO role (key, name, is_system, permissions) VALUES ($1, $2, true, $3) RETURNING id`,
+			role.key, role.name, policy.MustDefaultJSON(role.key)).Scan(&roleID)
 		if err != nil {
 			return err
 		}
@@ -204,8 +204,8 @@ func seedSystemRoles(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, admin
 		}
 	}
 	_, err := tx.Exec(ctx,
-		`INSERT INTO role_assignment (workspace_id, role_id, user_id) VALUES ($1, $2, $3)`,
-		wsID, adminRoleID, adminUserID)
+		`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
+		adminRoleID, adminUserID)
 	return err
 }
 

--- a/backend/internal/modules/identity/users.go
+++ b/backend/internal/modules/identity/users.go
@@ -122,8 +122,8 @@ func (s *Service) InviteUser(ctx context.Context, actor Identity, in InviteUserI
 			return insErr
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO role_assignment (workspace_id, role_id, user_id) VALUES ($1, $2, $3)`,
-			wsID, roleID, newUserID); err != nil {
+			`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
+			roleID, newUserID); err != nil {
 			return err
 		}
 		if err := joinTeamsTx(ctx, tx, newUserID.UUID, in.TeamIDs); err != nil {
@@ -459,8 +459,7 @@ func (s *Service) ChangeUserRole(ctx context.Context, actor Identity, userID ids
 			return err
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO role_assignment (workspace_id, role_id, user_id)
-			 VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)`,
+			`INSERT INTO role_assignment (role_id, user_id) VALUES ($1, $2)`,
 			roleID, userID); err != nil {
 			return err
 		}

--- a/backend/internal/modules/identity/users_admin_integration_test.go
+++ b/backend/internal/modules/identity/users_admin_integration_test.go
@@ -356,9 +356,9 @@ func TestTheAgentSeatIsNotTheOtherAdminWhoCouldRecoverTheOrganization(t *testing
 	e := setupRevocationEnv(t, "agent-lockout")
 	seat := agentSeatOf(t, e)
 	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO role_assignment (workspace_id, role_id, user_id)
-		 SELECT $1, r.id, $2 FROM role r WHERE r.workspace_id = $1 AND r.key = 'admin'`,
-		e.admin.WorkspaceID, seat); err != nil {
+		`INSERT INTO role_assignment (role_id, user_id)
+		 SELECT r.id, $1 FROM role r WHERE r.key = 'admin'`,
+		seat); err != nil {
 		t.Fatalf("granting the agent seat the admin role directly: %v", err)
 	}
 

--- a/backend/migrations/core/1787216237_role_drops_the_tenant_column.down.sql
+++ b/backend/migrations/core/1787216237_role_drops_the_tenant_column.down.sql
@@ -1,0 +1,22 @@
+-- Reverse of the phase D drop on role and role_assignment.
+--
+-- The column comes back bound to the installation's own workspace, which is the
+-- only one a single-organization installation has (ADR-0061) and therefore the
+-- one every restored row belonged to. This is the shape restored, not a per-row
+-- reconstruction: nothing else records which workspace a role was for.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE role ADD COLUMN workspace_id uuid;
+UPDATE role SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+ALTER TABLE role
+  ALTER COLUMN workspace_id SET NOT NULL,
+  ADD CONSTRAINT role_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT,
+  ADD CONSTRAINT uq_role_ws_id UNIQUE (id);
+
+ALTER TABLE role_assignment ADD COLUMN workspace_id uuid;
+UPDATE role_assignment SET workspace_id = (SELECT id FROM workspace ORDER BY created_at LIMIT 1);
+ALTER TABLE role_assignment
+  ALTER COLUMN workspace_id SET NOT NULL,
+  ADD CONSTRAINT role_assignment_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;

--- a/backend/migrations/core/1787216237_role_drops_the_tenant_column.up.sql
+++ b/backend/migrations/core/1787216237_role_drops_the_tenant_column.up.sql
@@ -1,0 +1,19 @@
+-- ADR-0091 §8 phase D: role and role_assignment drop the tenant column.
+--
+-- A single-organization installation has one workspace (ADR-0061), so every
+-- role and every assignment already belonged to it; `key` is unique across the
+-- table without the column, and no read predicate names it.
+--
+-- uq_role_ws_id goes with it. It is a phase B leftover — collapsed to
+-- UNIQUE (id), which is what role_pkey already says — and no foreign key uses
+-- it as its referenced index, so it is an index kept warm for nobody.
+--
+-- SET LOCAL lock_timeout: each ALTER takes an ACCESS EXCLUSIVE lock on a table
+-- every authenticated request reads, and an unbounded wait would queue behind
+-- one open transaction for as long as it lives.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE role DROP CONSTRAINT uq_role_ws_id;
+
+ALTER TABLE role DROP COLUMN workspace_id;
+ALTER TABLE role_assignment DROP COLUMN workspace_id;

--- a/backend/migrations/custom/20260716130000_overlay_connection_rbac.down.sql
+++ b/backend/migrations/custom/20260716130000_overlay_connection_rbac.down.sql
@@ -1,10 +1,14 @@
+-- AMENDED (ADR-0091 §8 phase D): the `AND role.workspace_id = ws` predicate on
+-- each statement below was removed, and with it the per-workspace loop's reason
+-- to exist. `dbmigrate.Up` applies ALL of `core` before ANY of `custom`, so on
+-- a FRESH database this file runs against the FINAL core schema — where
+-- `role.workspace_id` no longer exists — and the install fails outright.
+-- Amending is what keeps a fresh install working; a deployed database already
+-- ran the original and is unaffected, because a single-organization
+-- installation (ADR-0061) has exactly one workspace, which made the predicate a
+-- no-op the day it was written.
 DO $$
-DECLARE ws uuid;
 BEGIN
-  FOR ws IN SELECT id FROM workspace LOOP
-    PERFORM set_config('app.workspace_id', ws::text, true);
     UPDATE role SET permissions = permissions #- '{objects,overlay_connection}'
-    WHERE (is_system)
-      AND role.workspace_id = ws;
-  END LOOP;
+    WHERE (is_system);
 END $$;

--- a/backend/migrations/custom/20260716130000_overlay_connection_rbac.up.sql
+++ b/backend/migrations/custom/20260716130000_overlay_connection_rbac.up.sql
@@ -1,3 +1,12 @@
+-- AMENDED (ADR-0091 §8 phase D): the `AND role.workspace_id = ws` predicate
+-- that each UPDATE below carried was removed, and with it the per-workspace
+-- loop's reason to exist. `dbmigrate.Up` applies ALL of `core` before ANY of
+-- `custom`, so on a FRESH database this file runs against the FINAL core
+-- schema — where `role.workspace_id` no longer exists — and the install fails
+-- outright. Amending is what keeps a fresh install working; a deployed
+-- database already ran the original and is unaffected, because a
+-- single-organization installation (ADR-0061) has exactly one workspace, which
+-- made the predicate a no-op the day it was written.
 -- 20260716130000: backfill the `overlay_connection` RBAC object into the
 -- seeded system-role policy documents of EXISTING workspaces (new
 -- workspaces get it from the code-side seed, identity/internal/policy).
@@ -11,22 +20,16 @@
 -- create/update/delete are admin/ops-only; every role may read the
 -- connection status.
 DO $$
-DECLARE ws uuid;
 BEGIN
-  FOR ws IN SELECT id FROM workspace LOOP
-    PERFORM set_config('app.workspace_id', ws::text, true);
     UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,overlay_connection}',
       '{"create":true,"read":true,"update":true,"delete":true}'::jsonb)
     WHERE (is_system AND key IN ('admin','ops')
-      AND NOT permissions->'objects' ? 'overlay_connection')
-      AND role.workspace_id = ws;
+      AND NOT permissions->'objects' ? 'overlay_connection');
 
     UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,overlay_connection}',
       '{"create":false,"read":true,"update":false,"delete":false}'::jsonb)
     WHERE (is_system AND key IN ('manager','rep','read_only')
-      AND NOT permissions->'objects' ? 'overlay_connection')
-      AND role.workspace_id = ws;
-  END LOOP;
+      AND NOT permissions->'objects' ? 'overlay_connection');
 END $$;

--- a/backend/migrations/custom/20260730130000_import_run_rbac.down.sql
+++ b/backend/migrations/custom/20260730130000_import_run_rbac.down.sql
@@ -1,15 +1,19 @@
+-- AMENDED (ADR-0091 §8 phase D): the `AND role.workspace_id = ws` predicate on
+-- each statement below was removed, and with it the per-workspace loop's reason
+-- to exist. `dbmigrate.Up` applies ALL of `core` before ANY of `custom`, so on
+-- a FRESH database this file runs against the FINAL core schema — where
+-- `role.workspace_id` no longer exists — and the install fails outright.
+-- Amending is what keeps a fresh install working; a deployed database already
+-- ran the original and is unaffected, because a single-organization
+-- installation (ADR-0061) has exactly one workspace, which made the predicate a
+-- no-op the day it was written.
 -- Removes the object from the two roles the up grants it to, and only those.
 -- Stripping every system role would erase the key a freshly seeded installation
 -- writes for manager/rep/read_only — the up never touched those, so a rollback
 -- has no business removing them.
 DO $$
-DECLARE ws uuid;
 BEGIN
-  FOR ws IN SELECT id FROM workspace LOOP
-    PERFORM set_config('app.workspace_id', ws::text, true);
     UPDATE role SET permissions = permissions #- '{objects,import_run}'
     WHERE (is_system AND key IN ('admin','ops')
-      AND permissions->'objects' ? 'import_run')
-      AND role.workspace_id = ws;
-  END LOOP;
+      AND permissions->'objects' ? 'import_run');
 END $$;

--- a/backend/migrations/custom/20260730130000_import_run_rbac.up.sql
+++ b/backend/migrations/custom/20260730130000_import_run_rbac.up.sql
@@ -1,3 +1,12 @@
+-- AMENDED (ADR-0091 §8 phase D): the `AND role.workspace_id = ws` predicate on
+-- each statement below was removed, and with it the per-workspace loop's reason
+-- to exist. `dbmigrate.Up` applies ALL of `core` before ANY of `custom`, so on
+-- a FRESH database this file runs against the FINAL core schema — where
+-- `role.workspace_id` no longer exists — and the install fails outright.
+-- Amending is what keeps a fresh install working; a deployed database already
+-- ran the original and is unaffected, because a single-organization
+-- installation (ADR-0061) has exactly one workspace, which made the predicate a
+-- no-op the day it was written.
 -- 20260730130000: backfill the `import_run` RBAC object into the seeded
 -- system-role policy documents of EXISTING workspaces (new workspaces get
 -- it from the code-side seed, identity/internal/policy). Fork-owned
@@ -10,15 +19,10 @@
 -- through it), so every verb is admin/ops-only; other roles hold no
 -- grant at all — a rep neither starts nor reads migration runs.
 DO $$
-DECLARE ws uuid;
 BEGIN
-  FOR ws IN SELECT id FROM workspace LOOP
-    PERFORM set_config('app.workspace_id', ws::text, true);
     UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,import_run}',
       '{"create":true,"read":true,"update":true,"delete":true}'::jsonb)
     WHERE (is_system AND key IN ('admin','ops')
-      AND NOT permissions->'objects' ? 'import_run')
-      AND role.workspace_id = ws;
-  END LOOP;
+      AND NOT permissions->'objects' ? 'import_run');
 END $$;

--- a/backend/migrations/custom/20260806120000_rbac_backfill_repair.up.sql
+++ b/backend/migrations/custom/20260806120000_rbac_backfill_repair.up.sql
@@ -1,3 +1,12 @@
+-- AMENDED (ADR-0091 §8 phase D): the `AND role.workspace_id = ws` predicate
+-- that each UPDATE below carried was removed, and with it the per-workspace
+-- loop's reason to exist. `dbmigrate.Up` applies ALL of `core` before ANY of
+-- `custom`, so on a FRESH database this file runs against the FINAL core
+-- schema — where `role.workspace_id` no longer exists — and the install fails
+-- outright. Amending is what keeps a fresh install working; a deployed
+-- database already ran the original and is unaffected, because a
+-- single-organization installation (ADR-0061) has exactly one workspace, which
+-- made the predicate a no-op the day it was written.
 -- Re-apply every fork-owned RBAC backfill that row-level security may have
 -- discarded, for databases that already recorded the migration carrying it.
 -- The core namespace's counterpart is 0192_rbac_backfill_repair; this is the
@@ -13,31 +22,24 @@
 -- TestTheRepairsCoverEveryGuardedRBACBackfill derives both sides from the tree
 -- and fails if they ever disagree.
 DO $$
-DECLARE ws uuid;
 BEGIN
-  FOR ws IN SELECT id FROM workspace LOOP
-    PERFORM set_config('app.workspace_id', ws::text, true);
 
     -- 20260716130000_overlay_connection_rbac
     UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,overlay_connection}',
       '{"create":true,"read":true,"update":true,"delete":true}'::jsonb)
     WHERE (is_system AND key IN ('admin','ops')
-      AND NOT permissions->'objects' ? 'overlay_connection')
-      AND role.workspace_id = ws;
+      AND NOT permissions->'objects' ? 'overlay_connection');
     UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,overlay_connection}',
       '{"create":false,"read":true,"update":false,"delete":false}'::jsonb)
     WHERE (is_system AND key IN ('manager','rep','read_only')
-      AND NOT permissions->'objects' ? 'overlay_connection')
-      AND role.workspace_id = ws;
+      AND NOT permissions->'objects' ? 'overlay_connection');
 
     -- 20260730130000_import_run_rbac
     UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,import_run}',
       '{"create":true,"read":true,"update":true,"delete":true}'::jsonb)
     WHERE (is_system AND key IN ('admin','ops')
-      AND NOT permissions->'objects' ? 'import_run')
-      AND role.workspace_id = ws;
-  END LOOP;
+      AND NOT permissions->'objects' ? 'import_run');
 END $$;

--- a/backend/migrations/rbac_backfill_parity_integration_test.go
+++ b/backend/migrations/rbac_backfill_parity_integration_test.go
@@ -282,6 +282,11 @@ func policyDocument(alreadyHeld []rbacBackfill) []byte {
 	return raw
 }
 
+// seedRole plants a role in the ROLLED-BACK schema this suite seeds against, so
+// it still names workspace_id: the column is dropped by the newest core
+// migration, and rolling core back past any backfill under test rolls that drop
+// back too. readGrant below reads at HEAD and cannot name it — the two run in
+// different eras of the same schema, which is why they are not one helper.
 func seedRole(t *testing.T, conn *pgx.Conn, workspaceID, key string, system bool, permissions []byte) {
 	t.Helper()
 	if _, err := conn.Exec(context.Background(),
@@ -301,9 +306,9 @@ func readGrant(ctx context.Context, t *testing.T, conn *pgx.Conn, workspaceID, k
 	var present bool
 	var raw []byte
 	err := conn.QueryRow(ctx,
-		`SELECT COALESCE(permissions->'objects' ? $3, false), permissions->'objects'->$3
-		   FROM role WHERE workspace_id = $1 AND key = $2`,
-		workspaceID, key, object).Scan(&present, &raw)
+		`SELECT COALESCE(permissions->'objects' ? $2, false), permissions->'objects'->$2
+		   FROM role WHERE key = $1`,
+		key, object).Scan(&present, &raw)
 	if err != nil {
 		t.Fatalf("reading %s grant for %s: %v", object, key, err)
 	}

--- a/backend/migrations/rbac_repair_integration_test.go
+++ b/backend/migrations/rbac_repair_integration_test.go
@@ -55,6 +55,15 @@ func TestTheRepairMigrationsHealADatabaseThatAlreadyRecordedTheLostBackfill(t *t
 				resetSchema(t, admin)
 				migrator := asMigrator(t, admin)
 				migrateAll(t, migrator)
+				// Then back ONE core step, because the newest core migration is
+				// ADR-0091 §8 phase D's drop of role.workspace_id and these
+				// repairs name it. The migration is correct in its own position
+				// — core runs in order, so core/0192 executes while the column
+				// is still there — and replaying it at head asks it to run in an
+				// era it never belonged to. One step back IS that era, and the
+				// suite migrates forward again below so every assertion is read
+				// at head.
+				rollBackThePhaseDDrop(t, admin)
 
 				want := grantsWrittenBy(t, repair)
 				objects := objectsIn(want)
@@ -91,6 +100,9 @@ func TestTheRepairMigrationsHealADatabaseThatAlreadyRecordedTheLostBackfill(t *t
 				if _, err := migrator.Exec(ctx, repair.UpSQL); err != nil {
 					t.Fatalf("applying the %s/%s repair: %v", namespace.Name, repair.Version, err)
 				}
+				// Forward again: every assertion below reads the schema an
+				// installation actually runs on, not the era the replay needed.
+				migrateAll(t, migrator)
 
 				for _, object := range objects {
 					for _, role := range systemRoleKeys {
@@ -139,6 +151,10 @@ func TestTheRepairMigrationsHealADatabaseThatAlreadyRecordedTheLostBackfill(t *t
 				resetSchema(t, admin)
 				narrowMigrator := repointed(t, admin, migrator)
 				migrateAll(t, narrowMigrator)
+				// Same one step back as above, for the same reason: the replay
+				// below runs a migration from before role.workspace_id was
+				// dropped, so the fixture is seeded in that era too.
+				rollBackThePhaseDDrop(t, admin)
 				narrowed := seedWorkspace(t, admin, "repair-narrowed-"+namespace.Name+"-"+repair.Version)
 				for _, role := range systemRoleKeys {
 					seedRole(t, admin, narrowed, role, true, documentGranting(t, objects, alteredGrant))
@@ -245,4 +261,27 @@ func repointed(t *testing.T, admin, conn *pgx.Conn) *pgx.Conn {
 		t.Fatalf("re-pointing the migrator at the recreated schema: %v", err)
 	}
 	return conn
+}
+
+// rollBackThePhaseDDrop takes core back one migration and proves the step
+// landed where it was aimed: the assertion is what stops this from silently
+// becoming a no-op if the newest core migration is ever something else, which
+// would leave the replay below failing for a reason nobody could read off the
+// error.
+func rollBackThePhaseDDrop(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	core, _ := namespaces(t)
+	if _, err := dbmigrate.Down(context.Background(), conn, core, 1); err != nil {
+		t.Fatalf("rolling core back one step to the era these repairs belong to: %v", err)
+	}
+	var present bool
+	if err := conn.QueryRow(context.Background(), `
+		SELECT EXISTS (SELECT 1 FROM information_schema.columns
+		                WHERE table_name = 'role' AND column_name = 'workspace_id')`).Scan(&present); err != nil {
+		t.Fatalf("checking whether the rollback restored role.workspace_id: %v", err)
+	}
+	if !present {
+		t.Fatal("one core step back did not restore role.workspace_id — the newest core migration is no longer " +
+			"the phase D drop these repairs need rolled back, so this suite is replaying them in the wrong era again")
+	}
 }

--- a/backend/migrations/rbac_upgrade_replay_integration_test.go
+++ b/backend/migrations/rbac_upgrade_replay_integration_test.go
@@ -287,8 +287,8 @@ func readPermissions(ctx context.Context, t *testing.T, conn *pgx.Conn, workspac
 	t.Helper()
 	var raw []byte
 	err := conn.QueryRow(ctx,
-		`SELECT permissions FROM role WHERE workspace_id = $1 AND key = $2`,
-		workspaceID, key).Scan(&raw)
+		`SELECT permissions FROM role WHERE key = $1`,
+		key).Scan(&raw)
 	if err != nil {
 		t.Fatalf("reading the permissions document for role %q: %v", key, err)
 	}

--- a/backend/migrations/rbacrepair_test.go
+++ b/backend/migrations/rbacrepair_test.go
@@ -92,11 +92,18 @@ var guardedVerbGrantPattern = regexp.MustCompile(
 // list, the write would grant to every system role, and the reconciliation
 // would see one write and one read and call it covered.
 //
-// What it anchors on is the workspace predicate every one of these carries —
-// required of any migration writing tenant rows, since RLS discards an unbound
-// write — so a role grant that skips it is not read as guarded either, and the
-// unread-write check refuses it. One anchor, two obligations.
-const predicateEnd = `\s*AND role\.workspace_id = \w+;`
+// It used to anchor on `AND role.workspace_id = <ws>`, which carried a SECOND
+// obligation: a migration writing tenant rows had to bind its workspace or RLS
+// discarded the write. That obligation is gone — core 0217 retired row-level
+// security and ADR-0091 §8 phase D dropped the column — so the terminator is
+// the anchor now, and only the prefix obligation is left for it to hold.
+//
+// The predicate stays OPTIONAL rather than being deleted, because both eras are
+// in this tree at once: a migration that shipped before the drop still carries
+// it and still has to be read, and one written after cannot. Anchoring on
+// either alone makes half the tree's backfills invisible to the coverage check
+// — which is the one failure this file exists to prevent.
+const predicateEnd = `(?:\s*AND role\.workspace_id = \w+)?\s*;`
 
 // Every write to role.permissions, however it is spelled. This has to be
 // STRICTLY BROADER than guardedBackfillPattern, not a prefix of it: a canary
@@ -350,7 +357,7 @@ func TestNoGuardedPatternReadsAWiderPredicateAsItsOwn(t *testing.T) {
       permissions, '{objects,automation}', '{"read":true}'::jsonb)
     WHERE (is_system AND key = 'rep'
       AND NOT permissions->'objects' ? 'automation')
-      AND role.workspace_id = ws OR is_system;`,
+      OR is_system;`,
 		},
 		{
 			name: "verb-level grant widened by a trailing OR",
@@ -358,15 +365,13 @@ func TestNoGuardedPatternReadsAWiderPredicateAsItsOwn(t *testing.T) {
       permissions, '{objects,capture_settings,create}', 'true'::jsonb)
     WHERE is_system AND key IN ('rep')
       AND permissions->'objects' ? 'capture_settings'
-      AND role.workspace_id = ws OR is_system;`,
+      OR is_system;`,
 		},
-		{
-			name: "verb-level grant with no workspace predicate at all",
-			sql: `UPDATE role SET permissions = jsonb_set(
-      permissions, '{objects,capture_settings,create}', 'true'::jsonb)
-    WHERE is_system AND key IN ('rep')
-      AND permissions->'objects' ? 'capture_settings';`,
-		},
+		// A third case here used to pin "no workspace predicate at all". It is
+		// the shape every one of these statements has now — core 0217 retired
+		// row-level security and phase D dropped role.workspace_id — so it is
+		// the guarded grant, not a widened one, and asserting otherwise would
+		// refuse the tree's own migrations.
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if guardedBackfillPattern.MatchString(tc.sql) {
@@ -388,13 +393,11 @@ func TestBothGuardedShapesAreStillRead(t *testing.T) {
 	wholeObject := `UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,automation}', '{"read":true}'::jsonb)
     WHERE (is_system AND key = 'rep'
-      AND NOT permissions->'objects' ? 'automation')
-      AND role.workspace_id = ws;`
+      AND NOT permissions->'objects' ? 'automation');`
 	verbLevel := `UPDATE role SET permissions = jsonb_set(
       permissions, '{objects,capture_settings,create}', 'true'::jsonb)
     WHERE is_system AND key IN ('admin','rep')
-      AND permissions->'objects' ? 'capture_settings'
-      AND role.workspace_id = ws;`
+      AND permissions->'objects' ? 'capture_settings';`
 	if !guardedBackfillPattern.MatchString(wholeObject) {
 		t.Error("the whole-object shape this tree's backfills use is no longer read as a guarded grant")
 	}

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -149,10 +149,10 @@ BEGIN
   -- (seeded at workspace bootstrap): team-scoped read/write, so Rep One sees the
   -- team's records plus whatever is explicitly shared. Idempotent via NOT EXISTS
   -- (role_assignment's uniqueness is an expression index over COALESCE(team_id)).
-  INSERT INTO role_assignment (workspace_id, role_id, user_id)
-  SELECT ws, r.id, rep_id
+  INSERT INTO role_assignment (role_id, user_id)
+  SELECT r.id, rep_id
     FROM role r
-    WHERE r.workspace_id = ws AND r.key = 'rep'
+    WHERE r.key = 'rep'
       AND NOT EXISTS (
         SELECT 1 FROM role_assignment ra
         WHERE ra.user_id = rep_id AND ra.role_id = r.id AND ra.team_id IS NULL
@@ -164,11 +164,11 @@ BEGIN
   -- lockstep) with row_scope overridden to 'own'. Not a system role — it exists
   -- so the individual demo seat (Rep Two, below) makes record sharing OBSERVABLE:
   -- with no team and no owned records, a grant is the sole reason a record shows.
-  INSERT INTO role (workspace_id, key, name, is_system, permissions)
-  SELECT ws, 'individual', 'Individual (own records)', false,
+  INSERT INTO role (key, name, is_system, permissions)
+  SELECT 'individual', 'Individual (own records)', false,
          jsonb_set(r.permissions, '{row_scope}', '"own"'::jsonb)
     FROM role r
-    WHERE r.workspace_id = ws AND r.key = 'rep'
+    WHERE r.key = 'rep'
   ON CONFLICT (key) DO NOTHING;
 
   -- Rep Two: an individual contributor — own-scoped, in NO team. Contrast with
@@ -182,10 +182,10 @@ BEGIN
     FROM app_user
     WHERE workspace_id = ws AND lower(email) = lower('rep2@demo.test');
 
-  INSERT INTO role_assignment (workspace_id, role_id, user_id)
-  SELECT ws, r.id, rep2_id
+  INSERT INTO role_assignment (role_id, user_id)
+  SELECT r.id, rep2_id
     FROM role r
-    WHERE r.workspace_id = ws AND r.key = 'individual'
+    WHERE r.key = 'individual'
       AND NOT EXISTS (
         SELECT 1 FROM role_assignment ra
         WHERE ra.user_id = rep2_id AND ra.role_id = r.id AND ra.team_id IS NULL


### PR DESCRIPTION
Closes #1826. ADR-0091 §8 phase D — **6 remaining tables become 4**:
`app_user`, `audit_log`, `session`, `system_log`.

Role keys are already unique across the installation, no read predicate names
the column, and `uq_role_ws_id` goes with it — a phase B leftover collapsed to
`UNIQUE (id)`, which `role_pkey` already says, referenced by no foreign key as
its index.

## #1826 framed this as a test problem. It is not, and its list was incomplete.

`dbmigrate.Up` applies **all** of `core` before **any** of `custom`, so on a
fresh database every custom migration runs against the FINAL core schema —
where `role.workspace_id` is gone — and the install fails outright.

**Five custom files name it, not the two the issue lists.** A grep of the whole
namespace turned up `20260730130000_import_run_rbac` and two down halves as
well. Each is amended with the reason at the top: the predicate was a no-op the
day it was written, because a single-organization installation (ADR-0061) has
exactly one workspace, and a deployed database already ran the original.

**`core/0192` needed no amendment.** Core runs in order, so it executes while
the column is still there. It is only unreplayable *at head* — which is what
`rbac_repair_integration_test.go` was doing. That suite now steps core back one
migration before the replay and forward again before its assertions, and
asserts the step landed where it was aimed: a silent no-op there would leave
the replay failing for a reason nobody could read off the error.

## Two gates were anchored on the thing being removed

`rbacrepair_test.go` closed its patterns on `AND role.workspace_id = ws` — one
anchor carrying **two** obligations, and the second (bind the workspace or RLS
discards the write) died with core `0217` and this drop. The predicate is now
**optional rather than deleted**, because both eras are in this tree at once: a
migration that shipped before the drop still carries it and still has to be
read. Anchoring on either alone makes half the tree's backfills invisible to
the coverage check — the one failure that file exists to prevent.

Its canary for "no workspace predicate at all" is retired: that is the
*legitimate* shape now, and asserting otherwise would refuse the tree's own
migrations.

The seed/read split is spelled out where it is easy to get wrong — `seedRole`
writes the ROLLED-BACK schema and still names the column, `readGrant` reads at
head and cannot.

`scripts/seed-dev.sql` follows, caught by the script-schema drift gate rather
than by reading.

## Verification

- `make check-backend` — green
- `make test-integration` — `OK: integration passed with 0 skips (41 packages)`
- `make craft-static` / `make migration-versions` — green
- migration lane exercises apply → reverse → reapply against a real database
- remaining columns verified by querying `pg_attribute` on the migrated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `workspace_id` tenant column from `role` and `role_assignment`. Previously roles and grants were tenant-scoped; now they are installation-scoped by key. This removes a redundant column, fixes fresh installs where `custom` migrations ran after the drop, and simplifies seeding.

- Core: adds `1787216237` to drop the columns and `uq_role_ws_id` with a 3s lock timeout; the down migration restores the column, binds rows to the single workspace, and reintroduces constraints.
- Custom migrations: remove `AND role.workspace_id = ...` predicates and per-workspace loops; notes explain why this is safe in single-organization installs and necessary for fresh installs.
- Tests/seed: update queries and seeds to stop naming `workspace_id`; `seedSystemRoles` no longer accepts a workspace; `rbacrepair_test.go` now treats the workspace predicate as optional; the repair replay suite rolls core back one step before replay and forward again after.
- Migration actions: run the database migrations; do not introduce new `custom` migrations that reference `role.workspace_id`.

<sup>Written for commit 69795d5731d0944deaa64d10b0eee918a8c5d7d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

