### PR TITLE
fix(passports): an expired session says so instead of failing the mint in silence

### DIFF
--- a/frontend/src/screens/settings-passports.test.tsx
+++ b/frontend/src/screens/settings-passports.test.tsx
@@ -30,6 +30,7 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   globalThis.localStorage.clear();
+  globalThis.location.hash = "";
 });
 
 function jsonResponse(body: unknown, status = 200) {
@@ -204,20 +205,44 @@ describe("PassportCard — minting", () => {
 
   // An expired session is not a mint that quietly did nothing.
   //
-  // The `me` probe is cached for five minutes, so a 401 on this POST used to
-  // leave the screen believing it was signed in: the button failed in silence
-  // and the human had no way to learn why. That silence is what made the OAuth
-  // consent screen's empty-passport guide inescapable — it sends you here to
-  // mint, the mint 401s without saying so, and going back finds no passport and
-  // renders the same guide again. Resetting the probe lets the AuthGate put the
-  // login screen up, which is the only thing that can make the mint succeed.
-  it("re-probes the session when the mint is refused as unauthorized", async () => {
+  // The `me` probe is cached for five minutes, so a 401 here used to leave the
+  // screen believing it was signed in: the button failed in silence and the
+  // human had no way to learn why. That silence is what made the OAuth consent
+  // screen's empty-passport guide inescapable — it sends you here to mint, the
+  // mint 401s without saying so, and going back finds no passport and renders
+  // the same guide again.
+  //
+  // Held here: the probe is re-run (so AuthGate re-evaluates and puts up the
+  // login screen), every other cached answer is dropped (so the next person to
+  // sign in this tab is not shown this one's passport list), and the refusal is
+  // still reported. The boundary's own rendering is AuthGate's contract and is
+  // covered where AuthGate is.
+  it("re-probes the session and drops other caches when the mint is unauthorized", async () => {
     const user = userEvent.setup();
     const backend = mintBackend({ expired: true });
     vi.stubGlobal("fetch", backend);
-    const dialog = await openDrawer(user);
 
-    const meCallsBeforeMint = backend.mock.calls.filter((call) =>
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    rtlRender(
+      <QueryClientProvider client={client}>
+        <LocaleProvider initial="en">
+          <SettingsScreen tab="agents" />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Mint passport" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+
+    // A cache entry from this session, which the next one must not inherit.
+    client.setQueryData(["some-other-screen"], { secret: "previous session" });
+    const meCallsBefore = backend.mock.calls.filter((call) =>
       String(call[0] instanceof Request ? call[0].url : call[0]).endsWith(
         "/v1/me",
       ),
@@ -231,15 +256,18 @@ describe("PassportCard — minting", () => {
     const alert = await within(dialog).findByRole("alert");
     expect(alert).toHaveTextContent(/session has expired/i);
 
-    // And the probe was re-run rather than left on its cached answer.
+    // The probe was re-run rather than left on its cached answer.
     await vi.waitFor(() => {
-      const meCallsAfterMint = backend.mock.calls.filter((call) =>
+      const meCallsAfter = backend.mock.calls.filter((call) =>
         String(call[0] instanceof Request ? call[0].url : call[0]).endsWith(
           "/v1/me",
         ),
       ).length;
-      expect(meCallsAfterMint).toBeGreaterThan(meCallsBeforeMint);
+      expect(meCallsAfter).toBeGreaterThan(meCallsBefore);
     });
+
+    // And nothing of this session is left for the next one to render.
+    expect(client.getQueryData(["some-other-screen"])).toBeUndefined();
   });
 
   // The one that is about losing a credential rather than about layout.

--- a/frontend/src/screens/settings-passports.test.tsx
+++ b/frontend/src/screens/settings-passports.test.tsx
@@ -56,7 +56,7 @@ const render = (tab: string) => {
 // succeeds or hangs, so a refusal and an in-flight attempt are both reachable
 // without a second fixture.
 function mintBackend(
-  opts: { refuse?: boolean; hang?: boolean } = {},
+  opts: { refuse?: boolean; hang?: boolean; expired?: boolean } = {},
 ): ReturnType<typeof vi.fn> {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
@@ -72,6 +72,17 @@ function mintBackend(
       // Never settles, so the pending branch is a real state rather than a
       // window a test has to race.
       if (opts.hang) return new Promise<Response>(() => {});
+      if (opts.expired) {
+        return jsonResponse(
+          {
+            type: "about:blank",
+            title: "Unauthorized",
+            status: 401,
+            detail: "Your session has expired.",
+          },
+          401,
+        );
+      }
       if (opts.refuse) {
         return jsonResponse(
           {
@@ -189,6 +200,46 @@ describe("PassportCard — minting", () => {
     expect(alert).toHaveTextContent(/cannot lend that scope/i);
     // In the form, not in a band elsewhere on the card.
     expect(alert.closest("form")).toBeTruthy();
+  });
+
+  // An expired session is not a mint that quietly did nothing.
+  //
+  // The `me` probe is cached for five minutes, so a 401 on this POST used to
+  // leave the screen believing it was signed in: the button failed in silence
+  // and the human had no way to learn why. That silence is what made the OAuth
+  // consent screen's empty-passport guide inescapable — it sends you here to
+  // mint, the mint 401s without saying so, and going back finds no passport and
+  // renders the same guide again. Resetting the probe lets the AuthGate put the
+  // login screen up, which is the only thing that can make the mint succeed.
+  it("re-probes the session when the mint is refused as unauthorized", async () => {
+    const user = userEvent.setup();
+    const backend = mintBackend({ expired: true });
+    vi.stubGlobal("fetch", backend);
+    const dialog = await openDrawer(user);
+
+    const meCallsBeforeMint = backend.mock.calls.filter((call) =>
+      String(call[0] instanceof Request ? call[0].url : call[0]).endsWith(
+        "/v1/me",
+      ),
+    ).length;
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Mint passport" }),
+    );
+
+    // The refusal is still shown where every other mint failure is shown.
+    const alert = await within(dialog).findByRole("alert");
+    expect(alert).toHaveTextContent(/session has expired/i);
+
+    // And the probe was re-run rather than left on its cached answer.
+    await vi.waitFor(() => {
+      const meCallsAfterMint = backend.mock.calls.filter((call) =>
+        String(call[0] instanceof Request ? call[0].url : call[0]).endsWith(
+          "/v1/me",
+        ),
+      ).length;
+      expect(meCallsAfterMint).toBeGreaterThan(meCallsBeforeMint);
+    });
   });
 
   // The one that is about losing a credential rather than about layout.

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1004,22 +1004,38 @@ function PassportCard() {
           )[],
         },
       });
+      // An expired session must not read as a mint that did nothing. The `me`
+      // probe is cached for five minutes, so without this the screen keeps
+      // believing it is signed in and the button simply fails in silence —
+      // which is how the OAuth consent screen's empty-passport guide became an
+      // inescapable loop: it sends the human here to mint, the mint 401s
+      // without saying so, and returning finds no passport and shows the same
+      // guide again.
+      //
+      // Keyed on the STATUS rather than on `error` being truthy: a non-2xx
+      // with no body leaves `error` undefined in this client (compose.tsx
+      // documents the same shape), and that response would otherwise pass as
+      // a success and then render an undefined token.
+      if (response.status === 401) {
+        // useLogout's order, for its reason: drop every other cached answer
+        // BEFORE resetting the probe. AuthGate restores this route after the
+        // next sign-in, and whoever signs in then must not be shown the
+        // previous session's passport list out of cache.
+        queryClient.removeQueries({
+          predicate: (query) => query.queryKey[0] !== "me",
+        });
+        await queryClient.resetQueries({ queryKey: ["me"] });
+      }
       if (error) {
-        // An expired session must not read as a mint that did nothing. The
-        // `me` probe is cached for five minutes, so without this reset the
-        // screen keeps believing it is signed in and the button simply fails
-        // in silence — which is how the OAuth consent screen's empty-passport
-        // guide became an inescapable loop: it sends the human here to mint,
-        // the mint 401s without saying so, and returning finds no passport
-        // and shows the same guide again.
-        //
-        // Resetting the probe is what useLogout already does; the AuthGate in
-        // App.tsx then renders the login screen in place, which is the one
-        // action that can actually make the mint succeed.
-        if (response.status === 401) {
-          await queryClient.resetQueries({ queryKey: ["me"] });
-        }
         throwProblem(error);
+      }
+      if (!response.ok) {
+        // A refusal that carried no problem document still has to refuse.
+        throwProblem({
+          type: "about:blank",
+          title: response.statusText || "Request failed",
+          status: response.status,
+        });
       }
       return data;
     },

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -963,6 +963,7 @@ function scopeLabelKey(scope: (typeof PASSPORT_SCOPES)[number]): MessageKey {
 function PassportCard() {
   const t = useT();
   const { locale } = useLocale();
+  const queryClient = useQueryClient();
   const [label, setLabel] = useState("");
   const [scopes, setScopes] = useState<Set<string>>(new Set(["read", "draft"]));
   const [confirmId, setConfirmId] = useState<string | null>(null);
@@ -991,7 +992,7 @@ function PassportCard() {
 
   const mint = useMutation({
     mutationFn: async () => {
-      const { data, error } = await api.POST("/passports", {
+      const { data, error, response } = await api.POST("/passports", {
         body: {
           label: label.trim() || null,
           scopes: [...scopes] as (
@@ -1004,6 +1005,20 @@ function PassportCard() {
         },
       });
       if (error) {
+        // An expired session must not read as a mint that did nothing. The
+        // `me` probe is cached for five minutes, so without this reset the
+        // screen keeps believing it is signed in and the button simply fails
+        // in silence — which is how the OAuth consent screen's empty-passport
+        // guide became an inescapable loop: it sends the human here to mint,
+        // the mint 401s without saying so, and returning finds no passport
+        // and shows the same guide again.
+        //
+        // Resetting the probe is what useLogout already does; the AuthGate in
+        // App.tsx then renders the login screen in place, which is the one
+        // action that can actually make the mint succeed.
+        if (response.status === 401) {
+          await queryClient.resetQueries({ queryKey: ["me"] });
+        }
         throwProblem(error);
       }
       return data;


### PR DESCRIPTION
Closes #1988.

`POST /passports` answered 401 like any other problem: the form showed the detail and nothing touched the `me` probe — cached for five minutes. So the screen went on believing it was signed in while its one action could not succeed.

**That silence is what made the OAuth consent screen inescapable.** With no passport in the workspace, `oauthconsent.tsx` renders `ConsentGuide`, which by design has no approve control and one CTA: go to Settings › Agents and mint one. A data reset clears both the session and every passport, so the mint fails invisibly, the human returns via `ResumeConnectBanner`, `/oauth/authorize` still finds zero passports, and the same guide comes back. Hit twice on a fresh install.

## The fix

The mint resets the `me` query on a 401 — the same ordering `useLogout` uses — so `AuthGate` renders the login screen in place. That is the only action that can make the mint succeed, and it is one step from where the human already is.

Two corrections from the Codex review:

- **Other caches are cleared first.** Resetting only `["me"]` left the passport list cached, so a different person signing into the same tab could be shown the previous session's data after `AuthGate` restored the route.
- **Keyed on `response.status`, not on `error` being truthy.** A non-2xx with no body leaves `error` undefined in this client (`compose.tsx` documents the same shape); that response would have skipped the reset, passed as a success, and rendered an undefined token.

Non-401 failures are untouched — they were already rendered in the form.

## Verification

- New test asserts the probe is re-run, a seeded non-`me` cache entry is gone, and the refusal still shows. Verified it fails without the production change.
- `make check-fe` green: 3586 tests.
- An App-level test asserting the login screen itself was attempted and dropped — `App` pulls in onboarding, company probes and composed screens, and the harness cost outgrew a one-line fix. What the boundary renders from an unauthorized probe is `AuthGate`'s contract and is covered where `AuthGate` is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops silent failures when minting a passport with an expired session. Previously a 401 from POST /passports only showed a form error and left the cached `["me"]` probe, so the app still looked signed in and users hit an OAuth consent loop (fixes #1988). Now a 401 clears non-`me` caches, resets `["me"]`, and `AuthGate` shows the login while the mint form still displays the refusal.

- Handles bodiless non-2xx responses by checking `response.status` and throwing for any non-ok result; non-401 failures are unchanged.
- `PassportCard` follows `useLogout` order: `queryClient.removeQueries` for non-`me`, then `resetQueries(["me"])`. Tests assert `["me"]` re-probes, other caches are dropped, and the refusal remains visible.

<sup>Written for commit 9bc86a453dab4b24d70eda9a78b9e0680449e0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

