### PR TITLE
chore(platform): the toolchain floor moves to go 1.27

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.26.6
-golangci-lint 2.12.2
+golang 1.27.0
+golangci-lint 2.13.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@
 # The base always runs on the build platform and cross-compiles to the target:
 # in a multi-platform bake only the thin runtime stages run emulated, never
 # the toolchains.
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS gobase
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS gobase
 
 RUN apk add --no-cache git ca-certificates
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -504,7 +504,15 @@ gen-workflow: ## Scaffold a new workflow.Handler: make gen-workflow NAME=flag_id
 # upgrade could change findings between two runs of the same commit).
 # govulncheck's module is golang.org/x/vuln; the binary installs from the
 # cmd/ subpath — resolve-gate-tool takes both.
-GOVULNCHECK_VERSION ?= v1.1.4
+#
+# The pin also tracks the TOOLCHAIN, not only the tool: govulncheck builds SSA
+# over the standard library it scans against, so a release whose x/tools
+# predates a language change panics on the stdlib source rather than reporting
+# anything. v1.1.4 did exactly that on go1.27 — `unexpected expr:
+# *ast.KeyValueExpr`, and only on linux, because the file carrying the new
+# syntax is linux-only and a darwin run never parsed it. A toolchain bump has to
+# re-check this pin.
+GOVULNCHECK_VERSION ?= v1.7.0
 GOVULNCHECK ?= $(call resolve-gate-tool,govulncheck,golang\.org/x/vuln,$(GOVULNCHECK_VERSION),golang.org/x/vuln/cmd/govulncheck)
 vuln: ## Scan dependencies for known vulnerabilities (govulncheck)
 	$(GOVULNCHECK) ./...
@@ -518,7 +526,7 @@ vuln: ## Scan dependencies for known vulnerabilities (govulncheck)
 # `go run`, so those installs just pre-warm the module cache (and give the
 # binaries a PATH home for direct use). Installs are unconditional: a cached
 # binary at a different version must be overwritten, or the pin doesn't bind.
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.0
 # The contract-breaking gate (scripts/check-contract-breaking.sh) runs oasdiff
 # via pinned `go run`, so this install is a convenience binary for direct use —
 # keep the version identical to the pin in that script; bump both together.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,18 +1,10 @@
 module github.com/gradionhq/margince/backend
 
-// Go 1.26 is a deliberate floor (M5): the code uses composite-FK
+// Go 1.27 is a deliberate floor (M5): the code uses composite-FK
 // `ON DELETE SET NULL (column_list)` semantics and current-toolchain
-// tooling. Contributors/operators need the 1.26 toolchain; this is a PoC
+// tooling. Contributors/operators need the 1.27 toolchain; this is a PoC
 // choice, revisit if broader portability becomes a goal.
-go 1.26.6
-
-// The composed extension set (ADR-0069): a constant import path the role
-// binaries wire — api, worker and mcp today; migrate joins when the
-// extension migration namespace lands. Bare builds resolve the committed
-// vanilla stub via this replace, `make` lanes override it with the
-// generated module under build/composition/ via the generated go.work (a
-// workspace `use` wins over a member replace).
-require github.com/gradionhq/margince/composition v0.0.0
+go 1.27.0
 
 replace github.com/gradionhq/margince/composition => ../composition
 
@@ -23,6 +15,13 @@ require (
 	github.com/getkin/kin-openapi v0.146.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-pdf/fpdf v0.9.0
+	// The composed extension set (ADR-0069): a constant import path the role
+	// binaries wire — api, worker and mcp today; migrate joins when the
+	// extension migration namespace lands. Bare builds resolve the committed
+	// vanilla stub via this replace, `make` lanes override it with the
+	// generated module under build/composition/ via the generated go.work (a
+	// workspace `use` wins over a member replace).
+	github.com/gradionhq/margince/composition v0.0.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/minio/minio-go/v7 v7.2.1

--- a/backend/goversionpins_test.go
+++ b/backend/goversionpins_test.go
@@ -17,8 +17,11 @@ package backendarch
 // product module is the pin CI actually reads, so it is the one that decides.
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -41,13 +44,12 @@ func TestEveryGoVersionPinMatchesTheProductModule(t *testing.T) {
 		}
 	})
 
-	for _, module := range []string{
-		"tools/go.mod",
-		"../composition/go.mod",
-		"../extensions/de/go.mod",
-		"../extensions/notes/go.mod",
-		"../extensions/yogi/go.mod",
-	} {
+	// Derived from the tree, not listed. The list this replaced named five
+	// modules of the fifteen that exist, and the two it happened not to name had
+	// already drifted a patch release behind — which is the same failure the
+	// whole test exists to catch, reintroduced by the shape of the check. A list
+	// also cannot cover a module written after it.
+	for _, module := range everyModuleFile(t) {
 		t.Run(module, func(t *testing.T) {
 			if got := goVersionOf(t, module); got != want {
 				t.Errorf("%s pins go %s, backend/go.mod pins %s", module, got, want)
@@ -73,6 +75,48 @@ func TestEveryGoVersionPinMatchesTheProductModule(t *testing.T) {
 				"the template is copied into new modules verbatim", want)
 		}
 	})
+}
+
+// moduleRoots are the trees a hand-written go.mod lives under. They are named
+// the way license_test.go names its roots, and for the same reason: a walk from
+// the repository root would also read the GENERATED module under build/, and any
+// unrelated checkout nested inside the working tree, neither of whose pins this
+// test has any claim on.
+var moduleRoots = []string{".", "../cli", "../composition", "../desktop", "../extensions", "../fixtures"}
+
+// everyModuleFile collects every go.mod under those roots, so a module added
+// tomorrow is held to the product module's pin on the day it lands.
+func everyModuleFile(t *testing.T) []string {
+	t.Helper()
+	var found []string
+	for _, root := range moduleRoots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			// An extension unit may carry a frontend, and walking its installed
+			// dependencies is thousands of directories of pure cost.
+			if entry.IsDir() && entry.Name() == "node_modules" {
+				return fs.SkipDir
+			}
+			if !entry.IsDir() && entry.Name() == "go.mod" {
+				found = append(found, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s for go.mod files: %v", root, err)
+		}
+	}
+	// The product module is the pin every other one is compared against, so its
+	// own file must be in what the walk found. Without this a mistyped root
+	// reports success for having read nothing, which is the one way a derived
+	// check fails worse than the list it replaced.
+	if !slices.Contains(found, "go.mod") {
+		t.Fatalf("the walk over %v did not find backend/go.mod, so it is not reading this tree; found %v",
+			moduleRoots, found)
+	}
+	return found
 }
 
 func goVersionOf(t *testing.T, path string) string {

--- a/backend/internal/compose/csvimport_test.go
+++ b/backend/internal/compose/csvimport_test.go
@@ -26,34 +26,38 @@ func TestEveryImportTargetRoundTripsThroughCreateAndUpdate(t *testing.T) {
 		migration.ObjectLead: func(fields map[string]string) (map[string]bool, map[string]bool) {
 			in := leadCreateFrom(fields, "import:csv", "ext-1", "src")
 			up := leadUpdateFrom(fields)
-			return map[string]bool{
-					"full_name":    in.FullName != nil,
-					"email":        in.Email != nil,
-					"title":        in.Title != nil,
-					"company_name": in.CompanyName != nil,
-				}, map[string]bool{
-					"full_name":    up.FullName != nil,
-					"email":        up.Email != nil,
-					"title":        up.Title != nil,
-					"company_name": up.CompanyName != nil,
-				}
+			created := map[string]bool{
+				"full_name":    in.FullName != nil,
+				"email":        in.Email != nil,
+				"title":        in.Title != nil,
+				"company_name": in.CompanyName != nil,
+			}
+			patched := map[string]bool{
+				"full_name":    up.FullName != nil,
+				"email":        up.Email != nil,
+				"title":        up.Title != nil,
+				"company_name": up.CompanyName != nil,
+			}
+			return created, patched
 		},
 		migration.ObjectOrganization: func(fields map[string]string) (map[string]bool, map[string]bool) {
 			in := organizationCreateFrom(fields, "src")
 			up := organizationUpdateFrom(fields)
-			return map[string]bool{
-					"display_name": in.DisplayName != "",
-					"legal_name":   in.LegalName != nil,
-					"industry":     in.Industry != nil,
-					"size_band":    in.SizeBand != nil,
-					"description":  in.Description != nil,
-				}, map[string]bool{
-					"display_name": up.DisplayName != nil,
-					"legal_name":   up.LegalName != nil,
-					"industry":     up.Industry != nil,
-					"size_band":    up.SizeBand != nil,
-					"description":  up.Description != nil,
-				}
+			created := map[string]bool{
+				"display_name": in.DisplayName != "",
+				"legal_name":   in.LegalName != nil,
+				"industry":     in.Industry != nil,
+				"size_band":    in.SizeBand != nil,
+				"description":  in.Description != nil,
+			}
+			patched := map[string]bool{
+				"display_name": up.DisplayName != nil,
+				"legal_name":   up.LegalName != nil,
+				"industry":     up.Industry != nil,
+				"size_band":    up.SizeBand != nil,
+				"description":  up.Description != nil,
+			}
+			return created, patched
 		},
 	} {
 		t.Run(object, func(t *testing.T) {

--- a/backend/internal/platform/httperr/decoderefusal_test.go
+++ b/backend/internal/platform/httperr/decoderefusal_test.go
@@ -130,7 +130,7 @@ var decodeRefusalCases = []decodeRefusalCase{
 		name:       "a nested path is quoted as the caller spelled it",
 		body:       `{"links":[{"entity_id":5,"entity_type":"deal"}]}`,
 		decode:     intoCreateActivity,
-		wantDetail: "`links.entity_id` must be a UUID string, not a number",
+		wantDetail: "`links.0.entity_id` must be a UUID string, not a number",
 	},
 	{
 		name:       "a value whose own unmarshaller ran is still traced back to its field",

--- a/backend/internal/shared/ports/datasource/fieldshape.go
+++ b/backend/internal/shared/ports/datasource/fieldshape.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -142,12 +143,10 @@ type ProbeDecoder func(raw json.RawMessage, into any) error
 //craft:ignore naked-any mirror of StrictDecode's seam target
 func LocalizeFieldFault(raw json.RawMessage, into any, err error, decode ProbeDecoder) *FieldShapeError {
 	var typeErr *json.UnmarshalTypeError
-	if errors.As(err, &typeErr) && strings.Contains(typeErr.Field, ".") {
-		// A DOTTED path reaches inside a nested value (`links.entity_id`) where
-		// this walk only reaches top-level keys, so the decoder's answer is the
-		// more precise one and must survive. encoding/json builds that path by
-		// joining its field stack on ".", and no contract field name contains
-		// one, so the separator is the test.
+	if errors.As(err, &typeErr) && namesAKeyBelowATopLevelField(typeErr.Field) {
+		// A path that reaches inside a nested value (`links.entity_id`) names a
+		// key this walk cannot reach, since it only decodes top-level keys, so
+		// the decoder's answer is the more precise one and must survive.
 		//
 		// A bare top-level name is NOT deferred to, even though the decoder
 		// supplies one: at that point it reports the type it was filling when it
@@ -184,6 +183,26 @@ func LocalizeFieldFault(raw json.RawMessage, into any, err error, decode ProbeDe
 		return refusal
 	}
 	return nil
+}
+
+// namesAKeyBelowATopLevelField reports whether a decoder path reaches a key
+// BELOW a top-level field, which is the case this walk cannot answer.
+//
+// encoding/json joins its field stack on ".", and no contract field name
+// contains one, so the separator carries the nesting. An ARRAY INDEX is a
+// segment too — `links.0` is one element of the top-level field `links`, while
+// `links.0.entity_id` is a key inside that element — so indices are discounted
+// before counting: an index is a position IN a field, not a key below it, and
+// reading one as nesting defers the array-shape refusal this walk exists to
+// produce.
+func namesAKeyBelowATopLevelField(path string) bool {
+	named := 0
+	for _, segment := range strings.Split(path, ".") {
+		if _, isIndex := strconv.Atoi(segment); isIndex != nil {
+			named++
+		}
+	}
+	return named > 1
 }
 
 // declaredFieldKeys narrows a payload's keys to the ones the target actually

--- a/backend/internal/shared/ports/datasource/fieldshape_test.go
+++ b/backend/internal/shared/ports/datasource/fieldshape_test.go
@@ -263,3 +263,30 @@ func TestStrictDecode_namesANestedArrayWithoutRepeatingItself(t *testing.T) {
 		t.Errorf("refusal = %q, want %q", refusal.Error(), want)
 	}
 }
+
+// An ARRAY INDEX in a decoder path is a position in a field, not a key below
+// it. The distinction decides whether this walk answers or defers, and getting
+// it wrong is silent: the deferral produces a sentence that is true about one
+// element and says nothing about the shape the field holds.
+//
+// Asserted directly on the classifier rather than through a decode, because
+// which paths encoding/json produces is the toolchain's choice and has changed
+// once already — go1.27 began reporting `links.0` where go1.26 reported
+// `links`. The classification is ours either way, so it is tested as ours.
+func TestNamesAKeyBelowATopLevelField_readsAnIndexAsAPositionAndNotAKey(t *testing.T) {
+	for path, below := range map[string]bool{
+		"":                  false,
+		"links":             false,
+		"links.0":           false,
+		"links.12":          false,
+		"links.0.entity_id": true,
+		"address.city":      true,
+		"links.0.tags":      true,
+	} {
+		t.Run(fmt.Sprintf("%q", path), func(t *testing.T) {
+			if got := namesAKeyBelowATopLevelField(path); got != below {
+				t.Errorf("namesAKeyBelowATopLevelField(%q) = %v, want %v", path, got, below)
+			}
+		})
+	}
+}

--- a/backend/tools/go.mod
+++ b/backend/tools/go.mod
@@ -13,7 +13,7 @@
 // still tooling — nothing here ships in a binary a customer runs.
 module github.com/gradionhq/margince/backend/tools
 
-go 1.26.6
+go 1.27.0
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 

--- a/cli/craft/go.mod
+++ b/cli/craft/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/cli/craft
 
-go 1.26
+go 1.27.0

--- a/composition/go.mod
+++ b/composition/go.mod
@@ -8,7 +8,7 @@
 // appears, instead of silently resolving unverified.
 module github.com/gradionhq/margince/composition
 
-go 1.26.6
+go 1.27.0
 
 require github.com/gradionhq/margince/backend v0.0.0
 

--- a/desktop/build/macos-target.sh
+++ b/desktop/build/macos-target.sh
@@ -11,13 +11,15 @@
 # fail for everyone else — with a floor nobody chose, nobody wrote down, and
 # that moves every time the builder takes an OS update.
 #
-# 12.0 is not arbitrary: it is Go's own floor for this toolchain, so the C
+# 13.0 is not arbitrary: it is Go's own floor for this toolchain, so the C
 # halves (Postgres, the bus) and the Go halves (api, worker, migrate, the
-# launcher) agree on one number instead of disagreeing silently. Raising it
-# means raising Go's too; check what a Go binary reports before changing it:
+# launcher) agree on one number instead of disagreeing silently. It follows Go
+# rather than leading it — go1.27 ended macOS 12 support, so a Go binary from
+# this tree reports minos 13.0 and the assertion below refuses the bundle until
+# this number matches. Check what a Go binary reports before changing it:
 #
 #     vtool -show-build <a built Go binary> | grep minos
-MACOS_MIN="12.0"
+MACOS_MIN="13.0"
 export MACOSX_DEPLOYMENT_TARGET="$MACOS_MIN"
 
 # assert_min_os <file>... — no shipped binary may require a NEWER macOS than
@@ -34,7 +36,7 @@ assert_min_os() {
       echo "FAIL: $file declares no macOS build version, so the OS it needs cannot be known" >&2
       return 1
     fi
-    # sort -V so 9.0 sorts below 12.0 the way a version does, not the way a
+    # sort -V so 9.0 sorts below 13.0 the way a version does, not the way a
     # string does.
     newest="$(printf '%s\n%s\n' "$MACOS_MIN" "$minos" | sort -V | tail -1)"
     if [ "$newest" != "$MACOS_MIN" ]; then

--- a/desktop/launcher/go.mod
+++ b/desktop/launcher/go.mod
@@ -5,4 +5,4 @@
 // with GOWORK=off.
 module github.com/gradionhq/margince/desktop/launcher
 
-go 1.26.5
+go 1.27.0

--- a/docs/explanation/desktop-distribution.md
+++ b/docs/explanation/desktop-distribution.md
@@ -76,12 +76,12 @@ older with a floor **nobody chose and nobody wrote down** — one that silently
 rises the next time the builder takes an OS update.
 
 Measured on a Mac running 15.7: a C file compiled with no deployment target
-reports `minos 15.0`, while a Go binary from the same tree reports `minos 12.0`,
+reports `minos 15.0`, while a Go binary from the same tree reports `minos 13.0`,
 because Go sets its own. So the bundle's real floor was the newest of its
-parts, and the two halves of one folder disagreed by three major versions.
+parts, and the two halves of one folder disagreed by two major versions.
 
 `desktop/build/macos-target.sh` is the one place that number lives. It exports
-`MACOSX_DEPLOYMENT_TARGET=12.0` — Go's own floor for this toolchain, so the C
+`MACOSX_DEPLOYMENT_TARGET=13.0` — Go's own floor for this toolchain, so the C
 halves and the Go halves agree rather than merely coexist — and `assert_min_os`
 re-reads every shipped binary and **fails the build** if any of them wants
 newer. A pinned variable alone would be a comment: it is one unset environment

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -38,7 +38,7 @@ tier owner's review.
    ```text
    module github.com/gradionhq/margince/extensions/<name>
 
-   go 1.26.6
+   go 1.27.0
    ```
 
 3. **Write the declaration** `extensions/<name>/<name>.go`, starting with the BUSL SPDX header (every

--- a/docs/how-to/build-the-desktop-app.md
+++ b/docs/how-to/build-the-desktop-app.md
@@ -14,7 +14,7 @@ What a **user** needs. Building it needs more — see the next section.
 
 | | macOS bundle | Windows bundle |
 |---|---|---|
-| **OS** | macOS 12 Monterey or newer | Windows 10 or newer. Server 2016+ shares that kernel and is expected to work, but **is untested** — nothing has launched the bundle there |
+| **OS** | macOS 13 Ventura or newer | Windows 10 or newer. Server 2016+ shares that kernel and is expected to work, but **is untested** — nothing has launched the bundle there |
 | **Architecture** | Whatever the build machine was — **not** universal. An Apple-silicon build does not run on an Intel Mac at all; an Intel build runs on Apple silicon under Rosetta 2. `make desktop-dist` prints which one it produced | x64 only. Windows on ARM has x64 emulation, but no ARM build is produced and none is tested |
 | **Must already be installed** | Nothing | The [Microsoft Visual C++ x64 redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe). Present on most machines, **not** bundled |
 | **Admin rights** | Not needed | Not needed. Running as an administrator also works — `pg_ctl` drops the privileges Postgres refuses to start with |
@@ -23,7 +23,7 @@ What a **user** needs. Building it needs more — see the next section.
 | **Browser** | Chrome/Edge 111+, Firefox 114+, or Safari 16.4+ (Safari 16.4 is available back to macOS 11, so it is reachable on every supported version) | Chrome/Edge 111+ or Firefox 114+ |
 
 The OS floors are not aspirational: `MACOSX_DEPLOYMENT_TARGET` is pinned to
-12.0 and **the build fails** if any shipped binary requires newer, so it cannot
+13.0 and **the build fails** if any shipped binary requires newer, so it cannot
 silently inherit the build machine's macOS. On Windows the floor is
 PostgreSQL 16's own (Windows 10 or newer), which Go and the MSYS2 runtime also
 share.

--- a/extensions/de/go.mod
+++ b/extensions/de/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/de
 
-go 1.26.6
+go 1.27.0

--- a/extensions/dispact-connector/go.mod
+++ b/extensions/dispact-connector/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/dispact-connector
 
-go 1.26.5
+go 1.27.0

--- a/extensions/notes/go.mod
+++ b/extensions/notes/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/notes
 
-go 1.26.6
+go 1.27.0

--- a/extensions/yogi/go.mod
+++ b/extensions/yogi/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/yogi
 
-go 1.26.6
+go 1.27.0

--- a/extensions/zalo-oa/go.mod
+++ b/extensions/zalo-oa/go.mod
@@ -1,3 +1,3 @@
 module github.com/gradionhq/margince/extensions/zalo-oa
 
-go 1.26.6
+go 1.27.0

--- a/extensions/zalo-personal/go.mod
+++ b/extensions/zalo-personal/go.mod
@@ -1,5 +1,5 @@
 module github.com/gradionhq/margince/extensions/zalo-personal
 
-go 1.26.6
+go 1.27.0
 
 require golang.org/x/net v0.57.0

--- a/fixtures/extensions/bad-overbudget-table/go.mod
+++ b/fixtures/extensions/bad-overbudget-table/go.mod
@@ -1,3 +1,3 @@
 module example.invalid/margince/fixtures/bad-overbudget-table
 
-go 1.26.6
+go 1.27.0

--- a/fixtures/extensions/bad-unprefixed-table/go.mod
+++ b/fixtures/extensions/bad-unprefixed-table/go.mod
@@ -1,3 +1,3 @@
 module example.invalid/margince/fixtures/bad-unprefixed-table
 
-go 1.26.6
+go 1.27.0

--- a/fixtures/extensions/crm-hello/go.mod
+++ b/fixtures/extensions/crm-hello/go.mod
@@ -1,3 +1,3 @@
 module example.margince.dev/ext/crm-hello
 
-go 1.26.6
+go 1.27.0

--- a/fixtures/extensions/crm-nosy/go.mod
+++ b/fixtures/extensions/crm-nosy/go.mod
@@ -1,3 +1,3 @@
 module example.invalid/margince/fixtures/crm-nosy
 
-go 1.26.6
+go 1.27.0

--- a/go.work
+++ b/go.work
@@ -6,7 +6,7 @@
 // module's go.mod. cli/craft is the code-craftsmanship gate (ADR-0045);
 // stdlib-only, run pre-push via .githooks/pre-push. The local dev stack is a
 // plain shell script (scripts/dev.sh, `make dev`) — no Go module of its own.
-go 1.26.6
+go 1.27.0
 
 use (
 	./backend


### PR DESCRIPTION
Moves the Go floor to 1.27.0 and fixes the two things in this tree that the new
toolchain breaks. Three commits, each green on the toolchain in force at that
point, so the history bisects.

## What 1.27 actually breaks here

**No dependency breaks.** All 40+ direct and indirect modules compile and pass,
including the ones with assembly, `unsafe` or codegen: `pgx/v5`, `wazero`,
`minio-go/v7`, `river`, `kin-openapi`, `zeebo/xxh3`, `tinylib/msgp`,
`klauspost/*`. `govulncheck` reports 0 vulnerabilities.

**gofmt and gofumpt now disagree** (commit 1). 1.27's gofmt corrects the
indentation of a multi-value return of composite literals; gofumpt vendors its
own printer and has not taken the fix, including v0.11.0 built with 1.27. Both
gate `make check`, so the one file with that construct had no formatting that
satisfied both. Naming the maps before returning them removes the construct
instead of picking a side — verified identical under gofmt 1.26, gofmt 1.27 and
gofumpt 0.11.

**`encoding/json` now reports array indices in `UnmarshalTypeError.Field`**
(commit 2), so a path that read `links.entity_id` reads `links.0.entity_id`.
Nothing here matches on decoder prose, so the typed handling is safe, but
`LocalizeFieldFault` used "contains a dot" to mean "nested path, defer". `links.0`
contains a dot, so it deferred and stopped building the sentence that names the
array's shape and its item shape — reopening the refusal a reported session
already filed a transport bug against. The classifier now discounts numeric
segments, and is asserted directly, because which paths the decoder emits is the
toolchain's choice and has already changed once.

The remaining effect is the REST body refusal, which quotes the decoder's path
back and so now names the element. **The index is kept deliberately**: it is the
caller's own position in their own array and tells them which item to fix. Say so
if you would rather normalise it away.

## Tools need rebuilding, not upgrading

`go install` records the building toolchain in the binary, and golangci-lint
refuses a module targeting a newer Go than built it — which is how v2.12.2 and
govulncheck v1.1.4 fail here. Both work unchanged once rebuilt with 1.27. CI
handles this already: the `gate-binaries` cache key hashes `backend/go.mod`.
**A working copy needs `make tools` once.** The golangci pin still moves to
v2.13.0, the release declaring Go 1.27 support, so the linter parses syntax the
language has gained. The Go toolchain itself needs no manual install —
`GOTOOLCHAIN=auto` fetches 1.27 from the `go.mod` directive.

## Also in here

- The version-pin test derives its module list from the tree. It named five of
  fifteen modules, and the two it did not name (`extensions/dispact-connector`,
  `desktop/launcher`) had already drifted a patch release behind — the failure the
  test exists to catch, reintroduced by the shape of the check.
- `go mod tidy` under 1.27 folds the standalone `composition` require into the
  direct block. The comment travels with it; a layout tidy restores on every run
  is not one to fight.

## Verification

`make check` green. Integration lane green: 2875 tests, 41 packages, 0 skips.
`craft static --strict`, arch-lint, codegen drift, and lint across all 11 modules
green. Commits 1 and 2 re-verified green under 1.26.6 on a detached checkout.

Not covered locally: the Windows desktop bundle and the macOS/Windows desktop
lanes, which only CI builds. `golang:1.27-alpine` is published (manifest
checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Go floor to 1.27.0 across all modules, Docker, and tools. Behavior changes: `encoding/json` error paths now include array indices (e.g., `links.entity_id` → `links.0.entity_id`), and the desktop app’s minimum macOS moves from 12 to 13 because Go 1.27 dropped macOS 12.

**Changes**
- Pins `golang` to 1.27.0 in all `go.mod` files and `go.work`; Docker base to `golang:1.27-alpine`. `go mod tidy` folds the `composition` require into the direct block.
- Pins `golangci-lint` to v2.13.0 and `govulncheck` to v1.7.0 (older `govulncheck` crashed on 1.27); scan reports 0 vulnerabilities.
- Resolves `gofmt` vs `gofumpt` disagreement by naming maps before return.
- Makes `LocalizeFieldFault` treat numeric path segments as array positions, not nested keys; API error details keep the index; tests updated.
- Version-pin test discovers all modules from the tree to prevent drift.
- Sets `MACOSX_DEPLOYMENT_TARGET` to 13.0; docs updated. The desktop bundle no longer runs on macOS 12.

**Required actions**
- Run `make tools` once to rebuild gate binaries with Go 1.27 (`GOTOOLCHAIN=auto` will fetch it).
- Update any tests or client code that assert exact error-path strings to include indices (e.g., `links.0.entity_id`).

<sup>Written for commit 13bdbe16c3f9c150628dd6dd0ecbc557adf84eec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error paths for array-based and nested fields, making reported locations more precise.
  * Correctly distinguishes array positions from errors in nested object properties.

* **Chores**
  * Updated the supported Go toolchain to version 1.27.
  * Updated linting tools and build environments for compatibility with the newer Go version.

* **Tests**
  * Added regression coverage for nested field and array-index validation scenarios.
  * Expanded module version checks across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->