### PR TITLE
feat(reports): revenue can be read by partner, not just "some partner"

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2314,12 +2314,14 @@ raises only.
    participants", but no AI task, formula or capture rule anywhere produces
    them, and the build sets them manually only. DEAL-EXT-5 (turning `role`
    into a CHECK-constrained enum) is still an unminted contract extension.
-4. **Referral attribution and commission are not joined up.**
-   `relationship.kind` already carries `referred_by` and the partner extension
-   already carries `margin_tier`, but nothing connects a referral edge to a
-   won deal's margin. Wanted: whether `referred_by` on an organization or deal
-   is the sanctioned way to record who brought the account, and how commission
-   resolves at won time.
+4. **Referral attribution and commission are joined up now** (#2019), with one
+   question left. A deal says what its partner did (`partner_attribution`:
+   sourced or influenced), and winning a sourced deal accrues a
+   `commission_entry` at the partner's `margin_tier` frozen that day. What is
+   still unsettled is `relationship.kind = 'referred_by'`: it remains
+   unconnected to any of this, and whether a referral EDGE should also record
+   who brought an account — or whether the deal's own partner field is the one
+   sanctioned answer — is a product decision nobody has made.
 5. **Which entity the site-read draft audits under.** See the field-history
    defect above: draft columns are written under
    `entity_type='organization'`, so they surface as changes to the company.

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 18
+	wantFixtureAnnotations = 19
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -147,6 +147,18 @@ type reportSpec struct {
 	filters      map[string]string
 	defaultBy    []string
 	defaultAggs  []reportAggregate
+	// referenceScopes names the columns that point at a ROW-SCOPED record of
+	// another kind, mapped to that record's table. The engine's own gate covers
+	// spec.entity — the deals of this report — and says nothing about the
+	// records those deals point AT, which a normal read masks per row
+	// (deals/fieldmask.go). Without this, grouping by such a column reports an
+	// id the same caller's ordinary read would have withheld.
+	//
+	// The clause it renders EXCLUDES the row rather than blanking the id: an
+	// aggregate has no per-row place to put "withheld", and a total that
+	// silently included those deals under a null key would still disclose that
+	// somebody's partner brought them.
+	referenceScopes map[string]string
 }
 
 // forecastCategoryExpr is the forecast's effective-category dimension

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -34,6 +33,7 @@ const (
 	colPipelineID     = "t.pipeline_id"
 	colStageID        = "t.stage_id"
 	colOrganizationID = "t.organization_id"
+	colPartnerOrgID   = "t.partner_org_id"
 	colCurrency       = "t.currency"
 	colStatus         = "t.status"
 	whereArchivedNull = "t.archived_at IS NULL"
@@ -71,6 +71,7 @@ const (
 	fieldWinProbability = "win_probability"
 	fieldOrganizationID = "organization_id"
 	fieldPartnerSourced = "partner_sourced"
+	fieldPartnerOrgID   = "partner_org_id"
 	fieldStalled        = "stalled"
 	fieldCurrency       = "currency"
 	fieldPipelineID     = "pipeline_id"
@@ -174,135 +175,6 @@ const forecastCategoryExpr = `(CASE WHEN t.forecast_category IN ('commit','best_
 // that reaches Postgres with the token unsubstituted fails loudly rather than
 // quietly reporting in the wrong zone.
 const reportZoneToken = "<<installation-timezone>>"
-
-// prebuiltReports is the report catalog (data-model §13 shape): keys
-// are never UUIDs, so saved-report ids cannot collide.
-var prebuiltReports = map[string]reportSpec{
-	"open-deals-per-company": {
-		entity:    datasource.EntityDeal,
-		table:     tableDeal,
-		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
-		basePlain: "live (unarchived) open deals",
-		// Currency is a dimension AND a filter because amount_minor is a
-		// measure here: a caller summing money on this key has to be able to
-		// split it by currency. It stays OUT of defaultBy, unlike the two
-		// reports below — this key's default plan counts deals and sums
-		// nothing, so a currency split would multiply its rows while reporting
-		// no more than it does now.
-		dimensions: map[string]string{
-			fieldOrganizationID: colOrganizationID,
-			fieldOwnerID:        colOwnerID,
-			fieldCurrency:       colCurrency,
-		},
-		measures: map[string]string{fieldAmountMinor: colAmountMinor},
-		filters: map[string]string{
-			fieldOwnerID:    colOwnerID,
-			fieldPipelineID: colPipelineID,
-			fieldCurrency:   colCurrency,
-		},
-		defaultBy: []string{fieldOrganizationID},
-		defaultAggs: []reportAggregate{
-			{Fn: aggFnCount, As: "open_deals"},
-		},
-	},
-	"deals-by-stage": {
-		entity:    datasource.EntityDeal,
-		table:     tableDeal,
-		joins:     []string{joinStageForWinProbability},
-		baseWhere: whereArchivedNull,
-		basePlain: "live (unarchived) deals",
-		dimensions: map[string]string{
-			fieldStageID:        colStageID,
-			fieldStatus:         colStatus,
-			fieldPipelineID:     colPipelineID,
-			fieldWinProbability: colWinProbability,
-			fieldCurrency:       colCurrency,
-		},
-		measures: map[string]string{
-			fieldAmountMinor:         colAmountMinor,
-			fieldWeightedAmountMinor: weightedAmountMinorExpr,
-		},
-		// No stage_id filter: nothing serves it (the screen groups BY stage_id
-		// instead), and a filter key this report has no caller for is public
-		// agent surface (the run_report catalog, mcp-info.{json,md}) with no
-		// concrete use behind it. The rest match the board's own filter dials:
-		// partner_sourced and stalled are boolean-valued expressions, which
-		// the engine's generic `expr = $n` rendering already handles with no
-		// special-casing.
-		filters: map[string]string{
-			fieldPipelineID:     colPipelineID,
-			fieldStatus:         colStatus,
-			fieldOwnerID:        colOwnerID,
-			fieldOrganizationID: colOrganizationID,
-			fieldPartnerSourced: deals.PartnerSourcedSQL("t"),
-			fieldStalled:        deals.StalledSQL("t"),
-			fieldCurrency:       colCurrency,
-		},
-		defaultBy: moneyDefaultBy(fieldStageID),
-		defaultAggs: []reportAggregate{
-			{Fn: aggFnCount, As: aliasDeals},
-			{Fn: aggFnSum, Field: fieldAmountMinor, As: "amount_minor_sum"},
-		},
-	},
-	"activities-by-kind": {
-		entity:       datasource.EntityActivity,
-		table:        "activity",
-		baseWhere:    whereArchivedNull,
-		basePlain:    "live (unarchived) activities",
-		activityWalk: true,
-		dimensions:   map[string]string{"kind": "t.kind", "direction": "t.direction"},
-		measures:     map[string]string{},
-		filters:      map[string]string{"kind": "t.kind", "direction": "t.direction"},
-		defaultBy:    []string{"kind"},
-		defaultAggs: []reportAggregate{
-			{Fn: aggFnCount, As: "activities"},
-		},
-	},
-	// win-loss (REPORT-KEY-8) is assembled by winLossSpec in reportperiod.go
-	// rather than spelled inline: it carries the period-bucket vocabulary with
-	// it, and this file is at the package's file-length cap.
-	"win-loss": winLossSpec(),
-	// The forecast (B-E09.10) is a parameterized report over this same
-	// engine, not a separate subsystem. Weighted value follows
-	// formulas-and-rules §6: round(amount_minor × stage.win_probability
-	// / 100) PER DEAL (half away from zero), so the roll-up total equals
-	// the sum of the per-deal weighted values exactly (AC-F1) — the same
-	// expression the drill-through rows expose. Stakeholders never join
-	// in: the grain is one row per deal, so a multi-stakeholder deal
-	// counts once (AC-F2).
-	"forecast": {
-		entity:    datasource.EntityDeal,
-		table:     tableDeal,
-		joins:     []string{joinStageForWinProbability},
-		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
-		basePlain: "open, unarchived deals (win probability read live from the deal's current stage; a commit/best_case deal whose close date is past, missing, or provisional reports as 'slipped' instead, per formulas §11)",
-		dimensions: map[string]string{
-			fieldOwnerID:        colOwnerID,
-			fieldStageID:        colStageID,
-			fieldPipelineID:     colPipelineID,
-			"forecast_category": forecastCategoryExpr,
-			fieldCurrency:       colCurrency,
-			fieldWinProbability: colWinProbability,
-		},
-		measures: map[string]string{
-			fieldAmountMinor:         colAmountMinor,
-			fieldWeightedAmountMinor: weightedAmountMinorExpr,
-		},
-		filters: map[string]string{
-			fieldOwnerID:        colOwnerID,
-			fieldStageID:        colStageID,
-			fieldPipelineID:     colPipelineID,
-			"forecast_category": forecastCategoryExpr,
-			fieldCurrency:       colCurrency,
-		},
-		defaultBy: moneyDefaultBy("forecast_category"),
-		defaultAggs: []reportAggregate{
-			{Fn: aggFnCount, As: aliasDeals},
-			{Fn: aggFnSum, Field: fieldAmountMinor, As: "unweighted_minor"},
-			{Fn: aggFnSum, Field: fieldWeightedAmountMinor, As: "weighted_minor"},
-		},
-	},
-}
 
 // fromClause renders the base table (aliased t) plus the spec's fixed
 // lookup joins — the one spelling shared by the aggregate plan and the

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -212,6 +213,52 @@ func TestDealsByStageGroupsRevenueByPartner(t *testing.T) {
 	}
 	if got := byPartner[kestrel.String()]; got != 70000 {
 		t.Errorf("Kestrel total = %d, want 70000", got)
+	}
+}
+
+// Grouping by partner must not report a partner the caller could not open.
+//
+// A normal deal read masks partner_org_id per row when the referenced
+// organization is out of reach (deals/fieldmask.go). The report engine gates
+// only the deal entity, so without the reference-scope clause an aggregate
+// would hand back exactly the id the same caller's own read withholds — and an
+// aggregate has no per-row place to write "withheld".
+func TestGroupingByPartnerDoesNotNameAPartnerTheCallerCannotOpen(t *testing.T) {
+	e := setupForecast(t)
+	// Capture-private to Rep3: readable to its owner, invisible to every other
+	// seat, exactly as a connector-captured company can be.
+	hidden := e.seedID(t, `INSERT INTO organization (id, owner_id, display_name, visibility, source, captured_by)
+		VALUES ($1, $2, 'Hidden Partners', 'owner', 'manual', 'human:x')`, e.Rep3)
+	open := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Open Partners', 'manual', 'human:x')`)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'From the hidden partner', $2, $3, $4, 'sourced', 90000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], hidden)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'From the open partner', $2, $3, $4, 'sourced', 10000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], open)
+
+	// A reader of every deal who holds no organization grant at all.
+	reader := e.dealReadCtx(ids.NewV7(), nil, principal.RowScopeAll)
+	result := e.runReport(reader, t, "deals-by-stage",
+		`{"group_by":["partner_org_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}],"filters":{"partner_sourced":true}}`)
+
+	for _, row := range result.Rows {
+		if id, ok := row["partner_org_id"].(string); ok && id == hidden.String() {
+			t.Errorf("the report named partner %s, which this caller's own deal read masks", id)
+		}
+	}
+	// The partner they CAN open is still reported: the clause narrows, it does
+	// not blank the whole dimension.
+	var sawOpen bool
+	for _, row := range result.Rows {
+		if id, ok := row["partner_org_id"].(string); ok && id == open.String() {
+			sawOpen = true
+			if got := wireInt(t, row, "amount_minor_sum"); got != 10000 {
+				t.Errorf("open partner total = %d, want 10000", got)
+			}
+		}
+	}
+	if !sawOpen {
+		t.Error("the readable partner vanished too; the clause excluded more than it should")
 	}
 }
 

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -182,6 +182,39 @@ func TestDealsByStageFiltersByOrganizationID(t *testing.T) {
 	}
 }
 
+// The question the partner program is actually run on: what has each partner
+// brought us. It was unanswerable while partner_sourced was a filter alone —
+// the report could say "these deals came from some partner" and never say which.
+func TestDealsByStageGroupsRevenueByPartner(t *testing.T) {
+	e := setupForecast(t)
+	northgate := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Northgate', 'manual', 'human:x')`)
+	kestrel := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Kestrel', 'manual', 'human:x')`)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Northgate one', $2, $3, $4, 'sourced', 30000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], northgate)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Northgate two', $2, $3, $4, 'influenced', 20000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], northgate)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Kestrel one', $2, $3, $4, 'sourced', 70000, 'EUR', 'manual', 'human:x')`, e.pipeline, e.stages[60], kestrel)
+
+	result := e.runReport(e.Admin(), t, "deals-by-stage",
+		`{"group_by":["partner_org_id"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}],"filters":{"partner_sourced":true}}`)
+
+	byPartner := map[string]int64{}
+	for _, row := range result.Rows {
+		id, ok := row["partner_org_id"].(string)
+		if !ok {
+			continue
+		}
+		byPartner[id] = wireInt(t, row, "amount_minor_sum")
+	}
+	if got := byPartner[northgate.String()]; got != 50000 {
+		t.Errorf("Northgate total = %d, want 50000 (both of their deals)", got)
+	}
+	if got := byPartner[kestrel.String()]; got != 70000 {
+		t.Errorf("Kestrel total = %d, want 70000", got)
+	}
+}
+
 func TestDealsByStageFiltersByPartnerSourced(t *testing.T) {
 	e := setupForecast(t)
 	partner := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Partner', 'manual', 'human:x')`)

--- a/backend/internal/compose/reportcatalog.go
+++ b/backend/internal/compose/reportcatalog.go
@@ -4,11 +4,10 @@
 package compose
 
 // What the run_report TOOL tells a caller about the report catalog. Separate
-// from report.go because it answers a different question: that file is the
-// engine — which SQL each report compiles to — and this one is the surface, the
-// vocabulary a caller may send. They change for different reasons, and the
-// engine file sits at the package's file-length cap precisely because it has
-// only one concern in it.
+// from the engine (report.go, which compiles a spec to SQL) and from the specs
+// themselves (reportspecs.go, which says what each report asks) because it
+// answers a third question: the vocabulary a caller may send. All three change
+// for different reasons.
 
 import (
 	"bytes"

--- a/backend/internal/compose/reportperiod.go
+++ b/backend/internal/compose/reportperiod.go
@@ -114,8 +114,12 @@ func winLossSpec() reportSpec {
 		// Cloned rather than aliased — the two vocabularies are equal today and
 		// nothing about them has to stay equal, so sharing one map would make a
 		// later edit to either silently change both.
-		filters:   maps.Clone(dimensions),
-		defaultBy: moneyDefaultBy(fieldStatus),
+		filters: maps.Clone(dimensions),
+		// The company a won or lost deal points at is row-scoped and masked on
+		// a normal deal read, so grouping by it carries the same obligation the
+		// partner dimension does on deals-by-stage.
+		referenceScopes: map[string]string{colOrganizationID: tableOrganization},
+		defaultBy:       moneyDefaultBy(fieldStatus),
 		defaultAggs: []reportAggregate{
 			{Fn: aggFnCount, As: aliasDeals},
 			{Fn: aggFnSum, Field: fieldAmountMinor, As: "amount_minor_sum"},

--- a/backend/internal/compose/reportreferencescope_test.go
+++ b/backend/internal/compose/reportreferencescope_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A report dimension over a REFERENCE column hands its ids back in the
+// aggregate. The engine's own gate covers the report's entity and says nothing
+// about the records those rows point at, while a normal read of the same row
+// masks exactly those references when the caller cannot open them
+// (deals/fieldmask.go). So every reference dimension has to declare the table
+// it points at, and this derives that obligation from the catalog rather than
+// keeping a second list of which ones were remembered.
+
+import (
+	"strings"
+	"testing"
+)
+
+// referenceColumns are the row-scoped records a report's rows can point AT,
+// mapped to the table each names. A column here that a spec exposes as a
+// dimension without declaring its scope is the finding.
+//
+// gatekit:fixture the reference columns a report row can carry, and the table each points at
+var referenceColumns = map[string]string{
+	colOrganizationID: tableOrganization,
+	colPartnerOrgID:   tableOrganization,
+}
+
+func TestEveryReferenceDimensionDeclaresItsScope(t *testing.T) {
+	for name, spec := range prebuiltReports {
+		for field, expr := range spec.dimensions {
+			table, isReference := referenceColumns[expr]
+			if !isReference {
+				continue
+			}
+			declared, ok := spec.referenceScopes[expr]
+			if !ok {
+				t.Errorf("%s groups by %q, which names a row in %s the caller may not be able to open, "+
+					"but declares no referenceScopes entry — the aggregate would report an id "+
+					"this caller's own read of the same row masks",
+					name, field, table)
+				continue
+			}
+			if declared != table {
+				t.Errorf("%s scopes %q against %q, want %q", name, field, declared, table)
+			}
+		}
+	}
+}
+
+// The reverse direction: a declared scope must name a table the row-scope
+// helpers actually know, or the clause it renders would fail at query time on
+// a path no unit test reaches.
+func TestEveryDeclaredReferenceScopeNamesARowScopedTable(t *testing.T) {
+	for name, spec := range prebuiltReports {
+		for column, table := range spec.referenceScopes {
+			if !strings.HasPrefix(column, "t.") {
+				t.Errorf("%s scopes %q, which is not a column of the report's own row", name, column)
+			}
+			if table == "" {
+				t.Errorf("%s scopes %q against no table", name, column)
+			}
+		}
+	}
+}

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -95,7 +95,10 @@ var prebuiltReports = map[string]reportSpec{
 			fieldStalled:        deals.StalledSQL("t"),
 			fieldCurrency:       colCurrency,
 		},
-		defaultBy: moneyDefaultBy(fieldStageID),
+		// partner_org_id points at an organization, which a normal deal read
+		// masks per row when the caller cannot open it.
+		referenceScopes: map[string]string{colPartnerOrgID: tableOrganization},
+		defaultBy:       moneyDefaultBy(fieldStageID),
 		defaultAggs: []reportAggregate{
 			{Fn: aggFnCount, As: aliasDeals},
 			{Fn: aggFnSum, Field: fieldAmountMinor, As: "amount_minor_sum"},
@@ -117,7 +120,7 @@ var prebuiltReports = map[string]reportSpec{
 	},
 	// win-loss (REPORT-KEY-8) is assembled by winLossSpec in reportperiod.go
 	// rather than spelled inline: it carries the period-bucket vocabulary with
-	// it, and this file is at the package's file-length cap.
+	// it, and that vocabulary belongs beside the buckets it names.
 	"win-loss": winLossSpec(),
 	// The forecast (B-E09.10) is a parameterized report over this same
 	// engine, not a separate subsystem. Weighted value follows

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// The activity report's own vocabulary. Spelled here rather than borrowed from
+// an unrelated surface that happens to use the same words: renaming a report
+// dimension must never rename a capture target type.
+const (
+	fieldKind      = "kind"
+	fieldDirection = "direction"
+	colKind        = "t.kind"
+	colDirection   = "t.direction"
+)
+
+// The prebuilt report catalog: WHAT each report asks, as data.
+//
+// Split from report.go, which holds the machinery that RUNS a spec — the
+// validation, the SQL assembly, the row mapping. The two change for unrelated
+// reasons: a new report is a new entry here and nothing else, while a change to
+// how a report is executed touches none of these entries. Keeping them in one
+// file put the catalog over the 500-line cap the moment a report grew a
+// dimension.
+
+// prebuiltReports is the report catalog (data-model §13 shape): keys
+// are never UUIDs, so saved-report ids cannot collide.
+var prebuiltReports = map[string]reportSpec{
+	"open-deals-per-company": {
+		entity:    datasource.EntityDeal,
+		table:     tableDeal,
+		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
+		basePlain: "live (unarchived) open deals",
+		// Currency is a dimension AND a filter because amount_minor is a
+		// measure here: a caller summing money on this key has to be able to
+		// split it by currency. It stays OUT of defaultBy, unlike the two
+		// reports below — this key's default plan counts deals and sums
+		// nothing, so a currency split would multiply its rows while reporting
+		// no more than it does now.
+		dimensions: map[string]string{
+			fieldOrganizationID: colOrganizationID,
+			fieldOwnerID:        colOwnerID,
+			fieldCurrency:       colCurrency,
+		},
+		measures: map[string]string{fieldAmountMinor: colAmountMinor},
+		filters: map[string]string{
+			fieldOwnerID:    colOwnerID,
+			fieldPipelineID: colPipelineID,
+			fieldCurrency:   colCurrency,
+		},
+		defaultBy: []string{fieldOrganizationID},
+		defaultAggs: []reportAggregate{
+			{Fn: aggFnCount, As: "open_deals"},
+		},
+	},
+	"deals-by-stage": {
+		entity:    datasource.EntityDeal,
+		table:     tableDeal,
+		joins:     []string{joinStageForWinProbability},
+		baseWhere: whereArchivedNull,
+		basePlain: "live (unarchived) deals",
+		dimensions: map[string]string{
+			fieldStageID:        colStageID,
+			fieldStatus:         colStatus,
+			fieldPipelineID:     colPipelineID,
+			fieldWinProbability: colWinProbability,
+			fieldCurrency:       colCurrency,
+			// Grouping BY the partner is what turns "is this deal
+			// partner-sourced" into "what did this partner bring us" — the
+			// question the partner program is run on, and the one this report
+			// could not answer while partner_sourced was a filter alone.
+			fieldPartnerOrgID: colPartnerOrgID,
+		},
+		measures: map[string]string{
+			fieldAmountMinor:         colAmountMinor,
+			fieldWeightedAmountMinor: weightedAmountMinorExpr,
+		},
+		// No stage_id filter: nothing serves it (the screen groups BY stage_id
+		// instead), and a filter key this report has no caller for is public
+		// agent surface (the run_report catalog, mcp-info.{json,md}) with no
+		// concrete use behind it. The rest match the board's own filter dials:
+		// partner_sourced and stalled are boolean-valued expressions, which
+		// the engine's generic `expr = $n` rendering already handles with no
+		// special-casing.
+		filters: map[string]string{
+			fieldPipelineID:     colPipelineID,
+			fieldStatus:         colStatus,
+			fieldOwnerID:        colOwnerID,
+			fieldOrganizationID: colOrganizationID,
+			fieldPartnerSourced: deals.PartnerSourcedSQL("t"),
+			fieldStalled:        deals.StalledSQL("t"),
+			fieldCurrency:       colCurrency,
+		},
+		defaultBy: moneyDefaultBy(fieldStageID),
+		defaultAggs: []reportAggregate{
+			{Fn: aggFnCount, As: aliasDeals},
+			{Fn: aggFnSum, Field: fieldAmountMinor, As: "amount_minor_sum"},
+		},
+	},
+	"activities-by-kind": {
+		entity:       datasource.EntityActivity,
+		table:        tableActivity,
+		baseWhere:    whereArchivedNull,
+		basePlain:    "live (unarchived) activities",
+		activityWalk: true,
+		dimensions:   map[string]string{fieldKind: colKind, fieldDirection: colDirection},
+		measures:     map[string]string{},
+		filters:      map[string]string{fieldKind: colKind, fieldDirection: colDirection},
+		defaultBy:    []string{fieldKind},
+		defaultAggs: []reportAggregate{
+			{Fn: aggFnCount, As: "activities"},
+		},
+	},
+	// win-loss (REPORT-KEY-8) is assembled by winLossSpec in reportperiod.go
+	// rather than spelled inline: it carries the period-bucket vocabulary with
+	// it, and this file is at the package's file-length cap.
+	"win-loss": winLossSpec(),
+	// The forecast (B-E09.10) is a parameterized report over this same
+	// engine, not a separate subsystem. Weighted value follows
+	// formulas-and-rules §6: round(amount_minor × stage.win_probability
+	// / 100) PER DEAL (half away from zero), so the roll-up total equals
+	// the sum of the per-deal weighted values exactly (AC-F1) — the same
+	// expression the drill-through rows expose. Stakeholders never join
+	// in: the grain is one row per deal, so a multi-stakeholder deal
+	// counts once (AC-F2).
+	"forecast": {
+		entity:    datasource.EntityDeal,
+		table:     tableDeal,
+		joins:     []string{joinStageForWinProbability},
+		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
+		basePlain: "open, unarchived deals (win probability read live from the deal's current stage; a commit/best_case deal whose close date is past, missing, or provisional reports as 'slipped' instead, per formulas §11)",
+		dimensions: map[string]string{
+			fieldOwnerID:        colOwnerID,
+			fieldStageID:        colStageID,
+			fieldPipelineID:     colPipelineID,
+			"forecast_category": forecastCategoryExpr,
+			fieldCurrency:       colCurrency,
+			fieldWinProbability: colWinProbability,
+		},
+		measures: map[string]string{
+			fieldAmountMinor:         colAmountMinor,
+			fieldWeightedAmountMinor: weightedAmountMinorExpr,
+		},
+		filters: map[string]string{
+			fieldOwnerID:        colOwnerID,
+			fieldStageID:        colStageID,
+			fieldPipelineID:     colPipelineID,
+			"forecast_category": forecastCategoryExpr,
+			fieldCurrency:       colCurrency,
+		},
+		defaultBy: moneyDefaultBy("forecast_category"),
+		defaultAggs: []reportAggregate{
+			{Fn: aggFnCount, As: aliasDeals},
+			{Fn: aggFnSum, Field: fieldAmountMinor, As: "unweighted_minor"},
+			{Fn: aggFnSum, Field: fieldWeightedAmountMinor, As: "weighted_minor"},
+		},
+	},
+}

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -52,7 +52,11 @@ var prebuiltReports = map[string]reportSpec{
 			fieldPipelineID: colPipelineID,
 			fieldCurrency:   colCurrency,
 		},
-		defaultBy: []string{fieldOrganizationID},
+		// The company a deal points at is row-scoped and masked on a normal
+		// deal read, so grouping by it carries the same obligation the partner
+		// dimension does.
+		referenceScopes: map[string]string{colOrganizationID: tableOrganization},
+		defaultBy:       []string{fieldOrganizationID},
 		defaultAggs: []reportAggregate{
 			{Fn: aggFnCount, As: "open_deals"},
 		},

--- a/backend/internal/compose/reportsql.go
+++ b/backend/internal/compose/reportsql.go
@@ -12,7 +12,9 @@ package compose
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -121,7 +123,43 @@ func buildReportWhere(ctx context.Context, spec reportSpec, req reportRequest, a
 	if scope != "" {
 		where = append(where, scope)
 	}
-	return where, nil
+	refs, err := referenceScopeClauses(ctx, spec, arg)
+	if err != nil {
+		return nil, err
+	}
+	return append(where, refs...), nil
+}
+
+// referenceScopeClauses narrows a report to the rows whose REFERENCED records
+// the caller could open, for every reference the spec declares.
+//
+// The engine's own gate covers the report's entity and nothing it points at, so
+// a dimension over a reference column would otherwise hand back ids that the
+// same caller's ordinary read of the same row masks. Excluding the row is the
+// only honest aggregate answer: there is no per-row place to write "withheld",
+// and folding those deals under a null key would still say that SOME partner
+// brought them.
+func referenceScopeClauses(ctx context.Context, spec reportSpec, arg func(any) int) ([]string, error) {
+	if len(spec.referenceScopes) == 0 {
+		return nil, nil
+	}
+	clauses := make([]string, 0, len(spec.referenceScopes))
+	for _, column := range slices.Sorted(maps.Keys(spec.referenceScopes)) {
+		table := spec.referenceScopes[column]
+		scope, err := auth.ScopeClauseFor(ctx, table, "ref", arg)
+		if err != nil {
+			return nil, err
+		}
+		if scope == "" {
+			// An unbounded reader of that table: every row it could name is one
+			// they may open, so there is nothing to narrow.
+			continue
+		}
+		clauses = append(clauses, fmt.Sprintf(
+			"(%s IS NULL OR EXISTS (SELECT 1 FROM %s ref WHERE ref.id = %s AND %s))",
+			column, table, column, scope))
+	}
+	return clauses, nil
 }
 
 // reportSQL renders the aggregate query: the validated SELECT list over the

--- a/backend/internal/modules/agents/tools_report.go
+++ b/backend/internal/modules/agents/tools_report.go
@@ -120,7 +120,7 @@ func describeReportCatalog(catalog []ReportCatalogEntry) string {
 		b.WriteString(vocabulary(entry.GroupBy))
 		b.WriteString("; filters: ")
 		b.WriteString(vocabulary(entry.Filters))
-		b.WriteString("; aggregate fields: ")
+		b.WriteString("; aggregates: ")
 		b.WriteString(vocabulary(entry.Aggregates))
 		if entry.Defaults != "" {
 			b.WriteString("; default: ")

--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -87,9 +87,12 @@ partners so filtering stays useful.
   scan for partners whose stage is behind reality and correct it; make sure every in-flight
   partner has a next step with a due date.
 
-Agents see partners too: the partner list and partner updates are exposed as governed MCP
-tools, so an agent working for you can look partners up and (within its granted scopes) update
-the same fields you edit here — every such write lands in the same audit trail.
+Agents reach partners INDIRECTLY today. A partner organization is an ordinary company to the
+generic record tools, so an agent can find it, read it and see that it carries the `partner`
+relationship type — but `partner` is not yet one of the record types those tools accept, so the
+partner extension's own fields (tier, certification, relationship stage) are not readable or
+writable that way. A deal's partner and what that partner did for it ARE agent-visible, through
+the deal's own `partner_org_id` and `partner_attribution` fields.
 
 ## Changing the value lists themselves
 

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 43,
     "resources": 8,
-    "tool_catalog_bytes": 124477,
+    "tool_catalog_bytes": 124463,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 31896,
-    "largest_tool_bytes": 4723,
+    "approx_wire_tokens_total": 31892,
+    "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
       "description_bytes": 32392,
-      "input_schema_bytes": 28831,
+      "input_schema_bytes": 28817,
       "output_schema_bytes": 53807,
-      "description_plus_input_schema_bytes": 61223
+      "description_plus_input_schema_bytes": 61209
     }
   },
   "tools": {
@@ -6057,7 +6057,7 @@
               "type": "array"
             },
             "report": {
-              "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: currency, pipeline_id, stage_id, status, win_probability; filters: currency, organization_id, owner_id, partner_sourced, pipeline_id, stalled, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id, currency. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category, currency. open-deals-per-company — group_by: currency, organization_id, owner_id; filters: currency, owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. win-loss — group_by: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; filters: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; aggregate fields: amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by status, currency. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
+              "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregates: (none); default: count as activities grouped by kind. deals-by-stage — group_by: currency, partner_org_id, pipeline_id, stage_id, status, win_probability; filters: currency, organization_id, owner_id, partner_sourced, pipeline_id, stalled, status; aggregates: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id, currency. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregates: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category, currency. open-deals-per-company — group_by: currency, organization_id, owner_id; filters: currency, owner_id, pipeline_id; aggregates: amount_minor; default: count as open_deals grouped by organization_id. win-loss — group_by: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; filters: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; aggregates: amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by status, currency. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
               "enum": [
                 "activities-by-kind",
                 "deals-by-stage",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 43 |
 | Resources | 8 |
-| Tool catalog | 121.6 KB |
+| Tool catalog | 121.5 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 31896 |
+| Approx. wire tokens | 31892 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,7 +30,7 @@ budget in `agenttooldescriptions_test.go`.
 |---|---:|---:|---|
 | Output schemas | 52.5 KB | 43% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 31.6 KB | 26% | Yes, every step |
-| Input schemas | 28.2 KB | 23% | Yes, every step |
+| Input schemas | 28.1 KB | 23% | Yes, every step |
 | _Names, annotations, punctuation_ | 9.2 KB | 7% | Partly |
 | **Description + input schema** | **59.8 KB** | **49%** | **the recurring cost** |
 
@@ -6611,7 +6611,7 @@ Answer a question about totals, counts or breakdowns — pipeline by stage, deal
       "type": "array"
     },
     "report": {
-      "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregate fields: (none); default: count as activities grouped by kind. deals-by-stage — group_by: currency, pipeline_id, stage_id, status, win_probability; filters: currency, organization_id, owner_id, partner_sourced, pipeline_id, stalled, status; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id, currency. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregate fields: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category, currency. open-deals-per-company — group_by: currency, organization_id, owner_id; filters: currency, owner_id, pipeline_id; aggregate fields: amount_minor; default: count as open_deals grouped by organization_id. win-loss — group_by: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; filters: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; aggregate fields: amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by status, currency. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
+      "description": "The prebuilt report to run. Send `report` alone to get its defaults; the three plan arguments accept ONLY the names listed for that report. activities-by-kind — group_by: direction, kind; filters: direction, kind; aggregates: (none); default: count as activities grouped by kind. deals-by-stage — group_by: currency, partner_org_id, pipeline_id, stage_id, status, win_probability; filters: currency, organization_id, owner_id, partner_sourced, pipeline_id, stalled, status; aggregates: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id, currency. forecast — group_by: currency, forecast_category, owner_id, pipeline_id, stage_id, win_probability; filters: currency, forecast_category, owner_id, pipeline_id, stage_id; aggregates: amount_minor, weighted_amount_minor; default: count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category, currency. open-deals-per-company — group_by: currency, organization_id, owner_id; filters: currency, owner_id, pipeline_id; aggregates: amount_minor; default: count as open_deals grouped by organization_id. win-loss — group_by: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; filters: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status; aggregates: amount_minor; default: count as deals, sum(amount_minor) as amount_minor_sum grouped by status, currency. A `pipeline_id` or `stage_id` used here comes from list_pipelines — no other tool on this surface yields one.",
       "enum": [
         "activities-by-kind",
         "deals-by-stage",


### PR DESCRIPTION
## What this changes

`deals-by-stage` could filter to partner-sourced deals and never say **which** partner brought them. `partner_org_id` becomes a `group_by` dimension, so "what has each partner brought us" — the question a partner program is run on — is one report call.

Phase 3 of making the partner program real. [#2019](https://github.com/gradionhq/margince-poc-v1/pull/2019) added the attribution and the commission ledger; this makes the result readable.

## It also closes a disclosure hole, including two instances that predate it

Adding the dimension exposed a gap in the report engine: it gates the report's **entity** — the deals — and says nothing about the records those deals point at. A normal deal read masks `partner_org_id` and `organization_id` per row when the referenced company is out of reach (`deals/fieldmask.go`). Grouping by one of those columns therefore handed back exactly the id the same caller's own read withholds.

That was true of my new partner dimension, and **already true** of `organization_id` on `open-deals-per-company` and `win-loss`. All three are fixed here — leaving a known hole beside a fixed one is not a defensible place to stop.

`reportSpec` gains `referenceScopes`: the columns pointing at a row-scoped record of another kind, and the table each points at. The clause **excludes the row** rather than blanking the id — an aggregate has no per-row place to write "withheld", and folding those deals under a null key would still disclose that somebody's partner brought them. A caller unbounded on the referenced table narrows nothing.

A fitness function derives the obligation from the catalog, so the next reference dimension is caught at the gate rather than by the next reviewer.

**On disclosure:** the fix ships in this PR, so nothing is public while unpatched. If you would rather this had gone through a private advisory first, say so and I will route findings that way in future — SECURITY.md's rule is about reports landing *before* a fix, which is not the case here.

## Two other costs, both worth stating

**The agent tool listing sits against a hard ceiling** and the new dimension put it over. Reclaimed by shortening the report catalog's repeated `aggregate fields:` label to `aggregates:` — what the argument it describes is actually called. The ceiling now has 18 bytes of headroom, filed as #2040; it blocks #2041 (making `partner` a real agent `record_type`).

**`report.go` crossed the 500-line cap**, so the prebuilt catalog moved to `reportspecs.go`. A new report is an entry in the catalog and nothing else; a change to how reports execute touches none of the entries.

## Tests

Three integration tests against real Postgres, all mutation-checked:
- grouping by partner totals each partner's own deals (removing the dimension → 422);
- a capture-private partner is **not** named to a caller holding no organization grant, while the partner they *can* open still is (removing `referenceScopes` → the hidden partner appears);
- the fitness function fails by name when a spec forgets its declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)