### PR TITLE
feat(deals): bulk assign, move and archive from the deals table

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1549,6 +1549,17 @@ export const de = {
   "deals.unit": "Deals",
   "deals.capped":
     "Zeigt die bisher geladenen Deals. Grenzen Sie die Liste ein, um die übrigen zu erreichen.",
+  "deals.bulkSelected": "{count} ausgewählt",
+  "deals.bulkSelectRow": "{name} auswählen",
+  "deals.bulkOwner": "Neuer Verantwortlicher",
+  "deals.bulkOwnerPick": "Verantwortlichen wählen",
+  "deals.bulkAssign": "Zuweisen",
+  "deals.bulkStage": "In Phase verschieben",
+  "deals.bulkStagePick": "Phase wählen",
+  "deals.bulkMove": "Verschieben",
+  "deals.bulkArchive": "Archivieren",
+  "deals.bulkFailed": "{count} nicht übernommen –",
+  "deals.bulkFailedRow": "konnte nicht gespeichert werden",
 
   "deal.offers": "Angebote",
   "deal.newOffer": "Neues Angebot",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1558,6 +1558,9 @@ export const de = {
   "deals.bulkStagePick": "Phase wählen",
   "deals.bulkMove": "Verschieben",
   "deals.bulkArchive": "Archivieren",
+  "deals.bulkArchiveConfirmTitle": "{count} Deals archivieren?",
+  "deals.bulkArchiveConfirmBody":
+    "Sie verschwinden aus allen Listen und Auswertungen. Wiederherstellen geht nur einzeln, direkt am Deal.",
   "deals.bulkFailed": "{count} nicht übernommen –",
   "deals.bulkFailedRow": "konnte nicht gespeichert werden",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1553,6 +1553,17 @@ export const en = {
   "deals.unit": "deals",
   "deals.capped":
     "Showing the deals loaded so far. Narrow the list to reach the rest.",
+  "deals.bulkSelected": "{count} selected",
+  "deals.bulkSelectRow": "Select {name}",
+  "deals.bulkOwner": "New owner",
+  "deals.bulkOwnerPick": "Pick an owner",
+  "deals.bulkAssign": "Assign",
+  "deals.bulkStage": "Move to stage",
+  "deals.bulkStagePick": "Pick a stage",
+  "deals.bulkMove": "Move",
+  "deals.bulkArchive": "Archive",
+  "deals.bulkFailed": "{count} not applied —",
+  "deals.bulkFailedRow": "could not be saved",
 
   "deal.offers": "Offers",
   "deal.newOffer": "New offer",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1562,6 +1562,9 @@ export const en = {
   "deals.bulkStagePick": "Pick a stage",
   "deals.bulkMove": "Move",
   "deals.bulkArchive": "Archive",
+  "deals.bulkArchiveConfirmTitle": "Archive {count} deals?",
+  "deals.bulkArchiveConfirmBody":
+    "They leave every list and report. Restoring one is done from the deal itself, one at a time.",
   "deals.bulkFailed": "{count} not applied —",
   "deals.bulkFailedRow": "could not be saved",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1540,6 +1540,17 @@ export const vi = {
   "deals.unit": "deal",
   "deals.capped":
     "Đang hiển thị các deal đã tải. Hãy thu hẹp danh sách để xem phần còn lại.",
+  "deals.bulkSelected": "Đã chọn {count}",
+  "deals.bulkSelectRow": "Chọn {name}",
+  "deals.bulkOwner": "Người phụ trách mới",
+  "deals.bulkOwnerPick": "Chọn người phụ trách",
+  "deals.bulkAssign": "Gán",
+  "deals.bulkStage": "Chuyển sang giai đoạn",
+  "deals.bulkStagePick": "Chọn giai đoạn",
+  "deals.bulkMove": "Chuyển",
+  "deals.bulkArchive": "Lưu trữ",
+  "deals.bulkFailed": "{count} không áp dụng được —",
+  "deals.bulkFailedRow": "không lưu được",
 
   "deal.offers": "Báo giá",
   "deal.newOffer": "Báo giá mới",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1549,6 +1549,9 @@ export const vi = {
   "deals.bulkStagePick": "Chọn giai đoạn",
   "deals.bulkMove": "Chuyển",
   "deals.bulkArchive": "Lưu trữ",
+  "deals.bulkArchiveConfirmTitle": "Lưu trữ {count} deal?",
+  "deals.bulkArchiveConfirmBody":
+    "Chúng sẽ biến mất khỏi mọi danh sách và báo cáo. Khôi phục phải làm từng deal một.",
   "deals.bulkFailed": "{count} không áp dụng được —",
   "deals.bulkFailedRow": "không lưu được",
 

--- a/frontend/src/screens/dealbulk.stories.tsx
+++ b/frontend/src/screens/dealbulk.stories.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { DealBulkBar } from "./dealbulk";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The bar that appears under the deals table while rows are selected. It reads
+// the user roster for the owner picker; everything else it needs is passed in,
+// so these stories are the bar's own states rather than the table's.
+const meta: Meta = {
+  title: "Records/Deal bulk bar",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj;
+type Deal = components["schemas"]["Deal"];
+type Stage = components["schemas"]["Stage"];
+
+const stages: Stage[] = [
+  {
+    id: "s1",
+    pipeline_id: "pl",
+    name: "Qualify",
+    position: 1,
+    semantic: "open",
+    win_probability: 20,
+  },
+  {
+    id: "s2",
+    pipeline_id: "pl",
+    name: "Proposal",
+    position: 2,
+    semantic: "open",
+    win_probability: 40,
+  },
+  // Terminal stages are deliberately absent from the picker: closing a deal
+  // asks for a reason and freezes a rate, which is not a bulk gesture.
+  {
+    id: "s3",
+    pipeline_id: "pl",
+    name: "Won",
+    position: 3,
+    semantic: "won",
+    win_probability: 100,
+  },
+];
+
+function deal(id: string, name: string): Deal {
+  return {
+    id,
+    name,
+    amount_minor: 4_800_000,
+    currency: "EUR",
+    pipeline_id: "pl",
+    stage_id: "s1",
+    status: "open",
+    source: "manual",
+    captured_by: "human:u1",
+    version: 4,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+  } as Deal;
+}
+
+const roster = {
+  data: [
+    {
+      id: "u-1",
+      email: "mila@acme.test",
+      display_name: "Mila Brandt",
+      timezone: "UTC",
+      status: "active",
+      is_agent: false,
+    },
+  ],
+  page: { next_cursor: null, has_more: false },
+};
+
+export const Selected: Story = {
+  render: () => {
+    installFetchStub({ "GET /users": () => jsonResponse(roster) });
+    return (
+      <StoryProviders>
+        <div className="lt-bulkbar">
+          <DealBulkBar
+            deals={[deal("d1", "Fleet retrofit"), deal("d2", "Depot rollout")]}
+            stages={stages}
+            onDone={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};
+
+// The German copy, whose length is the thing worth looking at here: three
+// verbs and two pickers share one row.
+export const German: Story = {
+  render: () => {
+    installFetchStub({ "GET /users": () => jsonResponse(roster) });
+    return (
+      <StoryProviders locale="de">
+        <div className="lt-bulkbar">
+          <DealBulkBar
+            deals={[deal("d1", "Fleet retrofit"), deal("d2", "Depot rollout")]}
+            stages={stages}
+            onDone={() => {}}
+          />
+        </div>
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/dealbulk.tsx
+++ b/frontend/src/screens/dealbulk.tsx
@@ -1,0 +1,190 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ifMatch, requireVersion } from "../api/version";
+import { Button } from "../design-system/atoms";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import { ProblemError, problemMessageOf, throwProblem } from "./common";
+import { useRoster } from "./entityref";
+
+type Deal = components["schemas"]["Deal"];
+type Stage = components["schemas"]["Stage"];
+
+/** One row's outcome in a fan-out: it went through, or it did not and why. */
+export type DealBulkOutcome = { id: string; name: string; error?: string };
+
+/**
+ * Bulk verbs over selected deals: assign an owner, move to a stage, archive.
+ *
+ * Every verb is a client-side fan-out of the record's own write — there is no
+ * bulk endpoint, and inventing one would bypass the per-row version guard.
+ * Each row sends ITS OWN If-Match from the version the list holds; one version
+ * copied across the selection would conflict on every row but the one it came
+ * from. A row that moved under the reader answers 409, is reported by name,
+ * and can be retried once the list has refetched.
+ *
+ * Only OPEN stages are offered. Closing a deal asks for a lost reason and
+ * freezes an exchange rate, and doing that to a dozen deals behind one button
+ * — with one reason standing for all of them — is not a thing this bar should
+ * make easy.
+ */
+export function DealBulkBar({
+  deals,
+  stages,
+  onDone,
+}: Readonly<{
+  /** The selected rows, with the versions the list currently holds. */
+  deals: readonly Deal[];
+  /** The pipeline's stages; the terminal ones are filtered out here. */
+  stages: readonly Stage[];
+  /** Called after any run — the caller refetches and clears the selection. */
+  onDone: (outcomes: readonly DealBulkOutcome[]) => void;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [ownerId, setOwnerId] = useState("");
+  const [stageId, setStageId] = useState("");
+  const roster = useRoster("user", true);
+  const [outcomes, setOutcomes] = useState<readonly DealBulkOutcome[]>([]);
+  const openStages = stages.filter((stage) => stage.semantic === "open");
+
+  const run = useMutation({
+    mutationFn: async ({
+      write,
+    }: {
+      write: (deal: Deal) => Promise<void>;
+    }): Promise<DealBulkOutcome[]> =>
+      // Sequential, not Promise.all: a bulk verb over a working list is a
+      // handful of rows, and a burst of concurrent writes against one
+      // reader's own deals buys nothing but contention.
+      deals.reduce<Promise<DealBulkOutcome[]>>(async (acc, deal) => {
+        const done = await acc;
+        const name = deal.name;
+        try {
+          await write(deal);
+          done.push({ id: deal.id, name });
+        } catch (error) {
+          done.push({
+            id: deal.id,
+            name,
+            error:
+              error instanceof ProblemError
+                ? problemMessageOf(error, t)
+                : t("deals.bulkFailedRow"),
+          });
+        }
+        return done;
+      }, Promise.resolve([])),
+    onSuccess: async (result) => {
+      // Awaited: the rows that refused keep their selection so they can be
+      // retried, and a retry that fired before the refetch landed would
+      // resend the very version that just conflicted. The run stays pending
+      // — and the verbs disabled — until the list holds fresh versions.
+      await queryClient.invalidateQueries({ queryKey: ["deals"] });
+      setOutcomes(result);
+      onDone(result);
+    },
+  });
+
+  const assign = () =>
+    run.mutate({
+      write: async (deal) => {
+        const { error } = await api.PATCH("/deals/{id}", {
+          params: {
+            path: { id: deal.id },
+            ...ifMatch(requireVersion(deal.version)),
+          },
+          body: { owner_id: ownerId },
+        });
+        if (error) {
+          throwProblem(error, t);
+        }
+      },
+    });
+
+  const moveStage = () =>
+    run.mutate({
+      write: async (deal) => {
+        const { error } = await api.POST("/deals/{id}/advance", {
+          params: {
+            path: { id: deal.id },
+            ...ifMatch(requireVersion(deal.version)),
+          },
+          body: { to_stage_id: stageId },
+        });
+        if (error) {
+          throwProblem(error, t);
+        }
+      },
+    });
+
+  const archive = () =>
+    run.mutate({
+      write: async (deal) => {
+        const { error } = await api.DELETE("/deals/{id}", {
+          params: { path: { id: deal.id } },
+        });
+        if (error) {
+          throwProblem(error, t);
+        }
+      },
+    });
+
+  const failed = outcomes.filter((outcome) => outcome.error);
+  const busy = run.isPending || deals.length === 0;
+  return (
+    <>
+      <span className="t-caption">
+        {t("deals.bulkSelected", { count: deals.length })}
+      </span>
+      <Select
+        aria-label={t("deals.bulkOwner")}
+        value={ownerId}
+        placeholder={t("deals.bulkOwnerPick")}
+        disabled={run.isPending}
+        onChange={setOwnerId}
+        options={(roster.data ?? []).map((entry) => ({
+          value: entry.id,
+          // The user roster: every entry carries a display name; a team
+          // (the other roster kind) is never asked for here.
+          label: "display_name" in entry ? entry.display_name : entry.id,
+        }))}
+      />
+      <Button
+        small
+        variant="primary"
+        disabled={busy || ownerId === ""}
+        onClick={assign}
+      >
+        {t("deals.bulkAssign")}
+      </Button>
+      <Select
+        aria-label={t("deals.bulkStage")}
+        value={stageId}
+        placeholder={t("deals.bulkStagePick")}
+        disabled={run.isPending}
+        onChange={setStageId}
+        options={openStages.map((stage) => ({
+          value: stage.id,
+          label: stage.name,
+        }))}
+      />
+      <Button small disabled={busy || stageId === ""} onClick={moveStage}>
+        {t("deals.bulkMove")}
+      </Button>
+      <Button small disabled={busy} onClick={archive}>
+        {t("deals.bulkArchive")}
+      </Button>
+      {failed.length > 0 && (
+        <span className="t-caption" style={{ color: "var(--danger)" }}>
+          {t("deals.bulkFailed", { count: failed.length })}{" "}
+          {failed
+            .map((outcome) => `${outcome.name}: ${outcome.error}`)
+            .join(" · ")}
+        </span>
+      )}
+    </>
+  );
+}

--- a/frontend/src/screens/dealbulk.tsx
+++ b/frontend/src/screens/dealbulk.tsx
@@ -4,6 +4,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { Button } from "../design-system/atoms";
+import { ConfirmModal } from "../design-system/confirmmodal";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import { ProblemError, problemMessageOf, throwProblem } from "./common";
@@ -48,18 +49,51 @@ export function DealBulkBar({
   const [stageId, setStageId] = useState("");
   const roster = useRoster("user", true);
   const [outcomes, setOutcomes] = useState<readonly DealBulkOutcome[]>([]);
+  const [confirmingArchive, setConfirmingArchive] = useState(false);
   const openStages = stages.filter((stage) => stage.semantic === "open");
 
+  // The bar unmounts only when the selection empties, so going from one set of
+  // deals straight to another keeps this instance — and with it an owner or
+  // stage chosen for rows that are no longer selected. A verb armed for one
+  // selection must not fire at another, so the pickers clear when the
+  // membership changes.
+  const selectionKey = deals
+    .map((deal) => deal.id)
+    .sort()
+    .join(",");
+  const [armedFor, setArmedFor] = useState(selectionKey);
+  if (armedFor !== selectionKey) {
+    setArmedFor(selectionKey);
+    setOwnerId("");
+    setStageId("");
+  }
+
+  // Shown only for rows still in the selection. A run that partly failed
+  // narrows the selection to the rows that refused, and those messages are
+  // exactly what the reader needs; a message about a row they have since
+  // deselected is not, and clearing outright would take the first with the
+  // second.
+  const failed = outcomes.filter(
+    (outcome) => outcome.error && deals.some((deal) => deal.id === outcome.id),
+  );
+
   const run = useMutation({
+    // The rows ride the VARIABLES, never the closure. React Query re-arms a
+    // mutation's options in a passive effect, so a verb pressed immediately
+    // after the selection changed would otherwise fan out over the PREVIOUS
+    // render's selection — writing to deals the reader had just deselected,
+    // at versions the list no longer shows.
     mutationFn: async ({
+      rows,
       write,
     }: {
+      rows: readonly Deal[];
       write: (deal: Deal) => Promise<void>;
     }): Promise<DealBulkOutcome[]> =>
       // Sequential, not Promise.all: a bulk verb over a working list is a
       // handful of rows, and a burst of concurrent writes against one
       // reader's own deals buys nothing but contention.
-      deals.reduce<Promise<DealBulkOutcome[]>>(async (acc, deal) => {
+      rows.reduce<Promise<DealBulkOutcome[]>>(async (acc, deal) => {
         const done = await acc;
         const name = deal.name;
         try {
@@ -90,6 +124,7 @@ export function DealBulkBar({
 
   const assign = () =>
     run.mutate({
+      rows: [...deals],
       write: async (deal) => {
         const { error } = await api.PATCH("/deals/{id}", {
           params: {
@@ -106,6 +141,12 @@ export function DealBulkBar({
 
   const moveStage = () =>
     run.mutate({
+      // A deal already in the target stage is left alone. The server treats
+      // every advance as a transition — it writes a stage-history row and
+      // emits deal.stage_changed without asking whether anything moved — so
+      // sending one for a row already there would record a move that never
+      // happened, in the table the velocity reports read.
+      rows: deals.filter((deal) => deal.stage_id !== stageId),
       write: async (deal) => {
         const { error } = await api.POST("/deals/{id}/advance", {
           params: {
@@ -122,6 +163,7 @@ export function DealBulkBar({
 
   const archive = () =>
     run.mutate({
+      rows: [...deals],
       write: async (deal) => {
         const { error } = await api.DELETE("/deals/{id}", {
           params: { path: { id: deal.id } },
@@ -132,7 +174,6 @@ export function DealBulkBar({
       },
     });
 
-  const failed = outcomes.filter((outcome) => outcome.error);
   const busy = run.isPending || deals.length === 0;
   return (
     <>
@@ -174,9 +215,26 @@ export function DealBulkBar({
       <Button small disabled={busy || stageId === ""} onClick={moveStage}>
         {t("deals.bulkMove")}
       </Button>
-      <Button small disabled={busy} onClick={archive}>
+      <Button small disabled={busy} onClick={() => setConfirmingArchive(true)}>
         {t("deals.bulkArchive")}
       </Button>
+      {/* Archiving many deals at once is the most destructive thing this bar
+          does, and every other archive in the product asks first. One click
+          that removes a dozen rows from every list must not be the exception. */}
+      <ConfirmModal
+        open={confirmingArchive}
+        onClose={() => setConfirmingArchive(false)}
+        title={t("deals.bulkArchiveConfirmTitle", { count: deals.length })}
+        confirmLabel={t("deals.bulkArchive")}
+        confirmVariant="danger"
+        pending={run.isPending}
+        onConfirm={() => {
+          setConfirmingArchive(false);
+          archive();
+        }}
+      >
+        <p className="t-caption">{t("deals.bulkArchiveConfirmBody")}</p>
+      </ConfirmModal>
       {failed.length > 0 && (
         <span className="t-caption" style={{ color: "var(--danger)" }}>
           {t("deals.bulkFailed", { count: failed.length })}{" "}

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -337,6 +337,21 @@ function stubBackend(
     const request = input instanceof Request ? input : null;
     const url = String(request ? request.url : input);
     const method = request ? request.method : (init?.method ?? "GET");
+    if (method === "GET" && url.includes("/users")) {
+      return jsonResponse({
+        data: [
+          {
+            id: "u-me",
+            email: "me@acme.test",
+            display_name: "Me",
+            timezone: "UTC",
+            status: "active",
+            is_agent: false,
+          },
+        ],
+        page: { next_cursor: null },
+      });
+    }
     if (method === "POST" && url.includes("/views")) {
       const body = request
         ? await request.json()
@@ -590,6 +605,64 @@ describe("DealsScreen", () => {
     await user.click(await screen.findByRole("button", { name: "Table" }));
 
     expect(screen.queryByRole("button", { name: "Save view" })).toBeNull();
+  });
+
+  // A bulk verb is a fan-out of each row's own write, so every row must carry
+  // ITS OWN version. One version copied across the selection would conflict on
+  // every row but the one it came from.
+  it("assigning an owner in bulk sends each row's own version", async () => {
+    const patches: { body: unknown; ifMatch: string | null }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend(
+        [
+          deal({ id: "d1", name: "First", version: 3 }),
+          deal({ id: "d2", name: "Second", version: 9 }),
+        ],
+        { onPatch: (body, ifMatch) => patches.push({ body, ifMatch }) },
+      ),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+
+    await user.click(
+      await screen.findByRole("checkbox", { name: "Select First" }),
+    );
+    await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "New owner" }),
+      "Me",
+    );
+    await user.click(screen.getByRole("button", { name: "Assign" }));
+
+    await waitFor(() => expect(patches.length).toBe(2));
+    expect(patches.map((patch) => patch.ifMatch).sort()).toEqual(["3", "9"]);
+    expect((patches[0].body as { owner_id: string }).owner_id).toBe("u-me");
+  });
+
+  // A closed deal takes no bulk write: archiving it is done or meaningless,
+  // and moving it between open stages would be the silent reopen the record
+  // page's stepper already refuses.
+  it("offers no checkbox on a closed deal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([
+        deal({ id: "d1", name: "Open one" }),
+        deal({ id: "d2", name: "Won one", status: "won", stage_id: "s3" }),
+      ]),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+
+    expect(
+      await screen.findByRole("checkbox", { name: "Select Open one" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("checkbox", { name: "Select Won one" }),
+    ).toBeNull();
   });
 
   // The board's column total must come from the deals-by-stage

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -642,6 +642,71 @@ describe("DealsScreen", () => {
     expect((patches[0].body as { owner_id: string }).owner_id).toBe("u-me");
   });
 
+  // The server treats every advance as a transition — it writes a stage-history
+  // row and emits deal.stage_changed without asking whether anything moved — so
+  // a row already in the target stage must not be sent at all, or the velocity
+  // reports read a move that never happened.
+  it("moving to a stage skips the rows already in it", async () => {
+    const advances: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend(
+        [
+          deal({ id: "d1", name: "Already there", stage_id: "s2" }),
+          deal({ id: "d2", name: "Needs moving", stage_id: "s1" }),
+        ],
+        { onAdvance: (_body, _ifMatch) => advances.push("advance") },
+      ),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+
+    await user.click(
+      await screen.findByRole("checkbox", { name: "Select Already there" }),
+    );
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select Needs moving" }),
+    );
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "Move to stage" }),
+      "Proposal",
+    );
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    // One write, for the row that actually moves.
+    await waitFor(() => expect(advances.length).toBe(1));
+  });
+
+  // Archiving many deals at once is the most destructive thing this bar does,
+  // and every other archive in the product asks first.
+  it("bulk archive asks before it removes anything", async () => {
+    let deleted = 0;
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({ id: "d1", name: "First" })], {
+        onDelete: () => {
+          deleted += 1;
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await user.click(await screen.findByRole("button", { name: "Table" }));
+    await user.click(
+      await screen.findByRole("checkbox", { name: "Select First" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+    expect(deleted).toBe(0);
+
+    // The dialog's own Archive button, not the bar's.
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Archive" }));
+    await waitFor(() => expect(deleted).toBe(1));
+  });
+
   // A closed deal takes no bulk write: archiving it is done or meaningless,
   // and moving it between open stages would be the silent reopen the record
   // page's stepper already refuses.

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -73,6 +73,7 @@ import type { CreateField } from "./create";
 import { CreateAction } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
+import { DealBulkBar } from "./dealbulk";
 import { EditAction } from "./edit";
 import { RecordHistoryTab } from "./history";
 import { usePendingApprovals } from "./inbox.queries";
@@ -910,6 +911,9 @@ export function DealsScreen({
     overlay ? "table" : "board",
   );
   const [pending, setPending] = useState<PendingAdvance | null>(null);
+  // Bulk selection, by deal id. Cleared after any bulk run except for the rows
+  // that refused, since every other row's version has moved.
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
   const toast = useToast();
   const dragging = useRef<string | null>(null);
   const lastDragEnd = useRef(0);
@@ -918,6 +922,13 @@ export function DealsScreen({
 
   const stages = effectivePipeline?.stages ?? [];
   const stageName = new Map(stages.map((stage) => [stage.id, stage.name]));
+  // Only ids the list currently holds count as selected: a row that left the
+  // result set (refetched away, filtered out, archived by this very run) must
+  // not linger as an invisible selection nobody can clear.
+  const selectedRows = (dealsQuery.data?.data ?? []).filter((deal) =>
+    selected.has(deal.id),
+  );
+  const liveSelection = new Set(selectedRows.map((deal) => deal.id));
 
   // dealsQuery is a plain (non-infinite) query — the board reads one honest
   // screenful, never a keyset walk (see useDeals) — so the table view's
@@ -1231,6 +1242,43 @@ export function DealsScreen({
           tools={tableTools}
           dataChips={dealChips}
           dataViews={savedViews}
+          selection={{
+            selected: liveSelection,
+            // A closed or archived deal takes no bulk write: archiving it is
+            // done or meaningless, and moving it between open stages would be
+            // the silent reopen the stepper already refuses.
+            selectable: (deal) =>
+              deal.archived_at == null && deal.status === "open",
+            onToggle: (deal) =>
+              setSelected((prev) => {
+                const next = new Set(prev);
+                if (next.has(deal.id)) {
+                  next.delete(deal.id);
+                } else {
+                  next.add(deal.id);
+                }
+                return next;
+              }),
+            label: (deal) => t("deals.bulkSelectRow", { name: deal.name }),
+            bar: (
+              <DealBulkBar
+                deals={selectedRows}
+                stages={stages}
+                // The rows that went through leave the selection; the ones
+                // that refused stay in it, named, so the reader can retry
+                // them once the list has refetched their versions.
+                onDone={(outcomes) =>
+                  setSelected(
+                    new Set(
+                      outcomes
+                        .filter((outcome) => outcome.error)
+                        .map((outcome) => outcome.id),
+                    ),
+                  )
+                }
+              />
+            ),
+          }}
           chips={[
             {
               key: "stalled",


### PR DESCRIPTION
## What was missing

Changing the owner of a dozen deals meant opening a dozen deals. The table primitive has carried selection and a bulk bar all along, and the leads screen has used them since it shipped; the deals table passed no selection at all.

## The change

Three verbs: **assign an owner**, **move to an open stage**, **archive**. Each is a client-side fan-out of the record's own write, because there is no bulk endpoint and inventing one would bypass the per-row version guard. Every row sends its own `If-Match` from the version the list holds, so a row that moved under the reader answers 409, is reported by name, and can be retried once the list has refetched.

Only open stages are offered. Closing a deal asks for a lost reason and freezes an exchange rate, and doing that to a dozen deals behind one button — with one reason standing for all of them — is not something this bar should make easy. A closed or archived deal offers no checkbox at all.

## Defects found in review and fixed here

- **The rows now ride the mutation variables, not the render closure.** React Query re-arms mutation options in a passive effect, so a verb pressed right after the selection changed fanned out over the *previous* selection. `frontend/CLAUDE.md` documents this exact shape.
- **The pickers clear when the selection changes**, so a verb armed for one set of deals cannot fire at another. Failure messages are filtered to still-selected rows rather than cleared, since a partly failed run narrows the selection to exactly the rows whose messages matter.
- **Rows already in the target stage are skipped.** The server records a stage-history row and emits `deal.stage_changed` for every advance without asking whether anything moved, so sending a no-op wrote a transition that never happened.
- **Bulk archive asks first**, through the same confirm every other archive uses.

## Not fixed here

`DELETE /deals/{id}` takes no `If-Match` — the contract declares none and the store archives with no version predicate — so bulk archive cannot pin versions the way assign and move do. Filed as #2031.

## Tests

Five, each mutation-checked: per-row version pinning on assign, no checkbox on a closed deal, same-stage rows skipped, archive confirming before it removes anything. Plus a Storybook story in both English and German, since three verbs and two pickers share one row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk actions to the deals table: assign owner, move to an open stage, and archive. Previously, you had to open each deal; now each row writes with its own version guard and reports conflicts by name.

- Uses per-row `If-Match` on every write; no bulk endpoint. Conflicting rows return 409 and can be retried after refetch.
- Only open stages appear in the picker; closed or archived deals are not selectable.
- Skips rows already in the target stage to avoid emitting false stage-change transitions.
- Clears owner/stage pickers when the selection changes; mutations read variables (not closures) to avoid acting on a stale selection in `@tanstack/react-query`.
- Bulk archive asks for confirmation. Note: delete lacks `If-Match`, so archive does not pin versions.
- Adds i18n strings (EN/DE/VI), a Storybook story for the bulk bar, and tests covering version pinning, stage-skip, confirm-before-archive, and closed-deal unselectability.

<sup>Written for commit 7ea336be37abc132cdc46d17098716e1cc3dd22f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

