### PR TITLE
fix(ci): the cache-warm job installs the tools its gate needs

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -80,6 +80,23 @@ jobs:
         uses: ./.github/actions/go-build-cache
         with:
           flavor: plain
+      # `make check-backend` runs golangci over every module, so the gate
+      # binaries have to be here or lint-modules fails before it compiles
+      # anything — which is what this job exists to do. Same cache and same key
+      # as the ci lane's own step, so the two share one entry rather than each
+      # paying the ~75s compile.
+      - name: Cache the gate binaries
+        id: gate-binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/bin
+          key: gate-binaries-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.mod', 'backend/Makefile') }}
+      - name: Install the pinned gate binaries
+        if: steps.gate-binaries.outputs.cache-hit != 'true'
+        working-directory: .
+        run: make tools
+      - name: Gate binaries onto PATH
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
       - name: Compile what the gate compiles (make check-backend)
         working-directory: .
         env:


### PR DESCRIPTION
## What was red

The scheduled `cache-warm` workflow's `warm plain` job has failed **every run since it was added** — four for four:

```
FAIL: golangci-lint not found — run 'make tools'
FAIL — golangci-lint findings in: backend/tools cli/craft composition desktop/launcher extensions/…
make: *** [Makefile:651: lint-modules] Error 1
```

It runs `make check-backend`, which lints every module, but the job never installed the gate binaries. So `lint-modules` failed before compiling anything — which is the one thing this job exists to do. Its sibling `warm integration` passes, because `make test-integration` needs no linter.

## The fix

Cache and install the gate binaries exactly as the `ci` lane does, on the same cache key, so the two share one entry rather than each paying the ~75s compile. Three steps, lifted from `ci.yml`: cache `~/go/bin`, run `make tools` on a miss, put it on `PATH` — before `make check-backend`.

## Why it is worth fixing rather than muting

The workflow says of itself that it is **not a verdict**: it warms a build cache, and its save step is deliberately `if: !cancelled()` so that even a red run leaves the cache better than it found it. A job that cannot be a verdict should not be able to report `main` as broken — and for four runs, on the repository's default branch, this one did. That is the same cost `priority: critical` names in CLAUDE.md: a red run nobody trusts makes every other verdict unreadable.

## Verification

`make check-backend` green locally. The proof that matters is the next scheduled run of this workflow on `main` after merge — the first one that should ever have gone green.

Found while confirming #2046's fixes had landed: both halves (#2052, #2055) do pass on current `main`, so the failure keeping the branch red was this separate one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs and caches the gate binaries in the scheduled cache-warm workflow before running make check-backend, so the `warm plain` job stops failing. Previously it ran without tools and failed with “golangci-lint not found”; now it shares the `ci` lane’s `~/go/bin` cache and adds it to PATH.

- Adds a `actions/cache` step for `~/go/bin` keyed by OS/arch and `hashFiles('backend/go.mod', 'backend/Makefile')`; runs `make tools` on a miss.
- Appends `~/go/bin` to `$GITHUB_PATH`; no other workflow inputs or env changes.
- Side effects: shares one tools cache with `ci`, avoids duplicate ~75s tool builds, and prevents this non-verdict job from reporting main as broken.

<sup>Written for commit 09662ee36a600bfac80fe95e9f24d11fad4677b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

