### PR TITLE
perf(ci-tests): the lane's harness stops paying for itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SEED_DSN ?= postgres://margince_owner:dev@localhost:15432/margince
 # every company renders as a placeholder initial.
 MINIO_PORT ?= 29000
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict secret-scan test-secret-scan test-dev-dsn test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -74,7 +74,7 @@ ai-routing-local:
 ## #1639 is about: a backend-only author never runs the lane that would
 ## otherwise catch a stranded frontend schema. On a pull request CI covers the
 ## same ground from the other side, through fe-quality's fe-drift.
-check-backend: check-craft-doc craft-test test-golangci-guard test-scheduled-report test-ci-verdict check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze
+check-backend: check-craft-doc craft-test test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -557,6 +557,14 @@ test-scheduled-report:
 ## the real thing on every dashboard.
 test-ci-verdict:
 	@./scripts/test-ci-verdict.sh
+
+## test-laneorder — prove the integration lane still dispatches its long pole
+## first. The order is only a scheduling hint, so a regression here never turns
+## a lane red: it makes the run longer and says nothing, which is why it needs a
+## test of its own rather than the lane's own verdict. Also pins the committed
+## baseline a fresh clone orders by, which has no measurements to fall back on.
+test-laneorder:
+	@./scripts/test-laneorder.sh
 
 ## check-image-pins — every `uses:` in .github/workflows/ AND every container
 ## `image:` (workflow service containers + infra/docker-compose.dev.yml) is

--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -218,8 +218,13 @@ deps:
     # emersion: the in-memory IMAP server the standing-connect transport
     # test drives; production compose reaches IMAP only through capture.
     canUse: [pgx, chi, oapi, river, xtext, yaml, emersion, kinopenapi]
+  # migrations depends on itself, which no production file can express: Go
+  # forbids a package importing itself. It is reachable only from the external
+  # test package this directory's tagged suites live in (package
+  # migrations_test), which they need in order to reach platform/testdb — and
+  # testdb imports migrations, so the internal test package would be a cycle.
   migrations:
-    mayDependOn: [platform]
+    mayDependOn: [platform, migrations]
     canUse: [pgx]
   # The root fitness tests walk the authoritative contract document
   # (api/crm.yaml) directly — the RD-AC-7 negative-scope gate reads the

--- a/backend/cmd/worker/observe_integration_test.go
+++ b/backend/cmd/worker/observe_integration_test.go
@@ -146,7 +146,13 @@ func TestEachDeclaredReadinessCheckCanActuallyFail(t *testing.T) {
 		// unlike closing the shared test client it leaves no other test's
 		// dependency broken. Without this arm the redis check could be deleted
 		// outright and every other test here would stay green.
-		unreachable := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+		//
+		// MaxRetries: -1 switches go-redis's retry ladder off. The default ladder
+		// re-dials a port nothing listens on three more times with backoff, which
+		// is 1.7s of this package's 2.9s and proves nothing the first refusal did
+		// not: the claim under test is what /readyz answers once the bus is
+		// unreachable, and a connection refused is already that answer.
+		unreachable := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1", MaxRetries: -1})
 		t.Cleanup(func() {
 			if err := unreachable.Close(); err != nil {
 				t.Errorf("closing the unreachable bus client: %v", err)

--- a/backend/internal/compose/integration/overlay/overlay_connect_incumbent_down_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_connect_incumbent_down_integration_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+// Connect reaches the incumbent twice before it answers — for the portal id the
+// webhook binding needs, and for the owners directory mirror_user_map is seeded
+// from — and both are best-effort by design: an admin who has just pasted a
+// valid token must not be told the connection failed because a vendor was slow.
+//
+// That tolerance had no test. It was covered by accident: the lane dialled
+// api.hubapi.com for real with a fixture token, HubSpot answered 401, and the
+// swallow path ran on every single connect in the suite (#1996). Removing the
+// dial removed the coverage with it, so this states the property deliberately —
+// and states it over the incumbent the composed server binds ITSELF, with no
+// resolver override, which is the one arrangement no other test in this package
+// exercises.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+)
+
+func TestConnectStandsUpAnOverlayTheIncumbentWouldNotAnswer(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(keyvault.NewMemory()))
+	e.BootstrapWorkspace(t)
+
+	var conn apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
+		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
+	}, nil, &conn); status != http.StatusCreated {
+		t.Fatalf("connect overlay = %d %v — a connect must survive an incumbent that will not answer", status, conn)
+	}
+
+	ctx := context.Background()
+	// NULL, not the empty string. The column is what a later webhook matches a
+	// portal against, and "" would match a payload carrying no portal at all —
+	// which is why insertConnection writes NULLIF($5, '') rather than the raw id.
+	var accountID *string
+	if err := e.Owner.QueryRow(ctx,
+		`SELECT incumbent_account_id FROM incumbent_connection`).Scan(&accountID); err != nil {
+		t.Fatalf("reading the stored account id: %v", err)
+	}
+	if accountID != nil {
+		t.Fatalf("incumbent_account_id = %q, want NULL — the portal fetch did not answer, so there is nothing to bind yet", *accountID)
+	}
+
+	// And the second best-effort call: no owners directory means no mappings,
+	// not a half-seeded one.
+	var mappings int
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM mirror_user_map`).Scan(&mappings); err != nil {
+		t.Fatalf("counting the seeded user map: %v", err)
+	}
+	if mappings != 0 {
+		t.Fatalf("mirror_user_map holds %d row(s) after a connect whose owners fetch failed, want none", mappings)
+	}
+}

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -20,9 +20,17 @@ package overlay
 // Connect can seal a credential and the guard sees an active connection),
 // then overrides the live-incumbent resolver with compose.
 // WithOverlayIncumbentResolver pointing at an overlay/fake.Adapter — no
-// mocked provider, no real HubSpot account, no network call (T11): the
-// fake stands in for the vaulted hubspot.Adapter WithKeyvault would
-// otherwise build from the connection's own region+token.
+// mocked provider and no real HubSpot account: the fake stands in for the
+// adapter WithKeyvault would otherwise build from the connection's own
+// region+token.
+//
+// "No network call" used to be asserted here and was not true — Connect
+// reached api.hubapi.com twice per test through the Service's own factory,
+// which this resolver does not reach (#1996). It is true now, and by
+// construction rather than by claim: under this build tag compose binds a
+// refusing incumbent (compose/overlayincumbent_refusing.go), and a HubSpot
+// client built anyway cannot leave the machine
+// (overlay/hubspot/httpclient_integration.go).
 
 import (
 	"context"

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -139,7 +139,7 @@ func (a OverlayReconcileWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspa
 // its outcome against the sweep backoff.
 //
 // Building the per-workspace incumbent adapter HERE — via newIncumbent
-// (hubspotIncumbentFactory in production) from the due connection's own
+// (liveIncumbentFactory in production) from the due connection's own
 // vaulted token + region — answers the seam left open by
 // compose/overlay.go's NewOverlayProvider (which wires FreshnessReader
 // with inc:nil, "a per-workspace credential lookup the Dispatcher — one
@@ -278,7 +278,7 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 		return fmt.Errorf("overlay reconcile: resolving the vaulted token: %w", err)
 	}
 	// newIncumbent builds THIS connection's adapter from its own vaulted
-	// region+token — injected (hubspotIncumbentFactory in production) so
+	// region+token — injected (liveIncumbentFactory in production) so
 	// the whole sweep is drivable against a fake incumbent in a test,
 	// rather than reaching a real HubSpot over the network.
 	inc := newIncumbent(d.Region, string(token))

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -115,19 +115,6 @@ func OverlayProjectionFingerprints() map[string]string {
 	return hubspot.ProjectionFingerprints()
 }
 
-// hubspotIncumbentFactory builds a live HubSpot adapter over one
-// connection's own region + vaulted token — the per-connection seam
-// Connect's mirror_user_map seeding resolves the owners directory
-// through. It is the ONE place compose binds the concrete incumbent for
-// the connection lifecycle (the reconcile poller builds its own the same
-// way, jobs.go's reconcileConnection); the overlay module never selects
-// an incumbent itself (ADR-0054 §8 — concrete choice injected at compose).
-//
-//nolint:ireturn // returns the overlay.Incumbent seam by design — it is injected as a per-connection factory the module holds behind the interface, so tests substitute a fake.
-func hubspotIncumbentFactory(region, token string) overlay.Incumbent {
-	return hubspot.NewAdapter(hubspot.NewClient(region, token))
-}
-
 // NewOverlayProvider builds the overlay-mode read seam Dispatcher routes
 // to: a MirrorStore over pool plus a FreshnessReader wired with the
 // canonical->incumbent translator (hubspot.IncumbentClassesFor) and meter

--- a/backend/internal/compose/overlay_backfill_cap.go
+++ b/backend/internal/compose/overlay_backfill_cap.go
@@ -134,12 +134,12 @@ func splitCappedCursor(cursor string) (consumed int, inner string) {
 // builder the overlay connection lifecycle and reconcile sweep resolve the
 // owners directory and backfill through. When limit > 0 it wraps the live
 // HubSpot adapter in cappedIncumbent so backfill is bounded; limit == 0
-// (the unset default) returns the plain hubspotIncumbentFactory uncapped.
+// (the unset default) returns the plain liveIncumbentFactory uncapped.
 func overlayIncumbentFactory(limit int) func(region, token string) overlay.Incumbent {
 	if limit <= 0 {
-		return hubspotIncumbentFactory
+		return liveIncumbentFactory
 	}
 	return func(region, token string) overlay.Incumbent {
-		return cappedIncumbent{Incumbent: hubspotIncumbentFactory(region, token), limit: limit}
+		return cappedIncumbent{Incumbent: liveIncumbentFactory(region, token), limit: limit}
 	}
 }

--- a/backend/internal/compose/overlayincumbent.go
+++ b/backend/internal/compose/overlayincumbent.go
@@ -70,6 +70,6 @@ func OverlayIncumbentResolver(pool *pgxpool.Pool, vault keyvault.Vault) func(con
 		if err != nil {
 			return nil, err
 		}
-		return hubspotIncumbentFactory(conn.Region, string(token)), nil
+		return liveIncumbentFactory(conn.Region, string(token)), nil
 	}
 }

--- a/backend/internal/compose/overlayincumbent_live.go
+++ b/backend/internal/compose/overlayincumbent_live.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package compose
+
+import (
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+)
+
+// liveIncumbentFactory builds a HubSpot adapter over one connection's own
+// region + vaulted token — the per-connection seam Connect's mirror_user_map
+// seeding resolves the owners directory through. It is the ONE place compose
+// binds the concrete incumbent for the connection lifecycle (the reconcile
+// poller builds its own the same way, jobs_overlay.go's reconcileConnection);
+// the overlay module never selects an incumbent itself (ADR-0054 §8 — concrete
+// choice injected at compose).
+//
+// Split by build tag. This is the production half; overlayincumbent_refusing.go
+// is the integration one, and it refuses rather than dials — see there.
+//
+//nolint:ireturn // returns the overlay.Incumbent seam by design — it is injected as a per-connection factory the module holds behind the interface, so tests substitute a fake.
+func liveIncumbentFactory(region, token string) overlay.Incumbent {
+	return hubspot.NewAdapter(hubspot.NewClient(region, token))
+}

--- a/backend/internal/compose/overlayincumbent_refusing.go
+++ b/backend/internal/compose/overlayincumbent_refusing.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// In the integration build, compose binds an incumbent that refuses every call
+// instead of one that reaches HubSpot.
+//
+// The suites were reaching it for real. WithKeyvault builds the overlay Service
+// with the live factory, and Connect resolves the incumbent's portal id and its
+// owners directory through it — both best-effort, so the vendor's 401 came back,
+// was logged as a warning, and the suite went green while a merge gate depended
+// on a third party being up (#1996). Measured at 32 connects x 2 round trips per
+// overlay run, ~24s of a 34s package.
+//
+// Refusing rather than answering, because a fixture that answers plausibly is
+// the thing this seam already has: a suite that wants connect-path behaviour
+// passes its own incumbent through WithOverlayIncumbentResolver, and one that
+// does not should get a named refusal it can read rather than a vendor status
+// code that means nothing here.
+//
+// Both call sites tolerate the error by design — overlay/connection.go's
+// fetchPortalID stores NULL and seedUserMapOnConnect logs and returns — so this
+// changes what the suites SAY, not what they do.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+)
+
+// errNoLiveIncumbent is what every method below returns. It names the
+// substitution to make, because the reader hitting it is running a suite that
+// unexpectedly depends on incumbent behaviour and needs to know there is a seam.
+//
+// It WRAPS hubspot.ErrUnreachable, and that is load-bearing rather than
+// decorative. jobs_overlay.go's isConnectionLevelIncumbentError is what decides
+// whether a reconcile sweep aborts and backs the connection off or logs one
+// object class and carries on; an error it does not recognise takes the second
+// branch. So a bare sentinel here would let the fleet worker sweep a connection
+// where EVERY incumbent call refused, treat each refusal as one class's data
+// defect, and finish by calling RecordSweepSuccess — a green sweep that did
+// nothing, which is the exact false-green this build is supposed to remove.
+// "Could not reach the incumbent" is also simply what happened.
+var errNoLiveIncumbent = fmt.Errorf(
+	"compose: the integration build binds no live incumbent — this suite reached one; "+
+		"pass your own through WithOverlayIncumbentResolver (applied AFTER WithKeyvault) "+
+		"if it needs incumbent behaviour: %w", hubspot.ErrUnreachable)
+
+// liveIncumbentFactory is the integration half of the split — see
+// overlayincumbent_live.go for the production one.
+//
+//nolint:ireturn // returns the overlay.Incumbent seam by design, matching the production half's signature.
+func liveIncumbentFactory(_, _ string) overlay.Incumbent {
+	return refusingIncumbent{}
+}
+
+// refusingIncumbent implements overlay.Incumbent by declining, with the same
+// error from every method. It reports HubSpot's name so a caller that only
+// switches on the incumbent's identity behaves as it does in production.
+type refusingIncumbent struct{}
+
+func (refusingIncumbent) Name() string { return incumbentHubSpot }
+
+func (refusingIncumbent) Backfill(context.Context, string, string) (overlay.Page, error) {
+	return overlay.Page{}, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Modified(context.Context, string, time.Time, string) (overlay.Page, error) {
+	return overlay.Page{}, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Deletions(context.Context, string, time.Time, string) (overlay.DeletionPage, error) {
+	return overlay.DeletionPage{}, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Get(context.Context, string, string) (overlay.Record, error) {
+	return overlay.Record{}, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Associations(context.Context, string, string, string) ([]overlay.Assoc, error) {
+	return nil, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) OwnerEmail(context.Context, string) (string, error) {
+	return "", errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Owners(context.Context) ([]overlay.OwnerRef, error) {
+	return nil, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Create(context.Context, string, map[string]any) (overlay.WriteResult, error) {
+	return overlay.WriteResult{}, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (overlay.WriteResult, error) {
+	return overlay.WriteResult{}, errNoLiveIncumbent
+}
+
+func (refusingIncumbent) Archive(context.Context, string, string, time.Time) error {
+	return errNoLiveIncumbent
+}
+
+// AccountID answers fetchPortalID's optional incumbentAccountReader. Implemented
+// rather than omitted: leaving it off takes the "adapter exposes no account
+// accessor" path, which is a legitimate production shape and would hide the fact
+// that a suite asked.
+func (refusingIncumbent) AccountID(context.Context) (string, error) {
+	return "", errNoLiveIncumbent
+}

--- a/backend/internal/compose/overlayincumbent_refusing_integration_test.go
+++ b/backend/internal/compose/overlayincumbent_refusing_integration_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What the refusing incumbent's error MEANS to the code that reads it, which is
+// a separate question from whether it refuses.
+//
+// jobs_overlay.go's isConnectionLevelIncumbentError decides whether a reconcile
+// sweep aborts and backs the connection off, or logs one object class and
+// carries on. An error it does not recognise takes the second branch — so a
+// refusal it cannot classify would let the fleet worker sweep a connection where
+// EVERY call refused, treat each refusal as that class's own data defect, and
+// finish by recording the sweep a success. A green sweep that did nothing is the
+// precise false green this build exists to remove, so the classification is
+// pinned here rather than left to the wrapping to imply.
+//
+// Needs no database despite the tag: the behaviour under test exists only in
+// this build.
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+)
+
+// refusals is every way the connect and reconcile paths can reach this
+// incumbent. Enumerated rather than asserted through errNoLiveIncumbent
+// directly, because the claim is about the METHODS: a later one that forgets to
+// refuse, or refuses with a bare error of its own, is the regression, and
+// comparing the sentinel to itself could never see it.
+//
+// A hand-written list is a census, and a census goes stale in silence — adding a
+// method to overlay.Incumbent forces refusingIncumbent to implement it, but
+// nothing would force it in here, so the new method would ship with this test
+// green. TestTheRefusalCensusCoversEveryMethod holds the list to the interface.
+func refusals(inc refusingIncumbent) map[string]error {
+	ctx := context.Background()
+	epoch := time.Time{}
+	_, backfillErr := inc.Backfill(ctx, "person", "")
+	_, modifiedErr := inc.Modified(ctx, "person", epoch, "")
+	_, deletionsErr := inc.Deletions(ctx, "person", epoch, "")
+	_, getErr := inc.Get(ctx, "person", "1")
+	_, assocErr := inc.Associations(ctx, "person", "1", "organization")
+	_, ownerEmailErr := inc.OwnerEmail(ctx, "owner-1")
+	_, ownersErr := inc.Owners(ctx)
+	_, accountErr := inc.AccountID(ctx)
+	_, createErr := inc.Create(ctx, "person", nil)
+	_, updateErr := inc.Update(ctx, "person", "1", nil, epoch)
+	return map[string]error{
+		"Backfill":     backfillErr,
+		"Modified":     modifiedErr,
+		"Deletions":    deletionsErr,
+		"Get":          getErr,
+		"Associations": assocErr,
+		"OwnerEmail":   ownerEmailErr,
+		"Owners":       ownersErr,
+		"AccountID":    accountErr,
+		"Create":       createErr,
+		"Update":       updateErr,
+		"Archive":      inc.Archive(ctx, "person", "1", epoch),
+	}
+}
+
+func TestEveryRefusalReadsAsAWholeConnectionFailure(t *testing.T) {
+	for method, err := range refusals(refusingIncumbent{}) {
+		if err == nil {
+			t.Errorf("%s answered instead of refusing — the integration build binds no live incumbent, so nothing here can have an answer to give", method)
+			continue
+		}
+		if !isConnectionLevelIncumbentError(err) {
+			t.Errorf("%s refused with an error the reconcile sweep reads as one object class's data defect: %v.\n"+
+				"A sweep where every call refuses would then record itself a success.", method, err)
+		}
+	}
+}
+
+// The census's own gate. Without it, the test above asserts a property of
+// whichever methods somebody remembered — which is the shape it exists to catch,
+// one level up.
+func TestTheRefusalCensusCoversEveryMethod(t *testing.T) {
+	seam := reflect.TypeOf((*overlay.Incumbent)(nil)).Elem()
+	covered := refusals(refusingIncumbent{})
+	for i := range seam.NumMethod() {
+		name := seam.Method(i).Name
+		if name == "Name" {
+			// Reports the incumbent's identity; it has nothing to refuse.
+			continue
+		}
+		if _, ok := covered[name]; !ok {
+			t.Errorf("overlay.Incumbent.%s is not in the refusal census — it can refuse with an error "+
+				"the reconcile sweep reads as one object class's data defect and nothing here would say so", name)
+		}
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/client.go
+++ b/backend/internal/modules/overlay/hubspot/client.go
@@ -122,6 +122,9 @@ func NewClient(region, token string, opts ...Option) *Client {
 	for _, opt := range opts {
 		opt(c)
 	}
+	// Last, after the options, so no caller-supplied client escapes it. It is a
+	// no-op in every build but the integration one — see guardEgress.
+	c.httpClient = guardEgress(c.httpClient)
 	return c
 }
 

--- a/backend/internal/modules/overlay/hubspot/httpclient.go
+++ b/backend/internal/modules/overlay/hubspot/httpclient.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package hubspot
+
+import "net/http"
+
+// guardEgress is the production half of a build-tag split, and it is the whole
+// of it: the client goes out as its caller built it. The integration half in
+// httpclient_integration.go stops that client leaving the machine — see there
+// for why the lane needs it and why netguard cannot provide it.
+func guardEgress(hc *http.Client) *http.Client { return hc }

--- a/backend/internal/modules/overlay/hubspot/httpclient_egress_integration_test.go
+++ b/backend/internal/modules/overlay/hubspot/httpclient_egress_integration_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package hubspot
+
+// The lane's egress gate, exercised through the client NewClient actually
+// hands its callers rather than through the hook in isolation.
+//
+// That distinction is the test. Asserting the predicate alone proves the
+// predicate and says nothing about whether NewClient installed it, and the
+// wiring is the half that regresses — a second construction path, or a plain
+// http.Client restored "because the timeout is all it needs", and a unit test
+// over the hook keeps passing while the lane goes back to dialling the vendor.
+//
+// It reads c.httpClient because the request has to be observed at the transport:
+// do() maps every transport failure onto ErrUnreachable and deliberately drops
+// the cause, so through the public surface a refused dial and a thirty-second
+// timeout are the same error — and this test's whole job is to tell them apart.
+//
+// It needs no database despite the tag. The behaviour under test exists only in
+// this build, and a tagged test is the only way to reach it.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// unroutable is TEST-NET-1 (RFC 5737): reserved for documentation, routed
+// nowhere. Naming a real public host would make this test's verdict depend on
+// that host being up, which is the dependency the gate exists to remove.
+const unroutable = "http://192.0.2.1:9"
+
+// The same address over TLS. DialTLSContext is only consulted for https, so the
+// arm that exists to prove it was cleared has to ask for that scheme.
+const unroutableTLS = "https://192.0.2.1:9"
+
+// The three ways a client's transport can arrive here. The middle two are the
+// ones the gate used to let through, and both read as ordinary test seams:
+// WithHTTPClient is documented for injecting a transport, and a client with no
+// Transport at all silently uses net/http's DefaultTransport, which dials.
+var dialingClients = []struct {
+	name string
+	url  string
+	opts []Option
+}{
+	{"the client NewClient builds itself", unroutable, nil},
+	{"a caller's client with no transport of its own", unroutable, []Option{WithHTTPClient(&http.Client{})}},
+	{"a caller's client carrying a real transport", unroutable, []Option{WithHTTPClient(&http.Client{Transport: &http.Transport{}})}},
+	// The one net/http calls INSTEAD of DialContext for an https URL, which is
+	// the scheme the vendor is reached over. A transport carrying one kept a
+	// dialer the gate never saw.
+	{"a caller's transport with its own TLS dialer", unroutableTLS, []Option{WithHTTPClient(&http.Client{Transport: &http.Transport{
+		DialTLSContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("this dialer must never be reached: the gate should have replaced it")
+		},
+	}})}},
+}
+
+func TestTheIntegrationBuildRefusesToDialOffThisHost(t *testing.T) {
+	for _, tc := range dialingClients {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient("na1", "token", tc.opts...)
+
+			resp, err := client.httpClient.Get(tc.url)
+			if err == nil {
+				if cerr := resp.Body.Close(); cerr != nil {
+					t.Errorf("closing the response body: %v", cerr)
+				}
+				t.Fatal("a request to an off-host address was attempted and answered — the integration build must not reach the network")
+			}
+			if !strings.Contains(err.Error(), "the integration build refuses to dial") {
+				t.Fatalf("the request failed, but not because the gate refused it — a timeout looks like this too: %v", err)
+			}
+		})
+	}
+}
+
+// The gate must not touch a RoundTripper the caller wrote. Those dial nothing,
+// and rewriting one would break every recorded-fixture test in this package for
+// no gain — so the exemption is stated here rather than left to be rediscovered.
+func TestTheEgressGateLeavesACallersOwnRoundTripperAlone(t *testing.T) {
+	var reached bool
+	client := NewClient("na1", "token", WithHTTPClient(&http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			reached = true
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}),
+	}))
+
+	resp, err := client.httpClient.Get(unroutable)
+	if err != nil {
+		t.Fatalf("the gate replaced a caller's own RoundTripper: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("closing the response body: %v", err)
+	}
+	if !reached {
+		t.Fatal("the caller's RoundTripper never ran — something stood in front of it")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestTheEgressGateStillAdmitsALoopbackTestServer(t *testing.T) {
+	// The other direction, and the one that decides whether the gate is usable at
+	// all: every other test in this package drives the client against an httptest
+	// server, so a gate that refused loopback would take the whole suite with it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := NewClient("na1", "token").httpClient.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("the gate refused a loopback test server: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("closing the response body: %v", err)
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/httpclient_integration.go
+++ b/backend/internal/modules/overlay/hubspot/httpclient_integration.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package hubspot
+
+// In the integration build, a HubSpot client cannot reach the internet.
+//
+// The lane was calling api.hubapi.com for real. Every overlay suite connects an
+// overlay, and Connect resolves the incumbent's portal id and owners directory
+// through this client; both are best-effort, so 32 connects × 2 round trips came
+// back 401 and were swallowed as warnings while the suite went green. It cost
+// ~24s of a 34s package and made a merge gate depend on a vendor being up
+// (#1996).
+//
+// The calls themselves are gone — compose binds a refusing incumbent under this
+// tag rather than a live adapter — and this is what keeps them gone. It is the
+// gate rather than the fix: the next provider call somebody adds to the connect
+// path will not announce itself either, and a suite that dials a vendor and
+// swallows the answer looks exactly like one that does not.
+//
+// netguard cannot do this job. It is an SSRF guard, so it refuses PRIVATE
+// addresses and permits public ones — a public vendor host is precisely what it
+// is built to allow. What the lane needs is the inverse.
+//
+// It runs AFTER every Option, so WithHTTPClient does not open a way around it.
+// That mattered: leaving the injected client alone was an escape hatch worth
+// more than the gate, since `WithHTTPClient(http.DefaultClient)` reads as an
+// ordinary test seam and dials the vendor.
+//
+// One arm is not a gate and says so: a RoundTripper that is not net/http's own
+// is left exactly as the caller built it. This TRUSTS the caller — a wrapper
+// around a real transport would dial — and it is the right trade only because
+// the alternative is rewriting the recorded fixtures every test in this package
+// drives the client with. No non-test code passes WithHTTPClient at all.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+)
+
+// guardEgress returns hc with any dialing transport replaced by one that
+// refuses to leave this host. The client is copied rather than edited: the
+// caller may hold the one it passed in and use it elsewhere.
+func guardEgress(hc *http.Client) *http.Client {
+	guarded := *hc
+	switch transport := hc.Transport.(type) {
+	case nil:
+		// net/http falls back to DefaultTransport, which dials.
+		guarded.Transport = gatedTransport()
+	case *http.Transport:
+		clone := transport.Clone()
+		clone.DialContext = (&net.Dialer{Control: refuseOffHostDial}).DialContext
+		// DialTLSContext, not only DialContext. Clone preserves it, and for an
+		// https URL net/http calls it INSTEAD of DialContext — so a caller that
+		// set one would have kept a dialer the gate never sees, on exactly the
+		// scheme the vendor is reached over. Clearing it puts the connection
+		// back through DialContext with net/http's own TLS on top.
+		clone.DialTLSContext = nil
+		clone.Proxy = nil
+		guarded.Transport = clone
+	default:
+		// A RoundTripper of the caller's own: a recorded fixture, an httptest
+		// transport. It reaches no socket through this package.
+	}
+	return &guarded
+}
+
+// gatedTransport declares only the two fields that decide this build's
+// behaviour.
+//
+// Proxy is left nil ON PURPOSE, here and in the clone above, and it is the half
+// that is easy to miss. With http.ProxyFromEnvironment a machine carrying
+// HTTPS_PROXY would dial the proxy instead of the vendor — the gate would see
+// the proxy's address, admit it if it were loopback, and the proxy would fetch
+// api.hubapi.com on the test's behalf. A gate that a stray environment variable
+// routes around is not one.
+func gatedTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: (&net.Dialer{Control: refuseOffHostDial}).DialContext,
+	}
+}
+
+// refuseOffHostDial fails any connection to an address that is not loopback.
+//
+// The hook fires on the resolved address just before connect, so an httptest
+// server — which is how every test in this package drives the client — is
+// unaffected, and a name that resolves anywhere else fails with a message
+// naming what to do instead.
+func refuseOffHostDial(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("hubspot: the integration build refuses to dial %q, which it could not parse as an address", address)
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("hubspot: the integration build refuses to dial %s — a test reached the real vendor. "+
+		"Point the client at an httptest server with WithBaseURL, or substitute the incumbent "+
+		"(compose builds a refusing one under this tag)", address)
+}

--- a/backend/internal/platform/keyvault/local_integration_test.go
+++ b/backend/internal/platform/keyvault/local_integration_test.go
@@ -14,9 +14,15 @@ package keyvault_test
 //
 // So this exercises the local provider over a real pool, and pins the property
 // behaviourally rather than by inspection: with the pool narrowed to ONE
-// connection and that connection held by an open transaction, a Get must fail
-// to acquire and a GetOn through the transaction must answer. A GetOn that took
-// its own connection cannot pass this.
+// connection and that connection held by an open transaction, a GetOn through
+// the transaction must answer. A GetOn that took its own connection cannot pass
+// this.
+//
+// The control below then shows Get is not that — and it does so by COUNTING the
+// pool's acquires, not by waiting for a deadline to expire. "Get must fail"
+// would be the easier sentence and it is no longer what happens: the test hands
+// the connection back and Get completes. Anyone reintroducing a wait here would
+// be putting back the two seconds this shape exists to remove.
 
 import (
 	"context"
@@ -103,7 +109,10 @@ func TestLocalGetOnReadsThroughTheCallersTransaction(t *testing.T) {
 		t.Fatalf("opening the transaction: %v", err)
 	}
 	defer func() {
-		//craft:ignore swallowed-errors the transaction is read-only and being abandoned
+		// The control below rolls this back itself — releasing the connection is
+		// the event it turns on — so by the time this runs the transaction is
+		// normally already closed.
+		//craft:ignore swallowed-errors the transaction is read-only, and on the happy path already rolled back
 		_ = tx.Rollback(context.Background())
 	}()
 
@@ -125,12 +134,36 @@ func TestLocalGetOnReadsThroughTheCallersTransaction(t *testing.T) {
 
 	// And the control, which is what makes the assertion above mean something:
 	// the same read through Get asks the pool for a SECOND connection, and the
-	// pool has none to give while the transaction holds its one. It blocks
-	// rather than failing, so the deadline is the observation.
-	blocked, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	if _, err := vault.Get(blocked, ws, ref); err == nil {
-		t.Fatal("Get succeeded while the pool's only connection was held by an open transaction — " +
-			"it no longer takes a connection of its own, and GetOn's reason for existing is gone")
+	// pool has none to give while the transaction holds its one.
+	//
+	// The observable is the pool's own acquire counter, not a deadline. Waiting
+	// one out was the earlier shape and its pass condition WAS the deadline
+	// expiring, so every green run paid the full wait — 63 % of this package.
+	// Counting acquires states the claim directly instead of inferring it from
+	// a duration: Get takes a connection of its own. A Get that stopped needing
+	// one leaves the counter untouched however long anybody waits, and there is
+	// no clock in the assertion to be slow, contended or flaky.
+	//
+	// Snapshotted after Put and the Begin above, so the only acquire this can
+	// count is the one Get makes.
+	acquiredBefore := pool.Stat().AcquireCount()
+	answered := make(chan error, 1)
+	go func() {
+		_, err := vault.Get(ctx, ws, ref)
+		answered <- err
+	}()
+
+	// Handing the connection back is what lets that Get finish, and nothing else
+	// can — which is why the rollback happens here rather than being left to the
+	// deferred cleanup.
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatalf("releasing the pool's only connection: %v", err)
+	}
+	if err := <-answered; err != nil {
+		t.Fatalf("Get once the transaction released the pool's connection: %v", err)
+	}
+	if after := pool.Stat().AcquireCount(); after <= acquiredBefore {
+		t.Fatalf("Get answered without taking a connection of its own (pool acquires %d, unchanged) — "+
+			"it no longer needs one, and GetOn's reason for existing is gone", acquiredBefore)
 	}
 }

--- a/backend/migrations/agentseatbackfill_integration_test.go
+++ b/backend/migrations/agentseatbackfill_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 0216 gives an installation that already booted the agent seat bootstrap now
 // writes for a new one. Nothing else in the lane can prove it works.
@@ -28,6 +28,8 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func TestTheAgentSeatBackfillGivesEverySeatlessWorkspaceExactlyOneSeat(t *testing.T) {
@@ -119,7 +121,7 @@ func assertOneAgentSeat(ctx context.Context, t *testing.T, admin *pgx.Conn, wsID
 // changed.
 func agentSeatBackfillSQL(t *testing.T) string {
 	t.Helper()
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core migrations: %v", err)
 	}

--- a/backend/migrations/archivedresidue_integration_test.go
+++ b/backend/migrations/archivedresidue_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // The archived-tenant gate (0272) refuses, and refuses for the right reason.
 //
@@ -78,8 +78,7 @@ func seedArchivedTenantHolding(ctx context.Context, t *testing.T, conn *pgx.Conn
 func TestTheArchivedResidueGateRefusesAndNamesWhatItFound(t *testing.T) {
 	ctx := context.Background()
 	conn := connect(t, mustOwnerDSN(t))
-	resetSchema(t, conn)
-	migrateAll(t, conn)
+	headSchema(t, conn)
 
 	table := seedArchivedTenantHolding(ctx, t, conn)
 
@@ -106,8 +105,7 @@ func TestTheArchivedResidueGateRefusesAndNamesWhatItFound(t *testing.T) {
 func TestTheArchivedResidueGateAdmitsOnceTheResidueIsCleared(t *testing.T) {
 	ctx := context.Background()
 	conn := connect(t, mustOwnerDSN(t))
-	resetSchema(t, conn)
-	migrateAll(t, conn)
+	headSchema(t, conn)
 
 	seedArchivedTenantHolding(ctx, t, conn)
 	if _, err := conn.Exec(ctx, gateSQL(t)); err == nil {
@@ -130,8 +128,7 @@ func TestTheArchivedResidueGateAdmitsOnceTheResidueIsCleared(t *testing.T) {
 func TestTheArchivedResidueGateExemptsTheAppendOnlyLedgers(t *testing.T) {
 	ctx := context.Background()
 	conn := connect(t, mustOwnerDSN(t))
-	resetSchema(t, conn)
-	migrateAll(t, conn)
+	headSchema(t, conn)
 
 	var ws string
 	if err := conn.QueryRow(ctx, `

--- a/backend/migrations/capture_auto_enrich_rollback_integration_test.go
+++ b/backend/migrations/capture_auto_enrich_rollback_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 0206's reverse carries data, and a reverse that carries data needs a test
 // that carries data through it. The forward direction dropped
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func TestRollingBackTheAutoEnrichColumnRestoresTheCurrentPosture(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRollingBackTheAutoEnrichColumnRestoresTheCurrentPosture(t *testing.T) {
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestRollingBackTolerAtesASettingValueThisBuildCannotRead(t *testing.T) {
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/capture_connection_reconcile_integration_test.go
+++ b/backend/migrations/capture_connection_reconcile_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 0078's data transforms proven directly (CAP-DDL-2): a database that held
 // improvised connector_connection rows migrates to capture_connection with the
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func TestCaptureConnectionReconcile(t *testing.T) {
@@ -61,7 +62,7 @@ func TestCaptureConnectionReconcile(t *testing.T) {
 func rewindToBeforeReconcile(t *testing.T, conn *pgx.Conn) dbmigrate.Namespace {
 	t.Helper()
 	ctx := context.Background()
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
+++ b/backend/migrations/comms_outbound_inflight_rollback_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 0156's rollback proven directly. The in-flight marker is the ONLY record that
 // a channel message may already be with the customer, and a channel seam has no
@@ -29,6 +29,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func TestRollingBackTheInflightMarkerParksUnlearnedSends(t *testing.T) {
@@ -37,7 +38,7 @@ func TestRollingBackTheInflightMarkerParksUnlearnedSends(t *testing.T) {
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/company_context_rollout_integration_test.go
+++ b/backend/migrations/company_context_rollout_integration_test.go
@@ -3,13 +3,14 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func TestCompanyContextBackfillAddsOnlyMissingAnchorProvenance(t *testing.T) {
@@ -17,7 +18,7 @@ func TestCompanyContextBackfillAddsOnlyMissingAnchorProvenance(t *testing.T) {
 	conn := connect(t, ownerDSN)
 	resetSchema(t, conn)
 	ctx := context.Background()
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/coreversions_test.go
+++ b/backend/migrations/coreversions_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package migrations
+package migrations_test
 
 import (
 	"regexp"

--- a/backend/migrations/employment_dedupe_repair_integration_test.go
+++ b/backend/migrations/employment_dedupe_repair_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 1787111736 adds a UNIQUE index to a table that is already allowed to hold
 // the rows it forbids, so it ships with a repair. A repair needs a test that
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 // employmentRow is one seeded edge and what the repair is expected to do to it.
@@ -92,7 +93,7 @@ func TestTheEmploymentDedupeIndexRepairsTheDuplicatesItWouldRefuseToApplyOver(t 
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/employment_notice_period_repair_integration_test.go
+++ b/backend/migrations/employment_notice_period_repair_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 1787128142 undoes damage 1787111736 did, so its test has to carry that damage
 // through it. Applied to a fresh schema the repair matches nothing — there is
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 // noticeRow is one seeded employment and whether the repair should hand its
@@ -95,7 +96,7 @@ func TestTheNoticePeriodRepairGivesBackOnlyTheFlagsItShould(t *testing.T) {
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/headschema_integration_test.go
+++ b/backend/migrations/headschema_integration_test.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+// headSchema is for the tests in this package that want the schema the
+// migrations BUILD, not the act of building it.
+//
+// Most suites here rewind and replay: they drop everything, apply a prefix,
+// assert on what a repair or a rollback did. That is why this package is carved
+// out of backend/integrationmigrateonce_test.go's migrate-once rule, and it
+// stays carved out. But roughly a quarter of its tests only read the head
+// catalog — is this column generated, is that view security_invoker, does every
+// row-scoped FK carry a visibility decision — and they were taking the carve-out
+// too, paying a DROP SCHEMA CASCADE and a full replay of every embedded
+// migration (~1.3s each) to arrive at a schema the lane had already handed them:
+// every clone is copied from an already-migrated template.
+//
+// So: build head ONCE per process, then verify it is still head before each
+// later use and rebuild only when it is not. The verification is what makes this
+// safe to mix with the rewinding suites in the same binary — they run on the
+// same database, and one of them leaves it two migrations short.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+)
+
+// headFingerprint is the catalog of the schema this process built at head,
+// captured the first time headSchema ran. Empty until then.
+//
+// A digest of the catalog, not the migration ledger's version set. The ledger
+// records a version, not a checksum — scripts/lib-testdb.sh says so where it
+// decides whether to reuse the template — so a version set answers "which
+// migrations were applied" and cannot answer "is the schema still what they
+// build". Both questions have to come out right here: a rewinding suite that
+// leaves the ledger at head having altered a table would pass a version check
+// and hand the next reader a schema nothing in this package built.
+var headFingerprint string
+
+// headRebuilds counts the full drop-and-replay rebuilds headSchema has done, so
+// its own test can tell the cheap path from the expensive one. Nothing else
+// distinguishes them: both leave a database at head with no rows in it, which is
+// exactly why a helper that quietly rebuilt every time would go unnoticed and
+// give back the whole saving.
+var headRebuilds int
+
+// headSchema hands the caller a database at head with no rows in it.
+//
+// The FIRST call in the process rebuilds unconditionally — drop, then replay
+// every embedded migration — so the reference catalog is one this binary's own
+// migrations produced rather than whatever the template happened to hold. That
+// closes the case the template cannot: the ledger cannot see an edited or
+// renumbered migration, so a clone built from a template that diverged from this
+// checkout is at "head" by the only measure the database keeps.
+//
+// Later calls compare the live catalog against that reference and rebuild only
+// on a mismatch, which is what the rewinding suites in this package produce.
+// Matching costs one query instead of a full replay.
+//
+// Data is emptied by testdb.Reset either way, so a caller may write rows; it
+// gets the same clean slate a rebuild gave it.
+func headSchema(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	ctx := context.Background()
+	if headFingerprint == "" || catalogDigest(t, conn) != headFingerprint {
+		resetSchema(t, conn)
+		migrateAll(t, conn)
+		headFingerprint = catalogDigest(t, conn)
+		headRebuilds++
+	}
+	if err := testdb.Reset(ctx, conn); err != nil {
+		t.Fatalf("emptying the head schema: %v", err)
+	}
+}
+
+// catalogDigest is one md5 over the schema the migrations build, at the grain the
+// tests that ride it actually read.
+//
+// That last clause is the whole design, and getting it wrong is worse than
+// having no digest at all — a fingerprint blind to the objects its readers care
+// about still READS as verification. So the contents are derived from what the
+// head-only tests in this package assert on, one line each:
+//
+//   - columns, types, nullability — every one of them, and the baseline
+//   - column defaults and generated expressions — schema_fitness asserts that
+//     amount_minor_base is database-generated, and a column keeping its name,
+//     type and nullability while losing its GENERATED clause is precisely the
+//     move a rewind makes
+//   - view definitions and reloptions — schema_fitness asserts a rollup view is
+//     security_invoker, which lives in reloptions and in nothing else here
+//   - triggers AND the function bodies they execute — the version bump and
+//     audit_log's append-only guard are trigger behaviour, asserted by two
+//     tests. Both halves, because pg_get_triggerdef prints which function a
+//     trigger calls and not what that function does, and this tree ships
+//     migrations that change nothing but a function body (core 0291 is one)
+//   - table grants — the two behaviour tests above connect as the app role, so
+//     a revoked grant changes what they observe while disturbing no object
+//   - indexes and constraints — asserted directly by the cascade-index and FK
+//     visibility tests
+//
+// A schema with no objects at all digests to the empty string rather than to
+// SQL NULL, so a caller arriving after a suite that dropped the schema and left
+// it dropped reads a mismatch and rebuilds — the outcome it needs — instead of
+// failing on a scan.
+func catalogDigest(t *testing.T, conn *pgx.Conn) string {
+	t.Helper()
+	var digest string
+	err := conn.QueryRow(context.Background(), `
+		WITH parts AS (
+			SELECT n.nspname || '.' || c.relname || '.' || a.attname || ' ' ||
+			       format_type(a.atttypid, a.atttypmod) ||
+			       CASE WHEN a.attnotnull THEN ' NOT NULL' ELSE '' END ||
+			       ' gen=' || COALESCE(NULLIF(a.attgenerated::text, ''), '-') ||
+			       ' def=' || COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '-') AS part
+			  FROM pg_attribute a
+			  JOIN pg_class c ON c.oid = a.attrelid
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			  LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+			 WHERE n.nspname IN ('public', 'ext')
+			   AND c.relkind IN ('r', 'p', 'v', 'm')
+			   AND a.attnum > 0
+			   AND NOT a.attisdropped
+			UNION ALL
+			SELECT n.nspname || '.' || c.relname || ' opts=' ||
+			       COALESCE(array_to_string(c.reloptions, ','), '-') || ' ' ||
+			       COALESCE(pg_get_viewdef(c.oid), '-')
+			  FROM pg_class c
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname IN ('public', 'ext')
+			   AND c.relkind IN ('v', 'm')
+			UNION ALL
+			SELECT n.nspname || '.' || c.relname || '.' || t.tgname || ' ' ||
+			       pg_get_triggerdef(t.oid)
+			  FROM pg_trigger t
+			  JOIN pg_class c ON c.oid = t.tgrelid
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname IN ('public', 'ext')
+			   AND NOT t.tgisinternal
+			UNION ALL
+			SELECT n.nspname || '.' || p.proname || '(' ||
+			       pg_get_function_identity_arguments(p.oid) || ') ' || p.prosrc
+			  FROM pg_proc p
+			  JOIN pg_namespace n ON n.oid = p.pronamespace
+			 WHERE n.nspname IN ('public', 'ext')
+			UNION ALL
+			SELECT n.nspname || '.' || c.relname || ' acl=' ||
+			       COALESCE(array_to_string(c.relacl, ','), '-')
+			  FROM pg_class c
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname IN ('public', 'ext')
+			   AND c.relkind IN ('r', 'p', 'v', 'm')
+			UNION ALL
+			SELECT n.nspname || '.' || c.relname || '.' || con.conname || ' ' ||
+			       pg_get_constraintdef(con.oid)
+			  FROM pg_constraint con
+			  JOIN pg_class c ON c.oid = con.conrelid
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname IN ('public', 'ext')
+			UNION ALL
+			SELECT schemaname || '.' || indexname || ' ' || indexdef
+			  FROM pg_indexes
+			 WHERE schemaname IN ('public', 'ext')
+		)
+		SELECT COALESCE(md5(string_agg(part, E'\n' ORDER BY part)), '') FROM parts`).Scan(&digest)
+	if err != nil {
+		t.Fatalf("fingerprinting the schema catalog: %v", err)
+	}
+	return digest
+}
+
+// The helper's own two claims, which nothing else in this package can make:
+// a database still at head is not rebuilt, and one that is NOT still at head is.
+// Both matter, and they fail in opposite directions — rebuilding always gives up
+// the entire saving silently, rebuilding never hands a rewound schema to a test
+// that asserts on the head catalog and blames the migration it was reading.
+func TestHeadSchemaDoesNotRebuildADatabaseAlreadyAtHead(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+
+	headSchema(t, conn)
+	settled := headRebuilds
+
+	headSchema(t, conn)
+	if headRebuilds != settled {
+		t.Fatalf("headSchema rebuilt a database already at head (%d rebuilds, want %d) — "+
+			"every caller pays a full replay for a schema it was already handed", headRebuilds, settled)
+	}
+}
+
+// schemaMove is one way a suite in this package can leave the schema off head
+// while the migration ledger still reads head. Each names an object class the
+// digest claims to cover, and each is DERIVED from the live catalog rather than
+// hardcoded: a named object the migrations later rename turns into a
+// missing-object error that reads like a broken helper, and the coverage it was
+// standing for goes quietly.
+var schemaMoves = []struct {
+	name string
+	// find returns the statement that moves the schema, or "" when this schema
+	// has no such object to move.
+	find func(t *testing.T, conn *pgx.Conn) string
+}{
+	{"an index is dropped", func(t *testing.T, conn *pgx.Conn) string {
+		return scanOne(t, conn, `
+			SELECT 'DROP INDEX ' || quote_ident(schemaname) || '.' || quote_ident(indexname)
+			  FROM pg_indexes
+			 WHERE schemaname = 'public'
+			   AND indexname NOT IN (SELECT conname FROM pg_constraint)
+			 ORDER BY indexname LIMIT 1`)
+	}},
+	{"a trigger is dropped", func(t *testing.T, conn *pgx.Conn) string {
+		return scanOne(t, conn, `
+			SELECT 'DROP TRIGGER ' || quote_ident(t.tgname) || ' ON ' ||
+			       quote_ident(n.nspname) || '.' || quote_ident(c.relname)
+			  FROM pg_trigger t
+			  JOIN pg_class c ON c.oid = t.tgrelid
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname = 'public' AND NOT t.tgisinternal
+			 ORDER BY t.tgname LIMIT 1`)
+	}},
+	{"a view stops being security_invoker", func(t *testing.T, conn *pgx.Conn) string {
+		return scanOne(t, conn, `
+			SELECT 'ALTER VIEW ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname) ||
+			       ' SET (security_invoker = false)'
+			  FROM pg_class c
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname = 'public' AND c.relkind = 'v'
+			   AND array_to_string(c.reloptions, ',') LIKE '%security_invoker=true%'
+			 ORDER BY c.relname LIMIT 1`)
+	}},
+	{"a trigger function's body is replaced", func(t *testing.T, conn *pgx.Conn) string {
+		// The class a dropped trigger CANNOT stand in for: the trigger
+		// definition names its function and says nothing about what that
+		// function does, and this tree ships migrations that change only a body.
+		return scanOne(t, conn, `
+			SELECT 'CREATE OR REPLACE FUNCTION ' || quote_ident(n.nspname) || '.' ||
+			       quote_ident(p.proname) || '() RETURNS trigger LANGUAGE plpgsql AS $body$ BEGIN RETURN NEW; END $body$'
+			  FROM pg_proc p
+			  JOIN pg_namespace n ON n.oid = p.pronamespace
+			  JOIN pg_trigger t ON t.tgfoid = p.oid AND NOT t.tgisinternal
+			 WHERE n.nspname = 'public'
+			   AND pg_get_function_identity_arguments(p.oid) = ''
+			 ORDER BY p.proname LIMIT 1`)
+	}},
+	{"a grant is revoked", func(t *testing.T, conn *pgx.Conn) string {
+		return scanOne(t, conn, `
+			SELECT 'REVOKE SELECT ON ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname) ||
+			       ' FROM margince_app'
+			  FROM pg_class c
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname = 'public' AND c.relkind = 'r'
+			   AND array_to_string(c.relacl, ',') LIKE '%margince_app=%r%'
+			 ORDER BY c.relname LIMIT 1`)
+	}},
+	{"a column loses its default", func(t *testing.T, conn *pgx.Conn) string {
+		return scanOne(t, conn, `
+			SELECT 'ALTER TABLE ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname) ||
+			       ' ALTER COLUMN ' || quote_ident(a.attname) || ' DROP DEFAULT'
+			  FROM pg_attrdef ad
+			  JOIN pg_class c ON c.oid = ad.adrelid
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			  JOIN pg_attribute a ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+			 WHERE n.nspname = 'public' AND c.relkind = 'r' AND a.attgenerated = ''
+			 ORDER BY c.relname, a.attname LIMIT 1`)
+	}},
+}
+
+func TestHeadSchemaRebuildsWhateverTheDigestClaimsToWatch(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+
+	for _, move := range schemaMoves {
+		t.Run(move.name, func(t *testing.T) {
+			headSchema(t, conn)
+			settled := headRebuilds
+
+			stmt := move.find(t, conn)
+			if stmt == "" {
+				t.Fatalf("this schema has no object to move for %q — the digest still claims to cover that class, "+
+					"so either the class is gone and the digest should say so, or this query stopped finding it", move.name)
+			}
+			if _, err := conn.Exec(context.Background(), stmt); err != nil {
+				t.Fatalf("moving the schema off head with %q: %v", stmt, err)
+			}
+
+			headSchema(t, conn)
+			if headRebuilds != settled+1 {
+				t.Fatalf("headSchema did not rebuild after %q (%d rebuilds, want %d) — "+
+					"the ledger still reads head, so the digest is the only thing that can see this", move.name, headRebuilds, settled+1)
+			}
+			if catalogDigest(t, conn) != headFingerprint {
+				t.Fatal("the rebuilt catalog does not match the head this process built")
+			}
+		})
+	}
+}
+
+// scanOne runs a query expected to return at most one text value, answering ""
+// when it returns no row.
+func scanOne(t *testing.T, conn *pgx.Conn, sql string) string {
+	t.Helper()
+	var out string
+	switch err := conn.QueryRow(context.Background(), sql).Scan(&out); {
+	case errors.Is(err, pgx.ErrNoRows):
+		return ""
+	case err != nil:
+		t.Fatalf("finding an object to move: %v", err)
+	}
+	return out
+}

--- a/backend/migrations/managementrole_test.go
+++ b/backend/migrations/managementrole_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package migrations
+package migrations_test
 
 // The obligation: the management document 0268 inserts into an upgraded
 // installation is the document the server seeds into a fresh one. The
@@ -17,6 +17,8 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 const managementRoleMigration = "0268"
@@ -25,7 +27,7 @@ const managementRoleMigration = "0268"
 var managementLiteral = regexp.MustCompile(`'(\{.*\})'::jsonb`)
 
 func TestManagementRoleMigrationInsertsTheSeededDocument(t *testing.T) {
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/migrationrole_integration_test.go
+++ b/backend/migrations/migrationrole_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // A deployed installation's migration role owns the schema and is NOT a
 // superuser. That single difference decides whether a migration's data half runs

--- a/backend/migrations/migrations_test.go
+++ b/backend/migrations/migrations_test.go
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package migrations
+package migrations_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/migrations"
+)
 
 func TestEmbeddedMigrationNamespacesLoad(t *testing.T) {
 	loaders := map[string]func() error{
 		"core": func() error {
-			_, err := Core()
+			_, err := migrations.Core()
 			return err
 		},
 		"custom": func() error {
-			_, err := Custom()
+			_, err := migrations.Custom()
 			return err
 		},
 	}

--- a/backend/migrations/namespaces_test.go
+++ b/backend/migrations/namespaces_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package migrations
+package migrations_test
 
 // Loading the embedded migration namespaces, once, for every test in this
 // package that reads or replays them.
@@ -10,15 +10,16 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func namespaces(t *testing.T) (core, custom dbmigrate.Namespace) {
 	t.Helper()
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading the core namespace: %v", err)
 	}
-	custom, err = Custom()
+	custom, err = migrations.Custom()
 	if err != nil {
 		t.Fatalf("loading the custom namespace: %v", err)
 	}

--- a/backend/migrations/person_channel_identity_index_integration_test.go
+++ b/backend/migrations/person_channel_identity_index_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // 0152's index shape, proven against the live catalog rather than read off the
 // migration text: an index the FOREIGN KEY cannot use is indistinguishable from
@@ -26,8 +26,7 @@ import (
 func TestPersonChannelIdentityCascadeIndexIsUnconditional(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	conn := connect(t, ownerDSN)
-	resetSchema(t, conn)
-	migrateAll(t, conn)
+	headSchema(t, conn)
 
 	var predicate *string
 	var columns []string

--- a/backend/migrations/rbac_backfill_parity_integration_test.go
+++ b/backend/migrations/rbac_backfill_parity_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // The RBAC backfill migrations are the ONLY thing that gives an existing
 // installation a grant on an object added after it bootstrapped: the code-side
@@ -31,6 +31,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 // grant is one role's CRUD row inside a permissions document.
@@ -128,7 +129,7 @@ func TestRBACBackfillsWriteTheIntendedGrants(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	conn := connect(t, ownerDSN)
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/rbac_repair_integration_test.go
+++ b/backend/migrations/rbac_repair_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // The obligation: the repair migrations heal a database that already recorded the
 // backfills they re-apply, and grant exactly what those backfills granted — no

--- a/backend/migrations/rbac_upgrade_replay_integration_test.go
+++ b/backend/migrations/rbac_upgrade_replay_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // The obligation: an installation that predates every backfill, upgraded to
 // head, holds exactly the matrix the server seeds today. This executes it

--- a/backend/migrations/rbacrepair_test.go
+++ b/backend/migrations/rbacrepair_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package migrations
+package migrations_test
 
 // The obligation: a repair migration re-applies EVERY guarded RBAC backfill that
 // shipped before it, granting exactly what that backfill granted.

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // Catalog-derived fitness functions over the migrated schema: the RLS
 // coverage, composite-tenant-FK, and row-scoped-FK-visibility invariants
@@ -32,8 +32,7 @@ import (
 func TestSchema_amountMinorBaseIsDatabaseGenerated(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	owner := connect(t, ownerDSN)
-	resetSchema(t, owner)
-	migrateAll(t, owner)
+	headSchema(t, owner)
 	ctx := context.Background()
 
 	var isGenerated, generationExpr string
@@ -77,8 +76,7 @@ func TestSchema_amountMinorBaseIsDatabaseGenerated(t *testing.T) {
 func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	owner := connect(t, ownerDSN)
-	resetSchema(t, owner)
-	migrateAll(t, owner)
+	headSchema(t, owner)
 	ctx := context.Background()
 
 	var reloptions []string
@@ -359,8 +357,7 @@ func TestFK_rowScopedTargetsHaveVisibilityDecision(t *testing.T) {
 
 	ownerDSN, _ := dsns(t)
 	owner := connect(t, ownerDSN)
-	resetSchema(t, owner)
-	migrateAll(t, owner)
+	headSchema(t, owner)
 	ctx := context.Background()
 
 	rows, err := owner.Query(ctx, `

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // Integration lane (make test-integration): exercises the real schema on
 // Postgres 16 — apply/reverse/re-apply, the version bump (data-model §1.3a),
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 // ownerDSN administers the throwaway test database; appDSNFmt is the
@@ -53,11 +54,11 @@ func connect(t *testing.T, dsn string) *pgx.Conn {
 
 func migrateAll(t *testing.T, conn *pgx.Conn) {
 	t.Helper()
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core migrations: %v", err)
 	}
-	custom, err := Custom()
+	custom, err := migrations.Custom()
 	if err != nil {
 		t.Fatalf("loading custom migrations: %v", err)
 	}
@@ -99,7 +100,7 @@ func TestMigrations_applyReverseReapply(t *testing.T) {
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}
@@ -186,8 +187,7 @@ func withGUC(t *testing.T, conn *pgx.Conn, wsID string, fn func(pgx.Tx) error) e
 func TestVersionBumpAndSkewSemantics(t *testing.T) {
 	ownerDSN, appDSN := dsns(t)
 	owner := connect(t, ownerDSN)
-	resetSchema(t, owner)
-	migrateAll(t, owner)
+	headSchema(t, owner)
 	ws := seedWorkspace(t, owner, "tenant-v")
 
 	app := connect(t, appDSN)
@@ -236,8 +236,7 @@ func TestVersionBumpAndSkewSemantics(t *testing.T) {
 func TestAuditLogIsAppendOnly(t *testing.T) {
 	ownerDSN, appDSN := dsns(t)
 	owner := connect(t, ownerDSN)
-	resetSchema(t, owner)
-	migrateAll(t, owner)
+	headSchema(t, owner)
 	ws := seedWorkspace(t, owner, "tenant-audit")
 
 	app := connect(t, appDSN)
@@ -287,7 +286,7 @@ func TestSignalVisibilityBackfillNarrowsOnlyWhatAProducerWrote(t *testing.T) {
 	resetSchema(t, conn)
 	ctx := context.Background()
 
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core: %v", err)
 	}

--- a/backend/migrations/scriptschemadrift_integration_test.go
+++ b/backend/migrations/scriptschemadrift_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 // The seed and ops scripts are build artifacts of the schema, and nothing was
 // checking that they still match it.
@@ -51,8 +51,7 @@ var (
 func TestEveryScriptNamesColumnsTheSchemaHas(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	conn := connect(t, ownerDSN)
-	resetSchema(t, conn)
-	migrateAll(t, conn)
+	headSchema(t, conn)
 
 	columns := schemaColumns(t, conn)
 	scripts := scriptFiles(t)

--- a/backend/migrations/voice_profile_lifecycle_integration_test.go
+++ b/backend/migrations/voice_profile_lifecycle_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package migrations
+package migrations_test
 
 import (
 	"bytes"
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/migrations"
 )
 
 func TestVoiceProfileLifecycleUpgradePreservesBuiltProfile(t *testing.T) {
@@ -75,7 +76,7 @@ func TestVoiceProfileLifecycleUpgradePreservesBuiltProfile(t *testing.T) {
 
 func migrateToBeforeVoiceLifecycle(t *testing.T, conn *pgx.Conn) dbmigrate.Namespace {
 	t.Helper()
-	core, err := Core()
+	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading core migrations: %v", err)
 	}

--- a/scripts/integration-lane-timing.txt
+++ b/scripts/integration-lane-timing.txt
@@ -1,0 +1,54 @@
+# The parallel integration lane's dispatch baseline: how long each package took
+# on one real full run, longest first. scripts/lib-laneorder.sh reads it as an
+# ORDER, never as a prediction — a fresh clone has no .tmp/ measurements of its
+# own, and without this it dispatches in discovery order and queues its long
+# pole behind short packages.
+#
+# The seconds are wall clock from one machine under one load. They do not
+# transfer; the ranking does. A package this file does not name keeps discovery
+# order, so letting it go stale costs a little scheduling, never a red lane —
+# refresh it from .tmp/integration-lane-timing.txt after a full
+# `make test-integration` when the ranking has visibly moved.
+# Sorted longest-first for a reader; the runner sorts by value and does not care.
+./internal/compose/integration|255.831
+./migrations|133.142
+./internal/compose|127.043
+./internal/compose/integration/agentaccess|49.698
+./internal/modules/people|36.219
+./internal/compose/integration/channels|30.629
+./internal/compose/integration/overlay|30.114
+./internal/modules/identity|28.752
+./internal/compose/integration/org360|27.690
+./internal/modules/overlay|27.639
+./internal/compose/integration/capture|23.226
+./internal/compose/integration/jobfanout|20.120
+./internal/compose/integration/webhooks|15.577
+./internal/compose/integration/customfields|14.137
+./internal/compose/integration/collections|13.607
+./cmd/migrate|13.599
+./internal/modules/activities|8.004
+./internal/compose/briefs|7.620
+./tools/extmigrategate|7.459
+./internal/platform/testdb|6.827
+./internal/platform/jobs|6.550
+./internal/platform/events|5.674
+./internal/modules/comms|5.041
+./internal/platform/extsecrets|5.008
+./internal/platform/keyvault|4.576
+./internal/modules/capture|4.152
+./internal/modules/finance|3.479
+./internal/modules/approvals|2.648
+./internal/modules/migration|2.487
+./internal/modules/consent|2.426
+./internal/modules/automation|2.381
+./internal/modules/integrations|2.255
+./internal/modules/ai|2.195
+./internal/compose/costestimate|1.636
+./internal/modules/customfields|1.126
+./cmd/worker|0.911
+./internal/platform/overlaybudget|0.789
+./internal/modules/overlay/hubspot|0.672
+./internal/platform/blobstore|0.612
+./internal/modules/privacy|0.440
+./internal/platform/agentquota|0.356
+./internal/platform/database|0.236

--- a/scripts/lib-laneorder.sh
+++ b/scripts/lib-laneorder.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Shared helper for the parallel integration lane: decide which packages the
+# dispatcher starts first. Source this; don't execute it.
+#
+# Wall clock is set by when the LONGEST package finishes, so it should start at
+# t=0. Dispatched in discovery order it does not: measured, this lane's long
+# pole waited 16s of a 252s run for a slot while shorter packages held all
+# eight. That is the classic longest-processing-time-first result.
+#
+# The durations are read as an ORDER, never as a prediction. They are wall-clock
+# seconds from one machine under one load, so the numbers themselves carry
+# little across hosts; what survives the move is which package is the long pole.
+#
+# Lives in its own file so `scripts/test-laneorder.sh` can exercise the two
+# properties that decide whether the ordering helps or quietly hurts — a named
+# package sorts by its duration, and an unnamed one keeps the order it would
+# have had with no hint at all — without standing up a database.
+
+# resolve_order_hint MEASURED BASELINE — print the hint file to dispatch by, or
+# nothing when neither is usable.
+#
+# MEASURED is what the last full run on THIS machine recorded and wins whenever
+# it exists: a machine's own durations beat anybody else's. BASELINE is the
+# committed fallback, so a fresh clone — which has no .tmp/ at all — still
+# dispatches longest-first on its very first lane. The committed file is never
+# written by a run; see the publish step in test-integration-parallel.sh for why
+# a shard's slice measurements must not become anyone's baseline.
+resolve_order_hint() {
+  local measured="$1" baseline="$2"
+  if [[ -s "$measured" ]]; then
+    printf '%s' "$measured"
+  elif [[ -s "$baseline" ]]; then
+    printf '%s' "$baseline"
+  fi
+}
+
+# order_by_hint GROUPED HINT — print GROUPED's lines longest-package-first.
+#
+# GROUPED lines are `moduledir|package|run-regex`; HINT lines are
+# `package|seconds`. Only fields 1 and 2 of each are read, and the GROUPED line
+# is reprinted whole, because its third field is a -run regex containing its own
+# pipes.
+#
+# A HINT line naming something that is not a package in GROUPED is simply never
+# looked up, which is what makes the committed file's human-readable header
+# harmless: it becomes an entry keyed on its own text that nothing asks for.
+#
+# A package with no USABLE time sorts FIRST, not last. The unknown is usually a
+# new small package, where the cost of guessing wrong is one slot occupied early;
+# guessing wrong the other way puts a new heavy package last and pays its whole
+# duration after everything else has finished.
+#
+# "Usable" and not merely "present", because awk reads a non-numeric field as
+# ZERO — which sorts that package LAST, the exact schedule this ordering exists
+# to avoid, and it is reachable: the lane's own report has a branch for a package
+# that "recorded no test duration", and such a line reaches the hint as
+# `package|` with an empty second field. A duration that is not a positive number
+# is therefore treated as no duration at all.
+#
+# -s (stable) is what makes an unnamed package degrade to the order it would
+# have had with no hint at all. Every unnamed package shares one sort key, and
+# without -s sort breaks those ties on the whole line — under -r, in REVERSE
+# input order. A stale baseline must hand the packages it does not name back to
+# the order they arrived in, never to an order the sort invented from them.
+order_by_hint() {
+  local grouped="$1" hint="$2"
+  awk -F'|' -v hint="$hint" '
+    BEGIN {
+      while ((getline l < hint) > 0) {
+        split(l, f, "|")
+        if (f[2] ~ /^[0-9]+(\.[0-9]+)?$/ && f[2] + 0 > 0) secs[f[1]] = f[2] + 0
+      }
+    }
+    { printf "%012.3f|%s\n", ($2 in secs ? secs[$2] : 999999), $0 }
+  ' "$grouped" | LC_ALL=C sort -s -t'|' -k1,1 -rn | cut -d'|' -f2-
+}

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -62,6 +62,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 # shellcheck source=scripts/lib-testdb.sh
 source "$ROOT/scripts/lib-testdb.sh"
+source "$ROOT/scripts/lib-laneorder.sh"
 parse_test_dsn
 
 SHARD_IDX=0 SHARD_TOTAL=0
@@ -353,31 +354,17 @@ awk -F'|' '
 REGEX_DIR="$(mktemp -d)"
 export REGEX_DIR
 : > "$WORK"
-# Longest package first, from what the last run measured.
-#
-# Wall clock is set by when the LONGEST package finishes, so it should start at
-# t=0. Dispatched in discovery order it does not: measured, this lane's long pole
-# waited 16s of a 252s run for a slot while shorter packages held all eight. That
-# is the classic longest-processing-time-first result, and the durations to order
-# by are the ones the run below is about to print anyway.
-#
-# A package with no recorded time sorts FIRST, not last. The unknown is usually a
-# new small package, where the cost of guessing wrong is one slot occupied early;
-# guessing wrong the other way puts a new heavy package last and pays its whole
-# duration after everything else has finished. On the first run the cache is
-# absent and the order is discovery's, unchanged.
+# Longest package first, from what the last run measured — the ordering rules
+# and their rationale live in scripts/lib-laneorder.sh, which is unit-tested.
 #
 # Ordered HERE, before slots are numbered, so each package's -run slice, clone,
 # bucket and Redis db follow it rather than being handed to whoever inherits its
 # slot number.
-ORDER_HINT="$ROOT/.tmp/integration-lane-timing.txt"
-if [[ -s "$ORDER_HINT" ]]; then
-  # Only fields 1 and 2 are read; $0 is reprinted whole, because field 3 is a
-  # -run regex that contains its own pipes.
-  awk -F'|' -v hint="$ORDER_HINT" '
-    BEGIN { while ((getline l < hint) > 0) { split(l, f, "|"); secs[f[1]] = f[2] + 0 } }
-    { printf "%012.3f|%s\n", ($2 in secs ? secs[$2] : 999999), $0 }
-  ' "$GROUPED" | LC_ALL=C sort -t'|' -k1 -rn | cut -d'|' -f2- > "${GROUPED}.ordered"
+MEASURED_HINT="$ROOT/.tmp/integration-lane-timing.txt"
+BASELINE_HINT="$ROOT/scripts/integration-lane-timing.txt"
+ORDER_HINT="$(resolve_order_hint "$MEASURED_HINT" "$BASELINE_HINT")"
+if [[ -n "$ORDER_HINT" ]]; then
+  order_by_hint "$GROUPED" "$ORDER_HINT" > "${GROUPED}.ordered"
   mv "${GROUPED}.ordered" "$GROUPED"
 fi
 
@@ -609,10 +596,10 @@ fi
 # untouched. A scheduling hint that could fail a green lane would be a worse
 # trade than dispatching in discovery order forever.
 if [[ -s "$TIMING" ]] && (( SHARD_TOTAL == 0 )); then
-  hint_dir="$(dirname "$ORDER_HINT")"
+  hint_dir="$(dirname "$MEASURED_HINT")"
   if mkdir -p "$hint_dir" 2>/dev/null && hint_tmp="$(mktemp "$hint_dir/.integration-lane-timing.XXXXXX" 2>/dev/null)"; then
     cut -d'|' -f1,2 "$TIMING" > "$hint_tmp" 2>/dev/null \
-      && mv -f "$hint_tmp" "$ORDER_HINT" 2>/dev/null \
+      && mv -f "$hint_tmp" "$MEASURED_HINT" 2>/dev/null \
       || rm -f "$hint_tmp"
   fi
 fi

--- a/scripts/test-laneorder.sh
+++ b/scripts/test-laneorder.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# test-laneorder.sh — unit test for scripts/lib-laneorder.sh, the parallel
+# integration lane's dispatch order.
+#
+# The order is a scheduling hint, so getting it wrong never turns a lane red —
+# it just makes the run longer, or, in the case this exists to catch, shorter
+# for the packages that do not matter and longer for the one that does. That
+# silence is the whole reason for a test: a regression here is invisible on
+# every dashboard and shows up only as a lane that drifted back to costing what
+# it cost before the hint was added.
+#
+# Three properties, each of which has a failure mode nothing else would report:
+#   1. a named package sorts by its recorded duration, longest first;
+#   2. an UNNAMED package keeps the order it arrived in — a stale baseline must
+#      degrade to no-hint behaviour, not to an order the sort invented;
+#   3. the measured hint beats the committed baseline, and an empty or missing
+#      file is not a hint at all.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$root_dir/scripts/lib-laneorder.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+fails=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  fails=$((fails + 1))
+}
+
+expect_order() {
+  local label="$1" want="$2" got="$3"
+  if [[ "$want" != "$got" ]]; then
+    fail "$label
+  want: $(echo "$want" | tr '\n' ' ')
+  got:  $(echo "$got" | tr '\n' ' ')"
+  fi
+}
+
+# The regex field carries its own pipes, exactly as the dispatcher's does. If
+# the helper ever split on them, these lines would come back mangled.
+cat > "$work/grouped" <<'GROUPED'
+backend|./internal/compose/integration|^(TestA|TestB)$
+backend|./internal/modules/people|^(TestC)$
+backend|./migrations|^(TestD)$
+backend|./cmd/worker|^(TestE)$
+GROUPED
+
+cat > "$work/measured" <<'HINT'
+./internal/modules/people|31.500
+./migrations|104.135
+./internal/compose/integration|221.093
+./cmd/worker|4.498
+HINT
+
+# 1. Longest first, and the -run regex survives the trip intact.
+expect_order "named packages must sort longest-first" \
+  './internal/compose/integration
+./migrations
+./internal/modules/people
+./cmd/worker' \
+  "$(order_by_hint "$work/grouped" "$work/measured" | cut -d'|' -f2)"
+
+if ! order_by_hint "$work/grouped" "$work/measured" | grep -qxF 'backend|./internal/compose/integration|^(TestA|TestB)$'; then
+  fail "the -run regex did not survive ordering — its own pipes were treated as fields"
+fi
+
+# 2. A baseline that names only one package: the three it does not name sort
+# ahead of it (unknown is treated as heaviest) AND keep their input order.
+# Without a stable sort they come back reversed, which is the regression.
+cat > "$work/partial" <<'HINT'
+./internal/compose/integration|221.093
+HINT
+expect_order "unnamed packages must keep the order they arrived in" \
+  './internal/modules/people
+./migrations
+./cmd/worker
+./internal/compose/integration' \
+  "$(order_by_hint "$work/grouped" "$work/partial" | cut -d'|' -f2)"
+
+# A baseline naming nothing this tree still has must leave the order untouched.
+cat > "$work/stale" <<'HINT'
+./internal/modules/gone|900.000
+./internal/modules/alsogone|800.000
+HINT
+expect_order "a wholly stale baseline must degrade to discovery order" \
+  "$(cut -d'|' -f2 "$work/grouped")" \
+  "$(order_by_hint "$work/grouped" "$work/stale" | cut -d'|' -f2)"
+
+# A duration the lane could not record reaches the hint as an empty field, and
+# awk reads that as zero — which would sort the package LAST. It has to read as
+# "no time recorded" instead, or one unmeasurable package silently becomes the
+# thing the whole run waits for.
+cat > "$work/unmeasured" <<'HINT'
+./internal/compose/integration|
+./internal/modules/people|31.500
+./migrations|not-a-number
+./cmd/worker|0
+HINT
+expect_order "a duration that is not a positive number is no duration at all" \
+  './internal/compose/integration
+./migrations
+./cmd/worker
+./internal/modules/people' \
+  "$(order_by_hint "$work/grouped" "$work/unmeasured" | cut -d'|' -f2)"
+
+# The committed baseline carries a human-readable header. It must not disturb the
+# order: an unrecognised key is one nothing looks up, and this pins that reading
+# rather than leaving it to be rediscovered the next time somebody edits the file.
+cat > "$work/commented" <<'HINT'
+# a header a person wrote
+
+./migrations|104.135
+HINT
+expect_order "a header in a hint file leaves the order alone" \
+  './internal/compose/integration
+./internal/modules/people
+./cmd/worker
+./migrations' \
+  "$(order_by_hint "$work/grouped" "$work/commented" | cut -d'|' -f2)"
+
+
+# 3. Hint resolution.
+: > "$work/empty"
+cat > "$work/baseline" <<'HINT'
+./cmd/worker|4.498
+HINT
+[[ "$(resolve_order_hint "$work/measured" "$work/baseline")" == "$work/measured" ]] \
+  || fail "a measured hint must beat the committed baseline"
+[[ "$(resolve_order_hint "$work/empty" "$work/baseline")" == "$work/baseline" ]] \
+  || fail "an EMPTY measured hint must fall through to the committed baseline"
+[[ "$(resolve_order_hint "$work/absent" "$work/baseline")" == "$work/baseline" ]] \
+  || fail "an ABSENT measured hint must fall through to the committed baseline"
+[[ -z "$(resolve_order_hint "$work/absent" "$work/alsoabsent")" ]] \
+  || fail "with neither file present there is no hint, and the lane dispatches in discovery order"
+
+# A hint whose only content is a header must order nothing rather than sort every
+# package behind a phantom named '#'.
+cat > "$work/commented" <<'HINT'
+# a header a person wrote
+
+./migrations|104.135
+HINT
+expect_order "comment and blank lines in a hint are not packages" \
+  './internal/compose/integration
+./internal/modules/people
+./cmd/worker
+./migrations' \
+  "$(order_by_hint "$work/grouped" "$work/commented" | cut -d'|' -f2)"
+
+# The committed baseline itself has to be usable by the helper it feeds: every
+# line `package|seconds`, and every package a directory this tree still has. A
+# baseline of nothing but dead paths is indistinguishable from no baseline, and
+# nothing else in the tree would say so.
+baseline="$root_dir/scripts/integration-lane-timing.txt"
+if [[ ! -s "$baseline" ]]; then
+  fail "$baseline is missing or empty — the committed dispatch baseline is what a fresh clone orders by"
+else
+  live=0
+  while IFS='|' read -r pkg secs; do
+    [[ -z "$pkg" || "$pkg" == \#* ]] && continue
+    if [[ ! "$secs" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+      fail "baseline line for '$pkg' has a non-numeric duration '$secs' — awk would read it as 0 and sort the package last"
+      continue
+    fi
+    [[ -d "$root_dir/backend/${pkg#./}" ]] && live=$((live + 1))
+  done < "$baseline"
+  if (( live == 0 )); then
+    fail "no package named in $baseline still exists — the baseline orders nothing"
+  fi
+fi
+
+if (( fails > 0 )); then
+  echo "test-laneorder: $fails failure(s)" >&2
+  exit 1
+fi
+echo "test-laneorder: OK"


### PR DESCRIPTION
Four of the six remaining items from the integration-lane cost audit, one commit
each so every claim can be read alone. #1994 was the first half; this is the
harness half.

| | before | after | how measured |
|---|---|---|---|
| `compose/integration/overlay` | 47.78s | **14.23s** | back-to-back, origin/main worktree vs this branch |
| `platform/keyvault` | 6.49s | **1.72s** | package solo |
| `cmd/worker` | 2.86s | **1.51s** | package solo |
| `migrations` | 48.98s | **44.11s** | package solo, interleaved A/B |
| lane dispatch on a fresh clone | discovery order | longest-first | — |

## What each commit claims

**`a fresh clone dispatches the lane's long pole first`** — the runner orders
packages longest-first from `.tmp/integration-lane-timing.txt`, which no clone
has until it has already run the lane once; until then the long pole queues
behind short packages (21s of a full run, measured). A baseline from a real run
is committed beside the runner, and the machine's own measurements still win
whenever they exist. The committed file is never written by a run — a shard
measures a twelfth of each package, and a machine's durations belong to that
machine.

The ordering moved to `scripts/lib-laneorder.sh` with `make test-laneorder`
beside it, and writing that test found the defect worth having it for: **the
sort was not stable**, so every unnamed package shared one key and `sort -r`
broke those ties in *reverse* input order. A stale baseline was inventing an
order rather than degrading to the one it would have had with no hint at all.

**`two waits stop being the way a test states its claim`** — both of these
passed by letting a clock run out, so both paid the full wait on every green
run. keyvault's control asserted "Get takes a connection of its own" by
deadlocking it against a single-connection pool and watching a 2s deadline
expire — 63% of the package, spent proving a negative. The pool already counts
acquires, so the claim is now made directly and there is no clock left in the
assertion to be slow or contended. cmd/worker's redis arm dialled a dead port
and paid go-redis's retry ladder to re-refuse a refused connection three more
times.

**`the head-catalog tests stop rebuilding the schema to read it`** — ten tests
in `backend/migrations` only read the head catalog and were each paying a
`DROP SCHEMA CASCADE` plus a full replay to reach a schema the lane had already
handed them. `headSchema` builds head once per process and verifies it before
each later use.

It compares a **digest of the catalog, not the ledger's version set**. The
ledger records a version, not a checksum, so it answers "which migrations were
applied" and cannot answer "is the schema still what they build" — a rewinding
suite that drops an index leaves it reading head. The digest covers columns,
types, nullability, constraints and index definitions, which is the object class
these tests assert on.

The tagged test files move to `package migrations_test` to reach
`platform/testdb` for the data reset: testdb imports migrations, so the internal
test package would be a cycle. `.go-arch-lint.yml` gains `migrations` in its own
`mayDependOn` — a dependency no production file can express, since Go forbids a
package importing itself.

**`the integration lane stops calling api.hubapi.com`** — closes **#1996**.
Every overlay suite connects an overlay, and Connect resolves the incumbent's
portal id and owners directory through the Service's own factory, which
`WithKeyvault` wires to a live HubSpot adapter. Both calls are best-effort, so
the vendor's 401 came back, was logged as a warning, and the suite went green
while a merge gate depended on a third party being up. 32 connects, two round
trips each, ~718ms per connect.

`WithOverlayIncumbentResolver` could not reach it — it substitutes the read
dispatch's resolver, not the Service's factory — and widening it would not have
been enough either: options run in order and `WithKeyvault` *builds* the
handlers when it runs, so an option applied after it sets a field nobody reads.
So the concrete incumbent is split by build tag, as compose already splits
`WithOverlayIncumbentResolver` itself.

## Review found four defects, all of them in the gates

A Codex pass over the branch before it was pushed. Every finding was real and
every one was in added machinery, not in the change — the same shape as #1994,
where thirteen out of thirteen were.

1. **`lib-laneorder.sh` read an unrecorded duration as ZERO**, which sorts that
   package LAST — the exact schedule the ordering exists to avoid. Reachable:
   the lane's own report has a branch for a package that "recorded no test
   duration", and such a line reaches the hint as `package|`. A duration that is
   not a positive number is now no duration at all, so it sorts first with the
   other unknowns. Mutation-tested.
2. **`headSchema`'s digest was blind to three of the four object classes its
   readers assert on** — view options (`security_invoker`), generated-column
   expressions and defaults, and triggers. And its comment claimed the coverage
   it lacked, which is worse than no digest: it *reads* as verification. The
   digest now covers all of them, and there is a subtest per class, each
   deriving its own target from the live catalog. Mutation-tested by narrowing
   the digest back: three of four subtests fail.
3. **The refusing incumbent's error read as one object class's data defect.**
   `jobs_overlay.go`'s `isConnectionLevelIncumbentError` decides whether a
   reconcile sweep aborts or carries on, so a sweep where EVERY incumbent call
   refused would have logged each refusal and then recorded itself a success — a
   green sweep that did nothing, the precise false green this build exists to
   remove. The refusal now wraps `hubspot.ErrUnreachable`, which is also simply
   what happened, and all eleven methods are pinned.
4. **`WithHTTPClient` walked straight around the egress gate**, and the first
   version of the comment *rationalized* that as by-design. It is applied after
   every Option now, and it guards a nil transport too (net/http falls back to
   `DefaultTransport`, which dials). A caller's own RoundTripper is still left
   alone — it reaches no socket — and that exemption has its own test. The
   mutation is stark: the pre-review shape takes **105 seconds** of real dial
   attempts where the fixed one takes 0.2.

## The gates, which is where to look hardest

Every defect on #1994 — thirteen across three review passes — was in machinery
added to make a change safe, never in the change. This branch adds four such
pieces, so each is called out:

- **`make test-laneorder`** — mutation-tested against a non-stable sort (fails 3
  assertions) and against accepting a malformed duration. A speculative awk
  change was *deleted* because its mutation **passed**: an unrecognised hint key
  is simply never looked up, so comment-skipping was unobservable.
- **`headSchema`'s digest** — mutation-tested in both directions: a helper that
  always rebuilds, and a digest narrowed to what it covered before review.
- **the egress dialer** — `Proxy` on that transport is deliberately nil. With
  `ProxyFromEnvironment`, a machine carrying `HTTPS_PROXY` would dial the proxy,
  the gate would see the proxy's address, admit it if it were loopback, and the
  proxy would fetch the vendor on the test's behalf. A gate a stray environment
  variable routes around is not one. Every transport shape a client can arrive
  with has its own subtest.
- **the refusing incumbent** — two claims that were resting on the accidental
  401 now stand on their own: `overlay_write_shadow`'s "no network call" said so
  and was false, and the connect path's tolerance of an unreachable incumbent
  had no test at all. Mutation-tested against a refusing incumbent that answers.

## What is NOT here, and why

**D6 (module suites take the shared pool) needs D5 (`EnsureSchema` probes the
ledger) first, and the audit did not say so.** `testdb.Pool` returns
`ErrSchemaNotReady` until `EnsureSchema` has run, and the module suites
deliberately never migrate — they ride the pre-migrated clone. Forcing
`EnsureSchema` on ~14 packages adds roughly what D6 saves. Doing D6 the cheap
way instead gives up both things that make it worth having: the
`AssertPoolsQuiesced` pairing (a shared pool converts per-test blast radius into
per-package) and bringing those pools under the lane's connection pin, which
`lib-testdb.sh` names as what would turn its *measured* budget into a proved
ceiling (#1744). They ship together, next.

## main was red on arrival — three times, none from here

`git diff origin/main` was empty for every file involved. All three are fixed
now and this branch is rebased onto all of them, so CI here is green.

| | found how | fixed by |
|---|---|---|
| `TestFK_rowScopedTargetsHaveVisibilityDecision` | already filed as #2046 | #2052 |
| `TestSweepTargetsCarryNoDeleteBlockingTrigger` | filed from this branch's lane run as **#2058** | #2055 |
| `AC-pipeline-7: board↔table` | filed as **#2067** | **#2068**, from this session |

The third is the one worth keeping. It had been red since #2032 and nobody could
see it: `ci.yml:183` puts the root `Makefile` in the FRONTEND path filter, so the
AC lane opens for a backend PR that happens to edit it and skips for one that
does not. That is why a backend/harness PR is what surfaced a frontend
regression, and why "the uat lane is green" on a typical PR means "the uat lane
did not run".

## Verification

- `make check-backend` green
- `make craft-static` — 0 blocker / 0 major / 0 minor across backend, extensions,
  fixtures and desktop
- `make arch-lint` clean
- full `make test-integration`, and every touched package re-run individually
  after each rebase
- every timing figure is a per-package A/B on this machine. The lane's absolute
  wall clock is **not** cited: two full runs this session came in at 200s and
  274s on the same tree, and the first lost seven packages to `tls error: EOF`
  when a parallel session's lane shared the container's 408 connections.
