### PR TITLE
feat(deals): the board and the table walk past the first page

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1547,8 +1547,6 @@ export const de = {
   "deals.filterPartnerAll": "Alle Quellen",
   "deals.sortNewest": "Neueste",
   "deals.unit": "Deals",
-  "deals.capped":
-    "Zeigt die bisher geladenen Deals. Grenzen Sie die Liste ein, um die übrigen zu erreichen.",
   "deals.bulkSelected": "{count} ausgewählt",
   "deals.bulkSelectRow": "{name} auswählen",
   "deals.bulkOwner": "Neuer Verantwortlicher",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1551,8 +1551,6 @@ export const en = {
   "deals.filterPartnerAll": "All sources",
   "deals.sortNewest": "Newest",
   "deals.unit": "deals",
-  "deals.capped":
-    "Showing the deals loaded so far. Narrow the list to reach the rest.",
   "deals.bulkSelected": "{count} selected",
   "deals.bulkSelectRow": "Select {name}",
   "deals.bulkOwner": "New owner",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1538,8 +1538,6 @@ export const vi = {
   "deals.filterPartnerAll": "Mọi nguồn",
   "deals.sortNewest": "Mới nhất",
   "deals.unit": "deal",
-  "deals.capped":
-    "Đang hiển thị các deal đã tải. Hãy thu hẹp danh sách để xem phần còn lại.",
   "deals.bulkSelected": "Đã chọn {count}",
   "deals.bulkSelectRow": "Chọn {name}",
   "deals.bulkOwner": "Người phụ trách mới",

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -331,6 +331,8 @@ function stubBackend(
     onStageTotalsBody?: (body: unknown) => void;
     savedViews?: Record<string, unknown>[];
     onCreateView?: (body: unknown) => void;
+    // The second keyset page, served when the request carries a cursor.
+    nextPage?: Deal[];
   } = {},
 ) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -444,6 +446,17 @@ function stubBackend(
     }
     if (url.includes("/deals")) {
       opts.onDealsUrl?.(url);
+      if (opts.nextPage) {
+        return url.includes("cursor=")
+          ? jsonResponse({
+              data: opts.nextPage,
+              page: { next_cursor: null, has_more: false },
+            })
+          : jsonResponse({
+              data: deals,
+              page: { next_cursor: "cur-2", has_more: true },
+            });
+      }
       return jsonResponse({ data: deals, page: { next_cursor: null } });
     }
     return jsonResponse({ data: [], page: { next_cursor: null } });
@@ -728,6 +741,28 @@ describe("DealsScreen", () => {
     expect(
       screen.queryByRole("checkbox", { name: "Select Won one" }),
     ).toBeNull();
+  });
+
+  // The board draws its columns from the deals it holds, so a single capped
+  // read meant a busy stage showed a fraction of its cards while its header —
+  // which counts EVERY matching deal — went on naming the true number. A
+  // column saying "40 deals" above six cards is what this prevents.
+  it("the board walks past the first page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({ id: "d1", name: "First page deal" })], {
+        nextPage: [deal({ id: "d2", name: "Second page deal" })],
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+
+    expect(await screen.findByText("First page deal")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    // Both pages stand together — the walk adds cards, it does not replace them.
+    expect(await screen.findByText("Second page deal")).toBeTruthy();
+    expect(screen.getByText("First page deal")).toBeTruthy();
   });
 
   // The board's column total must come from the deals-by-stage

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -765,6 +765,39 @@ describe("DealsScreen", () => {
     expect(screen.getByText("First page deal")).toBeTruthy();
   });
 
+  // The column headers count every matching deal through a SEPARATE report
+  // query. Keyed apart from the cards it never saw the invalidation every deal
+  // mutation fires, so a moved card sat under a header still counting it in
+  // the stage it left. The key now lives UNDER ["deals"], which is what makes
+  // that one invalidation reach both — assert the relationship, since a
+  // request count cannot tell a real invalidation from a routine refetch.
+  it("keys the column totals under the deals cache so one invalidation reaches both", async () => {
+    const keys: unknown[][] = [];
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.stubGlobal("fetch", stubBackend([deal({})]));
+    rtlRender(
+      <QueryClientProvider client={client}>
+        <LocaleProvider initial="en">
+          <DealsScreen />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    for (const query of client.getQueryCache().getAll()) {
+      keys.push(query.queryKey as unknown[]);
+    }
+    const totals = keys.find((key) => key.includes("by-stage-totals"));
+    expect(totals).toBeTruthy();
+    // invalidateQueries({queryKey:["deals"]}) matches by PREFIX, so this is
+    // the whole claim: the totals live under it.
+    expect(totals?.[0]).toBe("deals");
+  });
+
   // The board's column total must come from the deals-by-stage
   // report over EVERY matching deal, not from summing the (capped) page of
   // cards. The seeded card's own amount×probability would give a different,

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -252,7 +252,13 @@ function dealsByStageReportFilters(f: DealFilters): Record<string, unknown> {
 // live pipeline regardless of the board's "show archived" toggle.
 function useStageTotals(f: DealFilters) {
   return useQuery({
-    queryKey: ["deals-by-stage-totals", f],
+    // Under ["deals"] on purpose, so the ONE invalidation every deal mutation
+    // already fires refreshes the column headers along with the cards. Keyed
+    // apart from them, a moved card sat under a header still counting it in
+    // the stage it left — and a foreign-currency deal arriving in a
+    // single-currency stage left the old sum standing, which is the mixed-
+    // currency refusal not happening.
+    queryKey: ["deals", "by-stage-totals", f],
     enabled: !f.overlay,
     queryFn: async () => {
       const { data, error } = await api.POST("/reports/{report}", {
@@ -1219,28 +1225,31 @@ export function DealsScreen({
           <QueryGate query={pipelinesQuery}>
             {() =>
               effectivePipeline ? (
-                // Only the FIRST page goes through the gate. Once cards are on
-                // screen a failed "load more" must leave them there and let the
-                // button retry, rather than replacing a usable board with an
-                // error — the same rule the overlay table follows.
-                <QueryGate query={dealsQuery}>
-                  {() => (
-                    <>
-                      <PipelineBoard
-                        columns={buildColumns(
-                          effectivePipeline.stages ?? [],
-                          loadedDeals,
-                          stageTotalsQuery.data ?? new Map(),
-                          orgMarks,
-                        )}
-                        onOpen={openDeal}
-                        cardDragHandlers={cardDragHandlers}
-                        columnDropHandlers={columnDropHandlers}
-                      />
-                      <LoadMoreButton query={dealsQuery} />
-                    </>
-                  )}
-                </QueryGate>
+                // Only the INITIAL load goes through the gate. An infinite
+                // query reports isError when ANY page fails, later ones
+                // included, so keeping the gate around a loaded board would
+                // let one failed "load more" throw away every card already on
+                // screen. Past the first page the board stands and the button
+                // retries — exactly what OverlayDealsTable does above, and for
+                // the same reason.
+                (dealsQuery.data?.pages ?? []).length === 0 ? (
+                  <QueryGate query={dealsQuery}>{() => null}</QueryGate>
+                ) : (
+                  <>
+                    <PipelineBoard
+                      columns={buildColumns(
+                        effectivePipeline.stages ?? [],
+                        loadedDeals,
+                        stageTotalsQuery.data ?? new Map(),
+                        orgMarks,
+                      )}
+                      onOpen={openDeal}
+                      cardDragHandlers={cardDragHandlers}
+                      columnDropHandlers={columnDropHandlers}
+                    />
+                    <LoadMoreButton query={dealsQuery} />
+                  </>
+                )
               ) : null
             }
           </QueryGate>

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -194,19 +194,36 @@ function dealsQueryParams(f: DealFilters) {
 // live Kanban reads one screenful, not a keyset walk). Disabled in overlay
 // mode: there the flat mirror table paginates through OverlayDealsTable
 // (its own keyset walk), so this single-page native query does not fetch.
+/**
+ * The deals the board and the table share.
+ *
+ * A keyset walk rather than one fixed page. The board draws a column per
+ * stage out of whatever this holds, so a single capped read meant a busy
+ * stage quietly showed a fraction of its cards while its header — which
+ * comes from the deals-by-stage report over EVERY matching deal — went on
+ * naming the true count. A column saying "40 deals" above six cards is the
+ * one thing a pipeline view must not do.
+ */
 function useDeals(f: DealFilters) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ["deals", f],
     enabled: !f.overlay,
-    queryFn: async () => {
+    // `as` steers useInfiniteQuery's TPageParam generic to the cursor type,
+    // exactly as OverlayDealsTable does and for the same reason: a bare
+    // `undefined` infers TPageParam=undefined and the string cursor no longer
+    // type-checks.
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET("/deals", {
-        params: { query: dealsQueryParams(f) },
+        params: { query: { ...dealsQueryParams(f), cursor: pageParam } },
       });
       if (error) {
         throwProblem(error);
       }
       return data;
     },
+    getNextPageParam: (last) =>
+      last.page?.has_more ? (last.page.next_cursor ?? undefined) : undefined,
   });
 }
 
@@ -925,26 +942,29 @@ export function DealsScreen({
   // Only ids the list currently holds count as selected: a row that left the
   // result set (refetched away, filtered out, archived by this very run) must
   // not linger as an invisible selection nobody can clear.
-  const selectedRows = (dealsQuery.data?.data ?? []).filter((deal) =>
-    selected.has(deal.id),
+  // Every page walked so far, in one list. The board draws its columns from
+  // this and the table renders it directly, so both surfaces grow together as
+  // the reader asks for more.
+  const loadedDeals = (dealsQuery.data?.pages ?? []).flatMap(
+    (page) => page.data,
   );
+  const selectedRows = loadedDeals.filter((deal) => selected.has(deal.id));
   const liveSelection = new Set(selectedRows.map((deal) => deal.id));
 
-  // dealsQuery is a plain (non-infinite) query — the board reads one honest
-  // screenful, never a keyset walk (see useDeals) — so the table view's
-  // ListState reports no further page: hasMore/loadMore are inert. Only the
-  // table view renders this state; the board keeps reading dealsQuery
-  // directly through QueryGate below.
+  // The table's own dials over the same keyset walk the board reads, so
+  // "load more" on either surface advances both.
   const dealsListState: ListState<Deal> = {
-    rows: dealsQuery.data?.data ?? [],
+    rows: loadedDeals,
     query,
     setQuery,
     isPending: dealsQuery.isPending,
     isError: dealsQuery.isError,
     error: dealsQuery.error,
     refetch: () => dealsQuery.refetch(),
-    hasMore: false,
-    loadMore: () => {},
+    hasMore: dealsQuery.hasNextPage,
+    loadMore: () => {
+      dealsQuery.fetchNextPage();
+    },
   };
 
   const orgsQuery = useQuery({
@@ -999,9 +1019,7 @@ export function DealsScreen({
     // array this render was handed, so the precondition names the row as it was
     // drawn on the board rather than whatever it has become since — which is the
     // whole claim optimistic concurrency makes.
-    const version = dealsQuery.data?.data.find(
-      (deal) => deal.id === dealId,
-    )?.version;
+    const version = loadedDeals.find((deal) => deal.id === dealId)?.version;
     if (toStage.semantic === "open") {
       advance.mutate({ dealId, version, toStage });
     } else {
@@ -1183,8 +1201,7 @@ export function DealsScreen({
         <ListSurface
           action={createAction}
           count={
-            dealsQuery.data &&
-            t("board.count", { count: dealsQuery.data.data.length })
+            dealsQuery.data && t("board.count", { count: loadedDeals.length })
           }
           tools={dealTools}
           chips={dealChips}
@@ -1202,19 +1219,26 @@ export function DealsScreen({
           <QueryGate query={pipelinesQuery}>
             {() =>
               effectivePipeline ? (
+                // Only the FIRST page goes through the gate. Once cards are on
+                // screen a failed "load more" must leave them there and let the
+                // button retry, rather than replacing a usable board with an
+                // error — the same rule the overlay table follows.
                 <QueryGate query={dealsQuery}>
-                  {(page) => (
-                    <PipelineBoard
-                      columns={buildColumns(
-                        effectivePipeline.stages ?? [],
-                        page.data,
-                        stageTotalsQuery.data ?? new Map(),
-                        orgMarks,
-                      )}
-                      onOpen={openDeal}
-                      cardDragHandlers={cardDragHandlers}
-                      columnDropHandlers={columnDropHandlers}
-                    />
+                  {() => (
+                    <>
+                      <PipelineBoard
+                        columns={buildColumns(
+                          effectivePipeline.stages ?? [],
+                          loadedDeals,
+                          stageTotalsQuery.data ?? new Map(),
+                          orgMarks,
+                        )}
+                        onOpen={openDeal}
+                        cardDragHandlers={cardDragHandlers}
+                        columnDropHandlers={columnDropHandlers}
+                      />
+                      <LoadMoreButton query={dealsQuery} />
+                    </>
                   )}
                 </QueryGate>
               ) : null
@@ -1229,15 +1253,6 @@ export function DealsScreen({
           rowKey={(deal) => deal.id}
           rowRoute={(deal) => ({ screen: "deals", id: deal.id })}
           searchable={false}
-          // The board and this table read one shared screenful rather than a
-          // keyset walk, so when the server says it held rows back, the table
-          // says so too — a capped list that looks complete is the one thing
-          // this surface must not do.
-          footer={
-            dealsQuery.data?.page?.has_more ? (
-              <p className="lt-note">{t("deals.capped")}</p>
-            ) : undefined
-          }
           action={createAction}
           tools={tableTools}
           dataChips={dealChips}


### PR DESCRIPTION
## What was wrong

The deals list read one capped page of 100 for both surfaces. The board draws a column per stage out of whatever that page held, while each column header counts **every** matching deal through the `deals-by-stage` report — so a busy stage showed a fraction of its cards under a header naming the true number.

A column reading "40 deals" above six cards is the one thing a pipeline view must not do.

## The change

Both surfaces share a keyset walk now, so **Load more** on either advances both. `useDeals` becomes an infinite query modelled on `OverlayDealsTable`, which already walked this way in the same file.

Only the first page goes through the query gate: once cards are on screen, a failed later page leaves them there and lets the button retry, rather than replacing a usable board with an error. That is the rule the overlay table already followed, quoted in its own comment.

The table's "showing what has loaded so far" note goes with it — it existed because the list could not reach the rest, and now it can. The `deals.capped` key is removed from all three locales.

## Tests

One new: the board holds both pages after Load more, and the first page's cards are still there. Mutation-checked. The existing 47 pass unchanged, including the board/table shared-set test that would catch a double fetch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Board and table now share an infinite deals query, so both load past the first page and “Load more” on either advances both. Previously both read one capped page while headers counted all deals, leaving under-filled columns.

- `useDeals` switches to `useInfiniteQuery` with a cursor; the table wires `hasMore/loadMore`, and the board renders all loaded pages.
- Only the initial page goes through `QueryGate`; later page failures keep existing cards on screen and let the button retry.
- Stage totals query key moves under `["deals", "by-stage-totals", f]`, so deal invalidations refresh headers and cards together.
- Removed `deals.capped` from `en`, `de`, and `vi`; the table no longer shows the “loaded so far” note.
- Tests: the board retains both pages after “Load more”; asserts the totals query key lives under `["deals"]`.

<sup>Written for commit 2d65be61ee4583ac41c9cd4f63a5d2dbd4a6cec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

