### PR TITLE
docs(system-requirements): name the AI providers and size a self-hosted model host

### DIFF
--- a/docs/reference/system-requirements.md
+++ b/docs/reference/system-requirements.md
@@ -6,9 +6,10 @@ services run on one host. With separate nodes, the api, the worker, the web
 server and the database each run on their own node. The two shapes use the
 same installation mechanism and the same configuration.
 
-The sizes below apply when the AI lanes use a cloud provider. A model on the
-installation's own hardware needs much more memory and possibly a GPU. This
-page does not give sizes for that configuration.
+The sizes below apply when the AI functions use a cloud provider. A model on
+the installation's own hardware needs more memory and possibly a GPU — see
+*Self-hosted AI models*. The AI functions are optional: without a model
+binding, the rest of the product operates normally.
 
 ## Software
 
@@ -20,6 +21,7 @@ page does not give sizes for that configuration.
 | **A correct system clock** | Retention, automation triggers and job schedules use the system time. |
 | **An S3-compatible object store** | Attachments, company logos, offer PDFs, file custom fields and CSV import keep their data in it. |
 | Outbound HTTPS | Optional, for some features. The core CRM, authentication and license validation operate fully offline. |
+| A model endpoint | Optional, only for the AI functions: a cloud provider with your own key, or your own Ollama / vLLM host. See below. |
 
 The api, worker and web containers keep no permanent local state. Postgres,
 Redis and the object store keep all permanent state.
@@ -103,6 +105,43 @@ model-price sources, the Gmail / Microsoft capture connectors, outbound
 webhook subscribers, and the SMTP relay. An air-gapped installation is
 possible. Without an AI key, the AI lanes stop, and the other functions
 continue.
+
+## AI providers
+
+The product runs no inference of its own. You connect a provider with your
+own key. Supported: **Anthropic** (Claude), **OpenAI** (GPT), **Google**
+(Gemini), and any **OpenAI-compatible** vendor (Mistral, DeepSeek, Groq,
+OpenRouter, a gateway, …).
+
+- The api and the worker both call the provider. Give both of them outbound
+  HTTPS to the endpoint.
+- The embeddings function needs a provider with an embeddings endpoint. A
+  chat-only vendor cannot serve it. A local embedding model is an
+  alternative.
+
+## Self-hosted AI models
+
+**Ollama** and **vLLM** serve a model on your own hardware. No key is
+necessary, and these are the only options in the zero-egress profile.
+
+The model host comes in addition to the node tables above. The sizes below
+assume the default model class (Gemma 3), a 32,768-token context window, and
+an embedding model (for example `bge-m3`) on the same host. Plan **50 GB
+disk** for model files.
+
+| Host | Hardware | Serves |
+|---|---|---|
+| **Minimum** | GPU with 8 GB memory, 16 GB RAM | A quantized 4B model plus the embedding model. Good enough to try the AI functions; expect thin extraction results. |
+| **Recommended** | GPU with 24 GB memory (RTX 4090, L4, A10), 32 GB RAM | A quantized 12B–27B model with the full context window, the embedding model beside it, and interactive latency. |
+| **Concurrent / unquantized** | 48 GB GPU memory or more (L40S, RTX 6000 Ada, 2 × 24 GB), 64 GB RAM | A 12B model unquantized on vLLM, or several requests at the same time without queueing. |
+
+- A CPU-only host works, but only for background tasks: answers take minutes,
+  and interactive functions become unusable.
+- The model server must support JSON-schema output. Most tasks constrain the
+  answer with a schema.
+- A task can escalate from a local model to a cloud tier. For a fully local
+  installation, bind every tier to a local model, or use the zero-egress
+  profile — it refuses a cloud provider at start.
 
 ## Availability
 


### PR DESCRIPTION
## What

Two new sections in [docs/reference/system-requirements.md](docs/reference/system-requirements.md), plus a model-endpoint row in the software table:

- **AI providers** — the supported vendors (Anthropic, OpenAI, Google, any OpenAI-compatible endpoint), that the api and the worker both need outbound HTTPS to the endpoint, and that the embeddings lane needs a vendor that serves it.
- **Self-hosted AI models** — Ollama and vLLM as the zero-egress options, a three-tier hardware table (8 GB / 24 GB / 48 GB+ GPU memory) sized for the default Gemma-3 model class at the 32,768-token context window the adapter asks for, a CPU-only caveat, the JSON-schema-output requirement, and the ladder caveat that a local binding on one tier alone does not keep calls on-premises.

## Why

The page told an operator that an own-hardware model needs "much more memory and possibly a GPU" and gave nothing else. An end customer deciding between BYOK cloud and self-hosting had no requirements to plan a host from.

## Scope

Requirements only, written for end customers: no config file paths, env var names, or provider config keys — those stay in [docs/reference/configuration.md](docs/reference/configuration.md) and the two how-tos. The hardware tiers are sized from what the repo fixes (the Gemma-3 default bindings, the 32,768-token Ollama window, a `bge-m3`-class embedder); the GPU examples are current common SKUs and will need refreshing as hardware generations move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents supported AI providers and concrete sizing for a self‑hosted model host so operators can plan egress and hardware. Previously the page only said self‑hosted models need more memory/GPU; now it names vendors, clarifies api/worker and embeddings egress, and adds three GPU tiers for `Ollama`/`vLLM`.

**Highlights**
- Adds AI providers section: Anthropic, OpenAI, Google, and OpenAI‑compatible endpoints; both api and worker require outbound HTTPS; embeddings require a provider with an embeddings endpoint or a local embedding model.
- Adds self‑hosted model guidance: zero‑egress options `Ollama` and `vLLM`; 8/24/48+ GB GPU tiers sized for Gemma 3 at a 32,768‑token window; ~50 GB disk for models; CPU‑only is background‑only; model server must support JSON‑schema output; cloud escalation can occur unless all tiers are bound locally or the zero‑egress profile is used.
- Updates Software table with an optional “model endpoint” row; AI functions remain optional and the rest of the product works without a binding.

**Operator actions**
- If using a cloud provider: allow outbound HTTPS from api and worker; ensure your vendor serves embeddings or run a local embedder.
- If self‑hosting: provision a GPU per the tiers above, allocate ~50 GB disk, and bind all tiers to a local model or enable the zero‑egress profile to prevent cloud fallback.

<sup>Written for commit ac80381aff2c0cf1d1e4316caefaf406098f413e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that AI capabilities are optional and the product remains operational without a configured model.
  - Added requirements for cloud-hosted and self-hosted AI providers, including Ollama and vLLM.
  - Documented connectivity, embeddings, hardware tiers, model storage, JSON Schema support, CPU-only limitations, and local/cloud escalation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->