### PR TITLE
fix(api): every configuration fault this layer can see arrives in one error

### DIFF
--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
@@ -134,14 +135,30 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	// consulted.
 	cfg.unknownVars = registry.Undeclared(config.Environ())
 	cfg.posture = runtimeenv.Parse(config.FromOS(runtimeenv.EnvVar))
+	// Every configuration fault this layer can see is collected and reported
+	// TOGETHER, rather than returned at the first one.
+	//
+	// Returning early made starting the binary by hand a guessing game played
+	// one boot at a time: the missing DSN was the only thing said, and the next
+	// run then answered with the licence refusal, which is a second fact that
+	// was true all along. Two boots to learn two requirements, and an operator
+	// who fixes both at once never sees the second message at all.
+	var faults []string
 	if cfg.dsn == "" {
-		return apiConfig{}, errors.New("api: --dsn or MARGINCE_DSN required")
+		faults = append(faults, "--dsn or MARGINCE_DSN required")
 	}
 	// A TTL the mint would refuse must fail the BOOT, not the first handshake
 	// of a connector nobody is watching.
 	if cfg.oauthAccessTokenTTL < 0 || cfg.oauthAccessTokenTTL > identity.MaxOAuthAccessTokenTTL {
-		return apiConfig{}, fmt.Errorf("api: --oauth-access-token-ttl %s is out of range: 0 (the default) or up to %s",
-			cfg.oauthAccessTokenTTL, identity.MaxOAuthAccessTokenTTL)
+		faults = append(faults, fmt.Sprintf("--oauth-access-token-ttl %s is out of range: 0 (the default) or up to %s",
+			cfg.oauthAccessTokenTTL, identity.MaxOAuthAccessTokenTTL))
+	}
+	if len(faults) == 1 {
+		return apiConfig{}, errors.New("api: " + faults[0])
+	}
+	if len(faults) > 1 {
+		return apiConfig{}, errors.New("api: the configuration is incomplete:\n  - " +
+			strings.Join(faults, "\n  - "))
 	}
 	return *cfg, nil
 }

--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -56,6 +56,11 @@ type apiConfig struct {
 	// it, and stderr before the log handler is built is a different stream in a
 	// different format from everything else they are reading.
 	unknownVars []string
+	// envFaults are configuration faults found while REGISTERING the flags,
+	// before parsing can begin — a malformed duration in the environment is
+	// the only one today. Carried so they join the faults found after parsing
+	// rather than pre-empting them.
+	envFaults []string
 }
 
 // apiFlagSet registers this role's flags and their environment bindings, and
@@ -98,9 +103,15 @@ func apiFlagSet() (*flag.FlagSet, *cliflags.Env, *apiConfig, error) {
 	env.String(fs, &cfg.connectorStateKey, "connector-state-key", "MARGINCE_CONNECTOR_STATE_KEY", "", "HMAC key (>=32 bytes) signing the OAuth connect `state`; required for the Gmail and Graph connect flows")
 	env.String(fs, &cfg.webhookKey, "webhook-key", "MARGINCE_WEBHOOK_KEY", "", "base64 32-byte key sealing outbound-webhook signing secrets; enables the mutating /webhook-subscriptions surface, and (with --inline-relay) the cg:webhooks delivery consumer. Empty = those paths answer 503 and no inline delivery runs. Re-attempting a parked delivery is the worker role's River job, never this one's.")
 	env.String(fs, &cfg.metricsToken, "metrics-token", "MARGINCE_METRICS_TOKEN", "", "shared secret /metrics requires as a Bearer credential; empty (the default) answers 404 for /metrics rather than serving per-workspace job telemetry with no authentication at all")
-	accessTokenTTL, err := envDuration(oauthAccessTokenTTLEnv)
-	if err != nil {
-		return nil, nil, nil, err
+	// A malformed TTL is CARRIED rather than returned, so it can be reported
+	// beside a missing DSN instead of hiding it for a boot. Returning here
+	// would put this fault ahead of every other one by accident of ordering —
+	// the same one-fault-per-boot the collection below exists to end. The flag
+	// still registers, on the compiled default, so parsing proceeds far enough
+	// to find whatever else is wrong.
+	accessTokenTTL, ttlErr := envDuration(oauthAccessTokenTTLEnv)
+	if ttlErr != nil {
+		cfg.envFaults = append(cfg.envFaults, ttlErr.Error())
 	}
 	fs.DurationVar(&cfg.oauthAccessTokenTTL, "oauth-access-token-ttl", accessTokenTTL,
 		"lifetime of the access token (an Agent Seat Passport) the OAuth handshake mints, for the code exchange and every refresh rotation; 0 = the passport default of 720h (30 days), maximum 2160h (90 days)")
@@ -143,7 +154,7 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	// run then answered with the licence refusal, which is a second fact that
 	// was true all along. Two boots to learn two requirements, and an operator
 	// who fixes both at once never sees the second message at all.
-	var faults []string
+	faults := append([]string{}, cfg.envFaults...)
 	if cfg.dsn == "" {
 		faults = append(faults, "--dsn or MARGINCE_DSN required")
 	}

--- a/backend/cmd/api/config_test.go
+++ b/backend/cmd/api/config_test.go
@@ -152,3 +152,35 @@ func TestValidatePublicBaseURLRefusesUserinfoWithoutEchoingIt(t *testing.T) {
 		t.Errorf("refusal %q does not say what is wrong", err)
 	}
 }
+
+// Every configuration fault this layer can see is reported together.
+//
+// Starting the binary by hand used to be a guessing game played one boot at a
+// time: the first return said only what it had reached, and the next run
+// answered with a fault that had been true all along.
+func TestParseReportsEveryConfigurationFaultAtOnce(t *testing.T) {
+	t.Setenv("MARGINCE_DSN", "")
+	_, err := parseAPIFlags([]string{"--oauth-access-token-ttl", "99999h"})
+	if err == nil {
+		t.Fatal("parsing answered no error, want both faults reported")
+	}
+	for _, want := range []string{"--dsn", "--oauth-access-token-ttl"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not mention %s — an operator fixing one fault at a time "+
+				"pays a boot per fault:\n%s", want, err)
+		}
+	}
+}
+
+// One fault still reads as one sentence: a list of one is a worse message than
+// the sentence it replaces.
+func TestOneFaultIsNotRenderedAsAList(t *testing.T) {
+	t.Setenv("MARGINCE_DSN", "")
+	_, err := parseAPIFlags(nil)
+	if err == nil {
+		t.Fatal("parsing answered no error, want the missing DSN")
+	}
+	if strings.Contains(err.Error(), "\n  - ") {
+		t.Errorf("a single fault was rendered as a bullet list:\n%s", err)
+	}
+}

--- a/backend/cmd/api/config_test.go
+++ b/backend/cmd/api/config_test.go
@@ -184,3 +184,23 @@ func TestOneFaultIsNotRenderedAsAList(t *testing.T) {
 		t.Errorf("a single fault was rendered as a bullet list:\n%s", err)
 	}
 }
+
+// A fault found while REGISTERING the flags joins the ones found after
+// parsing, instead of pre-empting them.
+//
+// A malformed duration in the environment used to return before the flag set
+// even existed, so it hid a missing DSN for a boot — the same one-fault-per-run
+// this collection exists to end, reintroduced by ordering.
+func TestAMalformedEnvDurationIsReportedBesideTheOtherFaults(t *testing.T) {
+	t.Setenv("MARGINCE_DSN", "")
+	t.Setenv(oauthAccessTokenTTLEnv, "not-a-duration")
+	_, err := parseAPIFlags(nil)
+	if err == nil {
+		t.Fatal("parsing answered no error, want both faults")
+	}
+	for _, want := range []string{"--dsn", oauthAccessTokenTTLEnv} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not mention %s:\n%s", want, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes MCP-TODO item 9.

Starting `./bin/api` by hand was a guessing game played one boot at a time. The first return said only what it had reached — `--dsn or MARGINCE_DSN required` — and the next run answered with the licence refusal, a fact that had been true all along. Two boots to learn two requirements, and an operator who fixes both at once never sees the second message.

`parseAPIFlags` now collects its faults and reports them together. A single fault still reads as one sentence — a list of one is a worse message than the sentence it replaces — and a test pins that.

## What stays where it is

The licence check (`compose/license.go`) cannot move into config parsing: it needs the installation read from the database first, so it is not knowable there. Its message already names the fix (`set MARGINCE_ENV=dev`), which is what the todo asked of it.

## Correcting the todo

Verified by running the binary bare: **`MARGINCE_BLOBSTORE_*` is not required.** `blobstore.FromEnv` reports "not configured" and the api boots with attachments disabled. Only the DSN and `MARGINCE_ENV` actually bite. The findings doc now says so, with the working recipe.

Full local gate green, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregates configuration parse errors so operators see all actionable faults in one run. Previously the parser returned on the first fault; now it emits a combined error, while a single fault still renders as one sentence.

- Fault collection covers a missing DSN, out-of-range `--oauth-access-token-ttl`, and a malformed `MARGINCE_OAUTH_ACCESS_TOKEN_TTL` found during flag registration; the malformed TTL no longer pre-empts other faults and is reported with them.
- Error text changes; update any tests or log scrapers that match exact messages.
- The licence check stays outside config parsing and runs after DB init; it is not part of the combined parse error.
- `MARGINCE_BLOBSTORE_*` remains optional; the API starts with attachments disabled when absent.

<sup>Written for commit ea1066b72dd446f32b8bf0e598fe7eb8c33c85c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

