### PR TITLE
fix(privacy): the record-history join named a column that no longer exists

### DIFF
--- a/backend/internal/compose/integration/recordhistoryclient_integration_test.go
+++ b/backend/internal/compose/integration/recordhistoryclient_integration_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The record-history line names the TOOL a delegated change came through, not
+// "an agent".
+//
+// This suite exists because the join that resolves that name reaches four
+// tables — audit_log → passport → oauth_grant → oauth_client — and nothing
+// unit-testable runs it. The first version of that join named
+// oauth_client.workspace_id, a column migration 1787109970 had dropped, and
+// every record-history read answered 500. It shipped because the only tests
+// touching this path seeded audit rows with no passport at all, so the join
+// matched nothing and its column names were never resolved.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/privacy"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestRecordHistoryNamesTheClientADelegatedChangeCameThrough(t *testing.T) {
+	e := Setup(t)
+	person := e.SeedPerson(t, "History Subject", nil)
+	human := seedWorkspaceUser(t, e, "Ada Authority")
+
+	passport := seedGrantedPassport(t, e, human, "Claude")
+	seedDelegatedAuditRow(t, e, person, human, passport, // Dated FORWARD: SeedPerson's own create row is stamped at real now, and
+		// the read is chronological, so a row dated backward would not be last.
+		time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond))
+
+	page := readRecordHistory(t, e, person)
+	if len(page.Entries) == 0 {
+		t.Fatal("the history is empty; the seeded row should be in it")
+	}
+	last := page.Entries[len(page.Entries)-1]
+	if last.Summary != "Ada Authority, via Claude, updated the record" {
+		t.Errorf("the line reads %q, want the client named rather than \"via an agent\"", last.Summary)
+	}
+	if last.AgentClient == nil || *last.AgentClient != "Claude" {
+		t.Errorf("agent_client = %v, want Claude — a client rendering its own attribution "+
+			"must not have to parse the sentence", last.AgentClient)
+	}
+}
+
+// A passport minted by hand has no OAuth grant behind it, so there is no
+// registered client to name and the generic qualifier is the honest answer.
+func TestAHandMintedPassportKeepsTheGenericQualifier(t *testing.T) {
+	e := Setup(t)
+	person := e.SeedPerson(t, "History Subject", nil)
+	human := seedWorkspaceUser(t, e, "Ada Authority")
+
+	passport := seedUngrantedPassport(t, e, human)
+	seedDelegatedAuditRow(t, e, person, human, passport, // Dated FORWARD: SeedPerson's own create row is stamped at real now, and
+		// the read is chronological, so a row dated backward would not be last.
+		time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond))
+
+	page := readRecordHistory(t, e, person)
+	last := page.Entries[len(page.Entries)-1]
+	if last.Summary != "Ada Authority, via an agent, updated the record" {
+		t.Errorf("the line reads %q, want the generic qualifier", last.Summary)
+	}
+	if last.AgentClient != nil {
+		t.Errorf("agent_client = %v, want nil — there is no registered client to name", *last.AgentClient)
+	}
+}
+
+// seedGrantedPassport writes the whole chain the join walks: a client, a grant
+// under it, and a passport issued for that grant.
+func seedGrantedPassport(t *testing.T, e *Env, human ids.UUID, clientName string) ids.UUID {
+	t.Helper()
+	clientID := "client-" + ids.NewV7().String()
+	grantID, passportID := ids.NewV7(), ids.NewV7()
+	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO oauth_client (client_id, client_name, redirect_uris)
+			 VALUES ($1, $2, ARRAY['https://example.test/cb'])`, clientID, clientName); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO oauth_grant (id, client_id, user_id, scopes)
+			 VALUES ($1, $2, $3, ARRAY['read'])`, grantID, clientID, human); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx,
+			`INSERT INTO passport (id, on_behalf_of, granted_by, label, scopes, token_hash,
+			                       expires_at, oauth_grant_id)
+			 VALUES ($1, $2, $2, $3, ARRAY['read'], $4, now() + interval '1 day', $5)`,
+			passportID, human, "oauth:"+clientID, "hash-"+passportID.String(), grantID)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding the granted passport: %v", err)
+	}
+	return passportID
+}
+
+// seedUngrantedPassport writes a passport with NO oauth_grant_id — what
+// minting one by hand in Settings produces.
+func seedUngrantedPassport(t *testing.T, e *Env, human ids.UUID) ids.UUID {
+	t.Helper()
+	passportID := ids.NewV7()
+	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO passport (id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
+			 VALUES ($1, $2, $2, 'My laptop', ARRAY['read'], $3, now() + interval '1 day')`,
+			passportID, human, "hash-"+passportID.String())
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding the hand-minted passport: %v", err)
+	}
+	return passportID
+}
+
+// seedDelegatedAuditRow writes the audit row the join reads: an agent actor,
+// the human it acted for, and the passport it presented.
+func seedDelegatedAuditRow(t *testing.T, e *Env, person, human, passport ids.UUID, at time.Time) {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, on_behalf_of, passport_id,
+			                        action, entity_type, entity_id, occurred_at)
+			 VALUES ($1, $2, 'agent', $3, $4, $5, 'update', 'person', $6, $7)`,
+			ids.NewV7(), e.WS, "agent:"+passport.String(), human, passport, person, at)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding the delegated audit row: %v", err)
+	}
+}
+
+// readRecordHistory reads the whole page through the same call the transport
+// makes.
+func readRecordHistory(t *testing.T, e *Env, person ids.UUID) privacy.RecordHistoryPage {
+	t.Helper()
+	page, err := privacy.ListRecordHistory(e.Admin(), e.DB(), privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: person,
+	})
+	if err != nil {
+		t.Fatalf("reading the record history: %v", err)
+	}
+	return page
+}

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -108,6 +108,7 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		{"whoami", `{}`},
 		{"list_colleagues", `{}`},
 		{"list_colleagues", `{"q":"nothing here matches this"}`},
+
 		// An enumeration, narrowed and unnarrowed. The narrowed one is the
 		// answer worth holding to the shape: a filter that reached no SQL still
 		// returns a well-formed page, of the wrong rows.
@@ -226,6 +227,10 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 // listed here and then made reachable fails as loudly as one that was never
 // covered, so the list cannot quietly outlive its reason.
 var unreachableInThisLane = gatekit.Waive(map[string]string{
+	"apply_tag": "needs a seat holding tag.read, which this lane's seat does not carry — " +
+		"granting it here would widen the authority every other tool in the sweep runs under, " +
+		"and the answer shape it would prove is the one remove_tag already shares",
+	"remove_tag":           "same missing tag.read as apply_tag above",
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
 	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -152,15 +152,14 @@ const auditActorNameJoins = `
 // was not a delegated write. Every one of those falls back to the generic
 // "via an agent", which is why this is a LEFT JOIN chain and not a filter.
 //
-// The client name is not a workspace-scoped lookup by accident: oauth_client
-// is keyed (workspace_id, client_id), so the join carries the grant's own
-// workspace rather than the caller's — the row says which grant wrote it, and
-// that grant belongs to exactly one workspace.
+// The join is on client_id ALONE. oauth_client used to be keyed
+// (workspace_id, client_id) and this join said so; migration 1787109970 dropped
+// the workspace column from every credential table, so client_id is the key
+// now and naming the old one made every record-history read a 500.
 const agentClientNameJoin = `
 		LEFT JOIN passport p ON p.id = a.passport_id
 		LEFT JOIN oauth_grant g ON g.id = p.oauth_grant_id
-		LEFT JOIN oauth_client oc
-		  ON oc.workspace_id = g.workspace_id AND oc.client_id = g.client_id`
+		LEFT JOIN oauth_client oc ON oc.client_id = g.client_id`
 
 // RecordHistoryFilter carries the validated query surface of
 // (GET /records/{entity_type}/{id}/history).


### PR DESCRIPTION
Every record-history read on main answers 500. GET
/v1/records/{type}/{id}/history returns "column oc.workspace_id does not
exist", so the 360 view's history panel is broken for every record.

I wrote that join yesterday (#2104) against oauth_client's ORIGINAL schema,
which was keyed (workspace_id, client_id). Migration 1787109970 dropped the
workspace column from every credential table months ago and made client_id the
key on its own. The join is on client_id alone now.

IT SHIPPED GREEN, and that is the part worth fixing properly. Four integration
tests exercise record history, and all four seed audit rows with no passport at
all — so the LEFT JOIN chain matched nothing, Postgres never had to resolve the
column names in it, and a plainly wrong query passed every gate. A join nothing
exercises is a query nobody has run.

So this adds the coverage that was missing rather than only the one-word fix.
recordhistoryclient_integration_test.go seeds the whole chain the join walks —
an oauth_client, a grant under it, a passport issued for that grant — and
asserts the line reads "Ada Authority, via Claude, updated the record". A
second test seeds a passport with NO grant, the hand-minted kind, and asserts
it keeps the generic "via an agent" with agent_client nil. Either test fails on
the broken column.

Also on main and also red: the schema-conformance sweep demanded apply_tag and
remove_tag be invoked, which #2083 registered without adding. They are waived
with the real reason — this lane's seat holds no tag.read, and granting it
would widen the authority every other tool in the sweep runs under.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500s on record history reads by correcting the join to `oauth_client`. Old behavior: join referenced dropped column `oc.workspace_id`, so GET /v1/records/{type}/{id}/history failed. New behavior: join on `client_id` only (per migration 1787109970), restoring the 360 history panel and correctly naming delegated clients.

- Review notes:
  - SQL: `LEFT JOIN oauth_client oc ON oc.client_id = g.client_id`; removed the workspace qualifier. This matches the current schema and only changes the prior erroneous failure.
  - Tests: Adds `recordhistoryclient_integration_test.go` to seed `oauth_client` → `oauth_grant` → `passport` and assert “via {client}” attribution; covers hand‑minted passports (no grant) to keep “via an agent” with `agent_client` nil.
  - Conformance sweep: Waives `apply_tag` and `remove_tag` because this lane lacks `tag.read`; avoids widening authority while documenting the reason.

<sup>Written for commit 830df4b3c4c99da51dcf1587e49e5a17a349417c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

