### PR TITLE
fix(privacy): a sweep waiver ratifies one trigger, not a table (#2046)

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -296,6 +296,11 @@ func TestDropResetCustomFieldColumns(t *testing.T) {
 // A row-conditional hold refuses deletes for SOME rows and is not a protected
 // store — preserving it would exempt a table the reset exists to clear. So the
 // second shape is classified here, with what the reset owes it.
+//
+// Keyed "<table> <trigger>", on the PAIR the gate reports, because a table-keyed
+// entry ratifies the category rather than the instance: it clears the trigger it
+// was written for AND every DELETE trigger added to that table afterwards,
+// including one that really does block. Each trigger earns its own line.
 var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	// Not a protected table: the guard refuses a DELETE only while a row carries
 	// `restricted_at`, which is a statutory hold on that one record. Preserving
@@ -308,10 +313,16 @@ var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	// lands, the reset must LIFT the restrictions it is entitled to clear before
 	// deleting, or the sweep aborts on the first held activity. This entry is
 	// that obligation, not a record of one already met.
-	"activity": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
+	"activity activity_refuse_restricted_mutation": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
 	// Not guards at all (migration 1787032690).
-	"activity_link": "a clock-maintenance trigger, not a guard: it recomputes the last_activity_at of the records the deleted link reached and refuses no delete; the sweep deletes those records too, so the recompute is discarded with them",
-	"relationship":  "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
+	"activity_link activity_link_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the last_activity_at of the records the deleted link reached and refuses no delete; the sweep deletes those records too, so the recompute is discarded with them",
+	"relationship relationship_last_activity":   "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
+	// Also not a guard (migration 1787226902): BEFORE DELETE ON organization,
+	// it sets deal.partner_org_id and deal.partner_attribution to NULL so a
+	// deleted partner leaves no dangling attribution behind. It refuses no
+	// delete. The sweep clears `deal` too, so the rows it just nulled are
+	// deleted immediately after and the clearing is discarded with them.
+	"organization organization_delete_clears_deal_partner": "a clear-the-reference trigger, not a guard: deleting an organization nulls the partner attribution on deals that named it and refuses no delete; the sweep deletes those deals too, so the clearing is discarded with them",
 })
 
 func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {
@@ -346,7 +357,7 @@ func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {
 			if err := rows.Scan(&table, &trigger); err != nil {
 				return err
 			}
-			if targetSet[table] && !deleteGuardedSweepTargets.Waived(t, table) {
+			if targetSet[table] && !deleteGuardedSweepTargets.Waived(t, table+" "+trigger) {
 				t.Errorf("sweep target %q carries DELETE-firing trigger %q — an append-only or otherwise protected table belongs in preservedResetTables; a row-conditional guard belongs in deleteGuardedSweepTargets, with what the reset owes it", table, trigger)
 			}
 		}

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -317,12 +317,26 @@ var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	// Not guards at all (migration 1787032690).
 	"activity_link activity_link_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the last_activity_at of the records the deleted link reached and refuses no delete; the sweep deletes those records too, so the recompute is discarded with them",
 	"relationship relationship_last_activity":   "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
-	// Also not a guard (migration 1787226902): BEFORE DELETE ON organization,
-	// it sets deal.partner_org_id and deal.partner_attribution to NULL so a
-	// deleted partner leaves no dangling attribution behind. It refuses no
-	// delete. The sweep clears `deal` too, so the rows it just nulled are
-	// deleted immediately after and the clearing is discarded with them.
-	"organization organization_delete_clears_deal_partner": "a clear-the-reference trigger, not a guard: deleting an organization nulls the partner attribution on deals that named it and refuses no delete; the sweep deletes those deals too, so the clearing is discarded with them",
+	// Also not a guard (migration 1787226902): BEFORE DELETE ON organization, it
+	// sets deal.partner_org_id and deal.partner_attribution to NULL so a deleted
+	// partner leaves no dangling attribution. It refuses no delete.
+	//
+	// It is not free, either, and "the deals go too" is not why it is safe.
+	// resetTargetTables orders alphabetically and the sweep retries per pass, so
+	// `deal` sorts before `offer` — whose deal_id is ON DELETE RESTRICT — and any
+	// installation holding one offer defers `deal` to a later pass. `organization`
+	// is then deleted in that same pass with `deal` still fully populated, and the
+	// trigger runs its UPDATE once per organization row. The only index on the
+	// column, idx_deal_partner, is partial on `archived_at IS NULL` while the
+	// trigger's predicate carries no archived_at term, so the planner cannot use
+	// it: each organization costs a sequential scan of `deal`, repeated on every
+	// deferred pass.
+	//
+	// It is safe because the work is discarded — `deal` is swept before the reset
+	// commits either way — not because it never happens. A workspace with tens of
+	// thousands of both pays O(orgs x deals) inside the reset transaction, and
+	// that is the cost this entry exists to put on the record.
+	"organization organization_delete_clears_deal_partner": "a clear-the-reference trigger, not a guard: it nulls the partner attribution on deals that named the deleted organization and refuses no delete. Not free — the sweep can defer `deal` behind `offer`'s ON DELETE RESTRICT, so this runs against a populated `deal` with a predicate idx_deal_partner cannot serve (it is partial on archived_at IS NULL), costing a scan per organization; the rows are swept afterwards regardless, so the work is discarded rather than wrong",
 })
 
 func TestSweepTargetsCarryNoDeleteBlockingTrigger(t *testing.T) {

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -339,10 +339,27 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// writer lands it must derive both from rows the actor could already see —
 	// this entry is the obligation, not a record of one already met.
 	"activity_retention_evidence.activity_id": "schema only, no writer yet (#1557): the evidence is written by the qualifying pass from the activity it substantiates, never from a request body — when that pass lands, the activity it names must be one the actor could already see",
-	"activity_retention_evidence.deal_id":     "schema only, no writer yet (#1557): the qualifying transaction is resolved from the activity's own link, not supplied — and it is ON DELETE SET NULL beside a frozen deal_name, so the evidence answers after the deal is gone",
-	"finance_customer_link.organization_id":   "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
-	"finance_invoice.organization_id":         "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
-	"finance_payment.organization_id":         "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	// Server-derived on both writers, never a client-supplied reference.
+	//
+	// This pair of entries is an obligation as much as a classification: it holds
+	// only while no request body names either id. A contract operation that
+	// accepts one — a hand-written entry, an import, a correction — makes it
+	// false, and that writer must put the named record through
+	// auth.EnsureLinkTarget rather than inherit this line.
+	// accrue.go takes deal_id from the outbox envelope's own entity and
+	// partner_org_id from the deal's stored partner carried on StageChanged;
+	// decide.go's insertReversal copies both from the ledger row it reverses,
+	// which the decide path already read under its gate. No contract operation
+	// accepts either id in a body, so there is no request for a target probe to
+	// check. Reads are not ungated either: commissions/visibility.go inherits an
+	// entry's visibility from its deal rather than copying an owner at accrual,
+	// so a reassigned deal carries its entries in the same query.
+	"commission_entry.deal_id":              "server-derived: the accrual reads it from the won-deal event's entity, and a reversal copies it from the entry it undoes — no request body names it; the row's own visibility is inherited from this deal (commissions/visibility.go)",
+	"commission_entry.partner_org_id":       "server-derived: the accrual reads it from the deal's stored partner_org_id carried on StageChanged, and a reversal copies it from the entry it undoes — no request body names it",
+	"activity_retention_evidence.deal_id":   "schema only, no writer yet (#1557): the qualifying transaction is resolved from the activity's own link, not supplied — and it is ON DELETE SET NULL beside a frozen deal_name, so the evidence answers after the deal is gone",
+	"finance_customer_link.organization_id": "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
+	"finance_invoice.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	"finance_payment.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
 })
 
 // TestFK_rowScopedTargetsHaveVisibilityDecision derives the H1 obligation

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -339,27 +339,10 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// writer lands it must derive both from rows the actor could already see —
 	// this entry is the obligation, not a record of one already met.
 	"activity_retention_evidence.activity_id": "schema only, no writer yet (#1557): the evidence is written by the qualifying pass from the activity it substantiates, never from a request body — when that pass lands, the activity it names must be one the actor could already see",
-	// Server-derived on both writers, never a client-supplied reference.
-	//
-	// This pair of entries is an obligation as much as a classification: it holds
-	// only while no request body names either id. A contract operation that
-	// accepts one — a hand-written entry, an import, a correction — makes it
-	// false, and that writer must put the named record through
-	// auth.EnsureLinkTarget rather than inherit this line.
-	// accrue.go takes deal_id from the outbox envelope's own entity and
-	// partner_org_id from the deal's stored partner carried on StageChanged;
-	// decide.go's insertReversal copies both from the ledger row it reverses,
-	// which the decide path already read under its gate. No contract operation
-	// accepts either id in a body, so there is no request for a target probe to
-	// check. Reads are not ungated either: commissions/visibility.go inherits an
-	// entry's visibility from its deal rather than copying an owner at accrual,
-	// so a reassigned deal carries its entries in the same query.
-	"commission_entry.deal_id":              "server-derived: the accrual reads it from the won-deal event's entity, and a reversal copies it from the entry it undoes — no request body names it; the row's own visibility is inherited from this deal (commissions/visibility.go)",
-	"commission_entry.partner_org_id":       "server-derived: the accrual reads it from the deal's stored partner_org_id carried on StageChanged, and a reversal copies it from the entry it undoes — no request body names it",
-	"activity_retention_evidence.deal_id":   "schema only, no writer yet (#1557): the qualifying transaction is resolved from the activity's own link, not supplied — and it is ON DELETE SET NULL beside a frozen deal_name, so the evidence answers after the deal is gone",
-	"finance_customer_link.organization_id": "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
-	"finance_invoice.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
-	"finance_payment.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	"activity_retention_evidence.deal_id":     "schema only, no writer yet (#1557): the qualifying transaction is resolved from the activity's own link, not supplied — and it is ON DELETE SET NULL beside a frozen deal_name, so the evidence answers after the deal is gone",
+	"finance_customer_link.organization_id":   "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
+	"finance_invoice.organization_id":         "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	"finance_payment.organization_id":         "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
 })
 
 // TestFK_rowScopedTargetsHaveVisibilityDecision derives the H1 obligation


### PR DESCRIPTION
Closes #2046's second half.

**Scope changed after #2052 landed.** A parallel session shipped the
`commission_entry` FK classification while this was open, so that half is gone
from here and main's wording is kept. What remains is the gate #2046 did not
name and #2052 did not touch — plus a hole in that gate found while fixing it.

## The failure

```
sweep target "organization" carries DELETE-firing trigger "organization_delete_clears_deal_partner"
    — backend/internal/compose/datareset_integration_test.go:350
```

Still red on `origin/main`. Same origin as the FK half: `648371973` (#2019) added
the table *and* the trigger, and each tripped a different fitness function, in a
different package. #2046 named only the first.

## The decision

`organization_delete_clears_deal_partner` is `BEFORE DELETE ON organization FOR
EACH ROW` and nulls `deal.partner_org_id` / `partner_attribution`. It refuses no
delete — the same shape as `activity_link` and `relationship`, already classified
as maintenance rather than guards.

But "the sweep deletes those deals too, so the clearing is discarded" is **not**
why it is safe, and the entry does not say that. `resetTargetTables` orders
alphabetically and the sweep retries per pass; `offer.deal_id` is
`ON DELETE RESTRICT` (core/0218:330) and `offer` sorts after `deal`, so an
installation holding one offer defers `deal` to a later pass — and `organization`
is deleted in that same pass with `deal` still populated. The trigger then runs
its `UPDATE` once per organization row, and `idx_deal_partner` is partial on
`archived_at IS NULL` (core/1787021916:53) while the trigger's predicate carries
no such term, so the planner cannot use it: a sequential scan of `deal` per
organization, repeated on every deferred pass.

It is safe because the work is **discarded**, not because it never happens. The
entry records the cost, which is what the gate exists to force someone to write.

## The hole in the gate itself

The gate reports a **(table, trigger) pair** and looked its waiver up by **table**:

```go
if targetSet[table] && !deleteGuardedSweepTargets.Waived(t, table) {
```

So an entry ratifies the *category*: it clears the trigger it was written for
**and every DELETE trigger added to that table afterwards**. Adding `organization`
under the old key would have exempted that table from this gate permanently —
fixing the reported bug by widening the hole.

Proven, not argued. I planted a second trigger on `organization` that raises on
every delete — a real blocking guard, exactly what this gate exists to catch:

| waiver keyed on | plant |
|---|---|
| the **pair** (this PR) | **REFUSED** — `carries DELETE-firing trigger "organization_planted_blocks_delete"` |
| the **table** (main today) | **PASS** — silently admitted |

All four entries are re-keyed to the pair. `gatekit`'s ratchet caught three
trigger names I guessed wrong while doing it, which is that mechanism working.

An independent enumeration during review confirmed the re-key loses nothing:
seven non-internal DELETE-firing triggers exist across `migrations/core`,
`migrations/custom` and `extensions/`, and every sweep-target table among them
has a key.

## Coverage

**Test-only change** — one classification table and one waiver key — so it
produces no measured new-code coverage. The proof is the planted-guard matrix.

## Reviews

Fable reviewed twice (5 findings on the first shape, all fixed; the enumeration
above is from the second). CodeRabbit reviewed with no findings.
**Codex has not reviewed this PR** — `/codex:*` cannot be invoked by an agent.

## Gates

`make check-q` → `OK: check-q passed` · `make craft-static` →
`PASS — 0 blocker, 0 major, 0 minor` on all four trees ·
`TestSweepTargetsCarryNoDeleteBlockingTrigger` **PASS**,
`TestFK_rowScopedTargetsHaveVisibilityDecision` **PASS** on the rebased head.