### PR TITLE
feat(search): retrieval trust reads who said it, not which door it came through

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -101,6 +101,13 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 	calls := []struct{ tool, args string }{
 		{"list_pipelines", `{}`},
 		{"read_brief", `{}`},
+		// Who the caller is, and who else they can hand work to. Both answer
+		// about the acting human rather than about a record, so the empty
+		// object is the whole input; list_colleagues also runs narrowed,
+		// because the filtered answer is the one that can come back truncated.
+		{"whoami", `{}`},
+		{"list_colleagues", `{}`},
+		{"list_colleagues", `{"q":"nothing here matches this"}`},
 		// An enumeration, narrowed and unnarrowed. The narrowed one is the
 		// answer worth holding to the shape: a filter that reached no SQL still
 		// returns a well-formed page, of the wrong rows.

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -113,9 +113,10 @@ func followUpDrafter(provider datasource.SystemOfRecordProvider) agents.FollowUp
 		ref, err := provider.Create(ctx, datasource.CreateInput{
 			EntityType: datasource.EntityActivity,
 			Fields:     fields,
-			// The MCP provenance channel, same as every write on the tool
-			// surface; captured_by comes from the principal, never from here.
-			Source: "mcp",
+			// A person asked for this through an assistant, which is the same
+			// origin as a person asking through a form; captured_by comes from
+			// the principal, never from here, and it is what says which.
+			Source: agents.ToolSource,
 		})
 		if err != nil {
 			return ids.Nil, "", err

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -27,8 +27,18 @@ import (
 // times is a value nobody can grep for when the surface finally versions.
 const toolVersionV1 = "1.0.0"
 
-// toolSource is the provenance channel every MCP write carries.
-const toolSource = "mcp"
+// ToolSource is the origin every MCP write carries.
+//
+// Exported because compose writes one activity on the tool surface's behalf
+// (the slipping-deal follow-up) and must stamp the same word; a second literal
+// there is how the three spellings this replaced got started.
+//
+// It is `manual` — the same word the web app writes — because `source` names
+// where a row came from, and a tool call is a person asking for it through an
+// assistant rather than through a form. Which door it came through, and who
+// walked through it, are recorded in captured_by, where retrieval ranking and
+// the record history both read them.
+const ToolSource = "manual"
 
 // StageResolver supplies the advance_deal tier resolver's input: the
 // target stage's configured semantic (won/lost is a property of pipeline
@@ -233,7 +243,7 @@ func (t createRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	ref, err := t.p.Create(ctx, datasource.CreateInput{
 		EntityType: datasource.EntityType(args.RecordType),
 		Fields:     args.Fields,
-		Source:     toolSource,
+		Source:     ToolSource,
 	})
 	if err != nil {
 		return nil, err
@@ -351,7 +361,7 @@ func (t logActivity) Handle(ctx context.Context, in json.RawMessage) (json.RawMe
 	ref, err := t.p.Create(ctx, datasource.CreateInput{
 		EntityType: datasource.EntityActivity,
 		Fields:     in,
-		Source:     toolSource,
+		Source:     ToolSource,
 	})
 	if err != nil {
 		return nil, err
@@ -437,7 +447,7 @@ func (t advanceDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawMe
 		DealID:                   args.DealID,
 		ToStageID:                args.ToStageID,
 		LostReason:               args.LostReason,
-		Source:                   toolSource,
+		Source:                   ToolSource,
 		IfVersion:                pin,
 	})
 	if err != nil {

--- a/backend/internal/modules/agents/tools_progress.go
+++ b/backend/internal/modules/agents/tools_progress.go
@@ -101,7 +101,7 @@ func (t progressDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 		DealID:     args.DealID,
 		ToStageID:  args.ToStageID,
 		LostReason: args.LostReason,
-		Source:     toolSource,
+		Source:     ToolSource,
 		IfVersion:  pin,
 	}); err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (t progressDeal) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 		ref, err := t.p.Create(ctx, datasource.CreateInput{
 			EntityType: datasource.EntityActivity,
 			Fields:     fields,
-			Source:     toolSource,
+			Source:     ToolSource,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("crmagents: deal advanced but logging the note failed — the move stands, retry via log_activity: %w", err)

--- a/backend/internal/modules/agents/tools_progress_test.go
+++ b/backend/internal/modules/agents/tools_progress_test.go
@@ -103,8 +103,8 @@ func TestProgressDealAdvancesThenLogsTheLinkedNote(t *testing.T) {
 	if len(p.advances) != 1 || p.advances[0].DealID != dealID || p.advances[0].ToStageID != stageID {
 		t.Fatalf("advances = %+v, want the one requested move", p.advances)
 	}
-	if p.advances[0].Source != toolSource {
-		t.Fatalf("advance source = %q, want %q", p.advances[0].Source, toolSource)
+	if p.advances[0].Source != ToolSource {
+		t.Fatalf("advance source = %q, want %q", p.advances[0].Source, ToolSource)
 	}
 	if len(p.creates) != 1 {
 		t.Fatalf("creates = %d, want the one note", len(p.creates))

--- a/backend/internal/modules/agents/tools_qualify.go
+++ b/backend/internal/modules/agents/tools_qualify.go
@@ -92,7 +92,7 @@ func (t qualifyLead) Handle(ctx context.Context, in json.RawMessage) (json.RawMe
 		if _, err := t.p.Update(ctx, datasource.UpdateInput{
 			Ref:       datasource.EntityRef{Type: datasource.EntityLead, ID: args.RecordID},
 			Patch:     raw,
-			Source:    toolSource,
+			Source:    ToolSource,
 			IfVersion: &rec.Version,
 		}); err != nil {
 			return nil, err

--- a/backend/internal/modules/agents/tools_qualify_test.go
+++ b/backend/internal/modules/agents/tools_qualify_test.go
@@ -124,8 +124,8 @@ func TestQualifyLeadFillsOnlyInferableEmptyFieldsWithEvidence(t *testing.T) {
 	if p.updates[0].IfVersion == nil || *p.updates[0].IfVersion != 3 {
 		t.Fatalf("IfVersion = %v, want the version the fill was decided on (3)", p.updates[0].IfVersion)
 	}
-	if p.updates[0].Source != toolSource {
-		t.Fatalf("update source = %q, want the tool surface's provenance channel %q", p.updates[0].Source, toolSource)
+	if p.updates[0].Source != ToolSource {
+		t.Fatalf("update source = %q, want the tool surface's provenance channel %q", p.updates[0].Source, ToolSource)
 	}
 }
 

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -253,7 +253,7 @@ func (t updateRecord) applyRecord(ctx context.Context, args updateRecordArgs, pa
 	ref, err := t.p.Update(ctx, datasource.UpdateInput{
 		Ref:       datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.ID},
 		Patch:     patch,
-		Source:    toolSource,
+		Source:    ToolSource,
 		IfVersion: args.IfVersion,
 	})
 	if err != nil {

--- a/backend/internal/modules/ai/voice.go
+++ b/backend/internal/modules/ai/voice.go
@@ -231,7 +231,7 @@ func (s *VoiceStore) CreateProfile(ctx context.Context, in CreateVoiceProfileInp
 		p, err = scanVoiceProfile(tx.QueryRow(ctx, storekit.SQLf(`
 			INSERT INTO voice_profile
 			  (owner_id, scope, status, personality_md, source, captured_by, updated_at)
-			VALUES ($1, 'user', 'collecting', $2, 'ui', $3, $4)
+			VALUES ($1, 'user', 'collecting', $2, 'manual', $3, $4)
 			RETURNING %s`, voiceProfileColumns),
 			actor.UserID, in.PersonalityMD, actor.ID, s.now().UTC()))
 		if storekit.IsUniqueViolation(err) {

--- a/backend/internal/modules/ai/voice_profile_artifact.go
+++ b/backend/internal/modules/ai/voice_profile_artifact.go
@@ -150,7 +150,7 @@ func persistDerivedVoiceVersion(ctx context.Context, tx pgx.Tx, build derivedPro
 			   model_provider, model_name, builder_version, activation_policy_version,
 			   evaluation_json, activated_at, source, captured_by, updated_at)
 			VALUES ($1, $2, 'active', $3, $4, '{}'::jsonb, $5, $6, 'manual', $7,
-			        'internal', $8, 'legacy-set-derived', '1', $9, $10, 'ui', $11, $10)
+			        'internal', $8, 'legacy-set-derived', '1', $9, $10, 'manual', $11, $10)
 			RETURNING id`, build.profileID, build.nextVersion, build.voiceProfileMD,
 		storekit.JSONArg(map[string]any{voiceKeyDocument: build.voiceProfileMD}), build.sourceHash,
 		build.sourceCount, build.predecessorVersion, modelName, storekit.JSONArg(evaluation), build.now,

--- a/backend/internal/modules/ai/voice_source_store.go
+++ b/backend/internal/modules/ai/voice_source_store.go
@@ -122,7 +122,7 @@ func (s *VoiceStore) persistPreparedSource(ctx context.Context, tx pgx.Tx, profi
 			   source_ref, content, content_hash, word_count, excluded, exclusion_reason,
 			   extractor_version, occurred_at, source, captured_by, updated_at)
 			VALUES ($1, 'manual', $2, $3, $4, $5, $6, $7, $8, $9,
-			        false, NULL, 'voice-v1', $10, 'ui', $11, $12)
+			        false, NULL, 'voice-v1', $10, 'manual', $11, $12)
 			ON CONFLICT (voice_profile_id, source_ref) DO UPDATE SET
 			  origin = 'manual',
 			  kind = EXCLUDED.kind,

--- a/backend/internal/modules/ai/voice_versions.go
+++ b/backend/internal/modules/ai/voice_versions.go
@@ -294,7 +294,7 @@ func (s *VoiceStore) RollbackVersion(ctx context.Context, profileID ids.UUID, so
 			   model_provider, model_name, builder_version, activation_policy_version,
 			   evaluation_json, review_reasons, activated_at, source, captured_by, updated_at)
 			VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, 'rollback', $8,
-			        $9, $10, $11, $12, $13, $14, $15, 'ui', $16, $15)
+			        $9, $10, $11, $12, $13, $14, $15, 'manual', $16, $15)
 			RETURNING %s`, voiceVersionColumns), profileID, nextVersion, source.VoiceProfileMD,
 			storekit.JSONArg(source.ProfileJSON), storekit.JSONArg(source.StatsJSON), source.SourceHash,
 			source.SourceCount, profile.ProfileVersion, source.ModelProvider, source.ModelName,

--- a/backend/internal/modules/people/projectstakeholder.go
+++ b/backend/internal/modules/people/projectstakeholder.go
@@ -23,10 +23,11 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// projectStakeholderSource is the provenance of an edge created through
-// the project surface: a human attached it, as opposed to an import or a
-// capture run.
-const projectStakeholderSource = "ui"
+// projectStakeholderSource is the origin of an edge created through the
+// project surface: a person attached it, as opposed to an import or a capture
+// run. `manual` is that word everywhere in this schema — this constant used to
+// say "ui", which named the screen rather than the origin.
+const projectStakeholderSource = "manual"
 
 // SetProjectStakeholderInput is one idempotent attach: the same person on
 // the same project twice is a role correction, not a duplicate.

--- a/backend/internal/modules/search/graph.go
+++ b/backend/internal/modules/search/graph.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"slices"
 	"sort"
 	"strings"
@@ -35,29 +34,6 @@ const (
 	// a touch loses half its recency weight every 30 days.
 	recencyHalfLifeDays = 30
 )
-
-// sourceTrust maps provenance channels to the trust factor: a human
-// statement outranks an agent write outranks captured external content
-// (the T0/T1/T2 ladder projected onto activity.source).
-var sourceTrust = map[string]float64{
-	"manual": 1.0,
-	"mcp":    0.7,
-}
-
-const defaultSourceTrust = 0.4 // captured/connector content — T2
-
-func rankScore(similarity float64, occurredAt time.Time, source string, now time.Time) float64 {
-	days := now.Sub(occurredAt).Hours() / 24
-	if days < 0 {
-		days = 0
-	}
-	recency := math.Exp2(-days / recencyHalfLifeDays)
-	trust, ok := sourceTrust[source]
-	if !ok {
-		trust = defaultSourceTrust
-	}
-	return wRankSim*similarity + wRankRec*recency + wRankTrust*trust
-}
 
 type graphSection struct {
 	name  string
@@ -242,7 +218,7 @@ func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids
 		return nil, nil, nil, err
 	}
 	activitySQL := fmt.Sprintf(`
-		SELECT a.id, coalesce(a.subject, a.kind), a.kind, a.is_done, a.occurred_at, a.source
+		SELECT a.id, coalesce(a.subject, a.kind), a.kind, a.is_done, a.occurred_at, coalesce(a.captured_by, '')
 		FROM activity a JOIN activity_link l ON l.activity_id = a.id
 		WHERE l.%s = $%d AND a.archived_at IS NULL`, linkCol, anchorPos)
 	if scope != "" {
@@ -256,10 +232,10 @@ func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids
 	defer rows.Close()
 	for rows.Next() {
 		var id ids.ActivityID
-		var summary, kind, source string
+		var summary, kind, capturedBy string
 		var isDone bool
 		var occurredAt time.Time
-		if err := rows.Scan(&id, &summary, &kind, &isDone, &occurredAt, &source); err != nil {
+		if err := rows.Scan(&id, &summary, &kind, &isDone, &occurredAt, &capturedBy); err != nil {
 			return nil, nil, nil, err
 		}
 		activityIDs = append(activityIDs, id)
@@ -268,7 +244,7 @@ func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids
 		// the untyped UUID.
 		item := graphItem{
 			entityType: string(datasource.EntityActivity), id: id.UUID, summary: summary,
-			score: rankScore(0, occurredAt, source, now), occurredAt: occurredAt,
+			score: rankScore(0, occurredAt, capturedBy, now), occurredAt: occurredAt,
 		}
 		if kind == "task" && !isDone {
 			openTasks = append(openTasks, item)

--- a/backend/internal/modules/search/graphtrust.go
+++ b/backend/internal/modules/search/graphtrust.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The retrieval trust ladder: how much a piece of evidence counts for, based
+// on who put it there. It is one of the three terms in rankScore (graph.go),
+// and the only one that is about provenance rather than about the query or
+// the clock. rankScore itself lives here with it, because the three weights
+// and the ladder are one formula — §10.7.2 — and reading half of it elsewhere
+// is how the ladder came to be keyed off the wrong column in the first place.
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// The trust factor: a human statement outranks an agent write outranks
+// captured external content — the T0/T1/T2 ladder.
+//
+// IT IS KEYED OFF WHO SAID IT, not off the channel the row arrived through.
+// The ladder used to read activity.source, where `manual` scored 1.0 and `mcp`
+// scored 0.7. That worked only while the two words happened to line up with
+// human and agent, and they no longer do: an agent tool call and a human form
+// submission both write source=manual, so a channel-keyed ladder would hand
+// every agent-written note full human-statement trust — silently, and exactly
+// inside the retrieval path that answers questions about a company's history.
+//
+// captured_by is the authenticated principal, stamped by the write path and
+// never taken from a request body, and it already spells the distinction the
+// ladder is about: `human:<user>` or `agent:<passport>`.
+const (
+	trustHumanStatement   = 1.0 // T0 — a person said this
+	trustAgentWrite       = 0.7 // T1 — an agent wrote it, on a person's authority
+	trustCapturedExternal = 0.4 // T2 — a connector or importer brought it in
+)
+
+// The two prefixes a captured_by value can carry. They are built from the
+// principal types rather than written out, so the ladder cannot drift from the
+// vocabulary the write path stamps.
+var (
+	humanWriterPrefix = string(principal.PrincipalHuman) + ":"
+	agentWriterPrefix = string(principal.PrincipalAgent) + ":"
+)
+
+// trustOfWriter reads the ladder off a captured_by value.
+//
+// An unrecognized or empty prefix takes T2 rather than a middle value: an
+// unattributed row is captured content until something says otherwise, and
+// guessing upward is the direction that misleads.
+func trustOfWriter(capturedBy string) float64 {
+	switch {
+	case strings.HasPrefix(capturedBy, humanWriterPrefix):
+		return trustHumanStatement
+	case strings.HasPrefix(capturedBy, agentWriterPrefix):
+		return trustAgentWrite
+	default:
+		return trustCapturedExternal
+	}
+}
+
+// The `similarity` term is always 0 at today's only call site, and that is the
+// formula being honest rather than a dead parameter: a graph walk has no query
+// to be similar TO, so §10.7.2's first term is genuinely zero there. Dropping
+// it would leave two thirds of a published formula in the code and the missing
+// third only in the spec.
+//
+//nolint:unparam // see above — the zero is meaningful, not unused.
+func rankScore(similarity float64, occurredAt time.Time, capturedBy string, now time.Time) float64 {
+	days := now.Sub(occurredAt).Hours() / 24
+	if days < 0 {
+		days = 0
+	}
+	recency := math.Exp2(-days / recencyHalfLifeDays)
+	return wRankSim*similarity + wRankRec*recency + wRankTrust*trustOfWriter(capturedBy)
+}

--- a/backend/internal/modules/search/graphtrust_test.go
+++ b/backend/internal/modules/search/graphtrust_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The trust ladder reads WHO said it, off captured_by.
+//
+// It used to read activity.source, which stopped meaning "a human typed this"
+// the moment agent tool calls began writing source=manual like every other
+// first-party write. This test is the pin: it is written against captured_by
+// values, so keying the ladder back onto a channel word fails it.
+func TestTheTrustLadderReadsTheWriterNotTheChannel(t *testing.T) {
+	human := "human:" + ids.NewV7().String()
+	agent := "agent:" + ids.NewV7().String()
+
+	for _, c := range []struct {
+		name       string
+		capturedBy string
+		want       float64
+	}{
+		{"a person said it", human, trustHumanStatement},
+		{"an agent wrote it", agent, trustAgentWrite},
+		{"a connector brought it in", "connector:gmail", trustCapturedExternal},
+		{"nobody is named", "", trustCapturedExternal},
+		{"the old channel word, which names no writer", "manual", trustCapturedExternal},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := trustOfWriter(c.capturedBy); got != c.want {
+				t.Errorf("trustOfWriter(%q) = %v, want %v", c.capturedBy, got, c.want)
+			}
+		})
+	}
+}
+
+// Two notes of the same age rank by who wrote them: the human statement first.
+//
+// This is the property case 6 rests on — asking what happened with a client
+// must surface what a person recorded ahead of what an agent inferred.
+func TestAHumanNoteOutranksAnAgentNoteOfTheSameAge(t *testing.T) {
+	now := time.Now()
+	when := now.Add(-72 * time.Hour)
+	humanScore := rankScore(0, when, "human:"+ids.NewV7().String(), now)
+	agentScore := rankScore(0, when, "agent:"+ids.NewV7().String(), now)
+	if humanScore <= agentScore {
+		t.Fatalf("the human note scored %v and the agent note %v; the human one must rank higher",
+			humanScore, agentScore)
+	}
+}
+
+// Recency still outweighs trust, which is the §10.7.2 weighting and not an
+// accident: a captured email from this morning is more use than a human note
+// from last quarter, and the ladder is a tie-break between comparable ages
+// rather than an override.
+func TestFreshCapturedContentStillBeatsAStaleHumanNote(t *testing.T) {
+	now := time.Now()
+	fresh := rankScore(0, now, "connector:gmail", now)
+	stale := rankScore(0, now.Add(-365*24*time.Hour), "human:"+ids.NewV7().String(), now)
+	if fresh <= stale {
+		t.Fatalf("fresh captured content scored %v and a year-old human note %v; recency must still win",
+			fresh, stale)
+	}
+}

--- a/backend/internal/modules/signals/signal.go
+++ b/backend/internal/modules/signals/signal.go
@@ -350,7 +350,7 @@ func (s *Store) UpdateSignal(ctx context.Context, id ids.SignalID, in UpdateSign
 				`INSERT INTO signal_resolution (id, signal_id, outcome, note, resolved_by, source, captured_by)
 				 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 				ids.NewV7(), id, *in.Status, in.Note,
-				storekit.UUIDOrNil(actor.UserID), "ui", actor.ID); err != nil {
+				storekit.UUIDOrNil(actor.UserID), "manual", actor.ID); err != nil {
 				return fmt.Errorf("append signal outcome: %w", err)
 			}
 		}

--- a/backend/migrations/core/1787315000_source_names_the_origin.down.sql
+++ b/backend/migrations/core/1787315000_source_names_the_origin.down.sql
@@ -1,5 +1,14 @@
 -- Irreversible by design: `mcp`, `ui` and `manual` are one word now, and the
--- row no longer carries which of the three it was. `captured_by` does.
+-- row no longer carries which of the three it was.
 --
--- A down migration that guessed would be worse than one that does nothing.
+-- Nothing else carries it either. captured_by records WHO wrote the row — the
+-- person, or the passport acting for them — not which surface they used, so a
+-- row written by a person through an assistant and one written by that person
+-- through a form are now identical in the database. That distinction is gone,
+-- deliberately: `source` is meant to say where a row came FROM, and "a person
+-- asked us to write it down" is one origin however they asked.
+--
+-- If a later feature needs the channel back it needs a column that means the
+-- channel, populated going forward. A down migration that guessed would be
+-- worse than one that does nothing.
 SELECT 1;

--- a/backend/migrations/core/1787315000_source_names_the_origin.down.sql
+++ b/backend/migrations/core/1787315000_source_names_the_origin.down.sql
@@ -1,0 +1,5 @@
+-- Irreversible by design: `mcp`, `ui` and `manual` are one word now, and the
+-- row no longer carries which of the three it was. `captured_by` does.
+--
+-- A down migration that guessed would be worse than one that does nothing.
+SELECT 1;

--- a/backend/migrations/core/1787315000_source_names_the_origin.up.sql
+++ b/backend/migrations/core/1787315000_source_names_the_origin.up.sql
@@ -1,0 +1,32 @@
+-- `source` names WHERE a row came from, not which door it arrived through.
+--
+-- Two spellings meant "a first-party write by a person using this product":
+-- `manual` from the web app and `ui` from the project surface, plus `mcp` from
+-- the tool surface — where a person is likewise the one who asked, through an
+-- assistant instead of a form. Three words for one origin made the column
+-- unreadable and, worse, load-bearing in the wrong place: retrieval ranking
+-- used to read it to tell a human statement from an agent write. That ladder
+-- now reads `captured_by`, which records the actual writer, so this column is
+-- free to say the one thing it should.
+--
+-- Collapsing to `manual` is safe ONLY because that ranking change landed
+-- first. Reversed, every agent-written note would have been promoted to
+-- human-statement trust silently.
+--
+-- The down migration cannot restore the distinction: once the three words are
+-- one word, nothing in the row says which it was. `captured_by` still does,
+-- for anything that needs to know.
+
+SET LOCAL lock_timeout = '3s';
+
+UPDATE person             SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE organization       SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE deal               SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE lead               SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE activity           SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE project            SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE relationship       SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE organization_domain SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE dedupe_candidate   SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE person_email       SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE person_phone       SET source = 'manual' WHERE source IN ('mcp', 'ui');

--- a/backend/migrations/core/1787315000_source_names_the_origin.up.sql
+++ b/backend/migrations/core/1787315000_source_names_the_origin.up.sql
@@ -17,6 +17,17 @@
 -- one word, nothing in the row says which it was. `captured_by` still does,
 -- for anything that needs to know.
 
+-- COST, stated rather than discovered. None of these tables has an index on
+-- `source`, so each UPDATE is a full scan, and all fifteen run in one
+-- transaction — the row locks it takes are held until the whole thing commits.
+-- lock_timeout bounds how long a statement WAITS for a lock; it does not bound
+-- how long these scans run.
+--
+-- That is acceptable here because the predicate matches a minority of rows and
+-- these tables are small at this stage. On a large installation this wants
+-- batching by primary key with a commit per batch. It is written as one
+-- transaction on purpose: a half-applied spelling is the one outcome worse
+-- than a slow one, since nothing afterwards could tell which tables were swept.
 SET LOCAL lock_timeout = '3s';
 
 UPDATE person             SET source = 'manual' WHERE source IN ('mcp', 'ui');
@@ -30,3 +41,14 @@ UPDATE organization_domain SET source = 'manual' WHERE source IN ('mcp', 'ui');
 UPDATE dedupe_candidate   SET source = 'manual' WHERE source IN ('mcp', 'ui');
 UPDATE person_email       SET source = 'manual' WHERE source IN ('mcp', 'ui');
 UPDATE person_phone       SET source = 'manual' WHERE source IN ('mcp', 'ui');
+
+-- The same word on four tables outside the CRM record set. Each is written by
+-- a person acting through this product — recording their own writing voice,
+-- resolving a signal — so each carried 'ui' for the same reason and gets the
+-- same correction. They are here rather than left alone because a spelling
+-- half-collapsed is worse than either whole one: a reader would have to know
+-- which tables were swept.
+UPDATE voice_profile         SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE voice_corpus_source   SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE voice_profile_version SET source = 'manual' WHERE source IN ('mcp', 'ui');
+UPDATE signal_resolution     SET source = 'manual' WHERE source IN ('mcp', 'ui');

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -897,7 +897,11 @@ function AddEmploymentModal({
                 organization_id: org.id,
                 role: role.trim() || undefined,
                 is_current_primary: isCurrent,
-                source: "ui",
+                // `manual` is the one word for a first-party write by a
+                // person — through this form or through an assistant. It used
+                // to say "ui", which named the screen rather than the origin,
+                // and would have re-created the spelling the backfill removed.
+                source: "manual",
               },
               { onSuccess: close },
             );


### PR DESCRIPTION
Two changes that must land in this order, and this commit is the order.

FIRST, the ranking. search/graph.go scored evidence by activity.source:
manual 1.0, mcp 0.7, everything else 0.4, under a comment naming the real rule
— a human statement outranks an agent write outranks captured external
content. The rule is right. Its input was wrong. `source` says where a row came
from; it does not say who wrote it, and the two only ever agreed by accident.
The ladder now reads captured_by, which is the authenticated principal stamped
by the write path and never taken from a request body: `human:` scores 1.0,
`agent:` 0.7, anything else 0.4. An unattributed row takes the bottom rung
rather than a middle one, because guessing upward is the direction that
misleads.

SECOND, the spelling. Three words meant one origin: `manual` from the web app,
`ui` from the project surface, `mcp` from the tool surface. All three are a
person asking this product to write something down — through a form or through
an assistant — so all three are now `manual`, in the code and in the existing
rows. agents.ToolSource is exported for the one compose caller that writes an
activity on the tool surface's behalf; a second literal there is how three
spellings got started.

Doing the second without the first would have handed every agent-written note
full human-statement trust — silently, and precisely inside the retrieval path
that answers questions about a company's history. That is the whole reason for
the order.

The down migration deliberately does nothing: once three words are one word the
row no longer carries which it was, and a down migration that guessed would be
worse than one that does not.

Also: whoami and list_colleagues were registered but never invoked in the
schema-conformance lane, so nothing held their answers to their declared
shapes. Both are called now, list_colleagues narrowed as well as whole, since
the filtered answer is the one that can come back truncated. And the trust
ladder moved to its own file with rankScore — graph.go crossed the 500-line cap,
and the formula and its ladder are one concept.

Codex review of this branch. Three findings worth acting on, one false alarm
worth recording.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Search ranking now scores evidence by who wrote it (`captured_by`) instead of which channel it arrived through (`activity.source`), and we collapse `source` spelling to a single `manual` origin across code and data. Old behavior: `source=manual` 1.0, `mcp` 0.7, other 0.4; new behavior: `captured_by` `human:` 1.0, `agent:` 0.7, anything else 0.4, with unattributed rows at the bottom.

- Extracts trust logic into `graphtrust.go`; `rankScore` unchanged in shape, now calls `trustOfWriter(captured_by)`. The query path reads `captured_by`, not `source`.
- Exports `agents.ToolSource = "manual"` and uses it across tool writes and compose follow-ups; removes remaining `"ui"`/`"mcp"` literals in backend and frontend.
- Adds tests for the trust ladder and updates tool schema conformance to run `whoami` and `list_colleagues` (narrowed and whole).

**Rollout / migration**
- Runs an `UP` migration that rewrites `source IN ('mcp','ui')` to `manual` across CRM, voice, and signals tables in one transaction; no `DOWN` (the original value is not recoverable). Statement cost is full-table scans; acceptable at current sizes.
- Required: If you used `source` to infer human vs agent, switch to `captured_by` prefixes (`human:`, `agent:`).
- Required: Any external writer that previously sent `source="ui"` or `"mcp"` must send `source="manual"`.

<sup>Written for commit 5c264ace361fbceecb25500aee45828ffe2764bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized activity and record provenance to consistently identify manually created or updated information.
  * Improved search result ranking by considering content freshness and the reliability of its recorded source.
  * Updated employment, voice profile, signal, deal, and lead actions to use consistent origin labeling.
* **Data Updates**
  * Existing records using legacy origin labels are normalized to the new manual classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->