### PR TITLE
feat(privacy): record history names the tool, not "an agent"

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -22104,6 +22104,15 @@ components:
         actor_name: { type: [string, 'null'], description: "Resolved display name for a human actor_id; null for machine actors and for a member whose user row no longer resolves." }
         on_behalf_of: { type: [string, 'null'], format: uuid, description: Granting human's user id for agent actions. }
         on_behalf_of_name: { type: [string, 'null'], description: Resolved display name for on_behalf_of. }
+        agent_client:
+          type: [string, 'null']
+          description: |
+            The NAME of the tool a delegated change was typed through — "Claude",
+            "Cursor" — resolved from the OAuth client behind the row's passport.
+            Null when the passport was minted by hand in Settings (there is no
+            registered client to name), when the client row is gone, and for
+            every write that was not delegated. A reader that has it should say
+            "via {agent_client}" where it would otherwise say "via an agent".
         action: { type: string }
         occurred_at: { type: string, format: date-time }
         authorization_rule: { type: [string, 'null'] }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12213,13 +12213,21 @@ type AuditHistoryEntry struct {
 	ActorId string `json:"actor_id"`
 
 	// ActorName Resolved display name for a human actor_id; null for machine actors and for a member whose user row no longer resolves.
-	ActorName         *string                    `json:"actor_name,omitempty"`
-	ActorType         AuditHistoryEntryActorType `json:"actor_type"`
-	After             *map[string]interface{}    `json:"after,omitempty"`
-	AuthorizationRule *string                    `json:"authorization_rule,omitempty"`
-	Before            *map[string]interface{}    `json:"before,omitempty"`
-	Id                openapi_types.UUID         `json:"id"`
-	OccurredAt        time.Time                  `json:"occurred_at"`
+	ActorName *string                    `json:"actor_name,omitempty"`
+	ActorType AuditHistoryEntryActorType `json:"actor_type"`
+	After     *map[string]interface{}    `json:"after,omitempty"`
+
+	// AgentClient The NAME of the tool a delegated change was typed through — "Claude",
+	// "Cursor" — resolved from the OAuth client behind the row's passport.
+	// Null when the passport was minted by hand in Settings (there is no
+	// registered client to name), when the client row is gone, and for
+	// every write that was not delegated. A reader that has it should say
+	// "via {agent_client}" where it would otherwise say "via an agent".
+	AgentClient       *string                 `json:"agent_client,omitempty"`
+	AuthorizationRule *string                 `json:"authorization_rule,omitempty"`
+	Before            *map[string]interface{} `json:"before,omitempty"`
+	Id                openapi_types.UUID      `json:"id"`
+	OccurredAt        time.Time               `json:"occurred_at"`
 
 	// OnBehalfOf Granting human's user id for agent actions.
 	OnBehalfOf *openapi_types.UUID `json:"on_behalf_of,omitempty"`

--- a/backend/internal/modules/privacy/handlers_recordhistory.go
+++ b/backend/internal/modules/privacy/handlers_recordhistory.go
@@ -69,6 +69,7 @@ func recordHistoryEntryToWire(e RecordHistoryEntry) crmcontracts.AuditHistoryEnt
 		OccurredAt:        e.OccurredAt,
 		AuthorizationRule: e.AuthorizationRule,
 		OnBehalfOfName:    e.OnBehalfOfName,
+		AgentClient:       e.AgentClient,
 		Summary:           e.Summary,
 	}
 	if e.OnBehalfOf != nil {

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -142,6 +142,26 @@ const auditActorNameJoins = `
 		  ON a.actor_type = 'human' AND a.actor_id = 'human:' || actor_user.id::text
 		LEFT JOIN app_user obo ON obo.id = a.on_behalf_of`
 
+// agentClientNameJoin resolves the NAME of the tool a delegated change was
+// typed through — "Claude", "Cursor" — from the passport the row recorded.
+//
+// Three hops, all of them nullable, and each null means something different:
+// a passport minted by hand in Settings has no oauth_grant_id (a person made
+// it for themselves, and its own label is whatever they typed); a grant whose
+// client row was deleted resolves nothing; and a row with no passport at all
+// was not a delegated write. Every one of those falls back to the generic
+// "via an agent", which is why this is a LEFT JOIN chain and not a filter.
+//
+// The client name is not a workspace-scoped lookup by accident: oauth_client
+// is keyed (workspace_id, client_id), so the join carries the grant's own
+// workspace rather than the caller's — the row says which grant wrote it, and
+// that grant belongs to exactly one workspace.
+const agentClientNameJoin = `
+		LEFT JOIN passport p ON p.id = a.passport_id
+		LEFT JOIN oauth_grant g ON g.id = p.oauth_grant_id
+		LEFT JOIN oauth_client oc
+		  ON oc.workspace_id = g.workspace_id AND oc.client_id = g.client_id`
+
 // RecordHistoryFilter carries the validated query surface of
 // (GET /records/{entity_type}/{id}/history).
 type RecordHistoryFilter struct {
@@ -172,6 +192,11 @@ type RecordHistoryEntry struct {
 	Before            map[string]any
 	After             map[string]any
 	Summary           string
+	// AgentClient is the tool's registered name when the write came through an
+	// OAuth grant. Nil for a hand-minted passport and for anything undelegated;
+	// the Summary line already reads correctly either way, and this is here so
+	// a client rendering its own sentence does not have to parse one.
+	AgentClient *string
 }
 
 // RecordHistoryPage is one keyset window of the timeline, chronological
@@ -198,6 +223,10 @@ type recordAuditRow struct {
 	passportID        *ids.UUID
 	actorDisplayName  *string
 	onBehalfOfName    *string
+	// agentClientName is the tool's own name, when the passport behind the row
+	// came from an OAuth grant. Nil for a hand-minted passport, for a deleted
+	// client, and for every write that was not delegated.
+	agentClientName *string
 }
 
 // recordHistoryEntry renders one audit row as a history entry: mask both
@@ -213,6 +242,7 @@ func recordHistoryEntry(row recordAuditRow, mask entityFieldMask) RecordHistoryE
 		display = *row.actorDisplayName
 	}
 	return RecordHistoryEntry{
+		AgentClient:       row.agentClientName,
 		ID:                row.id,
 		ActorType:         row.actorType,
 		ActorID:           row.actorID,
@@ -225,7 +255,7 @@ func recordHistoryEntry(row recordAuditRow, mask entityFieldMask) RecordHistoryE
 		Before:            applyFieldMask(row.before, mask),
 		After:             applyFieldMask(row.after, mask),
 		Summary: composeRecordSummary(row.actorType, display, row.onBehalfOfName,
-			row.action, row.passportID != nil),
+			row.action, row.passportID != nil, row.agentClientName),
 	}
 }
 
@@ -347,8 +377,8 @@ func queryRecordHistoryWindow(ctx context.Context, tx pgx.Tx, f RecordHistoryFil
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT a.id, a.actor_type, a.actor_id, a.on_behalf_of, a.action, a.occurred_at,
 		       a.authorization_rule, a.before, a.after, a.passport_id,
-		       actor_user.display_name, obo.display_name
-		FROM audit_log a`+auditActorNameJoins+`
+		       actor_user.display_name, obo.display_name, oc.client_name
+		FROM audit_log a`+auditActorNameJoins+agentClientNameJoin+`
 		WHERE %s
 		ORDER BY a.occurred_at ASC, a.id ASC
 		LIMIT $%d`, strings.Join(conds, " AND "), len(args)), args...)
@@ -363,7 +393,7 @@ func queryRecordHistoryWindow(ctx context.Context, tx pgx.Tx, f RecordHistoryFil
 		var beforeJSON, afterJSON []byte
 		if err := rows.Scan(&r.id, &r.actorType, &r.actorID, &r.onBehalfOf, &r.action, &r.occurredAt,
 			&r.authorizationRule, &beforeJSON, &afterJSON, &r.passportID,
-			&r.actorDisplayName, &r.onBehalfOfName); err != nil {
+			&r.actorDisplayName, &r.onBehalfOfName, &r.agentClientName); err != nil {
 			return nil, err
 		}
 		if err := unmarshalJSONBMap(beforeJSON, &r.before); err != nil {
@@ -379,10 +409,19 @@ func queryRecordHistoryWindow(ctx context.Context, tx pgx.Tx, f RecordHistoryFil
 
 // machineQualifier names the tool a delegated change was typed through, as
 // the phrase that qualifies the PERSON who authorized it — "via an agent",
-// not "an agent". The generic word is deliberate: the passport's own label
-// ("Claude Desktop", "Cursor") would name the tool precisely, but a revoked
-// passport's label outliving the grant on every audit row it ever wrote is a
-// separate decision from this one.
+// not "an agent".
+//
+// It is the FALLBACK now. When the passport came from an OAuth grant the line
+// names the client instead — "Demo Admin, via Claude, created the record" —
+// because "via an agent" on every row of a company's history tells a rep
+// nothing they did not already know, and the question they actually have is
+// which tool did it.
+//
+// The name comes from oauth_client.client_name, not from passport.label. The
+// concern the generic word was protecting against — a revoked passport's label
+// outliving the grant on every row it ever wrote — does not apply: client_name
+// is the registered identity of the tool, it does not change when a grant is
+// revoked, and a client row that is gone falls back to this map.
 var machineQualifier = map[string]string{
 	actorTypeAgent:     "via an agent",
 	actorTypeConnector: "via a connector",
@@ -404,13 +443,16 @@ var machineQualifier = map[string]string{
 // party to anything — a line whose subject is the tool lets every human in
 // the chain disclaim it.
 func composeRecordSummary(actorType, actorDisplayName string, onBehalfOfName *string,
-	action string, passportBacked bool,
+	action string, passportBacked bool, agentClientName *string,
 ) string {
 	verb := recordHistoryVerbs[action]
 	if verb == "" {
 		verb = action
 	}
 	if qualifier, delegated := machineQualifier[actorType]; delegated && onBehalfOfName != nil && *onBehalfOfName != "" {
+		if agentClientName != nil && *agentClientName != "" {
+			qualifier = "via " + *agentClientName
+		}
 		return fmt.Sprintf("%s, %s, %s the record", *onBehalfOfName, qualifier, verb)
 	}
 	switch {

--- a/backend/internal/modules/privacy/recordhistory_test.go
+++ b/backend/internal/modules/privacy/recordhistory_test.go
@@ -22,6 +22,7 @@ func TestComposeRecordSummary(t *testing.T) {
 		onBehalfOfName   *string
 		action           string
 		passportBacked   bool
+		agentClientName  *string
 		want             string
 	}{
 		{
@@ -133,11 +134,49 @@ func TestComposeRecordSummary(t *testing.T) {
 			action:           "frobnicate",
 			want:             "Alice frobnicate the record",
 		},
+		{
+			// The point of the whole join: a rep reading a company's history
+			// learns WHICH tool made the change, not merely that one did.
+			name:             "a delegated write names the client it came through",
+			actorType:        "agent",
+			actorDisplayName: "agent:01a0-…",
+			onBehalfOfName:   strPtr("Demo Admin"),
+			action:           "create",
+			passportBacked:   true,
+			agentClientName:  strPtr("Claude"),
+			want:             "Demo Admin, via Claude, created the record",
+		},
+		{
+			// A passport minted by hand in Settings has no OAuth grant behind
+			// it, so there is no registered client to name. The generic
+			// qualifier is the honest answer, not a defect.
+			name:             "a hand-minted passport keeps the generic qualifier",
+			actorType:        "agent",
+			actorDisplayName: "agent:01a0-…",
+			onBehalfOfName:   strPtr("Demo Admin"),
+			action:           "create",
+			passportBacked:   true,
+			want:             "Demo Admin, via an agent, created the record",
+		},
+		{
+			// An empty client_name must not produce "via , created": the join
+			// can only ever yield NULL or a NOT NULL column, but the renderer
+			// is pure and reachable, and a blank name is a worse line than the
+			// generic one.
+			name:             "a blank client name falls back rather than rendering an empty phrase",
+			actorType:        "agent",
+			actorDisplayName: "agent:01a0-…",
+			onBehalfOfName:   strPtr("Demo Admin"),
+			action:           "update",
+			passportBacked:   true,
+			agentClientName:  strPtr(""),
+			want:             "Demo Admin, via an agent, updated the record",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := composeRecordSummary(tt.actorType, tt.actorDisplayName, tt.onBehalfOfName,
-				tt.action, tt.passportBacked)
+				tt.action, tt.passportBacked, tt.agentClientName)
 			if got != tt.want {
 				t.Errorf("composeRecordSummary(%q, %q, %v, %q, passport=%v) = %q, want %q",
 					tt.actorType, tt.actorDisplayName, tt.onBehalfOfName, tt.action,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16132,6 +16132,15 @@ export interface components {
             on_behalf_of?: string | null;
             /** @description Resolved display name for on_behalf_of. */
             on_behalf_of_name?: string | null;
+            /**
+             * @description The NAME of the tool a delegated change was typed through — "Claude",
+             *     "Cursor" — resolved from the OAuth client behind the row's passport.
+             *     Null when the passport was minted by hand in Settings (there is no
+             *     registered client to name), when the client row is gone, and for
+             *     every write that was not delegated. A reader that has it should say
+             *     "via {agent_client}" where it would otherwise say "via an agent".
+             */
+            agent_client?: string | null;
             action: string;
             /** Format: date-time */
             occurred_at: string;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2422,6 +2422,7 @@ export const de = {
   "audit.unknownMember": "Unbekanntes Mitglied",
   "audit.viaAgent": "über einen Agenten",
   "audit.viaConnector": "über einen Connector",
+  "audit.viaNamed": "über {client}",
   "audit.noHumanAuthority": "Keine menschliche Autorisierung erfasst",
   "settings.auditSub": "jede Aktion, zugeordnet — Mensch, Agent oder Connector",
   "settings.auditAdminOnly":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2427,6 +2427,7 @@ export const en = {
   "audit.unknownMember": "Unknown member",
   "audit.viaAgent": "via an agent",
   "audit.viaConnector": "via a connector",
+  "audit.viaNamed": "via {client}",
   "audit.noHumanAuthority": "No human authority recorded",
   "settings.auditSub": "every action, attributed — human, agent, or connector",
   "settings.auditAdminOnly":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2397,6 +2397,7 @@ export const vi = {
   "audit.unknownMember": "Thành viên không xác định",
   "audit.viaAgent": "qua một agent",
   "audit.viaConnector": "qua một connector",
+  "audit.viaNamed": "qua {client}",
   "audit.noHumanAuthority": "Không ghi nhận người uỷ quyền",
   "settings.auditSub":
     "mọi hành động đều được quy trách — người, Agent hay connector",

--- a/frontend/src/screens/audit.tsx
+++ b/frontend/src/screens/audit.tsx
@@ -22,7 +22,12 @@ type ActorFields = Pick<
   | "on_behalf_of"
   | "on_behalf_of_name"
   | "passport_id"
->;
+> & {
+  // The tool's registered name, when the write came through an OAuth grant.
+  // Optional because the compliance log's own entry does not carry it yet —
+  // record history does, and both surfaces render through this one component.
+  agent_client?: string | null;
+};
 
 // A snake_case enum value from the wire (an action / entity_type) is data, not
 // UI copy — de-underscore it into a readable phrase so the reader sees "custom
@@ -68,6 +73,10 @@ function actorAttribution(
   labelKey?: MessageKey;
   name?: string;
   qualifierKey?: MessageKey;
+  // The tool's own name, when the row records which one. Mutually exclusive
+  // with qualifierKey: a named client replaces the generic phrase rather than
+  // appending to it.
+  qualifierName?: string;
   identifier?: string;
 } {
   if (entry.actor_type === "human") {
@@ -86,12 +95,18 @@ function actorAttribution(
   }
 
   const qualifierKey = MACHINE_QUALIFIER[entry.actor_type];
+  // The tool's own name beats the generic phrase. "via Claude" tells a reader
+  // which connection wrote the row; "via an agent" tells them what they could
+  // already see from the icon.
+  const qualifier = entry.agent_client
+    ? { qualifierName: entry.agent_client }
+    : { qualifierKey };
   // A machine acting under a human's authority READS AS THAT HUMAN.
   if (entry.on_behalf_of && meUserId && entry.on_behalf_of === meUserId) {
-    return { labelKey: "audit.you", qualifierKey };
+    return { labelKey: "audit.you", ...qualifier };
   }
   if (entry.on_behalf_of_name) {
-    return { name: entry.on_behalf_of_name, qualifierKey };
+    return { name: entry.on_behalf_of_name, ...qualifier };
   }
   if (entry.passport_id) {
     // A GRANT was presented and yet no human resolved behind it. That is a
@@ -103,6 +118,7 @@ function actorAttribution(
     return {
       labelKey: "audit.noHumanAuthority",
       identifier: machineIdentifier(entry),
+      ...qualifier,
     };
   }
   // No grant was presented, so there is no human to name and no gap to report:
@@ -110,7 +126,7 @@ function actorAttribution(
   // flow. The deciding question is whether a grant was presented — not which
   // machine word actor_type happens to carry. The id is the readable,
   // workspace-chosen name of the thing that acted.
-  return { identifier: machineIdentifier(entry) };
+  return { identifier: machineIdentifier(entry), ...qualifier };
 }
 
 // machineIdentifier is the machine's own id, with a typed fallback for the one
@@ -118,6 +134,12 @@ function actorAttribution(
 // as a bare `string` with no minimum length, and an empty one would render an
 // icon with no label beside it — a row attributed to nothing at all.
 function machineIdentifier(entry: ActorFields): string {
+  // A registered client name, when there is one: `agent:01a0216f-…` is the
+  // truth and unreadable, and a reader asking "what changed my record" is not
+  // helped by a uuid they cannot look up.
+  if (entry.agent_client) {
+    return entry.agent_client;
+  }
   return entry.actor_id === "" ? entry.actor_type : entry.actor_id;
 }
 
@@ -131,10 +153,8 @@ export function ActorTag({
 }: Readonly<{ entry: ActorFields; meUserId?: string }>) {
   const t = useT();
   const Icon = ACTOR_ICON[entry.actor_type];
-  const { labelKey, name, qualifierKey, identifier } = actorAttribution(
-    entry,
-    meUserId,
-  );
+  const { labelKey, name, qualifierKey, qualifierName, identifier } =
+    actorAttribution(entry, meUserId);
 
   return (
     <span className="audit-actor">
@@ -148,7 +168,14 @@ export function ActorTag({
       {identifier && (
         <span className="t-mono audit-actor-id">{identifier}</span>
       )}
-      {qualifierKey && <span className="audit-behalf">{t(qualifierKey)}</span>}
+      {qualifierName && (
+        <span className="audit-behalf">
+          {t("audit.viaNamed", { client: qualifierName })}
+        </span>
+      )}
+      {!qualifierName && qualifierKey && (
+        <span className="audit-behalf">{t(qualifierKey)}</span>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
A rep opening a company's history saw "Demo Admin, via an agent, created the
record" on every row an assistant wrote, and on the compliance log a bare
`agent:01a0216f-…`. Neither answers the question they actually have, which is
which connection did this.

The name was one join away the whole time. audit_log already records
passport_id; passport carries oauth_grant_id; the grant names its client; and
oauth_client.client_name is the tool's registered name — "Claude", "Cursor".
The record-history query now walks that chain and the line reads "Demo Admin,
via Claude, created the record".

Every hop is a LEFT JOIN and every null means something different. A passport
minted by hand in Settings has no grant behind it, so there is no registered
client to name. A grant whose client row was deleted resolves nothing. A row
with no passport was not a delegated write at all. All three keep the generic
"via an agent", which is the honest answer rather than a defect.

The earlier code deliberately did NOT do this, and said why: a revoked
passport's label outliving the grant on every audit row it ever wrote was a
separate decision. That reasoning does not apply to client_name — it is the
tool's registered identity, it does not change when a grant is revoked, and a
client row that is gone falls back. passport.label and oauthPassportLabel are
untouched.

Contract gains `agent_client` on the history entry, additively. The frontend's
shared ActorTag renders "via {client}" when it is present and keeps the generic
phrase when it is not; machineIdentifier prefers the client name over the raw
`agent:<uuid>`, so the compliance log stops showing a uuid a reader cannot look
up. New key audit.viaNamed in all three locales.

All three regenerations ran: make gen, pnpm gen:api, -update-mcp-info.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record history and audit views now name the tool that performed delegated writes. Previously we showed “via an agent” and sometimes a raw `agent:<uuid>`; now we resolve and display the OAuth client name (e.g., “via Claude”), which answers “which connection did this?”

- Resolves client name via LEFT JOINs: `audit_log.passport_id` → `passport.oauth_grant_id` → `oauth_grant.(workspace_id, client_id)` → `oauth_client.client_name`. Nulls mean: hand‑minted passport (no grant), deleted client, or non‑delegated write; all fall back to the generic phrase.
- API is additive: `AuditHistoryEntry` gains optional `agent_client` (`backend/api/crm.yaml`, generated `api_gen.go`, and `frontend/src/api/schema.d.ts`). Older clients ignore it; newer clients work against older servers via fallback.
- Rendering updates: backend `composeRecordSummary` prefers client name when present; frontend `ActorTag` shows “via {client}” and uses the client name as the machine identifier instead of `agent:<uuid>` when available.
- I18n: adds `audit.viaNamed` in `en`, `de`, and `vi`.
- Intentional non-change: does not use `passport.label`; revoked-grant concerns remain avoided.

<sup>Written for commit b983c96b97d80475149517f704397ba134ef81f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

