### PR TITLE
fix(commissions): classify the ledger's foreign keys, and unbreak main

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -104,18 +104,20 @@ func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
 // the map's completeness is the invariant.
 var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// Client-supplied references — visibility-gated at the store:
-	"site_read.organization_id":     "gated: auth.EnsureVisible in StartSiteRead (the one human entry point); Begin/Finish only re-address a row Start created, and GetSiteRead re-checks EnsureVisible on every read",
-	"deal.organization_id":          "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1)",
-	"project.organization_id":       "gated: auth.EnsureLinkTarget in CreateProject/UpdateProject (H1) — the anchor company is client-supplied, so naming it is a read of it",
-	"deal.partner_org_id":           "gated: auth.EnsureLinkTarget in UpdateDeal (H1)",
-	"organization.parent_org_id":    "gated: auth.EnsureLinkTarget in Create/UpdateOrganization (H1)",
-	"activity_link.person_id":       "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.organization_id": "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.deal_id":         "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.lead_id":         "gated: auth.EnsureLinkTarget in LogActivity",
-	"activity_link.project_id":      "gated: auth.EnsureLinkTarget in LogActivity — the link target is probed by its wire entity_type, so project rides the same gate as its siblings",
-	"deal.project_id":               "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1) — the anchor project is client-supplied, so naming it is a read of it",
-	"contract.organization_id":      "gated: auth.EnsureLinkTarget in createContractTx (H1) — the counterparty is client-supplied, so naming it is a read of it",
+	"site_read.organization_id":       "gated: auth.EnsureVisible in StartSiteRead (the one human entry point); Begin/Finish only re-address a row Start created, and GetSiteRead re-checks EnsureVisible on every read",
+	"deal.organization_id":            "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1)",
+	"project.organization_id":         "gated: auth.EnsureLinkTarget in CreateProject/UpdateProject (H1) — the anchor company is client-supplied, so naming it is a read of it",
+	"deal.partner_org_id":             "gated: auth.EnsureLinkTarget in UpdateDeal (H1)",
+	"commission_entry.deal_id":        "gated: auth.EnsureLinkTarget in accrueTx — an entry priced against a deal the caller cannot open would be unreadable the moment it was written",
+	"commission_entry.partner_org_id": "gated: auth.EnsureLinkTarget in accrueTx — naming the partner an entry pays is a read of that organization",
+	"organization.parent_org_id":      "gated: auth.EnsureLinkTarget in Create/UpdateOrganization (H1)",
+	"activity_link.person_id":         "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.organization_id":   "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.deal_id":           "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.lead_id":           "gated: auth.EnsureLinkTarget in LogActivity",
+	"activity_link.project_id":        "gated: auth.EnsureLinkTarget in LogActivity — the link target is probed by its wire entity_type, so project rides the same gate as its siblings",
+	"deal.project_id":                 "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1) — the anchor project is client-supplied, so naming it is a read of it",
+	"contract.organization_id":        "gated: auth.EnsureLinkTarget in createContractTx (H1) — the counterparty is client-supplied, so naming it is a read of it",
 	// The deal and project links carry a SECOND obligation the sibling columns
 	// above do not, and it is the reason this table's gate is not just a copy.
 	// A contract's row visibility is INHERITED from its deal (falling back to


### PR DESCRIPTION
Closes #2046.

`TestFK_rowScopedTargetsHaveVisibilityDecision` has been red on `main` since [#2019](https://github.com/gradionhq/margince-poc-v1/pull/2019): `commission_entry`'s foreign keys to `deal` and `organization` carried no visibility decision, so the integration lane failed and every other verdict in it became unreadable.

**Both FKs are genuinely gated.** `accrueTx` puts each through `auth.EnsureLinkTarget` before the insert — an entry priced against a deal the caller cannot open would be unreadable the moment it was written, and naming the partner an entry pays is a read of that organization. What was missing is the *classification* the gate demands either way, which is the whole point of it: a new FK to a row-scoped record cannot pass without somebody stating which kind it is.

**Why it escaped.** The lane that runs this test is not the one a local `make check-backend` runs, and the commission work's own integration runs were scoped to the packages it touched (`compose/integration`, later `compose`). `backend/migrations` was never in that set.

Verified: the named test passes, and the whole `backend/migrations` integration package is green (64s, no skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies `commission_entry` foreign keys as visibility-gated in the schema fitness test to fix the migrations integration lane and unblock `main`. Previously, `commission_entry.deal_id` and `commission_entry.partner_org_id` lacked a decision, failing `TestFK_rowScopedTargetsHaveVisibilityDecision`; now both are marked as gated via `auth.EnsureLinkTarget` in `accrueTx`. Runtime behavior was already gated; this PR records the classification.

- Changes are limited to `backend/migrations/schema_fitness_integration_test.go`; no runtime or DB schema changes.
- Adds `commission_entry.deal_id` and `commission_entry.partner_org_id` to `rowScopedFKDecisions` with their gate rationale.
- Verified the `backend/migrations` integration package is green; the lane that caught this does not run in local `make check-backend`.

<sup>Written for commit f70c6354f539dd2c43ae09df079c57f116797e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

