### PR TITLE
feat(capture): a company a person created gets a dossier too

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7321,8 +7321,10 @@ paths:
       summary: Update the workspace's capture settings (admin/ops).
       description: |
         Admin/ops-only. Toggles the captured-organization auto-enrich posture (ADR-0072/A118):
-        when ON, every surviving auto-created company gets a governed deep-read under a daily
-        spend cap. Human session only (x-agent-access: human-only) — an agent never changes a
+        when ON, every company with a primary domain and no dossier gets a governed deep-read
+        under a daily spend cap — however it was named, since a person creating one is usually
+        the moment they want it. The installation's own company (the anchor) is excluded: cold
+        start has already read it. Human session only (x-agent-access: human-only) — an agent never changes a
         workspace-wide capture posture. Audit-only write (no event stream, EVT-NOEVT-3).
       requestBody:
         required: true
@@ -14126,8 +14128,9 @@ components:
         auto_enrich:
           type: boolean
           description: |
-            When true, every surviving auto-created organization gets a governed web deep-read
-            under a daily spend cap. Default is ON (the testing posture).
+            When true, every organization with a primary domain and no dossier gets a governed
+            web deep-read under a daily spend cap — however it was named. The anchor is
+            excluded (cold start reads it). Default is ON (the testing posture).
     AiRouting:
       type: object
       description: |

--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -5,10 +5,12 @@ package compose
 
 // The captured-organization auto-enrich sweep (CAP-PARAM-7, ADR-0072/A118):
 // a leader-elected periodic pass (run-on-start + daily) that gives every
-// surviving auto-created company a governed web dossier. Per workspace, when
+// company with a primary domain and no dossier a governed web one — however it
+// was named, since a person creating one is usually the moment they want it.
+// The anchor is excluded; cold start has already read it. Per workspace, when
 // the capture_auto_enrich flag is on, it enqueues a deep read
-// (system:capture_auto_enrich, auto-applied on completion) for each due
-// domain-named org — newest first, under an atomically-reserved daily cap. It
+// (system:capture_auto_enrich, auto-applied on completion) for each due org —
+// newest first, under an atomically-reserved daily cap. It
 // is the ONE trigger and the self-healing reconciler in one: a missed org is
 // simply picked up next pass. The deep-read worker's auto-apply lane
 // (deepread.go) records the terminal outcome on the sweep's cursor.

--- a/backend/internal/compose/captureautoenrich_integration_test.go
+++ b/backend/internal/compose/captureautoenrich_integration_test.go
@@ -13,6 +13,8 @@ package compose
 
 import (
 	"context"
+	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -103,12 +105,13 @@ func TestAutoEnrichStoreEligibilityAndCap(t *testing.T) {
 	store := capture.NewAutoEnrichStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
 
-	// Two captured domain-named orgs are due; a human-named org (from insertOrg,
-	// name_source='human') is not; nor is one that already has a dossier.
+	// How the company was NAMED no longer decides: a person creating one is
+	// usually the moment they want the dossier, and the old name_source='domain'
+	// rule had made this lane inert anyway (every org in the demo workspace is
+	// human-named). What still excludes a company is having a dossier already.
 	due1 := insertDomainOrg(t, e, "gitex.com")
 	insertDomainOrg(t, e, "acme.example")
-	humanOrg := insertOrg(t, e, e.Rep1, "human.example", "") // name_source='human'
-	_ = humanOrg
+	insertOrg(t, e, e.Rep1, "human.example", "") // name_source='human' — now DUE
 	// Give due1 a completed site read so it is excluded (already enriched).
 	if _, _, err := e.People.StartSiteRead(ctx, due1, "https://gitex.com", "human:"+e.Rep1.String()); err != nil {
 		t.Fatalf("seed dossier: %v", err)
@@ -118,8 +121,14 @@ func TestAutoEnrichStoreEligibilityAndCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListDueOrgs: %v", err)
 	}
-	if len(dueList) != 1 || dueList[0].Domain != "acme.example" {
-		t.Fatalf("due = %+v, want exactly acme.example (human-named excluded, dossier'd excluded)", dueList)
+	gotDomains := []string{}
+	for _, d := range dueList {
+		gotDomains = append(gotDomains, d.Domain)
+	}
+	sort.Strings(gotDomains)
+	if !slices.Equal(gotDomains, []string{"acme.example", "human.example"}) {
+		t.Fatalf("due = %v, want acme.example and human.example — a human-named company "+
+			"is enriched too, and only the one holding a dossier is excluded", gotDomains)
 	}
 
 	// The daily cap is atomic: with a cap of 2, the first two reservations
@@ -156,11 +165,13 @@ func runReadTo(t *testing.T, e *integration.Env, orgID ids.OrganizationID, seedU
 }
 
 func TestTheInstallationsOwnCompanyIsNeverSwept(t *testing.T) {
-	// The anchor is the company a person named, from a read they inspected field
-	// by field, and its refresh compares every proposal against confirmed truth
-	// (ADR-0065 §8) — while this lane applies what it finds directly. It differs
-	// from a swept company in exactly the thing the sweep selects on, and the
-	// exclusion is the point rather than an oversight.
+	// This test carries more weight than it used to. The anchor was excluded as
+	// a SIDE EFFECT of being human-named, and the sweep no longer selects on
+	// that — so `NOT o.is_anchor` is now the only thing keeping the company the
+	// installation IS out of a lane that applies machine values directly. Its
+	// own refresh compares each proposal against confirmed truth and asks the
+	// human to resolve conflicts (ADR-0065 §8), and cold start has already read
+	// it, so a sweep here would be both redundant and unreviewed.
 	e := integration.Setup(t)
 	store := capture.NewAutoEnrichStore(e.DB())
 	ctx := e.As(e.Rep1, nil, integration.AdminPerms)

--- a/backend/internal/compose/deepreadstop.go
+++ b/backend/internal/compose/deepreadstop.go
@@ -80,8 +80,9 @@ func diagnoseCrawlFailure(cause error) (code, detail string) {
 
 // autoEnrichMaxPages is the page ceiling every AUTOMATIC read runs under
 // (ADR-0072 §9). A read nobody asked for should cost a fraction of one somebody
-// did: the setting is on by default and sweeps up to ten organizations a day
-// per workspace, so the deployment-wide crawler budget is the wrong unit here.
+// did: the setting is on by default and sweeps up to autoEnrichDailyCap (500)
+// organizations a day per workspace, so the deployment-wide crawler budget is
+// the wrong unit here.
 const autoEnrichMaxPages = 12
 
 // pageCeiling is the page cap for one run: the automatic lane's own ceiling,

--- a/backend/internal/compose/deepreadtriage.go
+++ b/backend/internal/compose/deepreadtriage.go
@@ -221,9 +221,9 @@ func (w *siteDeepReadWorker) settleTriage(ctx context.Context, args SiteDeepRead
 	claim := people.SiteReadClaim{OrganizationID: &res.OrganizationID.UUID, SeedURL: payload.SeedURL}
 	// The logo, on the same terms as every other company (A55): a 🟢 display
 	// asset read off the seed page's own markup. Nothing else would ever give
-	// these organizations one — the auto-enrich sweep only offers rows with
-	// name_source='domain' and no finished read, and a triage company has
-	// neither — so skipping it here means faceless forever.
+	// these organizations one — the auto-enrich sweep only offers rows with no
+	// finished read, and a triage company already has one — so skipping it here
+	// means faceless forever.
 	w.resolveLogo(ctx, args, claim, payload.Crawl)
 	// One verdict, one bundle, one transaction: the people this triage published
 	// were all asked about by the same act, and reach the inbox as one question.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12544,8 +12544,9 @@ type CaptureExclusionScope string
 // CaptureSettings The workspace-shared capture posture (ADR-0072/A118, CAP-PARAM-7). Read by every role,
 // changed only by admin/ops.
 type CaptureSettings struct {
-	// AutoEnrich When true, every surviving auto-created organization gets a governed web deep-read
-	// under a daily spend cap. Default is ON (the testing posture).
+	// AutoEnrich When true, every organization with a primary domain and no dossier gets a governed
+	// web deep-read under a daily spend cap — however it was named. The anchor is
+	// excluded (cold start reads it). Default is ON (the testing posture).
 	AutoEnrich bool `json:"auto_enrich"`
 
 	// MailSharing The workspace's mail-sharing posture, ON by default: a captured email is readable by

--- a/backend/internal/modules/capture/autoenrich.go
+++ b/backend/internal/modules/capture/autoenrich.go
@@ -53,17 +53,29 @@ func NewAutoEnrichStore(db *database.DB) *AutoEnrichStore { return &AutoEnrichSt
 // no cursor row or a due one under the attempt bound. The query's own
 // workspace predicate scopes it to the bound workspace.
 //
-// name_source='domain' IS the sweep's population. ADR-0072 gives a dossier to
-// every surviving AUTO-CREATED company, and a domain-derived name is what marks
-// the company nobody has named: capture minted it from a mail domain, and no
-// human, dossier or signature has since said what it is called. A company a
-// person named is out of scope by that same rule — including the installation's
-// OWN company, deliberately. The anchor is created human-named by the
-// confirmation of a deep read a person inspected field by field, and a later
-// refresh of it compares every proposal against confirmed truth and asks the
-// human to resolve each conflict (ADR-0065 §8), while this lane applies what it
-// finds directly. Offering the anchor here would write machine values onto the
-// one company the installation IS, outside the comparison that exists for it.
+// The population is every company with a live primary domain and no dossier,
+// however it was named. ADR-0072 scoped this lane to auto-created companies
+// (name_source='domain') — "the company nobody has named". Lars overruled that
+// on 2026-08-19, twice: "when I create a company and if admin enabled automatic
+// website read then this should be also put on the list for website ingestion",
+// and "If I manually create a company auto enrich must also be triggered." A
+// person typing the name is not a reason to withhold the dossier; it is usually
+// the moment they want one.
+//
+// The old rule had also made the lane inert rather than selective: all 195
+// organizations in the demo workspace carry name_source='human', so the sweep
+// had no candidate at all and had never enriched anything.
+//
+// The anchor stays out, now by its OWN predicate rather than as a side effect
+// of being human-named — removing name_source without this would have started
+// offering it. Two reasons it does not belong here. It is enriched during cold
+// start already (people/company.go's cold-start read-back, distinct from the
+// human write), so a sweep over it is redundant — Lars, 2026-08-20: "Gradion
+// (anchor) IS enriched during coldstart and does not require auto enrichment
+// later." And this lane applies what it finds directly, while the anchor's own
+// refresh compares every proposal against confirmed truth and asks the human to
+// resolve each conflict (ADR-0065 §8); offering it here would write machine
+// values onto the one company the installation IS, outside that comparison.
 //
 // The site-read clause excludes a company whose dossier exists or is still
 // coming. A read that ended with NO dossier is not one: a failure, and a
@@ -81,7 +93,7 @@ func (s *AutoEnrichStore) ListDueOrgs(ctx context.Context, limit int) ([]DueOrg,
 			  ON d.organization_id = o.id AND d.is_primary AND d.archived_at IS NULL
 			LEFT JOIN capture_auto_enrich_state s ON s.organization_id = o.id
 			WHERE o.archived_at IS NULL
-			  AND o.name_source = 'domain'
+			  AND NOT o.is_anchor
 			  AND NOT EXISTS (
 				SELECT 1 FROM site_read sr
 				WHERE sr.organization_id = o.id

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4791,8 +4791,10 @@ export interface paths {
         /**
          * Update the workspace's capture settings (admin/ops).
          * @description Admin/ops-only. Toggles the captured-organization auto-enrich posture (ADR-0072/A118):
-         *     when ON, every surviving auto-created company gets a governed deep-read under a daily
-         *     spend cap. Human session only (x-agent-access: human-only) — an agent never changes a
+         *     when ON, every company with a primary domain and no dossier gets a governed deep-read
+         *     under a daily spend cap — however it was named, since a person creating one is usually
+         *     the moment they want it. The installation's own company (the anchor) is excluded: cold
+         *     start has already read it. Human session only (x-agent-access: human-only) — an agent never changes a
          *     workspace-wide capture posture. Audit-only write (no event stream, EVT-NOEVT-3).
          */
         patch: operations["updateCaptureSettings"];
@@ -9098,8 +9100,9 @@ export interface components {
              */
             mail_sharing: boolean;
             /**
-             * @description When true, every surviving auto-created organization gets a governed web deep-read
-             *     under a daily spend cap. Default is ON (the testing posture).
+             * @description When true, every organization with a primary domain and no dossier gets a governed
+             *     web deep-read under a daily spend cap — however it was named. The anchor is
+             *     excluded (cold start reads it). Default is ON (the testing posture).
              */
             auto_enrich: boolean;
         };


### PR DESCRIPTION
Closes MCP-TODO item 16.

ADR-0072 scoped the auto-enrich sweep to auto-created companies via `o.name_source = 'domain'` — "the company nobody has named". Lars overruled that on 2026-08-19, twice:

> when I create a company and if admin enabled automatic website read then this should be also put on the list for website ingestion

> If I manually create a company auto enrich must also be triggered.

A person typing the name is not a reason to withhold the dossier; it is usually the moment they want one.

## The rule had made the lane inert, not selective

All **195** organizations in the demo workspace carry `name_source='human'`. The sweep therefore had no candidate at all and had never enriched anything — the daily budget showed slots enqueued and nothing to spend them on. The feature was on by default and could not fire.

## The anchor stays out — by its own predicate now

It was excluded only as a *side effect* of being human-named. Removing that predicate without adding `NOT o.is_anchor` would have started offering the installation's own company to a lane that applies machine values directly.

Lars, 2026-08-20: *"Gradion (anchor) IS enriched during coldstart and does not require auto enrichment later."* Verified — `people/company.go` names the cold-start read-back as a path distinct from the human write. Its own refresh compares each proposal against confirmed truth and asks the human to resolve conflicts (ADR-0065 §8), which this lane does not do.

Budget cap and attempt backoff unchanged.

## Tests

`TestAutoEnrichStoreEligibilityAndCap` now asserts a human-named company **is** due — only the one already holding a dossier is excluded. `TestTheInstallationsOwnCompanyIsNeverSwept` carries more weight than before, since it is now the only thing keeping the anchor out, and its comment says so. Integration lane green under a private template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-enrich now sweeps any company with a primary domain and no dossier, excluding the anchor. Previously it only swept `name_source='domain'` companies. This makes human-created companies eligible and repairs lanes with no candidates.

- Replace the `name_source='domain'` filter with `NOT o.is_anchor` plus the existing “no dossier or in-flight read” check; still requires a live primary domain.
- Keep daily budget cap and attempt backoff unchanged; correct public docs to state the cap is 500 and to describe the new rule (API descriptions in `backend/api/crm.yaml`, generated `backend/internal/contracts/api_gen.go`, and `frontend/src/api/schema.d.ts`; package comments and triage notes).
- Update tests to assert human-named companies are due and to enforce anchor exclusion.

<sup>Written for commit 50a8434eee7b904e51caa76456da0cbbd378ad10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

