### PR TITLE
fix(frontend): the board-to-table AC asks the table for what the table draws

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -414,8 +414,18 @@ test("AC-pipeline-7: board↔table swaps views preserving the deal set", async (
   await page.goto("/#/deals");
   await expect(page.getByText("Fleet retrofit")).toBeVisible();
   await page.getByRole("button", { name: "Tabelle" }).click();
-  await expect(page.getByText("Fleet retrofit")).toBeVisible();
-  await expect(page.getByText("Service contract")).toBeVisible();
+  // By ROLE on the far side of the swap, not by text. The two views draw a deal
+  // differently: the board card is a button wrapping the name, while a table row
+  // is a link PLUS a visually-hidden "<name> auswählen" label for its bulk-select
+  // checkbox — so a bare text locator matches twice there and Playwright refuses
+  // it. The board assertion above stays as text because a card carries no such
+  // second copy; matching the DOM each view actually renders is the point.
+  await expect(
+    page.getByRole("link", { name: "Fleet retrofit" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Service contract" }),
+  ).toBeVisible();
 });
 
 test("AC-deal-6: a terminal-stage drop is a 🟡 confirm — nothing runs before Confirm", async ({


### PR DESCRIPTION
Closes **#2067**. `main` is red on
`AC-pipeline-7: board↔table swaps views preserving the deal set`, and has been
since #2032 without blocking anybody — which is the more interesting half.

## The failure

```
Error: strict mode violation: getByText('Fleet retrofit') resolved to 2 elements:
    1) <span class="sr-only">Fleet retrofit auswählen</span>
    2) <a class="lt-cellink" href="#/deals/d-fleet">Fleet retrofit</a>
```

The deals table gained a per-row bulk-select checkbox with a visually-hidden
`"<name> auswählen"` label. Both elements genuinely exist and both genuinely
contain the text, so the product is right and the locator stopped being
specific enough.

## The fix

The two views do not draw a deal the same way, and the test now says so: a
board card is a `<button>` wrapping the name, a table row is a link. The board
assertion stays as text — a card carries no second copy — and the two
assertions after the swap ask for the link by role, which is what the failure
message itself suggested.

Checked the siblings rather than only the line under review: the other three
`getByText("Fleet retrofit")` assertions in the suite are all on the board, so
none shares the shape.

## Verified both directions

- `make frontend-e2e`: **1 failed / 93 passed → 94 passed**
- with `Fleet retrofit` renamed out of `frontend/e2e/seed.ts`, the test fails
  again — so the assertion still says the deal is *there*, rather than having
  been narrowed until it stopped looking
- `make check-fe` green

## Why nobody saw it

The change classifier skips `uat (AC screens + axe WCAG 2.2 AA + 390px,
mocked)` for a diff that touches no frontend. Most pull requests therefore read
green over a red lane, and it surfaces only on a PR whose diff happens to open
it — here, a backend/harness PR (#2066) that also edits the root `Makefile`.
That gap is worth its own look and is recorded in #2067; this PR only puts the
lane back to green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AC board↔table swap e2e by querying table rows by link role instead of bare text. Previously the test used `getByText("…")` after the swap; since the table now renders both a link and a visually hidden “<name> auswählen” label, Playwright strict mode found two matches and failed. The test now asks the table for the link it actually draws; product behavior is unchanged and the uat lane is unblocked.

- Changes `frontend/e2e/ac.spec.ts` only: replaces two post-swap `getByText(...)` assertions with `getByRole("link", { name: "…" })`.
- Keeps the board-side assertion as text; a card renders a single name inside a button.
- Other deal-name assertions in this suite remain on the board and are unaffected.

<sup>Written for commit 8eaa7fd5efa7904f0790915e97263ad27735ad8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for board-to-table view switching.
  * Improved table-row assertions to reliably identify “Fleet retrofit” and “Service contract” entries.
  * Preserved existing board-view validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->