### PR TITLE
fix(deals): a deal can be marked won from the UI

### DIFF
--- a/docs/how-to/work-your-pipeline.md
+++ b/docs/how-to/work-your-pipeline.md
@@ -69,33 +69,37 @@ Moving to a **Won** or **Lost** stage never happens on the drop. A dialog asks f
 lights up. If you cancel — or press Escape, or click outside — anything you typed is cleared,
 so the next deal you close never inherits the last one's reason.
 
-**Won needs evidence, and this is the part that surprises people.** A deal can only be marked
-won when the deal has a **contract** attached that is:
+**Won asks what is behind the win.** Margince accepts a won deal two ways, and both are
+legitimate — it just refuses to record a win that says nothing at all.
 
-- past **draft**,
-- with a **Signed** date filled in,
-- carrying an attached file categorised **contract** or **legal**,
-- in a **current** or **final** document state.
+The first way is a **signed contract on the deal**. Press **Confirm** and, if one is there, the
+deal closes immediately with no further questions.
 
-**Today you cannot satisfy that from the UI, so a deal cannot be marked won here at all.**
-This is a defect, not something you are missing —
-[#2088](https://github.com/gradionhq/margince-poc-v1/issues/2088) — and until it is fixed,
-pressing **Won** leaves the deal open and prints a message naming values that appear nowhere in
-the interface.
+The second way is **saying there is no contract**. When there is none, the dialog does not give
+up — it stays open and asks:
 
-Two links in the chain are missing. The contract form (Company → **Documents** →
-**Add a contract**) has no field that names a **deal**, so a contract recorded there belongs to
-the company but not to the opportunity. And a contract is created in **draft** with no control
-anywhere to move it out, which the evidence rule also rejects. Recording the agreement and
-attaching the signed PDF both work; the two links that would make it count do not exist yet.
+> **How was it won?**
+> This deal has no signed contract attached, so tell us how it was won. The answer is kept on
+> the deal and counted in reports.
 
-The API can express all of it — including a short reason why there is no contract at all (an
-import, a purchase order, a verbal agreement, a renewal by email) — so anyone driving Margince
-through the API or an agent can close a won deal today. It is the screens that are missing.
+Pick one of five: **On a purchase order**, **Verbally, in person or by phone**, **Renewed by
+email**, **Imported from another system**, or **Something else**. Choosing *Something else*
+opens a **What was it?** box that must say something before **Confirm** lights up — the other
+four explain themselves, that one does not.
 
-Until then, a deal you have actually won stays open in Margince, and the honest workaround is to
-say so where a human will read it: put the outcome in a note on the deal, so the record does not
-silently claim the deal is still live.
+You are only asked when there is nothing to point at, so a deal with paper behind it is still
+one click. The answer is stored on the deal, which is what lets a report later count how many
+won deals had no agreement and why.
+
+Two things to know about the contract path, because you cannot complete it from the UI yet: the
+contract form (Company → **Documents** → **Add a contract**) has no field naming a **deal**, and
+a contract is created in **draft** with no control to move it out. Both links are missing, so in
+practice today every win goes through the reason. Recording the agreement and attaching the
+signed PDF still work and are still worth doing — they just do not yet count as the evidence.
+
+**The reason is not shown back on the deal afterwards**
+([#2105](https://github.com/gradionhq/margince-poc-v1/issues/2105)). It is recorded and reports
+can read it; the record page does not display it yet.
 
 **Closing is one deal at a time, on purpose.** The bulk bar offers open stages only: a lost
 reason is specific to one deal, and one reason standing for a dozen would be a lie in the
@@ -224,9 +228,11 @@ Stated plainly, so you don't hunt for them:
   ([#2034](https://github.com/gradionhq/margince-poc-v1/issues/2034))
 - **The board cannot be dragged on touch devices.** Use the deal page's stage stepper.
 - **There is no text search within the deals list.** Use global search.
-- **A deal cannot be marked won from the UI at all.** The evidence rule needs a contract linked
-  to the deal and out of draft, and no screen does either. See *Close a deal* above.
+- **A contract cannot be tied to a deal, or moved out of draft.** So a win always goes through
+  the reason rather than the paperwork. See *Close a deal* above.
   ([#2088](https://github.com/gradionhq/margince-poc-v1/issues/2088))
+- **A won deal does not show why it had no contract.** The answer is recorded, just not
+  displayed. ([#2105](https://github.com/gradionhq/margince-poc-v1/issues/2105))
 
 ## Where deals meet the rest of Margince
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1541,6 +1541,16 @@ export const de = {
   "deals.confirmTerminal":
     "Damit wird der Deal als {status} geschlossen. Erst bestätigen — bis dahin passiert nichts.",
   "deals.lostReason": "Verlustgrund",
+  "deals.winNoEvidence":
+    "Für diesen Deal ist kein unterschriebener Vertrag hinterlegt. Bitte geben Sie an, wie er gewonnen wurde. Die Angabe bleibt am Deal und wird in Berichten gezählt.",
+  "deals.winReason": "Wie wurde er gewonnen?",
+  "deals.winReasonPick": "Bitte auswählen",
+  "deals.winReasonImported": "Aus einem anderen System importiert",
+  "deals.winReasonPurchaseOrder": "Per Bestellung",
+  "deals.winReasonVerbal": "Mündlich, persönlich oder telefonisch",
+  "deals.winReasonRenewalByEmail": "Per E-Mail verlängert",
+  "deals.winReasonOther": "Etwas anderes",
+  "deals.winReasonDetail": "Was war es?",
   "deals.confirm": "Bestätigen",
   "deals.cancel": "Abbrechen",
   "deals.advanced": "Nach {stage} verschoben",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1545,6 +1545,16 @@ export const en = {
   "deals.confirmTerminal":
     "This closes the deal as {status}. Confirm first — nothing happens until you do.",
   "deals.lostReason": "Lost reason",
+  "deals.winNoEvidence":
+    "This deal has no signed contract attached, so tell us how it was won. The answer is kept on the deal and counted in reports.",
+  "deals.winReason": "How was it won?",
+  "deals.winReasonPick": "Pick how it was won",
+  "deals.winReasonImported": "Imported from another system",
+  "deals.winReasonPurchaseOrder": "On a purchase order",
+  "deals.winReasonVerbal": "Verbally, in person or by phone",
+  "deals.winReasonRenewalByEmail": "Renewed by email",
+  "deals.winReasonOther": "Something else",
+  "deals.winReasonDetail": "What was it?",
   "deals.confirm": "Confirm",
   "deals.cancel": "Cancel",
   "deals.advanced": "Moved to {stage}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1533,6 +1533,16 @@ export const vi = {
   "deals.confirmTerminal":
     "Thao tác này chốt deal ở trạng thái {status}. Hãy xác nhận trước — chưa có gì xảy ra cho đến khi bạn xác nhận.",
   "deals.lostReason": "Lý do thua",
+  "deals.winNoEvidence":
+    "Thương vụ này chưa có hợp đồng đã ký đính kèm, hãy cho biết nó được chốt bằng cách nào. Câu trả lời được lưu trên thương vụ và được tính trong báo cáo.",
+  "deals.winReason": "Chốt bằng cách nào?",
+  "deals.winReasonPick": "Chọn cách chốt",
+  "deals.winReasonImported": "Nhập từ hệ thống khác",
+  "deals.winReasonPurchaseOrder": "Theo đơn đặt hàng",
+  "deals.winReasonVerbal": "Bằng lời, trực tiếp hoặc qua điện thoại",
+  "deals.winReasonRenewalByEmail": "Gia hạn qua email",
+  "deals.winReasonOther": "Trường hợp khác",
+  "deals.winReasonDetail": "Cụ thể là gì?",
   "deals.confirm": "Xác nhận",
   "deals.cancel": "Huỷ",
   "deals.advanced": "Đã chuyển sang {stage}",

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -37,11 +37,11 @@ afterEach(() => {
 // Drops deal d1 on a stage column the way the board's drag does. jsdom carries
 // no drag-and-drop, so the drop handler is dispatched directly — the click path
 // the reader takes on touch is the stepper, which its own tests cover.
-function dropOnStage(stageId: string) {
+function dropOnStage(stageId: string, dealId = "d1") {
   const column = document.querySelector(
     `[data-stage="${stageId}"]`,
   ) as HTMLElement;
-  const dataTransfer = { getData: () => "d1", setData: () => {} };
+  const dataTransfer = { getData: () => dealId, setData: () => {} };
   const dropEvent = new Event("drop", { bubbles: true });
   Object.assign(dropEvent, { dataTransfer });
   column.dispatchEvent(dropEvent);
@@ -338,7 +338,10 @@ function stubBackend(
     // neither a contract nor a reason is refused 422 the way the real one
     // refuses it. Off by default, so every existing test keeps the deal that
     // wins on the first confirm.
-    demandsWinEvidence?: boolean;
+    //
+    // `true` refuses every deal; a list of ids refuses only those, which is how
+    // a test says "this deal has a contract and that one does not".
+    demandsWinEvidence?: boolean | readonly string[];
     single?: Deal;
     onPatch?: (body: unknown, ifMatch: string | null) => void;
     onDelete?: () => void;
@@ -425,8 +428,12 @@ function stubBackend(
         ? await request.json()
         : JSON.parse(String(init?.body));
       opts.onAdvance?.(body, request?.headers.get("If-Match") ?? null);
+      const advancedId = url.split("/deals/")[1]?.split("/")[0] ?? "";
+      const demands = Array.isArray(opts.demandsWinEvidence)
+        ? opts.demandsWinEvidence.includes(advancedId)
+        : Boolean(opts.demandsWinEvidence);
       if (
-        opts.demandsWinEvidence &&
+        demands &&
         body.status === "won" &&
         !body.won_without_contract_reason
       ) {
@@ -1021,6 +1028,141 @@ describe("DealsScreen", () => {
       won_without_contract_reason: "other",
       won_without_contract_detail: "a barter deal",
     });
+  });
+
+  // The refusal belongs to the deal that earned it. Read off the shared
+  // mutation's error instead, it outlives that deal: cancel, open Won on a
+  // deal that DOES have a contract, and the reason picker greets it — and the
+  // server takes a stated reason at its word without looking for a contract,
+  // so that deal is recorded as won-without-paper when it was not.
+  it("a refusal on one deal does not ask the next deal how it was won", async () => {
+    const withoutPaper = deal({ id: "d1", name: "No contract" });
+    const withPaper = deal({ id: "d2", name: "Has contract" });
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([withoutPaper, withPaper], {
+        // Only d1 lacks evidence. d2 wins on the first confirm.
+        demandsWinEvidence: ["d1"],
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await waitFor(() => expect(screen.getByText("No contract")).toBeTruthy());
+
+    dropOnStage("s3");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await waitFor(() =>
+      expect(screen.getByText("How was it won?")).toBeTruthy(),
+    );
+
+    // Walk away from that deal without answering.
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByText("Move to Won?")).toBeNull());
+
+    dropOnStage("s3", "d2");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+    expect(screen.queryByText("How was it won?")).toBeNull();
+  });
+
+  // A win that succeeds on the first confirm has nothing left to ask, so the
+  // dialog must close. Left open, its Confirm stays live over a version the
+  // write just replaced.
+  it("a win that needs no reason closes the dialog on success", async () => {
+    vi.stubGlobal("fetch", stubBackend([deal({})]));
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    dropOnStage("s3");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(screen.queryByText("Move to Won?")).toBeNull());
+  });
+
+  // The detail belongs to "Something else" alone. Carried across a change of
+  // reason it would be stored anyway — the server writes both columns as given
+  // — leaving text on the deal behind a field the reader can no longer see.
+  it('changing away from "Something else" does not send the detail', async () => {
+    const advances: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        demandsWinEvidence: true,
+        onAdvance: (body) => advances.push(body),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    dropOnStage("s3");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await waitFor(() =>
+      expect(screen.getByText("How was it won?")).toBeTruthy(),
+    );
+
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "How was it won?" }),
+      "Something else",
+    );
+    await user.type(screen.getByLabelText("What was it?"), "a barter deal");
+
+    // Change your mind: the detail field disappears, and so must its text.
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "How was it won?" }),
+      "On a purchase order",
+    );
+    expect(screen.queryByLabelText("What was it?")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(advances).toHaveLength(2));
+    expect(advances[1]).toEqual({
+      to_stage_id: "s3",
+      status: "won",
+      won_without_contract_reason: "purchase_order",
+    });
+  });
+
+  // The server rejects a detail of format-only characters (`saysSomething` in
+  // win_evidence.go). Enabling Confirm on one earns a second refusal for the
+  // omission the reader was already asked about.
+  it('a zero-width detail does not satisfy "Something else"', async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], { demandsWinEvidence: true }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    dropOnStage("s3");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await waitFor(() =>
+      expect(screen.getByText("How was it won?")).toBeTruthy(),
+    );
+
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "How was it won?" }),
+      "Something else",
+    );
+    await user.type(screen.getByLabelText("What was it?"), "​​");
+
+    expect(
+      screen.getByRole("button", { name: "Confirm" }).hasAttribute("disabled"),
+    ).toBe(true);
   });
 
   it("the advance-confirm dot reads the live catalog tier, not a hardcode", async () => {

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -34,6 +34,19 @@ afterEach(() => {
   localStorage.clear();
 });
 
+// Drops deal d1 on a stage column the way the board's drag does. jsdom carries
+// no drag-and-drop, so the drop handler is dispatched directly — the click path
+// the reader takes on touch is the stepper, which its own tests cover.
+function dropOnStage(stageId: string) {
+  const column = document.querySelector(
+    `[data-stage="${stageId}"]`,
+  ) as HTMLElement;
+  const dataTransfer = { getData: () => "d1", setData: () => {} };
+  const dropEvent = new Event("drop", { bubbles: true });
+  Object.assign(dropEvent, { dataTransfer });
+  column.dispatchEvent(dropEvent);
+}
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -321,6 +334,11 @@ function stubBackend(
   deals: Deal[],
   opts: {
     onAdvance?: (body: unknown, ifMatch: string | null) => void;
+    // Makes the stub enforce the server's win-evidence rule: a win naming
+    // neither a contract nor a reason is refused 422 the way the real one
+    // refuses it. Off by default, so every existing test keeps the deal that
+    // wins on the first confirm.
+    demandsWinEvidence?: boolean;
     single?: Deal;
     onPatch?: (body: unknown, ifMatch: string | null) => void;
     onDelete?: () => void;
@@ -407,6 +425,28 @@ function stubBackend(
         ? await request.json()
         : JSON.parse(String(init?.body));
       opts.onAdvance?.(body, request?.headers.get("If-Match") ?? null);
+      if (
+        opts.demandsWinEvidence &&
+        body.status === "won" &&
+        !body.won_without_contract_reason
+      ) {
+        return jsonResponse(
+          {
+            code: "validation_error",
+            details: {
+              errors: [
+                {
+                  field: "won_without_contract_reason",
+                  code: "win_evidence_required",
+                  message:
+                    "a won deal needs a signed contract with its paper attached, or a reason why there is none",
+                },
+              ],
+            },
+          },
+          422,
+        );
+      }
       return jsonResponse(deal({ stage_id: body.to_stage_id }));
     }
     if (method === "GET" && /\/deals\/[^/?]+(\?.*)?$/.test(url)) {
@@ -879,6 +919,108 @@ describe("DealsScreen", () => {
     await userEvent.click(screen.getByRole("button", { name: "Confirm" }));
     await waitFor(() => expect(advances).toHaveLength(1));
     expect(advances[0]).toEqual([{ to_stage_id: "s3", status: "won" }, "4"]);
+  });
+
+  // A deal genuinely won on a purchase order or a phone call has no contract to
+  // point at, and before this the confirm dialog offered no way to say so: the
+  // win was refused, the reason the server wanted appeared in no field, and the
+  // deal stayed open. The dialog now asks the question the refusal implies.
+  it("a win the server refuses for want of evidence asks how it was won, and sends the answer", async () => {
+    const advances: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        demandsWinEvidence: true,
+        onAdvance: (body) => advances.push(body),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    dropOnStage("s3");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+
+    // The first confirm asks for nothing: a deal WITH a contract wins here, and
+    // only the server knows which this is.
+    expect(screen.queryByText("How was it won?")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    // Refused — the dialog stays open and grows the question rather than
+    // dropping the reader back on a board that has snapped the card home.
+    await waitFor(() =>
+      expect(screen.getByText("How was it won?")).toBeTruthy(),
+    );
+    expect(screen.getByText("Move to Won?")).toBeTruthy();
+    expect(advances).toHaveLength(1);
+
+    // Confirm stays refused until the question is answered.
+    expect(
+      screen.getByRole("button", { name: "Confirm" }).hasAttribute("disabled"),
+    ).toBe(true);
+
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "How was it won?" }),
+      "On a purchase order",
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(advances).toHaveLength(2));
+    expect(advances[1]).toEqual({
+      to_stage_id: "s3",
+      status: "won",
+      won_without_contract_reason: "purchase_order",
+    });
+  });
+
+  // "Something else" is the one member that explains nothing on its own, so the
+  // server demands a detail after it. Sending the reason without one would be a
+  // refusal the reader could have been spared.
+  it('picking "Something else" holds Confirm until the detail says what it was', async () => {
+    const advances: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        demandsWinEvidence: true,
+        onAdvance: (body) => advances.push(body),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    dropOnStage("s3");
+    await waitFor(() => expect(screen.getByText("Move to Won?")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await waitFor(() =>
+      expect(screen.getByText("How was it won?")).toBeTruthy(),
+    );
+
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "How was it won?" }),
+      "Something else",
+    );
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    expect(confirm.hasAttribute("disabled")).toBe(true);
+
+    await user.type(screen.getByLabelText("What was it?"), "a barter deal");
+    expect(confirm.hasAttribute("disabled")).toBe(false);
+    await user.click(confirm);
+
+    await waitFor(() => expect(advances).toHaveLength(2));
+    expect(advances[1]).toEqual({
+      to_stage_id: "s3",
+      status: "won",
+      won_without_contract_reason: "other",
+      won_without_contract_detail: "a barter deal",
+    });
   });
 
   it("the advance-confirm dot reads the live catalog tier, not a hardcode", async () => {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -750,11 +750,10 @@ function dealColumns(
 /**
  * The closed vocabulary for winning a deal with no contract behind it.
  *
- * The type comes from the generated contract, so adding a member to `crm.yaml`
- * without offering it here stops compiling rather than silently leaving a
- * choice the server accepts and no screen shows. `WON_REASONS` is the display
- * order — deliberately not the contract's, which is a storage list; this one
- * puts the two answers a rep actually reaches for first.
+ * The type comes from the generated contract, and the labels are a Record over
+ * it, so adding a member to `crm.yaml` stops this file compiling until the new
+ * member has a label — rather than leaving a choice the server accepts and no
+ * screen offers.
  */
 type WonReason = NonNullable<
   NonNullable<
@@ -762,13 +761,46 @@ type WonReason = NonNullable<
   >
 >;
 
-const WON_REASONS: readonly { value: WonReason; label: MessageKey }[] = [
-  { value: "purchase_order", label: "deals.winReasonPurchaseOrder" },
-  { value: "verbal", label: "deals.winReasonVerbal" },
-  { value: "renewal_by_email", label: "deals.winReasonRenewalByEmail" },
-  { value: "imported", label: "deals.winReasonImported" },
-  { value: "other", label: "deals.winReasonOther" },
+const WON_REASON_LABELS: Record<WonReason, MessageKey> = {
+  purchase_order: "deals.winReasonPurchaseOrder",
+  verbal: "deals.winReasonVerbal",
+  renewal_by_email: "deals.winReasonRenewalByEmail",
+  imported: "deals.winReasonImported",
+  other: "deals.winReasonOther",
+};
+
+// Display order — deliberately not the contract's, which is a storage list.
+// This one puts the answers a rep reaches for first. The Record above is what
+// guarantees the set is complete; this only decides the sequence.
+const WON_REASONS: readonly WonReason[] = [
+  "purchase_order",
+  "verbal",
+  "renewal_by_email",
+  "imported",
+  "other",
 ];
+
+// Narrows the Select's plain string back to the vocabulary. The control is
+// built from WON_REASONS, so this never rejects in practice — but a cast would
+// make that an assumption instead of a check, and the value goes on to be
+// stored as an assertion about how a deal closed.
+function asWonReason(value: string): WonReason | "" {
+  const known = WON_REASONS.find((reason) => reason === value);
+  return known ?? "";
+}
+
+/**
+ * Whether a detail carries any visible character, matching the rule the server
+ * applies (`saysSomething` in win_evidence.go).
+ *
+ * `trim()` alone is not the same test. A zero-width space is not whitespace to
+ * either language, so a detail of "​" would pass a trim check here, enable
+ * Confirm, and then be refused by the server — the reader having explained
+ * precisely nothing, which is the state the vocabulary exists to prevent.
+ */
+function saysSomething(text: string): boolean {
+  return /\P{White_Space}/u.test(text.replace(/\p{Cf}/gu, ""));
+}
 
 // The one member that explains nothing on its own, so the server demands a
 // detail after it (`WonReasonDetailRequiredError`).
@@ -1485,8 +1517,15 @@ export function DealsScreen({
       <ConfirmAdvanceModal
         pending={pending}
         onClose={() => setPending(null)}
-        onConfirm={(input) => advance.mutate(input)}
-        advanceError={advance.error}
+        onConfirm={(input) =>
+          // mutateAsync REJECTS on failure; this dialog wants the outcome, and
+          // an unhandled rejection in a click handler is not one. onError still
+          // runs, so the screen's own error surface is unaffected.
+          advance.mutateAsync(input).then(
+            () => null,
+            (error: unknown) => error,
+          )
+        }
       />
     </div>
   );
@@ -1505,21 +1544,31 @@ function ConfirmAdvanceModal({
   pending,
   onClose,
   onConfirm,
-  advanceError,
 }: Readonly<{
   pending: PendingAdvance | null;
   onClose: () => void;
-  onConfirm: (input: AdvanceInput) => void;
-  // The last advance failure, so this dialog can tell the one refusal it must
-  // answer — "this win names no evidence" — from every other 422 and 409, which
-  // it must not. Undefined on the surfaces that do not track it.
-  advanceError?: unknown;
+  // Resolves when the advance settles, so this dialog acts on the outcome of
+  // THIS attempt. It returns the error rather than throwing it: the caller's
+  // own error surface still reports the failure, and a rejection here would be
+  // an unhandled one in an event handler.
+  onConfirm: (input: AdvanceInput) => Promise<unknown>;
 }>) {
   const t = useT();
   const tierMap = useAgentTierMap();
   const [lostReason, setLostReason] = useState("");
-  const [wonReason, setWonReason] = useState("");
+  const [wonReason, setWonReason] = useState<WonReason | "">("");
   const [wonDetail, setWonDetail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  // The deal this dialog has been told has no contract behind it, pinned to the
+  // exact attempt that was refused.
+  //
+  // Read off the shared mutation's `error` instead, the refusal outlives the
+  // deal that earned it: cancel here, open Won on a DIFFERENT deal, and the
+  // reason panel greets a deal that may well have a contract — and the server
+  // takes a stated reason at its word without looking for one, so that deal is
+  // recorded as won-without-paper when it was not. That falsifies the exact
+  // count the reason vocabulary exists to make truthful.
+  const [refusedDealId, setRefusedDealId] = useState<string | null>(null);
 
   // EVERY way out of this dialog clears what was typed — the buttons, Escape,
   // and the backdrop alike. The component stays mounted between openings, so a
@@ -1529,18 +1578,20 @@ function ConfirmAdvanceModal({
     setLostReason("");
     setWonReason("");
     setWonDetail("");
+    setRefusedDealId(null);
     onClose();
   };
 
   const needsLostReason = pending?.toStage.semantic === "lost";
-  // The reason panel appears only once the server has ASKED for it. A win with
-  // a signed contract is one click, exactly as before: making every rep justify
-  // a win the paperwork already explains is how a required field becomes a
-  // field everyone fills with the same lie.
+  // The reason panel appears only once the server has asked for it, and only
+  // for the deal it asked about. A win with a signed contract is one click,
+  // exactly as before: making every rep justify a win the paperwork already
+  // explains is how a required field becomes a field everyone fills with the
+  // same lie.
   const needsWonReason =
-    pending?.toStage.semantic === "won" && winEvidenceRefused(advanceError);
+    pending?.toStage.semantic === "won" && refusedDealId === pending.dealId;
   const detailMissing =
-    wonReason === WON_REASON_NEEDING_DETAIL && wonDetail.trim() === "";
+    wonReason === WON_REASON_NEEDING_DETAIL && !saysSomething(wonDetail);
 
   return (
     <Modal open={pending !== null} onClose={dismiss} labelledBy="advance-title">
@@ -1569,7 +1620,16 @@ function ConfirmAdvanceModal({
             <WonReasonFields
               reason={wonReason}
               detail={wonDetail}
-              onReason={setWonReason}
+              onReason={(next) => {
+                setWonReason(next);
+                // The detail belongs to "Something else" alone. Kept across a
+                // change of reason it would sit invisibly behind a field the
+                // reader can no longer see, which is not a state they can
+                // correct.
+                if (next !== WON_REASON_NEEDING_DETAIL) {
+                  setWonDetail("");
+                }
+              }}
               onDetail={setWonDetail}
             />
           )}
@@ -1578,29 +1638,32 @@ function ConfirmAdvanceModal({
             <Button
               variant="primary"
               disabled={
+                submitting ||
                 (needsLostReason && lostReason.trim() === "") ||
                 (needsWonReason && (wonReason === "" || detailMissing))
               }
-              onClick={() => {
-                onConfirm({
+              onClick={async () => {
+                setSubmitting(true);
+                const error = await onConfirm({
                   dealId: pending.dealId,
                   version: pending.version,
                   toStage: pending.toStage,
                   lostReason: lostReason.trim() || undefined,
-                  ...(needsWonReason
-                    ? {
-                        wonWithoutContractReason: wonReason as WonReason,
-                        wonWithoutContractDetail: wonDetail.trim() || undefined,
-                      }
-                    : {}),
+                  ...wonAnswer(needsWonReason, wonReason, wonDetail),
                 });
-                // A win the server may still refuse for want of evidence keeps
-                // the dialog open, so the reason panel can appear in place
-                // rather than the reader having to start the move again from a
-                // board that has already snapped the card back.
-                if (pending.toStage.semantic !== "won" || needsWonReason) {
-                  dismiss();
+                setSubmitting(false);
+                // ONE refusal keeps this dialog open: the server saying this
+                // win names no evidence, because the answer to that is a field
+                // the reader can fill in right here. Every other outcome closes
+                // it — a success has nothing left to ask, and a 403 or a 409
+                // has no answer this dialog can offer, so holding it open would
+                // trap the reader behind a modal whose error text renders on
+                // the screen underneath it.
+                if (error && winEvidenceRefused(error)) {
+                  setRefusedDealId(pending.dealId);
+                  return;
                 }
+                dismiss();
               }}
             >
               {t("deals.confirm")}
@@ -1610,6 +1673,27 @@ function ConfirmAdvanceModal({
       )}
     </Modal>
   );
+}
+
+/**
+ * The won-without-contract answer as the advance should carry it, or nothing.
+ *
+ * The detail rides ONLY with the reason that needs one. Sent alongside any
+ * other reason it would be stored anyway — the server writes both columns as
+ * given — so a reader who typed a detail under "Something else" and then chose
+ * "On a purchase order" would leave text on the deal, and in its audit trail,
+ * that they had every reason to believe they had discarded when the field
+ * disappeared.
+ */
+function wonAnswer(active: boolean, reason: WonReason | "", detail: string) {
+  if (!active || reason === "") {
+    return {};
+  }
+  const explained = reason === WON_REASON_NEEDING_DETAIL;
+  return {
+    wonWithoutContractReason: reason,
+    wonWithoutContractDetail: explained ? detail.trim() : undefined,
+  };
 }
 
 // Whether a failed advance is the server asking how a contract-less deal was
@@ -1629,9 +1713,9 @@ function WonReasonFields({
   onReason,
   onDetail,
 }: Readonly<{
-  reason: string;
+  reason: WonReason | "";
   detail: string;
-  onReason: (value: string) => void;
+  onReason: (value: WonReason | "") => void;
   onDetail: (value: string) => void;
 }>) {
   const t = useT();
@@ -1648,10 +1732,10 @@ function WonReasonFields({
           aria-labelledby="won-reason-label"
           placeholder={t("deals.winReasonPick")}
           value={reason}
-          onChange={onReason}
+          onChange={(value) => onReason(asWonReason(value))}
           options={WON_REASONS.map((option) => ({
-            value: option.value,
-            label: t(option.label),
+            value: option,
+            label: t(WON_REASON_LABELS[option]),
           }))}
         />
       </div>
@@ -2642,8 +2726,12 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
               <ConfirmAdvanceModal
                 pending={pending}
                 onClose={() => setPending(null)}
-                onConfirm={(input) => advance.mutate(input)}
-                advanceError={advance.error}
+                onConfirm={(input) =>
+                  advance.mutateAsync(input).then(
+                    () => null,
+                    (error: unknown) => error,
+                  )
+                }
               />
               <ToastRegion toast={toast} />
             </RecordView>

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -57,6 +57,7 @@ import { ArchiveAction } from "./archive";
 import {
   LoadMoreButton,
   OverlayUnavailable,
+  problemFieldErrorsOf,
   problemMessageOf,
   provenanceOf,
   QueryGate,
@@ -746,6 +747,39 @@ function dealColumns(
   ];
 }
 
+/**
+ * The closed vocabulary for winning a deal with no contract behind it.
+ *
+ * The type comes from the generated contract, so adding a member to `crm.yaml`
+ * without offering it here stops compiling rather than silently leaving a
+ * choice the server accepts and no screen shows. `WON_REASONS` is the display
+ * order — deliberately not the contract's, which is a storage list; this one
+ * puts the two answers a rep actually reaches for first.
+ */
+type WonReason = NonNullable<
+  NonNullable<
+    components["schemas"]["AdvanceDealRequest"]["won_without_contract_reason"]
+  >
+>;
+
+const WON_REASONS: readonly { value: WonReason; label: MessageKey }[] = [
+  { value: "purchase_order", label: "deals.winReasonPurchaseOrder" },
+  { value: "verbal", label: "deals.winReasonVerbal" },
+  { value: "renewal_by_email", label: "deals.winReasonRenewalByEmail" },
+  { value: "imported", label: "deals.winReasonImported" },
+  { value: "other", label: "deals.winReasonOther" },
+];
+
+// The one member that explains nothing on its own, so the server demands a
+// detail after it (`WonReasonDetailRequiredError`).
+const WON_REASON_NEEDING_DETAIL: WonReason = "other";
+
+// The server's refusal when a win names neither a contract nor a reason. The
+// dialog keys on THIS rather than on the 422 status: an advance can be refused
+// for reasons that have nothing to do with evidence, and asking "how was it
+// won?" after a version conflict would be nonsense.
+const WIN_EVIDENCE_REQUIRED = "win_evidence_required";
+
 type PendingAdvance = {
   dealId: string;
   // Carried through the confirm rather than looked up when it closes: the write
@@ -760,6 +794,12 @@ type AdvanceInput = {
   version: number | undefined;
   toStage: Stage;
   lostReason?: string;
+  // Why this win has no signed contract behind it. Absent on the ordinary win,
+  // where the contract IS the answer — the server distinguishes the two, and
+  // that distinction is what makes "how many won deals have no paper" a
+  // question reports can answer.
+  wonWithoutContractReason?: WonReason;
+  wonWithoutContractDetail?: string;
 };
 
 /**
@@ -776,6 +816,28 @@ type AdvanceInput = {
  * instance minted here would be a second one the caller's `ToastRegion` never
  * renders, and every confirmation would be shown to nobody.
  */
+/**
+ * What a terminal advance says about HOW the deal closed, on top of the stage
+ * and status every advance carries.
+ *
+ * A lost deal states its reason. A won deal states one only when there is no
+ * signed contract to point at — the server looks for the contract first, and a
+ * win that has one says nothing here, which is what keeps "won with paper" and
+ * "won without it" distinguishable in reports.
+ */
+function closingFields(input: AdvanceInput) {
+  if (input.toStage.semantic === "lost") {
+    return { lost_reason: input.lostReason };
+  }
+  if (input.toStage.semantic === "won" && input.wonWithoutContractReason) {
+    return {
+      won_without_contract_reason: input.wonWithoutContractReason,
+      won_without_contract_detail: input.wonWithoutContractDetail,
+    };
+  }
+  return {};
+}
+
 function useAdvanceDeal(toast: Toast) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -790,9 +852,7 @@ function useAdvanceDeal(toast: Toast) {
         body: {
           to_stage_id: input.toStage.id,
           ...(terminal ? { status: input.toStage.semantic } : {}),
-          ...(input.toStage.semantic === "lost"
-            ? { lost_reason: input.lostReason }
-            : {}),
+          ...closingFields(input),
         },
       });
       if (error) {
@@ -1426,6 +1486,7 @@ export function DealsScreen({
         pending={pending}
         onClose={() => setPending(null)}
         onConfirm={(input) => advance.mutate(input)}
+        advanceError={advance.error}
       />
     </div>
   );
@@ -1444,23 +1505,42 @@ function ConfirmAdvanceModal({
   pending,
   onClose,
   onConfirm,
+  advanceError,
 }: Readonly<{
   pending: PendingAdvance | null;
   onClose: () => void;
   onConfirm: (input: AdvanceInput) => void;
+  // The last advance failure, so this dialog can tell the one refusal it must
+  // answer — "this win names no evidence" — from every other 422 and 409, which
+  // it must not. Undefined on the surfaces that do not track it.
+  advanceError?: unknown;
 }>) {
   const t = useT();
   const tierMap = useAgentTierMap();
   const [lostReason, setLostReason] = useState("");
+  const [wonReason, setWonReason] = useState("");
+  const [wonDetail, setWonDetail] = useState("");
 
-  // EVERY way out of this dialog clears the reason — the buttons, Escape, and
-  // the backdrop alike. The component stays mounted between openings, so a
+  // EVERY way out of this dialog clears what was typed — the buttons, Escape,
+  // and the backdrop alike. The component stays mounted between openings, so a
   // reason typed and then abandoned would otherwise still be sitting there the
   // next time a deal is closed, and it would describe a different deal.
   const dismiss = () => {
     setLostReason("");
+    setWonReason("");
+    setWonDetail("");
     onClose();
   };
+
+  const needsLostReason = pending?.toStage.semantic === "lost";
+  // The reason panel appears only once the server has ASKED for it. A win with
+  // a signed contract is one click, exactly as before: making every rep justify
+  // a win the paperwork already explains is how a required field becomes a
+  // field everyone fills with the same lie.
+  const needsWonReason =
+    pending?.toStage.semantic === "won" && winEvidenceRefused(advanceError);
+  const detailMissing =
+    wonReason === WON_REASON_NEEDING_DETAIL && wonDetail.trim() === "";
 
   return (
     <Modal open={pending !== null} onClose={dismiss} labelledBy="advance-title">
@@ -1473,7 +1553,7 @@ function ConfirmAdvanceModal({
           <p className="t-caption" style={{ marginTop: "var(--space-2)" }}>
             {t("deals.confirmTerminal", { status: pending.toStage.semantic })}
           </p>
-          {pending.toStage.semantic === "lost" && (
+          {needsLostReason && (
             <div className="field" style={{ marginTop: "var(--space-2)" }}>
               <span className="t-label" id="lost-reason-label">
                 {t("deals.lostReason")}
@@ -1485,12 +1565,21 @@ function ConfirmAdvanceModal({
               />
             </div>
           )}
+          {needsWonReason && (
+            <WonReasonFields
+              reason={wonReason}
+              detail={wonDetail}
+              onReason={setWonReason}
+              onDetail={setWonDetail}
+            />
+          )}
           <div className="actions">
             <Button onClick={dismiss}>{t("deals.cancel")}</Button>
             <Button
               variant="primary"
               disabled={
-                pending.toStage.semantic === "lost" && lostReason.trim() === ""
+                (needsLostReason && lostReason.trim() === "") ||
+                (needsWonReason && (wonReason === "" || detailMissing))
               }
               onClick={() => {
                 onConfirm({
@@ -1498,8 +1587,20 @@ function ConfirmAdvanceModal({
                   version: pending.version,
                   toStage: pending.toStage,
                   lostReason: lostReason.trim() || undefined,
+                  ...(needsWonReason
+                    ? {
+                        wonWithoutContractReason: wonReason as WonReason,
+                        wonWithoutContractDetail: wonDetail.trim() || undefined,
+                      }
+                    : {}),
                 });
-                dismiss();
+                // A win the server may still refuse for want of evidence keeps
+                // the dialog open, so the reason panel can appear in place
+                // rather than the reader having to start the move again from a
+                // board that has already snapped the card back.
+                if (pending.toStage.semantic !== "won" || needsWonReason) {
+                  dismiss();
+                }
               }}
             >
               {t("deals.confirm")}
@@ -1508,6 +1609,65 @@ function ConfirmAdvanceModal({
         </>
       )}
     </Modal>
+  );
+}
+
+// Whether a failed advance is the server asking how a contract-less deal was
+// won. Keyed on the field code, not the 422: an advance is refused for several
+// reasons, and only this one has an answer the reader can give here.
+function winEvidenceRefused(error: unknown): boolean {
+  return problemFieldErrorsOf(error).some(
+    (fault) => fault.code === WIN_EVIDENCE_REQUIRED,
+  );
+}
+
+// The reason a deal was won with no paper behind it: a closed vocabulary, plus
+// the free-text detail the one open-ended member needs.
+function WonReasonFields({
+  reason,
+  detail,
+  onReason,
+  onDetail,
+}: Readonly<{
+  reason: string;
+  detail: string;
+  onReason: (value: string) => void;
+  onDetail: (value: string) => void;
+}>) {
+  const t = useT();
+  return (
+    <>
+      <p className="t-caption" style={{ marginTop: "var(--space-2)" }}>
+        {t("deals.winNoEvidence")}
+      </p>
+      <div className="field" style={{ marginTop: "var(--space-2)" }}>
+        <span className="t-label" id="won-reason-label">
+          {t("deals.winReason")}
+        </span>
+        <Select
+          aria-labelledby="won-reason-label"
+          placeholder={t("deals.winReasonPick")}
+          value={reason}
+          onChange={onReason}
+          options={WON_REASONS.map((option) => ({
+            value: option.value,
+            label: t(option.label),
+          }))}
+        />
+      </div>
+      {reason === WON_REASON_NEEDING_DETAIL && (
+        <div className="field" style={{ marginTop: "var(--space-2)" }}>
+          <span className="t-label" id="won-detail-label">
+            {t("deals.winReasonDetail")}
+          </span>
+          <TextInput
+            aria-labelledby="won-detail-label"
+            value={detail}
+            onChange={(event) => onDetail(event.target.value)}
+          />
+        </div>
+      )}
+    </>
   );
 }
 
@@ -2483,6 +2643,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                 pending={pending}
                 onClose={() => setPending(null)}
                 onConfirm={(input) => advance.mutate(input)}
+                advanceError={advance.error}
               />
               <ToastRegion toast={toast} />
             </RecordView>


### PR DESCRIPTION
## What was broken

**No deal could be closed as won from any screen.** Not a company-less deal — any deal. This was #2088, filed as `priority: critical`.

The win-evidence rule (`backend/internal/modules/deals/win_evidence.go`) admits a win two ways:

1. a signed contract **on the deal**, past draft, with its paper attached; or
2. a stated reason why there is none, from a closed vocabulary.

Neither was reachable. Path 1 has no UI at all — nothing sets `contract.deal_id` and no screen moves a contract out of `draft`. Path 2 had no field. So pressing **Won** always produced a 422, the deal stayed open, and the message named raw enum members (`imported, purchase_order, verbal, renewal_by_email, other`) that appear nowhere in the interface.

## The fix

The confirm dialog offers the reason — **but only once the server has asked for it.**

The first **Confirm** sends the win exactly as before, so a deal that *has* a contract closes in one click. Only when the server answers `win_evidence_required` does the dialog stay open and grow the question, rather than dropping the reader back on a board that has already snapped the card home.

This ordering is deliberate. Asking every rep to justify a win the paperwork already explains is how a required field becomes a field everyone fills with the same lie — and it would also make "won with paper" and "won without it" indistinguishable in reports, which is the whole reason the server keeps them apart.

Two details that follow the server's own rules:

- **"Something else" holds Confirm until the detail says what it was** (`WonReasonDetailRequiredError`), so the reader is not refused twice for the same omission.
- **The dialog keys on the field code, not the 422.** An advance is refused for several reasons — a version conflict among them — and only this one has an answer the reader can give in this dialog.

The reason vocabulary's TS type is derived from the generated contract, so adding a member to `crm.yaml` without offering it here stops compiling instead of silently leaving a choice the server accepts and no screen shows.

Both surfaces are covered by one change: the board's drag and the deal page's stepper share this dialog.

## Scope

**Frontend only.** Every field already existed in `crm.yaml`, was already mapped in `advanceDealInput`, and was already validated and persisted. Only the UI was missing. No contract change, no migration, no `make gen`.

## Verification

Driven in a browser against a real stack, not only against the test stub:

- Pressing **Won** on a deal with no contract → dialog stays open, reason panel appears, **Confirm** disabled until a reason is picked.
- Picking *On a purchase order* and confirming → deal reads **won**, stepper goes inert, `won_without_contract_reason = purchase_order` in the row.
- The write shape held: domain row + `audit_log` (`advance_stage`) + `event_outbox` (`deal.stage_changed`, `to_status: won`) in one transaction, linked by `audit_log_id` and `correlation_id`.
- The real server's refusal body was confirmed to be `details.errors[].code = "win_evidence_required"` — the exact shape the dialog matches on.

Both new tests were mutation-checked twice: once with the reason panel suppressed, once with the request-body wiring removed. Each half fails independently, so neither passes for the wrong reason.

`make check-fe` green. `make craft-static` and `make rls-store-path` green.

## Not in this change

The stored reason is never displayed back on the won deal — filed separately rather than widening this fix.

Closes #2088

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow deals to be closed as Won from the UI. Old behavior: clicking Won returned 422 and left the deal open. New behavior: a deal with a signed contract closes in one click; otherwise the dialog asks how it was won and gates Confirm accordingly.

- The first Confirm is unchanged; on `win_evidence_required` the dialog stays open, renders a reason selector, and disables Confirm until answered. “Something else” additionally requires a detail; zero‑width input is rejected to match the server’s rule.
- Detection keys on the problem field code, not HTTP status. The refusal is pinned to the specific deal; opening Won on another deal does not inherit the reason UI.
- The dialog closes on success and for non‑evidence errors; it stays open only for a win‑evidence refusal. Confirm is disabled while submitting. State clears on dismiss.
- The reason detail is cleared when changing away from “Something else” and is only sent with that reason.
- Won‑reason type is derived from the generated contract; adding a reason in `crm.yaml` without wiring it here fails compilation.
- Shared dialog for board drag and the deal stepper; i18n strings added in `en`, `de`, and `vi`. Docs updated to describe both win paths and current contract‑linking limits.
- Frontend only; no API or contract changes; no migration. Tests cover the server‑demanded evidence path, dialog lifecycle, “other + detail” validation (including zero‑width), state isolation between deals, and non‑regression of ordinary advances.

<sup>Written for commit e193ec50f34131dedb3759775b577521b8da298f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

