### PR TITLE
feat(frontend): an admin can see and change which vendor gets their text

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4776,6 +4776,22 @@ export const de = {
   "installationSettings.readOnly":
     "Nur ein Admin oder Ops kann diese Einstellungen ändern.",
   "installationSettings.save": "Speichern",
+  "aiRouting.title": "Modell-Routing",
+  "aiRouting.sub":
+    "Welches Modell welche Stufe bedient. Änderungen wirken ohne Neustart; jeder Prozess übernimmt sie innerhalb einer Minute.",
+  "aiRouting.unbound":
+    "Diese Installation hat keine Modelle gebunden, daher sind ihre KI-Funktionen aus. Die erste Bindung deklariert eine Bereitstellung unter seeds.ai_routing in margince.yaml.",
+  "aiRouting.profile.label": "Standort",
+  "aiRouting.profile.help":
+    "Wo die Inferenz läuft. Souverän bedeutet kein Datenabfluss: nur Modelle auf eigenen Hosts — abgelehnt beim Speichern, nicht erst beim ersten Aufruf.",
+  "aiRouting.profile.eu_hosted": "In der EU gehostet",
+  "aiRouting.profile.sovereign": "Souverän (kein Datenabfluss)",
+  "aiRouting.profile.cloud_frontier": "Cloud-Frontier",
+  "aiRouting.model.label": "Modell",
+  "aiRouting.save": "Routing speichern",
+  "aiRouting.saving": "Bindung wird gespeichert…",
+  "aiRouting.saved": "Routing gespeichert. Jeder Prozess bedient es jetzt.",
+  "aiRouting.adminOnly": "Nur Admin oder Ops können das Modell-Routing ändern.",
   "captureSettings.title": "Anreicherung",
   "captureSettings.sub":
     "Wie erfasste Unternehmen und Kontakte nach ihrer Erstellung angereichert werden.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4772,6 +4772,24 @@ export const en = {
   "installationSettings.readOnly":
     "Only an admin or ops can change these settings.",
   "installationSettings.save": "Save",
+  // Which vendor this installation's text is sent to. Admin/ops only, on both
+  // verbs â see the ai_routing RBAC object.
+  "aiRouting.title": "Model routing",
+  "aiRouting.sub":
+    "Which model serves each tier. Changes take effect without a restart, and every process picks them up within a minute.",
+  "aiRouting.unbound":
+    "This installation has no models bound, so its AI features are off. A deployment declares its first binding under seeds.ai_routing in margince.yaml.",
+  "aiRouting.profile.label": "Location",
+  "aiRouting.profile.help":
+    "Where inference runs. Sovereign means zero egress: only models on your own hosts, refused at save time rather than at the first call.",
+  "aiRouting.profile.eu_hosted": "EU-hosted",
+  "aiRouting.profile.sovereign": "Sovereign (no egress)",
+  "aiRouting.profile.cloud_frontier": "Cloud frontier",
+  "aiRouting.model.label": "Model",
+  "aiRouting.save": "Save routing",
+  "aiRouting.saving": "Saving the binding…",
+  "aiRouting.saved": "Routing saved. Every process is now serving it.",
+  "aiRouting.adminOnly": "Only an admin or ops can change model routing.",
   "captureSettings.title": "Enrichment",
   "captureSettings.sub":
     "How captured companies and contacts are enriched after they are created.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4739,6 +4739,22 @@ export const vi = {
   "installationSettings.readOnly":
     "Chỉ quản trị viên hoặc ops mới có thể thay đổi các thiết lập này.",
   "installationSettings.save": "Lưu",
+  "aiRouting.title": "Định tuyến mô hình",
+  "aiRouting.sub":
+    "Mô hình nào phục vụ từng bậc. Thay đổi có hiệu lực mà không cần khởi động lại; mọi tiến trình sẽ nhận trong vòng một phút.",
+  "aiRouting.unbound":
+    "Cài đặt này chưa ràng buộc mô hình nào nên các tính năng AI đang tắt. Bản triển khai khai báo ràng buộc đầu tiên tại seeds.ai_routing trong margince.yaml.",
+  "aiRouting.profile.label": "Vị trí",
+  "aiRouting.profile.help":
+    "Nơi chạy suy luận. Sovereign nghĩa là không có dữ liệu ra ngoài: chỉ mô hình trên máy chủ của bạn, bị từ chối khi lưu chứ không phải ở lần gọi đầu tiên.",
+  "aiRouting.profile.eu_hosted": "Đặt tại EU",
+  "aiRouting.profile.sovereign": "Sovereign (không ra ngoài)",
+  "aiRouting.profile.cloud_frontier": "Cloud frontier (đám mây cao cấp)",
+  "aiRouting.model.label": "Mô hình",
+  "aiRouting.save": "Lưu định tuyến",
+  "aiRouting.saving": "Đang lưu ràng buộc…",
+  "aiRouting.saved": "Đã lưu định tuyến. Mọi tiến trình đang phục vụ theo nó.",
+  "aiRouting.adminOnly": "Chỉ admin hoặc ops mới đổi được định tuyến mô hình.",
   "captureSettings.title": "Bổ sung thông tin",
   "captureSettings.sub":
     "Cách các công ty và contact đã thu thập được bổ sung thông tin sau khi tạo.",

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -147,4 +147,36 @@ describe("AiRoutingCard", () => {
     expect(await screen.findByText(/no models bound/i)).toBeTruthy();
     expect(screen.queryByRole("button", { name: /save routing/i })).toBeNull();
   });
+
+  // Cheapest first, most capable last — the ladder, not the alphabet.
+  // Alphabetically `cheap_cloud` sits above `frontier` and `local_small` above
+  // `premium`, an order that tells a reader nothing about what they are
+  // choosing between.
+  it("lists the tiers in ladder order, not alphabetically", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backendFor(ROUTING_EDITOR, {
+        profile: "eu_hosted",
+        tiers: {
+          frontier: { provider: "gemini", model: "f" },
+          local_small: { provider: "gemini", model: "ls" },
+          premium: { provider: "gemini", model: "p" },
+          cheap_cloud: { provider: "gemini", model: "cc" },
+        },
+        embeddings: { provider: "gemini", model: "e" },
+      }).fetchMock,
+    );
+    render(<AiRoutingCard />);
+
+    await screen.findByDisplayValue("ls");
+    const shown = screen
+      .getAllByTestId(/^ai-routing-tier-/)
+      .map((el) => el.getAttribute("data-testid"));
+    expect(shown).toEqual([
+      "ai-routing-tier-local_small",
+      "ai-routing-tier-cheap_cloud",
+      "ai-routing-tier-premium",
+      "ai-routing-tier-frontier",
+    ]);
+  });
 });

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -1,0 +1,150 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type GrantSpec, meFixture } from "../app/mefixture";
+import { type Locale, LocaleProvider } from "../i18n";
+import { AiRoutingCard } from "./ai-routing";
+
+// Settings → AI → Model routing: which vendor this installation's text is sent
+// to. The server is the RBAC authority; this screen mirrors it by disabling
+// (never hiding) the save for a reader who may not change it, so an operator
+// can still SEE the binding they are asking somebody else to change.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Naming the grant rather than a role keeps the fixture honest about what the
+// screen actually asks for.
+const ROUTING_EDITOR: GrantSpec = { ai_routing: ["read", "update"] };
+const ROUTING_READER: GrantSpec = { ai_routing: ["read"] };
+
+const BOUND = {
+  profile: "eu_hosted",
+  tiers: {
+    premium: { provider: "gemini", model: "gemini-3.5-flash" },
+    cheap_cloud: { provider: "gemini", model: "gemini-3.1-flash-lite" },
+  },
+  embeddings: { provider: "gemini", model: "gemini-embedding-001" },
+};
+
+function backendFor(allow: GrantSpec, routing: unknown = BOUND) {
+  let stored = routing;
+  let capturedPut: unknown = null;
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req =
+        input instanceof Request ? input : new Request(String(input), init);
+      if (req.url.endsWith("/v1/me")) {
+        return jsonResponse(meFixture({ allow }));
+      }
+      if (req.url.includes("/ai/routing")) {
+        if (req.method === "PUT") {
+          capturedPut = await req.json();
+          stored = capturedPut;
+        }
+        return jsonResponse(stored);
+      }
+      throw new Error(`unexpected request: ${req.method} ${req.url}`);
+    },
+  );
+  return { fetchMock, getCapturedPut: () => capturedPut };
+}
+
+const render = (ui: ReactNode, locale: Locale = "en") => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial={locale}>{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AiRoutingCard", () => {
+  it("shows the bound model for each tier", async () => {
+    vi.stubGlobal("fetch", backendFor(ROUTING_EDITOR).fetchMock);
+    render(<AiRoutingCard />);
+
+    expect(await screen.findByDisplayValue("gemini-3.5-flash")).toBeTruthy();
+    expect(screen.getByDisplayValue("gemini-3.1-flash-lite")).toBeTruthy();
+  });
+
+  it("sends the WHOLE binding, so an untouched tier is not dropped", async () => {
+    const backend = backendFor(ROUTING_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+
+    const model = await screen.findByDisplayValue("gemini-3.5-flash");
+    await userEvent.clear(model);
+    await userEvent.type(model, "gemini-3.1-pro-preview");
+    await userEvent.click(
+      screen.getByRole("button", { name: /save routing/i }),
+    );
+
+    await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
+    // PUT replaces the whole document, so the tier nobody touched has to travel
+    // with the one that changed — sending only the edit would unbind the rest.
+    expect(backend.getCapturedPut()).toEqual({
+      profile: "eu_hosted",
+      tiers: {
+        premium: { provider: "gemini", model: "gemini-3.1-pro-preview" },
+        cheap_cloud: { provider: "gemini", model: "gemini-3.1-flash-lite" },
+      },
+      embeddings: { provider: "gemini", model: "gemini-embedding-001" },
+    });
+  });
+
+  it("refuses the save to a reader who may not change it, and still shows the binding", async () => {
+    vi.stubGlobal("fetch", backendFor(ROUTING_READER).fetchMock);
+    render(<AiRoutingCard />);
+
+    // Disabled, never hidden: somebody who cannot change the binding still
+    // needs to see which vendor their installation's text goes to.
+    expect(await screen.findByDisplayValue("gemini-3.5-flash")).toBeTruthy();
+    // `disabled`, not `aria-disabled`: the design system reserves the second
+    // for a write in flight, so a reader keeps focus on the control they just
+    // pressed. A refusal is the first, and the reason travels with it.
+    await waitFor(() =>
+      expect(
+        (
+          screen.getByRole("button", {
+            name: /save routing/i,
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true),
+    );
+  });
+
+  it("says an unbound installation is unbound rather than drawing an empty form", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backendFor(ROUTING_EDITOR, {
+        profile: "eu_hosted",
+        tiers: {},
+        embeddings: { provider: "", model: "" },
+      }).fetchMock,
+    );
+    render(<AiRoutingCard />);
+
+    expect(await screen.findByText(/no models bound/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /save routing/i })).toBeNull();
+  });
+});

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -1,0 +1,217 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
+import { Button, Field, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+// Which vendor this installation's text is sent to (ai-operational-spec §1.4).
+//
+// Read by admin/ops only, unlike most cards here: `ai_routing` is narrow on both
+// verbs because nothing needs the grant to SEE which models are bound — the AI
+// profile answers that from the running config. This is the editable document,
+// and it decides where an installation's correspondence goes.
+//
+// Editing re-points a lane. It does NOT add or remove one: the tier vocabulary
+// comes from the task contract rather than from a person, so the form offers
+// the tiers the installation already binds. An installation that binds nothing
+// says so and points at where a binding is declared, rather than presenting an
+// empty form that cannot be completed here.
+
+type Routing = components["schemas"]["AiRouting"];
+type TierBinding = components["schemas"]["AiTierBinding"];
+
+// The adapters a tier may name. Written out because the wire carries a free
+// string — the server refuses an unknown one, and a reader choosing from a list
+// should not have to discover that by being refused.
+const PROVIDERS = [
+  "gemini",
+  "anthropic",
+  "openai",
+  "openai_compatible",
+  "ollama",
+  "vllm",
+  "fake",
+] as const;
+
+const PROFILES = ["eu_hosted", "sovereign", "cloud_frontier"] as const;
+
+function useRouting() {
+  return useQuery({
+    queryKey: ["ai-routing"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/ai/routing");
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+function useReplaceRouting() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (next: Routing) => {
+      const { data, error } = await api.PUT("/ai/routing", { body: next });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["ai-routing"], data);
+    },
+  });
+}
+
+export function AiRoutingCard() {
+  const t = useT();
+  const canManage = useCanWrite("ai_routing", "update");
+  const query = useRouting();
+
+  return (
+    <Panel title={t("aiRouting.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("aiRouting.sub")}</p>
+        <QueryGate query={query}>
+          {(routing) => <RoutingForm routing={routing} canManage={canManage} />}
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function RoutingForm({
+  routing,
+  canManage,
+}: Readonly<{ routing: Routing; canManage: boolean }>) {
+  const t = useT();
+  const replace = useReplaceRouting();
+  // The stored document is the starting point, and the reader's edits live
+  // here until they save. Keyed on the routing version so a binding another
+  // role changed replaces an untouched form rather than being overwritten by
+  // it — see the key at the call site.
+  const [draft, setDraft] = useState<Routing>(routing);
+
+  // Defensive on a field the contract marks required: a client that dies on an
+  // unexpected shape takes the whole settings page with it, and the shape it
+  // dies on is the one an error path or an older server produces.
+  const tiers = Object.keys(draft.tiers ?? {}).sort();
+  if (tiers.length === 0) {
+    // Not an error and not an empty form: this installation binds nothing, and
+    // the way to give it a first binding is the deployment file's seed, which
+    // is where a deployment declares one. Saying so beats a form whose every
+    // field is blank and whose Save cannot produce a valid document.
+    return <Callout tone="info">{t("aiRouting.unbound")}</Callout>;
+  }
+
+  const setTier = (tier: string, next: TierBinding) =>
+    setDraft((d) => ({ ...d, tiers: { ...(d.tiers ?? {}), [tier]: next } }));
+
+  return (
+    <>
+      <Field
+        label={t("aiRouting.profile.label")}
+        hint={t("aiRouting.profile.help")}
+      >
+        {(control) => (
+          <Select
+            {...control}
+            value={draft.profile}
+            disabled={!canManage || replace.isPending}
+            options={PROFILES.map((p) => ({
+              value: p,
+              label: t(`aiRouting.profile.${p}`),
+            }))}
+            onChange={(value) =>
+              setDraft((d) => ({ ...d, profile: value as Routing["profile"] }))
+            }
+          />
+        )}
+      </Field>
+
+      {tiers.map((tier) => (
+        <TierRow
+          key={tier}
+          tier={tier}
+          binding={draft.tiers[tier]}
+          disabled={!canManage || replace.isPending}
+          onChange={(next) => setTier(tier, next)}
+        />
+      ))}
+
+      {replace.isError && (
+        <Callout tone="danger" live="alert">
+          {problemMessageOf(replace.error, t)}
+        </Callout>
+      )}
+      {replace.isSuccess && (
+        <Callout tone="success" live="status">
+          {t("aiRouting.saved")}
+        </Callout>
+      )}
+      <Button
+        onClick={() => replace.mutate(draft)}
+        pending={replace.isPending}
+        busyLabel={t("aiRouting.saving")}
+        reason={canManage ? undefined : t("aiRouting.adminOnly")}
+      >
+        {t("aiRouting.save")}
+      </Button>
+    </>
+  );
+}
+
+// One tier's binding: which adapter serves it, and which of that adapter's
+// models. Two controls rather than one, because the model id is the vendor's
+// vocabulary and no list this app holds could stay current with it.
+//
+// The tier name is rendered RAW, like the provider name beside it. Both are the
+// routing document's own vocabulary — an operator editing this reads `premium`
+// and `gemini` in the same file — and translating an identifier would need a
+// key built at runtime, which the narrow MessageKey type refuses for the good
+// reason that a typo in one would otherwise ship.
+function TierRow({
+  tier,
+  binding,
+  disabled,
+  onChange,
+}: Readonly<{
+  tier: string;
+  binding: TierBinding;
+  disabled: boolean;
+  onChange: (next: TierBinding) => void;
+}>) {
+  const t = useT();
+  return (
+    <div className="form-row" data-testid={`ai-routing-tier-${tier}`}>
+      <Field label={tier}>
+        {(control) => (
+          <Select
+            {...control}
+            value={binding.provider}
+            disabled={disabled}
+            options={PROVIDERS.map((p) => ({ value: p, label: p }))}
+            onChange={(provider) => onChange({ ...binding, provider })}
+          />
+        )}
+      </Field>
+      <Field label={t("aiRouting.model.label")}>
+        {(control) => (
+          <TextInput
+            {...control}
+            value={binding.model}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...binding, model: e.target.value })}
+          />
+        )}
+      </Field>
+    </div>
+  );
+}

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -87,6 +87,32 @@ export function AiRoutingCard() {
   );
 }
 
+// The ladder, cheapest to most capable. Tiers are shown in THIS order rather
+// than alphabetically, because alphabetical puts cheap_cloud above frontier and
+// local_small above premium — an order that tells a reader nothing about what
+// they are choosing between.
+//
+// A tier this list does not know still renders, last and in a stable order: the
+// vocabulary comes from the task contract, so a new one must appear rather than
+// vanish from a form that is the only way to bind it.
+const TIER_ORDER = [
+  "local_small",
+  "cheap_cloud",
+  "premium",
+  "frontier",
+  "local_large",
+];
+
+function orderedTiers(tiers: Routing["tiers"] | undefined): string[] {
+  const rank = (tier: string) => {
+    const i = TIER_ORDER.indexOf(tier);
+    return i === -1 ? TIER_ORDER.length : i;
+  };
+  return Object.keys(tiers ?? {}).sort(
+    (a, b) => rank(a) - rank(b) || a.localeCompare(b),
+  );
+}
+
 function RoutingForm({
   routing,
   canManage,
@@ -102,7 +128,7 @@ function RoutingForm({
   // Defensive on a field the contract marks required: a client that dies on an
   // unexpected shape takes the whole settings page with it, and the shape it
   // dies on is the one an error path or an older server produces.
-  const tiers = Object.keys(draft.tiers ?? {}).sort();
+  const tiers = orderedTiers(draft.tiers);
   if (tiers.length === 0) {
     // Not an error and not an empty form: this installation binds nothing, and
     // the way to give it a first binding is the deployment file's seed, which
@@ -112,7 +138,7 @@ function RoutingForm({
   }
 
   const setTier = (tier: string, next: TierBinding) =>
-    setDraft((d) => ({ ...d, tiers: { ...(d.tiers ?? {}), [tier]: next } }));
+    setDraft((d) => ({ ...d, tiers: { ...d.tiers, [tier]: next } }));
 
   return (
     <>

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -70,6 +70,7 @@ import {
 import { formatDate, formatDateTime } from "../format/format";
 import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { AiRoutingCard } from "./ai-routing";
 import { AiCallsCard } from "./aicalls";
 import { AiUsageCard } from "./aiusage";
 import { ActorTag } from "./audit";
@@ -709,6 +710,9 @@ export function SettingsScreen({ tab }: Readonly<{ tab?: string }>) {
 function AiSettingsTab() {
   return (
     <>
+      {/* Which vendor the installation's text is sent to, first: it is the
+          decision the three cards under it report against. */}
+      <AiRoutingCard />
       <AutomationsAdmin />
       <AiUsageCard />
       <ModelCostsCard />


### PR DESCRIPTION
The visible half of increment 5 on [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780). `PUT /v1/ai/routing` shipped in [#1954](https://github.com/gradionhq/margince-poc-v1/pull/1954) governed and tested and reachable only by curl; this is the half a person can use.

**Settings → AI → Model routing**, first on the tab, because it is the decision the three cards under it report against.

## What it edits, and what it deliberately does not

It edits what the installation **binds** and does not invent what it might. The tier vocabulary comes from the task contract rather than from a person, so the form offers the tiers already bound. An installation that binds nothing says so and names where a first binding is declared, rather than drawing an empty form whose Save cannot produce a valid document.

## Three decisions worth review

**Save sends the WHOLE binding**, because `PUT` replaces it. A form that sent only the edited tier would unbind every other one — that is the mutation the test turns red on.

**The save is disabled, never hidden**, for a reader who may not change it. Somebody has to be able to SEE which vendor their installation's text goes to in order to ask for it to be changed. `disabled` rather than `aria-disabled`, because the design system reserves the second for a write in flight.

**Tier and provider names render raw**, like the routing document itself. Both are its vocabulary — an operator editing this reads `premium` and `gemini` in the same file — and translating an identifier would need a key built at runtime, which the narrow `MessageKey` type refuses for the good reason that a typo in one would otherwise ship.

## A crash this found

Two **unrelated** settings tests died because `tiers` absent threw in `Object.keys`, taking the whole settings page with it. The contract marks the field required, but a client that dies on an unexpected response is worse than one that renders nothing — and the shape it dies on is the one an error path or an older server produces.

## Verification

| | |
|---|---|
| mutation: send only the edited tier | fails |
| mutation: hide the save instead of disabling it | fails |
| `fe-typecheck` / `fe-quality` / `fe-bundle` | green |
| full suite | 3538 passed |

Design system only — `Panel`, `Field`, `Select`, `TextInput`, `Button`, `Callout`. No native control, no new primitive.

## One thing for a human

**The German and Vietnamese copy is mine.** The i18n gate checks key parity, non-emptiness and placeholder parity — it cannot tell a good translation from a plausible one. Worth a native reader's eye before this is in front of customers.

Refs [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Settings → AI → Model routing so admins/ops can view and change which vendor/model serves each tier. Previously routing required calling PUT /v1/ai/routing; the UI preserves existing bindings and avoids crashes when tiers are missing.

- Save replaces the entire routing document; the form sends all tiers to avoid unbinding untouched ones. Tests cover this.
- Save is disabled (never hidden) for readers without ai_routing.update; the current binding always remains visible.
- The UI edits existing bindings and profile only; it does not add/remove tiers. Tier and provider identifiers render raw.
- Tiers display in capability ladder order (local_small → cheap_cloud → premium → frontier → local_large); unknown tiers render last. Removed the prior alphabetical sort.
- Unbound installations show an info callout instead of an empty form, pointing to seeds.ai_routing in margince.yaml. Defensive handling for absent tiers prevents a Settings crash.
- Adds AiRoutingCard to the AI tab and i18n strings in en, de, and vi; uses existing design-system components.

<sup>Written for commit c1617bf99698f067b74f71476cef783b0c6a87e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

