### PR TITLE
docs(deals): the guide said you could win a deal; you cannot

### DIFF
--- a/docs/how-to/work-your-pipeline.md
+++ b/docs/how-to/work-your-pipeline.md
@@ -77,14 +77,25 @@ won when the deal has a **contract** attached that is:
 - carrying an attached file categorised **contract** or **legal**,
 - in a **current** or **final** document state.
 
-Contracts live on the **company page**, not on the deal. Create the contract there, point it at
-this deal, set the signed date, attach the paper — then Won will go through.
+**Today you cannot satisfy that from the UI, so a deal cannot be marked won here at all.**
+This is a defect, not something you are missing —
+[#2088](https://github.com/gradionhq/margince-poc-v1/issues/2088) — and until it is fixed,
+pressing **Won** leaves the deal open and prints a message naming values that appear nowhere in
+the interface.
 
-Without that, pressing **Confirm** on Won leaves the deal open and shows a message listing
-values that appear nowhere in the interface. That is a known defect, tracked as
-[#2084](https://github.com/gradionhq/margince-poc-v1/issues/2084) — the rule is deliberate, the
-way it is surfaced is not. The API supports recording *why* there is no contract (an import, a
-purchase order, a verbal agreement, a renewal by email); no screen collects that yet.
+Two links in the chain are missing. The contract form (Company → **Documents** →
+**Add a contract**) has no field that names a **deal**, so a contract recorded there belongs to
+the company but not to the opportunity. And a contract is created in **draft** with no control
+anywhere to move it out, which the evidence rule also rejects. Recording the agreement and
+attaching the signed PDF both work; the two links that would make it count do not exist yet.
+
+The API can express all of it — including a short reason why there is no contract at all (an
+import, a purchase order, a verbal agreement, a renewal by email) — so anyone driving Margince
+through the API or an agent can close a won deal today. It is the screens that are missing.
+
+Until then, a deal you have actually won stays open in Margince, and the honest workaround is to
+say so where a human will read it: put the outcome in a note on the deal, so the record does not
+silently claim the deal is still live.
 
 **Closing is one deal at a time, on purpose.** The bulk bar offers open stages only: a lost
 reason is specific to one deal, and one reason standing for a dozen would be a lie in the
@@ -213,13 +224,15 @@ Stated plainly, so you don't hunt for them:
   ([#2034](https://github.com/gradionhq/margince-poc-v1/issues/2034))
 - **The board cannot be dragged on touch devices.** Use the deal page's stage stepper.
 - **There is no text search within the deals list.** Use global search.
-- **Marking a deal won needs a contract with signed paper**, and the escape hatch the API
-  offers has no screen. ([#2084](https://github.com/gradionhq/margince-poc-v1/issues/2084))
+- **A deal cannot be marked won from the UI at all.** The evidence rule needs a contract linked
+  to the deal and out of draft, and no screen does either. See *Close a deal* above.
+  ([#2088](https://github.com/gradionhq/margince-poc-v1/issues/2088))
 
 ## Where deals meet the rest of Margince
 
 - **Companies** — a deal belongs to one company, and that company's page shows its deals,
-  its people, its contracts and its timeline. Contracts are reached from there.
+  its people, its contracts and its timeline. Contracts live under its **Documents** tab —
+  though one recorded there cannot yet be tied to a specific deal (see *Close a deal*).
 - **Leads** — qualifying a lead can open a deal in the same step, seating the contact on it.
   See [set-up-a-partner-program.md](set-up-a-partner-program.md) for the partner side of a
   deal, including what "Brought us the deal" versus "Helped a deal we had" means for


### PR DESCRIPTION
The stop-time review caught this: the guide's central workflow cannot be completed in the UI. It is right, and the situation is worse than "awkward".

## What the guide claimed

> Contracts live on the **company page**, not on the deal. Create the contract there, point it at this deal, set the signed date, attach the paper — then Won will go through.

## What actually happens

Two links in the chain do not exist:

1. **Nothing sets `contract.deal_id`.** The contract form (Company → Documents → **Add a contract**, dialog titled "Record an agreement") offers Title, Contract number, Value, dates, Signed, and a file dropzone. There is no deal field, and `grep -rn "deal_id"` across `contractform.tsx` and `companycontracts.tsx` returns nothing.
2. **Nothing leaves `draft`.** No frontend surface calls `POST /contracts/{id}/status`.

`evidenceQuery` requires both. Filling the form in a browser and reading the row confirms it:

```
          title           | status | signed_on  | deal_unset
--------------------------+--------+------------+------------
 Fleet retrofit agreement | draft  | 2026-08-01 | t
```

So **no deal can be marked won from the UI at all** — not only company-less ones.

## What the guide says now

That the path does not exist, which two links are missing, that the API can do it (so an agent or API caller is unblocked), and an honest workaround: log a note on the deal, so the record does not silently claim a won deal is still live. I verified **Log activity → Note** exists on the deal page before recommending it.

The limits section and the cross-reference to contracts are corrected to match.

## Issues

Filed **#2088** (critical: the product's core loop is unusable on a default install). Closed **#2084**, which read this as a bad error message over a working path — the wrong diagnosis, and it would have sent the next person looking for a surfacing fix.

## On the original mistake

I wrote that instruction from the shape of the API, having verified only the refusals. An instruction is a claim, and a claim about a UI is only verified by performing it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deals guide by removing an impossible UI workflow and documenting the current limitation. The old guide said you could mark a deal Won by creating a contract on the company page; the new guide states you cannot mark a deal Won from the UI today, explains the two missing links, and gives a safe workaround.

- Calls out that the contract form has no deal field and contracts stay in draft; links to #2088.
- Updates “Close a deal,” “Limits,” and the contracts cross‑reference to match current behavior.
- Notes the API can still close a deal and suggests logging a note on the deal as a temporary workaround.

<sup>Written for commit 933ad7934a3a799b33e6c2bcd03a432c341e5345. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deal-closing guidance to clarify that deals cannot currently be marked as Won through the UI.
  * Documented the API-based workaround and recommended recording the outcome in a deal note.
  * Clarified where company contracts are stored and that they cannot yet be linked to a specific deal.
  * Added details about the missing contract linking and status controls affecting the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->