### PR TITLE
feat(ai): a BYOK key stops living in the process environment

### DIFF
--- a/backend/internal/compose/integration/providerkeyseal_integration_test.go
+++ b/backend/internal/compose/integration/providerkeyseal_integration_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A BYOK key leaving the process environment, against a real database.
+//
+// Two things need one and neither can be shown with a unit test: that the ref
+// is actually recorded (so the next boot resolves from the vault rather than
+// sealing a second blob), and that sealing is idempotent — a boot that sealed
+// nothing new must not rewrite the setting, or every restart strands another
+// copy of the same secret in the vault.
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func sealingEnv() config.Lookup {
+	return config.Static(map[string]string{
+		"GEMINI_API_KEY":    "a-gemini-key",
+		"ANTHROPIC_API_KEY": "an-anthropic-key",
+	})
+}
+
+func TestAnExportedKeyIsSealedOnceAndResolvedFromTheVaultAfterwards(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	vault := keyvault.NewMemory()
+	ws := ids.From[ids.WorkspaceKind](e.WS)
+	log := slog.New(slog.DiscardHandler)
+
+	refs := compose.SealProviderKeys(ctx, e.Pool, vault, ws, sealingEnv(), log)
+	if len(refs) != 2 {
+		t.Fatalf("sealed %d credential(s), want the two the environment carries: %v", len(refs), refs)
+	}
+
+	// Recorded, not merely sealed. A ref held only in memory would leave the
+	// next boot sealing the same secret again.
+	stored, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatalf("reading the recorded refs: %v", err)
+	}
+	if stored["gemini"] != refs["gemini"] {
+		t.Errorf("recorded %q, sealed %q", stored["gemini"], refs["gemini"])
+	}
+
+	// And what the router will actually resolve with reads back the secret.
+	got := ai.SealedKeys(ctx, vault, ws, stored, config.Static(nil))("GEMINI_API_KEY")
+	if got != "a-gemini-key" {
+		t.Errorf("resolved %q from the vault, want the sealed key", got)
+	}
+}
+
+// Idempotent across boots. Without this every restart seals another copy of the
+// same secret and strands the previous one — inert, encrypted, and collected by
+// nobody.
+func TestASecondBootSealsNothingNew(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	vault := keyvault.NewMemory()
+	ws := ids.From[ids.WorkspaceKind](e.WS)
+	log := slog.New(slog.DiscardHandler)
+
+	first := compose.SealProviderKeys(ctx, e.Pool, vault, ws, sealingEnv(), log)
+	second := compose.SealProviderKeys(ctx, e.Pool, vault, ws, sealingEnv(), log)
+
+	for provider, ref := range first {
+		if second[provider] != ref {
+			t.Errorf("%s was resealed: %q then %q — the previous blob is stranded", provider, ref, second[provider])
+		}
+	}
+}
+
+// An installation with no vault keeps resolving from the environment, which is
+// where every installation was before this existed. Nothing is sealed and
+// nothing is recorded.
+func TestWithNoVaultNothingIsSealed(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+
+	refs := compose.SealProviderKeys(ctx, e.Pool, nil, ids.From[ids.WorkspaceKind](e.WS), sealingEnv(), slog.New(slog.DiscardHandler))
+
+	if len(refs) != 0 {
+		t.Errorf("sealed %v without a vault to seal into", refs)
+	}
+}

--- a/backend/internal/compose/integration/providerkeyseal_integration_test.go
+++ b/backend/internal/compose/integration/providerkeyseal_integration_test.go
@@ -94,3 +94,47 @@ func TestWithNoVaultNothingIsSealed(t *testing.T) {
 		t.Errorf("sealed %v without a vault to seal into", refs)
 	}
 }
+
+// A provider added AFTER the first seal must be recorded too.
+//
+// The refs accumulate in one row, so an insert-only write stores nothing once
+// that row exists: the second vendor's blob would be sealed, its ref dropped on
+// the floor, and the environment would keep answering while a stranded secret
+// sat in the vault. Nothing about the installation would look wrong.
+func TestAProviderAddedAfterTheFirstSealIsRecorded(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	vault := keyvault.NewMemory()
+	ws := ids.From[ids.WorkspaceKind](e.WS)
+	log := slog.New(slog.DiscardHandler)
+
+	first := compose.SealProviderKeys(ctx, e.Pool, vault, ws,
+		config.Static(map[string]string{"GEMINI_API_KEY": "a-gemini-key"}), log)
+	if _, ok := first["gemini"]; !ok {
+		t.Fatalf("the first seal recorded nothing: %v", first)
+	}
+	if _, ok := first["anthropic"]; ok {
+		t.Fatal("anthropic was sealed before its key existed")
+	}
+
+	// A second vendor arrives. The row already exists.
+	second := compose.SealProviderKeys(ctx, e.Pool, vault, ws, sealingEnv(), log)
+
+	if _, ok := second["anthropic"]; !ok {
+		t.Errorf("anthropic was not recorded: %v — its key stays in the environment and its blob is stranded", second)
+	}
+	if second["gemini"] != first["gemini"] {
+		t.Errorf("gemini was repointed: %q then %q; the map is only ever grown", first["gemini"], second["gemini"])
+	}
+
+	// And it survives the process: what the next boot reads must hold both.
+	stored, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatalf("reading the recorded refs: %v", err)
+	}
+	for _, provider := range []string{"gemini", "anthropic"} {
+		if stored[provider] != second[provider] {
+			t.Errorf("%s recorded as %q, want %q", provider, stored[provider], second[provider])
+		}
+	}
+}

--- a/backend/internal/compose/integration/providerkeyseal_integration_test.go
+++ b/backend/internal/compose/integration/providerkeyseal_integration_test.go
@@ -14,7 +14,9 @@ package integration
 // copy of the same secret in the vault.
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"log/slog"
 	"os"
@@ -219,5 +221,52 @@ func TestAnUnreadableSettingRowFallsBackToTheEnvironment(t *testing.T) {
 
 	if refs != nil {
 		t.Errorf("returned %v from a database that cannot be read; the caller would treat those as sealed", refs)
+	}
+}
+
+// The seal is reached from routing resolution, not merely reachable.
+//
+// ResolveRouting → sealedKeys → SealProviderKeys is the chain a booting role
+// actually walks, and every case above enters it one function too late by
+// calling SealProviderKeys itself. That proves the seal works and proves
+// nothing about whether routing asks for it — and an unasked seal fails OPEN:
+// the router comes up, resolves every key from the environment exactly as
+// before, and the credentials never move. Nothing looks wrong.
+//
+// So this one sets the root key the way a deployment does and starts at
+// ResolveRouting.
+func TestRoutingResolutionSealsTheKeysItResolvesWith(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	// The root key rides the SAME lookup as the provider keys, because that is
+	// how sealedKeys reads it — in production both come from config.FromOS. A
+	// t.Setenv here would set the process environment and leave the static
+	// lookup this call actually consults without a vault, which is a green
+	// test that exercises nothing.
+	env := config.Static(map[string]string{
+		"GEMINI_API_KEY":    "a-gemini-key",
+		"ANTHROPIC_API_KEY": "an-anthropic-key",
+		keyvault.EnvRootKey: base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{3}, 32)),
+	})
+
+	// A stored binding, because sealedKeys is reached on the LAST line of
+	// ResolveRouting — an installation with nothing bound returns before it,
+	// and a test without this would pass while proving nothing.
+	if err := settings.Set(ctx, compose.NewSettingsStore(e.Pool), ai.Routing, parsedRouting(t, "resolver-model")); err != nil {
+		t.Fatalf("storing the binding to resolve: %v", err)
+	}
+
+	if _, err := compose.ResolveRouting(ctx, e.Pool, "", env, slog.New(slog.DiscardHandler)); err != nil {
+		t.Fatalf("resolving routing with a vault configured: %v", err)
+	}
+
+	// The keys the environment carried are now sealed and recorded, which only
+	// happens if routing resolution called the seal.
+	stored, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatalf("reading the recorded refs: %v", err)
+	}
+	if len(stored) == 0 {
+		t.Fatal("routing resolved with a vault configured and sealed nothing; the seal is not wired into the boot that was supposed to call it")
 	}
 }

--- a/backend/internal/compose/integration/providerkeyseal_integration_test.go
+++ b/backend/internal/compose/integration/providerkeyseal_integration_test.go
@@ -14,8 +14,13 @@ package integration
 // copy of the same secret in the vault.
 
 import (
+	"context"
+	"errors"
 	"log/slog"
+	"os"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
@@ -136,5 +141,83 @@ func TestAProviderAddedAfterTheFirstSealIsRecorded(t *testing.T) {
 		if stored[provider] != second[provider] {
 			t.Errorf("%s recorded as %q, want %q", provider, stored[provider], second[provider])
 		}
+	}
+}
+
+// refusingVault seals everything except one nominated secret, so the test can
+// fail exactly one provider and watch what happens to the other.
+//
+// A stub rather than the memory vault because the behaviour under test is a
+// FAILURE, and the memory vault has no way to produce one. It delegates every
+// other method so the parts that are not under test stay real.
+type refusingVault struct {
+	keyvault.Vault
+	refuse string
+}
+
+func (v refusingVault) Put(ctx context.Context, ws ids.WorkspaceID, secret []byte) (keyvault.Ref, error) {
+	if string(secret) == v.refuse {
+		return "", errors.New("keyvault: the custodian refused this write")
+	}
+	return v.Vault.Put(ctx, ws, secret)
+}
+
+// One provider's vault failure is not the others'.
+//
+// The comment in SealProviderKeys says exactly this and nothing proved it. It
+// matters because the alternative is silent and total: a boot that abandoned
+// the whole seal on the first refusal would leave every provider on the
+// environment, and the log line naming one vendor would be the only clue that
+// the other three had not moved either.
+func TestAProviderThatCannotBeSealedLeavesTheOthersSealed(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	ws := ids.From[ids.WorkspaceKind](e.WS)
+	vault := refusingVault{Vault: keyvault.NewMemory(), refuse: "a-gemini-key"}
+
+	refs := compose.SealProviderKeys(ctx, e.Pool, vault, ws, sealingEnv(), slog.New(slog.DiscardHandler))
+
+	if _, sealed := refs["gemini"]; sealed {
+		t.Error("gemini is recorded as sealed although the vault refused it; the environment is the only place its key still is")
+	}
+	if refs["anthropic"] == "" {
+		t.Fatal("anthropic was not sealed, so one vendor's refusal cost the others their move out of the environment")
+	}
+	// Recorded, not just returned — the next boot must not re-seal anthropic.
+	stored, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatalf("reading the recorded refs: %v", err)
+	}
+	if stored["anthropic"] != refs["anthropic"] {
+		t.Errorf("recorded %q, sealed %q", stored["anthropic"], refs["anthropic"])
+	}
+	// And the refused one resolves from the environment, which is the whole
+	// reason the failure is survivable.
+	if got := ai.SealedKeys(ctx, vault, ws, stored, sealingEnv())("GEMINI_API_KEY"); got != "a-gemini-key" {
+		t.Errorf("the refused provider resolves to %q, want its environment value", got)
+	}
+}
+
+// A database that cannot answer at boot costs the installation its seal, not
+// its boot. The environment still holds every key, so falling back to it is a
+// working posture — and it is the posture every installation had before the
+// vault existed.
+func TestAnUnreadableSettingRowFallsBackToTheEnvironment(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+
+	// A pool that is closed is how a database looks when it has gone away
+	// mid-boot: every query fails immediately rather than hanging.
+	dead, err := pgxpool.New(context.Background(), os.Getenv("MARGINCE_TEST_APP_DSN"))
+	if err != nil {
+		t.Fatalf("opening the pool to close: %v", err)
+	}
+	dead.Close()
+
+	refs := compose.SealProviderKeys(ctx, dead, keyvault.NewMemory(),
+		ids.From[ids.WorkspaceKind](e.WS), sealingEnv(), slog.New(slog.DiscardHandler))
+
+	if refs != nil {
+		t.Errorf("returned %v from a database that cannot be read; the caller would treat those as sealed", refs)
 	}
 }

--- a/backend/internal/compose/integration/routingbootstrapwiring_integration_test.go
+++ b/backend/internal/compose/integration/routingbootstrapwiring_integration_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 )
 
@@ -75,7 +76,12 @@ seeds:
 		t.Fatalf("bootstrapping with a declared binding: %v", err)
 	}
 
-	stored, err := compose.ResolveRouting(ctx, e.Pool, "", nil, slog.New(slog.DiscardHandler))
+	// config.Static(nil), never a nil Lookup. ResolveRouting hands the lookup
+	// down to the key vault, which CALLS it — a nil one panics deep inside
+	// keyvault with an address, several frames from the test that supplied it.
+	// No production caller passes nil; this one did, and it stayed invisible
+	// until a change downstream started dereferencing it.
+	stored, err := compose.ResolveRouting(ctx, e.Pool, "", config.Static(nil), slog.New(slog.DiscardHandler))
 	if err != nil {
 		t.Fatalf("reading the binding the bootstrap stored: %v", err)
 	}

--- a/backend/internal/compose/providerkeyseal.go
+++ b/backend/internal/compose/providerkeyseal.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Moving a BYOK key out of the process environment and into the vault, once.
+//
+// An installation exporting GEMINI_API_KEY today needs to do nothing: the key
+// is sealed on the next boot and the variable becomes how the key ARRIVED
+// rather than where it lives. That is the same shape the routing file took when
+// routing moved into the database, and for the same reason — a migration an
+// operator has to perform is a migration half of them will not.
+//
+// What it does NOT do is remove the variable from their deployment. Nothing
+// here can: the process cannot edit its own orchestrator. So the variable stays
+// readable until an operator drops it, and the sentence this logs is what tells
+// them they can.
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// SealProviderKeys stores any BYOK key this installation supplies in the
+// environment but has not sealed yet, and returns the refs to resolve with.
+//
+// Returns the refs it knows about even when sealing something fails, so a
+// vault that refuses one provider does not cost the installation the keys it
+// already sealed for the others.
+func SealProviderKeys(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, ws ids.WorkspaceID, env config.Lookup, log *slog.Logger) map[string]string {
+	stored, err := settings.Get(ctx, NewSettingsStore(pool), ai.ProviderKeys)
+	if err != nil {
+		log.WarnContext(ctx, "cannot read the sealed provider credentials; falling back to the environment for this boot", "error", err)
+		return nil
+	}
+	if vault == nil {
+		// No vault configured. The environment is still the source, which is
+		// exactly where every installation was before this existed.
+		return stored
+	}
+
+	next := maps.Clone(stored)
+	if next == nil {
+		next = map[string]string{}
+	}
+	sealedNow := make([]string, 0, len(ai.CloudProvidersNeedingKeys()))
+	for _, provider := range ai.CloudProvidersNeedingKeys() {
+		if _, already := next[provider]; already {
+			continue
+		}
+		secret := env(ai.KeyEnvVarFor(provider))
+		if secret == "" {
+			continue
+		}
+		ref, err := vault.Put(ctx, ws, []byte(secret))
+		if err != nil {
+			// One provider's failure is not the others'. The environment still
+			// answers for this one, so the installation keeps working.
+			log.ErrorContext(ctx, "cannot seal a provider credential; it stays in the environment for now",
+				"provider", provider, "error", err)
+			continue
+		}
+		next[provider] = string(ref)
+		sealedNow = append(sealedNow, provider)
+	}
+	if len(sealedNow) == 0 {
+		return stored
+	}
+
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		return settings.SeedValue(ctx, tx, ai.ProviderKeys, next)
+	}); err != nil {
+		// The blobs are sealed and nothing references them — inert, encrypted
+		// at rest, and collected by nobody. The installation keeps running on
+		// the environment and the next boot tries again, which will strand
+		// another. Loud because a stranded secret is not a non-event.
+		log.ErrorContext(ctx, "sealed provider credentials could not be recorded; they are stranded in the vault and the environment is still the source",
+			"providers", sealedNow, "error", err)
+		return stored
+	}
+	// The one sentence that tells an operator they may now drop the variables.
+	// Nothing here can remove them: the process cannot edit its orchestrator.
+	log.InfoContext(ctx, "sealed provider credentials into the key vault; the environment variables that carried them can be removed",
+		"providers", sealedNow)
+	return next
+}

--- a/backend/internal/compose/providerkeyseal.go
+++ b/backend/internal/compose/providerkeyseal.go
@@ -21,12 +21,10 @@ import (
 	"log/slog"
 	"maps"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -78,9 +76,17 @@ func SealProviderKeys(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Va
 		return stored
 	}
 
-	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		return settings.SeedValue(ctx, tx, ai.ProviderKeys, next)
-	}); err != nil {
+	// Set, not SeedValue. Seeding is insert-only by design — it exists so a
+	// restart never overwrites a value a human changed — and that is exactly
+	// wrong here: the refs accumulate. An installation that sealed gemini last
+	// boot and adds anthropic this one has a row already, so a seed would store
+	// nothing, the new ref would never be recorded, and its blob would be
+	// stranded in the vault while the environment silently kept answering.
+	//
+	// Overwriting is safe because this map is only ever GROWN: an existing
+	// provider's ref is carried forward untouched a few lines above, so a Set
+	// can add a key and can never drop or repoint one.
+	if err := settings.Set(ctx, NewSettingsStore(pool), ai.ProviderKeys, next); err != nil {
 		// The blobs are sealed and nothing references them — inert, encrypted
 		// at rest, and collected by nobody. The installation keeps running on
 		// the environment and the next boot tries again, which will strand

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -99,7 +100,31 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 	if stored.Unconfigured() {
 		return ai.RoutingConfig{}, nil
 	}
-	return ai.FromStored(stored, keys)
+	return ai.FromStored(stored, sealedKeys(ctx, pool, ws, keys, log))
+}
+
+// sealedKeys upgrades the environment lookup to one that resolves a provider's
+// BYOK key from the vault, sealing any the environment still carries.
+//
+// Built here rather than passed in because this is where the workspace is
+// already resolved, and both roles would otherwise construct the same thing
+// from the same three inputs. A second vault instance costs nothing: it holds a
+// pool and an AEAD derived from the root key, and no state that two of them
+// could disagree about.
+//
+// An installation with no vault configured gets the environment unchanged,
+// which is where every installation was before this existed.
+func sealedKeys(ctx context.Context, pool *pgxpool.Pool, ws ids.UUID, env config.Lookup, log *slog.Logger) config.Lookup {
+	vault, configured, err := keyvault.FromEnv(pool, env)
+	if err != nil || !configured {
+		if err != nil {
+			log.WarnContext(ctx, "the key vault is configured but unusable; provider credentials resolve from the environment this boot", "error", err)
+		}
+		return env
+	}
+	workspace := ids.From[ids.WorkspaceKind](ws)
+	refs := SealProviderKeys(ctx, pool, vault, workspace, env, log)
+	return ai.SealedKeys(ctx, vault, workspace, refs, env)
 }
 
 // routingCtx binds the boot's system principal on the installation's

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -115,9 +115,16 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 // An installation with no vault configured gets the environment unchanged,
 // which is where every installation was before this existed.
 func sealedKeys(ctx context.Context, pool *pgxpool.Pool, ws ids.UUID, env config.Lookup, log *slog.Logger) config.Lookup {
-	vault, configured, err := keyvault.FromEnv(pool, env)
+	vault, configured, err := keyvault.FromEnv(ctx, pool, env)
 	if err != nil || !configured {
 		if err != nil {
+			// Not fatal HERE, deliberately. FromEnv refuses a boot that finds
+			// sealed ciphertext with no root key, so by the time this runs the
+			// serving roles have already had their say on whether the vault is
+			// survivable. What is left for this path is a vault that cannot be
+			// built at all, and provider keys still resolve from the
+			// environment — which is where every installation kept them before
+			// the vault existed.
 			log.WarnContext(ctx, "the key vault is configured but unusable; provider credentials resolve from the environment this boot", "error", err)
 		}
 		return env

--- a/backend/internal/modules/ai/providerkeys.go
+++ b/backend/internal/modules/ai/providerkeys.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Where a provider's BYOK key lives.
+//
+// It was the process environment, which is the 12-factor answer and has one
+// property nobody chose: an environment variable is readable for the life of
+// the process by anything that can read /proc, by a crash dump, and by every
+// child process the server ever forks. A key an installation holds for years
+// sits in all of those the whole time.
+//
+// Sealed in the key vault it is at rest under AEAD, addressed by an opaque ref,
+// and reachable only by a process holding the vault's root key. The root key
+// still comes from the environment, so the environment does not leave the
+// picture — it holds ONE secret instead of one per vendor, which is the actual
+// improvement.
+//
+// The environment stays the way a key ARRIVES. An installation exporting
+// GEMINI_API_KEY today keeps working and needs no action: the key is sealed on
+// the next boot and the variable becomes a seed rather than the source. That is
+// the same shape the routing file took when routing moved into the database.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// providerKeysObject is the RBAC object gating the sealed credentials.
+//
+// The same object routing carries, deliberately: both are admin/ops-only on
+// both verbs, and no seeded role holds one without the other. A second object
+// would be a distinction the role matrix does not make — and every object costs
+// a backfill migration that has to reach installations that already exist.
+const providerKeysObject = routingSettingsObject
+
+// ProviderKeysKey is the settings key the vault refs are stored under.
+const ProviderKeysKey = "ai.provider_keys"
+
+// ProviderKeys maps a provider name to the vault ref holding its BYOK key.
+//
+// The REF is stored, never the key. A ref is opaque and workspace-bound — the
+// vault refuses one presented under another workspace — so a reader who can
+// see this setting learns which vendors have a credential and nothing about
+// any of them.
+var ProviderKeys = settings.Define[map[string]string](
+	ProviderKeysKey,
+	providerKeysObject,
+	"update",
+	map[string]string{},
+	validateProviderKeyRefs,
+).AsInstallationIdentity()
+
+// validateProviderKeyRefs refuses a ref for a provider this build cannot serve.
+// A key sealed against a name nothing routes is a credential nobody can use and
+// nobody will remember is there.
+func validateProviderKeyRefs(refs map[string]string) error {
+	for provider, ref := range refs {
+		if _, cloud := cloudKeyEnv[provider]; !cloud {
+			return fmt.Errorf("ai: %q takes no api key", provider)
+		}
+		if ref == "" {
+			return fmt.Errorf("ai: %s has an empty credential reference", provider)
+		}
+	}
+	return nil
+}
+
+// KeyDefinitions is the ai module's credential contribution to the settings
+// registry, kept beside Definitions so a module declares its catalog in one
+// place.
+func keyDefinitions() []settings.Definition {
+	return []settings.Definition{ProviderKeys}
+}
+
+// SealedKeys resolves BYOK keys from the vault, falling back to the environment
+// for one that has not been sealed yet.
+//
+// It satisfies config.Lookup so nothing downstream changes: buildClients still
+// asks for a variable NAME, cloudKey still resolves it, and byokKeyRequired
+// still names the variable to set when there is no key at all. Only where the
+// bytes come from moved.
+//
+// The environment fallback is what makes the move invisible to a running
+// installation. It is also what the seeder uses to fill the vault, so an
+// operator who exported a key once never exports it again.
+func SealedKeys(ctx context.Context, vault keyvault.Vault, ws ids.WorkspaceID, refs map[string]string, env config.Lookup) config.Lookup {
+	byName := make(map[string]string, len(cloudKeyEnv))
+	for provider, name := range cloudKeyEnv {
+		byName[name] = provider
+	}
+	return func(name string) string {
+		provider, cloud := byName[name]
+		if !cloud || vault == nil {
+			return envOrEmpty(env, name)
+		}
+		ref, sealed := refs[provider]
+		if !sealed {
+			return envOrEmpty(env, name)
+		}
+		secret, err := vault.Get(ctx, ws, keyvault.Ref(ref))
+		if err != nil {
+			// Falling back rather than failing: a vault that cannot answer
+			// leaves the installation exactly where it was before the key was
+			// sealed, and the caller's own byokKeyRequired says what is missing
+			// if the environment cannot answer either. Refusing here would turn
+			// an unreadable vault into "this provider does not work" with no
+			// sentence naming the vault.
+			return envOrEmpty(env, name)
+		}
+		return string(secret)
+	}
+}
+
+func envOrEmpty(env config.Lookup, name string) string {
+	if env == nil {
+		return ""
+	}
+	return env(name)
+}
+
+// CloudProvidersNeedingKeys names the providers whose credential this module
+// holds, in a stable order so a log line reads the same on every boot.
+//
+// Derived from cloudKeyEnv rather than restated, so a provider added there is
+// covered by the sealer the day it appears — the alternative is a second list
+// that silently leaves a new vendor's key in the environment.
+func CloudProvidersNeedingKeys() []string {
+	out := make([]string, 0, len(cloudKeyEnv))
+	for _, provider := range knownProviders {
+		if _, cloud := cloudKeyEnv[provider]; cloud {
+			out = append(out, provider)
+		}
+	}
+	return out
+}
+
+// KeyEnvVarFor is the variable a provider's key arrives in, or "" for one that
+// takes no key. The names match each vendor's own convention, which is why they
+// carry no MARGINCE_ prefix.
+func KeyEnvVarFor(provider string) string { return cloudKeyEnv[provider] }

--- a/backend/internal/modules/ai/providerkeys_test.go
+++ b/backend/internal/modules/ai/providerkeys_test.go
@@ -114,3 +114,43 @@ func TestSealedCredentialsSurviveADataReset(t *testing.T) {
 		t.Error("a data reset would delete the credential refs, stranding every sealed key in the vault")
 	}
 }
+
+// The sealer's provider list is DERIVED from cloudKeyEnv, and this is what
+// makes that claim true rather than a comment. A vendor added there must be
+// sealed the day it appears; one the derivation missed would keep its key in
+// the environment forever, and nothing else in the tree would say so.
+func TestEveryProviderWithAKeyIsOneTheSealerCoversAndNamesAVariable(t *testing.T) {
+	covered := map[string]bool{}
+	for _, provider := range CloudProvidersNeedingKeys() {
+		covered[provider] = true
+		if KeyEnvVarFor(provider) == "" {
+			t.Errorf("%s is sealed but names no environment variable, so nothing can supply its key", provider)
+		}
+	}
+	for provider := range cloudKeyEnv {
+		if !covered[provider] {
+			t.Errorf("%s takes an api key but the sealer does not cover it — its key stays in the environment", provider)
+		}
+	}
+	// And nothing local sneaks in: a provider that needs no key must not be
+	// asked for one, or an operator is told to set a variable that means
+	// nothing.
+	for _, provider := range CloudProvidersNeedingKeys() {
+		if localProviders[provider] {
+			t.Errorf("%s runs locally and needs no api key", provider)
+		}
+	}
+	if len(covered) == 0 {
+		t.Fatal("the sealer covers no provider at all; this gate would pass vacuously")
+	}
+}
+
+// A lookup built with no environment behind it answers empty rather than
+// panicking. It is the shape a role that resolved no config hands over, and a
+// nil dereference here would take the boot with it.
+func TestALookupWithNoEnvironmentAnswersEmpty(t *testing.T) {
+	got := SealedKeys(context.Background(), keyvault.NewMemory(), ids.From[ids.WorkspaceKind](ids.NewV7()), nil, nil)("GEMINI_API_KEY")
+	if got != "" {
+		t.Errorf("resolved %q with no environment and no vault entry, want empty", got)
+	}
+}

--- a/backend/internal/modules/ai/providerkeys_test.go
+++ b/backend/internal/modules/ai/providerkeys_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Where a BYOK key is resolved from, and what happens when the vault cannot
+// answer. The failure paths matter more than the happy one: each of them
+// decides whether an installation keeps serving or goes dark.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func sealed(t *testing.T, vault keyvault.Vault, ws ids.WorkspaceID, secret string) string {
+	t.Helper()
+	ref, err := vault.Put(context.Background(), ws, []byte(secret))
+	if err != nil {
+		t.Fatalf("sealing: %v", err)
+	}
+	return string(ref)
+}
+
+func TestASealedKeyIsResolvedFromTheVaultRatherThanTheEnvironment(t *testing.T) {
+	ctx := context.Background()
+	vault := keyvault.NewMemory()
+	ws := ids.From[ids.WorkspaceKind](ids.NewV7())
+	refs := map[string]string{providerGemini: sealed(t, vault, ws, "from-the-vault")}
+	// The environment still carries the OLD value, which is the ordinary state
+	// of an installation that has not yet dropped the variable. The vault must
+	// win, or sealing changes nothing.
+	env := config.Static(map[string]string{"GEMINI_API_KEY": "from-the-environment"})
+
+	got := SealedKeys(ctx, vault, ws, refs, env)("GEMINI_API_KEY")
+
+	if got != "from-the-vault" {
+		t.Errorf("resolved %q, want the sealed value — the environment outranked the vault", got)
+	}
+}
+
+// The migration path: a key the environment carries and the vault has not
+// sealed yet still answers, so an installation keeps working across the move
+// without anyone doing anything.
+func TestAnUnsealedKeyStillResolvesFromTheEnvironment(t *testing.T) {
+	ctx := context.Background()
+	env := config.Static(map[string]string{"ANTHROPIC_API_KEY": "not-sealed-yet"})
+
+	got := SealedKeys(ctx, keyvault.NewMemory(), ids.From[ids.WorkspaceKind](ids.NewV7()), nil, env)("ANTHROPIC_API_KEY")
+
+	if got != "not-sealed-yet" {
+		t.Errorf("resolved %q; an unsealed key must still answer from the environment", got)
+	}
+}
+
+// A ref the vault cannot resolve — deleted, or sealed under another workspace —
+// falls back rather than failing. An installation whose AI went dark because a
+// vault read failed, with no sentence naming the vault, is a worse outcome than
+// one still serving on the variable it always had.
+func TestAnUnresolvableRefFallsBackToTheEnvironment(t *testing.T) {
+	ctx := context.Background()
+	vault := keyvault.NewMemory()
+	ws := ids.From[ids.WorkspaceKind](ids.NewV7())
+	// A ref sealed under a DIFFERENT workspace. The vault refuses it, which is
+	// the isolation guarantee working, not a fault to propagate.
+	elsewhere := sealed(t, vault, ids.From[ids.WorkspaceKind](ids.NewV7()), "another tenant's key")
+	env := config.Static(map[string]string{"OPENAI_API_KEY": "still-here"})
+
+	got := SealedKeys(ctx, vault, ws, map[string]string{providerOpenAI: elsewhere}, env)("OPENAI_API_KEY")
+
+	if got == "another tenant's key" {
+		t.Fatal("a ref sealed under another workspace resolved; tenant isolation is broken")
+	}
+	if got != "still-here" {
+		t.Errorf("resolved %q, want the environment's value", got)
+	}
+}
+
+// A variable that is not a BYOK key is none of this lookup's business — it is
+// still a config.Lookup, and the rest of the process reads other variables
+// through the same shape.
+func TestANonCredentialVariableIsPassedStraightThrough(t *testing.T) {
+	env := config.Static(map[string]string{"MARGINCE_LOG_LEVEL": "debug"})
+	got := SealedKeys(context.Background(), keyvault.NewMemory(), ids.From[ids.WorkspaceKind](ids.NewV7()), nil, env)("MARGINCE_LOG_LEVEL")
+	if got != "debug" {
+		t.Errorf("resolved %q, want debug", got)
+	}
+}
+
+// A ref for a provider that takes no key is refused on the way in. A credential
+// sealed against a name nothing routes is one nobody can use and nobody will
+// remember is there.
+func TestARefForAProviderThatTakesNoKeyIsRefused(t *testing.T) {
+	if err := ProviderKeys.ValidateJSON([]byte(`{"ollama":"kv:something"}`)); err == nil {
+		t.Error("a ref was accepted for a local provider that takes no api key")
+	}
+	if err := ProviderKeys.ValidateJSON([]byte(`{"gemini":""}`)); err == nil {
+		t.Error("an empty credential reference was accepted")
+	}
+	if err := ProviderKeys.ValidateJSON([]byte(`{"gemini":"kv:something"}`)); err != nil {
+		t.Errorf("a real ref was refused: %v", err)
+	}
+}
+
+// The sealed credentials survive a data reset for the same reason the binding
+// does: a reset wipes an installation's data, not the credentials it uses to
+// reach the vendors it chose. Losing them would leave refs pointing at blobs
+// nothing can name.
+func TestSealedCredentialsSurviveADataReset(t *testing.T) {
+	if !ProviderKeys.SurvivesDataReset() {
+		t.Error("a data reset would delete the credential refs, stranding every sealed key in the vault")
+	}
+}

--- a/backend/internal/modules/ai/providerkeys_test.go
+++ b/backend/internal/modules/ai/providerkeys_test.go
@@ -66,13 +66,13 @@ func TestAnUnresolvableRefFallsBackToTheEnvironment(t *testing.T) {
 	ws := ids.From[ids.WorkspaceKind](ids.NewV7())
 	// A ref sealed under a DIFFERENT workspace. The vault refuses it, which is
 	// the isolation guarantee working, not a fault to propagate.
-	elsewhere := sealed(t, vault, ids.From[ids.WorkspaceKind](ids.NewV7()), "another tenant's key")
+	elsewhere := sealed(t, vault, ids.From[ids.WorkspaceKind](ids.NewV7()), "another workspace's key")
 	env := config.Static(map[string]string{"OPENAI_API_KEY": "still-here"})
 
 	got := SealedKeys(ctx, vault, ws, map[string]string{providerOpenAI: elsewhere}, env)("OPENAI_API_KEY")
 
-	if got == "another tenant's key" {
-		t.Fatal("a ref sealed under another workspace resolved; tenant isolation is broken")
+	if got == "another workspace's key" {
+		t.Fatal("a ref sealed under another workspace resolved; workspace isolation is broken")
 	}
 	if got != "still-here" {
 		t.Errorf("resolved %q, want the environment's value", got)

--- a/backend/internal/modules/ai/settingsentry.go
+++ b/backend/internal/modules/ai/settingsentry.go
@@ -59,7 +59,7 @@ var Routing = settings.Define[RoutingConfig](
 
 // Definitions is the ai module's contribution to the settings registry.
 func Definitions() []settings.Definition {
-	return []settings.Definition{Routing}
+	return append([]settings.Definition{Routing}, keyDefinitions()...)
 }
 
 // validateStoredRouting holds a stored binding to the same bar the file always


### PR DESCRIPTION
Increment 4 of [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780), first slice: the provider keys.

## Why

An environment variable is readable for the life of the process by anything that can read `/proc`, by a crash dump, and by every child the server forks. A provider key an installation holds for **years** sits in all of those the whole time. Sealed in the key vault it is at rest under AEAD, addressed by an opaque ref, reachable only by a process holding the root key.

**The environment does not leave the picture** — it holds the vault's root key. It holds *one* secret instead of one per vendor. That is the actual improvement, and worth saying plainly rather than claiming the keys left the environment.

## Nobody has to migrate

An installation exporting `GEMINI_API_KEY` today does nothing. The key is sealed on the next boot and the variable becomes how it **arrived** rather than where it lives — the same shape the routing file took when routing moved into the database.

What nothing here can do is remove the variable from a deployment: the process cannot edit its orchestrator. So the one line this logs is what tells an operator they may drop it.

## The seam is unchanged

`config.Lookup`. `buildClients` still asks for a variable NAME, `cloudKey` still resolves it, `byokKeyRequired` still names the variable to set when there is no key at all. Only where the bytes come from moved.

## Three failure paths, each deciding whether an installation keeps serving

| | |
|---|---|
| an unresolvable ref | falls back to the environment — including a ref sealed under **another workspace**, which the vault refuses. That is the isolation guarantee working, not a fault to propagate |
| one provider fails to seal | the others still seal; that one stays on its variable |
| a seal that cannot be **recorded** | logged loudly — the blob is inert and collected by nobody, so a stranded secret is not a non-event |

An installation whose AI went dark on a vault read, with nothing naming the vault, is a worse outcome than one still serving on the variable it always had.

## Mutation-proven

| Mutation | Result |
|---|---|
| environment wins over the vault (sealing changes nothing) | fails |
| a failed vault read returns empty instead of falling back | fails |

Integration, against a real database: an exported key is sealed **once**, the ref is recorded, and a second boot seals nothing new — without that, every restart strands another copy of the same secret.

The refs survive a data reset, like the binding they belong to. Losing them would leave every sealed key in the vault with nothing able to name it.

## Still to come in increment 4

`email.smtp.password` and the license token. The license one needs care on a point raised on the ticket: a boot that cannot reach the vault must say **the vault is unreachable**, not that the installation is unlicensed — those are the same refusal today and completely different problems for whoever is paged.

## Spec

ADR-0020 pins these keys to the environment. Per the decision on [#1780](https://github.com/gradionhq/margince-poc-v1/issues/1780) it is reconciled when the `margince-foundation` reset settles; the `status: spec-change` label and the deferral note stay on the ticket.

`make -C backend check` exit 0 · `make craft-static` PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves BYOK provider credentials from process env to the key vault while keeping the `config.Lookup` seam. Before: resolved from env only. Now: boot seals any present env keys, persists opaque refs in `ai.ProviderKeys`, and runtime resolves via the vault with env fallback.

- Routing path: `ResolveRouting` builds a vault via `keyvault.FromEnv`, seals with `compose.SealProviderKeys`, and exposes a vault-backed lookup using `ai.SealedKeys`.
- Idempotent/additive: uses `settings.Set` so refs accumulate; newly added providers are recorded; existing refs are never resealed or repointed.
- Fallbacks: vault absent/unusable warns and uses env; unreadable settings fall back; an unresolvable ref (including one sealed under another workspace) falls back; one provider failing to seal does not block others; non-credential variables pass through unchanged.
- Security/persistence: refs are workspace-bound; `ai.ProviderKeys` is registered and survives data resets; the sealer’s provider list derives from `cloudKeyEnv`; validation rejects providers that take no key and empty refs.
- Migration: none. First boot seals and records. Operators may remove provider env vars after the info log: "sealed provider credentials into the key vault; the environment variables that carried them can be removed."

<sup>Written for commit 2f7a037ca5942e5c203292bdf937dd8370d0ee1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure storage for AI provider API keys using the configured key vault.
  * Vault-backed credentials are used for AI routing, with environment-variable fallback when needed.
  * Existing key references persist across repeated operations and data resets.
  * Newly configured providers can be added without affecting existing credentials.

* **Bug Fixes**
  * Vault failures no longer prevent other providers from working.
  * Installations without a configured vault continue using environment credentials.
  * Failed credential migrations preserve existing settings and references.
  * Invalid provider references are rejected during configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->