### PR TITLE
feat(deals): a deal can be closed from its own page

### DIFF
--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -548,6 +548,21 @@
   background: var(--bgCard);
   border-radius: var(--r-full);
   padding: 4px 12px;
+  border: 0;
+  font-family: var(--f-body);
+}
+/* Every step but the current one is a button that moves the deal there, so it
+   has to read as pressable rather than as the label it sits beside. */
+.stepper button.step {
+  cursor: pointer;
+}
+.stepper button.step:hover:not(:disabled) {
+  color: var(--textOnAccentControl);
+  background: var(--accent);
+}
+.stepper button.step:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 .stepper .step.current {
   background: var(--accent);

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -535,11 +535,16 @@
 }
 
 /* Deal 360 stage stepper */
+/* A fieldset because the steps are a group of controls that act on one deal;
+   the browser's own border, padding and margin are not wanted with it. */
 .stepper {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
-  margin-bottom: 16px;
+  margin: 0 0 16px;
+  padding: 0;
+  border: 0;
+  min-inline-size: 0;
 }
 .stepper .step {
   font-size: 12.5px;

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1047,6 +1047,81 @@ describe("DealScreen — the stage stepper advances the deal", () => {
     expect(await screen.findByText("Moved to Proposal")).toBeTruthy();
   });
 
+  // A control that can only fail is worse than none: an archived deal is not
+  // moved through the pipeline, it is restored first.
+  it("offers no move on an archived deal", async () => {
+    const d = deal({ id: "x", archived_at: "2026-07-01T00:00:00Z" });
+    vi.stubGlobal("fetch", stubBackend([d], { single: d }));
+    render(<DealScreen id="x" />);
+
+    const step = await screen.findByRole("button", { name: "Proposal" });
+    expect(step.hasAttribute("disabled")).toBe(true);
+  });
+
+  // Reopening is its own deliberate action, with a dialog that says the close
+  // date and the frozen rate are being cleared. A stepper button that reopened
+  // silently would be a second, quieter door to the same write.
+  it("offers no move on a closed deal — reopening has its own action", async () => {
+    const d = deal({
+      id: "x",
+      status: "won",
+      stage_id: "s3",
+      closed_at: "2026-07-01T00:00:00Z",
+    });
+    vi.stubGlobal("fetch", stubBackend([d], { single: d }));
+    render(<DealScreen id="x" />);
+
+    const step = await screen.findByRole("button", { name: "Proposal" });
+    expect(step.hasAttribute("disabled")).toBe(true);
+  });
+
+  // The dialog stays mounted between openings, so an abandoned reason would
+  // otherwise still be sitting there the next time a deal is closed — and it
+  // would describe a different deal.
+  it("a lost reason typed and then cancelled does not come back", async () => {
+    const d = deal({ id: "x", version: 2, stage_id: "s1" });
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([d], {
+        single: d,
+        pipelines: [
+          {
+            id: "pl",
+            name: "Sales",
+            is_default: true,
+            position: 0,
+            stages: [
+              ...stages,
+              {
+                id: "s4",
+                pipeline_id: "pl",
+                name: "Lost",
+                position: 4,
+                semantic: "lost",
+                win_probability: 0,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealScreen id="x" />);
+
+    await user.click(await screen.findByRole("button", { name: "Lost" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Lost reason" }),
+      "typed then abandoned",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await user.click(await screen.findByRole("button", { name: "Lost" }));
+    expect(
+      (screen.getByRole("textbox", { name: "Lost reason" }) as HTMLInputElement)
+        .value,
+    ).toBe("");
+  });
+
   it("the stage the deal is already in is not a control", async () => {
     const d = deal({ id: "x", stage_id: "s1" });
     vi.stubGlobal("fetch", stubBackend([d], { single: d }));

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1004,6 +1004,113 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
   });
 });
 
+// Closing a deal used to be reachable only by dragging its card on the board,
+// which meant it could not be done from the deal's own page at all — and not
+// at all on a touch device, where HTML5 drag never fires.
+describe("DealScreen — the stage stepper advances the deal", () => {
+  beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
+
+  it("moving to an open stage posts the advance pinned to the version shown", async () => {
+    const advances: { body: unknown; ifMatch: string | null }[] = [];
+    const d = deal({ id: "x", version: 7, stage_id: "s1" });
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([d], {
+        single: d,
+        onAdvance: (body, ifMatch) => advances.push({ body, ifMatch }),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealScreen id="x" />);
+
+    await user.click(await screen.findByRole("button", { name: "Proposal" }));
+
+    await waitFor(() => expect(advances.length).toBe(1));
+    expect((advances[0].body as { to_stage_id: string }).to_stage_id).toBe(
+      "s2",
+    );
+    // The version the record was drawn from, so a change made elsewhere
+    // meanwhile fails loud rather than being erased.
+    expect(advances[0].ifMatch).toBe("7");
+  });
+
+  // The advance is only half the job: a write whose confirmation is shown to
+  // nobody reads exactly like one that did not happen.
+  it("confirms the move on the record itself", async () => {
+    const d = deal({ id: "x", version: 7, stage_id: "s1" });
+    vi.stubGlobal("fetch", stubBackend([d], { single: d }));
+    const user = userEvent.setup();
+    render(<DealScreen id="x" />);
+
+    await user.click(await screen.findByRole("button", { name: "Proposal" }));
+
+    expect(await screen.findByText("Moved to Proposal")).toBeTruthy();
+  });
+
+  it("the stage the deal is already in is not a control", async () => {
+    const d = deal({ id: "x", stage_id: "s1" });
+    vi.stubGlobal("fetch", stubBackend([d], { single: d }));
+    render(<DealScreen id="x" />);
+
+    await screen.findByRole("button", { name: "Proposal" });
+    expect(screen.queryByRole("button", { name: "Qualify" })).toBeNull();
+  });
+
+  // Terminal stages are the 🟡 confirm (AC-deal-6), and a lost deal must say
+  // why — the same rule the board's drop enforces, because it is the same
+  // dialog.
+  it("closing as lost asks for a reason before anything is written", async () => {
+    const advances: { body: unknown; ifMatch: string | null }[] = [];
+    const d = deal({ id: "x", version: 2, stage_id: "s1" });
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([d], {
+        single: d,
+        pipelines: [
+          {
+            id: "pl",
+            name: "Sales",
+            is_default: true,
+            position: 0,
+            stages: [
+              ...stages,
+              {
+                id: "s4",
+                pipeline_id: "pl",
+                name: "Lost",
+                position: 4,
+                semantic: "lost",
+                win_probability: 0,
+              },
+            ],
+          },
+        ],
+        onAdvance: (body, ifMatch) => advances.push({ body, ifMatch }),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealScreen id="x" />);
+
+    await user.click(await screen.findByRole("button", { name: "Lost" }));
+    // Nothing is written while the dialog stands open.
+    expect(advances.length).toBe(0);
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    expect(confirm.hasAttribute("disabled")).toBe(true);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Lost reason" }),
+      "went with a competitor",
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(advances.length).toBe(1));
+    const body = advances[0].body as { status: string; lost_reason: string };
+    expect(body.status).toBe("lost");
+    expect(body.lost_reason).toBe("went with a competitor");
+  });
+});
+
 describe("DealScreen — an archived deal keeps its verbs, refused", () => {
   beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
 

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -42,7 +42,7 @@ import { type ListChip, ListSurface } from "../design-system/listsurface";
 import type { ListColumn } from "../design-system/listtable";
 import { FieldGuard } from "../design-system/rbac";
 import { Select } from "../design-system/select";
-import { ToastRegion, useToast } from "../design-system/toast";
+import { type Toast, ToastRegion, useToast } from "../design-system/toast";
 import { AutonomyDot, ProvenanceTag } from "../design-system/trust";
 import {
   formatDate,
@@ -644,6 +644,59 @@ type PendingAdvance = {
   toStage: Stage;
 };
 
+type AdvanceInput = {
+  dealId: string;
+  version: number | undefined;
+  toStage: Stage;
+  lostReason?: string;
+};
+
+/**
+ * The ONE way this screen advances a deal, shared by the board's drag and the
+ * record page's stepper.
+ *
+ * An advance is a write like any other, so it is pinned like any other: the
+ * version the reader's own card or record was drawn from rides the variables,
+ * and two people moving one deal at the same moment no longer both succeed —
+ * the second reads the version the first replaced and fails 409 version_skew
+ * instead of quietly undoing a stage change nobody saw.
+ *
+ * The toast is the CALLER'S, not this hook's: `useToast` is local state, so an
+ * instance minted here would be a second one the caller's `ToastRegion` never
+ * renders, and every confirmation would be shown to nobody.
+ */
+function useAdvanceDeal(toast: Toast) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: AdvanceInput) => {
+      const terminal = input.toStage.semantic !== "open";
+      const { data, error } = await api.POST("/deals/{id}/advance", {
+        params: {
+          path: { id: input.dealId },
+          ...ifMatch(requireVersion(input.version)),
+        },
+        body: {
+          to_stage_id: input.toStage.id,
+          ...(terminal ? { status: input.toStage.semantic } : {}),
+          ...(input.toStage.semantic === "lost"
+            ? { lost_reason: input.lostReason }
+            : {}),
+        },
+      });
+      if (error) {
+        throwProblem(error, t);
+      }
+      return data;
+    },
+    onSuccess: (_deal, input) => {
+      queryClient.invalidateQueries({ queryKey: ["deals"] });
+      queryClient.invalidateQueries({ queryKey: ["deal", input.dealId] });
+      toast.show(t("deals.advanced", { stage: input.toStage.name }));
+    },
+  });
+}
+
 // Won reads success, lost reads danger, an open deal carries no status tone.
 function dealStatusTone(
   status: Deal["status"],
@@ -797,12 +850,10 @@ export function DealsScreen({
   const t = useT();
   const { locale } = useLocale();
   const cf = useObjectCustomFields("deal");
-  const queryClient = useQueryClient();
   const overlay = useSorMode() === "overlay";
   const pipelinesQuery = usePipelines(!overlay);
   const meQuery = useMe();
   const savedViews = useSavedViewTabs("deals");
-  const tierMap = useAgentTierMap();
   const [pipelineId, setPipelineId] = useState("");
   const [query, setQuery] = useState<ListQuery>({
     q: "",
@@ -839,47 +890,11 @@ export function DealsScreen({
     overlay ? "table" : "board",
   );
   const [pending, setPending] = useState<PendingAdvance | null>(null);
-  const [lostReason, setLostReason] = useState("");
   const toast = useToast();
   const dragging = useRef<string | null>(null);
   const lastDragEnd = useRef(0);
 
-  const advance = useMutation({
-    // An advance is a write like any other, so it is pinned like any other: the
-    // version the reader's own card was drawn from rides the variables, and two
-    // people moving one deal at the same moment no longer both succeed — the
-    // second reads the version the first replaced and fails 409 version_skew
-    // instead of quietly undoing a stage change nobody saw.
-    mutationFn: async (input: {
-      dealId: string;
-      version: number | undefined;
-      toStage: Stage;
-      lostReason?: string;
-    }) => {
-      const terminal = input.toStage.semantic !== "open";
-      const { data, error } = await api.POST("/deals/{id}/advance", {
-        params: {
-          path: { id: input.dealId },
-          ...ifMatch(requireVersion(input.version)),
-        },
-        body: {
-          to_stage_id: input.toStage.id,
-          ...(terminal ? { status: input.toStage.semantic } : {}),
-          ...(input.toStage.semantic === "lost"
-            ? { lost_reason: input.lostReason }
-            : {}),
-        },
-      });
-      if (error) {
-        throwProblem(error, t);
-      }
-      return data;
-    },
-    onSuccess: (_deal, input) => {
-      queryClient.invalidateQueries({ queryKey: ["deals"] });
-      toast.show(t("deals.advanced", { stage: input.toStage.name }));
-    },
-  });
+  const advance = useAdvanceDeal(toast);
 
   const stages = effectivePipeline?.stages ?? [];
   const stageName = new Map(stages.map((stage) => [stage.id, stage.name]));
@@ -960,7 +975,6 @@ export function DealsScreen({
       advance.mutate({ dealId, version, toStage });
     } else {
       // Terminal-stage advance is a 🟡 confirm (AC-deal-6).
-      setLostReason("");
       setPending({ dealId, version, toStage });
     }
   };
@@ -1241,59 +1255,84 @@ export function DealsScreen({
         </p>
       )}
       <ToastRegion toast={toast} />
-      <Modal
-        open={pending !== null}
+      <ConfirmAdvanceModal
+        pending={pending}
         onClose={() => setPending(null)}
-        labelledBy="advance-title"
-      >
-        {pending && (
-          <>
-            <p className="t-sub" id="advance-title">
-              <AutonomyDot tier={verbTier("progress_deal", tierMap)} />{" "}
-              {t("deals.confirmAdvance", { stage: pending.toStage.name })}
-            </p>
-            <p className="t-caption" style={{ marginTop: 6 }}>
-              {t("deals.confirmTerminal", { status: pending.toStage.semantic })}
-            </p>
-            {pending.toStage.semantic === "lost" && (
-              <div className="field" style={{ marginTop: 10 }}>
-                <span className="t-label" id="lost-reason-label">
-                  {t("deals.lostReason")}
-                </span>
-                <TextInput
-                  aria-labelledby="lost-reason-label"
-                  value={lostReason}
-                  onChange={(event) => setLostReason(event.target.value)}
-                />
-              </div>
-            )}
-            <div className="actions">
-              <Button onClick={() => setPending(null)}>
-                {t("deals.cancel")}
-              </Button>
-              <Button
-                variant="primary"
-                disabled={
-                  pending.toStage.semantic === "lost" &&
-                  lostReason.trim() === ""
-                }
-                onClick={() => {
-                  advance.mutate({
-                    dealId: pending.dealId,
-                    version: pending.version,
-                    toStage: pending.toStage,
-                    lostReason: lostReason.trim() || undefined,
-                  });
-                  setPending(null);
-                }}
-              >
-                {t("deals.confirm")}
-              </Button>
-            </div>
-          </>
-        )}
-      </Modal>
+        onConfirm={(input) => advance.mutate(input)}
+      />
     </div>
+  );
+}
+
+/**
+ * The 🟡 confirm a terminal advance goes through (AC-deal-6), wherever the
+ * advance was asked for — the board's drag or the record page's stepper.
+ *
+ * Closing a deal is the one stage move that cannot be undone by moving it
+ * back, so the question is asked in ONE place: a second copy of this dialog is
+ * how the two surfaces would end up disagreeing about whether a lost deal
+ * needs a reason.
+ */
+function ConfirmAdvanceModal({
+  pending,
+  onClose,
+  onConfirm,
+}: Readonly<{
+  pending: PendingAdvance | null;
+  onClose: () => void;
+  onConfirm: (input: AdvanceInput) => void;
+}>) {
+  const t = useT();
+  const tierMap = useAgentTierMap();
+  const [lostReason, setLostReason] = useState("");
+
+  return (
+    <Modal open={pending !== null} onClose={onClose} labelledBy="advance-title">
+      {pending && (
+        <>
+          <p className="t-sub" id="advance-title">
+            <AutonomyDot tier={verbTier("progress_deal", tierMap)} />{" "}
+            {t("deals.confirmAdvance", { stage: pending.toStage.name })}
+          </p>
+          <p className="t-caption" style={{ marginTop: "var(--space-2)" }}>
+            {t("deals.confirmTerminal", { status: pending.toStage.semantic })}
+          </p>
+          {pending.toStage.semantic === "lost" && (
+            <div className="field" style={{ marginTop: "var(--space-2)" }}>
+              <span className="t-label" id="lost-reason-label">
+                {t("deals.lostReason")}
+              </span>
+              <TextInput
+                aria-labelledby="lost-reason-label"
+                value={lostReason}
+                onChange={(event) => setLostReason(event.target.value)}
+              />
+            </div>
+          )}
+          <div className="actions">
+            <Button onClick={onClose}>{t("deals.cancel")}</Button>
+            <Button
+              variant="primary"
+              disabled={
+                pending.toStage.semantic === "lost" && lostReason.trim() === ""
+              }
+              onClick={() => {
+                onConfirm({
+                  dealId: pending.dealId,
+                  version: pending.version,
+                  toStage: pending.toStage,
+                  lostReason: lostReason.trim() || undefined,
+                });
+                setLostReason("");
+                onClose();
+              }}
+            >
+              {t("deals.confirm")}
+            </Button>
+          </div>
+        </>
+      )}
+    </Modal>
   );
 }
 
@@ -1899,6 +1938,9 @@ function DealOverviewPane({
   baseCurrency,
   onCreateOffer,
   overlay,
+  onAdvance,
+  advancing,
+  archived,
 }: Readonly<{
   deal: Deal;
   stages: Stage[];
@@ -1914,6 +1956,13 @@ function DealOverviewPane({
   baseCurrency: string | null;
   onCreateOffer: (currency: string) => void;
   overlay: boolean;
+  onAdvance: (toStage: Stage) => void;
+  /** One advance at a time: a second click while the first is in flight would
+   * send a second write pinned to the same version, and the loser reads as a
+   * conflict the reader never caused. */
+  advancing: boolean;
+  /** An archived deal is not moved through the pipeline; restore it first. */
+  archived: boolean;
 }>) {
   const t = useT();
   return (
@@ -1929,15 +1978,27 @@ function DealOverviewPane({
       )}
       {stages.length > 0 && (
         <nav className="stepper" aria-label={t("deals.stage")}>
-          {stages.map((stage) => (
-            <span
-              key={stage.id}
-              className={stage.id === deal.stage_id ? "step current" : "step"}
-              aria-current={stage.id === deal.stage_id ? "step" : undefined}
-            >
-              {stage.name}
-            </span>
-          ))}
+          {stages.map((stage) =>
+            stage.id === deal.stage_id ? (
+              <span key={stage.id} className="step current" aria-current="step">
+                {stage.name}
+              </span>
+            ) : (
+              // Where the deal is now is a fact, not a choice, so the current
+              // stage stays a marker. Every other stage is the move to it —
+              // which is what makes a deal closable from its own page rather
+              // than only by dragging its card on the board.
+              <button
+                key={stage.id}
+                type="button"
+                className="step"
+                disabled={advancing || archived}
+                onClick={() => onAdvance(stage)}
+              >
+                {stage.name}
+              </button>
+            ),
+          )}
         </nav>
       )}
       <DealApprovals approvals={dealApprovals} decide={onDecide} />
@@ -2017,6 +2078,9 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
   // point at it are two different slots of the same header.
   const archivedReasonId = useId();
   const [tab, setTab] = useState<DealTab>("overview");
+  const [pending, setPending] = useState<PendingAdvance | null>(null);
+  const toast = useToast();
+  const advance = useAdvanceDeal(toast);
   const dealQuery = useQuery({
     queryKey: ["deal", id],
     queryFn: async () => {
@@ -2208,12 +2272,47 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                   baseCurrency={baseCurrency}
                   onCreateOffer={(currency) => createOffer.mutate(currency)}
                   overlay={overlay}
+                  advancing={advance.isPending}
+                  archived={deal.archived_at != null}
+                  onAdvance={(toStage) => {
+                    // The version this record was drawn from, exactly as the
+                    // board pins the version its card was drawn from: the
+                    // write names the deal as the reader saw it, so a change
+                    // made elsewhere meanwhile fails loud.
+                    const input = {
+                      dealId: deal.id,
+                      version: deal.version,
+                      toStage,
+                    };
+                    if (toStage.semantic === "open") {
+                      advance.mutate(input);
+                    } else {
+                      setPending(input);
+                    }
+                  }}
                 />
               )}
               {tab === "history" && !overlay && (
                 <RecordHistoryTab kind="deal" id={deal.id} />
               )}
               {tab === "history" && overlay && <OverlayUnavailable />}
+              {advance.isError && (
+                <p
+                  className="t-caption"
+                  style={{
+                    color: "var(--danger)",
+                    marginTop: "var(--space-2)",
+                  }}
+                >
+                  {problemMessageOf(advance.error, t)}
+                </p>
+              )}
+              <ConfirmAdvanceModal
+                pending={pending}
+                onClose={() => setPending(null)}
+                onConfirm={(input) => advance.mutate(input)}
+              />
+              <ToastRegion toast={toast} />
             </RecordView>
           );
         }}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -100,9 +100,18 @@ type Stage = components["schemas"]["Stage"];
 type Pipeline = components["schemas"]["Pipeline"];
 type Offer = components["schemas"]["Offer"];
 
-function usePipeline() {
+/**
+ * The pipeline a record belongs to, falling back to the default.
+ *
+ * `pipelineId` is the deal's own. Without it this answered the DEFAULT
+ * pipeline for every deal, which was harmless while the stepper only drew
+ * stage names but is not once those stages are the moves on offer: the stages
+ * of a pipeline the deal is not in are targets the server refuses as a
+ * pipeline mismatch.
+ */
+function usePipeline(pipelineId?: string | null) {
   return useQuery({
-    queryKey: ["pipelines"],
+    queryKey: ["pipelines", pipelineId ?? "default"],
     queryFn: async () => {
       const { data, error } = await api.GET("/pipelines", {
         params: { query: {} },
@@ -111,7 +120,10 @@ function usePipeline() {
         throwProblem(error);
       }
       const pipeline =
-        data.data.find((candidate) => candidate.is_default) ?? data.data[0];
+        (pipelineId &&
+          data.data.find((candidate) => candidate.id === pipelineId)) ||
+        data.data.find((candidate) => candidate.is_default) ||
+        data.data[0];
       if (!pipeline) {
         throw new Error("no pipeline");
       }
@@ -689,7 +701,15 @@ function useAdvanceDeal(toast: Toast) {
       }
       return data;
     },
-    onSuccess: (_deal, input) => {
+    onSuccess: (deal, input) => {
+      // The advanced deal goes into the cache SYNCHRONOUSLY, before the
+      // refetch the invalidation schedules. isPending clears the moment this
+      // returns, so a reader who clicks a second stage immediately would
+      // otherwise pin the version this write just replaced and read a 409 they
+      // did not cause.
+      if (deal) {
+        queryClient.setQueryData(["deal", input.dealId], deal);
+      }
       queryClient.invalidateQueries({ queryKey: ["deals"] });
       queryClient.invalidateQueries({ queryKey: ["deal", input.dealId] });
       toast.show(t("deals.advanced", { stage: input.toStage.name }));
@@ -1286,8 +1306,17 @@ function ConfirmAdvanceModal({
   const tierMap = useAgentTierMap();
   const [lostReason, setLostReason] = useState("");
 
+  // EVERY way out of this dialog clears the reason — the buttons, Escape, and
+  // the backdrop alike. The component stays mounted between openings, so a
+  // reason typed and then abandoned would otherwise still be sitting there the
+  // next time a deal is closed, and it would describe a different deal.
+  const dismiss = () => {
+    setLostReason("");
+    onClose();
+  };
+
   return (
-    <Modal open={pending !== null} onClose={onClose} labelledBy="advance-title">
+    <Modal open={pending !== null} onClose={dismiss} labelledBy="advance-title">
       {pending && (
         <>
           <p className="t-sub" id="advance-title">
@@ -1310,7 +1339,7 @@ function ConfirmAdvanceModal({
             </div>
           )}
           <div className="actions">
-            <Button onClick={onClose}>{t("deals.cancel")}</Button>
+            <Button onClick={dismiss}>{t("deals.cancel")}</Button>
             <Button
               variant="primary"
               disabled={
@@ -1323,8 +1352,7 @@ function ConfirmAdvanceModal({
                   toStage: pending.toStage,
                   lostReason: lostReason.trim() || undefined,
                 });
-                setLostReason("");
-                onClose();
+                dismiss();
               }}
             >
               {t("deals.confirm")}
@@ -1940,7 +1968,7 @@ function DealOverviewPane({
   overlay,
   onAdvance,
   advancing,
-  archived,
+  advanceRefused,
 }: Readonly<{
   deal: Deal;
   stages: Stage[];
@@ -1961,8 +1989,9 @@ function DealOverviewPane({
    * send a second write pinned to the same version, and the loser reads as a
    * conflict the reader never caused. */
   advancing: boolean;
-  /** An archived deal is not moved through the pipeline; restore it first. */
-  archived: boolean;
+  /** Where this deal cannot be moved at all — archived (restore it first), or
+   * mirrored from an incumbent that refuses the write. */
+  advanceRefused: boolean;
 }>) {
   const t = useT();
   return (
@@ -1976,8 +2005,11 @@ function DealOverviewPane({
           locale={locale}
         />
       )}
+      {/* A group, not a nav: these buttons move the deal, they do not take the
+          reader anywhere, and a landmark in the navigation list that writes
+          when you press it misdescribes what it does. */}
       {stages.length > 0 && (
-        <nav className="stepper" aria-label={t("deals.stage")}>
+        <fieldset className="stepper" aria-label={t("deals.stage")}>
           {stages.map((stage) =>
             stage.id === deal.stage_id ? (
               <span key={stage.id} className="step current" aria-current="step">
@@ -1992,14 +2024,14 @@ function DealOverviewPane({
                 key={stage.id}
                 type="button"
                 className="step"
-                disabled={advancing || archived}
+                disabled={advancing || advanceRefused}
                 onClick={() => onAdvance(stage)}
               >
                 {stage.name}
               </button>
             ),
           )}
-        </nav>
+        </fieldset>
       )}
       <DealApprovals approvals={dealApprovals} decide={onDecide} />
       {/* Above the stakeholder list on purpose: the findings are ABOUT those
@@ -2093,7 +2125,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
       return data;
     },
   });
-  const pipelineQuery = usePipeline();
+  const pipelineQuery = usePipeline(dealQuery.data?.pipeline_id);
   // One shared singleton read (the ["installation-settings"] key), not a
   // per-deal request: the FX line has to name the base currency it converted
   // into, and nothing on the deal itself carries it.
@@ -2273,7 +2305,20 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                   onCreateOffer={(currency) => createOffer.mutate(currency)}
                   overlay={overlay}
                   advancing={advance.isPending}
-                  archived={deal.archived_at != null}
+                  // An archived deal is not moved through the pipeline, and
+                  // the mirror answers an advance with unsupported_by_sor —
+                  // a control that can only fail is worse than none.
+                  //
+                  // A CLOSED deal is refused here too, but for a different
+                  // reason: reopening is its own deliberate action, with a
+                  // dialog that says the close date and the frozen rate are
+                  // being cleared. A stepper button that reopened silently
+                  // would be a second, quieter door to the same write.
+                  advanceRefused={
+                    deal.archived_at != null ||
+                    overlay ||
+                    deal.status !== "open"
+                  }
                   onAdvance={(toStage) => {
                     // The version this record was drawn from, exactly as the
                     // board pins the version its card was drawn from: the


### PR DESCRIPTION
## What was missing

Advancing a deal was reachable only by dragging its card on the board. The stage stepper on the deal record was display-only, so a rep looking at a deal had to go back to the board to move it — and on a touch device could not move it at all, because HTML5 drag never fires there.

## The change

Every stage in the stepper except the current one is now the move to it. Terminal stages go through the same confirm the board's drop opens, including the lost-reason requirement, because it is now literally the same component: the dialog and the advance mutation were extracted so the two surfaces cannot drift into disagreeing about what closing a deal requires.

The advance pins the version the record was drawn from, exactly as the board pins the version its card was drawn from.

## What the stepper refuses

- **Archived** — restore it first.
- **Overlay** — the mirror answers an advance with `unsupported_by_sor`.
- **Closed** — reopening is its own action, with a dialog that says the close date and the frozen rate are being cleared.

## Defects found in review and fixed here

- The record read the **default** pipeline for every deal, so a deal in another pipeline would have offered stages the server rejects as a mismatch.
- The advanced deal is now placed in the cache synchronously, so a fast second click cannot pin a version the first write already replaced.
- Cancel, Escape and the backdrop clear the lost reason, not just Confirm — the dialog stays mounted, so an abandoned reason described the next deal closed.
- The toast is passed into the shared hook rather than minted inside it: `useToast` is local state, so an instance created in the hook would be a second one no `ToastRegion` renders, and every confirmation would be shown to nobody.

## Tests

Seven, covering the open-stage advance and its version pin, the confirmation appearing, the lost-reason requirement and its clearing on cancel, and the archived/closed refusals. Each was mutation-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the deal stage stepper actionable on the deal page so reps can advance or close a deal without going back to the board. Previously the stepper was read-only and moving a deal required drag-and-drop on the board, which doesn’t work on touch.

- Every non-current step is a button; terminal stages open the same confirmation used on the board, including the required lost reason for Lost.
- Use one shared advance mutation and one shared confirmation modal for board and record so closing rules cannot drift.
- Pin the advance to the record’s rendered version; update the deal in the cache synchronously; show the confirmation via the caller’s `useToast`/`ToastRegion` so toasts render.
- Disable stepper actions when the deal is archived, mirrored in overlay mode, or already closed (reopen remains a separate, explicit action).
- Resolve the deal’s own pipeline (not the default) to offer only valid target stages; adjust stepper semantics/styles to a fieldset of buttons with hover/disabled states.
- Add tests for version pinning, confirmation flow, lost-reason requirement and clearing on cancel/backdrop/Escape, and refusal cases for archived/closed deals.

<sup>Written for commit 56ccae15dafbd9ca7d55c3721db9840ffefe2f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deal stage steppers now support moving deals between stages directly from the deal record.
  - Stage changes include confirmation and lost-reason validation when applicable.
  - Deal pipelines are selected more accurately using each deal’s configured pipeline.

- **Bug Fixes**
  - Prevented stage changes for archived, mirrored, closed, or currently updating deals.
  - Improved handling when cancelled lost reasons are reset.
  - Added safeguards to keep stage updates consistent and current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->