### PR TITLE
test(collections): the team leaf's teamless-owner arm is asserted, with no new fixture

### DIFF
--- a/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
+++ b/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
@@ -73,10 +73,9 @@ func TestATeamFilterSelectsEveryMembersRecords(t *testing.T) {
 // `exists: false` on the team leaf finds the records no team's review covers, and
 // an unowned record is one of them.
 //
-// The OTHER arm — an owner who exists and belongs to no team — is the one that
-// distinguishes this leaf from `owner_id exists: false`, and it is asserted
-// directly below rather than here, so that a change breaking one of the two
-// reasons a record is uncovered names which one.
+// The OTHER arm — an owner who exists and belongs to no team — is asserted by
+// TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam rather than here, so that a
+// change breaking one of the two reasons a record is uncovered names which one.
 func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
 	f := setupFixture(t)
 	inATeam := f.ownedOrg(t, "Held by Rep1", f.e.Rep1)
@@ -109,23 +108,25 @@ func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
 	}
 }
 
-// The arm that distinguishes this leaf from `owner_id exists: false`: an owner
-// who EXISTS and belongs to no team.
+// An owner who EXISTS and belongs to no team.
 //
-// A wrong implementation compiling the leaf to `t.owner_id IS NULL` passes every
-// other assertion in this file — both spellings look plausible in a diff, and
-// only a row whose owner is real but teamless tells them apart.
+// What this lane adds is not the leaf's SPELLING — vocab_test.go pins that the
+// Link walks team_membership on t.owner_id, and compileLinkLeaf owns the
+// `exists:false` → NOT EXISTS turn for every link leaf alike. It is that ONE
+// NOT EXISTS covers two different data shapes, and only real rows tell them
+// apart: an owner that is NULL (the test above) and an owner that is present
+// with no membership row (this one). A leaf that answered only the first would
+// be `owner_id exists: false` under another name.
 //
-// No new fixture is needed for it, which is worth stating because the opposite
-// was believed: the harness seeds FOUR app_user rows and gives memberships to
-// three, so AdminUser is already a seat in no team. The precondition is asserted
-// rather than assumed — the day somebody puts that seat in a team, this test says
-// so in one line instead of failing as a filter bug.
+// AdminUser is the seat in no team — integration.Setup seeds four seats and
+// three memberships — so this arm needs no fixture of its own. The precondition
+// is asserted rather than assumed, so the day that seat joins a team this test
+// says so instead of failing as a filter bug.
 func TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam(t *testing.T) {
 	f := setupFixture(t)
-	if inATeam := f.e.WsCount(t,
-		"SELECT count(*) FROM team_membership WHERE user_id = $1", f.e.AdminUser); inATeam != 0 {
-		t.Fatalf("the admin seat now belongs to %d team(s), so it can no longer stand for a teamless owner — give this test a seat that belongs to none", inATeam)
+	if memberships := f.e.WsCount(t,
+		"SELECT count(*) FROM team_membership WHERE user_id = $1", f.e.AdminUser); memberships != 0 {
+		t.Fatalf("the admin seat now belongs to %d team(s), so it can no longer stand for a teamless owner — seed a seat with no team_membership row in integration.Setup and own the record below with it", memberships)
 	}
 
 	teamlessOwner := f.ownedOrg(t, "Held by a seat in no team", f.e.AdminUser)
@@ -148,11 +149,14 @@ func TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam(t *testing.T) {
 	if got[inATeam] {
 		t.Error("an account whose owner IS in a team is reported as covered by none")
 	}
-	// The owner is genuinely there, so this is not the unowned arm wearing a
-	// different name.
+	// Owned by the teamless seat SPECIFICALLY, which is the whole precondition:
+	// an explicit owner that silently fell back to the caller would leave a row
+	// owned by Rep1, who is in Team1, and this test would then be re-proving the
+	// in-a-team case under a name that claims otherwise.
 	if owned := f.e.WsCount(t,
-		"SELECT count(*) FROM organization WHERE id = $1 AND owner_id IS NOT NULL", teamlessOwner); owned != 1 {
-		t.Error("the record under test has no owner, so it proves the unowned arm a second time rather than the teamless-owner one")
+		"SELECT count(*) FROM organization WHERE id = $1 AND owner_id = $2",
+		teamlessOwner, f.e.AdminUser); owned != 1 {
+		t.Error("the record under test is not owned by the teamless seat, so whatever it proves is not the teamless-owner arm")
 	}
 }
 

--- a/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
+++ b/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
@@ -114,9 +114,9 @@ func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
 // Link walks team_membership on t.owner_id, and compileLinkLeaf owns the
 // `exists:false` → NOT EXISTS turn for every link leaf alike. It is that ONE
 // NOT EXISTS covers two different data shapes, and only real rows tell them
-// apart: an owner that is NULL (the test above) and an owner that is present
-// with no membership row (this one). A leaf that answered only the first would
-// be `owner_id exists: false` under another name.
+// apart: an owner that is NULL, which TestAnUnownedRecordIsCoveredByNoTeam owns,
+// and an owner that is present with no membership row, which this one does. A
+// leaf answering only the first would be `owner_id exists: false` renamed.
 //
 // AdminUser is the seat in no team — integration.Setup seeds four seats and
 // three memberships — so this arm needs no fixture of its own. The precondition
@@ -149,10 +149,9 @@ func TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam(t *testing.T) {
 	if got[inATeam] {
 		t.Error("an account whose owner IS in a team is reported as covered by none")
 	}
-	// Owned by the teamless seat SPECIFICALLY, which is the whole precondition:
-	// an explicit owner that silently fell back to the caller would leave a row
-	// owned by Rep1, who is in Team1, and this test would then be re-proving the
-	// in-a-team case under a name that claims otherwise.
+	// Owned by the teamless seat SPECIFICALLY: an explicit owner falling back to
+	// the caller would leave the row owned by Rep1, who is in Team1, and this
+	// test would re-prove the in-a-team case under a name claiming otherwise.
 	if owned := f.e.WsCount(t,
 		"SELECT count(*) FROM organization WHERE id = $1 AND owner_id = $2",
 		teamlessOwner, f.e.AdminUser); owned != 1 {

--- a/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
+++ b/backend/internal/compose/integration/collections/linkedleaves_integration_test.go
@@ -73,13 +73,10 @@ func TestATeamFilterSelectsEveryMembersRecords(t *testing.T) {
 // `exists: false` on the team leaf finds the records no team's review covers, and
 // an unowned record is one of them.
 //
-// It does NOT cover the other arm — a record whose owner exists and belongs to no
-// team — and the name says so, because that arm is what distinguishes this leaf
-// from `owner_id exists: false` and a wrong implementation would pass here
-// without it. The harness puts all three of its seats in a team, so the arm needs
-// a teamless seat that does not exist yet; adding one touches shared identity
-// seeding that the seat-ceiling and licence-entitlement suites count rows in.
-// Tracked rather than faked.
+// The OTHER arm — an owner who exists and belongs to no team — is the one that
+// distinguishes this leaf from `owner_id exists: false`, and it is asserted
+// directly below rather than here, so that a change breaking one of the two
+// reasons a record is uncovered names which one.
 func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
 	f := setupFixture(t)
 	inATeam := f.ownedOrg(t, "Held by Rep1", f.e.Rep1)
@@ -109,6 +106,53 @@ func TestAnUnownedRecordIsCoveredByNoTeam(t *testing.T) {
 	}
 	if got[inATeam] {
 		t.Error("an account whose owner IS in a team is reported as covered by none")
+	}
+}
+
+// The arm that distinguishes this leaf from `owner_id exists: false`: an owner
+// who EXISTS and belongs to no team.
+//
+// A wrong implementation compiling the leaf to `t.owner_id IS NULL` passes every
+// other assertion in this file — both spellings look plausible in a diff, and
+// only a row whose owner is real but teamless tells them apart.
+//
+// No new fixture is needed for it, which is worth stating because the opposite
+// was believed: the harness seeds FOUR app_user rows and gives memberships to
+// three, so AdminUser is already a seat in no team. The precondition is asserted
+// rather than assumed — the day somebody puts that seat in a team, this test says
+// so in one line instead of failing as a filter bug.
+func TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam(t *testing.T) {
+	f := setupFixture(t)
+	if inATeam := f.e.WsCount(t,
+		"SELECT count(*) FROM team_membership WHERE user_id = $1", f.e.AdminUser); inATeam != 0 {
+		t.Fatalf("the admin seat now belongs to %d team(s), so it can no longer stand for a teamless owner — give this test a seat that belongs to none", inATeam)
+	}
+
+	teamlessOwner := f.ownedOrg(t, "Held by a seat in no team", f.e.AdminUser)
+	inATeam := f.ownedOrg(t, "Held by Rep1", f.e.Rep1)
+
+	list, err := f.lists.CreateList(f.ctx, collectionsmod.CreateListInput{
+		Name: "no team covers these either", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{
+			"field": "owner_team_id", "op": "exists", "value": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create list: %v", err)
+	}
+
+	got := memberIDs(t, f, list.ID)
+	if !got[teamlessOwner] {
+		t.Error("an account whose owner is real but belongs to no team is not counted as covered by no team — which is what the leaf compiling to `owner_id IS NULL` would produce")
+	}
+	if got[inATeam] {
+		t.Error("an account whose owner IS in a team is reported as covered by none")
+	}
+	// The owner is genuinely there, so this is not the unowned arm wearing a
+	// different name.
+	if owned := f.e.WsCount(t,
+		"SELECT count(*) FROM organization WHERE id = $1 AND owner_id IS NOT NULL", teamlessOwner); owned != 1 {
+		t.Error("the record under test has no owner, so it proves the unowned arm a second time rather than the teamless-owner one")
 	}
 }
 

--- a/backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go
@@ -83,7 +83,9 @@ func setupFixture(t *testing.T) fixture {
 	return fixture{
 		e: e,
 		// A real seeded user, not a synthetic id: custom_field.created_by is
-		// foreign-keyed to app_user, and the harness seeds only Rep1/2/3.
+		// foreign-keyed to app_user. The harness seeds Rep1/2/3 AND AdminUser;
+		// only the three reps carry a team membership, which is the gap
+		// TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam owns a record through.
 		ctx:      e.As(e.Rep1, nil, testPerms),
 		svc:      svc,
 		people:   peoplemod.NewStore(e.DB()).WithFieldCatalog(svc),

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -39,6 +39,13 @@ type Env struct {
 	Rep1, Rep2, Rep3 ids.UUID
 	// AdminUser is the seat Admin() binds: a real app_user, because a manual
 	// create stamps the caller as owner and the owner column is a foreign key.
+	//
+	// It is also the seat in NO TEAM: the membership seeding below covers Rep1,
+	// Rep2 and Rep3 and deliberately not this one, which is what lets a suite own
+	// a record by a real-but-teamless seat. Putting it in a team breaks
+	// TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam, which asserts the gap
+	// rather than assuming it — so the failure names this decision instead of
+	// reading as a filter bug.
 	AdminUser    ids.UUID
 	Team1, Team2 ids.UUID
 }

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -103,9 +103,20 @@ const ownerTeamIDField = "owner_team_id"
 // `owner_id` with `exists: false`. A reader looking for it here should not
 // conclude it is missing.
 //
-// This is a FILTER, not a scope. The executor ANDs it with the caller's
-// row-scope clause, so naming a team the caller cannot see answers their own
-// visible rows filtered to nothing — never that team's rows.
+// This is a FILTER, not a scope, and the guarantee that follows is SUBTRACTION
+// rather than containment: predicateWhere ANDs it onto the caller's visibility
+// predicate, so it can only ever narrow what that predicate already admits.
+//
+// What that means for another team's rows depends on the table, and the loose
+// reading is wrong. On the identity engines — person, organization, lead, deal —
+// customer identity is workspace-readable and auth renders the own/team arm as
+// TRUE (platform/auth: identityTables), so naming a team the caller is not in is
+// an honest selection of that team's records, which is the product's intent
+// rather than a leak. Only `project` keeps the own/team/all predicate, and there
+// the same clause answers nothing.
+//
+// So a new surface reaching this leaf inherits its table's visibility predicate
+// and nothing more. It must not be read as a fence.
 var ownerTeamField = storekit.Field{
 	Expr:       "tm.team_id",
 	Type:       storekit.FieldID,


### PR DESCRIPTION
Closes [#1852](https://github.com/gradionhq/margince-poc-v1/issues/1852).

`owner_team_id exists: false` should select a record whose owner **exists and belongs to no team**, and nothing asserted it. That arm is the one thing distinguishing this leaf from `owner_id exists: false` — a leaf reducing to `owner_id IS NULL` passed every assertion in the file.

## It needed no fixture, and that is the interesting part

The ruling on #1852 was to add a fourth, teamless seat, run the full integration lane, and fix whatever seat-count assertions moved. I went to do that and found the seat already there: **the harness seeds four `app_user` rows and gives memberships to three.** `AdminUser` has never belonged to a team.

So the arm was reachable the whole time. What stood in the way was a comment in the test file asserting otherwise —

> The harness puts all three of its seats in a team, so the arm needs a teamless seat that does not exist yet; adding one touches shared identity seeding that the seat-ceiling and licence-entitlement suites count rows in. Tracked rather than faked.

— which named a cost that was not real to justify a gap that needed no payment. Nobody re-checked it, me included, until the fix turned out to be zero lines of seeding. That comment is **deleted** rather than softened: a rationalized gap reads as a decision and stops the next person from looking, which is exactly what review-loop rule 5 is about.

The precondition is now **asserted** rather than relied on. If somebody later puts the admin seat in a team, the test says so in one line instead of failing as a filter bug.

## Mutation-verified against the specific defect — two attempts, both worth recording

My first mutation rewrote the leaf as an owner-exists check. Both tests failed, and it proved nothing: that breaks the SQL shape, so anything would have caught it. A mutation that coarse flatters the test.

The second dropped only the correlation on `user_id`, which makes the leaf reduce to exactly `owner_id IS NULL` — the wrong implementation #1852 names. There:

```
--- PASS: TestAnUnownedRecordIsCoveredByNoTeam
--- FAIL: TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam
    an account whose owner is real but belongs to no team is not counted as
    covered by no team — which is what the leaf compiling to `owner_id IS NULL`
    would produce
```

The pre-existing test passes; the new one fails by name. That is the discrimination the issue said was missing, demonstrated rather than claimed.

## Verification

Whole `compose/integration/collections` package green (28 tests) · `make check-backend` green · `make craft-static` green (0 findings).

One note for whoever reads #1852's ruling later: its closing suggestion — that four suites depending on a seat **count** is itself a smell — still stands as an observation, but nothing in this change touches it, so it is not evidence either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Asserts the teamless-owner arm of the `owner_team_id exists: false` leaf and corrects docs to promise subtraction, not containment. No runtime behavior changes; this tightens test coverage and clarifies visibility semantics.

- Adds `TestARecordWhoseOwnerIsInNoTeamIsCoveredByNoTeam` to prove selection when the owner exists but has no team; asserts the precondition by checking `AdminUser` has zero `team_membership` rows. Keeps `TestAnUnownedRecordIsCoveredByNoTeam` separate to name which arm fails.
- Documents `AdminUser` as teamless in `backend/internal/compose/integration/harness.go`; fixes the fixture comment in `backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go`; replaces positional references with explicit test names.
- Updates `backend/internal/modules/collections/vocab.go` docs: the leaf narrows the caller’s visibility predicate (subtraction). Identity tables (`person`, `organization`, `lead`, `deal`) may return other teams’ rows by design; only `project` remains gated.
- Mutation check: dropping the `user_id` correlation (reducing to `owner_id IS NULL`) makes the new test fail while the existing one passes, proving the distinction.

<sup>Written for commit a96e02f162ddef3e69576db8df5f9d2f44c07c27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for records owned by users who are not members of any team.
  * Added coverage to ensure team-based filters return the correct records and ownership details.

* **Documentation**
  * Clarified team ownership and filtering behavior, including differences between identity resources and projects.
  * Documented test scenarios involving teamless users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->