### PR TITLE
fix(deals): a lost reason does not outlive the loss

### DIFF
--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -247,18 +247,17 @@ func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 	if closedAt != nil {
 		p.Set("closed_at", current.ClosedAt, *closedAt)
 	}
-	// Written only when this advance LANDS on lost. A reopen clears it in the
-	// terminal-field sweep below, but a lost deal re-decided as won takes neither
-	// branch and keeps the stale reason — the CHECK is one-directional, so nothing
-	// refuses that state (issue #483).
+	// Written when this advance lands on lost, and cleared on every other
+	// landing. A reason describing a previous close is worse than none: it
+	// answers the report with a fact about a different outcome — so a deal
+	// re-decided from lost to won must not carry the loss explanation with it.
 	if DealStatus(status) == DealLost && in.LostReason != nil {
 		p.Set("lost_reason", current.LostReason, *in.LostReason)
+	} else if DealStatus(status) != DealLost {
+		p.Set("lost_reason", current.LostReason, nil)
 	}
 	// The won-without-contract reason is written only on a win, and cleared on
-	// every other landing — including a re-decided lost deal, which is the case
-	// the lost_reason CHECK above misses. A reason describing a previous close
-	// is worse than none: it answers the report with a fact about a different
-	// outcome.
+	// every other landing, for the same reason.
 	if DealStatus(status) == DealWon {
 		p.Set("won_without_contract_reason", current.WonWithoutContractReason, in.WonWithoutContractReason)
 		p.Set("won_without_contract_detail", current.WonWithoutContractDetail, in.WonWithoutContractDetail)
@@ -273,13 +272,13 @@ func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 			return nil, "", err
 		}
 	}
-	// Reopening a won/lost deal must clear every terminal field —
-	// the DB CHECKs are one-directional, so a stale closed_at or
-	// lost_reason on an open deal would silently corrupt forecast
-	// and won-lost reporting.
+	// Reopening a won/lost deal must clear the remaining terminal fields —
+	// the DB CHECKs are one-directional, so a stale closed_at or frozen rate
+	// on an open deal would silently corrupt forecast and won-lost reporting.
+	// lost_reason is not here: it clears on every non-lost landing above,
+	// which covers the reopen too.
 	if DealStatus(status) == DealOpen && DealStatus(current.Status) != DealOpen {
 		p.Set("closed_at", current.ClosedAt, nil)
-		p.Set("lost_reason", current.LostReason, nil)
 		p.Set("fx_rate_to_base", nil, nil)
 		p.Set("fx_rate_date", nil, nil)
 	}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -251,9 +251,13 @@ func (s *Store) stageTransitionPatch(ctx context.Context, tx pgx.Tx,
 	// landing. A reason describing a previous close is worse than none: it
 	// answers the report with a fact about a different outcome — so a deal
 	// re-decided from lost to won must not carry the loss explanation with it.
+	// The clear is conditional on there being something to clear: Set records
+	// an assignment unconditionally, so clearing a column that is already NULL
+	// would put lost_reason into the UPDATE and the audit diff of every
+	// ordinary open-to-open advance.
 	if DealStatus(status) == DealLost && in.LostReason != nil {
 		p.Set("lost_reason", current.LostReason, *in.LostReason)
-	} else if DealStatus(status) != DealLost {
+	} else if DealStatus(status) != DealLost && current.LostReason != nil {
 		p.Set("lost_reason", current.LostReason, nil)
 	}
 	// The won-without-contract reason is written only on a win, and cleared on

--- a/backend/internal/modules/deals/deal_advance_lostreason_test.go
+++ b/backend/internal/modules/deals/deal_advance_lostreason_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// A reason for a loss must not outlive the loss. The report that counts why
+// deals are lost reads this column, so a reason left behind by a re-decided
+// deal answers that question with an outcome that no longer stands.
+//
+// The amount is left nil throughout: a closing deal with an amount freezes an
+// FX rate, which needs a transaction, and the reason-clearing this proves is
+// decided before any of that.
+func TestALostReasonIsClearedOnEveryLandingThatIsNotLost(t *testing.T) {
+	reason := "went with a competitor"
+	lost := crmcontracts.Deal{
+		Status:     crmcontracts.DealStatusLost,
+		LostReason: &reason,
+	}
+
+	for name, semantic := range map[string]string{
+		"re-decided as won": "won",
+		"reopened":          "open",
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &Store{}
+			patch, status, err := store.stageTransitionPatch(
+				context.Background(), nil, lost, AdvanceDealInput{}, semantic)
+			if err != nil {
+				t.Fatalf("stageTransitionPatch: %v", err)
+			}
+			if status == string(crmcontracts.DealStatusLost) {
+				t.Fatalf("status = %q, want a landing that is not lost", status)
+			}
+
+			cleared, assigned := patch.After()["lost_reason"]
+			if !assigned {
+				t.Fatal("lost_reason was never assigned, so the previous reason survives the transition")
+			}
+			if cleared != nil {
+				t.Errorf("lost_reason = %v, want nil — the reason describes a close that no longer stands", cleared)
+			}
+		})
+	}
+}
+
+// The reason still has to be written when the deal actually lands on lost,
+// which is the behaviour the clearing branch must not swallow.
+func TestALostReasonIsWrittenWhenTheDealLandsOnLost(t *testing.T) {
+	reason := "budget cut"
+	open := crmcontracts.Deal{Status: crmcontracts.DealStatusOpen}
+
+	store := &Store{}
+	patch, status, err := store.stageTransitionPatch(
+		context.Background(), nil, open, AdvanceDealInput{LostReason: &reason}, "lost")
+	if err != nil {
+		t.Fatalf("stageTransitionPatch: %v", err)
+	}
+	if status != string(crmcontracts.DealStatusLost) {
+		t.Fatalf("status = %q, want lost", status)
+	}
+	if got := patch.After()["lost_reason"]; got != reason {
+		t.Errorf("lost_reason = %v, want %q", got, reason)
+	}
+}

--- a/backend/internal/modules/deals/deal_advance_lostreason_test.go
+++ b/backend/internal/modules/deals/deal_advance_lostreason_test.go
@@ -50,6 +50,24 @@ func TestALostReasonIsClearedOnEveryLandingThatIsNotLost(t *testing.T) {
 	}
 }
 
+// An ordinary move between two open stages has no lost reason to clear, and
+// must not say that it cleared one: a patch records every assignment it is
+// given, so an unconditional clear would name lost_reason in the UPDATE and in
+// the audit diff of every advance a deal ever makes.
+func TestAnAdvanceWithNoLostReasonLeavesTheColumnOutOfThePatch(t *testing.T) {
+	open := crmcontracts.Deal{Status: crmcontracts.DealStatusOpen}
+
+	store := &Store{}
+	patch, _, err := store.stageTransitionPatch(
+		context.Background(), nil, open, AdvanceDealInput{}, "open")
+	if err != nil {
+		t.Fatalf("stageTransitionPatch: %v", err)
+	}
+	if _, assigned := patch.After()["lost_reason"]; assigned {
+		t.Error("lost_reason was assigned on an advance that never touched it")
+	}
+}
+
 // The reason still has to be written when the deal actually lands on lost,
 // which is the behaviour the clearing branch must not swallow.
 func TestALostReasonIsWrittenWhenTheDealLandsOnLost(t *testing.T) {

--- a/backend/migrations/core/1787225001_deal_lost_reason_only_when_lost.down.sql
+++ b/backend/migrations/core/1787225001_deal_lost_reason_only_when_lost.down.sql
@@ -1,0 +1,8 @@
+-- The repair UPDATE is not reversible: the cleared reasons described closes
+-- that had already been reversed, and the rows carry no record of what the
+-- text was. Dropping the constraint restores the old permissiveness, which is
+-- all the down half can honestly do.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE deal
+  DROP CONSTRAINT IF EXISTS deal_lost_reason_only_when_lost;

--- a/backend/migrations/core/1787225001_deal_lost_reason_only_when_lost.up.sql
+++ b/backend/migrations/core/1787225001_deal_lost_reason_only_when_lost.up.sql
@@ -1,0 +1,30 @@
+-- A lost reason belongs only to a lost deal.
+--
+-- `deal_lost_reason` is one-directional: it demands a reason when the deal is
+-- lost and says nothing about the other direction. A deal closed lost and then
+-- re-decided as won therefore kept the reason for the loss, and the won-lost
+-- report read a fact about an outcome that had been reversed. Migration 0266
+-- named this shape when it chose a different one for the won-without-contract
+-- columns.
+--
+-- The writer clears the column on every non-lost landing
+-- (deals/deal_advance.go, stageTransitionPatch). This constraint makes the
+-- state unrepresentable rather than merely unwritten.
+
+-- Both statements below block writers on `deal`. Bounding the wait means a
+-- long-open transaction fails this migration instead of stalling every write
+-- to the table for as long as the migration is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
+-- Repair first: the constraint cannot be added while rows violate it, and
+-- these rows exist wherever a deal was re-decided before the writer was fixed.
+-- The reason described a close that no longer stands, so dropping it loses
+-- nothing a report could honestly use.
+UPDATE deal
+   SET lost_reason = NULL
+ WHERE lost_reason IS NOT NULL
+   AND status <> 'lost';
+
+ALTER TABLE deal
+  ADD CONSTRAINT deal_lost_reason_only_when_lost CHECK (
+    lost_reason IS NULL OR status = 'lost');

--- a/backend/migrations/core/1787225001_deal_lost_reason_only_when_lost.up.sql
+++ b/backend/migrations/core/1787225001_deal_lost_reason_only_when_lost.up.sql
@@ -14,7 +14,14 @@
 -- Both statements below block writers on `deal`. Bounding the wait means a
 -- long-open transaction fails this migration instead of stalling every write
 -- to the table for as long as the migration is willing to queue.
+--
+-- The table lock is what makes the repair hold: during a rolling deployment an
+-- instance still running the old writer could otherwise re-decide a lost deal
+-- as won in the window between the repair and the constraint, and the new row
+-- would fail the ADD CONSTRAINT rather than be repaired by it. Holding writers
+-- out for the whole transaction closes that window.
 SET LOCAL lock_timeout = '3s';
+LOCK TABLE deal IN SHARE ROW EXCLUSIVE MODE;
 
 -- Repair first: the constraint cannot be added while rows violate it, and
 -- these rows exist wherever a deal was re-decided before the writer was fixed.


### PR DESCRIPTION
## What was wrong

The `deal_lost_reason` CHECK demands a reason when a deal is lost and says nothing about the other direction. `stageTransitionPatch` wrote `lost_reason` only on a lost landing and cleared it only on a reopen, so a deal closed **lost** and then re-decided as **won** kept the explanation for the loss. Nothing refused that state, and the won-lost report answered "why did we lose this" with a fact about an outcome that had been reversed.

## The fix

`lost_reason` is now cleared on every landing that is not lost — the shape the `won_without_contract_*` columns directly below it already use, and which they were given for this exact defect. The reopen sweep no longer clears it separately because the new branch covers that case.

A migration adds `deal_lost_reason_only_when_lost` so the state is unrepresentable rather than merely unwritten, repairing the rows the old writer left behind first, since the constraint cannot be added while they violate it. It holds `SHARE ROW EXCLUSIVE` on `deal` for the transaction so a rolling deployment cannot slip a new violator in between the repair and the constraint.

The clear is conditional on there being a reason to remove: a patch records every assignment it is given, so an unconditional clear would name `lost_reason` in the UPDATE and in both audit images of every ordinary advance.

## Tests

Four unit tests in `deal_advance_lostreason_test.go`: the reason clears on re-decide-as-won and on reopen, it is still written when the deal lands on lost, and it stays out of the patch entirely on an advance that never touched it. Each was mutation-checked — reverting the fix fails the matching test.

Closes #483.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears a deal’s lost reason on every non-lost landing and enforces it with a DB constraint, so a loss explanation cannot outlive the loss. This fixes won–lost reporting that previously used stale reasons after a re-decide to won.

- Old vs new behavior: previously wrote `lost_reason` only when landing on lost and cleared it only on reopen; now clears `lost_reason` on every landing that is not lost. The reopen sweep no longer clears it separately.
- The clear runs only when a reason exists, avoiding unnecessary UPDATEs and audit noise on ordinary open-to-open advances.
- Migration adds CHECK `deal_lost_reason_only_when_lost`, first repairing rows where `status <> 'lost' AND lost_reason IS NOT NULL`, then adding the constraint. Holds `SHARE ROW EXCLUSIVE` on `deal` for the whole transaction with a 3s `lock_timeout` to prevent racey violations during rolling deploys.
- Unit tests cover: clearing on re-decide-to-won and on reopen, writing on lost, and omitting `lost_reason` from patches for unrelated advances.

<sup>Written for commit 9dc83732f54871d0e11d9514354d6658341c00c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

