### PR TITLE
fix(tests): the RBAC repair suite finds its era instead of counting to one

### DIFF
--- a/backend/migrations/rbac_repair_integration_test.go
+++ b/backend/migrations/rbac_repair_integration_test.go
@@ -268,20 +268,45 @@ func repointed(t *testing.T, admin, conn *pgx.Conn) *pgx.Conn {
 // becoming a no-op if the newest core migration is ever something else, which
 // would leave the replay below failing for a reason nobody could read off the
 // error.
+// rollBackThePhaseDDrop returns the schema to the era these repairs belong to:
+// the one where role.workspace_id still exists, because ADR-0091 §8 phase D has
+// not dropped it yet.
+//
+// It steps back until the column reappears rather than a fixed number of times.
+// The drop was the newest core migration when this suite was written, so one
+// step reached it — but every later core migration pushes it further back, and
+// hardcoding the distance made an unrelated migration fail this test with a
+// message about an era it had nothing to do with.
 func rollBackThePhaseDDrop(t *testing.T, conn *pgx.Conn) {
 	t.Helper()
 	core, _ := namespaces(t)
-	if _, err := dbmigrate.Down(context.Background(), conn, core, 1); err != nil {
-		t.Fatalf("rolling core back one step to the era these repairs belong to: %v", err)
+	for step := 0; step < maxStepsBackToPhaseD; step++ {
+		if roleCarriesWorkspaceID(t, conn) {
+			return
+		}
+		if _, err := dbmigrate.Down(context.Background(), conn, core, 1); err != nil {
+			t.Fatalf("rolling core back to the era these repairs belong to: %v", err)
+		}
 	}
+	if !roleCarriesWorkspaceID(t, conn) {
+		t.Fatalf("stepping core back %d times never restored role.workspace_id — either the phase D drop is "+
+			"gone from the tree, or core has grown more migrations on top of it than this bound allows",
+			maxStepsBackToPhaseD)
+	}
+}
+
+// How far back the phase D drop may sit before this suite gives up. Generous
+// on purpose: it exists to fail a runaway loop, not to track how many
+// migrations core has grown since.
+const maxStepsBackToPhaseD = 200
+
+func roleCarriesWorkspaceID(t *testing.T, conn *pgx.Conn) bool {
+	t.Helper()
 	var present bool
 	if err := conn.QueryRow(context.Background(), `
 		SELECT EXISTS (SELECT 1 FROM information_schema.columns
 		                WHERE table_name = 'role' AND column_name = 'workspace_id')`).Scan(&present); err != nil {
 		t.Fatalf("checking whether the rollback restored role.workspace_id: %v", err)
 	}
-	if !present {
-		t.Fatal("one core step back did not restore role.workspace_id — the newest core migration is no longer " +
-			"the phase D drop these repairs need rolled back, so this suite is replaying them in the wrong era again")
-	}
+	return present
 }


### PR DESCRIPTION
## What was red

`TestTheRepairMigrationsHealADatabaseThatAlreadyRecordedTheLostBackfill` failed on `main` after the deal lost-reason migration landed:

```
one core step back did not restore role.workspace_id — the newest core migration is no longer
the phase D drop these repairs need rolled back, so this suite is replaying them in the wrong era again
```

## Why

The suite needs the schema in the era *before* ADR-0091 §8 phase D dropped `role.workspace_id`, and it reached that era by rolling core back exactly **one** step. That was true when the suite was written — the drop was the newest core migration — and it stops being true the moment any migration lands on top of it. The failure message predicted this precisely.

## The fix

It steps back until the column reappears, rather than a fixed number of times. The bound (200) exists to fail a runaway loop, not to track how far the drop has drifted.

Verified against a real database: the two subtests that were failing (`core/0192`, `custom/20260806120000`) now pass.

## Also found

`TestFK_rowScopedTargetsHaveVisibilityDecision` is **separately red on clean main** — `commission_entry.deal_id` and `commission_entry.partner_org_id` have no visibility decision. That arrives with #2019 and is unrelated to this fix; filed as #2046.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the RBAC repair integration test find its correct migration era by checking for `role.workspace_id` instead of rolling core back exactly one step. This removes brittleness when new core migrations land and fixes the failures seen on main.

- Replaces fixed rollback with a loop that steps back until `role.workspace_id` exists, capped by `maxStepsBackToPhaseD = 200`.
- Adds `roleCarriesWorkspaceID` helper; updates `rollBackThePhaseDDrop` accordingly.
- Test-only change; no production schema or runtime behavior.
- Verified against a real database: previously failing subtests now pass.

<sup>Written for commit 423a309e33c6209e112972ce750d69d73ef1b565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

