### PR TITLE
fix(privacy): the object store's region is chosen, never defaulted (#1792)

### DIFF
--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -48,12 +48,16 @@ package backendarch
 //     disappearing; they cannot stop a description going stale.
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -301,4 +305,286 @@ func assertNamesOnlyLiveVars(t *testing.T, path string) {
 		t.Errorf("%d var(s) named in %s that nothing in the product reads — delete them. A `MARGINCE_FOO_*` glob counts as the name `MARGINCE_FOO_`, which nothing reads: spell such vars out instead of globbing them:\n\t%s",
 			len(dead), path, strings.Join(dead, "\n\t"))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 5: a declared default and a documented default say the same thing.
+//
+// The four obligations above gate NAMES. Nothing gated VALUES, and the two
+// descriptions of a default drift apart in the direction that matters: the code
+// applies a fallback, the schema does not declare it, and the reference doc
+// documents one anyway. An operator reads the doc, sees a default, and supplies
+// nothing — while what the binary actually does is decided somewhere the doc
+// never described.
+//
+// Both sides are already in the tree, which is what makes this derivable rather
+// than a list: config.Item carries Default, and configuration.md's tables carry
+// a Default column. This asserts they agree, in both directions — a declared
+// default the doc does not show, and a documented default nothing declares.
+
+// configItemDefaults is one config.Item declaration's documented name and the
+// default it declares. An absent Default is the empty string, which is the same
+// thing the doc writes as an em dash.
+type configItemDefault struct {
+	name    string
+	value   string
+	pos     string
+	present bool
+}
+
+// docDefaultRow matches one reference-doc table row: the env name in backticks,
+// then the second cell.
+var docDefaultRow = regexp.MustCompile(`(?m)^\|\s*` + "`" + `(MARGINCE_[A-Z0-9_]+)` + "`" + `\s*\|\s*([^|]*?)\s*\|`)
+
+// docDefaultTable matches a table header whose SECOND column is the default.
+// configuration.md also carries tables whose second column is something else
+// entirely — which role reads the var, or which suite needs it — and reading
+// those cells as defaults would report prose where no default was ever claimed.
+var docDefaultTable = regexp.MustCompile(`(?mi)^\|\s*Env\s*\|\s*Default\s*\|`)
+
+// docDefaultLiteral pulls the value out of a default cell, which is written in
+// backticks when there is one.
+var docDefaultLiteral = regexp.MustCompile("^`([^`]*)`$")
+
+func TestEveryDeclaredDefaultMatchesTheDocumentedOne(t *testing.T) {
+	declared := declaredConfigDefaults(t)
+	documented := documentedDefaults(t)
+	if len(declared) == 0 {
+		t.Fatal("no config.Item declaration found — a sweep that scans nothing passes exactly like a clean one")
+	}
+
+	for _, item := range declared {
+		docValue, inDoc := documented[item.name]
+		if !inDoc {
+			continue // obligation 1 already requires the name to be documented
+		}
+		switch {
+		case item.present && docValue != item.value:
+			t.Errorf("%s: %s declares Default %q, %s documents %q — an operator supplying nothing gets the first and reads the second",
+				item.pos, item.name, item.value, configurationDoc, docValue)
+		case !item.present && docValue != "":
+			t.Errorf("%s: %s declares no Default, %s documents %q — either the code applies that fallback and the schema must declare it, or it does not and the doc is telling operators about a value nothing will supply",
+				item.pos, item.name, configurationDoc, docValue)
+		}
+	}
+}
+
+// declaredConfigDefaults finds every config.Item composite literal in the
+// hand-written trees and reads the env name and default out of it.
+//
+// Name is usually a constant rather than a literal, so package-level MARGINCE_*
+// constants are resolved first. A gate that only understood literals would see
+// almost nothing here and pass for that reason.
+func declaredConfigDefaults(t *testing.T) []configItemDefault {
+	t.Helper()
+	consts := envNameConstants(t)
+	var out []configItemDefault
+	fset := token.NewFileSet()
+	for _, tree := range licensedTrees {
+		walkTextFiles(t, tree.root, func(path, text string) {
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") || isGenerated(path, text) {
+				return
+			}
+			file, err := parser.ParseFile(fset, path, text, 0)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", path, err)
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, isLit := n.(*ast.CompositeLit)
+				if !isLit {
+					return true
+				}
+				// The declarations are elements of a []config.Item slice literal,
+				// so their own Type node is NIL — Go elides it. A walk keyed on
+				// each element's type finds nothing at all here, which passes for
+				// exactly the same reason a clean tree does.
+				for _, element := range elidedConfigItems(lit) {
+					if item, ok := readConfigItem(element, consts); ok {
+						item.pos = fset.Position(element.Pos()).String()
+						out = append(out, item)
+					}
+				}
+				return true
+			})
+		})
+	}
+	return out
+}
+
+// elidedConfigItems answers the config.Item literals a composite literal holds:
+// itself when it is written out as config.Item{…}, or its elements when it is
+// the []config.Item slice the declarations actually live in.
+func elidedConfigItems(lit *ast.CompositeLit) []*ast.CompositeLit {
+	if namesConfigItem(lit.Type) {
+		return []*ast.CompositeLit{lit}
+	}
+	array, isArray := lit.Type.(*ast.ArrayType)
+	if !isArray || !namesConfigItem(array.Elt) {
+		return nil
+	}
+	var out []*ast.CompositeLit
+	for _, element := range lit.Elts {
+		if inner, isLit := element.(*ast.CompositeLit); isLit {
+			out = append(out, inner)
+		}
+	}
+	return out
+}
+
+// namesConfigItem reports whether an expression names config.Item, by either
+// spelling — qualified from outside the package, bare from within it.
+func namesConfigItem(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.SelectorExpr:
+		return typed.Sel.Name == "Item"
+	case *ast.Ident:
+		return typed.Name == "Item"
+	}
+	return false
+}
+
+// readConfigItem pulls Name and Default out of one literal. A literal whose Name
+// does not resolve to a MARGINCE_* value is not a declaration this gate governs.
+func readConfigItem(lit *ast.CompositeLit, consts map[string]string) (configItemDefault, bool) {
+	var item configItemDefault
+	for _, element := range lit.Elts {
+		field, isField := element.(*ast.KeyValueExpr)
+		if !isField {
+			continue
+		}
+		key, isIdent := field.Key.(*ast.Ident)
+		if !isIdent {
+			continue
+		}
+		switch key.Name {
+		case "Name":
+			item.name = resolveStringExpr(field.Value, consts)
+		case "Default":
+			item.value = resolveStringExpr(field.Value, consts)
+			item.present = true
+		}
+	}
+	return item, strings.HasPrefix(item.name, "MARGINCE_")
+}
+
+// resolveStringExpr answers a string literal's value, or a constant's, or "".
+func resolveStringExpr(expr ast.Expr, consts map[string]string) string {
+	switch typed := expr.(type) {
+	case *ast.BasicLit:
+		if typed.Kind != token.STRING {
+			return ""
+		}
+		value, err := strconv.Unquote(typed.Value)
+		if err != nil {
+			return ""
+		}
+		return value
+	case *ast.Ident:
+		return consts[typed.Name]
+	case *ast.SelectorExpr:
+		// A name borrowed from another package, e.g. runtimeenv.EnvVar. The
+		// constant sweep is tree-wide, so the terminal identifier resolves.
+		return consts[typed.Sel.Name]
+	}
+	return ""
+}
+
+// envNameConstants maps every package-level identifier bound to a MARGINCE_*
+// string to that string, tree-wide.
+//
+// Keyed on the bare identifier so a qualified reference resolves too. Two
+// constants sharing a name and disagreeing about the value would make that
+// unsound, so the sweep refuses rather than picking one.
+func envNameConstants(t *testing.T) map[string]string {
+	t.Helper()
+	consts := map[string]string{}
+	fset := token.NewFileSet()
+	for _, tree := range licensedTrees {
+		walkTextFiles(t, tree.root, func(path, text string) {
+			if !strings.HasSuffix(path, ".go") || isGenerated(path, text) {
+				return
+			}
+			file, err := parser.ParseFile(fset, path, text, 0)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", path, err)
+			}
+			for _, decl := range file.Decls {
+				gen, isGen := decl.(*ast.GenDecl)
+				if !isGen || gen.Tok != token.CONST {
+					continue
+				}
+				collectEnvConstants(t, gen, consts, fset)
+			}
+		})
+	}
+	return consts
+}
+
+// collectEnvConstants records one const block's MARGINCE_* bindings.
+func collectEnvConstants(t *testing.T, gen *ast.GenDecl, consts map[string]string, fset *token.FileSet) {
+	t.Helper()
+	for _, spec := range gen.Specs {
+		value, isValue := spec.(*ast.ValueSpec)
+		if !isValue {
+			continue
+		}
+		for i, name := range value.Names {
+			if i >= len(value.Values) {
+				continue
+			}
+			resolved := resolveStringExpr(value.Values[i], nil)
+			if !strings.HasPrefix(resolved, "MARGINCE_") {
+				continue
+			}
+			if seen, dup := consts[name.Name]; dup && seen != resolved {
+				t.Fatalf("%s: two constants named %s bind different env vars (%q and %q); this sweep resolves a name to one value and cannot with both",
+					fset.Position(name.Pos()), name.Name, seen, resolved)
+			}
+			consts[name.Name] = resolved
+		}
+	}
+}
+
+// documentedDefaults reads the Default column out of configuration.md's tables.
+// An em dash means the doc is asserting there is no default, which is the same
+// claim as an absent Default field.
+func documentedDefaults(t *testing.T) map[string]string {
+	t.Helper()
+	b, err := os.ReadFile(configurationDoc) // #nosec G304 -- fixed path in the trusted source tree
+	if err != nil {
+		t.Fatalf("reading %s: %v", configurationDoc, err)
+	}
+	out := map[string]string{}
+	for _, section := range defaultBearingTables(string(b)) {
+		for _, row := range docDefaultRow.FindAllStringSubmatch(section, -1) {
+			cell := strings.TrimSpace(row[2])
+			if cell == "—" || cell == "-" || cell == "" {
+				out[row[1]] = ""
+				continue
+			}
+			if literal := docDefaultLiteral.FindStringSubmatch(cell); literal != nil {
+				out[row[1]] = literal[1]
+				continue
+			}
+			// Prose in a Default column is not a value this gate can compare, and
+			// silently treating it as "no default" would make the row invisible.
+			t.Errorf("%s: the Default cell for %s reads %q — a default is a literal in backticks or an em dash, so that a gate and an operator read the same thing",
+				configurationDoc, row[1], cell)
+		}
+	}
+	return out
+}
+
+// defaultBearingTables cuts the document into the table bodies whose second
+// column is a default, so rows from the other tables are never read as one.
+func defaultBearingTables(doc string) []string {
+	var out []string
+	for _, loc := range docDefaultTable.FindAllStringIndex(doc, -1) {
+		body := doc[loc[1]:]
+		if end := strings.Index(body, "\n\n"); end >= 0 {
+			body = body[:end]
+		}
+		out = append(out, body)
+	}
+	return out
 }

--- a/backend/internal/platform/blobstore/env_test.go
+++ b/backend/internal/platform/blobstore/env_test.go
@@ -4,6 +4,7 @@
 package blobstore_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
@@ -23,5 +24,48 @@ func TestFromEnvUnconfiguredIsNotAnError(t *testing.T) {
 	}
 	if store != nil {
 		t.Error("FromEnv returned a store with no endpoint set")
+	}
+}
+
+// A configured blobstore with no region is refused, and refused BEFORE anything
+// dials — the refusal is a statement about where a bucket would be created, not
+// a connection failure, so it must not depend on a reachable endpoint.
+//
+// Asserted in both directions on the region alone, with every other field held
+// constant. A one-directional test passes just as happily against a New that
+// refuses everything.
+func TestFromEnvRefusesAConfiguredStoreWithNoRegion(t *testing.T) {
+	env := map[string]string{
+		// Endpoint is syntactically invalid on purpose, so the second arm below
+		// fails while minio.New parses it rather than on a dial. A reachable-looking
+		// host would make this test spend half a minute retrying a closed port,
+		// and a unit test that waits on the network is a flake with a slow fuse.
+		blobstore.EnvEndpoint:  "not a valid host",
+		blobstore.EnvAccessKey: "a",
+		blobstore.EnvSecretKey: "b",
+		blobstore.EnvBucket:    "attachments",
+	}
+
+	store, configured, err := blobstore.FromEnv(t.Context(), config.Static(env))
+	if err == nil {
+		t.Fatal("a configured blobstore with no region was accepted; the bucket holding attachments would be created wherever the client defaulted to")
+	}
+	if !strings.Contains(err.Error(), blobstore.EnvRegion) {
+		t.Errorf("the refusal does not name %s, so an operator cannot tell what to set: %v", blobstore.EnvRegion, err)
+	}
+	if configured || store != nil {
+		t.Errorf("a refused configuration still reported configured=%v store!=nil=%v", configured, store != nil)
+	}
+
+	// The same configuration WITH a region gets past this check and fails on the
+	// endpoint instead. That is what proves the region was the refusal's subject
+	// rather than the configuration being rejected wholesale.
+	env[blobstore.EnvRegion] = "eu-central-1"
+	_, _, err = blobstore.FromEnv(t.Context(), config.Static(env))
+	if err == nil {
+		t.Fatal("expected the invalid endpoint to fail once the region was supplied")
+	}
+	if strings.Contains(err.Error(), blobstore.EnvRegion) {
+		t.Errorf("a supplied region is still reported as missing: %v", err)
 	}
 }

--- a/backend/internal/platform/blobstore/s3.go
+++ b/backend/internal/platform/blobstore/s3.go
@@ -44,10 +44,21 @@ func New(ctx context.Context, cfg Config) (Store, error) {
 	if cfg.Endpoint == "" || cfg.Bucket == "" {
 		return nil, fmt.Errorf("blobstore: endpoint and bucket are required")
 	}
-	region := cfg.Region
-	if region == "" {
-		region = "us-east-1"
+	// The region is chosen, never defaulted. ensureBucket passes it to
+	// MakeBucket, so an unset value does not stay inert — it decides where a
+	// bucket holding attachment bytes is CREATED, and any default here resolves
+	// that toward one jurisdiction for every operator who did not think about it.
+	// ADR-0051 makes object storage sovereign by default and ADR-0027 makes every
+	// installation operator-run; a silent fallback contradicts both in exactly
+	// the case where it matters and reports nothing afterwards.
+	//
+	// For MinIO the value is arbitrary and any string will do, which is why
+	// refusing costs a self-hosted operator one line of configuration and saves
+	// an S3 one from discovering the answer in a bucket listing.
+	if cfg.Region == "" {
+		return nil, fmt.Errorf("blobstore: region is required — it decides where the bucket holding attachments is created, so it is not defaulted; set MARGINCE_BLOBSTORE_REGION (for MinIO any value works, e.g. us-east-1)")
 	}
+	region := cfg.Region
 	client, err := minio.New(cfg.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
 		Secure: cfg.UseSSL,

--- a/backend/internal/platform/blobstore/s3_integration_test.go
+++ b/backend/internal/platform/blobstore/s3_integration_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
+// testRegion is what this lane names its region. Any value satisfies MinIO; the
+// point is that the lane chooses one, because blobstore.New refuses an empty
+// region and a lane that relied on a default would stop exercising the product.
+const testRegion = "us-east-1"
+
 // newS3Store builds a real MinIO-backed store from the MARGINCE_TEST_BLOBSTORE_*
 // contract. Like every integration test here, it fails loudly without its
 // dependency — it never skips (a skipped blobstore test looks exactly like a
@@ -34,6 +39,10 @@ func newS3Store(t *testing.T) blobstore.Store {
 		AccessKey: os.Getenv("MARGINCE_TEST_BLOBSTORE_ACCESS_KEY"),
 		SecretKey: os.Getenv("MARGINCE_TEST_BLOBSTORE_SECRET_KEY"),
 		Bucket:    os.Getenv("MARGINCE_TEST_BLOBSTORE_BUCKET"),
+		// MinIO ignores the value; New requires one because on real S3 it decides
+		// where the bucket is created. The lane names it rather than inheriting a
+		// default, which is the property under test everywhere else.
+		Region: testRegion,
 	})
 	if err != nil {
 		t.Fatalf("blobstore.New: %v", err)
@@ -71,6 +80,7 @@ func TestFromEnvConfiguredConnects(t *testing.T) {
 		blobstore.EnvAccessKey: os.Getenv("MARGINCE_TEST_BLOBSTORE_ACCESS_KEY"),
 		blobstore.EnvSecretKey: os.Getenv("MARGINCE_TEST_BLOBSTORE_SECRET_KEY"),
 		blobstore.EnvBucket:    os.Getenv("MARGINCE_TEST_BLOBSTORE_BUCKET"),
+		blobstore.EnvRegion:    testRegion,
 	}))
 	if err != nil {
 		t.Fatalf("FromEnv: %v", err)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -444,7 +444,7 @@ and the store tolerates a still-starting backend with a bounded retry.
 | `MARGINCE_BLOBSTORE_ACCESS_KEY` | — | access key |
 | `MARGINCE_BLOBSTORE_SECRET_KEY` | — | secret key |
 | `MARGINCE_BLOBSTORE_BUCKET` | — | bucket name (created on first connect) |
-| `MARGINCE_BLOBSTORE_REGION` | `us-east-1` | region |
+| `MARGINCE_BLOBSTORE_REGION` | — | region the bucket lives in; **required** when the blobstore is configured, and deliberately not defaulted — it decides where a bucket holding attachments is created (for MinIO any value works) |
 | `MARGINCE_BLOBSTORE_USE_SSL` | `false` | `true` for TLS to the store |
 
 ## Secret vault (api, worker) — connector credentials

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -608,6 +608,7 @@ up)
     MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin \
     MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
     MARGINCE_BLOBSTORE_BUCKET=margince-dev \
+    MARGINCE_BLOBSTORE_REGION=us-east-1 \
     ./bin/api --addr ":${api_port}" --dsn "$dev_app_url" --config "$deploy_cfg" \
     --redis "localhost:${REDIS_PORT}" \
     "${public_base_url_flag[@]}" \
@@ -661,6 +662,7 @@ up)
     MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin \
     MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
     MARGINCE_BLOBSTORE_BUCKET=margince-dev \
+    MARGINCE_BLOBSTORE_REGION=us-east-1 \
     ./bin/worker --dsn "$dev_app_url" --redis "localhost:${REDIS_PORT}" \
     --config "$deploy_cfg" \
     --retention-interval 720h \


### PR DESCRIPTION
Closes #1792.

`blobstore.New` required an `Endpoint` and a `Bucket` and resolved an empty
`Region` to `us-east-1`. The value is not inert — `ensureBucket` hands it to
`MakeBucket` — so on genuine S3 the bucket holding **attachment bytes, whatever a
customer emailed**, is created in the US whenever an operator did not think about
it. ADR-0051 makes object storage sovereign by default and ADR-0027 makes every
installation operator-run; a silent fallback contradicts the first in exactly the
case that matters, and nothing afterwards reports which region the bucket is in.

## The fix

`Region` joins `Endpoint` and `Bucket` in the line above — refused, not resolved.
For MinIO the value is arbitrary, so this costs a self-hosted operator one line of
configuration and saves an S3 operator from discovering the answer in a bucket
listing. The refusal says what to set, not just what is missing:

> blobstore: region is required — it decides where the bucket holding attachments is created, so it is not defaulted; set MARGINCE_BLOBSTORE_REGION (for MinIO any value works, e.g. us-east-1)

Both lanes that configure a blobstore now name a region rather than inheriting
one: `scripts/dev.sh` (api and worker) and the integration harness.

## Three sources disagreed, and nothing could see it

| Source | Said |
|---|---|
| `s3.go:47-49` | the default is `us-east-1` |
| `ConfigItems()` — `EnvRegion` declared with **no** `Default:` | there is no default |
| `configuration.md:447` | the default is `us-east-1` |

`EnvUseSSL`, declared immediately below in the same function, *does* carry
`Default: "false"` — so the omission was a gap, not a convention.

`envcontract_test.go` gated **names**; the string `Default` did not appear in the
file. All three now agree that there is no default, and a fifth obligation keeps
them agreeing.

## The gate

**Obligation 5: a declared default and a documented default say the same thing** —
in both directions, a declared default the doc contradicts and a documented
default nothing declares.

Proven red first, against unmodified `env.go`:

```
envcontract_test.go:366: internal/platform/blobstore/env.go:78:3: MARGINCE_BLOBSTORE_REGION declares no Default, ../docs/reference/configuration.md documents "us-east-1" — either the code applies that fallback and the schema must declare it, or it does not and the doc is telling operators about a value nothing will supply
```

**Blast radius: exactly one.** Not zero, and not bulk-waived — `EnvRegion` was the
only disagreement in the tree. The sweep is not vacuous: **17 `config.Item`
declarations scanned, 10 declaring a `Default`, against 7 documented default
cells.**

Two bugs in my own first draft, both of the "passes for the wrong reason" kind:

- It found **nothing**. The declarations are elements of a `[]config.Item` slice
  literal, so their own `Type` node is `nil` — Go elides it — and a walk keyed on
  each element's type sees zero items and passes exactly like a clean tree. It
  now handles the slice's element type.
- It read **every** table row with a backticked `MARGINCE_*` name. `configuration.md`
  has tables whose second column is not a default at all, so it reported prose
  like ``api (`runtimeenv.Parse`)`` as a malformed default. It now only reads
  tables whose header second column is `Default`.

## Related finding, not fixed here

Nine declarations (7 distinct vars) declare a `Default` with **no** default-bearing
doc row, so their defaults are undocumented rather than contradicted:
`MARGINCE_OVERLAY_BACKFILL_LIMIT`, `MARGINCE_OAUTH_ACCESS_TOKEN_TTL`,
`MARGINCE_PROVIDER_SURFE`, `MARGINCE_DEEPREAD_MAX_PAGES`, `MARGINCE_DEEPREAD_MAX_BYTES`,
`MARGINCE_DEEPREAD_WALL`, `MARGINCE_ENV`. That is a documentation gap of a different
shape — obligation 1 requires the name to appear, and it does — so it is filed
rather than folded in.

## One sentence on `UseSSL`, and no issue

`env.go:47` reads `env(EnvUseSSL) == "true"`, so `TRUE`, `1` and `yes` all read as
false. That is the house convention, stated at `platform/config/item.go:37-39`
and documented the same way, so no issue is filed — but it is worth recording
that this is the only security-relevant `KindBool` in the tree and its silent
failure direction is **plaintext transport to the object store**, the same class
as the region defect in the same file. Whether a TLS flag earns an exception is
not decided here.

## UAT

**The `us-east-1` bucket creation was NOT reproduced against real AWS.** No AWS
account was used and none of this was tested against S3; the issue's failure
scenario is the evidence for that half. Claiming otherwise would be worse than
saying so.

What is demonstrated is the refusal and its inverse, as a unit test asserting on
the region alone with every other field held constant — the configured store with
no region is refused and the refusal names `MARGINCE_BLOBSTORE_REGION`; the same
configuration with a region gets past the check and fails on the endpoint instead,
which is what proves the region was the refusal's subject.

## Gates

`make check-q` → `OK: check-q passed` · `make craft-static` →
`PASS — 0 blocker, 0 major, 0 minor` on all four trees ·
`./internal/platform/blobstore` integration package `ok`.

**Codex has not reviewed this PR** — `/codex:*` cannot be invoked by an agent.

The whole-lane local run is not clean and I am not claiming it is: every failing
package showed `tls error: EOF` against postgres with several agent worktrees
sharing one container, and `./internal/compose` is additionally red from #2046,
which is fixed in #2055 and not on this branch's base.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops defaulting the blobstore region to us-east-1 and requires operators to choose one. Previously `blobstore.New` created the attachments bucket in `us-east-1` when `Region` was empty; now it refuses and the error names `MARGINCE_BLOBSTORE_REGION`.

- `blobstore.New` now requires `Region` alongside `Endpoint` and `Bucket`; `MakeBucket` uses this value. On MinIO any string works.
- `docs/reference/configuration.md` removes the default and marks region required; `scripts/dev.sh` sets `MARGINCE_BLOBSTORE_REGION`; integration and unit tests name a test region and assert refusal when missing.
- Adds a default-consistency gate in `backend/envcontract_test.go` that compares every `config.Item.Default` with the docs; only the region entry changed here.
- Migration: Operators must set `MARGINCE_BLOBSTORE_REGION` when configuring object storage. For MinIO, any value (e.g., `us-east-1`) is acceptable.

<sup>Written for commit 406eab41ecf0efd2835858bbc8fba0428cecb81f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

