### PR TITLE
feat(agents): draft_email can compose a first message, not only a reply

### DIFF
--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -484,6 +484,10 @@ func (bothDoorsComms) DraftEmail(context.Context, ids.UUID, string) (string, str
 	return "", "", errBothDoorsExecuted
 }
 
+func (bothDoorsComms) DraftAccountEmail(context.Context, []agents.RecordLink, string) (string, string, error) {
+	return "", "", errBothDoorsExecuted
+}
+
 func (bothDoorsComms) SendEmail(context.Context, ids.UUID, agents.SendEmailArgs) (agents.SendEmailResult, error) {
 	return agents.SendEmailResult{}, errBothDoorsExecuted
 }

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -70,6 +70,10 @@ func (stubComms) DraftEmail(context.Context, ids.UUID, string) (string, string, 
 	return "", "", nil
 }
 
+func (stubComms) DraftAccountEmail(context.Context, []agents.RecordLink, string) (string, string, error) {
+	return "", "", nil
+}
+
 func (stubComms) SendEmail(context.Context, ids.UUID, agents.SendEmailArgs) (agents.SendEmailResult, error) {
 	return agents.SendEmailResult{}, nil
 }

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -124,10 +124,14 @@ func (c commsAdapter) DraftAccountEmail(
 	// the AI task behind it. Deliberately left for its own change: the tool's
 	// value is that a first message can be drafted AT ALL, and the copy says
 	// plainly that the fallback is a short deterministic note.
+	// Topic stays EMPTY, and the intent is passed once. DeterministicEmailDraft
+	// renders Topic into a "following up on …" line AND appends the intent as
+	// its own paragraph (handlers_email.go), so naming both would print the
+	// caller's instruction twice in consecutive sections. There is no thread
+	// here for a topic to name anyway — the intent is the whole substance.
 	subject, body := activities.DeterministicEmailDraft(activities.DraftContext{
 		Band:     convstate.BandFresh,
 		Threaded: false,
-		Topic:    intent,
 	}, intent)
 	return subject, body, nil
 }

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -10,6 +10,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -89,6 +90,45 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 		answering.Body = *activity.Body
 	}
 	subject, body := activities.DeterministicEmailDraft(answering, intent)
+	return subject, body, nil
+}
+
+// DraftAccountEmail composes the first message to a record.
+//
+// There is no thread to read, so the DraftContext is built from what a first
+// message actually is rather than from prior correspondence: BandFresh (this
+// IS the opening), Threaded false (nothing is being answered), and the intent
+// as the topic — the caller's own words for what the message should do, which
+// is the only subject material in existence before a conversation starts.
+//
+// It deliberately does NOT resolve a recipient. DraftEmail can ask the store
+// who a thread is with; here the caller names the addressee at send time
+// (send_account_email takes `to`), and inventing one from a link would put an
+// address in a draft nobody chose.
+//
+// The links are not read either, and that is a judgment worth stating: the
+// drafter takes text, not records, and reading a company's fields into the
+// opening line would make the draft's content depend on data the approving
+// human is not looking at. They are carried for the SEND to file under.
+func (c commsAdapter) DraftAccountEmail(
+	ctx context.Context, links []agents.RecordLink, intent string,
+) (string, string, error) {
+	if len(links) == 0 {
+		return "", "", &agents.BadArgsError{Cause: errors.New(
+			"links must name at least one record this conversation is filed under; " +
+				"a first message has no thread to inherit them from")}
+	}
+	// Deterministic only, for now. activities.EmailDrafter (the routed model
+	// lane) takes an anchor by signature — DraftEmail(ctx, anchor, intent) —
+	// so a first message cannot reach it without widening that interface and
+	// the AI task behind it. Deliberately left for its own change: the tool's
+	// value is that a first message can be drafted AT ALL, and the copy says
+	// plainly that the fallback is a short deterministic note.
+	subject, body := activities.DeterministicEmailDraft(activities.DraftContext{
+		Band:     convstate.BandFresh,
+		Threaded: false,
+		Topic:    intent,
+	}, intent)
 	return subject, body, nil
 }
 

--- a/backend/internal/modules/agents/outputshapes_derive_test.go
+++ b/backend/internal/modules/agents/outputshapes_derive_test.go
@@ -133,7 +133,7 @@ func TestEveryResultTypeSatisfiesTheSchemaDerivedFromIt(t *testing.T) {
 		"ArchiveResult":        ArchiveResult{Archived: true, RecordType: "person", ID: id},
 		"PromoteLeadResult":    PromoteLeadResult{Merged: true, Person: record},
 		"MergeRecordsResult":   MergeRecordsResult{Merged: true, RecordType: "person", SurvivorID: id},
-		"DraftEmailResult":     DraftEmailResult{Subject: "Re: x", Body: "hi", InReplyToActivityID: id},
+		"DraftEmailResult":     DraftEmailResult{Subject: "Re: x", Body: "hi", InReplyToActivityID: &id},
 		"AssembledContext":     AssembledContextResult{Anchor: ContextAnchor{RecordType: "deal", RecordID: id}, Sections: []ContextSection{{Name: "recent", Items: []ContextItem{{RecordType: "activity", RecordID: id, Summary: "s", Evidence: []ContextEvidence{{Source: "a", Snippet: "b"}}}}}}},
 		"PrepForMeetingResult": PrepForMeetingResult{Briefing: AssembledContextResult{Anchor: ContextAnchor{RecordType: "deal", RecordID: id}, Sections: []ContextSection{}}, MeetingFocus: []MeetingFocusItem{{RecordID: id, Summary: "s"}}},
 		"QualifyLeadResult":    QualifyLeadResult{RecordID: id, Filled: map[string]QualifiedField{"company_name": {Value: "Acme", Evidence: []ContextEvidence{{Source: "lead.email", Snippet: "a@acme"}}}}, Gaps: []string{"title"}},

--- a/backend/internal/modules/agents/results.go
+++ b/backend/internal/modules/agents/results.go
@@ -220,8 +220,13 @@ type DraftEmailResult struct {
 	Body    string `json:"body"`
 	// InReplyToActivityID is echoed back because send_email needs it, and a
 	// caller that had to remember it across the two calls is a caller that can
-	// send a draft against the wrong thread.
-	InReplyToActivityID ids.UUID `json:"in_reply_to_activity_id"`
+	// send a draft against the wrong thread. Empty on a FIRST message, which
+	// answers no thread.
+	InReplyToActivityID ids.UUID `json:"in_reply_to_activity_id,omitempty"`
+	// Links is the same echo for a first message: send_account_email takes
+	// them, and a caller re-deriving them can file a conversation under the
+	// wrong record. Empty on a reply, which inherits its filing.
+	Links []RecordLink `json:"links,omitempty"`
 }
 
 // ContextAnchor names the record an assembled picture was built around.

--- a/backend/internal/modules/agents/results.go
+++ b/backend/internal/modules/agents/results.go
@@ -220,9 +220,15 @@ type DraftEmailResult struct {
 	Body    string `json:"body"`
 	// InReplyToActivityID is echoed back because send_email needs it, and a
 	// caller that had to remember it across the two calls is a caller that can
-	// send a draft against the wrong thread. Empty on a FIRST message, which
+	// send a draft against the wrong thread. Absent on a FIRST message, which
 	// answers no thread.
-	InReplyToActivityID ids.UUID `json:"in_reply_to_activity_id,omitempty"`
+	//
+	// A POINTER, because ids.UUID is a [16]byte array and `omitempty` never
+	// fires on one: a first message would have serialized
+	// "00000000-0000-0000-0000-000000000000" and read as a reply to a thread
+	// that does not exist. The package's own optional-id idiom is a pointer
+	// for exactly this reason.
+	InReplyToActivityID *ids.UUID `json:"in_reply_to_activity_id,omitempty"`
 	// Links is the same echo for a first message: send_account_email takes
 	// them, and a caller re-deriving them can file a conversation under the
 	// wrong record. Empty on a reply, which inherits its filing.

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1539,13 +1539,31 @@
             "type": "string",
             "format": "uuid"
           },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "entity_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "entity_type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "entity_id",
+                "entity_type"
+              ]
+            }
+          },
           "subject": {
             "type": "string"
           }
         },
         "required": [
           "body",
-          "in_reply_to_activity_id",
           "subject"
         ]
       },

--- a/backend/internal/modules/agents/toolcopy_comms.go
+++ b/backend/internal/modules/agents/toolcopy_comms.go
@@ -8,18 +8,15 @@ package agents
 // toolcopy.go for what each field answers.
 
 var draftEmailCopy = toolCopy{
-	Purpose: "Compose a reply to a conversation already recorded here, anchored on the thread " +
-		"it answers.",
-	Limits: "It writes the message and stops. Nothing is sent, nobody is notified, and the draft " +
-		"is returned for a person — or a later send — to use. It needs the activity_id of the " +
-		"thread being replied to; it cannot compose from a goal alone. Read what comes back " +
-		"before sending it: where no drafting model is configured this falls back to a short " +
-		"deterministic note built from the thread's subject.",
-	Instead: "Use draft_follow_ups_for to draft across a whole set of slipping deals at once, and " +
-		"send_email only once a drafted message exists to send.",
-	Retain: "Keep the drafted subject and body and the activity_id; send_email takes all three, " +
-		"and re-writing the text between the draft and the send means a person approves one " +
-		"message and a different one goes out.",
+	Purpose: "Compose an email: a reply to a recorded thread (activity_id), or a FIRST message " +
+		"to a record (links).",
+	Limits: "It writes the message and stops: nothing is sent. With no drafting model configured " +
+		"the text is a short deterministic note rather than a composed one.",
+	Instead: "draft_follow_ups_for drafts across a set of slipping deals at once; send_email " +
+		"sends a reply, send_account_email a first message.",
+	Retain: "Keep what comes back — subject, body, and the activity_id or links echoed with it; " +
+		"the send takes them. Re-writing the text in between means a person approves one " +
+		"message and another goes out.",
 }
 
 var draftFollowUpsForCopy = toolCopy{

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -14,6 +14,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -26,6 +27,17 @@ import (
 // paths; compose implements it over the one store both transports use.
 type Comms interface {
 	DraftEmail(ctx context.Context, anchor ids.UUID, intent string) (subject, body string, err error)
+	// DraftAccountEmail composes the FIRST message to a record, where
+	// DraftEmail can only continue a thread that already exists. It takes the
+	// records the conversation would be filed under instead of an anchor —
+	// the same shape SendAccountEmail takes, for the same reason: there is no
+	// prior message, and the product refuses to fabricate a placeholder
+	// activity to obtain one (ADR-0087).
+	//
+	// Without it there is no way to draft the follow-up after a first meeting,
+	// which is the case the web app's own "Draft a follow-up" button serves;
+	// an assistant asked for one had to fall back on a note nobody can send.
+	DraftAccountEmail(ctx context.Context, links []RecordLink, intent string) (subject, body string, err error)
 	SendEmail(ctx context.Context, anchor ids.UUID, in SendEmailArgs) (SendEmailResult, error)
 	// SendAccountEmail starts a NEW conversation instead of continuing one
 	// (ADR-0087). It takes no anchor — there is no prior message, and the
@@ -122,9 +134,12 @@ func (t draftEmailTool) Spec() mcp.ToolSpec {
 		Description:   draftEmailCopy.render(),
 		RequiredScope: principal.ScopeDraft, Tier: mcp.TierAutoExecute,
 		OpenAPIOp: "draftEmail",
-		InputSchema: schema(`{"type":"object","required":["activity_id"],"properties":{
-			"activity_id":{"type":"string","format":"uuid","description":"The thread being replied to"},
-			"intent":{"type":"string","description":"What the reply should accomplish"}},
+		InputSchema: schema(`{"type":"object","properties":{
+			"activity_id":{"type":"string","format":"uuid","description":"The thread replied to; omit and give links for a first message"},
+			"links":{"type":"array","minItems":1,"maxItems":25,"items":{"type":"object","required":["entity_type","entity_id"],"properties":{
+				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
+				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false}},
+			"intent":{"type":"string"}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[DraftEmailResult](),
 	}
@@ -132,11 +147,41 @@ func (t draftEmailTool) Spec() mcp.ToolSpec {
 
 func (t draftEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
 	var args struct {
-		ActivityID ids.UUID `json:"activity_id"`
-		Intent     string   `json:"intent"`
+		ActivityID ids.UUID     `json:"activity_id"`
+		Links      []RecordLink `json:"links"`
+		Intent     string       `json:"intent"`
 	}
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
+	}
+	// Two shapes, one verb: continue a thread, or open one. A first message
+	// used to be impossible here — the anchor was required, and after a first
+	// meeting with no inbound mail there was no thread to name, so the
+	// follow-up the web app offers a button for could not be drafted at all.
+	//
+	// Kept on this tool rather than split into a second: the caller's question
+	// is the same ("draft an email"), and the tool listing rides in every
+	// prompt — a near-duplicate schema is paid for on every call by every
+	// caller, including the ones that never draft anything.
+	if args.ActivityID == (ids.UUID{}) {
+		if len(args.Links) == 0 {
+			return nil, &BadArgsError{Cause: errors.New(
+				"give activity_id to reply to a thread, or links to open a new conversation")}
+		}
+		subject, body, err := t.comms.DraftAccountEmail(ctx, args.Links, args.Intent)
+		if err != nil {
+			return nil, err
+		}
+		// No noteDerivedContent: this composes from the caller's own intent,
+		// not from captured thread content, so it carries no external tier.
+		for _, l := range args.Links {
+			noteEvidence(ctx, datasource.EntityType(l.EntityType), l.EntityID)
+		}
+		return json.Marshal(DraftEmailResult{Subject: subject, Body: body, Links: args.Links})
+	}
+	if len(args.Links) > 0 {
+		return nil, &BadArgsError{Cause: errors.New(
+			"give activity_id or links, not both: a reply is filed where its thread already is")}
 	}
 	subject, body, err := t.comms.DraftEmail(ctx, args.ActivityID, args.Intent)
 	if err != nil {

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -116,7 +116,7 @@ func RegisterCommsTools(r *Registry, comms Comms, p datasource.SystemOfRecordPro
 		//craft:ignore panic-in-domain composition-time wiring assertion — fires only while cmd wiring runs, never on a request path
 		panic("crmagents: RegisterCommsTools needs a record provider — the confirm-first sends, the account-started send and book_meeting all read the records they stage against")
 	}
-	r.Register(draftEmailTool{comms: comms})
+	r.Register(draftEmailTool{comms: comms, p: p})
 	r.Register(sendEmailTool{comms: comms, p: p})
 	r.Register(sendAccountEmailTool{comms: comms, p: p})
 	r.Register(sendMessageTool{comms: comms, p: p})
@@ -126,11 +126,14 @@ func RegisterCommsTools(r *Registry, comms Comms, p datasource.SystemOfRecordPro
 
 // --- draft_email (🟢: proposes, never sends) ---
 
-type draftEmailTool struct{ comms Comms }
+type draftEmailTool struct {
+	comms Comms
+	p     datasource.SystemOfRecordProvider
+}
 
 func (t draftEmailTool) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
-		Name: "draft_email", Title: "Draft an email reply", Version: toolVersionV1,
+		Name: "draft_email", Title: "Draft an email", Version: toolVersionV1,
 		Description:   draftEmailCopy.render(),
 		RequiredScope: principal.ScopeDraft, Tier: mcp.TierAutoExecute,
 		OpenAPIOp: "draftEmail",
@@ -147,7 +150,12 @@ func (t draftEmailTool) Spec() mcp.ToolSpec {
 
 func (t draftEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
 	var args struct {
-		ActivityID ids.UUID     `json:"activity_id"`
+		// A POINTER, so an omitted activity_id is distinguishable from an
+		// explicit all-zero one. Comparing against ids.UUID{} could not tell
+		// them apart, and the schema no longer requires the field, so a caller
+		// naming both an all-zero anchor and links would have slipped past the
+		// "not both" refusal below.
+		ActivityID *ids.UUID    `json:"activity_id"`
 		Links      []RecordLink `json:"links"`
 		Intent     string       `json:"intent"`
 	}
@@ -163,34 +171,51 @@ func (t draftEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	// is the same ("draft an email"), and the tool listing rides in every
 	// prompt — a near-duplicate schema is paid for on every call by every
 	// caller, including the ones that never draft anything.
-	if args.ActivityID == (ids.UUID{}) {
+	if args.ActivityID == nil {
 		if len(args.Links) == 0 {
 			return nil, &BadArgsError{Cause: errors.New(
 				"give activity_id to reply to a thread, or links to open a new conversation")}
 		}
-		subject, body, err := t.comms.DraftAccountEmail(ctx, args.Links, args.Intent)
+		// The same cap and de-duplication send_account_email applies, so a
+		// draft cannot succeed with a link set the advertised follow-on send
+		// would refuse.
+		links, err := uniqueRecordLinks(args.Links)
+		if err != nil {
+			return nil, err
+		}
+		// EVERY link is read before anything else happens, exactly as the send
+		// path's guard does (commandlinked.go). The composer reads nothing —
+		// the draft comes from the caller's own intent — so it would otherwise
+		// be possible for a passport holding only `draft` to name any id at
+		// all and have it recorded as evidence, and to learn from an
+		// idempotent replay whether that id is readable. A draft scope must not
+		// be a record-visibility oracle.
+		if _, err := readStageableLinks(ctx, t.p, links); err != nil {
+			return nil, err
+		}
+		subject, body, err := t.comms.DraftAccountEmail(ctx, links, args.Intent)
 		if err != nil {
 			return nil, err
 		}
 		// No noteDerivedContent: this composes from the caller's own intent,
 		// not from captured thread content, so it carries no external tier.
-		for _, l := range args.Links {
+		for _, l := range links {
 			noteEvidence(ctx, datasource.EntityType(l.EntityType), l.EntityID)
 		}
-		return json.Marshal(DraftEmailResult{Subject: subject, Body: body, Links: args.Links})
+		return json.Marshal(DraftEmailResult{Subject: subject, Body: body, Links: links})
 	}
 	if len(args.Links) > 0 {
 		return nil, &BadArgsError{Cause: errors.New(
 			"give activity_id or links, not both: a reply is filed where its thread already is")}
 	}
-	subject, body, err := t.comms.DraftEmail(ctx, args.ActivityID, args.Intent)
+	subject, body, err := t.comms.DraftEmail(ctx, *args.ActivityID, args.Intent)
 	if err != nil {
 		return nil, err
 	}
 	// The draft is composed from a captured thread, so its text carries that
 	// thread's content and its tier.
 	noteDerivedContent(ctx)
-	noteEvidence(ctx, datasource.EntityActivity, args.ActivityID)
+	noteEvidence(ctx, datasource.EntityActivity, *args.ActivityID)
 	return json.Marshal(DraftEmailResult{
 		Subject: subject, Body: body, InReplyToActivityID: args.ActivityID,
 	})

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -31,10 +31,17 @@ type recordingComms struct {
 	// accountSent is the same evidence for the account-started send: the links
 	// the seam was reached with, nil when the call never got that far.
 	accountSent []RecordLink
+	// accountDrafted is that evidence for the FIRST-message draft.
+	accountDrafted []RecordLink
 }
 
 func (c *recordingComms) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
 	return "", "", nil
+}
+
+func (c *recordingComms) DraftAccountEmail(_ context.Context, links []RecordLink, _ string) (string, string, error) {
+	c.accountDrafted = links
+	return "Following up", "As discussed.", nil
 }
 
 func (c *recordingComms) SendEmail(context.Context, ids.UUID, SendEmailArgs) (SendEmailResult, error) {
@@ -509,4 +516,56 @@ func TestAStagedSummaryNamesEveryArgumentItReleases(t *testing.T) {
 			}
 		}
 	})
+}
+
+// The first message, which this tool could not write at all until now.
+//
+// draft_email required an activity_id, so after a first meeting with no
+// inbound mail there was no thread to name and the follow-up could not be
+// drafted — the case the web app offers a "Draft a follow-up" button for. An
+// assistant asked for one fell back on a note nobody can send.
+func TestDraftEmailComposesAFirstMessageFromLinksAlone(t *testing.T) {
+	comms := &recordingComms{}
+	org := ids.NewV7()
+	out, err := draftEmailTool{comms: comms}.Handle(context.Background(),
+		json.RawMessage(`{"links":[{"entity_type":"organization","entity_id":"`+org.String()+`"}],`+
+			`"intent":"thank them for the meeting and propose a small first package"}`))
+	if err != nil {
+		t.Fatalf("drafting a first message answered %v, want a draft", err)
+	}
+	var got DraftEmailResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding the draft: %v", err)
+	}
+	if got.Subject == "" || got.Body == "" {
+		t.Errorf("draft = %+v, want a subject and a body", got)
+	}
+	// The links are echoed because send_account_email takes them: a caller
+	// re-deriving them can file the conversation under the wrong record.
+	if len(got.Links) != 1 || got.Links[0].EntityID != org {
+		t.Errorf("draft echoed links %+v, want the organization it was given", got.Links)
+	}
+	// And it reached the account-started seam, not the threaded one.
+	if len(comms.accountDrafted) != 1 {
+		t.Errorf("the first-message seam saw %+v, want the one link", comms.accountDrafted)
+	}
+}
+
+// The two shapes are alternatives, not a pair: a reply is filed where its
+// thread already is, so naming both leaves the filing ambiguous.
+func TestDraftEmailRefusesNeitherShapeAndBothAtOnce(t *testing.T) {
+	for name, args := range map[string]string{
+		"neither": `{"intent":"say hello"}`,
+		"both": `{"activity_id":"` + ids.NewV7().String() + `",` +
+			`"links":[{"entity_type":"organization","entity_id":"` + ids.NewV7().String() + `"}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := draftEmailTool{comms: &recordingComms{}}.Handle(
+				context.Background(), json.RawMessage(args))
+			var bad *BadArgsError
+			if !errors.As(err, &bad) {
+				t.Fatalf("answered %v, want a BadArgsError naming what to send", err)
+			}
+		})
+	}
 }

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -527,9 +527,12 @@ func TestAStagedSummaryNamesEveryArgumentItReleases(t *testing.T) {
 func TestDraftEmailComposesAFirstMessageFromLinksAlone(t *testing.T) {
 	comms := &recordingComms{}
 	org := ids.NewV7()
-	out, err := draftEmailTool{comms: comms}.Handle(context.Background(),
-		json.RawMessage(`{"links":[{"entity_type":"organization","entity_id":"`+org.String()+`"}],`+
-			`"intent":"thank them for the meeting and propose a small first package"}`))
+	// A provider that can SEE the organization: the first-message path reads
+	// every link before drafting, the same guard the send path applies.
+	out, err := draftEmailTool{comms: comms, p: oneRecord(datasource.EntityOrganization, org, `{}`, 1)}.
+		Handle(context.Background(),
+			json.RawMessage(`{"links":[{"entity_type":"organization","entity_id":"`+org.String()+`"}],`+
+				`"intent":"thank them for the meeting and propose a small first package"}`))
 	if err != nil {
 		t.Fatalf("drafting a first message answered %v, want a draft", err)
 	}
@@ -560,12 +563,51 @@ func TestDraftEmailRefusesNeitherShapeAndBothAtOnce(t *testing.T) {
 			`"links":[{"entity_type":"organization","entity_id":"` + ids.NewV7().String() + `"}]}`,
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, err := draftEmailTool{comms: &recordingComms{}}.Handle(
+			_, err := draftEmailTool{comms: &recordingComms{}, p: unreadableProvider{}}.Handle(
 				context.Background(), json.RawMessage(args))
 			var bad *BadArgsError
 			if !errors.As(err, &bad) {
 				t.Fatalf("answered %v, want a BadArgsError naming what to send", err)
 			}
 		})
+	}
+}
+
+// A draft scope must not be a record-visibility oracle.
+//
+// The composer reads nothing — a first message is written from the caller's
+// own intent — so without this guard a passport holding only `draft` could
+// name ANY id, have it recorded as evidence, and learn from an idempotent
+// replay whether that id is readable. The send path has always read every
+// link (commandlinked.go); the draft path now does too.
+func TestDraftingAFirstMessageRefusesALinkTheCallerCannotRead(t *testing.T) {
+	comms := &recordingComms{}
+	_, err := draftEmailTool{comms: comms, p: unreadableProvider{}}.Handle(context.Background(),
+		json.RawMessage(`{"links":[{"entity_type":"organization","entity_id":"`+
+			ids.NewV7().String()+`"}],"intent":"hello"}`))
+	if err == nil {
+		t.Fatal("drafting against an unreadable record answered a draft, want a refusal")
+	}
+	// And the composer was never reached, so nothing was written about a
+	// record the caller cannot see.
+	if comms.accountDrafted != nil {
+		t.Errorf("the composer saw %+v, want it never reached", comms.accountDrafted)
+	}
+}
+
+// The cap the follow-on send enforces is enforced here too, so a draft cannot
+// succeed with a link set send_account_email would refuse.
+func TestDraftingAFirstMessageAppliesTheSendsLinkCap(t *testing.T) {
+	links := make([]string, 0, maxRecordLinks+1)
+	for range maxRecordLinks + 1 {
+		links = append(links, `{"entity_type":"organization","entity_id":"`+ids.NewV7().String()+`"}`)
+	}
+	_, err := draftEmailTool{comms: &recordingComms{}, p: unreadableProvider{}}.Handle(
+		context.Background(),
+		json.RawMessage(`{"links":[`+strings.Join(links, ",")+`],"intent":"hello"}`))
+	var bad *BadArgsError
+	if !errors.As(err, &bad) {
+		t.Fatalf("drafting with %d links answered %v, want the cap refusal the send applies",
+			maxRecordLinks+1, err)
 	}
 }

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 43,
     "resources": 8,
-    "tool_catalog_bytes": 124463,
+    "tool_catalog_bytes": 124626,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 31892,
+    "approx_wire_tokens_total": 31933,
     "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 32392,
-      "input_schema_bytes": 28817,
-      "output_schema_bytes": 53807,
-      "description_plus_input_schema_bytes": 61209
+      "description_bytes": 32143,
+      "input_schema_bytes": 29072,
+      "output_schema_bytes": 53964,
+      "description_plus_input_schema_bytes": 61215
     }
   },
   "tools": {
@@ -2075,12 +2075,12 @@
           "readOnlyHint": false,
           "title": "Draft an email reply"
         },
-        "description": "Compose a reply to a conversation already recorded here, anchored on the thread it answers. It writes the message and stops. Nothing is sent, nobody is notified, and the draft is returned for a person — or a later send — to use. It needs the activity_id of the thread being replied to; it cannot compose from a goal alone. Read what comes back before sending it: where no drafting model is configured this falls back to a short deterministic note built from the thread's subject. Use draft_follow_ups_for to draft across a whole set of slipping deals at once, and send_email only once a drafted message exists to send. Keep the drafted subject and body and the activity_id; send_email takes all three, and re-writing the text between the draft and the send means a person approves one message and a different one goes out. (Governance: runs immediately; requires passport scope \"draft\".)",
+        "description": "Compose an email: a reply to a recorded thread (activity_id), or a FIRST message to a record (links). It writes the message and stops: nothing is sent. With no drafting model configured the text is a short deterministic note rather than a composed one. draft_follow_ups_for drafts across a set of slipping deals at once; send_email sends a reply, send_account_email a first message. Keep what comes back — subject, body, and the activity_id or links echoed with it; the send takes them. Re-writing the text in between means a person approves one message and another goes out. (Governance: runs immediately; requires passport scope \"draft\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
             "activity_id": {
-              "description": "The thread being replied to",
+              "description": "The thread replied to; omit and give links for a first message",
               "format": "uuid",
               "type": "string"
             },
@@ -2090,13 +2090,38 @@
               "type": "string"
             },
             "intent": {
-              "description": "What the reply should accomplish",
               "type": "string"
+            },
+            "links": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "entity_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "entity_type": {
+                    "enum": [
+                      "person",
+                      "organization",
+                      "deal",
+                      "lead",
+                      "project"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "entity_type",
+                  "entity_id"
+                ],
+                "type": "object"
+              },
+              "maxItems": 25,
+              "minItems": 1,
+              "type": "array"
             }
           },
-          "required": [
-            "activity_id"
-          ],
           "type": "object"
         },
         "name": "draft_email",
@@ -2111,13 +2136,31 @@
                   "format": "uuid",
                   "type": "string"
                 },
+                "links": {
+                  "items": {
+                    "properties": {
+                      "entity_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "entity_type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "entity_id",
+                      "entity_type"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
                 "subject": {
                   "type": "string"
                 }
               },
               "required": [
                 "body",
-                "in_reply_to_activity_id",
                 "subject"
               ],
               "type": "object"

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,9 +10,9 @@
   "totals": {
     "tools": 43,
     "resources": 8,
-    "tool_catalog_bytes": 124626,
+    "tool_catalog_bytes": 124614,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 31933,
+    "approx_wire_tokens_total": 31930,
     "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
@@ -2073,7 +2073,7 @@
         "annotations": {
           "openWorldHint": false,
           "readOnlyHint": false,
-          "title": "Draft an email reply"
+          "title": "Draft an email"
         },
         "description": "Compose an email: a reply to a recorded thread (activity_id), or a FIRST message to a record (links). It writes the message and stops: nothing is sent. With no drafting model configured the text is a short deterministic note rather than a composed one. draft_follow_ups_for drafts across a set of slipping deals at once; send_email sends a reply, send_account_email a first message. Keep what comes back — subject, body, and the activity_id or links echoed with it; the send takes them. Re-writing the text in between means a person approves one message and another goes out. (Governance: runs immediately; requires passport scope \"draft\".)",
         "inputSchema": {
@@ -2243,7 +2243,7 @@
           ],
           "type": "object"
         },
-        "title": "Draft an email reply"
+        "title": "Draft an email"
       },
       {
         "annotations": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 43 |
 | Resources | 8 |
-| Tool catalog | 121.5 KB |
+| Tool catalog | 121.7 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 31892 |
+| Approx. wire tokens | 31933 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -28,9 +28,9 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 52.5 KB | 43% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 31.6 KB | 26% | Yes, every step |
-| Input schemas | 28.1 KB | 23% | Yes, every step |
+| Output schemas | 52.7 KB | 43% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 31.4 KB | 25% | Yes, every step |
+| Input schemas | 28.4 KB | 23% | Yes, every step |
 | _Names, annotations, punctuation_ | 9.2 KB | 7% | Partly |
 | **Description + input schema** | **59.8 KB** | **49%** | **the recurring cost** |
 
@@ -71,7 +71,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 3.0 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 3.0 KB |
 | [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 2.0 KB |
-| [`draft_email`](#draft_email) | Draft an email reply |  |  | 2.4 KB |
+| [`draft_email`](#draft_email) | Draft an email reply |  |  | 2.6 KB |
 | [`draft_follow_ups_for`](#draft_follow_ups_for) | Draft follow-ups |  |  | 2.7 KB |
 | [`enrich`](#enrich) | Enrich an organization from its website |  |  | 2.6 KB |
 | [`intro_path_to`](#intro_path_to) | Find a warm introduction path | yes |  | 2.3 KB |
@@ -2426,7 +2426,7 @@ Close out a lead that is not going anywhere, so it stops appearing as live work.
 
 **Draft an email reply**
 
-Compose a reply to a conversation already recorded here, anchored on the thread it answers. It writes the message and stops. Nothing is sent, nobody is notified, and the draft is returned for a person — or a later send — to use. It needs the activity_id of the thread being replied to; it cannot compose from a goal alone. Read what comes back before sending it: where no drafting model is configured this falls back to a short deterministic note built from the thread's subject. Use draft_follow_ups_for to draft across a whole set of slipping deals at once, and send_email only once a drafted message exists to send. Keep the drafted subject and body and the activity_id; send_email takes all three, and re-writing the text between the draft and the send means a person approves one message and a different one goes out. (Governance: runs immediately; requires passport scope "draft".)
+Compose an email: a reply to a recorded thread (activity_id), or a FIRST message to a record (links). It writes the message and stops: nothing is sent. With no drafting model configured the text is a short deterministic note rather than a composed one. draft_follow_ups_for drafts across a set of slipping deals at once; send_email sends a reply, send_account_email a first message. Keep what comes back — subject, body, and the activity_id or links echoed with it; the send takes them. Re-writing the text in between means a person approves one message and another goes out. (Governance: runs immediately; requires passport scope "draft".)
 
 <details><summary>Input schema</summary>
 
@@ -2435,7 +2435,7 @@ Compose a reply to a conversation already recorded here, anchored on the thread 
   "additionalProperties": false,
   "properties": {
     "activity_id": {
-      "description": "The thread being replied to",
+      "description": "The thread replied to; omit and give links for a first message",
       "format": "uuid",
       "type": "string"
     },
@@ -2445,13 +2445,38 @@ Compose a reply to a conversation already recorded here, anchored on the thread 
       "type": "string"
     },
     "intent": {
-      "description": "What the reply should accomplish",
       "type": "string"
+    },
+    "links": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "entity_type": {
+            "enum": [
+              "person",
+              "organization",
+              "deal",
+              "lead",
+              "project"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_type",
+          "entity_id"
+        ],
+        "type": "object"
+      },
+      "maxItems": 25,
+      "minItems": 1,
+      "type": "array"
     }
   },
-  "required": [
-    "activity_id"
-  ],
   "type": "object"
 }
 ```
@@ -2472,13 +2497,31 @@ Compose a reply to a conversation already recorded here, anchored on the thread 
           "format": "uuid",
           "type": "string"
         },
+        "links": {
+          "items": {
+            "properties": {
+              "entity_id": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "entity_type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "entity_id",
+              "entity_type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
         "subject": {
           "type": "string"
         }
       },
       "required": [
         "body",
-        "in_reply_to_activity_id",
         "subject"
       ],
       "type": "object"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 8 |
 | Tool catalog | 121.7 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 31933 |
+| Approx. wire tokens | 31930 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -71,7 +71,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 3.0 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 3.0 KB |
 | [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 2.0 KB |
-| [`draft_email`](#draft_email) | Draft an email reply |  |  | 2.6 KB |
+| [`draft_email`](#draft_email) | Draft an email |  |  | 2.6 KB |
 | [`draft_follow_ups_for`](#draft_follow_ups_for) | Draft follow-ups |  |  | 2.7 KB |
 | [`enrich`](#enrich) | Enrich an organization from its website |  |  | 2.6 KB |
 | [`intro_path_to`](#intro_path_to) | Find a warm introduction path | yes |  | 2.3 KB |
@@ -2424,7 +2424,7 @@ Close out a lead that is not going anywhere, so it stops appearing as live work.
 
 ### draft_email
 
-**Draft an email reply**
+**Draft an email**
 
 Compose an email: a reply to a recorded thread (activity_id), or a FIRST message to a record (links). It writes the message and stops: nothing is sent. With no drafting model configured the text is a short deterministic note rather than a composed one. draft_follow_ups_for drafts across a set of slipping deals at once; send_email sends a reply, send_account_email a first message. Keep what comes back — subject, body, and the activity_id or links echoed with it; the send takes them. Re-writing the text in between means a person approves one message and another goes out. (Governance: runs immediately; requires passport scope "draft".)
 


### PR DESCRIPTION
Closes MCP-TODO item 4b — marked **MUST BE POSSIBLE**.

`draft_email` required an `activity_id`: the thread being answered. After a first meeting with no inbound mail there is no such thread, so the follow-up could not be drafted at all — the exact case the web app offers a "Draft a follow-up" button for. An assistant asked for one fell back on `file_note`, which writes into a notepad extension nobody can send from.

## What changed

`draft_email` now takes **either** `activity_id` (reply to that thread) **or** `links` (open a conversation filed under those records), refusing neither and both. The links echo back in the result because `send_account_email` takes them.

The seam gains `DraftAccountEmail`, mirroring `SendAccountEmail`'s shape (ADR-0087: no anchor, because there is no prior message and the product refuses to fabricate a placeholder activity to get one).

## Two decisions worth stating

**One tool, not two.** A separate `draft_account_email` was built first and cost ~378 tokens of the tool listing — capped at 15000 and already at ~14990. A near-duplicate schema is paid for on every call by every caller, including those that never draft. Folding it into `draft_email` and tightening that tool's copy for its two shapes landed under the bound with **no net growth**.

**Deterministic drafting only, for now.** `activities.EmailDrafter` — the routed model lane — takes an anchor by signature, so a first message cannot reach it without widening that interface and the AI task behind it. Left for its own change; the copy says the fallback is a short deterministic note.

## Codex review: one High, fixed

The first-message path passed links to the composer and recorded each as evidence **without reading any of them**. The composer reads nothing by design, so a passport holding only `draft` could name any id, have it asserted as evidence, and learn from an idempotent replay whether that id is readable. It now calls `readStageableLinks` — the guard the send path has always applied.

Four more from the same review, all fixed: `omitempty` on an `ids.UUID` (a `[16]byte` array) never fires, so a first message serialized an all-zero uuid and read as a reply to a nonexistent thread; the advertised `maxItems:25` was not enforced, so a 26-link draft succeeded and the follow-on send refused it; the deterministic fallback printed the intent twice; and a zero-uuid `activity_id` slipped past the "not both" refusal. Plus the title, which still said "reply".

## Verification

Four tests: the first message composes and echoes its links, neither-and-both are refused, an unreadable link is refused before the composer is reached, and the send's link cap applies. Full local gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables drafting a first outbound email in addition to replies. Previously `draft_email` required an `activity_id`; now it accepts either `activity_id` (reply) or `links` (start a conversation) and echoes back what the corresponding send call needs.

- Drafting a first message: `draft_email` input adds `links` (min 1, max 25); output adds `links` when composing a first message. For replies, `in_reply_to_activity_id` is now optional and only present when replying.
- New seam: `Comms.DraftAccountEmail(ctx, links, intent)` composes the first message; first-message drafts use a deterministic fallback for now.
- Safety and correctness: all provided links are de-duped and read via the same guard as `send_account_email`; calls naming neither or both shapes are refused; a zero UUID can’t bypass checks; tool title/copy and reference docs updated.

Bolded sections:

- Migration
  - Implement `DraftAccountEmail` on any `Comms` adapter and update mocks/stubs.
  - Update consumers of `DraftEmailResult` to handle a nullable `in_reply_to_activity_id` and to read `links` for first-message sends via `send_account_email`.

<sup>Written for commit 35c6ba4ccfa57a903f4f7a86b81a445f34e26da1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

