### PR TITLE
fix(contract): a nullable enum stops generating a "<nil>" member

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15590,6 +15590,8 @@ components:
         email_type:
           type: [string, 'null']
           enum: [professional, personal, null]
+          # Pinned: see OrganizationFactSuspectReason.
+          x-enum-varnames: [PersonProviderEmailEmailTypeProfessional, PersonProviderEmailEmailTypePersonal]
           description: May be classified from the frozen requested cascade when Surfe omits `emailType`.
         email_type_source:
           type: [string, 'null']
@@ -19340,7 +19342,14 @@ components:
       type: object
       required: [kind, source]
       properties:
-        kind: { type: string, enum: [email, call, meeting, note, task, message] }
+        kind:
+          type: string
+          enum: [email, call, meeting, note, task, message]
+          # Pinned: this type is part of the PUBLIC extension API
+          # (pkg/extension/crm). The generator only prefixes a constant to
+          # break a collision, so an unrelated contract edit can un-prefix it
+          # and break every extension that names it.
+          x-enum-varnames: [CreateActivityRequestKindEmail, CreateActivityRequestKindCall, CreateActivityRequestKindMeeting, CreateActivityRequestKindNote, CreateActivityRequestKindTask, CreateActivityRequestKindMessage]
         channel_provider:
           allOf: [{ $ref: '#/components/schemas/ProviderRef' }]
           nullable: true
@@ -21865,6 +21874,8 @@ components:
         trust_tier:
           type: [string, 'null']
           enum: [authoritative, external, unverified, null]
+          # Pinned for the same reason as OrganizationFactSuspectReason above.
+          x-enum-varnames: [SearchResultTrustTierAuthoritative, SearchResultTrustTierExternal, SearchResultTrustTierUnverified]
           description: >
             Provenance tier of the underlying record. In native mode every stored record is
             `authoritative`; `external`/`unverified` are reserved for overlay/connector-sourced rows
@@ -22291,6 +22302,10 @@ components:
         suspect_reason:
           type: [string, 'null']
           enum: [null, phone_shaped_location, not_a_phone, not_a_year, not_an_email, not_a_size]
+          # Pinned: without the null member the generator no longer needs the
+          # type prefix to disambiguate, and a bare `NotAPhone` in the shared
+          # contracts package reads as nobody's constant.
+          x-enum-varnames: [OrganizationFactSuspectReasonPhoneShapedLocation, OrganizationFactSuspectReasonNotAPhone, OrganizationFactSuspectReasonNotAYear, OrganizationFactSuspectReasonNotAnEmail, OrganizationFactSuspectReasonNotASize]
           readOnly: true
           description: >-
             Why this fact's VALUE contradicts its FIELD, or null when it does not. The extractor
@@ -22578,7 +22593,10 @@ components:
         next_required_field:
           type: [string, 'null']
           enum: [null, display_name, offer_summary, icp]
-          x-enum-varnames: [OnboardingNextRequiredNone, OnboardingNextRequiredDisplayName, OnboardingNextRequiredOfferSummary, OnboardingNextRequiredICP]
+          # The null member is gone in 3.0 (nullable: true carries it), so the
+          # pin must not label a slot that no longer exists — a stale name here
+          # shifts every later name onto the wrong value.
+          x-enum-varnames: [OnboardingNextRequiredDisplayName, OnboardingNextRequiredOfferSummary, OnboardingNextRequiredICP]
         remaining_required_fields:
           type: array
           uniqueItems: true
@@ -22589,7 +22607,8 @@ components:
         available_action:
           type: [string, 'null']
           enum: [null, confirm_company, start_voice_build, upload_voice_source, connect_inbox, finish]
-          x-enum-varnames: [OnboardingAvailableActionNone, OnboardingAvailableActionConfirmCompany, OnboardingAvailableActionStartVoiceBuild, OnboardingAvailableActionUploadVoiceSource, OnboardingAvailableActionConnectInbox, OnboardingAvailableActionFinish]
+          # See next_required_field above: no name for the dropped null slot.
+          x-enum-varnames: [OnboardingAvailableActionConfirmCompany, OnboardingAvailableActionStartVoiceBuild, OnboardingAvailableActionUploadVoiceSource, OnboardingAvailableActionConnectInbox, OnboardingAvailableActionFinish]
         ai_runtime: { $ref: '#/components/schemas/AiRunSummary' }
 
     OnboardingAct:
@@ -22684,7 +22703,8 @@ components:
         stopped_reason:
           type: [string, 'null']
           enum: [budget, page_cap, byte_cap, deadline, null]
-          x-enum-varnames: [CompanySiteReadStoppedReasonBudget, CompanySiteReadStoppedReasonPageCap, CompanySiteReadStoppedReasonByteCap, CompanySiteReadStoppedReasonDeadline, CompanySiteReadStoppedReasonNull]
+          # See next_required_field above: no name for the dropped null slot.
+          x-enum-varnames: [CompanySiteReadStoppedReasonBudget, CompanySiteReadStoppedReasonPageCap, CompanySiteReadStoppedReasonByteCap, CompanySiteReadStoppedReasonDeadline]
           description: 'Why the crawl ended early; null when it exhausted discovery. Same column and vocabulary as SiteReadReport — one deep-read engine serves onboarding and every organization.'
         phase: { type: [string, 'null'], enum: [crawling, extracting] }
         pages_read: { type: integer, minimum: 0 }
@@ -22837,7 +22857,13 @@ components:
         skipped:
           type: array
           items: { $ref: '#/components/schemas/SiteReadSkip' }
-        stopped_reason: { type: [string, 'null'], enum: [budget, page_cap, byte_cap, deadline, null], description: 'Why the crawl ended early; null when it exhausted discovery.' }
+        stopped_reason:
+          type: [string, 'null']
+          enum: [budget, page_cap, byte_cap, deadline, null]
+          # Pinned: see OrganizationFactSuspectReason. No name for the null
+          # slot — 3.0 carries nullability with `nullable: true`.
+          x-enum-varnames: [SiteReadReportStoppedReasonBudget, SiteReadReportStoppedReasonPageCap, SiteReadReportStoppedReasonByteCap, SiteReadReportStoppedReasonDeadline]
+          description: 'Why the crawl ended early; null when it exhausted discovery.'
         fact_count: { type: integer, description: Evidenced fields staged in the deepread proposal. }
         phase: { type: [string, 'null'], enum: [crawling, extracting, null], description: 'Live position while status is running; null once terminal.' }
         pages_read: { type: integer, description: 'Pages committed so far — live progress while running, final count once terminal.' }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -230,18 +230,15 @@ func (e AccountDraftReasonKind) Valid() bool {
 
 // Defines values for ActivityCaptureLabel.
 const (
-	ActivityCaptureLabelCommitment  ActivityCaptureLabel = "commitment"
-	ActivityCaptureLabelLessThannil ActivityCaptureLabel = "<nil>"
-	ActivityCaptureLabelMeeting     ActivityCaptureLabel = "meeting"
-	ActivityCaptureLabelNoise       ActivityCaptureLabel = "noise"
+	ActivityCaptureLabelCommitment ActivityCaptureLabel = "commitment"
+	ActivityCaptureLabelMeeting    ActivityCaptureLabel = "meeting"
+	ActivityCaptureLabelNoise      ActivityCaptureLabel = "noise"
 )
 
 // Valid indicates whether the value is a known member of the ActivityCaptureLabel enum.
 func (e ActivityCaptureLabel) Valid() bool {
 	switch e {
 	case ActivityCaptureLabelCommitment:
-		return true
-	case ActivityCaptureLabelLessThannil:
 		return true
 	case ActivityCaptureLabelMeeting:
 		return true
@@ -272,17 +269,14 @@ func (e ActivityContentState) Valid() bool {
 
 // Defines values for ActivityDirection.
 const (
-	ActivityDirectionInbound     ActivityDirection = "inbound"
-	ActivityDirectionLessThannil ActivityDirection = "<nil>"
-	ActivityDirectionOutbound    ActivityDirection = "outbound"
+	ActivityDirectionInbound  ActivityDirection = "inbound"
+	ActivityDirectionOutbound ActivityDirection = "outbound"
 )
 
 // Valid indicates whether the value is a known member of the ActivityDirection enum.
 func (e ActivityDirection) Valid() bool {
 	switch e {
 	case ActivityDirectionInbound:
-		return true
-	case ActivityDirectionLessThannil:
 		return true
 	case ActivityDirectionOutbound:
 		return true
@@ -323,11 +317,10 @@ func (e ActivityKind) Valid() bool {
 
 // Defines values for ActivityMeetingStatus.
 const (
-	ActivityMeetingStatusBooked      ActivityMeetingStatus = "booked"
-	ActivityMeetingStatusCanceled    ActivityMeetingStatus = "canceled"
-	ActivityMeetingStatusHeld        ActivityMeetingStatus = "held"
-	ActivityMeetingStatusLessThannil ActivityMeetingStatus = "<nil>"
-	ActivityMeetingStatusNoShow      ActivityMeetingStatus = "no_show"
+	ActivityMeetingStatusBooked   ActivityMeetingStatus = "booked"
+	ActivityMeetingStatusCanceled ActivityMeetingStatus = "canceled"
+	ActivityMeetingStatusHeld     ActivityMeetingStatus = "held"
+	ActivityMeetingStatusNoShow   ActivityMeetingStatus = "no_show"
 )
 
 // Valid indicates whether the value is a known member of the ActivityMeetingStatus enum.
@@ -338,8 +331,6 @@ func (e ActivityMeetingStatus) Valid() bool {
 	case ActivityMeetingStatusCanceled:
 		return true
 	case ActivityMeetingStatusHeld:
-		return true
-	case ActivityMeetingStatusLessThannil:
 		return true
 	case ActivityMeetingStatusNoShow:
 		return true
@@ -492,7 +483,6 @@ func (e AdvanceDealRequestStatus) Valid() bool {
 // Defines values for AdvanceDealRequestWonWithoutContractReason.
 const (
 	AdvanceDealRequestWonWithoutContractReasonImported       AdvanceDealRequestWonWithoutContractReason = "imported"
-	AdvanceDealRequestWonWithoutContractReasonLessThannil    AdvanceDealRequestWonWithoutContractReason = "<nil>"
 	AdvanceDealRequestWonWithoutContractReasonOther          AdvanceDealRequestWonWithoutContractReason = "other"
 	AdvanceDealRequestWonWithoutContractReasonPurchaseOrder  AdvanceDealRequestWonWithoutContractReason = "purchase_order"
 	AdvanceDealRequestWonWithoutContractReasonRenewalByEmail AdvanceDealRequestWonWithoutContractReason = "renewal_by_email"
@@ -503,8 +493,6 @@ const (
 func (e AdvanceDealRequestWonWithoutContractReason) Valid() bool {
 	switch e {
 	case AdvanceDealRequestWonWithoutContractReasonImported:
-		return true
-	case AdvanceDealRequestWonWithoutContractReasonLessThannil:
 		return true
 	case AdvanceDealRequestWonWithoutContractReasonOther:
 		return true
@@ -808,7 +796,6 @@ func (e ApprovalBundleMemberOutcome) Valid() bool {
 const (
 	ApprovalEvidenceSourceTypeActivity     ApprovalEvidenceSourceType = "activity"
 	ApprovalEvidenceSourceTypeDeal         ApprovalEvidenceSourceType = "deal"
-	ApprovalEvidenceSourceTypeLessThannil  ApprovalEvidenceSourceType = "<nil>"
 	ApprovalEvidenceSourceTypePage         ApprovalEvidenceSourceType = "page"
 	ApprovalEvidenceSourceTypeRelationship ApprovalEvidenceSourceType = "relationship"
 	ApprovalEvidenceSourceTypeSignal       ApprovalEvidenceSourceType = "signal"
@@ -820,8 +807,6 @@ func (e ApprovalEvidenceSourceType) Valid() bool {
 	case ApprovalEvidenceSourceTypeActivity:
 		return true
 	case ApprovalEvidenceSourceTypeDeal:
-		return true
-	case ApprovalEvidenceSourceTypeLessThannil:
 		return true
 	case ApprovalEvidenceSourceTypePage:
 		return true
@@ -1505,19 +1490,16 @@ func (e BackfillStatusState) Valid() bool {
 
 // Defines values for BackfillStatusWindow.
 const (
-	BackfillStatusWindowLessThannil BackfillStatusWindow = "<nil>"
-	BackfillStatusWindowN12m        BackfillStatusWindow = "12m"
-	BackfillStatusWindowN24m        BackfillStatusWindow = "24m"
-	BackfillStatusWindowN3m         BackfillStatusWindow = "3m"
-	BackfillStatusWindowN60m        BackfillStatusWindow = "60m"
-	BackfillStatusWindowN6m         BackfillStatusWindow = "6m"
+	BackfillStatusWindowN12m BackfillStatusWindow = "12m"
+	BackfillStatusWindowN24m BackfillStatusWindow = "24m"
+	BackfillStatusWindowN3m  BackfillStatusWindow = "3m"
+	BackfillStatusWindowN60m BackfillStatusWindow = "60m"
+	BackfillStatusWindowN6m  BackfillStatusWindow = "6m"
 )
 
 // Valid indicates whether the value is a known member of the BackfillStatusWindow enum.
 func (e BackfillStatusWindow) Valid() bool {
 	switch e {
-	case BackfillStatusWindowLessThannil:
-		return true
 	case BackfillStatusWindowN12m:
 		return true
 	case BackfillStatusWindowN24m:
@@ -2265,15 +2247,12 @@ func (e CompanySiteReadStatus) Valid() bool {
 // Defines values for CompanySiteReadStatusCode.
 const (
 	CompanySiteReadStatusCodeBudgetDeferred CompanySiteReadStatusCode = "budget_deferred"
-	CompanySiteReadStatusCodeLessThannil    CompanySiteReadStatusCode = "<nil>"
 )
 
 // Valid indicates whether the value is a known member of the CompanySiteReadStatusCode enum.
 func (e CompanySiteReadStatusCode) Valid() bool {
 	switch e {
 	case CompanySiteReadStatusCodeBudgetDeferred:
-		return true
-	case CompanySiteReadStatusCodeLessThannil:
 		return true
 	default:
 		return false
@@ -2285,7 +2264,6 @@ const (
 	CompanySiteReadStoppedReasonBudget   CompanySiteReadStoppedReason = "budget"
 	CompanySiteReadStoppedReasonByteCap  CompanySiteReadStoppedReason = "byte_cap"
 	CompanySiteReadStoppedReasonDeadline CompanySiteReadStoppedReason = "deadline"
-	CompanySiteReadStoppedReasonNull     CompanySiteReadStoppedReason = "<nil>"
 	CompanySiteReadStoppedReasonPageCap  CompanySiteReadStoppedReason = "page_cap"
 )
 
@@ -2297,8 +2275,6 @@ func (e CompanySiteReadStoppedReason) Valid() bool {
 	case CompanySiteReadStoppedReasonByteCap:
 		return true
 	case CompanySiteReadStoppedReasonDeadline:
-		return true
-	case CompanySiteReadStoppedReasonNull:
 		return true
 	case CompanySiteReadStoppedReasonPageCap:
 		return true
@@ -2348,11 +2324,10 @@ func (e CompanySiteReadComparisonClassification) Valid() bool {
 
 // Defines values for CompanySiteReadComparisonCurrentSource.
 const (
-	CompanySiteReadComparisonCurrentSourceConnector   CompanySiteReadComparisonCurrentSource = "connector"
-	CompanySiteReadComparisonCurrentSourceHuman       CompanySiteReadComparisonCurrentSource = "human"
-	CompanySiteReadComparisonCurrentSourceLessThannil CompanySiteReadComparisonCurrentSource = "<nil>"
-	CompanySiteReadComparisonCurrentSourceMigration   CompanySiteReadComparisonCurrentSource = "migration"
-	CompanySiteReadComparisonCurrentSourceSiteRead    CompanySiteReadComparisonCurrentSource = "site_read"
+	CompanySiteReadComparisonCurrentSourceConnector CompanySiteReadComparisonCurrentSource = "connector"
+	CompanySiteReadComparisonCurrentSourceHuman     CompanySiteReadComparisonCurrentSource = "human"
+	CompanySiteReadComparisonCurrentSourceMigration CompanySiteReadComparisonCurrentSource = "migration"
+	CompanySiteReadComparisonCurrentSourceSiteRead  CompanySiteReadComparisonCurrentSource = "site_read"
 )
 
 // Valid indicates whether the value is a known member of the CompanySiteReadComparisonCurrentSource enum.
@@ -2361,8 +2336,6 @@ func (e CompanySiteReadComparisonCurrentSource) Valid() bool {
 	case CompanySiteReadComparisonCurrentSourceConnector:
 		return true
 	case CompanySiteReadComparisonCurrentSourceHuman:
-		return true
-	case CompanySiteReadComparisonCurrentSourceLessThannil:
 		return true
 	case CompanySiteReadComparisonCurrentSourceMigration:
 		return true
@@ -2801,9 +2774,8 @@ func (e ConsentQualifyingEventKind) Valid() bool {
 
 // Defines values for ConsentQualifyingEventSourceEntityType.
 const (
-	ConsentQualifyingEventSourceEntityTypeActivity    ConsentQualifyingEventSourceEntityType = "activity"
-	ConsentQualifyingEventSourceEntityTypeDeal        ConsentQualifyingEventSourceEntityType = "deal"
-	ConsentQualifyingEventSourceEntityTypeLessThannil ConsentQualifyingEventSourceEntityType = "<nil>"
+	ConsentQualifyingEventSourceEntityTypeActivity ConsentQualifyingEventSourceEntityType = "activity"
+	ConsentQualifyingEventSourceEntityTypeDeal     ConsentQualifyingEventSourceEntityType = "deal"
 )
 
 // Valid indicates whether the value is a known member of the ConsentQualifyingEventSourceEntityType enum.
@@ -2812,8 +2784,6 @@ func (e ConsentQualifyingEventSourceEntityType) Valid() bool {
 	case ConsentQualifyingEventSourceEntityTypeActivity:
 		return true
 	case ConsentQualifyingEventSourceEntityTypeDeal:
-		return true
-	case ConsentQualifyingEventSourceEntityTypeLessThannil:
 		return true
 	default:
 		return false
@@ -3023,22 +2993,19 @@ func (e ConversationMemoryEntryDirection) Valid() bool {
 
 // Defines values for ConversationMemoryEntryStatus.
 const (
-	ConversationMemoryEntryStatusAwaitingThem ConversationMemoryEntryStatus = "awaiting_them"
-	ConversationMemoryEntryStatusLessThannil  ConversationMemoryEntryStatus = "<nil>"
-	ConversationMemoryEntryStatusReplied      ConversationMemoryEntryStatus = "replied"
-	ConversationMemoryEntryStatusUnanswered   ConversationMemoryEntryStatus = "unanswered"
+	AwaitingThem ConversationMemoryEntryStatus = "awaiting_them"
+	Replied      ConversationMemoryEntryStatus = "replied"
+	Unanswered   ConversationMemoryEntryStatus = "unanswered"
 )
 
 // Valid indicates whether the value is a known member of the ConversationMemoryEntryStatus enum.
 func (e ConversationMemoryEntryStatus) Valid() bool {
 	switch e {
-	case ConversationMemoryEntryStatusAwaitingThem:
+	case AwaitingThem:
 		return true
-	case ConversationMemoryEntryStatusLessThannil:
+	case Replied:
 		return true
-	case ConversationMemoryEntryStatusReplied:
-		return true
-	case ConversationMemoryEntryStatusUnanswered:
+	case Unanswered:
 		return true
 	default:
 		return false
@@ -3047,17 +3014,14 @@ func (e ConversationMemoryEntryStatus) Valid() bool {
 
 // Defines values for CreateActivityRequestDirection.
 const (
-	CreateActivityRequestDirectionInbound     CreateActivityRequestDirection = "inbound"
-	CreateActivityRequestDirectionLessThannil CreateActivityRequestDirection = "<nil>"
-	CreateActivityRequestDirectionOutbound    CreateActivityRequestDirection = "outbound"
+	CreateActivityRequestDirectionInbound  CreateActivityRequestDirection = "inbound"
+	CreateActivityRequestDirectionOutbound CreateActivityRequestDirection = "outbound"
 )
 
 // Valid indicates whether the value is a known member of the CreateActivityRequestDirection enum.
 func (e CreateActivityRequestDirection) Valid() bool {
 	switch e {
 	case CreateActivityRequestDirectionInbound:
-		return true
-	case CreateActivityRequestDirectionLessThannil:
 		return true
 	case CreateActivityRequestDirectionOutbound:
 		return true
@@ -3125,11 +3089,10 @@ func (e CreateActivityRequestLinksEntityType) Valid() bool {
 
 // Defines values for CreateActivityRequestMeetingStatus.
 const (
-	CreateActivityRequestMeetingStatusBooked      CreateActivityRequestMeetingStatus = "booked"
-	CreateActivityRequestMeetingStatusCanceled    CreateActivityRequestMeetingStatus = "canceled"
-	CreateActivityRequestMeetingStatusHeld        CreateActivityRequestMeetingStatus = "held"
-	CreateActivityRequestMeetingStatusLessThannil CreateActivityRequestMeetingStatus = "<nil>"
-	CreateActivityRequestMeetingStatusNoShow      CreateActivityRequestMeetingStatus = "no_show"
+	CreateActivityRequestMeetingStatusBooked   CreateActivityRequestMeetingStatus = "booked"
+	CreateActivityRequestMeetingStatusCanceled CreateActivityRequestMeetingStatus = "canceled"
+	CreateActivityRequestMeetingStatusHeld     CreateActivityRequestMeetingStatus = "held"
+	CreateActivityRequestMeetingStatusNoShow   CreateActivityRequestMeetingStatus = "no_show"
 )
 
 // Valid indicates whether the value is a known member of the CreateActivityRequestMeetingStatus enum.
@@ -3140,8 +3103,6 @@ func (e CreateActivityRequestMeetingStatus) Valid() bool {
 	case CreateActivityRequestMeetingStatusCanceled:
 		return true
 	case CreateActivityRequestMeetingStatusHeld:
-		return true
-	case CreateActivityRequestMeetingStatusLessThannil:
 		return true
 	case CreateActivityRequestMeetingStatusNoShow:
 		return true
@@ -3335,21 +3296,18 @@ func (e CreateListRequestListType) Valid() bool {
 
 // Defines values for CreateOrganizationRequestSizeBand.
 const (
-	CreateOrganizationRequestSizeBandLessThannil CreateOrganizationRequestSizeBand = "<nil>"
-	CreateOrganizationRequestSizeBandN10015000   CreateOrganizationRequestSizeBand = "1001-5000"
-	CreateOrganizationRequestSizeBandN110        CreateOrganizationRequestSizeBand = "1-10"
-	CreateOrganizationRequestSizeBandN1150       CreateOrganizationRequestSizeBand = "11-50"
-	CreateOrganizationRequestSizeBandN201500     CreateOrganizationRequestSizeBand = "201-500"
-	CreateOrganizationRequestSizeBandN5000       CreateOrganizationRequestSizeBand = "5000+"
-	CreateOrganizationRequestSizeBandN5011000    CreateOrganizationRequestSizeBand = "501-1000"
-	CreateOrganizationRequestSizeBandN51200      CreateOrganizationRequestSizeBand = "51-200"
+	CreateOrganizationRequestSizeBandN10015000 CreateOrganizationRequestSizeBand = "1001-5000"
+	CreateOrganizationRequestSizeBandN110      CreateOrganizationRequestSizeBand = "1-10"
+	CreateOrganizationRequestSizeBandN1150     CreateOrganizationRequestSizeBand = "11-50"
+	CreateOrganizationRequestSizeBandN201500   CreateOrganizationRequestSizeBand = "201-500"
+	CreateOrganizationRequestSizeBandN5000     CreateOrganizationRequestSizeBand = "5000+"
+	CreateOrganizationRequestSizeBandN5011000  CreateOrganizationRequestSizeBand = "501-1000"
+	CreateOrganizationRequestSizeBandN51200    CreateOrganizationRequestSizeBand = "51-200"
 )
 
 // Valid indicates whether the value is a known member of the CreateOrganizationRequestSizeBand enum.
 func (e CreateOrganizationRequestSizeBand) Valid() bool {
 	switch e {
-	case CreateOrganizationRequestSizeBandLessThannil:
-		return true
 	case CreateOrganizationRequestSizeBandN10015000:
 		return true
 	case CreateOrganizationRequestSizeBandN110:
@@ -3543,7 +3501,6 @@ func (e CreateSavedViewRequestResource) Valid() bool {
 // Defines values for CreateSignalRequestEntityType.
 const (
 	CreateSignalRequestEntityTypeDeal         CreateSignalRequestEntityType = "deal"
-	CreateSignalRequestEntityTypeLessThannil  CreateSignalRequestEntityType = "<nil>"
 	CreateSignalRequestEntityTypeOrganization CreateSignalRequestEntityType = "organization"
 	CreateSignalRequestEntityTypePerson       CreateSignalRequestEntityType = "person"
 )
@@ -3552,8 +3509,6 @@ const (
 func (e CreateSignalRequestEntityType) Valid() bool {
 	switch e {
 	case CreateSignalRequestEntityTypeDeal:
-		return true
-	case CreateSignalRequestEntityTypeLessThannil:
 		return true
 	case CreateSignalRequestEntityTypeOrganization:
 		return true
@@ -3803,11 +3758,10 @@ func (e DataSubjectRequestStatus) Valid() bool {
 
 // Defines values for DealForecastCategory.
 const (
-	DealForecastCategoryBestCase    DealForecastCategory = "best_case"
-	DealForecastCategoryCommit      DealForecastCategory = "commit"
-	DealForecastCategoryLessThannil DealForecastCategory = "<nil>"
-	DealForecastCategoryOmitted     DealForecastCategory = "omitted"
-	DealForecastCategoryPipeline    DealForecastCategory = "pipeline"
+	DealForecastCategoryBestCase DealForecastCategory = "best_case"
+	DealForecastCategoryCommit   DealForecastCategory = "commit"
+	DealForecastCategoryOmitted  DealForecastCategory = "omitted"
+	DealForecastCategoryPipeline DealForecastCategory = "pipeline"
 )
 
 // Valid indicates whether the value is a known member of the DealForecastCategory enum.
@@ -3816,8 +3770,6 @@ func (e DealForecastCategory) Valid() bool {
 	case DealForecastCategoryBestCase:
 		return true
 	case DealForecastCategoryCommit:
-		return true
-	case DealForecastCategoryLessThannil:
 		return true
 	case DealForecastCategoryOmitted:
 		return true
@@ -3852,7 +3804,6 @@ func (e DealStatus) Valid() bool {
 // Defines values for DealWonWithoutContractReason.
 const (
 	DealWonWithoutContractReasonImported       DealWonWithoutContractReason = "imported"
-	DealWonWithoutContractReasonLessThannil    DealWonWithoutContractReason = "<nil>"
 	DealWonWithoutContractReasonOther          DealWonWithoutContractReason = "other"
 	DealWonWithoutContractReasonPurchaseOrder  DealWonWithoutContractReason = "purchase_order"
 	DealWonWithoutContractReasonRenewalByEmail DealWonWithoutContractReason = "renewal_by_email"
@@ -3863,8 +3814,6 @@ const (
 func (e DealWonWithoutContractReason) Valid() bool {
 	switch e {
 	case DealWonWithoutContractReasonImported:
-		return true
-	case DealWonWithoutContractReasonLessThannil:
 		return true
 	case DealWonWithoutContractReasonOther:
 		return true
@@ -5195,7 +5144,6 @@ const (
 	OnboardingAvailableActionConfirmCompany    OnboardingCompanyMessageReplyAvailableAction = "confirm_company"
 	OnboardingAvailableActionConnectInbox      OnboardingCompanyMessageReplyAvailableAction = "connect_inbox"
 	OnboardingAvailableActionFinish            OnboardingCompanyMessageReplyAvailableAction = "finish"
-	OnboardingAvailableActionNone              OnboardingCompanyMessageReplyAvailableAction = "<nil>"
 	OnboardingAvailableActionStartVoiceBuild   OnboardingCompanyMessageReplyAvailableAction = "start_voice_build"
 	OnboardingAvailableActionUploadVoiceSource OnboardingCompanyMessageReplyAvailableAction = "upload_voice_source"
 )
@@ -5208,8 +5156,6 @@ func (e OnboardingCompanyMessageReplyAvailableAction) Valid() bool {
 	case OnboardingAvailableActionConnectInbox:
 		return true
 	case OnboardingAvailableActionFinish:
-		return true
-	case OnboardingAvailableActionNone:
 		return true
 	case OnboardingAvailableActionStartVoiceBuild:
 		return true
@@ -5224,7 +5170,6 @@ func (e OnboardingCompanyMessageReplyAvailableAction) Valid() bool {
 const (
 	OnboardingNextRequiredDisplayName  OnboardingCompanyMessageReplyNextRequiredField = "display_name"
 	OnboardingNextRequiredICP          OnboardingCompanyMessageReplyNextRequiredField = "icp"
-	OnboardingNextRequiredNone         OnboardingCompanyMessageReplyNextRequiredField = "<nil>"
 	OnboardingNextRequiredOfferSummary OnboardingCompanyMessageReplyNextRequiredField = "offer_summary"
 )
 
@@ -5234,8 +5179,6 @@ func (e OnboardingCompanyMessageReplyNextRequiredField) Valid() bool {
 	case OnboardingNextRequiredDisplayName:
 		return true
 	case OnboardingNextRequiredICP:
-		return true
-	case OnboardingNextRequiredNone:
 		return true
 	case OnboardingNextRequiredOfferSummary:
 		return true
@@ -5303,16 +5246,13 @@ func (e OnboardingStatePath) Valid() bool {
 
 // Defines values for OnboardingStateSourceMode.
 const (
-	OnboardingStateSourceModeLessThannil OnboardingStateSourceMode = "<nil>"
-	OnboardingStateSourceModeManual      OnboardingStateSourceMode = "manual"
-	OnboardingStateSourceModeWebsite     OnboardingStateSourceMode = "website"
+	OnboardingStateSourceModeManual  OnboardingStateSourceMode = "manual"
+	OnboardingStateSourceModeWebsite OnboardingStateSourceMode = "website"
 )
 
 // Valid indicates whether the value is a known member of the OnboardingStateSourceMode enum.
 func (e OnboardingStateSourceMode) Valid() bool {
 	switch e {
-	case OnboardingStateSourceModeLessThannil:
-		return true
 	case OnboardingStateSourceModeManual:
 		return true
 	case OnboardingStateSourceModeWebsite:
@@ -5354,16 +5294,15 @@ func (e OnboardingStateStep) Valid() bool {
 
 // Defines values for OrganizationClassification.
 const (
-	OrganizationClassificationAgency      OrganizationClassification = "agency"
-	OrganizationClassificationCompetitor  OrganizationClassification = "competitor"
-	OrganizationClassificationCustomer    OrganizationClassification = "customer"
-	OrganizationClassificationLessThannil OrganizationClassification = "<nil>"
-	OrganizationClassificationOther       OrganizationClassification = "other"
-	OrganizationClassificationPartner     OrganizationClassification = "partner"
-	OrganizationClassificationPlatform    OrganizationClassification = "platform"
-	OrganizationClassificationProspect    OrganizationClassification = "prospect"
-	OrganizationClassificationReseller    OrganizationClassification = "reseller"
-	OrganizationClassificationTechVendor  OrganizationClassification = "tech_vendor"
+	OrganizationClassificationAgency     OrganizationClassification = "agency"
+	OrganizationClassificationCompetitor OrganizationClassification = "competitor"
+	OrganizationClassificationCustomer   OrganizationClassification = "customer"
+	OrganizationClassificationOther      OrganizationClassification = "other"
+	OrganizationClassificationPartner    OrganizationClassification = "partner"
+	OrganizationClassificationPlatform   OrganizationClassification = "platform"
+	OrganizationClassificationProspect   OrganizationClassification = "prospect"
+	OrganizationClassificationReseller   OrganizationClassification = "reseller"
+	OrganizationClassificationTechVendor OrganizationClassification = "tech_vendor"
 )
 
 // Valid indicates whether the value is a known member of the OrganizationClassification enum.
@@ -5374,8 +5313,6 @@ func (e OrganizationClassification) Valid() bool {
 	case OrganizationClassificationCompetitor:
 		return true
 	case OrganizationClassificationCustomer:
-		return true
-	case OrganizationClassificationLessThannil:
 		return true
 	case OrganizationClassificationOther:
 		return true
@@ -5462,21 +5399,18 @@ func (e OrganizationRelationshipTypes) Valid() bool {
 
 // Defines values for OrganizationSizeBand.
 const (
-	OrganizationSizeBandLessThannil OrganizationSizeBand = "<nil>"
-	OrganizationSizeBandN10015000   OrganizationSizeBand = "1001-5000"
-	OrganizationSizeBandN110        OrganizationSizeBand = "1-10"
-	OrganizationSizeBandN1150       OrganizationSizeBand = "11-50"
-	OrganizationSizeBandN201500     OrganizationSizeBand = "201-500"
-	OrganizationSizeBandN5000       OrganizationSizeBand = "5000+"
-	OrganizationSizeBandN5011000    OrganizationSizeBand = "501-1000"
-	OrganizationSizeBandN51200      OrganizationSizeBand = "51-200"
+	OrganizationSizeBandN10015000 OrganizationSizeBand = "1001-5000"
+	OrganizationSizeBandN110      OrganizationSizeBand = "1-10"
+	OrganizationSizeBandN1150     OrganizationSizeBand = "11-50"
+	OrganizationSizeBandN201500   OrganizationSizeBand = "201-500"
+	OrganizationSizeBandN5000     OrganizationSizeBand = "5000+"
+	OrganizationSizeBandN5011000  OrganizationSizeBand = "501-1000"
+	OrganizationSizeBandN51200    OrganizationSizeBand = "51-200"
 )
 
 // Valid indicates whether the value is a known member of the OrganizationSizeBand enum.
 func (e OrganizationSizeBand) Valid() bool {
 	switch e {
-	case OrganizationSizeBandLessThannil:
-		return true
 	case OrganizationSizeBandN10015000:
 		return true
 	case OrganizationSizeBandN110:
@@ -5573,17 +5507,14 @@ func (e Organization360ContactConsent) Valid() bool {
 
 // Defines values for Organization360ContactTitleSource.
 const (
-	Organization360ContactTitleSourceCanonical   Organization360ContactTitleSource = "canonical"
-	Organization360ContactTitleSourceLessThannil Organization360ContactTitleSource = "<nil>"
-	Organization360ContactTitleSourceProvider    Organization360ContactTitleSource = "provider"
+	Organization360ContactTitleSourceCanonical Organization360ContactTitleSource = "canonical"
+	Organization360ContactTitleSourceProvider  Organization360ContactTitleSource = "provider"
 )
 
 // Valid indicates whether the value is a known member of the Organization360ContactTitleSource enum.
 func (e Organization360ContactTitleSource) Valid() bool {
 	switch e {
 	case Organization360ContactTitleSourceCanonical:
-		return true
-	case Organization360ContactTitleSourceLessThannil:
 		return true
 	case Organization360ContactTitleSourceProvider:
 		return true
@@ -5796,7 +5727,6 @@ func (e Organization360SuggestionKind) Valid() bool {
 // Defines values for Organization360SuggestionSubjectType.
 const (
 	Organization360SuggestionSubjectTypeDeal         Organization360SuggestionSubjectType = "deal"
-	Organization360SuggestionSubjectTypeLessThannil  Organization360SuggestionSubjectType = "<nil>"
 	Organization360SuggestionSubjectTypeOrganization Organization360SuggestionSubjectType = "organization"
 	Organization360SuggestionSubjectTypePerson       Organization360SuggestionSubjectType = "person"
 )
@@ -5805,8 +5735,6 @@ const (
 func (e Organization360SuggestionSubjectType) Valid() bool {
 	switch e {
 	case Organization360SuggestionSubjectTypeDeal:
-		return true
-	case Organization360SuggestionSubjectTypeLessThannil:
 		return true
 	case Organization360SuggestionSubjectTypeOrganization:
 		return true
@@ -6038,7 +5966,6 @@ func (e OrganizationFactSource) Valid() bool {
 
 // Defines values for OrganizationFactSuspectReason.
 const (
-	OrganizationFactSuspectReasonLessThannil         OrganizationFactSuspectReason = "<nil>"
 	OrganizationFactSuspectReasonNotAPhone           OrganizationFactSuspectReason = "not_a_phone"
 	OrganizationFactSuspectReasonNotASize            OrganizationFactSuspectReason = "not_a_size"
 	OrganizationFactSuspectReasonNotAYear            OrganizationFactSuspectReason = "not_a_year"
@@ -6049,8 +5976,6 @@ const (
 // Valid indicates whether the value is a known member of the OrganizationFactSuspectReason enum.
 func (e OrganizationFactSuspectReason) Valid() bool {
 	switch e {
-	case OrganizationFactSuspectReasonLessThannil:
-		return true
 	case OrganizationFactSuspectReasonNotAPhone:
 		return true
 	case OrganizationFactSuspectReasonNotASize:
@@ -6179,19 +6104,16 @@ func (e OrganizationGraphNodeKind) Valid() bool {
 
 // Defines values for OrganizationGraphNodeStrengthBucket.
 const (
-	OrganizationGraphNodeStrengthBucketDormant     OrganizationGraphNodeStrengthBucket = "dormant"
-	OrganizationGraphNodeStrengthBucketLessThannil OrganizationGraphNodeStrengthBucket = "<nil>"
-	OrganizationGraphNodeStrengthBucketStrong      OrganizationGraphNodeStrengthBucket = "strong"
-	OrganizationGraphNodeStrengthBucketWarm        OrganizationGraphNodeStrengthBucket = "warm"
-	OrganizationGraphNodeStrengthBucketWeak        OrganizationGraphNodeStrengthBucket = "weak"
+	OrganizationGraphNodeStrengthBucketDormant OrganizationGraphNodeStrengthBucket = "dormant"
+	OrganizationGraphNodeStrengthBucketStrong  OrganizationGraphNodeStrengthBucket = "strong"
+	OrganizationGraphNodeStrengthBucketWarm    OrganizationGraphNodeStrengthBucket = "warm"
+	OrganizationGraphNodeStrengthBucketWeak    OrganizationGraphNodeStrengthBucket = "weak"
 )
 
 // Valid indicates whether the value is a known member of the OrganizationGraphNodeStrengthBucket enum.
 func (e OrganizationGraphNodeStrengthBucket) Valid() bool {
 	switch e {
 	case OrganizationGraphNodeStrengthBucketDormant:
-		return true
-	case OrganizationGraphNodeStrengthBucketLessThannil:
 		return true
 	case OrganizationGraphNodeStrengthBucketStrong:
 		return true
@@ -6494,17 +6416,14 @@ func (e PartnerCertStatus) Valid() bool {
 
 // Defines values for PartnerMarginTier.
 const (
-	PartnerMarginTierLessThannil PartnerMarginTier = "<nil>"
-	PartnerMarginTierTier115     PartnerMarginTier = "tier1_15"
-	PartnerMarginTierTier220     PartnerMarginTier = "tier2_20"
-	PartnerMarginTierTier325     PartnerMarginTier = "tier3_25"
+	PartnerMarginTierTier115 PartnerMarginTier = "tier1_15"
+	PartnerMarginTierTier220 PartnerMarginTier = "tier2_20"
+	PartnerMarginTierTier325 PartnerMarginTier = "tier3_25"
 )
 
 // Valid indicates whether the value is a known member of the PartnerMarginTier enum.
 func (e PartnerMarginTier) Valid() bool {
 	switch e {
-	case PartnerMarginTierLessThannil:
-		return true
 	case PartnerMarginTierTier115:
 		return true
 	case PartnerMarginTierTier220:
@@ -6910,7 +6829,6 @@ func (e PersonMomentActionState) Valid() bool {
 const (
 	PersonMomentDestinationEntityTypeActivity     PersonMomentDestinationEntityType = "activity"
 	PersonMomentDestinationEntityTypeDeal         PersonMomentDestinationEntityType = "deal"
-	PersonMomentDestinationEntityTypeLessThannil  PersonMomentDestinationEntityType = "<nil>"
 	PersonMomentDestinationEntityTypeOrganization PersonMomentDestinationEntityType = "organization"
 	PersonMomentDestinationEntityTypePerson       PersonMomentDestinationEntityType = "person"
 )
@@ -6921,8 +6839,6 @@ func (e PersonMomentDestinationEntityType) Valid() bool {
 	case PersonMomentDestinationEntityTypeActivity:
 		return true
 	case PersonMomentDestinationEntityTypeDeal:
-		return true
-	case PersonMomentDestinationEntityTypeLessThannil:
 		return true
 	case PersonMomentDestinationEntityTypeOrganization:
 		return true
@@ -7121,7 +7037,6 @@ func (e PersonProfileFieldVerdict) Valid() bool {
 
 // Defines values for PersonProviderEmailEmailType.
 const (
-	PersonProviderEmailEmailTypeLessThannil  PersonProviderEmailEmailType = "<nil>"
 	PersonProviderEmailEmailTypePersonal     PersonProviderEmailEmailType = "personal"
 	PersonProviderEmailEmailTypeProfessional PersonProviderEmailEmailType = "professional"
 )
@@ -7129,8 +7044,6 @@ const (
 // Valid indicates whether the value is a known member of the PersonProviderEmailEmailType enum.
 func (e PersonProviderEmailEmailType) Valid() bool {
 	switch e {
-	case PersonProviderEmailEmailTypeLessThannil:
-		return true
 	case PersonProviderEmailEmailTypePersonal:
 		return true
 	case PersonProviderEmailEmailTypeProfessional:
@@ -7142,7 +7055,6 @@ func (e PersonProviderEmailEmailType) Valid() bool {
 
 // Defines values for PersonProviderEmailEmailTypeSource.
 const (
-	PersonProviderEmailEmailTypeSourceLessThannil      PersonProviderEmailEmailTypeSource = "<nil>"
 	PersonProviderEmailEmailTypeSourceProvider         PersonProviderEmailEmailTypeSource = "provider"
 	PersonProviderEmailEmailTypeSourceRequestedCascade PersonProviderEmailEmailTypeSource = "requested_cascade"
 )
@@ -7150,8 +7062,6 @@ const (
 // Valid indicates whether the value is a known member of the PersonProviderEmailEmailTypeSource enum.
 func (e PersonProviderEmailEmailTypeSource) Valid() bool {
 	switch e {
-	case PersonProviderEmailEmailTypeSourceLessThannil:
-		return true
 	case PersonProviderEmailEmailTypeSourceProvider:
 		return true
 	case PersonProviderEmailEmailTypeSourceRequestedCascade:
@@ -7541,7 +7451,6 @@ const (
 	ProviderRunSkipReasonAlreadyFresh              ProviderRunSkipReason = "already_fresh"
 	ProviderRunSkipReasonBudgetExhausted           ProviderRunSkipReason = "budget_exhausted"
 	ProviderRunSkipReasonDuplicateSubjectCandidate ProviderRunSkipReason = "duplicate_subject_candidate"
-	ProviderRunSkipReasonLessThannil               ProviderRunSkipReason = "<nil>"
 	ProviderRunSkipReasonLowBalance                ProviderRunSkipReason = "low_balance"
 	ProviderRunSkipReasonNotEligible               ProviderRunSkipReason = "not_eligible"
 	ProviderRunSkipReasonRateLimited               ProviderRunSkipReason = "rate_limited"
@@ -7556,8 +7465,6 @@ func (e ProviderRunSkipReason) Valid() bool {
 	case ProviderRunSkipReasonBudgetExhausted:
 		return true
 	case ProviderRunSkipReasonDuplicateSubjectCandidate:
-		return true
-	case ProviderRunSkipReasonLessThannil:
 		return true
 	case ProviderRunSkipReasonLowBalance:
 		return true
@@ -7652,16 +7559,13 @@ func (e ProviderRunTrigger) Valid() bool {
 
 // Defines values for PutOnboardingStateRequestSourceMode.
 const (
-	PutOnboardingStateRequestSourceModeLessThannil PutOnboardingStateRequestSourceMode = "<nil>"
-	PutOnboardingStateRequestSourceModeManual      PutOnboardingStateRequestSourceMode = "manual"
-	PutOnboardingStateRequestSourceModeWebsite     PutOnboardingStateRequestSourceMode = "website"
+	PutOnboardingStateRequestSourceModeManual  PutOnboardingStateRequestSourceMode = "manual"
+	PutOnboardingStateRequestSourceModeWebsite PutOnboardingStateRequestSourceMode = "website"
 )
 
 // Valid indicates whether the value is a known member of the PutOnboardingStateRequestSourceMode enum.
 func (e PutOnboardingStateRequestSourceMode) Valid() bool {
 	switch e {
-	case PutOnboardingStateRequestSourceModeLessThannil:
-		return true
 	case PutOnboardingStateRequestSourceModeManual:
 		return true
 	case PutOnboardingStateRequestSourceModeWebsite:
@@ -8099,28 +8003,25 @@ func (e SavedViewSharedScope) Valid() bool {
 
 // Defines values for ScheduledSendHeldReason.
 const (
-	ScheduledSendHeldReasonConsentWithdrawn ScheduledSendHeldReason = "consent_withdrawn"
-	ScheduledSendHeldReasonLessThannil      ScheduledSendHeldReason = "<nil>"
-	ScheduledSendHeldReasonMissedWindow     ScheduledSendHeldReason = "missed_window"
-	ScheduledSendHeldReasonSendRefused      ScheduledSendHeldReason = "send_refused"
-	ScheduledSendHeldReasonSenderInactive   ScheduledSendHeldReason = "sender_inactive"
-	ScheduledSendHeldReasonTimerExhausted   ScheduledSendHeldReason = "timer_exhausted"
+	ConsentWithdrawn ScheduledSendHeldReason = "consent_withdrawn"
+	MissedWindow     ScheduledSendHeldReason = "missed_window"
+	SendRefused      ScheduledSendHeldReason = "send_refused"
+	SenderInactive   ScheduledSendHeldReason = "sender_inactive"
+	TimerExhausted   ScheduledSendHeldReason = "timer_exhausted"
 )
 
 // Valid indicates whether the value is a known member of the ScheduledSendHeldReason enum.
 func (e ScheduledSendHeldReason) Valid() bool {
 	switch e {
-	case ScheduledSendHeldReasonConsentWithdrawn:
+	case ConsentWithdrawn:
 		return true
-	case ScheduledSendHeldReasonLessThannil:
+	case MissedWindow:
 		return true
-	case ScheduledSendHeldReasonMissedWindow:
+	case SendRefused:
 		return true
-	case ScheduledSendHeldReasonSendRefused:
+	case SenderInactive:
 		return true
-	case ScheduledSendHeldReasonSenderInactive:
-		return true
-	case ScheduledSendHeldReasonTimerExhausted:
+	case TimerExhausted:
 		return true
 	default:
 		return false
@@ -8158,7 +8059,6 @@ func (e ScheduledSendStatus) Valid() bool {
 const (
 	SearchResultTrustTierAuthoritative SearchResultTrustTier = "authoritative"
 	SearchResultTrustTierExternal      SearchResultTrustTier = "external"
-	SearchResultTrustTierLessThannil   SearchResultTrustTier = "<nil>"
 	SearchResultTrustTierUnverified    SearchResultTrustTier = "unverified"
 )
 
@@ -8168,8 +8068,6 @@ func (e SearchResultTrustTier) Valid() bool {
 	case SearchResultTrustTierAuthoritative:
 		return true
 	case SearchResultTrustTierExternal:
-		return true
-	case SearchResultTrustTierLessThannil:
 		return true
 	case SearchResultTrustTierUnverified:
 		return true
@@ -8307,7 +8205,6 @@ func (e SetProjectStakeholderRequestRole) Valid() bool {
 // Defines values for SignalEntityType.
 const (
 	SignalEntityTypeDeal         SignalEntityType = "deal"
-	SignalEntityTypeLessThannil  SignalEntityType = "<nil>"
 	SignalEntityTypeOrganization SignalEntityType = "organization"
 	SignalEntityTypePerson       SignalEntityType = "person"
 )
@@ -8316,8 +8213,6 @@ const (
 func (e SignalEntityType) Valid() bool {
 	switch e {
 	case SignalEntityTypeDeal:
-		return true
-	case SignalEntityTypeLessThannil:
 		return true
 	case SignalEntityTypeOrganization:
 		return true
@@ -8470,7 +8365,6 @@ func (e SignalStatus) Valid() bool {
 const (
 	SignalEvidenceSourceTypeActivity     SignalEvidenceSourceType = "activity"
 	SignalEvidenceSourceTypeDeal         SignalEvidenceSourceType = "deal"
-	SignalEvidenceSourceTypeLessThannil  SignalEvidenceSourceType = "<nil>"
 	SignalEvidenceSourceTypePage         SignalEvidenceSourceType = "page"
 	SignalEvidenceSourceTypeRelationship SignalEvidenceSourceType = "relationship"
 	SignalEvidenceSourceTypeSignal       SignalEvidenceSourceType = "signal"
@@ -8482,8 +8376,6 @@ func (e SignalEvidenceSourceType) Valid() bool {
 	case SignalEvidenceSourceTypeActivity:
 		return true
 	case SignalEvidenceSourceTypeDeal:
-		return true
-	case SignalEvidenceSourceTypeLessThannil:
 		return true
 	case SignalEvidenceSourceTypePage:
 		return true
@@ -8612,9 +8504,8 @@ func (e SiteReadPageKind) Valid() bool {
 
 // Defines values for SiteReadReportPhase.
 const (
-	SiteReadReportPhaseCrawling    SiteReadReportPhase = "crawling"
-	SiteReadReportPhaseExtracting  SiteReadReportPhase = "extracting"
-	SiteReadReportPhaseLessThannil SiteReadReportPhase = "<nil>"
+	SiteReadReportPhaseCrawling   SiteReadReportPhase = "crawling"
+	SiteReadReportPhaseExtracting SiteReadReportPhase = "extracting"
 )
 
 // Valid indicates whether the value is a known member of the SiteReadReportPhase enum.
@@ -8623,8 +8514,6 @@ func (e SiteReadReportPhase) Valid() bool {
 	case SiteReadReportPhaseCrawling:
 		return true
 	case SiteReadReportPhaseExtracting:
-		return true
-	case SiteReadReportPhaseLessThannil:
 		return true
 	default:
 		return false
@@ -8667,15 +8556,12 @@ func (e SiteReadReportStatus) Valid() bool {
 // Defines values for SiteReadReportStatusCode.
 const (
 	SiteReadReportStatusCodeBudgetDeferred SiteReadReportStatusCode = "budget_deferred"
-	SiteReadReportStatusCodeLessThannil    SiteReadReportStatusCode = "<nil>"
 )
 
 // Valid indicates whether the value is a known member of the SiteReadReportStatusCode enum.
 func (e SiteReadReportStatusCode) Valid() bool {
 	switch e {
 	case SiteReadReportStatusCodeBudgetDeferred:
-		return true
-	case SiteReadReportStatusCodeLessThannil:
 		return true
 	default:
 		return false
@@ -8684,11 +8570,10 @@ func (e SiteReadReportStatusCode) Valid() bool {
 
 // Defines values for SiteReadReportStoppedReason.
 const (
-	SiteReadReportStoppedReasonBudget      SiteReadReportStoppedReason = "budget"
-	SiteReadReportStoppedReasonByteCap     SiteReadReportStoppedReason = "byte_cap"
-	SiteReadReportStoppedReasonDeadline    SiteReadReportStoppedReason = "deadline"
-	SiteReadReportStoppedReasonLessThannil SiteReadReportStoppedReason = "<nil>"
-	SiteReadReportStoppedReasonPageCap     SiteReadReportStoppedReason = "page_cap"
+	SiteReadReportStoppedReasonBudget   SiteReadReportStoppedReason = "budget"
+	SiteReadReportStoppedReasonByteCap  SiteReadReportStoppedReason = "byte_cap"
+	SiteReadReportStoppedReasonDeadline SiteReadReportStoppedReason = "deadline"
+	SiteReadReportStoppedReasonPageCap  SiteReadReportStoppedReason = "page_cap"
 )
 
 // Valid indicates whether the value is a known member of the SiteReadReportStoppedReason enum.
@@ -8699,8 +8584,6 @@ func (e SiteReadReportStoppedReason) Valid() bool {
 	case SiteReadReportStoppedReasonByteCap:
 		return true
 	case SiteReadReportStoppedReasonDeadline:
-		return true
-	case SiteReadReportStoppedReasonLessThannil:
 		return true
 	case SiteReadReportStoppedReasonPageCap:
 		return true
@@ -8780,25 +8663,25 @@ func (e StageSemantic) Valid() bool {
 
 // Defines values for StartBackfillRequestWindow.
 const (
-	N12m StartBackfillRequestWindow = "12m"
-	N24m StartBackfillRequestWindow = "24m"
-	N3m  StartBackfillRequestWindow = "3m"
-	N60m StartBackfillRequestWindow = "60m"
-	N6m  StartBackfillRequestWindow = "6m"
+	StartBackfillRequestWindowN12m StartBackfillRequestWindow = "12m"
+	StartBackfillRequestWindowN24m StartBackfillRequestWindow = "24m"
+	StartBackfillRequestWindowN3m  StartBackfillRequestWindow = "3m"
+	StartBackfillRequestWindowN60m StartBackfillRequestWindow = "60m"
+	StartBackfillRequestWindowN6m  StartBackfillRequestWindow = "6m"
 )
 
 // Valid indicates whether the value is a known member of the StartBackfillRequestWindow enum.
 func (e StartBackfillRequestWindow) Valid() bool {
 	switch e {
-	case N12m:
+	case StartBackfillRequestWindowN12m:
 		return true
-	case N24m:
+	case StartBackfillRequestWindowN24m:
 		return true
-	case N3m:
+	case StartBackfillRequestWindowN3m:
 		return true
-	case N60m:
+	case StartBackfillRequestWindowN60m:
 		return true
-	case N6m:
+	case StartBackfillRequestWindowN6m:
 		return true
 	default:
 		return false
@@ -8930,17 +8813,14 @@ func (e UpdateAttachmentMetadataRequestDocState) Valid() bool {
 
 // Defines values for UpdateAutomationRequestStatus.
 const (
-	UpdateAutomationRequestStatusEnabled     UpdateAutomationRequestStatus = "enabled"
-	UpdateAutomationRequestStatusLessThannil UpdateAutomationRequestStatus = "<nil>"
-	UpdateAutomationRequestStatusPaused      UpdateAutomationRequestStatus = "paused"
+	UpdateAutomationRequestStatusEnabled UpdateAutomationRequestStatus = "enabled"
+	UpdateAutomationRequestStatusPaused  UpdateAutomationRequestStatus = "paused"
 )
 
 // Valid indicates whether the value is a known member of the UpdateAutomationRequestStatus enum.
 func (e UpdateAutomationRequestStatus) Valid() bool {
 	switch e {
 	case UpdateAutomationRequestStatusEnabled:
-		return true
-	case UpdateAutomationRequestStatusLessThannil:
 		return true
 	case UpdateAutomationRequestStatusPaused:
 		return true
@@ -8993,11 +8873,10 @@ func (e UpdateDataSubjectRequestStatus) Valid() bool {
 
 // Defines values for UpdateDealRequestForecastCategory.
 const (
-	UpdateDealRequestForecastCategoryBestCase    UpdateDealRequestForecastCategory = "best_case"
-	UpdateDealRequestForecastCategoryCommit      UpdateDealRequestForecastCategory = "commit"
-	UpdateDealRequestForecastCategoryLessThannil UpdateDealRequestForecastCategory = "<nil>"
-	UpdateDealRequestForecastCategoryOmitted     UpdateDealRequestForecastCategory = "omitted"
-	UpdateDealRequestForecastCategoryPipeline    UpdateDealRequestForecastCategory = "pipeline"
+	UpdateDealRequestForecastCategoryBestCase UpdateDealRequestForecastCategory = "best_case"
+	UpdateDealRequestForecastCategoryCommit   UpdateDealRequestForecastCategory = "commit"
+	UpdateDealRequestForecastCategoryOmitted  UpdateDealRequestForecastCategory = "omitted"
+	UpdateDealRequestForecastCategoryPipeline UpdateDealRequestForecastCategory = "pipeline"
 )
 
 // Valid indicates whether the value is a known member of the UpdateDealRequestForecastCategory enum.
@@ -9006,8 +8885,6 @@ func (e UpdateDealRequestForecastCategory) Valid() bool {
 	case UpdateDealRequestForecastCategoryBestCase:
 		return true
 	case UpdateDealRequestForecastCategoryCommit:
-		return true
-	case UpdateDealRequestForecastCategoryLessThannil:
 		return true
 	case UpdateDealRequestForecastCategoryOmitted:
 		return true
@@ -9128,21 +9005,18 @@ func (e UpdateOrganizationRequestRelationshipTypes) Valid() bool {
 
 // Defines values for UpdateOrganizationRequestSizeBand.
 const (
-	UpdateOrganizationRequestSizeBandLessThannil UpdateOrganizationRequestSizeBand = "<nil>"
-	UpdateOrganizationRequestSizeBandN10015000   UpdateOrganizationRequestSizeBand = "1001-5000"
-	UpdateOrganizationRequestSizeBandN110        UpdateOrganizationRequestSizeBand = "1-10"
-	UpdateOrganizationRequestSizeBandN1150       UpdateOrganizationRequestSizeBand = "11-50"
-	UpdateOrganizationRequestSizeBandN201500     UpdateOrganizationRequestSizeBand = "201-500"
-	UpdateOrganizationRequestSizeBandN5000       UpdateOrganizationRequestSizeBand = "5000+"
-	UpdateOrganizationRequestSizeBandN5011000    UpdateOrganizationRequestSizeBand = "501-1000"
-	UpdateOrganizationRequestSizeBandN51200      UpdateOrganizationRequestSizeBand = "51-200"
+	UpdateOrganizationRequestSizeBandN10015000 UpdateOrganizationRequestSizeBand = "1001-5000"
+	UpdateOrganizationRequestSizeBandN110      UpdateOrganizationRequestSizeBand = "1-10"
+	UpdateOrganizationRequestSizeBandN1150     UpdateOrganizationRequestSizeBand = "11-50"
+	UpdateOrganizationRequestSizeBandN201500   UpdateOrganizationRequestSizeBand = "201-500"
+	UpdateOrganizationRequestSizeBandN5000     UpdateOrganizationRequestSizeBand = "5000+"
+	UpdateOrganizationRequestSizeBandN5011000  UpdateOrganizationRequestSizeBand = "501-1000"
+	UpdateOrganizationRequestSizeBandN51200    UpdateOrganizationRequestSizeBand = "51-200"
 )
 
 // Valid indicates whether the value is a known member of the UpdateOrganizationRequestSizeBand enum.
 func (e UpdateOrganizationRequestSizeBand) Valid() bool {
 	switch e {
-	case UpdateOrganizationRequestSizeBandLessThannil:
-		return true
 	case UpdateOrganizationRequestSizeBandN10015000:
 		return true
 	case UpdateOrganizationRequestSizeBandN110:
@@ -9269,17 +9143,14 @@ func (e UpsertPartnerRequestCertStatus) Valid() bool {
 
 // Defines values for UpsertPartnerRequestMarginTier.
 const (
-	UpsertPartnerRequestMarginTierLessThannil UpsertPartnerRequestMarginTier = "<nil>"
-	UpsertPartnerRequestMarginTierTier115     UpsertPartnerRequestMarginTier = "tier1_15"
-	UpsertPartnerRequestMarginTierTier220     UpsertPartnerRequestMarginTier = "tier2_20"
-	UpsertPartnerRequestMarginTierTier325     UpsertPartnerRequestMarginTier = "tier3_25"
+	UpsertPartnerRequestMarginTierTier115 UpsertPartnerRequestMarginTier = "tier1_15"
+	UpsertPartnerRequestMarginTierTier220 UpsertPartnerRequestMarginTier = "tier2_20"
+	UpsertPartnerRequestMarginTierTier325 UpsertPartnerRequestMarginTier = "tier3_25"
 )
 
 // Valid indicates whether the value is a known member of the UpsertPartnerRequestMarginTier enum.
 func (e UpsertPartnerRequestMarginTier) Valid() bool {
 	switch e {
-	case UpsertPartnerRequestMarginTierLessThannil:
-		return true
 	case UpsertPartnerRequestMarginTierTier115:
 		return true
 	case UpsertPartnerRequestMarginTierTier220:
@@ -9419,25 +9290,22 @@ func (e VoiceBuildReason) Valid() bool {
 
 // Defines values for VoiceBuildStage.
 const (
-	VoiceBuildStageActivate    VoiceBuildStage = "activate"
-	VoiceBuildStageEvaluate    VoiceBuildStage = "evaluate"
-	VoiceBuildStageExtract     VoiceBuildStage = "extract"
-	VoiceBuildStageLessThannil VoiceBuildStage = "<nil>"
-	VoiceBuildStageSnapshot    VoiceBuildStage = "snapshot"
+	Activate VoiceBuildStage = "activate"
+	Evaluate VoiceBuildStage = "evaluate"
+	Extract  VoiceBuildStage = "extract"
+	Snapshot VoiceBuildStage = "snapshot"
 )
 
 // Valid indicates whether the value is a known member of the VoiceBuildStage enum.
 func (e VoiceBuildStage) Valid() bool {
 	switch e {
-	case VoiceBuildStageActivate:
+	case Activate:
 		return true
-	case VoiceBuildStageEvaluate:
+	case Evaluate:
 		return true
-	case VoiceBuildStageExtract:
+	case Extract:
 		return true
-	case VoiceBuildStageLessThannil:
-		return true
-	case VoiceBuildStageSnapshot:
+	case Snapshot:
 		return true
 	default:
 		return false
@@ -9473,31 +9341,28 @@ func (e VoiceBuildStatus) Valid() bool {
 
 // Defines values for VoiceBuildStatusCode.
 const (
-	VoiceBuildStatusCodeBudgetDeferred    VoiceBuildStatusCode = "budget_deferred"
-	VoiceBuildStatusCodeInternal          VoiceBuildStatusCode = "internal"
-	VoiceBuildStatusCodeInvalidOutput     VoiceBuildStatusCode = "invalid_output"
-	VoiceBuildStatusCodeLessThannil       VoiceBuildStatusCode = "<nil>"
-	VoiceBuildStatusCodeMaterialDrift     VoiceBuildStatusCode = "material_drift"
-	VoiceBuildStatusCodeModelUnavailable  VoiceBuildStatusCode = "model_unavailable"
-	VoiceBuildStatusCodeQualityRegression VoiceBuildStatusCode = "quality_regression"
+	BudgetDeferred    VoiceBuildStatusCode = "budget_deferred"
+	Internal          VoiceBuildStatusCode = "internal"
+	InvalidOutput     VoiceBuildStatusCode = "invalid_output"
+	MaterialDrift     VoiceBuildStatusCode = "material_drift"
+	ModelUnavailable  VoiceBuildStatusCode = "model_unavailable"
+	QualityRegression VoiceBuildStatusCode = "quality_regression"
 )
 
 // Valid indicates whether the value is a known member of the VoiceBuildStatusCode enum.
 func (e VoiceBuildStatusCode) Valid() bool {
 	switch e {
-	case VoiceBuildStatusCodeBudgetDeferred:
+	case BudgetDeferred:
 		return true
-	case VoiceBuildStatusCodeInternal:
+	case Internal:
 		return true
-	case VoiceBuildStatusCodeInvalidOutput:
+	case InvalidOutput:
 		return true
-	case VoiceBuildStatusCodeLessThannil:
+	case MaterialDrift:
 		return true
-	case VoiceBuildStatusCodeMaterialDrift:
+	case ModelUnavailable:
 		return true
-	case VoiceBuildStatusCodeModelUnavailable:
-		return true
-	case VoiceBuildStatusCodeQualityRegression:
+	case QualityRegression:
 		return true
 	default:
 		return false
@@ -9506,16 +9371,16 @@ func (e VoiceBuildStatusCode) Valid() bool {
 
 // Defines values for VoiceCorpusPreviewRequestFormat.
 const (
-	VoiceCorpusPreviewRequestFormatText       VoiceCorpusPreviewRequestFormat = "text"
-	VoiceCorpusPreviewRequestFormatTranscript VoiceCorpusPreviewRequestFormat = "transcript"
+	Text       VoiceCorpusPreviewRequestFormat = "text"
+	Transcript VoiceCorpusPreviewRequestFormat = "transcript"
 )
 
 // Valid indicates whether the value is a known member of the VoiceCorpusPreviewRequestFormat enum.
 func (e VoiceCorpusPreviewRequestFormat) Valid() bool {
 	switch e {
-	case VoiceCorpusPreviewRequestFormatText:
+	case Text:
 		return true
-	case VoiceCorpusPreviewRequestFormatTranscript:
+	case Transcript:
 		return true
 	default:
 		return false
@@ -10745,31 +10610,31 @@ func (e ListOrganizationsParamsRelationshipType) Valid() bool {
 
 // Defines values for ListOrganizationsParamsSizeBand.
 const (
-	N10015000 ListOrganizationsParamsSizeBand = "1001-5000"
-	N110      ListOrganizationsParamsSizeBand = "1-10"
-	N1150     ListOrganizationsParamsSizeBand = "11-50"
-	N201500   ListOrganizationsParamsSizeBand = "201-500"
-	N5000     ListOrganizationsParamsSizeBand = "5000+"
-	N5011000  ListOrganizationsParamsSizeBand = "501-1000"
-	N51200    ListOrganizationsParamsSizeBand = "51-200"
+	ListOrganizationsParamsSizeBandN10015000 ListOrganizationsParamsSizeBand = "1001-5000"
+	ListOrganizationsParamsSizeBandN110      ListOrganizationsParamsSizeBand = "1-10"
+	ListOrganizationsParamsSizeBandN1150     ListOrganizationsParamsSizeBand = "11-50"
+	ListOrganizationsParamsSizeBandN201500   ListOrganizationsParamsSizeBand = "201-500"
+	ListOrganizationsParamsSizeBandN5000     ListOrganizationsParamsSizeBand = "5000+"
+	ListOrganizationsParamsSizeBandN5011000  ListOrganizationsParamsSizeBand = "501-1000"
+	ListOrganizationsParamsSizeBandN51200    ListOrganizationsParamsSizeBand = "51-200"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationsParamsSizeBand enum.
 func (e ListOrganizationsParamsSizeBand) Valid() bool {
 	switch e {
-	case N10015000:
+	case ListOrganizationsParamsSizeBandN10015000:
 		return true
-	case N110:
+	case ListOrganizationsParamsSizeBandN110:
 		return true
-	case N1150:
+	case ListOrganizationsParamsSizeBandN1150:
 		return true
-	case N201500:
+	case ListOrganizationsParamsSizeBandN201500:
 		return true
-	case N5000:
+	case ListOrganizationsParamsSizeBandN5000:
 		return true
-	case N5011000:
+	case ListOrganizationsParamsSizeBandN5011000:
 		return true
-	case N51200:
+	case ListOrganizationsParamsSizeBandN51200:
 		return true
 	default:
 		return false
@@ -10835,22 +10700,22 @@ func (e ListOrganizationDocumentsParamsCategory) Valid() bool {
 
 // Defines values for ListOrganizationDocumentsParamsDocState.
 const (
-	Current    ListOrganizationDocumentsParamsDocState = "current"
-	Draft      ListOrganizationDocumentsParamsDocState = "draft"
-	Final      ListOrganizationDocumentsParamsDocState = "final"
-	Superseded ListOrganizationDocumentsParamsDocState = "superseded"
+	ListOrganizationDocumentsParamsDocStateCurrent    ListOrganizationDocumentsParamsDocState = "current"
+	ListOrganizationDocumentsParamsDocStateDraft      ListOrganizationDocumentsParamsDocState = "draft"
+	ListOrganizationDocumentsParamsDocStateFinal      ListOrganizationDocumentsParamsDocState = "final"
+	ListOrganizationDocumentsParamsDocStateSuperseded ListOrganizationDocumentsParamsDocState = "superseded"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationDocumentsParamsDocState enum.
 func (e ListOrganizationDocumentsParamsDocState) Valid() bool {
 	switch e {
-	case Current:
+	case ListOrganizationDocumentsParamsDocStateCurrent:
 		return true
-	case Draft:
+	case ListOrganizationDocumentsParamsDocStateDraft:
 		return true
-	case Final:
+	case ListOrganizationDocumentsParamsDocStateFinal:
 		return true
-	case Superseded:
+	case ListOrganizationDocumentsParamsDocStateSuperseded:
 		return true
 	default:
 		return false

--- a/backend/pkg/extension/crm/crm_gen.go
+++ b/backend/pkg/extension/crm/crm_gen.go
@@ -9,18 +9,15 @@ import (
 
 // Defines values for ActivityCaptureLabel.
 const (
-	ActivityCaptureLabelCommitment  ActivityCaptureLabel = "commitment"
-	ActivityCaptureLabelLessThannil ActivityCaptureLabel = "<nil>"
-	ActivityCaptureLabelMeeting     ActivityCaptureLabel = "meeting"
-	ActivityCaptureLabelNoise       ActivityCaptureLabel = "noise"
+	ActivityCaptureLabelCommitment ActivityCaptureLabel = "commitment"
+	ActivityCaptureLabelMeeting    ActivityCaptureLabel = "meeting"
+	ActivityCaptureLabelNoise      ActivityCaptureLabel = "noise"
 )
 
 // Valid indicates whether the value is a known member of the ActivityCaptureLabel enum.
 func (e ActivityCaptureLabel) Valid() bool {
 	switch e {
 	case ActivityCaptureLabelCommitment:
-		return true
-	case ActivityCaptureLabelLessThannil:
 		return true
 	case ActivityCaptureLabelMeeting:
 		return true
@@ -51,17 +48,14 @@ func (e ActivityContentState) Valid() bool {
 
 // Defines values for ActivityDirection.
 const (
-	ActivityDirectionInbound     ActivityDirection = "inbound"
-	ActivityDirectionLessThannil ActivityDirection = "<nil>"
-	ActivityDirectionOutbound    ActivityDirection = "outbound"
+	ActivityDirectionInbound  ActivityDirection = "inbound"
+	ActivityDirectionOutbound ActivityDirection = "outbound"
 )
 
 // Valid indicates whether the value is a known member of the ActivityDirection enum.
 func (e ActivityDirection) Valid() bool {
 	switch e {
 	case ActivityDirectionInbound:
-		return true
-	case ActivityDirectionLessThannil:
 		return true
 	case ActivityDirectionOutbound:
 		return true
@@ -102,11 +96,10 @@ func (e ActivityKind) Valid() bool {
 
 // Defines values for ActivityMeetingStatus.
 const (
-	ActivityMeetingStatusBooked      ActivityMeetingStatus = "booked"
-	ActivityMeetingStatusCanceled    ActivityMeetingStatus = "canceled"
-	ActivityMeetingStatusHeld        ActivityMeetingStatus = "held"
-	ActivityMeetingStatusLessThannil ActivityMeetingStatus = "<nil>"
-	ActivityMeetingStatusNoShow      ActivityMeetingStatus = "no_show"
+	ActivityMeetingStatusBooked   ActivityMeetingStatus = "booked"
+	ActivityMeetingStatusCanceled ActivityMeetingStatus = "canceled"
+	ActivityMeetingStatusHeld     ActivityMeetingStatus = "held"
+	ActivityMeetingStatusNoShow   ActivityMeetingStatus = "no_show"
 )
 
 // Valid indicates whether the value is a known member of the ActivityMeetingStatus enum.
@@ -117,8 +110,6 @@ func (e ActivityMeetingStatus) Valid() bool {
 	case ActivityMeetingStatusCanceled:
 		return true
 	case ActivityMeetingStatusHeld:
-		return true
-	case ActivityMeetingStatusLessThannil:
 		return true
 	case ActivityMeetingStatusNoShow:
 		return true
@@ -177,17 +168,14 @@ func (e ActivityLinkEntityType) Valid() bool {
 
 // Defines values for CreateActivityRequestDirection.
 const (
-	CreateActivityRequestDirectionInbound     CreateActivityRequestDirection = "inbound"
-	CreateActivityRequestDirectionLessThannil CreateActivityRequestDirection = "<nil>"
-	CreateActivityRequestDirectionOutbound    CreateActivityRequestDirection = "outbound"
+	CreateActivityRequestDirectionInbound  CreateActivityRequestDirection = "inbound"
+	CreateActivityRequestDirectionOutbound CreateActivityRequestDirection = "outbound"
 )
 
 // Valid indicates whether the value is a known member of the CreateActivityRequestDirection enum.
 func (e CreateActivityRequestDirection) Valid() bool {
 	switch e {
 	case CreateActivityRequestDirectionInbound:
-		return true
-	case CreateActivityRequestDirectionLessThannil:
 		return true
 	case CreateActivityRequestDirectionOutbound:
 		return true
@@ -255,25 +243,22 @@ func (e CreateActivityRequestLinksEntityType) Valid() bool {
 
 // Defines values for CreateActivityRequestMeetingStatus.
 const (
-	Booked      CreateActivityRequestMeetingStatus = "booked"
-	Canceled    CreateActivityRequestMeetingStatus = "canceled"
-	Held        CreateActivityRequestMeetingStatus = "held"
-	LessThannil CreateActivityRequestMeetingStatus = "<nil>"
-	NoShow      CreateActivityRequestMeetingStatus = "no_show"
+	CreateActivityRequestMeetingStatusBooked   CreateActivityRequestMeetingStatus = "booked"
+	CreateActivityRequestMeetingStatusCanceled CreateActivityRequestMeetingStatus = "canceled"
+	CreateActivityRequestMeetingStatusHeld     CreateActivityRequestMeetingStatus = "held"
+	CreateActivityRequestMeetingStatusNoShow   CreateActivityRequestMeetingStatus = "no_show"
 )
 
 // Valid indicates whether the value is a known member of the CreateActivityRequestMeetingStatus enum.
 func (e CreateActivityRequestMeetingStatus) Valid() bool {
 	switch e {
-	case Booked:
+	case CreateActivityRequestMeetingStatusBooked:
 		return true
-	case Canceled:
+	case CreateActivityRequestMeetingStatusCanceled:
 		return true
-	case Held:
+	case CreateActivityRequestMeetingStatusHeld:
 		return true
-	case LessThannil:
-		return true
-	case NoShow:
+	case CreateActivityRequestMeetingStatusNoShow:
 		return true
 	default:
 		return false

--- a/backend/tools/internal/oas30/downgrade.go
+++ b/backend/tools/internal/oas30/downgrade.go
@@ -72,13 +72,18 @@ var arbitraryKeyContainers = map[string]struct{}{
 }
 
 // opaqueValueKeys hold arbitrary DATA, not a schema: their subtree passes
-// through untouched. An `example`/`default`/`enum` value may itself contain a
+// through untouched. An `example`/`default` value may itself contain a
 // member named "type", "openapi", or "examples" (it is data, not a
 // type-union, a version, or a plural-examples form to rewrite), so the walker
 // must not descend into it interpreting those as schema keywords (the
 // example-corruption bug).
+//
+// `enum` belongs to the same class and is handled in rewriteKeyword instead:
+// it needs one 3.0 rewrite (dropping a null member) and is returned handled,
+// so its members are never descended into either. The guarantee is the same;
+// only the door differs.
 var opaqueValueKeys = map[string]struct{}{
-	"example": {}, "default": {}, "enum": {},
+	"example": {}, "default": {},
 }
 
 // Node downgrades a parsed OpenAPI 3.1 YAML node tree to 3.0.3 in place. The
@@ -171,6 +176,33 @@ func rewriteKeyword(mapping, key, val *yaml.Node) (bool, error) {
 			if err := rewriteTypeUnion(mapping, val); err != nil {
 				return false, err
 			}
+		}
+		return true, nil
+	case "enum":
+		// A 3.1 nullable enum spells its null member INSIDE the list
+		// (`enum: [null, booked, held]`); 3.0 has no such member and says
+		// nullable with the sibling `nullable: true` that rewriteTypeUnion
+		// already emits for the very same schemas. Passing the null through
+		// cost us a generated constant per nullable enum: oapi-codegen
+		// renders it with %v, so the member became the four-character string
+		// "<nil>" and the identifier sanitiser turned `<` into `LessThan`
+		// (ActivityMeetingStatusLessThannil = "<nil>", 84 of them across 42
+		// enums). Every generated Valid() then answered true for a value no
+		// column accepts.
+		//
+		// Dropping the member loses nothing 3.0 can express, and it is done
+		// HERE rather than in opaqueValueKeys' branch so the element contents
+		// stay opaque: the members themselves are still never descended into,
+		// which is what the example-corruption guard protects.
+		if val.Kind == yaml.SequenceNode {
+			kept := val.Content[:0]
+			for _, member := range val.Content {
+				if member.Kind == yaml.ScalarNode && member.Tag == "!!null" {
+					continue
+				}
+				kept = append(kept, member)
+			}
+			val.Content = kept
 		}
 		return true, nil
 	case "const":

--- a/backend/tools/internal/oas30/downgrade_test.go
+++ b/backend/tools/internal/oas30/downgrade_test.go
@@ -6,6 +6,8 @@ package oas30
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestDowngradeTransforms proves the four faithful 3.1 -> 3.0.3 rewrites the
@@ -146,10 +148,20 @@ components:
 	if err != nil {
 		t.Fatalf("Bytes: %v", err)
 	}
-	got := string(out)
-	if strings.Contains(got, "null\n") && strings.Contains(got, "- null") {
-		t.Errorf("a null enum member survived the downgrade:\n%s", got)
+	// Parse the result rather than grepping it: yaml.v3 preserves the flow
+	// style `enum: [null, booked]`, so a surviving null contains neither
+	// "- null" nor "null\n" and a text assertion would pass with the filter
+	// removed — which is the one regression this test exists to catch.
+	var doc yaml.Node
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("re-parsing downgraded doc: %v", err)
 	}
+	for _, member := range findEnumMembers(t, &doc) {
+		if member.Tag == "!!null" {
+			t.Errorf("a null enum member survived the downgrade:\n%s", string(out))
+		}
+	}
+	got := string(out)
 	if !strings.Contains(got, "nullable: true") {
 		t.Errorf("nullability was lost with the null member — 3.0 spells it `nullable: true`:\n%s", got)
 	}
@@ -162,7 +174,12 @@ components:
 
 // TestEnumMembersAreNotDescendedInto keeps the example-corruption guarantee
 // while `enum` is handled in rewriteKeyword rather than left opaque: a member
-// spelled like a schema keyword is DATA and must pass through unrewritten.
+// is DATA and must pass through unrewritten.
+//
+// The members here are OBJECTS carrying keys the walker rewrites in a schema
+// position — `openapi`, `type` as a union, `const`. A scalar member could not
+// catch a regression: scalars have no keys to reinterpret, so a version that
+// descended into the enum would still leave them alone.
 func TestEnumMembersAreNotDescendedInto(t *testing.T) {
 	src := `
 openapi: 3.1.0
@@ -171,22 +188,52 @@ components:
     Thing:
       type: object
       properties:
-        kind:
-          type: string
-          enum: [type, openapi, examples]
+        shape:
+          enum:
+            - openapi: 3.1.0
+              type: [string, "null"]
+              const: keep-me
 `
 	out, err := Bytes([]byte(src))
 	if err != nil {
 		t.Fatalf("Bytes: %v", err)
 	}
 	got := string(out)
-	for _, want := range []string{"type", "openapi", "examples"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("enum member %q was rewritten as a schema keyword:\n%s", want, got)
+	// The document's own version IS rewritten; the member's is data.
+	if strings.Count(got, "3.0.3") != 1 {
+		t.Errorf("an enum member's `openapi` was rewritten as the document version:\n%s", got)
+	}
+	if !strings.Contains(got, "3.1.0") {
+		t.Errorf("the member's `openapi: 3.1.0` was rewritten — enum members are data:\n%s", got)
+	}
+	// A member's `type` union and `const` are data too: no nullable/enum
+	// rewrite may reach inside.
+	if strings.Contains(got, "nullable: true") {
+		t.Errorf("an enum member's type union was rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "const: keep-me") {
+		t.Errorf("an enum member's `const` was rewritten into an enum:\n%s", got)
+	}
+}
+
+// findEnumMembers collects every member of every `enum` sequence in the tree,
+// so a test can assert on the members themselves rather than on rendered text.
+func findEnumMembers(t *testing.T, n *yaml.Node) []*yaml.Node {
+	t.Helper()
+	var found []*yaml.Node
+	var walkNode func(*yaml.Node)
+	walkNode = func(node *yaml.Node) {
+		if node.Kind == yaml.MappingNode {
+			for i := 0; i+1 < len(node.Content); i += 2 {
+				if node.Content[i].Value == "enum" && node.Content[i+1].Kind == yaml.SequenceNode {
+					found = append(found, node.Content[i+1].Content...)
+				}
+			}
+		}
+		for _, c := range node.Content {
+			walkNode(c)
 		}
 	}
-	// The document version is rewritten; a member spelled "openapi" is not.
-	if strings.Contains(got, "- 3.0.3") {
-		t.Errorf("an enum member was rewritten as the document version:\n%s", got)
-	}
+	walkNode(n)
+	return found
 }

--- a/backend/tools/internal/oas30/downgrade_test.go
+++ b/backend/tools/internal/oas30/downgrade_test.go
@@ -117,3 +117,76 @@ components:
 		t.Fatalf("property names that look like keywords must not fail the downgrade: %v", err)
 	}
 }
+
+// TestNullEnumMemberIsDropped proves the null member of a 3.1 nullable enum
+// does not survive into the 3.0.3 document.
+//
+// It used to. oapi-codegen renders an enum member with %v, so a YAML null
+// became the four-character string "<nil>" and the identifier sanitiser turned
+// `<` into `LessThan` — ActivityMeetingStatusLessThannil = "<nil>", 84 such
+// constants across 42 enums in two generated files. Every generated Valid()
+// then answered true for a value the database CHECK refuses, so the one method
+// that looks like a guard was not one.
+//
+// Nullability is not lost: rewriteTypeUnion emits `nullable: true` for the
+// same schema, which is how 3.0 spells it.
+func TestNullEnumMemberIsDropped(t *testing.T) {
+	src := `
+openapi: 3.1.0
+components:
+  schemas:
+    Activity:
+      type: object
+      properties:
+        meeting_status:
+          type: [string, "null"]
+          enum: [null, booked, held, no_show, canceled]
+`
+	out, err := Bytes([]byte(src))
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "null\n") && strings.Contains(got, "- null") {
+		t.Errorf("a null enum member survived the downgrade:\n%s", got)
+	}
+	if !strings.Contains(got, "nullable: true") {
+		t.Errorf("nullability was lost with the null member — 3.0 spells it `nullable: true`:\n%s", got)
+	}
+	for _, want := range []string{"booked", "held", "no_show", "canceled"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("real enum member %q was dropped:\n%s", want, got)
+		}
+	}
+}
+
+// TestEnumMembersAreNotDescendedInto keeps the example-corruption guarantee
+// while `enum` is handled in rewriteKeyword rather than left opaque: a member
+// spelled like a schema keyword is DATA and must pass through unrewritten.
+func TestEnumMembersAreNotDescendedInto(t *testing.T) {
+	src := `
+openapi: 3.1.0
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [type, openapi, examples]
+`
+	out, err := Bytes([]byte(src))
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{"type", "openapi", "examples"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("enum member %q was rewritten as a schema keyword:\n%s", want, got)
+		}
+	}
+	// The document version is rewritten; a member spelled "openapi" is not.
+	if strings.Contains(got, "- 3.0.3") {
+		t.Errorf("an enum member was rewritten as the document version:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #1987.

`crm.yaml` spells a nullable enum's null member inside the list (`enum: [null, booked, held, ...]`). The 3.0 downgrade left `enum` opaque, so that null reached oapi-codegen, which renders a member with `%v`: it became the four-character string `<nil>`, and the identifier sanitiser turned `<` into `LessThan`.

Result: **84 bogus constants across 42 enums** in two generated files —

```go
ActivityMeetingStatusLessThannil ActivityMeetingStatus = "<nil>"
```

— and every generated `Valid()` answered **true** for it. The one method that looks like a guard admitted a value no column accepts. Latent today (the JSON-schema layer rejects `"<nil>"` first and nothing calls `Valid()`), live the moment anything trusts it.

## The fix

`oas30.rewriteKeyword` drops a null enum member during the 3.1 → 3.0.3 downgrade. Nullability is not lost: `rewriteTypeUnion` already emits `nullable: true` for the same schemas, which is how 3.0 spells it. `enum` moves out of `opaqueValueKeys` and returns *handled*, so members are still never descended into — the example-corruption guarantee is unchanged and now tested.

## The part worth reviewing

Removing a member changes what the generator treats as a name collision, and it only prefixes a constant to break one. Three pins **already existed and named the null slot**. Left alone they would have shifted every later name onto the wrong value — `OnboardingAvailableActionConfirmCompany` would have compiled as `"start_voice_build"`. Those three lose the stale name; five more enums gain pins to keep names hand-written code and the public extension API already use.

## Verification

- 0 occurrences of `LessThannil` in `api_gen.go` and `crm_gen.go`
- Codex checked all 24 `x-enum-varnames` declarations bind name→value correctly, and searched all 85 removed identifiers across 3,605 files: no stale reference, no silent rebinding, no new duplicate declaration
- Nullability confirmed intact in `frontend/src/api/schema.d.ts`
- Both regression tests verified to FAIL when their guard is removed
- Full local gate green; all three regenerations run (gen, fe-drift, -update-mcp-info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop generating bogus "<nil>" enum members when downgrading 3.1 → 3.0.3 by dropping the null from `enum` and relying on `nullable: true`. This removes 84 invalid constants and prevents `Valid()` from accepting a value no column allows.

- `backend/tools/internal/oas30`: `rewriteKeyword` now handles `enum` and filters null members; `enum` is removed from `opaqueValueKeys`. Added tests to pin both the null-filter and the “do not descend into enum members” guarantee.
- `backend/api/crm.yaml`: adjusted/added `x-enum-varnames` pins to keep stable constant names where public or used by hand-written code. Removed stale names that pointed at the dropped null slot.
  - New/adjusted pins: `CreateActivityRequest.kind`, `OrganizationFactSuspectReason`, `SearchResultTrustTier`, `PersonProviderEmailEmailType`, `SiteReadReportStoppedReason`.
  - Removed null-slot pins: `OnboardingNextRequiredNone`, `OnboardingAvailableActionNone`, `CompanySiteReadStoppedReasonNull`.
- Regenerated code removes `<nil>` members and their `Valid()` branches in `backend/internal/contracts/api_gen.go` and `backend/pkg/extension/crm/crm_gen.go`. Nullability is preserved via `nullable: true`.

**Migration**
- Recompile. Remove any references to deleted null-slot constants (`*None`, `*Null`) and any `*LessThannil` identifiers.
- Some enums may now use prefixed constant names to avoid collisions; if you import these constants from the generated packages, update identifiers to the new names.

<sup>Written for commit 0df9240e39c8da53353e38fcfb3f24f855f5b45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API schema handling for nullable enum values.
  * Removed obsolete `null` enum entries while preserving nullable behavior.
  * Added clearer, consistent names for supported CRM enum values.
  * Prevented enum values from being incorrectly interpreted as schema definitions.

* **Tests**
  * Added regression coverage for nullable enums and enum values containing schema-like data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->