### PR TITLE
feat(deals): the deals list offers saved views

### DIFF
--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -330,12 +330,20 @@ function stubBackend(
     stageTotalsRows?: Record<string, unknown>[];
     onStageTotalsBody?: (body: unknown) => void;
     savedViews?: Record<string, unknown>[];
+    onCreateView?: (body: unknown) => void;
   } = {},
 ) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : null;
     const url = String(request ? request.url : input);
     const method = request ? request.method : (init?.method ?? "GET");
+    if (method === "POST" && url.includes("/views")) {
+      const body = request
+        ? await request.json()
+        : JSON.parse(String(init?.body));
+      opts.onCreateView?.(body);
+      return jsonResponse({ id: "new-view", ...body }, 201);
+    }
     if (method === "GET" && url.includes("/views")) {
       return jsonResponse({
         data: opts.savedViews ?? [],
@@ -495,8 +503,9 @@ describe("DealsScreen", () => {
         ],
       }),
     );
+    const user = userEvent.setup();
     render(<DealsScreen />);
-    await userEvent.click(await screen.findByRole("button", { name: "Table" }));
+    await user.click(await screen.findByRole("button", { name: "Table" }));
 
     expect(
       await screen.findByRole("button", { name: "Slipping this quarter" }),
@@ -524,15 +533,63 @@ describe("DealsScreen", () => {
         ],
       }),
     );
+    const user = userEvent.setup();
     render(<DealsScreen />);
-    await userEvent.click(await screen.findByRole("button", { name: "Table" }));
-    await userEvent.click(
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+    await user.click(
       await screen.findByRole("button", { name: "My stalled deals" }),
     );
 
     await waitFor(() =>
       expect(urls.some((url) => url.includes("stalled=true"))).toBe(true),
     );
+  });
+
+  // The pipeline picker is the strongest dial on this screen and it lives in
+  // its own state, outside the list query. Saved without it, a view would
+  // restore against whichever pipeline happened to be showing — a different
+  // list of deals under the name the reader chose.
+  it("saves the selected pipeline as part of the view", async () => {
+    let saved: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        onCreateView: (body) => {
+          saved = body as Record<string, unknown>;
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+    // The save action appears only once something narrows the list; a sort is
+    // the cheapest such narrowing to reach from here.
+    await user.click(screen.getByRole("button", { name: "Sort by Value" }));
+    await user.click(await screen.findByRole("button", { name: "Save view" }));
+    await user.type(
+      await screen.findByRole("textbox", { name: "Name" }),
+      "Pipeline view",
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(saved).toBeTruthy());
+    if (!saved) {
+      throw new Error("the save never reached the server");
+    }
+    const list = (saved.query as Record<string, Record<string, unknown>>).list;
+    expect((list.filters as Record<string, string>).pipeline_id).toBe("pl");
+  });
+
+  // A pipeline is always selected, so carrying it into the query must not make
+  // an untouched list look narrowed: the save action would then offer to store
+  // the default view, which is the clutter its own check exists to prevent.
+  it("offers no save action until the reader narrows something", async () => {
+    vi.stubGlobal("fetch", stubBackend([deal({})]));
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+
+    expect(screen.queryByRole("button", { name: "Save view" })).toBeNull();
   });
 
   // The board's column total must come from the deals-by-stage

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -329,12 +329,19 @@ function stubBackend(
     agentTools?: components["schemas"]["AgentTool"][];
     stageTotalsRows?: Record<string, unknown>[];
     onStageTotalsBody?: (body: unknown) => void;
+    savedViews?: Record<string, unknown>[];
   } = {},
 ) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : null;
     const url = String(request ? request.url : input);
     const method = request ? request.method : (init?.method ?? "GET");
+    if (method === "GET" && url.includes("/views")) {
+      return jsonResponse({
+        data: opts.savedViews ?? [],
+        page: { next_cursor: null },
+      });
+    }
     if (url.includes("/agent-tools")) {
       return jsonResponse({
         data: opts.agentTools ?? [],
@@ -465,6 +472,67 @@ describe("DealsScreen", () => {
     await userEvent.click(screen.getByRole("button", { name: "Table" }));
     expect(screen.getByText("Fleet retrofit")).toBeTruthy(); // same set, table view
     expect(dealFetches()).toBe(before); // no reload
+  });
+
+  // A view saved on the deals list is a server row, and the tab rail has to
+  // read it. The rail carried only the one hardcoded sort before, so a saved
+  // view was storable through the contract and then invisible.
+  it("offers a saved view as a tab beside the standing sort", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        savedViews: [
+          {
+            id: "v1",
+            resource: "deals",
+            name: "Slipping this quarter",
+            query: {
+              list: { sort: "-amount_minor", filters: { stalled: "true" } },
+            },
+            created_at: "2026-06-01T00:00:00Z",
+            updated_at: "2026-06-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    render(<DealsScreen />);
+    await userEvent.click(await screen.findByRole("button", { name: "Table" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Slipping this quarter" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Newest" })).toBeTruthy();
+  });
+
+  // Picking the tab has to narrow the list, not just highlight: the saved
+  // filters travel to the server or the view is decoration.
+  it("applies a saved view's filters to the deals request", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        onDealsUrl: (url) => urls.push(url),
+        savedViews: [
+          {
+            id: "v1",
+            resource: "deals",
+            name: "My stalled deals",
+            query: { list: { sort: "", filters: { stalled: "true" } } },
+            created_at: "2026-06-01T00:00:00Z",
+            updated_at: "2026-06-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    render(<DealsScreen />);
+    await userEvent.click(await screen.findByRole("button", { name: "Table" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "My stalled deals" }),
+    );
+
+    await waitFor(() =>
+      expect(urls.some((url) => url.includes("stalled=true"))).toBe(true),
+    );
   });
 
   // The board's column total must come from the deals-by-stage

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -84,6 +84,7 @@ import {
 } from "./listquery";
 import { LogActivity } from "./logactivity";
 import { DealCoverageCard } from "./network";
+import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import { ShareAction } from "./share";
 
 // Deal surfaces (B-EP09.11a/b/c): the five-stage Kanban with drag-to-advance
@@ -785,6 +786,7 @@ export function DealsScreen({
   const overlay = useSorMode() === "overlay";
   const pipelinesQuery = usePipelines(!overlay);
   const meQuery = useMe();
+  const savedViews = useSavedViewTabs("deals");
   const tierMap = useAgentTierMap();
   const [pipelineId, setPipelineId] = useState("");
   const [query, setQuery] = useState<ListQuery>({
@@ -1051,6 +1053,17 @@ export function DealsScreen({
       setQuery={setQuery}
     />
   );
+
+  // The save action rides beside the dials on the table only. A saved view
+  // restores a sort and a set of filters, and the board reads neither: its
+  // order is the pipeline's stage order, so a view restored there would
+  // silently change nothing a reader could see.
+  const tableTools = (
+    <>
+      {dealTools}
+      <SaveViewAction resource="deals" query={dealsListState.query} />
+    </>
+  );
   const dealChips = dealFilterChips(stages, t);
   // The companies this screen already read for the create form's picker carry
   // their resolved marks, so the board can show them without a second read.
@@ -1147,8 +1160,9 @@ export function DealsScreen({
             ) : undefined
           }
           action={createAction}
-          tools={dealTools}
+          tools={tableTools}
           dataChips={dealChips}
+          dataViews={savedViews}
           chips={[
             {
               key: "stalled",

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -693,6 +693,21 @@ async function searchCompanies(
   return data.data.map((org) => ({ value: org.id, label: org.display_name }));
 }
 
+// Whether the reader has narrowed this list themselves.
+//
+// The same question `SaveViewAction` asks before it offers to save, asked here
+// because the pipeline has to be folded into the saved query WITHOUT being the
+// thing that makes the query look narrowed: a pipeline is always selected, so
+// counting it would offer to save the default list.
+function narrowsTheDealList(query: ListQuery): boolean {
+  return (
+    Boolean(query.q) ||
+    Boolean(query.sort) ||
+    query.includeArchived ||
+    Object.values(query.filters).some(Boolean)
+  );
+}
+
 // The stage and company filters. The stage list is loaded whole already (a
 // pipeline has few stages), so it stays a fixed chip; the company filter
 // searches rather than listing (see searchCompanies above). Both are still
@@ -1058,10 +1073,29 @@ export function DealsScreen({
   // restores a sort and a set of filters, and the board reads neither: its
   // order is the pipeline's stage order, so a view restored there would
   // silently change nothing a reader could see.
+  //
+  // The pipeline goes in as a filter because it is the strongest dial on this
+  // screen and it lives in its own state, outside `query`. Left out, a view
+  // saved while looking at one pipeline would restore against whichever
+  // pipeline happened to be showing — a different list under the saved name.
+  //
+  // It is added only once the reader has narrowed something else. A pipeline is
+  // always selected, so folding it in unconditionally would make every list
+  // look narrowed and offer to save the default view, which is the clutter
+  // SaveViewAction's own check exists to prevent.
+  const savableQuery = narrowsTheDealList(dealsListState.query)
+    ? {
+        ...dealsListState.query,
+        filters: {
+          ...dealsListState.query.filters,
+          pipeline_id: effectivePipeline?.id ?? "",
+        },
+      }
+    : dealsListState.query;
   const tableTools = (
     <>
       {dealTools}
-      <SaveViewAction resource="deals" query={dealsListState.query} />
+      <SaveViewAction resource="deals" query={savableQuery} />
     </>
   );
   const dealChips = dealFilterChips(stages, t);


### PR DESCRIPTION
## What was missing

`ViewResource` in `savedviews.tsx` has always included `"deals"`, and `/views` has always accepted a view saved against them. The deals screen never read or wrote one: its tab rail carried a single hardcoded "Newest" sort. A view was storable through the contract and then invisible in the product.

## The change

The deals **table** now shows saved views as tabs beside that standing sort, and offers the save action next to its existing dials.

The **board** does not get either. A saved view restores a sort and a set of filters; the board's order is the pipeline's stage order, so a view restored there would change nothing a reader could see. Its filters still work as before through the shared chips.

## Tests

Two, in `deals.test.tsx`: the saved view appears as a tab beside the standing sort, and picking it carries the saved filters into the `/deals` request. Both were mutation-checked — removing `dataViews` fails both.

Part of the deals improvement work reviewed this session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The deals table now shows saved views as tabs and lets users save them. Previously a view for deals was storable but invisible; saving now also records the selected pipeline so restores match the same list, but only if the reader has narrowed the list. The board remains unchanged.

- Renders tabs via `useSavedViewTabs("deals")` and passes `dataViews` to the table; selecting a tab applies its sort/filters to `/deals`.
- Adds `SaveViewAction` beside the table tools; it appears only after a sort/search/filter narrows the list and saves `pipeline_id` into the view’s filters.
- Tests cover: tab appears, selecting a view sends saved filters in the `/deals` request, the saved view includes the current pipeline, and the save action stays hidden until something is narrowed.

<sup>Written for commit 52f7cc06dd438c96ea5c7e01835298a61c945e6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

