### PR TITLE
fix(deals): the archive confirm counts correctly and promises nothing

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1556,9 +1556,10 @@ export const de = {
   "deals.bulkStagePick": "Phase wählen",
   "deals.bulkMove": "Verschieben",
   "deals.bulkArchive": "Archivieren",
-  "deals.bulkArchiveConfirmTitle": "{count} Deals archivieren?",
+  "deals.bulkArchiveConfirmTitle.one": "Diesen Deal archivieren?",
+  "deals.bulkArchiveConfirmTitle.other": "{count} Deals archivieren?",
   "deals.bulkArchiveConfirmBody":
-    "Sie verschwinden aus allen Listen und Auswertungen. Wiederherstellen geht nur einzeln, direkt am Deal.",
+    "Sie verschwinden aus allen Listen und Auswertungen, und zurückholen lässt sich hier noch keiner.",
   "deals.bulkFailed": "{count} nicht übernommen –",
   "deals.bulkFailedRow": "konnte nicht gespeichert werden",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1560,9 +1560,10 @@ export const en = {
   "deals.bulkStagePick": "Pick a stage",
   "deals.bulkMove": "Move",
   "deals.bulkArchive": "Archive",
-  "deals.bulkArchiveConfirmTitle": "Archive {count} deals?",
+  "deals.bulkArchiveConfirmTitle.one": "Archive this deal?",
+  "deals.bulkArchiveConfirmTitle.other": "Archive {count} deals?",
   "deals.bulkArchiveConfirmBody":
-    "They leave every list and report. Restoring one is done from the deal itself, one at a time.",
+    "They leave every list and report, and there is no way to bring one back from here yet.",
   "deals.bulkFailed": "{count} not applied —",
   "deals.bulkFailedRow": "could not be saved",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1547,9 +1547,10 @@ export const vi = {
   "deals.bulkStagePick": "Chọn giai đoạn",
   "deals.bulkMove": "Chuyển",
   "deals.bulkArchive": "Lưu trữ",
-  "deals.bulkArchiveConfirmTitle": "Lưu trữ {count} deal?",
+  "deals.bulkArchiveConfirmTitle.one": "Lưu trữ deal này?",
+  "deals.bulkArchiveConfirmTitle.other": "Lưu trữ {count} deal?",
   "deals.bulkArchiveConfirmBody":
-    "Chúng sẽ biến mất khỏi mọi danh sách và báo cáo. Khôi phục phải làm từng deal một.",
+    "Chúng sẽ biến mất khỏi mọi danh sách và báo cáo, và hiện chưa có cách khôi phục từ đây.",
   "deals.bulkFailed": "{count} không áp dụng được —",
   "deals.bulkFailedRow": "không lưu được",
 

--- a/frontend/src/screens/dealbulk.tsx
+++ b/frontend/src/screens/dealbulk.tsx
@@ -224,7 +224,12 @@ export function DealBulkBar({
       <ConfirmModal
         open={confirmingArchive}
         onClose={() => setConfirmingArchive(false)}
-        title={t("deals.bulkArchiveConfirmTitle", { count: deals.length })}
+        title={t(
+          deals.length === 1
+            ? "deals.bulkArchiveConfirmTitle.one"
+            : "deals.bulkArchiveConfirmTitle.other",
+          { count: deals.length },
+        )}
         confirmLabel={t("deals.bulkArchive")}
         confirmVariant="danger"
         pending={run.isPending}

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -713,6 +713,8 @@ describe("DealsScreen", () => {
 
     await user.click(screen.getByRole("button", { name: "Archive" }));
     expect(deleted).toBe(0);
+    // One deal reads as one deal, not "1 deals".
+    expect(screen.getByText("Archive this deal?")).toBeTruthy();
 
     // The dialog's own Archive button, not the bar's.
     const dialog = screen.getByRole("dialog");


### PR DESCRIPTION
Found by clicking through the bulk archive on a running stack, not by a test.

**"Archive 1 deals?"** — now "Archive this deal?", through the `.one`/`.other` keys this tree uses at the call site.

**A promise the product cannot keep.** The dialog said restoring one is "done from the deal itself, one at a time". There is no restore path anywhere in Margince — that is issue #2034, and it carries an open product decision because archive currently deletes list memberships rather than soft-deleting them. A dialog that invents a way back makes archiving sound reversible at the exact moment the reader is deciding whether to risk it.

The confirm now says plainly that nothing here brings one back.

Test asserts the singular title; mutation-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deals bulk-archive confirmation to singularize correctly and remove an inaccurate restore promise. Previously: “Archive 1 deals?” and “Restoring one is done from the deal itself...”; now: “Archive this deal?” and clear copy that you cannot bring one back from here.

- Updates `deals.bulkArchiveConfirmTitle` to use `.one`/`.other` keys and adjusts confirm body in `en`, `de`, and `vi`. Other locales must add `deals.bulkArchiveConfirmTitle.one`, `deals.bulkArchiveConfirmTitle.other`, and align body copy.
- Adds a test asserting the singular title; no backend or data behavior changes.

<sup>Written for commit 2a1cf493e41c6dff55c340a263dd84ecc8e69458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

