### PR TITLE
fix(agents): archive_record archives an activity instead of refusing one it names

### DIFF
--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -164,6 +164,7 @@ var bothDoorsFixtures = map[string]bothDoorsFixture{
 	"archiveDeal":         archiveDoors("deals", "deal"),
 	"archiveProject":      archiveDoors("projects", "project"),
 	"archiveRelationship": archiveDoors("relationships", "relationship"),
+	"archiveActivity":     archiveDoors("activities", "activity"),
 
 	"createPerson":       createDoors("people", "person", `{"full_name":"Ada Lovelace"}`),
 	"createOrganization": createDoors("organizations", "organization", `{"display_name":"Acme"}`),

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -325,6 +325,8 @@ func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasou
 		return p.people.Archive(ctx, r)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.Archive(ctx, r)
+	case datasource.EntityActivity:
+		return p.activities.Archive(ctx, r)
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
 	}

--- a/backend/internal/modules/activities/provider.go
+++ b/backend/internal/modules/activities/provider.go
@@ -67,6 +67,22 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 	return ref(datasource.EntityActivity, v.Id), err
 }
 
+// Archive retires an activity, the same soft archive DELETE /v1/activities/{id}
+// performs — the contract has always declared archiveActivity as archive_record's
+// (agentPolicies), and the seam is what was missing: the tool staged a
+// confirmation, a human approved it, and the call then died at this switch with
+// `unsupported_entity_type`. An approval spent on a verb that could never run.
+func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasource.EntityRef, error) {
+	if r.Type != datasource.EntityActivity {
+		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
+	}
+	v, err := p.store.ArchiveActivity(ctx, ids.From[ids.ActivityKind](r.ID))
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	return ref(datasource.EntityActivity, v.Id), nil
+}
+
 func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
 	if in.EntityType != datasource.EntityActivity {
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(in.EntityType)}

--- a/backend/internal/modules/agents/commandsingle_test.go
+++ b/backend/internal/modules/agents/commandsingle_test.go
@@ -535,7 +535,10 @@ func linkFixture(p *tallyingProvider) ids.UUID {
 // half-knows stages one a human CAN release, onto a retry that then dies at
 // the provider with the one-shot authority already spent.
 func TestTheArchiveToolRefusesARecordTypeItsOwnWritePathCannotArchive(t *testing.T) {
-	for _, recordType := range []string{"tag", "list", "saved_view", "nonsense", ""} {
+	// `lead` is the one that looks safe and is not: a real seam entity, so the
+	// old check (the seam's whole vocabulary) admitted it, while Archive has no
+	// branch for it and never had. Exactly the trap `activity` sat in.
+	for _, recordType := range []string{"tag", "list", "saved_view", "lead", "nonsense", ""} {
 		t.Run(recordType, func(t *testing.T) {
 			// A provider that fails EVERY read, so a door that reached the seam
 			// anyway fails here rather than passing on a lenient stub.
@@ -545,6 +548,39 @@ func TestTheArchiveToolRefusesARecordTypeItsOwnWritePathCannotArchive(t *testing
 			if !errors.As(err, &bad) {
 				t.Fatalf("staging an archive of %q answered %v, want a BadArgsError — an approval for it "+
 					"could never be carried out", recordType, err)
+			}
+		})
+	}
+}
+
+// The other half of the same rule: a type the seam DOES archive must reach
+// staging, or the tool refuses work the contract promises.
+//
+// `activity` is the case this was written for. crm.yaml has always declared
+// archiveActivity as archive_record's (x-mcp-tool at DELETE /v1/activities/{id}),
+// but SystemOfRecordProvider.Archive had no branch for it: the tool staged the
+// confirmation, a human approved, and the retry died at the provider with
+// `unsupported_entity_type` — a one-shot authority spent on a call that could
+// never run, and the activity had to be removed over REST instead.
+func TestTheArchiveToolStagesEveryRecordTypeItsWritePathServes(t *testing.T) {
+	// Named here rather than ranged over archivableRecordTypes: a test that
+	// iterates the list it is asserting on cannot notice the list shrinking,
+	// which is the regression it exists to catch.
+	for _, recordType := range []string{
+		"person", "organization", "deal", "project", "relationship", "activity",
+	} {
+		t.Run(recordType, func(t *testing.T) {
+			id := ids.NewV7()
+			info, err := archiveRecord{p: oneRecord(datasource.EntityType(recordType), id, `{}`, 3)}.
+				StageInfo(context.Background(),
+					json.RawMessage(fmt.Sprintf(`{"record_type":%q,"id":%q}`, recordType, id)))
+			if err != nil {
+				t.Fatalf("staging an archive of %q answered %v, want it staged — the contract "+
+					"declares this type archivable over the tool surface", recordType, err)
+			}
+			// The approval names the record the human is deciding about.
+			if info.TargetType != recordType || info.TargetID != id {
+				t.Errorf("staged %s/%s, want %s/%s", info.TargetType, info.TargetID, recordType, id)
 			}
 		})
 	}

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -298,6 +298,7 @@ func recordLabel(rec datasource.Record) string {
 		Name        string `json:"name"`
 		Email       string `json:"email"`
 		Kind        string `json:"kind"`
+		Subject     string `json:"subject"`
 	}
 	//craft:ignore swallowed-errors label extraction is best-effort by design — unparseable fields fall through to the id below
 	_ = json.Unmarshal(rec.Fields, &f)
@@ -311,6 +312,14 @@ func recordLabel(rec datasource.Record) string {
 	// human needs to know WHICH note, and would suppress the id that told them.
 	if rec.Ref.Type == datasource.EntityRelationship && f.Kind != "" {
 		return fmt.Sprintf("%q", f.Kind)
+	}
+	// An activity's subject is the WHICH the kind cannot supply — "Archive
+	// activity 0195c3…" names nothing a human can weigh, while `Archive activity
+	// "Kickoff Migration Shopsystem"` is the decision they are being asked for.
+	// Also scoped to the one type, and to the field that identifies rather than
+	// classifies: an activity carrying no subject still falls through to the id.
+	if rec.Ref.Type == datasource.EntityActivity && f.Subject != "" {
+		return fmt.Sprintf("%q", f.Subject)
 	}
 	for _, s := range []string{f.FullName, f.DisplayName, f.Name, f.Email} {
 		if s != "" {

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -13,7 +13,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -22,6 +24,28 @@ import (
 )
 
 // --- archive_record (🟡 write — visibility change, hard to undo) ---
+
+// archivableRecordTypes is what SystemOfRecordProvider.Archive actually routes
+// (compose/provider.go) — narrower than datasource.EntityTypes(), which is the
+// whole seam vocabulary and includes `lead`, a type Archive does not serve.
+//
+// Stage-time truth has to equal execute-time truth here: this tool stages a
+// confirmation FIRST and archives on the approved retry, so a type admitted at
+// staging and refused at execution spends a human's approval on a call that
+// could never run. That is what happened to `activity` — the contract declared
+// archiveActivity as this tool's, the seam had no branch for it, and the
+// refusal arrived only after a human had said yes. The list is stated here
+// rather than derived so adding a branch to Archive is a deliberate edit in
+// both places.
+var archivableRecordTypes = []string{
+	string(datasource.EntityPerson), string(datasource.EntityOrganization),
+	string(datasource.EntityDeal), string(datasource.EntityProject),
+	string(datasource.EntityRelationship), string(datasource.EntityActivity),
+}
+
+func archivableByTheRecordSeam(recordType string) bool {
+	return slices.Contains(archivableRecordTypes, recordType)
+}
 
 type archiveArgs struct {
 	RecordType string   `json:"record_type"`
@@ -37,9 +61,9 @@ func (t archiveRecord) Spec() mcp.ToolSpec {
 		Name: "archive_record", Title: "Archive a record", Version: toolVersionV1,
 		Description:   archiveRecordCopy.render(),
 		RequiredScope: principal.ScopeWrite, Tier: mcp.TierConfirmationRequired,
-		OpenAPIOp: "archivePerson/archiveOrganization/archiveDeal/archiveProject/archiveRelationship",
+		OpenAPIOp: "archivePerson/archiveOrganization/archiveDeal/archiveProject/archiveRelationship/archiveActivity",
 		InputSchema: schema(`{"type":"object","required":["record_type","id"],"properties":{
-			"record_type":{"type":"string","enum":["person","organization","deal","project","relationship"]},
+			"record_type":{"type":"string","enum":["person","organization","deal","project","relationship","activity"]},
 			"id":{"type":"string","format":"uuid"},
 			"approval_id":{"type":"string","format":"uuid","description":"Set on retry after a human approved the staged call"}},
 			"additionalProperties":false}`),
@@ -60,13 +84,17 @@ func (t archiveRecord) Spec() mcp.ToolSpec {
 // ONE check runs HERE, before the command is built, for exactly the reason
 // createRecord.StageInfo's does (tools.go): a record type this verb's OWN
 // write path cannot express. Handle archives exclusively through
-// datasource.SystemOfRecordProvider.Archive, which cannot name a type outside
-// the seam's vocabulary — and the surface does not enforce the InputSchema
-// enum at this layer, so a raw tool call can put any string here. Without it,
-// `record_type:"tag"` stages an approval a human releases onto a retry that
-// dies at the provider, and an arbitrary string stages one with a target type
-// the approvals surface has no visibility rule for at all: a zombie authority
-// object, minted at the caller's choosing.
+// datasource.SystemOfRecordProvider.Archive — and the surface does not enforce
+// the InputSchema enum at this layer, so a raw tool call can put any string
+// here. Without it, `record_type:"tag"` stages an approval a human releases
+// onto a retry that dies at the provider, and an arbitrary string stages one
+// with a target type the approvals surface has no visibility rule for at all:
+// a zombie authority object, minted at the caller's choosing.
+//
+// It asks archivableRecordTypes rather than the seam's whole vocabulary,
+// because those two are not the same question: `lead` is a seam entity that
+// Archive does not route, so the broader check let it stage and fail after
+// approval — the trap `activity` fell into until Archive learned to serve it.
 //
 // That is a fact about THIS door's executor rather than about the operation,
 // which is why it cannot live in the resolver: the same command reaching it
@@ -77,10 +105,10 @@ func (t archiveRecord) StageInfo(ctx context.Context, in json.RawMessage) (Stage
 	if err := decodeArgs(in, &args); err != nil {
 		return StageInfo{}, err
 	}
-	if !servedByTheRecordSeam(args.RecordType) {
+	if !archivableByTheRecordSeam(args.RecordType) {
 		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
-			"this verb does not archive %q records, so no approval of it could ever be carried out",
-			args.RecordType)}
+			"this verb does not archive %q records, so no approval of it could ever be carried out; it archives %s",
+			args.RecordType, strings.Join(archivableRecordTypes, ", "))}
 	}
 	return StageSubject(ctx, NewArchiveCall(t.p, ArchiveCommand(args)))
 }

--- a/backend/internal/modules/agents/tools_confirm_test.go
+++ b/backend/internal/modules/agents/tools_confirm_test.go
@@ -39,6 +39,18 @@ func TestRecordLabelUsesKindOnlyForAnEdge(t *testing.T) {
 		"nothing to read falls back to the id": {
 			datasource.EntityPerson, edgeID, `{}`, edgeID.String(),
 		},
+		// An activity's kind classifies; its subject identifies. "Archive
+		// activity 0195c3…" names nothing an approver can weigh.
+		"an activity is named by its subject": {
+			datasource.EntityActivity, edgeID,
+			`{"kind":"meeting","subject":"Kickoff Migration Shopsystem"}`,
+			`"Kickoff Migration Shopsystem"`,
+		},
+		// Not by its kind, which would say `Archive activity "meeting"` and
+		// suppress the id that at least told the approver which one.
+		"an activity with no subject keeps the id": {
+			datasource.EntityActivity, edgeID, `{"kind":"meeting"}`, edgeID.String(),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got := recordLabel(datasource.Record{

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 43,
     "resources": 8,
-    "tool_catalog_bytes": 124450,
+    "tool_catalog_bytes": 124461,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 31889,
+    "approx_wire_tokens_total": 31892,
     "largest_tool_bytes": 4723,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
       "description_bytes": 32392,
-      "input_schema_bytes": 28804,
+      "input_schema_bytes": 28815,
       "output_schema_bytes": 53807,
-      "description_plus_input_schema_bytes": 61196
+      "description_plus_input_schema_bytes": 61207
     }
   },
   "tools": {
@@ -579,7 +579,8 @@
                 "organization",
                 "deal",
                 "project",
-                "relationship"
+                "relationship",
+                "activity"
               ],
               "type": "string"
             }

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 8 |
 | Tool catalog | 121.5 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 31889 |
+| Approx. wire tokens | 31892 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -62,7 +62,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.6 KB |
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.3 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.3 KB |
-| [`archive_record`](#archive_record) | Archive a record |  |  | 2.3 KB |
+| [`archive_record`](#archive_record) | Archive a record |  |  | 2.4 KB |
 | [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.4 KB |
 | [`book_meeting`](#book_meeting) | Book a meeting |  |  | 3.0 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.6 KB |
@@ -844,7 +844,8 @@ Retire a record that should no longer be worked — a duplicate, a dead account,
         "organization",
         "deal",
         "project",
-        "relationship"
+        "relationship",
+        "activity"
       ],
       "type": "string"
     }


### PR DESCRIPTION
Closes MCP-TODO item 25.

`crm.yaml` has always declared `archiveActivity` as `archive_record`'s operation, and the tool's own refusal listed `activity` among the valid types. But `SystemOfRecordProvider.Archive` had no branch for it — so the call staged a confirmation, **a human approved it**, and the retry died at the provider with `unsupported_entity_type`. The one-shot authority was spent on a call that could never run, and the activity had to be removed over REST instead.

Found driving the tool surface from claude.ai on 2026-08-19.

## What changed

- `activities.Provider` gains `Archive`, over the existing `Store.ArchiveActivity` that `DELETE /v1/activities/{id}` already uses; `compose.Provider` routes `EntityActivity` to it.
- The tool's schema enum and `OpenAPIOp` name activity.
- `StageInfo` asks a new `archivableRecordTypes` instead of `servedByTheRecordSeam`. Those were never the same question: `EntityTypes()` includes **`lead`**, which `Archive` does not route and never did — so the broader check let a lead stage and fail after approval too. Stage-time truth now equals execute-time truth.
- An activity approval names its **subject** rather than its uuid: `Archive activity "Kickoff Migration Shopsystem"`.

## Tests

The refusal case gains `lead`. A companion test asserts every archivable type reaches staging — naming the types literally rather than ranging over `archivableRecordTypes`, because a test that iterates the list it asserts on cannot notice the list shrinking (verified it fails when activity is removed). Plus the `archiveActivity` two-door fixture the parity gate demanded once the operation was twinned.

## Deferred, filed

A Codex review found three problems that reach beyond this PR, all pre-existing:

- **#2014** — staging checks readability, execution checks writability. Affects every archivable type.
- **#2015** — the approved version is not enforced in the transaction that archives. Both doors.
- **#2016** — `archivableRecordTypes` is context-free while overlay archives a narrower set, so a pending native approval that outlives a mode change spends itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `archive_record` actually archive activities and show their subject in approvals. Previously the tool staged and could be approved, but execution failed with `unsupported_entity_type` because the provider didn’t route activities.

- Add `activities.Provider.Archive` (wraps store `ArchiveActivity`) and route `datasource.EntityActivity` in `compose.Provider.Archive`, matching `DELETE /v1/activities/{id}`.
- Extend the tool surface: `archive_record` `OpenAPIOp` includes `archiveActivity`; input enum now allows `"activity"`.
- Gate staging by what the write path serves: replace the seam-wide check with `archivableRecordTypes` in `StageInfo`. Old behavior: types like `"lead"` could stage and then fail after approval. New behavior: such types are refused at staging with a clear list of allowed types.
- Improve approval labels: activities are identified by their `subject` instead of a UUID; falls back to ID if no subject.
- Tests: add refusal for `"lead"`, ensure every archivable type stages (including `"activity"`), add the two-door `archiveActivity` fixture. Rebuild `docs/reference/mcp-info.*`.

<sup>Written for commit 1e7263d73a879ae019c6e179f7d72b98a1ebaea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

