### PR TITLE
fix(platform): a discarded bootstrap seed is reported, not swallowed (#863)

### DIFF
--- a/backend/internal/compose/extjobseat_integration_test.go
+++ b/backend/internal/compose/extjobseat_integration_test.go
@@ -36,7 +36,7 @@ func TestTheDispatcherResolvesTheSeatBootstrapMinted(t *testing.T) {
 		t.Fatalf("archiving the harness workspace: %v", err)
 	}
 
-	wsID, created, err := identity.NewService(e.Pool).BootstrapInstallation(ctx,
+	wsID, created, _, err := identity.NewService(e.Pool).BootstrapInstallation(ctx,
 		func() (identity.InstallationBootstrap, error) {
 			return identity.InstallationBootstrap{
 				OrganizationName: "seatjoin",

--- a/backend/internal/compose/handlers_setup.go
+++ b/backend/internal/compose/handlers_setup.go
@@ -6,7 +6,9 @@ package compose
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -83,7 +85,7 @@ func setupStatus(svc *identity.Service, limit *ratelimit.Limiter) http.HandlerFu
 }
 
 // setupClaim creates the organization and its first admin from a claim.
-func setupClaim(svc *identity.Service, pool *pgxpool.Pool, seeds deployconfig.Seeds, limit *ratelimit.Limiter) http.HandlerFunc {
+func setupClaim(svc *identity.Service, pool *pgxpool.Pool, seeds deployconfig.Seeds, limit *ratelimit.Limiter, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !limit.Allow(httpserver.ClientIP(r)) {
 			httperr.Write(w, r, apperrors.ErrBudgetExceeded)
@@ -106,7 +108,7 @@ func setupClaim(svc *identity.Service, pool *pgxpool.Pool, seeds deployconfig.Se
 			return
 		}
 
-		wsID, err := svc.ClaimInstallation(r.Context(), in.SetupToken, identity.InstallationBootstrap{
+		wsID, discarded, err := svc.ClaimInstallation(r.Context(), in.SetupToken, identity.InstallationBootstrap{
 			OrganizationName: in.OrganizationName,
 			BaseCurrency:     in.BaseCurrency,
 			Timezone:         in.Timezone,
@@ -130,6 +132,15 @@ func setupClaim(svc *identity.Service, pool *pgxpool.Pool, seeds deployconfig.Se
 		case err != nil:
 			httperr.Write(w, r, err)
 			return
+		}
+		// The claim refuses a provisioned installation, but `setting` is not
+		// tenant-scoped: a claim over a database whose previous workspace was
+		// archived creates a new one beside settings rows that survived, and the
+		// identity the human just typed into the claim form is discarded. They
+		// see the old name in the UI and have no way to tell why (#863).
+		if len(discarded) > 0 {
+			log.Warn("the claim kept the identity already stored and discarded what was submitted; a previous installation's settings survived because they are not scoped to a workspace",
+				"discarded_keys", strings.Join(discarded, ", "), "workspace_id", wsID.String())
 		}
 		httperr.WriteJSON(w, http.StatusCreated, setupClaimResponse{WorkspaceID: wsID.String()})
 	}

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -71,7 +72,7 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 	}
 
 	svc := identity.NewService(pool)
-	wsID, created, err := svc.BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(InstallationDB(pool), DealsInstallation())))
+	wsID, created, discarded, err := svc.BootstrapInstallation(ctx, create, configuredSeed(cfg.Seeds, deals.NewHandlers(InstallationDB(pool), DealsInstallation())))
 	if errors.Is(err, identity.ErrNotBootstrapped) {
 		// An empty database and no configured bootstrap_admin is not an error:
 		// it is the claim path (ADR-0105). Boot mints the token the first human
@@ -86,6 +87,16 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 		log.Info("installation bootstrapped", "workspace_id", wsID.String(), "organization", cfg.Organization.Name)
 	} else {
 		log.Info("installation bound to existing organization", "workspace_id", wsID.String())
+	}
+	// `setting` is not tenant-scoped, so a bootstrap over a database that still
+	// holds a previous installation's rows creates a new workspace beside them
+	// and keeps the OLD identity. The values in margince.yaml are then read,
+	// validated, and dropped. This is the whole of #863 that needs no product
+	// ruling: what should happen instead is undecided, but the operator should
+	// not have to infer from the UI that their file was ignored.
+	if len(discarded) > 0 {
+		log.Warn("this installation kept the identity already stored and discarded the values margince.yaml supplied; a previous installation's settings survived because they are not scoped to a workspace",
+			"discarded_keys", strings.Join(discarded, ", "), "workspace_id", wsID.String())
 	}
 	return nil
 }
@@ -246,7 +257,13 @@ func seedRetentionPosture(ctx context.Context, tx pgx.Tx, seeds deployconfig.See
 	if !seeds.RetainOnly() {
 		return nil
 	}
-	return settings.SeedValue(ctx, tx, privacy.RetainOnly, true)
+	// The stored answer is deliberately dropped here, and this is the one seed
+	// where that is defensible: the value is the constant true, so a discard can
+	// only have preserved a row that already says what this would have written.
+	// Nothing an operator supplied is lost, which is exactly what separates it
+	// from the identity trio.
+	_, err := settings.SeedValue(ctx, tx, privacy.RetainOnly, true)
+	return err
 }
 
 // seedBookingPage provisions the admin's public booking page (the read carries

--- a/backend/internal/compose/integration/erasure_restriction_integration_test.go
+++ b/backend/internal/compose/integration/erasure_restriction_integration_test.go
@@ -258,7 +258,8 @@ func TestExpiredRestrictionCompletesTheSuspendedErasureUnderRetainOnly(t *testin
 		t.Fatalf("erasing the subject → %v", err)
 	}
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return settings.SeedValue(context.Background(), tx, privacy.RetainOnly, true)
+		_, err := settings.SeedValue(context.Background(), tx, privacy.RetainOnly, true)
+		return err
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/retention_authoring_integration_test.go
+++ b/backend/internal/compose/integration/retention_authoring_integration_test.go
@@ -205,7 +205,8 @@ func TestRetainOnlyPostureSuppressesDestructionButNotArchival(t *testing.T) {
 	// The posture is seeded the way bootstrap seeds it from margince.yaml, so
 	// the pass reads exactly what a `default_policy: retain_only` install has.
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return settings.SeedValue(context.Background(), tx, privacy.RetainOnly, true)
+		_, err := settings.SeedValue(context.Background(), tx, privacy.RetainOnly, true)
+		return err
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -431,7 +432,8 @@ func TestRetainOnlyPostureDoesNotDestroyContentThroughTheEmbedCascade(t *testing
 	withContent := seedEmbedCallWithPayload(t, e, 91, "Marek Janetzke, Q3 renewal terms")
 
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return settings.SeedValue(context.Background(), tx, privacy.RetainOnly, true)
+		_, err := settings.SeedValue(context.Background(), tx, privacy.RetainOnly, true)
+		return err
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/routingsource_integration_test.go
+++ b/backend/internal/compose/integration/routingsource_integration_test.go
@@ -26,11 +26,16 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -262,4 +267,47 @@ embeddings: {provider: fake, model: ` + model + `-embed, dimensions: 8}
 		t.Fatalf("ParseRouting: %v", err)
 	}
 	return cfg
+}
+
+// An UNCONFIGURED stored row is not the same as no row, and the difference is
+// the whole reason the seed's answer is now read.
+//
+// `Unconfigured()` is `len(Tiers) == 0`, so a row can exist and still report
+// unconfigured — which sends the boot down the adopt branch, where the seed's
+// ON CONFLICT DO NOTHING then stores nothing because the row is already there.
+// Announcing an adoption at that point names a binding the database does not
+// hold. A concurrent second replica reaches the same state by racing; this
+// fixture reaches it without needing one.
+func TestAnUnconfiguredStoredRowIsNotAdoptedOverAndIsNotAnnouncedAsAdopted(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+
+	// A stored row that binds nothing, written through the real seed path.
+	if err := database.WithWorkspaceTx(e.adminRoutingCtx(), e.Pool, func(tx pgx.Tx) error {
+		_, err := settings.SeedValue(ctx, tx, ai.Routing, ai.RoutingConfig{})
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the unconfigured row: %v", err)
+	}
+
+	var logged strings.Builder
+	log := slog.New(slog.NewTextHandler(&logged, nil))
+	got, err := compose.ResolveRouting(ctx, e.Pool, writeRouting(t, offlineRouting), config.Static(nil), log)
+	if err != nil {
+		t.Fatalf("ResolveRouting: %v", err)
+	}
+
+	// The stored row wins, so what comes back still binds nothing.
+	if !got.Unconfigured() {
+		t.Error("the file overwrote a stored row; ON CONFLICT DO NOTHING is what stops a restart replacing a binding an admin set")
+	}
+	// And the log does not claim otherwise. Asserting on the announcement, not
+	// only on the value, is the point: a boot that stored nothing while saying
+	// "adopted" sends an operator looking for a binding that is not there.
+	if strings.Contains(logged.String(), "adopted the routing file") {
+		t.Error("the boot announced an adoption it did not perform")
+	}
+	if !strings.Contains(logged.String(), "was not adopted") {
+		t.Error("the boot stored nothing and said nothing about it")
+	}
 }

--- a/backend/internal/compose/integration/settingsseed_integration_test.go
+++ b/backend/internal/compose/integration/settingsseed_integration_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What `ON CONFLICT DO NOTHING` reports, over a real database.
+//
+// This cannot be proven against a fake transaction: the whole question is what
+// Postgres puts in the command tag when the conflict clause fires, and a fake
+// Exec would be supplying the answer under test rather than checking it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+)
+
+// The SECOND attempt is the defect. The first insert proves nothing — it stores,
+// as it would whatever the discard reporting did.
+//
+// Both directions are asserted, and separately: "the value did not change"
+// passes against code that reports nothing, and "a discard was reported" passes
+// against code that also overwrote. Only the pair says what happened.
+func TestASecondSeedKeepsTheStoredValueAndSaysItDiscardedTheNewOne(t *testing.T) {
+	e := Setup(t)
+	ctx := e.Admin()
+
+	const first, second = "The First Installation", "The Second Installation"
+
+	var storedFirst, storedSecond bool
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		// Through the real writer. A hand-inserted row would prove nothing about
+		// the path bootstrap actually takes.
+		if _, err := tx.Exec(context.Background(), `DELETE FROM setting WHERE key = $1`, identity.Name.Key()); err != nil {
+			return err
+		}
+		var err error
+		if storedFirst, err = settings.SeedValue(context.Background(), tx, identity.Name, first); err != nil {
+			return err
+		}
+		storedSecond, err = settings.SeedValue(context.Background(), tx, identity.Name, second)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !storedFirst {
+		t.Fatal("the first seed reported a discard on a key with no row; the fixture is wrong, not the product")
+	}
+	// Direction 1: the stored value survived. Read straight off the row rather
+	// than through a Store, because the question is what the table holds, not
+	// what a registry resolves.
+	var got string
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT value #>> '{}' FROM setting WHERE key = $1`, identity.Name.Key()).Scan(&got)
+	}); err != nil {
+		t.Fatalf("reading the seeded name back: %v", err)
+	}
+	if got != first {
+		t.Errorf("the second seed overwrote the stored value: got %q, want %q — DO NOTHING is deliberate and must stay", got, first)
+	}
+	// Direction 2: and it SAID so. This is the half #863 is about; without it an
+	// operator whose margince.yaml was ignored has nothing to read.
+	if storedSecond {
+		t.Error("the second seed reported that it stored a value it did not store, so a caller cannot tell a discard from a write")
+	}
+}

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -146,7 +146,7 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 	// organization exists cannot live behind it. See handlers_setup.go.
 	setupLimit := newSetupLimiter()
 	mux.HandleFunc("GET /setup/status", setupStatus(identitySvc, setupLimit))
-	mux.HandleFunc("POST /setup/claim", setupClaim(identitySvc, pool, srv.bootstrapSeeds, setupLimit))
+	mux.HandleFunc("POST /setup/claim", setupClaim(identitySvc, pool, srv.bootstrapSeeds, setupLimit, log))
 	mux.HandleFunc("/metrics", requireMetricsToken(srv.metricsToken, httpserver.Metrics(pool,
 		func(ctx context.Context) (int64, error) { return events.OutboxBacklog(ctx, pool) },
 		events.PublishedTotal,

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -72,11 +72,20 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 		if err != nil {
 			return ai.RoutingConfig{}, err
 		}
-		if err := seedRouting(ctx, pool, fromFile); err != nil {
+		adopted, err := seedRouting(ctx, pool, fromFile)
+		if err != nil {
 			return ai.RoutingConfig{}, err
 		}
-		log.Info("adopted the routing file as this installation's stored binding; it is authoritative now and the file is no longer read",
-			"file", routingPath, "routing_version", fromFile.RoutingVersion())
+		if !adopted {
+			// A row appeared between the Unconfigured() read above and this
+			// write — another replica booting at the same time. Saying "adopted"
+			// would name a binding that is not the one now stored.
+			log.Warn("the routing file was not adopted: a stored binding appeared while this boot was reading the file, and it wins",
+				"file", routingPath)
+		} else {
+			log.Info("adopted the routing file as this installation's stored binding; it is authoritative now and the file is no longer read",
+				"file", routingPath, "routing_version", fromFile.RoutingVersion())
+		}
 		// Re-read rather than returning what was just written. The seed is
 		// ON CONFLICT DO NOTHING, so a role that lost the race to another one
 		// stored nothing — and returning its own file copy would put two roles
@@ -112,10 +121,17 @@ func readStoredRouting(ctx context.Context, pool *pgxpool.Pool) (ai.RoutingConfi
 // seedRouting plants the file's binding, consumed exactly once: settings.Seed
 // inserts only when no row exists, so a restart never overwrites a binding an
 // admin has since changed.
-func seedRouting(ctx context.Context, pool *pgxpool.Pool, cfg ai.RoutingConfig) error {
-	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		return settings.SeedValue(ctx, tx, ai.Routing, cfg)
+//
+// It answers whether the binding was STORED. "A restart" is the case the rule
+// was written for; a stored row that predates this file is the case it is silent
+// about, and an operator who edits ai-routing.yaml and sees no change deserves
+// to be told which of the two happened.
+func seedRouting(ctx context.Context, pool *pgxpool.Pool, cfg ai.RoutingConfig) (stored bool, err error) {
+	err = database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		stored, err = settings.SeedValue(ctx, tx, ai.Routing, cfg)
+		return err
 	})
+	return stored, err
 }
 
 // singletonWorkspace resolves the one live workspace this installation is

--- a/backend/internal/modules/identity/agentseat_integration_test.go
+++ b/backend/internal/modules/identity/agentseat_integration_test.go
@@ -59,7 +59,7 @@ func bootstrapForAgentSeat(t *testing.T, pool *pgxpool.Pool) (ids.WorkspaceID, s
 			AdminEmail:       "admin@" + slug + ".test",
 			AdminName:        "Admin",
 			AdminPassword:    agentSeatAdminPassword,
-		}, originConfigured, nil)
+		}, originConfigured, nil, &[]string{})
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/identity/changepassword_integration_test.go
+++ b/backend/internal/modules/identity/changepassword_integration_test.go
@@ -350,7 +350,7 @@ func mustChangeFor(t *testing.T, svc *Service, userID ids.UserID) bool {
 func TestAConfiguredBootstrapForcesTheAdminToChoosePassword(t *testing.T) {
 	svc := newSetupService(t)
 	ctx := context.Background()
-	wsID, created, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
+	wsID, created, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
 		return claimInput("configuredforce"), nil
 	}, nil)
 	if err != nil || !created {
@@ -378,7 +378,7 @@ func TestAClaimDoesNotForceTheAdminToChooseAgain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wsID, err := svc.ClaimInstallation(ctx, token, claimInput("claimedforce"), nil)
+	wsID, _, err := svc.ClaimInstallation(ctx, token, claimInput("claimedforce"), nil)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -73,7 +73,12 @@ type InstallationBootstrap struct {
 // organization exists, so the read would fail on exactly the installations
 // that followed the ADR. What is only needed to CREATE is only resolved
 // when creating.
-func (s *Service) BootstrapInstallation(ctx context.Context, create func() (InstallationBootstrap, error), seed func(ctx context.Context, tx pgx.Tx) error) (wsID ids.WorkspaceID, created bool, err error) {
+// discarded names the identity settings the caller supplied that a previous
+// installation's rows already occupied — empty on a first bootstrap, and empty
+// on the bind branch, which supplies nothing. It is returned rather than logged
+// because what a re-bootstrap SHOULD do with them is an open product question
+// (#863); refusing to be silent is the part that needs no ruling.
+func (s *Service) BootstrapInstallation(ctx context.Context, create func() (InstallationBootstrap, error), seed func(ctx context.Context, tx pgx.Tx) error) (wsID ids.WorkspaceID, created bool, discarded []string, err error) {
 	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, installationLockKey); err != nil {
 			return fmt.Errorf("identity: taking the bootstrap advisory lock: %w", err)
@@ -95,15 +100,15 @@ func (s *Service) BootstrapInstallation(ctx context.Context, create func() (Inst
 		if err != nil {
 			return err
 		}
-		wsID, err = createInstallation(ctx, tx, in, originConfigured, seed)
+		wsID, err = createInstallation(ctx, tx, in, originConfigured, seed, &discarded)
 		created = err == nil
 		return err
 	})
 	if err != nil {
-		return ids.WorkspaceID{}, false, err
+		return ids.WorkspaceID{}, false, nil, err
 	}
 	s.installation.Store(&wsID)
-	return wsID, created, nil
+	return wsID, created, discarded, nil
 }
 
 // InstallationWorkspace resolves the singleton organization for a
@@ -178,7 +183,13 @@ const (
 // createInstallation writes organization + first admin + system roles +
 // module seeds in the caller's transaction — either everything exists
 // afterwards or nothing does (the ADR-0043 bootstrap atomicity, kept).
-func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap, origin provisioningOrigin, seed func(ctx context.Context, tx pgx.Tx) error) (ids.WorkspaceID, error) {
+// discarded is an out-parameter rather than a third return value, and that is a
+// deliberate trade. This function has ten error returns; making the discards a
+// return value would restate every one of them to add a `nil`, which turns ten
+// untouched error paths into lines that read as changed to anything comparing
+// against the previous revision. The values it collects are a second OUTCOME of
+// a successful create, not a second result of the call.
+func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap, origin provisioningOrigin, seed func(ctx context.Context, tx pgx.Tx) error, discarded *[]string) (ids.WorkspaceID, error) {
 	boot := BootstrapInput{
 		WorkspaceName: in.OrganizationName,
 		Slug:          slugify(in.OrganizationName),
@@ -211,9 +222,11 @@ func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap
 	// by a caller: normalize() and the currency default above are the only
 	// place these values are resolved, and a second derivation elsewhere would
 	// drift from them (the columns that used to carry them are gone).
-	if err := seedInstallationIdentity(ctx, tx, boot.WorkspaceName, boot.Timezone, currency); err != nil {
+	dropped, err := seedInstallationIdentity(ctx, tx, boot.WorkspaceName, boot.Timezone, currency)
+	if err != nil {
 		return ids.WorkspaceID{}, err
 	}
+	*discarded = dropped
 
 	var userID ids.UserID
 	if err := tx.QueryRow(ctx,
@@ -324,7 +337,13 @@ func slugify(name string) string {
 // installation's identity (ADR-0090/A135). Seed, not Set: this runs inside
 // bootstrap's own transaction, before any principal exists to gate a settings
 // write, and it is creating the values rather than changing them.
-func seedInstallationIdentity(ctx context.Context, tx pgx.Tx, name, zone, currency string) error {
+//
+// It answers the keys that were NOT stored. `setting` is not tenant-scoped, so a
+// bootstrap over a database that already holds an installation's rows creates a
+// new workspace beside the old settings and every value the operator supplied is
+// discarded — which is #863. What should happen then is undecided; this only
+// makes sure the caller can say it happened.
+func seedInstallationIdentity(ctx context.Context, tx pgx.Tx, name, zone, currency string) (discarded []string, err error) {
 	for _, seed := range []struct {
 		entry *settings.Entry[string]
 		value string
@@ -333,9 +352,13 @@ func seedInstallationIdentity(ctx context.Context, tx pgx.Tx, name, zone, curren
 		{Timezone, zone},
 		{BaseCurrency, currency},
 	} {
-		if err := settings.SeedValue(ctx, tx, seed.entry, seed.value); err != nil {
-			return err
+		stored, err := settings.SeedValue(ctx, tx, seed.entry, seed.value)
+		if err != nil {
+			return nil, err
+		}
+		if !stored {
+			discarded = append(discarded, seed.entry.Key())
 		}
 	}
-	return nil
+	return discarded, nil
 }

--- a/backend/internal/modules/identity/oauth_cimd_integration_test.go
+++ b/backend/internal/modules/identity/oauth_cimd_integration_test.go
@@ -62,7 +62,7 @@ func setupCIMD(t *testing.T, slug string) *cimdEnv {
 			AdminEmail:       "admin@" + slug + ".test",
 			AdminName:        "Admin",
 			AdminPassword:    "correct-horse-battery-staple",
-		}, originConfigured, nil)
+		}, originConfigured, nil, &[]string{})
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -138,7 +138,7 @@ func setupRevocationEnv(t *testing.T, slug string) *revocationEnv {
 			OrganizationName: slug,
 			AdminEmail:       adminEmail, AdminName: "Admin",
 			AdminPassword: bootstrapPassword,
-		}, originConfigured, nil)
+		}, originConfigured, nil, &[]string{})
 		return err
 	})
 	if err != nil {

--- a/backend/internal/modules/identity/setuptoken.go
+++ b/backend/internal/modules/identity/setuptoken.go
@@ -194,7 +194,7 @@ var ErrAlreadyProvisioned = errors.New("identity: installation is already provis
 //
 // The provisioned check runs BEFORE the token is consumed, so a claim aimed at
 // a live installation is refused without spending anything.
-func (s *Service) ClaimInstallation(ctx context.Context, token string, in InstallationBootstrap, seed func(ctx context.Context, tx pgx.Tx) error) (ids.WorkspaceID, error) {
+func (s *Service) ClaimInstallation(ctx context.Context, token string, in InstallationBootstrap, seed func(ctx context.Context, tx pgx.Tx) error) (wsID ids.WorkspaceID, discarded []string, err error) {
 	// Refuse a provisioned installation WITHOUT taking the lock. This route is
 	// unauthenticated and stays mounted for the life of the installation, so
 	// the common case by far is a stranger reaching a live one; making that
@@ -203,10 +203,9 @@ func (s *Service) ClaimInstallation(ctx context.Context, token string, in Instal
 	// authoritative check still happens under the lock below — this one only
 	// declines to pay for a question already answered.
 	if cached := s.installation.Load(); cached != nil {
-		return ids.WorkspaceID{}, ErrAlreadyProvisioned
+		return ids.WorkspaceID{}, nil, ErrAlreadyProvisioned
 	}
-	var wsID ids.WorkspaceID
-	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
+	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, installationLockKey); err != nil {
 			return fmt.Errorf("identity: taking the bootstrap advisory lock: %w", err)
 		}
@@ -220,14 +219,14 @@ func (s *Service) ClaimInstallation(ctx context.Context, token string, in Instal
 		if err := consumeSetupToken(ctx, tx, token); err != nil {
 			return err
 		}
-		wsID, err = createInstallation(ctx, tx, in, originClaimed, seed)
+		wsID, err = createInstallation(ctx, tx, in, originClaimed, seed, &discarded)
 		return err
 	})
 	if err != nil {
-		return ids.WorkspaceID{}, err
+		return ids.WorkspaceID{}, nil, err
 	}
 	s.installation.Store(&wsID)
-	return wsID, nil
+	return wsID, discarded, nil
 }
 
 // SetupTokenOutstanding reports whether this installation is waiting to be

--- a/backend/internal/modules/identity/setuptoken_integration_test.go
+++ b/backend/internal/modules/identity/setuptoken_integration_test.go
@@ -55,7 +55,7 @@ func TestClaimCreatesTheOrganizationAndSpendsTheToken(t *testing.T) {
 		t.Fatalf("outstanding = %v, %v — a freshly minted token must read as claimable", outstanding, err)
 	}
 
-	if _, err := svc.ClaimInstallation(ctx, token, claimInput("claimed"), nil); err != nil {
+	if _, _, err := svc.ClaimInstallation(ctx, token, claimInput("claimed"), nil); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 
@@ -78,7 +78,7 @@ func TestClaimIsAttributedToTheAdminItCreates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wsID, err := svc.ClaimInstallation(ctx, token, claimInput("attributed"), nil)
+	wsID, _, err := svc.ClaimInstallation(ctx, token, claimInput("attributed"), nil)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestConfiguredBootstrapStaysASystemEvent(t *testing.T) {
 	svc := newSetupService(t)
 	ctx := context.Background()
 
-	wsID, created, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
+	wsID, created, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
 		return claimInput("configured"), nil
 	}, nil)
 	if err != nil || !created {
@@ -133,7 +133,7 @@ func TestAWrongTokenIsRefusedAndLeavesTheInstallationClaimable(t *testing.T) {
 	if _, err := svc.MintSetupToken(ctx); err != nil {
 		t.Fatal(err)
 	}
-	_, err := svc.ClaimInstallation(ctx, "not-the-token", claimInput("wrongtoken"), nil)
+	_, _, err := svc.ClaimInstallation(ctx, "not-the-token", claimInput("wrongtoken"), nil)
 	if !errors.Is(err, ErrSetupTokenMismatch) {
 		t.Fatalf("claim with a wrong token returned %v, want ErrSetupTokenMismatch", err)
 	}
@@ -164,13 +164,13 @@ func TestClaimingAProvisionedInstallationIsRefused(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
+	if _, _, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
 		return claimInput("incumbent"), nil
 	}, nil); err != nil {
 		t.Fatalf("seeding the provisioned installation: %v", err)
 	}
 
-	if _, err := svc.ClaimInstallation(ctx, token, claimInput("second"), nil); !errors.Is(err, ErrAlreadyProvisioned) {
+	if _, _, err := svc.ClaimInstallation(ctx, token, claimInput("second"), nil); !errors.Is(err, ErrAlreadyProvisioned) {
 		t.Fatalf("claiming a provisioned installation returned %v, want ErrAlreadyProvisioned", err)
 	}
 	// And minting a fresh one is refused too, so nothing can re-open the claim
@@ -193,7 +193,7 @@ func TestASecondTokenIsNotMintedWhileOneIsOutstanding(t *testing.T) {
 	}
 	// The first token must still be the credential: a boot that replaced it
 	// would invalidate what an operator had already read out of the log.
-	if _, err := svc.ClaimInstallation(ctx, first, claimInput("firsttoken"), nil); err != nil {
+	if _, _, err := svc.ClaimInstallation(ctx, first, claimInput("firsttoken"), nil); err != nil {
 		t.Fatalf("the originally minted token no longer claims: %v", err)
 	}
 }
@@ -252,7 +252,7 @@ func TestAConfiguredBootstrapRetiresAnOutstandingToken(t *testing.T) {
 	if _, err := svc.MintSetupToken(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
+	if _, _, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
 		return claimInput("configuredafter"), nil
 	}, nil); err != nil {
 		t.Fatalf("configured bootstrap: %v", err)
@@ -288,7 +288,7 @@ func TestAClaimCannotSetAnEmptyOrShortAdminPassword(t *testing.T) {
 			}
 			in := claimInput("weakpw")
 			in.AdminPassword = tc.password
-			if _, err := svc.ClaimInstallation(ctx, token, in, nil); err == nil {
+			if _, _, err := svc.ClaimInstallation(ctx, token, in, nil); err == nil {
 				t.Fatal("the claim created a root account with a password below the floor")
 			}
 			// And the refusal must not have spent the credential: an operator

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -57,7 +57,7 @@ func seedConfigWorkspace(t *testing.T, pool *pgxpool.Pool, label string) ids.UUI
 	var ws ids.WorkspaceID
 	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
 		var err error
-		ws, err = createInstallation(ctx, tx, boot, originConfigured, nil)
+		ws, err = createInstallation(ctx, tx, boot, originConfigured, nil, &[]string{})
 		return err
 	}); err != nil {
 		t.Fatalf("bootstrapping the %s installation: %v", label, err)

--- a/backend/internal/platform/settings/settings_test.go
+++ b/backend/internal/platform/settings/settings_test.go
@@ -262,6 +262,9 @@ type settingRowTx struct {
 	stored     json.RawMessage
 	absent     bool
 	refuseRead bool
+	// execErr, when set, is what Exec returns — the database refusing the insert
+	// Seed issues, which is a different outcome from the row already existing.
+	execErr error
 }
 
 // settingRow carries one answer back to the caller's Scan.
@@ -323,6 +326,9 @@ func (f *settingRowTx) Prepare(context.Context, string, string) (*pgconn.Stateme
 }
 
 func (f *settingRowTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	if f.execErr != nil {
+		return pgconn.CommandTag{}, f.execErr
+	}
 	panic("settingRowTx: Exec not implemented")
 }
 
@@ -330,3 +336,56 @@ func (f *settingRowTx) Query(context.Context, string, ...any) (pgx.Rows, error) 
 	panic("settingRowTx: Query not implemented")
 }
 func (f *settingRowTx) Conn() *pgx.Conn { panic("settingRowTx: Conn not implemented") }
+
+// Seed's two refusals, neither of which reaches the conflict clause at all. They
+// are the paths where `stored` must be false for a reason other than "a row was
+// already there", and a caller that read a false as "discarded" would report a
+// discard where the write never happened.
+func TestSeedRefusesAValueTheEntryWouldNotAccept(t *testing.T) {
+	tx := &settingRowTx{refuseRead: true}
+
+	entry := Define[string]("installation.seedprobe", "capture_settings", "update", "EUR",
+		func(v string) error {
+			if len(v) != 3 {
+				return fmt.Errorf("a currency is three letters, got %q", v)
+			}
+			return nil
+		})
+
+	stored, err := Seed(context.Background(), tx, entry, json.RawMessage(`"EURO"`))
+	if err == nil {
+		t.Fatal("Seed accepted a value the entry's validator rejects; bootstrap would have written it")
+	}
+	if stored {
+		t.Error("a refused seed reported that it stored something")
+	}
+}
+
+func TestSeedReportsNotStoredWhenTheInsertItselfFails(t *testing.T) {
+	refused := errors.New("connection reset")
+	tx := &settingRowTx{execErr: refused}
+
+	entry := Define[bool]("capture.seedprobe", "capture_settings", "update", true, nil)
+
+	stored, err := Seed(context.Background(), tx, entry, json.RawMessage(`true`))
+	if !errors.Is(err, refused) {
+		t.Fatalf("Seed swallowed the database's refusal: %v", err)
+	}
+	if stored {
+		t.Error("a failed insert reported that it stored the value, which a caller would read as a successful seed")
+	}
+}
+
+func TestSeedValueRefusesAValueItCannotEncode(t *testing.T) {
+	tx := &settingRowTx{refuseRead: true}
+
+	entry := Define[chan int]("capture.unencodable", "capture_settings", "update", nil, nil)
+
+	stored, err := SeedValue(context.Background(), tx, entry, make(chan int))
+	if err == nil {
+		t.Fatal("SeedValue accepted a value json.Marshal cannot represent")
+	}
+	if stored {
+		t.Error("a value that never became JSON was reported as stored")
+	}
+}

--- a/backend/internal/platform/settings/store.go
+++ b/backend/internal/platform/settings/store.go
@@ -232,16 +232,29 @@ func Set[T any](ctx context.Context, s *Store, e *Entry[T], v T) error {
 // human has since changed. Runs inside the caller's bootstrap transaction and
 // takes no RBAC gate — bootstrap runs before any human exists, and the caller
 // IS the boot path.
-func Seed(ctx context.Context, tx pgx.Tx, def Definition, raw json.RawMessage) error {
+//
+// It reports whether the row was STORED, and that is not a courtesy. DO NOTHING
+// is deliberate and stays, but "no row existed" is not the only way to reach it:
+// `setting` is not tenant-scoped, so a re-bootstrap creates a new workspace while
+// the previous installation's rows survive, and every value the operator just put
+// in margince.yaml is discarded. The columns that once carried a second copy of
+// these values are gone, so nothing downstream can notice the divergence.
+//
+// What Seed does NOT do is decide what should happen then — that is a product
+// question, open on #863. It refuses only to be silent about it, which is why
+// the boolean is returned rather than logged: platform plumbing owns no domain
+// and holds no logger.
+func Seed(ctx context.Context, tx pgx.Tx, def Definition, raw json.RawMessage) (stored bool, err error) {
 	if err := def.ValidateJSON(raw); err != nil {
-		return err
+		return false, err
 	}
-	if _, err := tx.Exec(ctx,
+	tag, err := tx.Exec(ctx,
 		`INSERT INTO setting (key, value) VALUES ($1, $2) ON CONFLICT (key) DO NOTHING`,
-		def.Key(), raw); err != nil {
-		return fmt.Errorf("settings: seeding %s: %w", def.Key(), err)
+		def.Key(), raw)
+	if err != nil {
+		return false, fmt.Errorf("settings: seeding %s: %w", def.Key(), err)
 	}
-	return nil
+	return tag.RowsAffected() == 1, nil
 }
 
 // hasRow reports whether the setting has a stored row at all, which is a
@@ -327,11 +340,13 @@ func ResetConfig(ctx context.Context, tx pgx.Tx, reg *Registry) error {
 	return nil
 }
 
-// SeedValue is the typed form of Seed, for a caller holding the entry.
-func SeedValue[T any](ctx context.Context, tx pgx.Tx, e *Entry[T], v T) error {
+// SeedValue is the typed form of Seed, for a caller holding the entry. It
+// reports what Seed reports: whether the value was stored, or discarded because
+// a row was already there.
+func SeedValue[T any](ctx context.Context, tx pgx.Tx, e *Entry[T], v T) (stored bool, err error) {
 	raw, err := json.Marshal(v)
 	if err != nil {
-		return fmt.Errorf("settings: encoding seed for %s: %w", e.Key(), err)
+		return false, fmt.Errorf("settings: encoding seed for %s: %w", e.Key(), err)
 	}
 	return Seed(ctx, tx, e, raw)
 }


### PR DESCRIPTION
Closes #863's visibility half. The product question it also poses is filed as
**#2069** (`status: needs-decision`), cross-referencing #1268 — see the end.

## The defect

`Seed`'s `ON CONFLICT DO NOTHING` is deliberate and stays: a restart must not
overwrite a setting a human has since changed. What the comment was silent about
is the other way to reach that clause.

`setting` is **not tenant-scoped**. `seedInstallationIdentity` runs inside the
same transaction as `INSERT INTO workspace … RETURNING id`, so a bootstrap over a
database that still holds a previous installation's rows creates a **new
workspace beside the old settings** and keeps the OLD identity. Every value the
operator put in `margince.yaml` is read, validated, and dropped. The workspace
columns that used to carry a second copy were removed, so nothing downstream can
notice the divergence.

## The fix, and which shape

`tx.Exec` already returns a command tag saying whether the insert fired. The
information existed and was thrown away.

The goal offered two shapes. **`Seed` reports it** — chosen — rather than having
only the bootstrap path collect the identity trio, because the second covers
three keys and the first makes the invariant hold at **every seed call site**.
That is the repo's own "fix the invariant, not the call site" rule; the trio is
where the defect was noticed, not where it lives.

`platform/settings` acquires **no logger**. It reports up, and the two
composition roots that already hold one warn: `compose/installation.go` for the
configured path and `handlers_setup.go` for the claim path — the claim refuses a
*provisioned* installation, but an archived workspace leaves the settings rows
behind, so the human who just typed a name into the claim form can lose it too.

Two other call sites came with the change:

- **`seedRouting`** gained the same answer, and the adoption line no longer
  claims a binding it did not write: when a row appears between the
  `Unconfigured()` read and the seed — another replica booting alongside — it
  warns instead of announcing an adoption that did not happen.
- **`seedRetentionPosture`** is the one seed that drops the answer, and says why:
  its value is the constant `true`, so a discard can only have preserved a row
  that already says it. Nothing an operator supplied is lost, which is exactly
  what separates it from the identity trio.

## The test

The **second** attempt is the defect; the first insert proves nothing. Both
directions are asserted **separately**, because either alone passes for the wrong
reason — "the value did not change" passes against code that reports nothing, and
"a discard was reported" passes against code that also overwrote.

Each was mutation-proven independently:

| mutation | which assertion fired |
|---|---|
| `Seed` returns `true` always (the `origin/main` behaviour) | **the reporting one**: "reported that it stored a value it did not store" |
| `DO NOTHING` → `DO UPDATE` | **the value one**: "overwrote the stored value … DO NOTHING is deliberate and must stay" |

It lives in the integration lane over a real database, deliberately: the whole
question is what Postgres puts in the command tag when the conflict clause fires,
and a fake `Exec` would be supplying the answer under test.

## Scope, stated

**`ON CONFLICT DO NOTHING` is unchanged.** The goal was explicit that changing it
means leaving the goal, and it is right — which of overwrite / refuse / explicit
flag is correct is a product call, entangled with #1268's first-run restructure.
A silent discard becoming a loud one is progress under every possible ruling and
needs no decision. That decision is **#2069**.

## Ripple

`Seed` and `SeedValue` changed signature, so six seed call sites and — because
the answer is threaded out through `createInstallation` — the
`BootstrapInstallation` and `ClaimInstallation` call sites moved too. Most are
tests taking `_`.

## Coverage · Gates

`make check-q` → `OK: check-q passed` · `make craft-static` →
`PASS — 0 blocker, 0 major, 0 minor` on all four trees.

UAT is the issue's own scenario and is **not** attached: it needs a dev stack, and
`make dev` sweeps every stack on this machine while several agent worktrees are
active. The mutation pair above is the behavioural proof; the boot-level
scenario is what a reviewer should ask for before merge if they want it.

**Codex has not reviewed this PR** — `/codex:*` cannot be invoked by an agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make bootstrap seed discards visible. Previously ON CONFLICT DO NOTHING hid whether a seed wrote or was ignored; now callers get a stored/discarded signal and composition roots warn when identity or routing values are dropped.

- `settings.Seed(ctx, tx, def, raw) (bool, error)` and `settings.SeedValue(...) (bool, error)` return whether the insert stored a row; tests cover entry validation failures and insert errors so callers do not misread failures as discards.
- `identity.Service.BootstrapInstallation(...) (wsID, created, discardedKeys []string, err)` and `ClaimInstallation(...) (wsID, discardedKeys []string, err)` surface identity keys the bootstrap/claim could not store; `EnsureInstallation` and `setupClaim` log a warning when discards occur. `setupClaim` now takes a `*slog.Logger`, and routes wire it.
- Routing adoption returns whether the file binding was stored; `ResolveRouting` warns if another replica or a preexisting unconfigured row prevented adoption, and re-reads the stored routing after seeding. An integration test asserts no false “adopted” announcement.
- The retention posture seed ignores the boolean by design (value is always true).
- Adds an integration test proving both directions: the stored value is preserved on a second seed and the discard is reported.

**Migration**
- Update call sites to handle the boolean from `settings.Seed`/`SeedValue`.
- Adjust to `identity.Service.BootstrapInstallation` and `ClaimInstallation` returning `discardedKeys`; pass a logger to `setupClaim` where warnings are emitted. No schema or config changes.

<sup>Written for commit 842d98159d933c3523d9ea0c4d6f96dbdfee6356. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

