### PR TITLE
feat(agents): an assistant can bring a spreadsheet in

### DIFF
--- a/.codex/visualizations/2026/08/21/01a021d6-d244-7eb2-80f9-e45c1a69c3c3/deal-room-states.html
+++ b/.codex/visualizations/2026/08/21/01a021d6-d244-7eb2-80f9-e45c1a69c3c3/deal-room-states.html
@@ -1,0 +1,1012 @@
+<div id="deal-room-state-lab" class="drx" aria-describedby="drx-summary">
+  <p id="drx-summary" class="sr-only">Interactive model of a Margince deal detail page showing the internal Deal Cockpit and external Shared Space across seller and buyer lifecycle states.</p>
+  <div class="drx-state-controls" aria-label="Deal Room states"></div>
+  <p class="drx-state-detail" aria-live="polite"></p>
+  <div class="drx-stage"></div>
+</div>
+
+<style>
+  #deal-room-state-lab {
+    --drx-soft: color-mix(in srgb, var(--muted) 70%, transparent);
+    --drx-accent-soft: color-mix(in srgb, var(--accent) 62%, transparent);
+    --drx-primary-soft: color-mix(in srgb, var(--primary) 13%, transparent);
+    --drx-danger-soft: color-mix(in srgb, var(--destructive) 12%, transparent);
+    --drx-line-strong: color-mix(in srgb, var(--foreground) 22%, var(--border));
+    color: var(--foreground);
+    width: 100%;
+  }
+
+  #deal-room-state-lab * { box-sizing: border-box; }
+
+  #deal-room-state-lab button,
+  #deal-room-state-lab input,
+  #deal-room-state-lab textarea { font: inherit; }
+
+  #deal-room-state-lab .drx-state-controls {
+    display: grid;
+    gap: 0.75rem;
+    margin-block-end: 0.75rem;
+  }
+
+  #deal-room-state-lab .drx-control-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  #deal-room-state-lab .drx-control-label {
+    color: var(--muted-foreground);
+    min-width: 5.5rem;
+  }
+
+  #deal-room-state-lab .drx-state-detail {
+    color: var(--muted-foreground);
+    margin: 0 0 1rem;
+  }
+
+  #deal-room-state-lab .drx-stage {
+    border-block: 1px solid var(--border);
+    background: var(--background);
+  }
+
+  #deal-room-state-lab .drx-product-topbar {
+    min-height: 3rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(10rem, 20rem) auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.625rem 1rem;
+    border-block-end: 1px solid var(--border);
+    color: var(--muted-foreground);
+  }
+
+  #deal-room-state-lab .drx-breadcrumb,
+  #deal-room-state-lab .drx-search,
+  #deal-room-state-lab .drx-user,
+  #deal-room-state-lab .drx-row,
+  #deal-room-state-lab .drx-actions,
+  #deal-room-state-lab .drx-person,
+  #deal-room-state-lab .drx-statusline,
+  #deal-room-state-lab .drx-section-line,
+  #deal-room-state-lab .drx-plan-row,
+  #deal-room-state-lab .drx-event,
+  #deal-room-state-lab .drx-question-head {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    min-width: 0;
+  }
+
+  #deal-room-state-lab .drx-breadcrumb span,
+  #deal-room-state-lab .drx-title-text,
+  #deal-room-state-lab .drx-clip {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  #deal-room-state-lab .drx-search {
+    border: 1px solid var(--input);
+    border-radius: 999px;
+    padding: 0.4rem 0.75rem;
+    background: var(--background);
+  }
+
+  #deal-room-state-lab .drx-user {
+    justify-content: flex-end;
+  }
+
+  #deal-room-state-lab .drx-avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    display: inline-grid;
+    place-items: center;
+    flex: none;
+    background: var(--accent);
+    color: var(--accent-foreground);
+    font-weight: 500;
+  }
+
+  #deal-room-state-lab .drx-avatar-sm {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+
+  #deal-room-state-lab .drx-internal {
+    padding: 1rem;
+  }
+
+  #deal-room-state-lab .drx-deal-head {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  #deal-room-state-lab .drx-title-wrap {
+    display: flex;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  #deal-room-state-lab h2,
+  #deal-room-state-lab h3,
+  #deal-room-state-lab p { margin-block-start: 0; }
+
+  #deal-room-state-lab .drx-title-wrap h2 { margin-block-end: 0.2rem; }
+
+  #deal-room-state-lab .drx-muted { color: var(--muted-foreground); }
+  #deal-room-state-lab .drx-small { font-size: 0.875em; }
+
+  #deal-room-state-lab .drx-stage-track {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-block: 0.9rem;
+    flex-wrap: wrap;
+  }
+
+  #deal-room-state-lab .drx-stage-step {
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    background: var(--muted);
+    color: var(--muted-foreground);
+  }
+
+  #deal-room-state-lab .drx-stage-step[aria-current="step"] {
+    background: var(--primary);
+    color: var(--primary-foreground);
+  }
+
+  #deal-room-state-lab .drx-factstrip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border-block: 1px solid var(--border);
+    margin-block-end: 1rem;
+  }
+
+  #deal-room-state-lab .drx-fact {
+    padding: 0.75rem;
+    min-width: 0;
+  }
+
+  #deal-room-state-lab .drx-fact + .drx-fact { border-inline-start: 1px solid var(--border); }
+  #deal-room-state-lab .drx-fact strong { display: block; font-weight: 500; }
+
+  #deal-room-state-lab .drx-cockpit-grid {
+    display: grid;
+    grid-template-columns: 1.35fr 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  #deal-room-state-lab .drx-card-content { display: grid; gap: 0.65rem; }
+  #deal-room-state-lab .card h3 { margin-block-end: 0.25rem; }
+  #deal-room-state-lab .card p:last-child { margin-block-end: 0; }
+
+  #deal-room-state-lab .drx-risk-list,
+  #deal-room-state-lab .drx-check-list,
+  #deal-room-state-lab .drx-source-list,
+  #deal-room-state-lab .drx-section-list,
+  #deal-room-state-lab .drx-events {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  #deal-room-state-lab .drx-risk,
+  #deal-room-state-lab .drx-check,
+  #deal-room-state-lab .drx-source {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.5rem;
+    align-items: start;
+  }
+
+  #deal-room-state-lab .drx-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 50%;
+    margin-block-start: 0.35rem;
+    background: var(--muted-foreground);
+  }
+
+  #deal-room-state-lab .drx-dot-warn { background: var(--viz-series-3); }
+  #deal-room-state-lab .drx-dot-good { background: var(--viz-series-1); }
+  #deal-room-state-lab .drx-dot-danger { background: var(--destructive); }
+
+  #deal-room-state-lab .drx-external-boundary {
+    border-block: 1px solid var(--drx-line-strong);
+    background: var(--drx-primary-soft);
+    padding: 0.75rem 1rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  #deal-room-state-lab .drx-external-title {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-weight: 500;
+  }
+
+  #deal-room-state-lab .drx-external-title svg { color: var(--primary); }
+
+  #deal-room-state-lab .drx-external {
+    padding: 1rem;
+    background: var(--drx-accent-soft);
+    box-shadow: inset 0.3rem 0 0 var(--primary);
+  }
+
+  #deal-room-state-lab .drx-external-label {
+    color: var(--muted-foreground);
+    margin-block-end: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  #deal-room-state-lab .drx-empty {
+    min-height: 14rem;
+    display: grid;
+    place-items: center;
+    text-align: center;
+  }
+
+  #deal-room-state-lab .drx-empty-inner { max-width: 34rem; }
+  #deal-room-state-lab .drx-empty-icon { margin-inline: auto; margin-block-end: 0.8rem; }
+
+  #deal-room-state-lab .drx-build-progress {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(14rem, 0.8fr);
+    gap: 1rem;
+  }
+
+  #deal-room-state-lab .drx-progress-line {
+    height: 0.4rem;
+    background: var(--muted);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+
+  #deal-room-state-lab .drx-progress-line span {
+    display: block;
+    height: 100%;
+    background: var(--primary);
+    border-radius: inherit;
+  }
+
+  #deal-room-state-lab .drx-composer {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(15rem, 0.75fr);
+    gap: 1rem;
+    align-items: start;
+  }
+
+  #deal-room-state-lab .drx-buyer-preview {
+    background: var(--card);
+    color: var(--card-foreground);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    overflow: hidden;
+  }
+
+  #deal-room-state-lab .drx-buyer-brand {
+    padding: 1rem;
+    border-block-end: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  #deal-room-state-lab .drx-brand-mark {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.55rem;
+    display: grid;
+    place-items: center;
+    background: var(--primary);
+    color: var(--primary-foreground);
+    font-weight: 500;
+  }
+
+  #deal-room-state-lab .drx-buyer-content { padding: 1.1rem; }
+
+  #deal-room-state-lab .drx-kicker {
+    color: var(--muted-foreground);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.78em;
+  }
+
+  #deal-room-state-lab .drx-hero {
+    padding-block-end: 1rem;
+    border-block-end: 1px solid var(--border);
+    margin-block-end: 1rem;
+  }
+
+  #deal-room-state-lab .drx-hero h3 { margin-block: 0.35rem 0.5rem; }
+
+  #deal-room-state-lab .drx-shared-grid {
+    display: grid;
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 1rem;
+  }
+
+  #deal-room-state-lab .drx-section {
+    padding-block: 0.75rem;
+    border-block-end: 1px solid var(--border);
+  }
+
+  #deal-room-state-lab .drx-section:last-child { border-block-end: 0; }
+
+  #deal-room-state-lab .drx-section-line,
+  #deal-room-state-lab .drx-plan-row,
+  #deal-room-state-lab .drx-event {
+    justify-content: space-between;
+  }
+
+  #deal-room-state-lab .drx-section-line + .drx-section-line,
+  #deal-room-state-lab .drx-plan-row + .drx-plan-row,
+  #deal-room-state-lab .drx-event + .drx-event {
+    border-block-start: 1px solid var(--border);
+    padding-block-start: 0.55rem;
+  }
+
+  #deal-room-state-lab .drx-review-rail {
+    display: grid;
+    gap: 0.8rem;
+  }
+
+  #deal-room-state-lab .drx-callout {
+    padding: 0.75rem;
+    border-inline-start: 0.25rem solid var(--primary);
+    background: var(--drx-primary-soft);
+  }
+
+  #deal-room-state-lab .drx-callout-warn {
+    border-inline-start-color: var(--viz-series-3);
+    background: color-mix(in srgb, var(--viz-series-3) 10%, transparent);
+  }
+
+  #deal-room-state-lab .drx-callout-danger {
+    border-inline-start-color: var(--destructive);
+    background: var(--drx-danger-soft);
+  }
+
+  #deal-room-state-lab .drx-question {
+    padding-block: 0.8rem;
+    border-block-end: 1px solid var(--border);
+  }
+
+  #deal-room-state-lab .drx-question:last-child { border-block-end: 0; }
+
+  #deal-room-state-lab .drx-question-body {
+    margin: 0.55rem 0;
+    padding-inline-start: 2.35rem;
+  }
+
+  #deal-room-state-lab .drx-diff {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    gap: 0.7rem;
+    align-items: center;
+    padding-block: 0.65rem;
+    border-block-end: 1px solid var(--border);
+  }
+
+  #deal-room-state-lab .drx-diff:last-child { border-block-end: 0; }
+  #deal-room-state-lab .drx-old { color: var(--muted-foreground); text-decoration: line-through; }
+  #deal-room-state-lab .drx-new { font-weight: 500; }
+
+  #deal-room-state-lab .drx-buyer-only {
+    background: var(--background);
+    padding: 1rem;
+  }
+
+  #deal-room-state-lab .drx-buyer-only .drx-buyer-preview {
+    max-width: 68rem;
+    margin-inline: auto;
+  }
+
+  #deal-room-state-lab .drx-buyer-nav {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+    color: var(--muted-foreground);
+  }
+
+  #deal-room-state-lab .drx-buyer-nav strong { color: var(--foreground); font-weight: 500; }
+
+  #deal-room-state-lab .drx-ask {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    align-items: end;
+    margin-block-start: 1rem;
+  }
+
+  #deal-room-state-lab .drx-access-state {
+    min-height: 26rem;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    padding: 2rem;
+  }
+
+  #deal-room-state-lab .drx-access-state > div { max-width: 34rem; }
+
+  #deal-room-state-lab .drx-footer-note {
+    padding: 0.65rem 1rem;
+    border-block-start: 1px solid var(--border);
+    color: var(--muted-foreground);
+  }
+
+  #deal-room-state-lab .drx-spin {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    border: 2px solid var(--border);
+    border-block-start-color: var(--primary);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    #deal-room-state-lab .drx-spin { animation: drx-spin 1s linear infinite; }
+  }
+
+  @keyframes drx-spin { to { transform: rotate(360deg); } }
+
+  @media (max-width: 760px) {
+    #deal-room-state-lab .drx-product-topbar { grid-template-columns: minmax(0, 1fr) auto; }
+    #deal-room-state-lab .drx-search { display: none; }
+    #deal-room-state-lab .drx-cockpit-grid,
+    #deal-room-state-lab .drx-composer,
+    #deal-room-state-lab .drx-build-progress,
+    #deal-room-state-lab .drx-shared-grid { grid-template-columns: 1fr; }
+    #deal-room-state-lab .drx-factstrip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    #deal-room-state-lab .drx-fact:nth-child(3) { border-inline-start: 0; border-block-start: 1px solid var(--border); }
+    #deal-room-state-lab .drx-fact:nth-child(4) { border-block-start: 1px solid var(--border); }
+  }
+
+  @media (max-width: 520px) {
+    #deal-room-state-lab .drx-deal-head,
+    #deal-room-state-lab .drx-external-boundary { grid-template-columns: 1fr; }
+    #deal-room-state-lab .drx-actions { flex-wrap: wrap; }
+    #deal-room-state-lab .drx-diff { grid-template-columns: 1fr; }
+    #deal-room-state-lab .drx-diff svg { transform: rotate(90deg); }
+    #deal-room-state-lab .drx-ask { grid-template-columns: 1fr; }
+  }
+</style>
+
+<script>
+(() => {
+  const root = document.getElementById("deal-room-state-lab");
+  if (!root) return;
+
+  const states = [
+    { id: "not-created", group: "Build", label: "Internal only", detail: "The deal is complete without a Shared Space; no buyer can see anything yet." },
+    { id: "building", group: "Build", label: "AI building", detail: "Margince assembles a grounded draft while the seller stays on the deal." },
+    { id: "draft-review", group: "Build", label: "Draft review", detail: "AI proposals are visibly drafts, with citations and safety checks before publication." },
+    { id: "ready", group: "Build", label: "Ready", detail: "All public blocks are reviewed; participants and the exact release are confirmed." },
+    { id: "publishing", group: "Build", label: "Publishing", detail: "The write is in flight, focus stays on the action, and the prior live release remains authoritative." },
+    { id: "live-unopened", group: "Live", label: "Live · unopened", detail: "The room is live, but nobody has opened it; absence of activity is stated honestly." },
+    { id: "live-active", group: "Live", label: "Live · active", detail: "Material buyer actions become a concise deal pulse, not a stream of page-view alerts." },
+    { id: "question", group: "Live", label: "Question waiting", detail: "The buyer asked something the published corpus cannot answer; Margince escalates instead of guessing." },
+    { id: "update", group: "Live", label: "Update proposed", detail: "New deal evidence makes the public release stale; the seller reviews a release diff." },
+    { id: "paused", group: "Access & end", label: "Paused", detail: "Buyer access is temporarily refused while the seller keeps the room and its history." },
+    { id: "expired", group: "Access & end", label: "Expired", detail: "The access window ended automatically; extending it is an explicit human action." },
+    { id: "closed", group: "Access & end", label: "Closed · handoff", detail: "The sales release is frozen and the stable space continues into onboarding." },
+    { id: "readonly", group: "Access & end", label: "Read only", detail: "The viewer may read the deal and live release but cannot publish or manage buyer access." },
+    { id: "unavailable", group: "Access & end", label: "Unavailable", detail: "The external surface failed without making the internal deal disappear or pretending the room is empty." },
+    { id: "buyer-first", group: "Buyer", label: "First visit", detail: "A named buyer lands on a calm decision path with the next action first." },
+    { id: "buyer-returning", group: "Buyer", label: "Returning", detail: "A returning buyer sees only material changes since the last visit." },
+    { id: "buyer-stopped", group: "Buyer", label: "Access stopped", detail: "Paused, revoked and expired access each say what happened without leaking internal detail." }
+  ];
+
+  const groups = ["Build", "Live", "Access & end", "Buyer"];
+  let current = "not-created";
+
+  const controls = root.querySelector(".drx-state-controls");
+  const detail = root.querySelector(".drx-state-detail");
+  const stage = root.querySelector(".drx-stage");
+
+  controls.innerHTML = groups.map(group => `
+    <div class="drx-control-group" role="group" aria-label="${group} states">
+      <span class="drx-control-label drx-small">${group}</span>
+      ${states.filter(state => state.group === group).map(state => `
+        <button type="button" class="btn btn-ghost" data-state="${state.id}" aria-pressed="false">${state.label}</button>
+      `).join("")}
+    </div>
+  `).join("");
+
+  function icon(name) {
+    return `<i data-lucide="${name}" aria-hidden="true"></i>`;
+  }
+
+  function button(label, go, kind = "") {
+    const cls = kind === "primary" ? "btn btn-primary" : kind === "ghost" ? "btn btn-ghost" : "btn";
+    return `<button type="button" class="${cls}" data-go="${go}">${label}</button>`;
+  }
+
+  function topbar() {
+    return `
+      <div class="drx-product-topbar">
+        <div class="drx-breadcrumb">${icon("panel-left-close")}<span>Pipeline&nbsp;&nbsp;/&nbsp;&nbsp;Sabine Fröschl TeamOne Immobilienbetreuung — Einführung</span></div>
+        <div class="drx-search">${icon("search")}<span>Search everything…</span></div>
+        <div class="drx-user"><span class="drx-avatar drx-avatar-sm">DA</span></div>
+      </div>
+    `;
+  }
+
+  function internalCockpit(mode = "risk") {
+    const won = mode === "won";
+    const pulse = mode === "active"
+      ? `<div class="drx-statusline"><span class="viz-badge">3 material changes</span><span class="drx-small drx-muted">since your last visit</span></div><p>The CFO joined, Security finished its task, and the revised offer is under review.</p>`
+      : mode === "question"
+        ? `<div class="drx-statusline"><span class="viz-badge">Buyer question</span><span class="drx-small drx-muted">18 minutes ago</span></div><p>Sabine asked where customer data is stored. The published room has no grounded answer.</p>`
+        : mode === "update"
+          ? `<div class="drx-statusline"><span class="viz-badge">Shared Space is stale</span><span class="drx-small drx-muted">3 facts changed</span></div><p>Tuesday’s meeting changed the go-live date, Security owner and SSO status.</p>`
+          : won
+            ? `<div class="drx-statusline"><span class="viz-badge">Won</span><span class="drx-small drx-muted">today</span></div><p>The signed agreement is recorded. Preserve the sales evidence and begin onboarding.</p>`
+            : `<div class="drx-statusline"><span class="viz-badge">At risk</span><span class="drx-small drx-muted">82 days quiet</span></div><p>Re-engage Sabine and add an operational stakeholder before presenting a proposal.</p>`;
+
+    return `
+      ${topbar()}
+      <section class="drx-internal" aria-label="Internal Deal Cockpit">
+        <div class="drx-deal-head">
+          <div class="drx-title-wrap">
+            <span class="drx-avatar">SF</span>
+            <div class="drx-title-text">
+              <h2>Sabine Fröschl TeamOne Immobilienbetreuung — Einführung</h2>
+              <div class="drx-muted">€160,100 · Internal Deal Cockpit</div>
+            </div>
+          </div>
+          <div class="drx-actions">
+            <span class="viz-badge">${won ? "won" : "open"}</span>
+            <button type="button" class="btn">Edit deal</button>
+            <button type="button" class="btn btn-ghost">History</button>
+          </div>
+        </div>
+
+        <div class="drx-stage-track" aria-label="Deal stage">
+          ${["Qualified", "Discovery", "Proposal", "Negotiation", "Won", "Lost"].map(name => `
+            <span class="drx-stage-step" ${name === (won ? "Won" : "Discovery") ? 'aria-current="step"' : ""}>${name}</span>
+          `).join("")}
+        </div>
+
+        <div class="drx-factstrip" aria-label="Deal readings">
+          <div class="drx-fact"><span class="drx-small drx-muted">Amount</span><strong>€160,100</strong></div>
+          <div class="drx-fact"><span class="drx-small drx-muted">Expected close</span><strong>${won ? "21 Aug 2026" : "30 Sep 2026"}</strong></div>
+          <div class="drx-fact"><span class="drx-small drx-muted">Last buyer reply</span><strong>${won ? "Today" : "82 days ago"}</strong></div>
+          <div class="drx-fact"><span class="drx-small drx-muted">Buying roles</span><strong>${won ? "4 of 4" : "1 of 4"}</strong></div>
+        </div>
+
+        <div class="drx-cockpit-grid">
+          <article class="card">
+            <div class="drx-card-content">
+              <div class="drx-row">${icon("sparkles")}<h3>Margince deal pulse</h3></div>
+              ${pulse}
+              <button type="button" class="btn btn-ghost">Open evidence</button>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Coverage</h3>
+            <div class="drx-risk-list">
+              <div class="drx-risk"><span class="drx-dot ${won ? "drx-dot-good" : "drx-dot-warn"}"></span><span>${won ? "Economic buyer engaged" : "Single-threaded"}</span></div>
+              <div class="drx-risk"><span class="drx-dot ${won ? "drx-dot-good" : "drx-dot-warn"}"></span><span>${won ? "Champion active" : "No engaged champion"}</span></div>
+              <div class="drx-risk"><span class="drx-dot ${won ? "drx-dot-good" : "drx-dot-danger"}"></span><span>${won ? "Both teams covered" : "Going cold"}</span></div>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Commercial</h3>
+            <div class="drx-card-content">
+              <div class="drx-section-line"><span>Offer</span><strong>${won ? "Accepted · R2" : "Draft · R1"}</strong></div>
+              <div class="drx-section-line"><span>Contract</span><strong>${won ? "Active" : "Not recorded"}</strong></div>
+              <div class="drx-section-line"><span>Next decision</span><strong>${won ? "Kickoff" : "Scope"}</strong></div>
+            </div>
+          </article>
+        </div>
+      </section>
+    `;
+  }
+
+  function boundary(status, people, actions = "") {
+    return `
+      <div class="drx-external-boundary">
+        <div>
+          <div class="drx-external-title">${icon("external-link")}<span>External Shared Space</span><span class="viz-badge">${status}</span></div>
+          <div class="drx-small drx-muted">${people}</div>
+        </div>
+        <div class="drx-actions">${actions}</div>
+      </div>
+    `;
+  }
+
+  function externalWrap(content) {
+    return `
+      <section class="drx-external" aria-label="External Shared Space">
+        <div class="drx-external-label">${icon("eye")}<span>External — only the published content below is buyer-visible</span></div>
+        ${content}
+      </section>
+    `;
+  }
+
+  function buyerPreview({ returning = false, editable = false } = {}) {
+    return `
+      <article class="drx-buyer-preview" aria-label="Buyer preview">
+        <div class="drx-buyer-brand">
+          <div class="drx-person"><span class="drx-brand-mark">M</span><div><strong>Margince × TeamOne</strong><div class="drx-small drx-muted">Shared decision space</div></div></div>
+          <div class="drx-actions">${editable ? '<span class="viz-badge">Draft for buyer</span>' : '<span class="viz-badge">Live release 4</span>'}</div>
+        </div>
+        <div class="drx-buyer-content">
+          ${returning ? '<div class="drx-callout"><strong>Since your last visit</strong><div class="drx-small">The go-live date moved to 15 October, Security is complete and offer R2 is ready.</div></div>' : ""}
+          <div class="drx-hero">
+            <span class="drx-kicker">Prepared for Sabine Fröschl and the TeamOne buying team</span>
+            <h3>A clear path to a faster, more reliable property-management handover</h3>
+            <p class="drx-muted">Align the operating team, validate the migration plan and make a confident commercial decision by 30 September.</p>
+            <div class="drx-actions"><span class="viz-badge">Next: confirm scope</span><span class="drx-small drx-muted">Owner · Sabine · due Friday</span></div>
+          </div>
+          <div class="drx-shared-grid">
+            <div>
+              <div class="drx-section">
+                <div class="drx-section-line"><strong>What we heard</strong><span class="viz-badge">3 priorities</span></div>
+                <p class="drx-small drx-muted">Reduce manual handovers, give owners clearer reporting, and migrate without disrupting the current team.</p>
+              </div>
+              <div class="drx-section">
+                <div class="drx-section-line"><strong>Mutual plan</strong><span class="drx-small drx-muted">3 of 5 complete</span></div>
+                <div class="drx-plan-row"><span>Discovery & success criteria</span><span class="viz-badge">Done</span></div>
+                <div class="drx-plan-row"><span>Security review</span><span class="viz-badge">Done</span></div>
+                <div class="drx-plan-row"><span>Confirm implementation scope</span><span class="viz-badge">Your turn</span></div>
+              </div>
+            </div>
+            <div>
+              <div class="drx-section">
+                <div class="drx-section-line"><strong>Key resources</strong><span class="drx-small drx-muted">Current</span></div>
+                <div class="drx-section-line"><span>${icon("file-text")} Solution overview</span><span>PDF</span></div>
+                <div class="drx-section-line"><span>${icon("shield-check")} Security profile</span><span>12 pages</span></div>
+                <div class="drx-section-line"><span>${icon("receipt-text")} Offer R2</span><span>€160,100</span></div>
+              </div>
+              <div class="drx-section">
+                <strong>Your team</strong>
+                <div class="drx-person"><span class="drx-avatar drx-avatar-sm">SF</span><span>Sabine · Economic buyer</span></div>
+                <div class="drx-person"><span class="drx-avatar drx-avatar-sm">NO</span><span>Nora · Finance</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+    `;
+  }
+
+  function sellerScreen(status, people, actions, content, mode = "risk") {
+    return `${internalCockpit(mode)}${boundary(status, people, actions)}${externalWrap(content)}<div class="drx-footer-note">Internal and external content are separated by projection and permissions, not merely by page position.</div>`;
+  }
+
+  function notCreated() {
+    return sellerScreen("Not created", "Visible to: no one", "", `
+      <div class="drx-empty">
+        <div class="drx-empty-inner">
+          <div class="drx-empty-icon">${icon("panels-top-left")}</div>
+          <h3>Turn this deal into a clear buyer journey</h3>
+          <p class="drx-muted">Margince will draft the shared objective, plan, resources and commercial next step from the evidence above. Nothing is shared until you publish.</p>
+          ${button("Create Shared Space", "building", "primary")}
+        </div>
+      </div>
+    `);
+  }
+
+  function building() {
+    return sellerScreen("Building draft", "Visible to: no one", '<button type="button" class="btn" disabled>Preview</button>', `
+      <div class="drx-build-progress">
+        <div class="card">
+          <div class="drx-row"> <span class="drx-spin" aria-hidden="true"></span><div><h3>Margince is building the Shared Space</h3><p class="drx-muted">Reading only evidence you can access. No buyer can see this draft.</p></div></div>
+          <div class="drx-progress-line" aria-label="Draft generation 64 percent complete"><span style="width:64%"></span></div>
+          <div class="drx-check-list">
+            <div class="drx-check"><span class="drx-dot drx-dot-good"></span><span>Deal, stakeholders and current stage read</span></div>
+            <div class="drx-check"><span class="drx-dot drx-dot-good"></span><span>Meetings and commitments grounded</span></div>
+            <div class="drx-check"><span class="drx-dot"></span><span>Selecting buyer-safe resources</span></div>
+            <div class="drx-check"><span class="drx-dot"></span><span>Checking claims and permissions</span></div>
+          </div>
+          <div class="drx-actions">${button("Show completed draft", "draft-review")}</div>
+        </div>
+        <div class="card">
+          <h3>What Margince will not do</h3>
+          <div class="drx-risk-list">
+            <div class="drx-risk"><span class="drx-dot"></span><span>Publish automatically</span></div>
+            <div class="drx-risk"><span class="drx-dot"></span><span>Expose internal notes or health</span></div>
+            <div class="drx-risk"><span class="drx-dot"></span><span>Invent prices, dates or promises</span></div>
+          </div>
+        </div>
+      </div>
+    `);
+  }
+
+  function draftReview() {
+    return sellerScreen("Draft · 3 to review", "Visible to: no one", `${button("Preview as buyer", "buyer-first")}${button("Continue review", "ready", "primary")}`, `
+      <div class="drx-composer">
+        ${buyerPreview({ editable: true })}
+        <aside class="drx-review-rail" aria-label="Draft review">
+          <div class="card">
+            <h3>Review before sharing</h3>
+            <div class="drx-check-list">
+              <div class="drx-check"><span class="drx-dot drx-dot-good"></span><span>11 factual claims grounded</span></div>
+              <div class="drx-check"><span class="drx-dot drx-dot-good"></span><span>No internal-only source selected</span></div>
+              <div class="drx-check"><span class="drx-dot drx-dot-warn"></span><span>Go-live date needs confirmation</span></div>
+              <div class="drx-check"><span class="drx-dot drx-dot-warn"></span><span>Offer R1 is still a draft</span></div>
+              <div class="drx-check"><span class="drx-dot drx-dot-warn"></span><span>Security owner not named</span></div>
+            </div>
+          </div>
+          <div class="card">
+            <h3>Evidence</h3>
+            <div class="drx-source-list">
+              <div class="drx-source">${icon("message-square-text")}<span>Discovery call · lines 42–51</span></div>
+              <div class="drx-source">${icon("mail")}<span>Sabine’s reply · 30 May</span></div>
+              <div class="drx-source">${icon("file-text")}<span>Implementation notes · current</span></div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    `);
+  }
+
+  function ready() {
+    return sellerScreen("Ready to publish", "Will be visible to: Sabine and Nora", `${button("Preview as Nora", "buyer-first")}${button("Publish release 1", "publishing", "primary")}`, `
+      <div class="drx-composer">
+        ${buyerPreview({ editable: true })}
+        <aside class="drx-review-rail">
+          <div class="drx-callout"><strong>Ready to publish</strong><div class="drx-small">Every buyer-visible claim is reviewed and the current offer is pinned.</div></div>
+          <div class="card">
+            <h3>Release 1</h3>
+            <div class="drx-section-list">
+              <div class="drx-section-line"><span>5 sections</span><span class="viz-badge">Reviewed</span></div>
+              <div class="drx-section-line"><span>3 resources</span><span class="viz-badge">Current</span></div>
+              <div class="drx-section-line"><span>2 participants</span><span class="viz-badge">Named</span></div>
+              <div class="drx-section-line"><span>Analytics</span><span class="viz-badge">Consent required</span></div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    `);
+  }
+
+  function publishing() {
+    return sellerScreen("Publishing release 1", "Prior state: no live release", '<button type="button" class="btn btn-primary" aria-busy="true" aria-disabled="true"><span class="drx-spin" aria-hidden="true"></span> Publish release 1</button>', `
+      <div class="drx-callout"><strong>Publishing the reviewed release…</strong><div class="drx-small">The exact draft version is pinned. Invitations send only after publication commits.</div></div>
+      ${buyerPreview({ editable: true })}
+      <div class="drx-actions">${button("Show published state", "live-unopened")}</div>
+    `);
+  }
+
+  function liveUnopened() {
+    return sellerScreen("Live · release 1", "Visible to: Sabine, Nora · neither has opened", `${button("Preview as buyer", "buyer-first")}${button("Copy link", "live-unopened")}`, `
+      <div class="drx-composer">
+        ${buyerPreview()}
+        <aside class="drx-review-rail">
+          <div class="card">
+            <h3>Participants</h3>
+            <div class="drx-section-list">
+              <div class="drx-section-line"><span>Sabine Fröschl</span><span class="viz-badge">Invited</span></div>
+              <div class="drx-section-line"><span>Nora Ortiz</span><span class="viz-badge">Invited</span></div>
+            </div>
+          </div>
+          <div class="drx-callout"><strong>No buyer activity yet</strong><div class="drx-small">The invitations were sent 2 hours ago. This is not a risk signal.</div></div>
+          ${button("Simulate buyer activity", "live-active", "primary")}
+        </aside>
+      </div>
+    `);
+  }
+
+  function liveActive() {
+    return sellerScreen("Live · release 4", "Visible to: Sabine, Nora, Ben + 1 · 3 active this week", `${button("Preview as Nora", "buyer-returning")}${button("Pause access", "paused")}`, `
+      <div class="drx-composer">
+        ${buyerPreview({ returning: true })}
+        <aside class="drx-review-rail">
+          <div class="card">
+            <h3>Meaningful engagement</h3>
+            <div class="drx-events">
+              <div class="drx-event"><span>Nora joined as Finance</span><span class="drx-small drx-muted">Today</span></div>
+              <div class="drx-event"><span>Security task completed</span><span class="drx-small drx-muted">Yesterday</span></div>
+              <div class="drx-event"><span>Offer R2 reviewed</span><span class="drx-small drx-muted">2 days ago</span></div>
+            </div>
+          </div>
+          <div class="drx-callout"><strong>Recommended next move</strong><div class="drx-small">Confirm whether Procurement needs a vendor form before Friday.</div></div>
+          <div class="drx-actions">${button("Show buyer question", "question")}${button("Show meeting update", "update")}</div>
+        </aside>
+      </div>
+    `, "active");
+  }
+
+  function questionWaiting() {
+    return sellerScreen("Live · question waiting", "Visible to: Sabine, Nora, Ben + 1", `${button("Preview thread", "buyer-returning")}`, `
+      <div class="drx-composer">
+        <div class="drx-buyer-preview">
+          <div class="drx-buyer-brand"><div class="drx-person"><span class="drx-brand-mark">M</span><strong>Questions</strong></div><span class="viz-badge">1 waiting</span></div>
+          <div class="drx-buyer-content">
+            <div class="drx-question">
+              <div class="drx-question-head"><span class="drx-avatar drx-avatar-sm">SF</span><div><strong>Sabine Fröschl</strong><div class="drx-small drx-muted">18 minutes ago · Security profile</div></div></div>
+              <p class="drx-question-body">Where will our tenant and document data be stored?</p>
+            </div>
+            <div class="drx-callout-warn drx-callout"><strong>Margince did not answer</strong><div class="drx-small">The published room does not contain a grounded residency answer. The question was routed to you.</div></div>
+          </div>
+        </div>
+        <aside class="drx-review-rail">
+          <div class="card">
+            <h3>Prepare a grounded reply</h3>
+            <label class="form-label" for="drx-answer">Answer to Sabine</label>
+            <textarea id="drx-answer" class="form-control" rows="5">Our deployment stores tenant data in the EU region selected by your organization. I’ll add the exact region and subprocessors to the Security section.</textarea>
+            <div class="drx-actions"><button type="button" class="btn">Save draft</button><button type="button" class="btn btn-primary" data-go="update">Reply and propose room update</button></div>
+          </div>
+        </aside>
+      </div>
+    `, "question");
+  }
+
+  function updateProposed() {
+    return sellerScreen("Live · release 4 · draft update", "Visible to buyers now: release 4", `${button("Preview current live", "buyer-returning")}${button("Publish release 5", "live-active", "primary")}`, `
+      <div class="drx-composer">
+        <div class="drx-buyer-preview">
+          <div class="drx-buyer-brand"><div class="drx-person"><span class="drx-brand-mark">M</span><div><strong>Release 5 diff</strong><div class="drx-small drx-muted">Proposed from Tuesday’s meeting</div></div></div><span class="viz-badge">Draft for buyer</span></div>
+          <div class="drx-buyer-content">
+            <div class="drx-diff"><span class="drx-old">Go-live · 1 October</span>${icon("arrow-right")}<span class="drx-new">Go-live · 15 October</span></div>
+            <div class="drx-diff"><span class="drx-old">Security owner · open</span>${icon("arrow-right")}<span class="drx-new">Security owner · Maya Becker</span></div>
+            <div class="drx-diff"><span class="drx-old">SSO · unanswered</span>${icon("arrow-right")}<span class="drx-new">SSO · confirmed in Enterprise plan</span></div>
+          </div>
+        </div>
+        <aside class="drx-review-rail">
+          <div class="drx-callout-warn drx-callout"><strong>The live room is now stale</strong><div class="drx-small">Buyers still see release 4 until you review and publish this exact diff.</div></div>
+          <div class="card">
+            <h3>Evidence</h3>
+            <div class="drx-source-list">
+              <div class="drx-source">${icon("mic")}<span>Steering call · lines 88–104</span></div>
+              <div class="drx-source">${icon("check-check")}<span>Commitment accepted by Sabine</span></div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    `, "update");
+  }
+
+  function accessState(kind) {
+    const map = {
+      paused: {
+        status: "Paused", people: "Buyer access temporarily refused · history preserved", title: "Shared Space access is paused", body: "Buyers see a clear temporary-access message. The seller can review the room and resume access without creating a new link.", action: button("Resume access", "live-active", "primary"), callout: "No buyer can open the current release while paused."
+      },
+      expired: {
+        status: "Expired", people: "Access ended 20 Aug 2026 · release 4 preserved", title: "The access window ended", body: "Extending access is explicit and records a new expiry. The existing release and engagement history remain unchanged.", action: button("Extend for 14 days", "live-active", "primary"), callout: "Buyers are not treated as disengaged after expiry."
+      },
+      readonly: {
+        status: "Live · read only", people: "Visible to: Sabine, Nora, Ben + 1", title: "You can read this Shared Space", body: "Managing participants and publishing releases requires deal-room write permission. The live buyer projection stays visible rather than disappearing.", action: button("Preview as buyer", "buyer-returning"), callout: "Publication and access controls are withheld for your role."
+      },
+      unavailable: {
+        status: "Unavailable", people: "The internal deal remains available", title: "The Shared Space could not be loaded", body: "Margince does not claim that the room is empty or closed. Retry the external read without losing your place in the deal.", action: button("Retry", "live-active", "primary"), callout: "Buyer access state is unknown until the read succeeds."
+      }
+    };
+    const s = map[kind];
+    return sellerScreen(s.status, s.people, kind === "readonly" ? "" : s.action, `
+      <div class="drx-empty">
+        <div class="drx-empty-inner">
+          <div class="drx-empty-icon">${icon(kind === "unavailable" ? "triangle-alert" : kind === "readonly" ? "lock-keyhole" : "pause-circle")}</div>
+          <h3>${s.title}</h3>
+          <p class="drx-muted">${s.body}</p>
+          <div class="drx-callout ${kind === "unavailable" ? "drx-callout-danger" : ""}">${s.callout}</div>
+          ${kind === "readonly" ? s.action : ""}
+        </div>
+      </div>
+    `);
+  }
+
+  function closed() {
+    return sellerScreen("Closed · sales release frozen", "Buyer access continues as onboarding", `${button("Open onboarding project", "closed", "primary")}${button("Preview as customer", "buyer-returning")}`, `
+      <div class="drx-composer">
+        <div class="drx-buyer-preview">
+          <div class="drx-buyer-brand"><div class="drx-person"><span class="drx-brand-mark">M</span><div><strong>TeamOne onboarding</strong><div class="drx-small drx-muted">The same stable Shared Space</div></div></div><span class="viz-badge">Sales release frozen</span></div>
+          <div class="drx-buyer-content">
+            <div class="drx-callout"><strong>Welcome to onboarding</strong><div class="drx-small">The offer and decision history are preserved. New work now comes from the onboarding project.</div></div>
+            <div class="drx-section">
+              <div class="drx-section-line"><strong>Kickoff plan</strong><span class="drx-small drx-muted">1 of 4 complete</span></div>
+              <div class="drx-plan-row"><span>Agreement recorded</span><span class="viz-badge">Done</span></div>
+              <div class="drx-plan-row"><span>Kickoff meeting</span><span class="viz-badge">28 Aug</span></div>
+              <div class="drx-plan-row"><span>Data preparation</span><span class="viz-badge">Your turn</span></div>
+            </div>
+          </div>
+        </div>
+        <aside class="drx-review-rail">
+          <div class="card"><h3>Sales evidence preserved</h3><div class="drx-section-list"><div class="drx-section-line"><span>Offer R2</span><span>Accepted</span></div><div class="drx-section-line"><span>Contract</span><span>Active</span></div><div class="drx-section-line"><span>Release 5</span><span>Frozen</span></div></div></div>
+        </aside>
+      </div>
+    `, "won");
+  }
+
+  function buyerScreen(kind) {
+    if (kind === "buyer-stopped") {
+      return `
+        <div class="drx-buyer-only">
+          <article class="drx-buyer-preview">
+            <div class="drx-buyer-brand"><div class="drx-person"><span class="drx-brand-mark">M</span><strong>Margince × TeamOne</strong></div><span class="viz-badge">Access paused</span></div>
+            <div class="drx-access-state"><div>${icon("lock-keyhole")}<h2>This Shared Space is not available right now</h2><p class="drx-muted">The seller has paused access. Your link is still valid; no action is required from you. Contact Hau if you need a document urgently.</p><button type="button" class="btn">Contact Hau</button></div></div>
+          </article>
+        </div>
+      `;
+    }
+    const returning = kind === "buyer-returning";
+    return `
+      <div class="drx-buyer-only">
+        <article class="drx-buyer-preview">
+          <div class="drx-buyer-brand">
+            <div class="drx-person"><span class="drx-brand-mark">M</span><div><strong>Margince × TeamOne</strong><div class="drx-small drx-muted">Shared decision space</div></div></div>
+            <nav class="drx-buyer-nav" aria-label="Shared Space"><strong>Start</strong><span>Plan</span><span>Resources</span><span>Commercials</span><span>Questions</span></nav>
+          </div>
+          <div class="drx-buyer-content">
+            ${returning ? '<div class="drx-callout"><strong>Three things changed since Tuesday</strong><div class="drx-small">Go-live moved to 15 October, Security is complete, and offer R2 is ready for review.</div></div>' : '<div class="drx-callout"><strong>Welcome, Sabine</strong><div class="drx-small">This space contains the current plan, documents and commercial proposal for your team.</div></div>'}
+            <div class="drx-hero">
+              <span class="drx-kicker">Prepared for Sabine Fröschl and the TeamOne buying team</span>
+              <h2>A clear path to a faster, more reliable property-management handover</h2>
+              <p class="drx-muted">Everything needed to align your team and make the decision—kept current in one place.</p>
+              <div class="drx-actions"><button type="button" class="btn btn-primary">Confirm implementation scope</button><span class="drx-small drx-muted">Due Friday · owned by you</span></div>
+            </div>
+            <div class="drx-shared-grid">
+              <div>
+                <div class="drx-section"><div class="drx-section-line"><strong>Shared outcome</strong><span class="viz-badge">Agreed</span></div><p class="drx-muted">Move 14 managed properties without interrupting tenant communication or owner reporting.</p></div>
+                <div class="drx-section"><div class="drx-section-line"><strong>Mutual plan</strong><span>3 of 5 complete</span></div><div class="drx-plan-row"><span>Security review</span><span class="viz-badge">Done</span></div><div class="drx-plan-row"><span>Confirm implementation scope</span><span class="viz-badge">Your turn</span></div><div class="drx-plan-row"><span>Commercial approval</span><span class="viz-badge">Next</span></div></div>
+              </div>
+              <div>
+                <div class="drx-section"><div class="drx-section-line"><strong>Current documents</strong><span>3</span></div><div class="drx-section-line"><span>${icon("file-text")} Solution overview</span><span>Open</span></div><div class="drx-section-line"><span>${icon("shield-check")} Security profile</span><span>Open</span></div><div class="drx-section-line"><span>${icon("receipt-text")} Offer R2</span><span>Review</span></div></div>
+                <div class="drx-section"><strong>Your contacts</strong><div class="drx-person"><span class="drx-avatar drx-avatar-sm">HG</span><span>Hau · Account lead</span></div><div class="drx-person"><span class="drx-avatar drx-avatar-sm">MB</span><span>Maya · Security</span></div></div>
+              </div>
+            </div>
+            <div class="drx-ask">
+              <div><label class="form-label" for="drx-buyer-question">Ask about this deal</label><input id="drx-buyer-question" class="form-control" placeholder="Ask about the plan, documents or offer"></div>
+              <button type="button" class="btn" data-go="question">Ask Margince</button>
+            </div>
+            <p class="drx-small drx-muted">Margince answers only from this published Shared Space and cites its source. If the answer is not here, your question goes to the seller.</p>
+          </div>
+        </article>
+      </div>
+    `;
+  }
+
+  const renderers = {
+    "not-created": notCreated,
+    building,
+    "draft-review": draftReview,
+    ready,
+    publishing,
+    "live-unopened": liveUnopened,
+    "live-active": liveActive,
+    question: questionWaiting,
+    update: updateProposed,
+    paused: () => accessState("paused"),
+    expired: () => accessState("expired"),
+    closed,
+    readonly: () => accessState("readonly"),
+    unavailable: () => accessState("unavailable"),
+    "buyer-first": () => buyerScreen("buyer-first"),
+    "buyer-returning": () => buyerScreen("buyer-returning"),
+    "buyer-stopped": () => buyerScreen("buyer-stopped")
+  };
+
+  function render() {
+    const state = states.find(item => item.id === current) || states[0];
+    detail.textContent = state.detail;
+    controls.querySelectorAll("[data-state]").forEach(control => {
+      control.setAttribute("aria-pressed", String(control.dataset.state === current));
+    });
+    stage.innerHTML = renderers[current]();
+    if (globalThis.lucide) globalThis.lucide.createIcons({ attrs: { width: 16, height: 16 } });
+  }
+
+  root.addEventListener("click", event => {
+    const stateControl = event.target.closest("[data-state]");
+    const flowControl = event.target.closest("[data-go]");
+    const next = stateControl?.dataset.state || flowControl?.dataset.go;
+    if (!next || !renderers[next]) return;
+    current = next;
+    render();
+  });
+
+  render();
+})();
+</script>

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12857,8 +12857,16 @@ paths:
     post:
       tags: [Import]
       operationId: createImportRun
-      security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
-      x-agent-access: human-only
+      security: [ { cookieAuth: [] }, { bearerAuth: [] } ]
+      # Open to an agent because this call writes NO domain rows (AC-M5): it
+      # validates a mapping against the estate and produces a report, which is
+      # exactly the work an assistant helping with a migration should do. What
+      # COMMITS is approveImportRun, and that stays confirm-first.
+      x-mcp-tool:
+        verb: preview_import
+        record_type: import_run
+        tier: auto_execute
+        scope: write
       summary: Create an import run from an uploaded source and a column mapping, and dry-run it.
       description: |
         IEM-WIRE-3. Takes the connector, the `source_ref` from
@@ -12895,8 +12903,14 @@ paths:
     get:
       tags: [Import]
       operationId: getImportRun
-      security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
-      x-agent-access: human-only
+      security: [ { cookieAuth: [] }, { bearerAuth: [] } ]
+      # A read. An assistant that staged the run has to be able to see what
+      # became of it, or it is helping with a migration it cannot observe.
+      x-mcp-tool:
+        verb: read_import_run
+        record_type: import_run
+        tier: auto_execute
+        scope: read
       summary: Read one import run's lifecycle state.
       description: |
         IEM-WIRE-6. A run that stopped part-way reports `failed` **with its
@@ -12921,8 +12935,15 @@ paths:
     get:
       tags: [Import]
       operationId: getImportRunReport
-      security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
-      x-agent-access: human-only
+      security: [ { cookieAuth: [] }, { bearerAuth: [] } ]
+      # The report is the whole point of a dry run. An assistant that cannot
+      # read it cannot tell a person what the import is about to do, which is
+      # the one thing worth asking an assistant about a migration.
+      x-mcp-tool:
+        verb: read_import_report
+        record_type: import_run
+        tier: auto_execute
+        scope: read
       summary: Read the run's report — what will happen, or what did.
       description: |
         IEM-WIRE-4. Available from `awaiting_approval` onward, and it is the
@@ -12949,8 +12970,16 @@ paths:
     post:
       tags: [Import]
       operationId: approveImportRun
-      security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
-      x-agent-access: human-only
+      security: [ { cookieAuth: [] }, { bearerAuth: [] } ]
+      # CONFIRMATION_REQUIRED, and it is the reason the three above can be
+      # auto_execute. This is the call that writes the estate, so an agent may
+      # ask for it and a person must approve it — the approval carries the run
+      # id, so what gets committed is the run whose report the person read.
+      x-mcp-tool:
+        verb: commit_import
+        record_type: import_run
+        tier: confirmation_required
+        scope: write
       summary: Approve a validated import run and commit it.
       description: |
         IEM-WIRE-5, and one of the three audited gates. Valid **only** from
@@ -22425,6 +22454,7 @@ components:
             - custom_field
             - data_subject_request
             - deal
+            - import_run
             - lead
             - list
             - offer

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -46,6 +46,12 @@ type restCommandDeps struct {
 	// there; this door holds the question alone, because a REST send_message
 	// needs to refuse a non-channel anchor without being able to send anything.
 	channels agents.ChannelKinds
+	// imports reads a staged import run's report, which is what a commit's
+	// summary is written from. Same reason `stages` is here: the sentence a
+	// human decides on cannot be written from the request alone, and a summary
+	// that cannot say what the import does asks somebody to approve a bulk
+	// write to their estate sight unseen.
+	imports agents.Imports
 }
 
 // restCommands maps a crm.yaml operationId to the decoder that turns an HTTP
@@ -234,12 +240,12 @@ const (
 //
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
 //nolint:ireturn // same as every other decoder here — GovernedCall is the table's value type.
-func previewImportCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+func previewImportCommand(_ agentPolicy, deps restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
 	cmd, err := agents.DecodeImportPreview(body)
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewImportCall(cmd), nil
+	return agents.NewImportCall(deps.imports, cmd), nil
 }
 
 // commitImportCommand decodes POST /v1/imports/{id}/approve. The run id IS the
@@ -247,12 +253,12 @@ func previewImportCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, bod
 // read belongs to that id.
 //
 //nolint:ireturn // every decoder in restCommands returns GovernedCall — that IS the table's value type, and a concrete return would not satisfy it.
-func commitImportCommand(_ agentPolicy, _ restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+func commitImportCommand(_ agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewImportCall(agents.ImportCommand{
+	return agents.NewImportCall(deps.imports, agents.ImportCommand{
 		Verb:  agents.ImportVerbCommit,
 		RunID: id,
 	}), nil

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -78,6 +78,7 @@ type restCommandDeps struct {
 // reason patch never had that question at all — see patchResolver.Guards'
 // own comment.
 var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *http.Request, body []byte) (agents.GovernedCall, error){
+	"approveImportRun":     commitImportCommand,
 	"archiveActivity":      archiveCommand,
 	"archiveDeal":          archiveCommand,
 	"archiveList":          archiveCommand,
@@ -93,6 +94,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 
 	"createCustomField":         createCommand,
 	"createDeal":                createCommand,
+	"createImportRun":           previewImportCommand,
 	"createLead":                createCommand,
 	"createList":                createCommand,
 	"createOfferTemplate":       createCommand,
@@ -226,7 +228,36 @@ const (
 // annotation, so a type spelled again in this file could disagree with the one
 // the gate admitted against.
 //
+// previewImportCommand decodes POST /v1/imports. The run does not exist yet,
+// so the approval binds to no id — which is safe because the call writes no
+// domain rows (AC-M5), and honest because inventing an id would be a lie.
+//
 //nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair the table above is typed by
+//nolint:ireturn // same as every other decoder here — GovernedCall is the table's value type.
+func previewImportCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	cmd, err := agents.DecodeImportPreview(body)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewImportCall(cmd), nil
+}
+
+// commitImportCommand decodes POST /v1/imports/{id}/approve. The run id IS the
+// target: what a person approves is one validated run, and the report they
+// read belongs to that id.
+//
+//nolint:ireturn // every decoder in restCommands returns GovernedCall — that IS the table's value type, and a concrete return would not satisfy it.
+func commitImportCommand(_ agentPolicy, _ restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
+	id, err := routedID(r)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewImportCall(agents.ImportCommand{
+		Verb:  agents.ImportVerbCommit,
+		RunID: id,
+	}), nil
+}
+
 func archiveCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, _ []byte) (agents.GovernedCall, error) {
 	id, err := routedID(r)
 	if err != nil {

--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -42,6 +42,7 @@ import (
 
 	chi "github.com/go-chi/chi/v5"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
@@ -159,6 +160,18 @@ func enrichDoors(path string, depth agents.EnrichDepth) bothDoorsFixture {
 // refuse an unknown key before staging anything, so a typo here would be
 // answered as a refusal on both doors and the comparison would hold vacuously.
 var bothDoorsFixtures = map[string]bothDoorsFixture{
+	// Both doors commit ONE run, named by id. The tool takes run_id where the
+	// route takes it in the path, and both must resolve to the same command —
+	// otherwise an approval staged by one could be redeemed against the other.
+	"approveImportRun": {
+		rest: func(primary, _ ids.UUID) (*http.Request, []byte) {
+			return doorRequest(http.MethodPost, "/v1/imports/"+primary.String()+"/approve", primary, "")
+		},
+		args: func(primary, _ ids.UUID) string {
+			return `{"run_id":"` + primary.String() + `"}`
+		},
+	},
+
 	"archivePerson":       archiveDoors("people", "person"),
 	"archiveOrganization": archiveDoors("organizations", "organization"),
 	"archiveDeal":         archiveDoors("deals", "deal"),
@@ -440,7 +453,33 @@ func bothDoorsRegistry(staging agents.Approvals) *agents.Registry {
 	agents.RegisterEnrichTool(reg, channelAnchor{}, nil)
 	agents.RegisterLifecycleTools(reg, channelAnchor{}, nil, nil, nil)
 	agents.RegisterCommsTools(reg, bothDoorsComms{}, channelAnchor{})
+	agents.RegisterImportTools(reg, bothDoorsImports{})
 	return reg
+}
+
+// bothDoorsImports answers a run in the one state a commit accepts, so the
+// tool door reaches staging rather than stopping at the state refusal — the
+// refusal has its own gate (TestNoConfirmFirstOperationStagesACallItsExecutorWouldRefuse).
+type bothDoorsImports struct{}
+
+func (bothDoorsImports) ProfileSource(context.Context, string, string) (crmcontracts.ImportSourceProfile, error) {
+	return crmcontracts.ImportSourceProfile{}, nil
+}
+
+func (bothDoorsImports) StageRun(context.Context, crmcontracts.CreateImportRunRequest) (crmcontracts.ImportRun, error) {
+	return crmcontracts.ImportRun{Status: "awaiting_approval"}, nil
+}
+
+func (bothDoorsImports) ReadRun(context.Context, ids.UUID) (crmcontracts.ImportRun, error) {
+	return crmcontracts.ImportRun{Status: "awaiting_approval"}, nil
+}
+
+func (bothDoorsImports) ReadReport(context.Context, ids.UUID) (crmcontracts.ImportRunReport, error) {
+	return crmcontracts.ImportRunReport{}, nil
+}
+
+func (bothDoorsImports) Commit(context.Context, ids.UUID) (crmcontracts.ImportRun, error) {
+	return crmcontracts.ImportRun{Status: "running"}, nil
 }
 
 // channelAnchor is seamRecord's answer plus the one field a channel reply's

--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -637,7 +637,7 @@ func compareDoors(t *testing.T, op, tool string, fixture bothDoorsFixture) {
 
 	req, body := fixture.rest(primary, secondary)
 	call, err := restCommands[op](pol,
-		restCommandDeps{records: channelAnchor{}, channels: channelKinds{}}, req, body)
+		restCommandDeps{records: channelAnchor{}, channels: channelKinds{}, imports: bothDoorsImports{}}, req, body)
 	if err != nil {
 		t.Fatalf("the REST door refused the request its own route declares: %v", err)
 	}

--- a/backend/internal/compose/agentcommandunrunnable_test.go
+++ b/backend/internal/compose/agentcommandunrunnable_test.go
@@ -153,6 +153,7 @@ var unrunnableCalls = map[string]unrunnableCall{
 	"archiveRelationship":  malformedRoutedID(http.MethodDelete, "/relationships"),
 	"archiveSavedView":     malformedRoutedID(http.MethodDelete, "/views"),
 
+	"approveImportRun":          malformedRoutedID(http.MethodPost, "/imports"),
 	"disqualifyLead":            malformedRoutedID(http.MethodDelete, "/leads"),
 	"retireCustomField":         malformedRoutedID(http.MethodPost, "/custom-fields"),
 	"updateCustomFieldOptions":  malformedRoutedID(http.MethodPatch, "/custom-fields"),

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -46,11 +46,11 @@ const approvalTokenHeader = "X-Approval-Token"
 // mutation; anything larger is not a plausible contract payload.
 const maxGatedBody = 1 << 20
 
-func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.StageResolver, records datasource.SystemOfRecordProvider, ownership agents.FieldOwnership, gate *auth.Gate) func(http.Handler) http.Handler {
+func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.StageResolver, records datasource.SystemOfRecordProvider, ownership agents.FieldOwnership, imports agents.Imports, gate *auth.Gate) func(http.Handler) http.Handler {
 	// ONE set of read-side dependencies for both questions this door asks of a
 	// command: what tier it runs at, and what an approval of it would bind to.
 	// They were two structs while the tier had its own table to feed.
-	deps := restCommandDeps{records: records, stages: stages, channels: channelKinds{}}
+	deps := restCommandDeps{records: records, stages: stages, channels: channelKinds{}, imports: imports}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -89,6 +89,13 @@ func TestStageRefusalNamesTheTargetAndSuppliesNoClientPin(t *testing.T) {
 // whether a column is live is a claim these rationales make and a reader must be
 // able to check.
 var unpinnableConfirmFirstTypes = gatekit.Waive(map[agentRecordType]string{
+	"import_run": "import_run has NO version column at all (migrations/custom/20260730120000_flip_and_import_run), and adding one " +
+		"would pin the wrong thing: what a person approves is the run's REPORT, and the report is " +
+		"written once by the dry run and never edited — a run whose report changed would have had to " +
+		"re-run the validation pass, which moves it out of awaiting_approval and makes the commit " +
+		"refuse on state before any pin could speak. The residue is the diff_hash identical-call " +
+		"binding, and it is narrower here than elsewhere: the only argument is the run id, so a " +
+		"drifted call is a different run and fails the hash.",
 	"custom_field": "custom_field HAS a version column (migrations/core/0063) but nothing maintains it: " +
 		"the catalog's own writers (customfields' rename, options and retire paths) issue bare UPDATEs " +
 		"rather than storekit's guarded patch, so the column never leaves 1 and never takes an If-Match. " +

--- a/backend/internal/compose/agentgateredeem_test.go
+++ b/backend/internal/compose/agentgateredeem_test.go
@@ -336,7 +336,7 @@ func gateCallCharges(t *testing.T, sourceSemantic, token string, redeemErr error
 
 	staging := &countingRedeemer{pin: 12, pinned: true, err: redeemErr}
 	recorder := httptest.NewRecorder()
-	gate := agentGate(reg, staging, stages, records, nil, auth.NewGate(fullSeat{}))
+	gate := agentGate(reg, staging, stages, records, nil, nil, auth.NewGate(fullSeat{}))
 	gate(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})).ServeHTTP(recorder, r)

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -39,6 +39,7 @@ const (
 	recordTypeCustomField         agentRecordType = "custom_field"
 	recordTypeDataSubjectRequest  agentRecordType = "data_subject_request"
 	recordTypeDeal                agentRecordType = "deal"
+	recordTypeImportRun           agentRecordType = "import_run"
 	recordTypeLead                agentRecordType = "lead"
 	recordTypeList                agentRecordType = "list"
 	recordTypeOffer               agentRecordType = "offer"
@@ -187,8 +188,8 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/embeddings/reindex/status":                                  {Op: "EmbedReindexStatus", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/extensions":                                                 {Op: "listExtensions", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/field-history":                                              {Op: "getFieldHistory", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"GET /v1/imports/{id}":                                               {Op: "getImportRun", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"GET /v1/imports/{id}/report":                                        {Op: "getImportRunReport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/imports/{id}":                                               {Op: "getImportRun", Access: "tool", Tool: "read_import_run", RecordType: "import_run", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/imports/{id}/report":                                        {Op: "getImportRunReport", Access: "tool", Tool: "read_import_report", RecordType: "import_run", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/installation/license":                                       {Op: "getLicenseEntitlement", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/leads":                                                      {Op: "listLeads", Access: "tool", Tool: "list_records", RecordType: "lead", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/leads/{id}":                                                 {Op: "getLead", Access: "tool", Tool: "read_record", RecordType: "lead", Tier: "auto_execute", Scope: "read"},
@@ -361,9 +362,9 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/filters/preview":                                           {Op: "previewFilter", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates":                                                  {Op: "setFxRate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates/propose-refresh":                                  {Op: "proposeFxRateRefresh", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"POST /v1/imports":                                                   {Op: "createImportRun", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/imports":                                                   {Op: "createImportRun", Access: "tool", Tool: "preview_import", RecordType: "import_run", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/imports/sources":                                           {Op: "uploadImportSource", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"POST /v1/imports/{id}/approve":                                      {Op: "approveImportRun", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/imports/{id}/approve":                                      {Op: "approveImportRun", Access: "tool", Tool: "commit_import", RecordType: "import_run", Tier: "confirmation_required", Scope: "write"},
 	"POST /v1/imports/{id}/undo":                                         {Op: "undoImportRun", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/lead-disqualify-reasons":                                   {Op: "createLeadDisqualifyReason", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/lead-sources":                                              {Op: "createLeadSource", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/agenttierfloor_integration_test.go
+++ b/backend/internal/compose/agenttierfloor_integration_test.go
@@ -143,7 +143,7 @@ func TestAnOrdinaryOrganizationPatchStillRunsUnattended(t *testing.T) {
 // production supplies it.
 func composedRegistry(e *integration.Env) *agents.Registry {
 	return registryWithGate(e.DB(), auth.NewGate(adminSeat{}), nil, nil,
-		SendPath{}, companyEnricher{}, nil, nil, nil)
+		SendPath{}, companyEnricher{}, nil, nil, nil, nil)
 }
 
 // stagedRow is what a staged approval must look like for the operation that

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -419,6 +419,7 @@ func collectStringConsts(file *ast.File, into map[string]string) {
 var exportedApprovalKinds = map[string]string{
 	"KindQuotaRelease":      approvals.KindQuotaRelease,
 	"KindScheduledSendHeld": approvals.KindScheduledSendHeld,
+	"KindImportCommit":      approvals.KindImportCommit,
 }
 
 // crossPackageKinds resolves a kind another module exports and compose stages

--- a/backend/internal/compose/csvimport.go
+++ b/backend/internal/compose/csvimport.go
@@ -92,47 +92,62 @@ func (h importHandlers) UploadImportSource(w http.ResponseWriter, r *http.Reques
 		httperr.Write(w, r, err)
 		return
 	}
-	profile, err := migration.ProfileCSV(bytes.NewReader(body), migration.ProfileRowLimit)
-	if err != nil {
-		httperr.Write(w, r, importProblem(err))
-		return
-	}
-	targets, err := importTargets(object)
+	out, err := h.profileAndStore(ctx, object, body)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
 	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
 
+// profileAndStore is everything the upload does once it HAS the bytes: read the
+// header, propose a mapping, put the file where a run can find it.
+//
+// It is separate from the transport because two doors arrive at this point with
+// bytes in hand. The REST one reads a multipart file. The tool surface takes
+// CSV as text, since an assistant holding a spreadsheet's contents cannot
+// perform a file upload — and asking it to invent a multipart body would be a
+// worse door than none.
+func (h importHandlers) profileAndStore(
+	ctx context.Context, object string, body []byte,
+) (crmcontracts.ImportSourceProfile, error) {
+	profile, err := migration.ProfileCSV(bytes.NewReader(body), migration.ProfileRowLimit)
+	if err != nil {
+		return crmcontracts.ImportSourceProfile{}, importProblem(err)
+	}
+	targets, err := importTargets(object)
+	if err != nil {
+		return crmcontracts.ImportSourceProfile{}, err
+	}
 	ws, ok := principal.WorkspaceID(ctx)
 	if !ok {
-		httperr.Write(w, r, fmt.Errorf("no workspace is bound to this request: %w", apperrors.ErrPermissionDenied))
-		return
+		return crmcontracts.ImportSourceProfile{}, fmt.Errorf(
+			"no workspace is bound to this request: %w", apperrors.ErrPermissionDenied)
 	}
 	key := blobstore.WorkspaceKey(ids.From[ids.WorkspaceKind](ws), importBlobKind, ids.NewV7().String())
 	if err := h.blobs.Put(ctx, key, bytes.NewReader(body), int64(len(body)), "text/csv"); err != nil {
-		httperr.Write(w, r, fmt.Errorf("storing the import source: %w", err))
-		return
+		return crmcontracts.ImportSourceProfile{}, fmt.Errorf("storing the import source: %w", err)
 	}
-
-	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ImportSourceProfile{
+	return crmcontracts.ImportSourceProfile{
 		SourceRef:        key,
 		Object:           crmcontracts.ImportObject(object),
 		Columns:          toContractColumns(profile),
 		RowsProfiled:     profile.RowsProfiled,
 		SuggestedMapping: migration.SuggestMapping(profile, targets),
 		Targets:          targets,
-	})
+	}, nil
 }
 
 // CreateImportRun validates a mapped file against the estate and writes
 // nothing (IEM-WIRE-3, AC-M5). The run arrives at awaiting_approval carrying
 // the report a human reads.
+//
+// Open to an agent: this call writes NO domain rows, by construction (AC-M5),
+// so the worst an ungranted-but-authenticated caller could do is produce a
+// report. What commits is approveImportRun, which stays confirm-first on the
+// tool surface — a person sees the report and says yes.
 func (h importHandlers) CreateImportRun(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if err := auth.RequireHuman(ctx); err != nil {
-		httperr.Write(w, r, err)
-		return
-	}
 	// The grant is taken BEFORE the body is read: an ungranted caller must not
 	// be able to tell a rejected mapping from an accepted one, which is what a
 	// 422 arriving ahead of the 403 would tell them.
@@ -148,15 +163,32 @@ func (h importHandlers) CreateImportRun(w http.ResponseWriter, r *http.Request) 
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	object := string(req.Object)
-	if err := h.ownsSource(ctx, req.SourceRef); err != nil {
-		httperr.Write(w, r, err)
-		return
-	}
-	mapping, err := mappingFrom(object, req)
+	staged, err := h.stageRun(ctx, req)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
+	}
+	httperr.WriteJSON(w, http.StatusAccepted, staged)
+}
+
+// stageRun is everything createImportRun does once it HAS the request: check
+// the source belongs to this workspace, validate the mapping, dry-run it, and
+// park the result for a human to approve.
+//
+// It is separate from the transport because the tool surface arrives here too,
+// and the dry run is the part that must be identical on both doors — G stays
+// product law, so nothing may commit an import that has not produced a report
+// through exactly this path.
+func (h importHandlers) stageRun(
+	ctx context.Context, req crmcontracts.CreateImportRunRequest,
+) (crmcontracts.ImportRun, error) {
+	object := string(req.Object)
+	if err := h.ownsSource(ctx, req.SourceRef); err != nil {
+		return crmcontracts.ImportRun{}, err
+	}
+	mapping, err := mappingFrom(object, req)
+	if err != nil {
+		return crmcontracts.ImportRun{}, err
 	}
 
 	runs := migration.NewRunStore(h.db)
@@ -167,8 +199,7 @@ func (h importHandlers) CreateImportRun(w http.ResponseWriter, r *http.Request) 
 		Mapping:   mapping,
 	})
 	if err != nil {
-		httperr.Write(w, r, err)
-		return
+		return crmcontracts.ImportRun{}, err
 	}
 
 	source := migration.NewCSVSource(h.blobs, req.SourceRef, object, mapping.Fields, mapping.SourceKey)
@@ -179,14 +210,12 @@ func (h importHandlers) CreateImportRun(w http.ResponseWriter, r *http.Request) 
 		// forever with nothing able to move it, so the failure is recorded on
 		// the run the caller was just handed rather than only in the response.
 		failValidation(ctx, runs, run.ID, err)
-		httperr.Write(w, r, importProblem(err))
-		return
+		return crmcontracts.ImportRun{}, importProblem(err)
 	}
 	report, err = refinePrediction(ctx, source, writers, object, report)
 	if err != nil {
 		failValidation(ctx, runs, run.ID, err)
-		httperr.Write(w, r, importProblem(err))
-		return
+		return crmcontracts.ImportRun{}, importProblem(err)
 	}
 	report = withSkippedLines(report, object, source.Skipped())
 	if err := runs.AwaitApproval(ctx, run.ID, report); err != nil {
@@ -194,16 +223,14 @@ func (h importHandlers) CreateImportRun(w http.ResponseWriter, r *http.Request) 
 		// parked for a human is a run in `validating` that neither approve nor
 		// resume will ever move.
 		failValidation(ctx, runs, run.ID, err)
-		httperr.Write(w, r, err)
-		return
+		return crmcontracts.ImportRun{}, err
 	}
 
 	staged, err := runs.GetStaged(ctx, run.ID)
 	if err != nil {
-		httperr.Write(w, r, err)
-		return
+		return crmcontracts.ImportRun{}, err
 	}
-	httperr.WriteJSON(w, http.StatusAccepted, toContractImportRun(staged))
+	return toContractImportRun(staged), nil
 }
 
 // GetImportRun reports the lifecycle (IEM-WIRE-6): a failed run carries its
@@ -234,26 +261,40 @@ func (h importHandlers) GetImportRunReport(w http.ResponseWriter, r *http.Reques
 
 // ApproveImportRun commits a validated run (IEM-WIRE-5).
 func (h importHandlers) ApproveImportRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	ctx := r.Context()
-	run, err := h.staged(r, id)
+	out, err := h.commitRun(r.Context(), id)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
 	}
+	httperr.WriteJSON(w, http.StatusAccepted, out)
+}
+
+// commitRun is the approval and the write, without the transport.
+//
+// Shared with the tool surface for the reason the whole import seam is shared:
+// this is the call that writes a customer's estate, and two paths that both
+// "commit an approved run" would be two chances to disagree about what an
+// approved run is.
+func (h importHandlers) commitRun(
+	ctx context.Context, id openapi_types.UUID,
+) (crmcontracts.ImportRun, error) {
+	run, err := h.stagedFor(ctx, id)
+	if err != nil {
+		return crmcontracts.ImportRun{}, err
+	}
 	if run.Mapping == nil {
-		httperr.Write(w, r, fmt.Errorf("import run %s carries no mapping, so it is not an approvable import: %w", run.ID, apperrors.ErrConflict))
-		return
+		return crmcontracts.ImportRun{}, fmt.Errorf(
+			"import run %s carries no mapping, so it is not an approvable import: %w",
+			run.ID, apperrors.ErrConflict)
 	}
 	if h.blobs == nil {
-		httperr.Write(w, r, errNoObjectStore)
-		return
+		return crmcontracts.ImportRun{}, errNoObjectStore
 	}
 
 	runs := migration.NewRunStore(h.db)
 	approved, err := h.startOrResume(ctx, runs, run)
 	if err != nil {
-		httperr.Write(w, r, err)
-		return
+		return crmcontracts.ImportRun{}, err
 	}
 
 	object := run.Mapping.Object
@@ -268,16 +309,14 @@ func (h importHandlers) ApproveImportRun(w http.ResponseWriter, r *http.Request,
 		// The engine has already recorded the failure and its checkpoint on the
 		// run; the caller is told which run to resume rather than being handed
 		// a bare 500.
-		httperr.Write(w, r, importProblem(err))
-		return
+		return crmcontracts.ImportRun{}, importProblem(err)
 	}
 
 	final, err := runs.GetStaged(commitCtx, approved.ID)
 	if err != nil {
-		httperr.Write(w, r, err)
-		return
+		return crmcontracts.ImportRun{}, err
 	}
-	httperr.WriteJSON(w, http.StatusAccepted, toContractImportRun(final))
+	return toContractImportRun(final), nil
 }
 
 // UndoImportRun reverses a completed csv run (IEM-WIRE-9). Mapping.Object is
@@ -328,14 +367,29 @@ func (h importHandlers) startOrResume(ctx context.Context, runs *migration.RunSt
 	return runs.Approve(ctx, run.ID)
 }
 
-// staged is the read every id-bearing operation starts from: human-only, then
-// the store's own gate, which answers not-found for a run outside the caller's
-// scope rather than disclosing that it exists.
+// staged is the read every id-bearing operation starts from: the store's own
+// gate answers not-found for a run outside the caller's scope rather than
+// disclosing that it exists.
 func (h importHandlers) staged(r *http.Request, id openapi_types.UUID) (migration.Run, error) {
-	ctx := r.Context()
-	if err := auth.RequireHuman(ctx); err != nil {
-		return migration.Run{}, err
-	}
+	return h.stagedFor(r.Context(), id)
+}
+
+// stagedFor is staged without a request, so the tool surface reaches the same
+// read the REST one does.
+//
+// THE HUMAN-ONLY CHECK THAT SAT HERE IS GONE, not moved. Reading an import run
+// and its report is open to an agent now — a migration an assistant is helping
+// with is unreadable to it otherwise, which was the whole gap. What bounds it
+// is the object grant, auth.Require(migration.ImportRunObject, …), taken by
+// every caller of this and unchanged: an agent with no import grant still gets
+// nothing, and the run store still answers not-found for another workspace's
+// run.
+//
+// Two operations keep RequireHuman, each for its own reason. uploadImportSource
+// is multipart and has no agent-shaped door at all. undoImportRun reverses a
+// committed estate-wide write, and reversing is not something a caller should
+// reach without a person present.
+func (h importHandlers) stagedFor(ctx context.Context, id openapi_types.UUID) (migration.Run, error) {
 	run, err := migration.NewRunStore(h.db).GetStaged(ctx, migration.RunID(id))
 	if err != nil {
 		return migration.Run{}, err

--- a/backend/internal/compose/importseam.go
+++ b/backend/internal/compose/importseam.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The import seam: the tool surface's four import verbs, over the SAME
+// handlers the REST transport uses.
+//
+// It delegates rather than reimplementing, and that is the whole design. The
+// dry run is the only review a migrate-in flow gets, so two code paths that
+// both "validate a mapping" would be two chances for them to disagree about
+// what an import is going to do — and the one a person read would not be the
+// one that ran.
+//
+// It holds the Server by pointer rather than copying importHandlers, because
+// the object store arrives after assembly (WithBlobstore) and a seam that
+// captured the handlers by value at wiring time could hold a copy with no
+// blobstore in it. Same reason companyEnricher holds `srv` rather than a
+// store. Both wiring sites build the seam AFTER the option loop has run, so
+// what it points at is the Server that is actually served.
+//
+// A registry built with no Server at all — NewRegistry, which several roles and
+// every parity gate use — gets a seam over bare handlers instead. Its reads
+// work; its three source-bearing verbs refuse with errNoObjectStore, which is
+// what a role that stores no objects can honestly offer. What it must NOT do is
+// go missing: the contract declares these four verbs, and a registry that does
+// not serve a declared verb advertises something tools/list cannot offer.
+
+import (
+	"context"
+	"fmt"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// importSeam adapts the import handlers to the agents module's Imports port.
+type importSeam struct {
+	// srv is the served Server, when there is one. The handlers are read off it
+	// per call so a blobstore installed after wiring is visible.
+	srv *Server
+	// handlers is the standalone fallback, used only when srv is nil.
+	handlers importHandlers
+}
+
+// door answers the handlers this seam speaks through.
+func (i importSeam) door() importHandlers {
+	if i.srv != nil {
+		return i.srv.importHandlers
+	}
+	return i.handlers
+}
+
+// importsFor answers the seam. It is never nil, and that is deliberate.
+//
+// The first cut returned nil for a role with no object store, on the reasoning
+// that four tools which always refuse are worse than none. That reasoning is
+// wrong here: the CONTRACT declares these four verbs, and a registry that does
+// not serve a declared verb fails TestEveryDeclaredToolVerbIsRegistered — the
+// contract would be advertising something tools/list cannot offer, which is
+// the exact dishonesty that gate exists to prevent. So the tools are always
+// registered, and the three that need the source bytes refuse at call time
+// with errNoObjectStore, naming what is missing.
+//
+//nolint:ireturn // the PORT is the return type: agents owns the interface, compose supplies an implementation of it, and naming the concrete type here would put the seam's shape on the wrong side of the module edge (ADR-0054). Same as tagSeam and colleagueLister.
+func importsFor(s *Server) agents.Imports {
+	return importSeam{srv: s}
+}
+
+// importsOverDB is importsFor for a registry with no Server: the reads reach
+// the database, and everything needing the source file refuses.
+//
+//nolint:ireturn // same as importsFor above — the port is the return type.
+func importsOverDB(db *database.DB) agents.Imports {
+	return importSeam{handlers: importHandlers{db: db}}
+}
+
+func (i importSeam) ProfileSource(
+	ctx context.Context, object, csv string,
+) (crmcontracts.ImportSourceProfile, error) {
+	if err := i.ready(); err != nil {
+		return crmcontracts.ImportSourceProfile{}, err
+	}
+	return i.door().profileAndStore(ctx, object, []byte(csv))
+}
+
+func (i importSeam) StageRun(
+	ctx context.Context, req crmcontracts.CreateImportRunRequest,
+) (crmcontracts.ImportRun, error) {
+	if err := i.ready(); err != nil {
+		return crmcontracts.ImportRun{}, err
+	}
+	return i.door().stageRun(ctx, req)
+}
+
+func (i importSeam) ReadRun(ctx context.Context, id ids.UUID) (crmcontracts.ImportRun, error) {
+	run, err := i.door().stagedFor(ctx, openapi_types.UUID(id))
+	if err != nil {
+		return crmcontracts.ImportRun{}, err
+	}
+	return toContractImportRun(run), nil
+}
+
+func (i importSeam) ReadReport(ctx context.Context, id ids.UUID) (crmcontracts.ImportRunReport, error) {
+	run, err := i.door().stagedFor(ctx, openapi_types.UUID(id))
+	if err != nil {
+		return crmcontracts.ImportRunReport{}, err
+	}
+	if run.Report == nil {
+		// The same 409 the REST door gives, and for the same reason: a run
+		// that has not been validated has no report, and answering an empty
+		// one would read as "this import will do nothing".
+		return crmcontracts.ImportRunReport{}, fmt.Errorf(
+			"import run %s has not been validated yet: %w", run.ID, apperrors.ErrConflict)
+	}
+	return toContractImportReport(run), nil
+}
+
+func (i importSeam) Commit(ctx context.Context, id ids.UUID) (crmcontracts.ImportRun, error) {
+	if err := i.ready(); err != nil {
+		return crmcontracts.ImportRun{}, err
+	}
+	return i.door().commitRun(ctx, openapi_types.UUID(id))
+}
+
+// ready refuses the three verbs that need the source bytes when this role
+// stores no objects.
+//
+// The two pure reads do not call it: reading a run's state or its report only
+// touches the database, and refusing those for want of a blobstore would hide
+// a run that genuinely exists.
+func (i importSeam) ready() error {
+	if i.door().blobs == nil {
+		return errNoObjectStore
+	}
+	return nil
+}

--- a/backend/internal/compose/importseam.go
+++ b/backend/internal/compose/importseam.go
@@ -34,9 +34,12 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // importSeam adapts the import handlers to the agents module's Imports port.
@@ -83,6 +86,16 @@ func importsOverDB(db *database.DB) agents.Imports {
 func (i importSeam) ProfileSource(
 	ctx context.Context, object, csv string,
 ) (crmcontracts.ImportSourceProfile, error) {
+	// THE GRANT IS TAKEN BEFORE THE FILE IS STORED. profileAndStore parses the
+	// CSV and puts it in the object store, and the first authorization check on
+	// the REST path is the one CreateImportRun makes before calling it. The
+	// tool path had no equivalent, so a caller with write scope and no
+	// import_run grant could call preview_import repeatedly, leaving an orphan
+	// blob each time before the refusal arrived — storage a stranger can spend,
+	// and a probe of whether their CSV parses.
+	if err := auth.Require(ctx, migration.ImportRunObject, principal.ActionCreate); err != nil {
+		return crmcontracts.ImportSourceProfile{}, err
+	}
 	if err := i.ready(); err != nil {
 		return crmcontracts.ImportSourceProfile{}, err
 	}

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -227,6 +227,13 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 // listed here and then made reachable fails as loudly as one that was never
 // covered, so the list cannot quietly outlive its reason.
 var unreachableInThisLane = gatekit.Waive(map[string]string{
+	"preview_import": "needs an object store to put the source file in; this lane composes none, " +
+		"so the call would exercise the refusal rather than the handler",
+	"read_import_run": "needs a seat holding import_run.read, which this lane's seat does not " +
+		"carry — a migration run is an admin-scoped object, and granting it here would widen the " +
+		"authority every other tool in the sweep runs under",
+	"read_import_report": "needs a run that has been dry-run, which needs the object store above",
+	"commit_import":      "confirm-first, and needs the object store above to reach a committable run",
 	"apply_tag": "needs a seat holding tag.read, which this lane's seat does not carry — " +
 		"granting it here would widen the authority every other tool in the sweep runs under, " +
 		"and the answer shape it would prove is the one remove_tag already shares",

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -47,7 +47,7 @@ func NewRegistryFor(db *database.DB, send SendPath) *agents.Registry {
 	// The gate resolves seats through identity, and identity binds the same
 	// handle: a registry built for a named workspace must not admit through a
 	// service that resolves a different one.
-	return registryWithGate(db, auth.NewGate(identity.NewServiceFor(db)), nil, nil, send, companyEnricher{}, nil, nil, slog.Default())
+	return registryWithGate(db, auth.NewGate(identity.NewServiceFor(db)), nil, nil, send, companyEnricher{}, nil, nil, nil, slog.Default())
 }
 
 // NewRegistryWithIncumbent is NewRegistry plus the per-workspace live-incumbent
@@ -55,14 +55,14 @@ func NewRegistryFor(db *database.DB, send SendPath) *agents.Registry {
 // through — the wiring a role with a vault (the api server) installs so the MCP
 // tool surface can actually write back, not just answer errNoWriteIncumbent.
 func NewRegistryWithIncumbent(pool *pgxpool.Pool, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath) *agents.Registry {
-	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, slog.Default())
+	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, nil, slog.Default())
 }
 
 func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath) *agents.Registry {
 	if brain == nil {
-		return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, slog.Default())
+		return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, nil, slog.Default())
 	}
-	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil, nil, slog.Default())
+	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil, nil, nil, slog.Default())
 }
 
 // registryWithGate composes the tool surface. The quota charger arrives as
@@ -79,7 +79,7 @@ func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumben
 // model path has none, and the offline fake binds no embeddings model — and
 // every path that can lose the vector lane says so on the wire rather than
 // serving a lexically-ranked page under a semantic label.
-func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, enricher agents.CompanyEnricher, embedder search.Embedder, transcriptOnLanding activities.TranscriptReadEnqueue, log *slog.Logger, opts ...agents.RegistryOption) *agents.Registry {
+func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, enricher agents.CompanyEnricher, embedder search.Embedder, transcriptOnLanding activities.TranscriptReadEnqueue, imports agents.Imports, log *slog.Logger, opts ...agents.RegistryOption) *agents.Registry {
 	// The Dispatcher is the datasource seam every core/slipping tool
 	// rides: a native-mode workspace lands on the composite SoR
 	// Provider exactly as before, an overlay-mode workspace's reads land
@@ -212,6 +212,16 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	agents.RegisterWhoamiTool(registry, actingIdentity(pool))
 	agents.RegisterColleaguesTool(registry, colleagueLister(pool))
 	agents.RegisterTagTools(registry, tagSeam(pool))
+	// The migrate-in verbs, ALWAYS served: the contract declares all four, and
+	// a registry that does not serve a declared verb advertises something
+	// tools/list cannot offer. A registry built with no Server falls back to
+	// bare handlers — its reads work, and the three verbs that need the source
+	// file refuse with errNoObjectStore, which is what a role storing no
+	// objects can honestly do.
+	if imports == nil {
+		imports = importsOverDB(db)
+	}
+	agents.RegisterImportTools(registry, imports)
 	// The pipeline-risk intents: the candidate set rides the deals
 	// module's row-scoped list, the drafts land through the provider.
 	agents.RegisterSlippingTools(registry, nativeOnlySlippingLister(sorMode, slippingLister(pool)), followUpDrafter(provider))

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -59,7 +59,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	// a counter it then never paid — the exact half-a-control this change exists
 	// to remove.
 	registry := registryWithGate(InstallationDB(pool), gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool), srv.send,
-		companyEnricher{}, srv.retrievalEmbedder, nil, srv.log, agents.WithQuotaCharger(srv.quotaMeter))
+		companyEnricher{}, srv.retrievalEmbedder, nil, importsFor(&srv), srv.log, agents.WithQuotaCharger(srv.quotaMeter))
 	// The ADR-0055 admission layer and the MCP tool surface share one
 	// provider seam: agentGate's StageResolver dispatches per workspace
 	// exactly like the MCP registry's tools do — and the overlay-mode

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -74,7 +74,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	api := crmcontracts.HandlerWithOptions(srv, crmcontracts.ChiServerOptions{
 		BaseURL: httpserver.BaseURL,
 		Middlewares: []crmcontracts.MiddlewareFunc{
-			agentGate(registry, staging, provider, provider, fieldOwnership{pool: pool}, gate),
+			agentGate(registry, staging, provider, provider, fieldOwnership{pool: pool}, importsFor(&srv), gate),
 			idempotency(pool, replayProbes(staging.svc, contracts.NewStore(InstallationDB(pool)))),
 			// Outermost: an overlay-mode SoR write is refused before it can
 			// be recorded under an idempotency key or staged as an agent

--- a/backend/internal/compose/toolregistry.go
+++ b/backend/internal/compose/toolregistry.go
@@ -33,6 +33,6 @@ func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 	s.toolRegistry = registryWithGate(InstallationDB(pool),
 		auth.NewGate(identity.NewService(pool), auth.WithQuota(s.quotaMeter)),
 		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s},
-		s.retrievalEmbedder, s.transcriptOnLanding, s.log,
+		s.retrievalEmbedder, s.transcriptOnLanding, importsFor(s), s.log,
 		agents.WithQuotaCharger(s.quotaMeter), agents.WithCostShare(s.quotaMeter))
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -42664,6 +42664,8 @@ func (siw *ServerInterfaceWrapper) CreateImportRun(w http.ResponseWriter, r *htt
 
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42716,6 +42718,8 @@ func (siw *ServerInterfaceWrapper) GetImportRun(w http.ResponseWriter, r *http.R
 
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42748,6 +42752,8 @@ func (siw *ServerInterfaceWrapper) ApproveImportRun(w http.ResponseWriter, r *ht
 
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42779,6 +42785,8 @@ func (siw *ServerInterfaceWrapper) GetImportRunReport(w http.ResponseWriter, r *
 	ctx := r.Context()
 
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
 
 	r = r.WithContext(ctx)
 

--- a/backend/internal/modules/agents/command_import.go
+++ b/backend/internal/modules/agents/command_import.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The import commands: what an approval of a migrate-in call binds to.
+//
+// An import run is not a record. It has no owner, no row scope of its own, no
+// custom fields — it is a unit of work over the estate, and the estate is what
+// the approval is really about. So these commands do not go through the record
+// seam the create/patch/archive family uses; they name the run, and the run's
+// own report is what the person approving reads.
+//
+// TWO OPERATIONS REACH HERE and they are asymmetric on purpose.
+// createImportRun writes no domain rows (AC-M5), so its approval is a
+// formality the tier never asks for — it is registered because the fitness
+// test requires every agent-reachable mutating route to decode into something
+// that can say what an approval would bind to, and answering "nothing" for a
+// route that touches the estate is exactly the gap that test exists to close.
+// approveImportRun is the one that writes, and its approval names the run.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// ImportCommand is one call against an import run.
+//
+// Verb distinguishes staging a dry run from committing it, because the two
+// bind approvals to different things: a dry run has no run yet, and a commit
+// names one.
+type ImportCommand struct {
+	Verb  string
+	RunID ids.UUID
+	// Object is what the file's rows are, carried so the summary a person
+	// reads says "import 400 organizations" rather than "import a file".
+	Object string
+}
+
+// The two verbs an ImportCommand can carry.
+const (
+	ImportVerbPreview = "preview"
+	ImportVerbCommit  = "commit"
+)
+
+// NewImportCall binds one import command to the resolver that speaks it.
+//
+//nolint:ireturn // the call is the product, same as every other family here
+func NewImportCall(cmd ImportCommand) GovernedCall {
+	return bind[ImportCommand](importResolver{}, cmd)
+}
+
+type importResolver struct{}
+
+// Subject names what the approval binds to.
+//
+// A commit binds to its run: the report a person read belongs to that id, and
+// an approval that named only "an import" could be redeemed against a
+// different run — one whose report nobody saw.
+//
+// A preview binds to nothing, because there is nothing yet: the run it will
+// create does not exist when the call is staged. That is honest rather than a
+// gap, and it is safe because a preview writes no domain rows.
+func (importResolver) Subject(_ context.Context, cmd ImportCommand) (StageInfo, error) {
+	if cmd.Verb == ImportVerbCommit {
+		return StageInfo{
+			TargetType: importRunRecordType,
+			TargetID:   cmd.RunID,
+			Summary: fmt.Sprintf("Import %s records from the file staged as run %s",
+				cmd.Object, cmd.RunID),
+		}, nil
+	}
+	return StageInfo{
+		TargetType: importRunRecordType,
+		Summary:    fmt.Sprintf("Check a file of %s records against this workspace, writing nothing", cmd.Object),
+	}, nil
+}
+
+// Guards is where a family refuses a call no approval could carry out. There
+// is nothing to refuse here that the handler does not already refuse better:
+// the run's state is the only precondition, the handler reads it, and reading
+// it twice would let the two disagree.
+func (importResolver) Guards(context.Context, ImportCommand) error { return nil }
+
+// DecodeImportPreview reads POST /v1/imports into the preview command.
+//
+// Only `object` is read. The mapping and the file are what the call DOES, not
+// what an approval of it binds to, and a summary quoting a thousand-row CSV
+// back at a person is not a summary.
+func DecodeImportPreview(body []byte) (ImportCommand, error) {
+	var req struct {
+		Object string `json:"object"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ImportCommand{}, &BadArgsError{Cause: fmt.Errorf("reading the import request: %w", err)}
+	}
+	return ImportCommand{Verb: ImportVerbPreview, Object: req.Object}, nil
+}

--- a/backend/internal/modules/agents/command_import.go
+++ b/backend/internal/modules/agents/command_import.go
@@ -23,7 +23,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -48,12 +50,17 @@ const (
 
 // NewImportCall binds one import command to the resolver that speaks it.
 //
+// The seam is REQUIRED for a commit, because the summary a person decides on
+// is written from the run's report — see Subject. Both doors pass the same one,
+// so a commit staged over REST and one staged over MCP describe the import
+// identically. A preview needs no seam and may pass nil.
+//
 //nolint:ireturn // the call is the product, same as every other family here
-func NewImportCall(cmd ImportCommand) GovernedCall {
-	return bind[ImportCommand](importResolver{}, cmd)
+func NewImportCall(imports Imports, cmd ImportCommand) GovernedCall {
+	return bind[ImportCommand](importResolver{imports: imports}, cmd)
 }
 
-type importResolver struct{}
+type importResolver struct{ imports Imports }
 
 // Subject names what the approval binds to.
 //
@@ -64,19 +71,83 @@ type importResolver struct{}
 // A preview binds to nothing, because there is nothing yet: the run it will
 // create does not exist when the call is staged. That is honest rather than a
 // gap, and it is safe because a preview writes no domain rows.
-func (importResolver) Subject(_ context.Context, cmd ImportCommand) (StageInfo, error) {
+// THE SUMMARY CARRIES THE REPORT'S COUNTS for a commit, and that is the whole
+// reason this resolver holds a seam. The approval row a person sees in the
+// inbox IS its summary — nothing renders the report beside it — so a summary
+// saying only "import run <uuid>" asks somebody to authorise a bulk write to
+// their estate without telling them what it does. They would be clicking yes
+// on a number they never saw.
+func (r importResolver) Subject(ctx context.Context, cmd ImportCommand) (StageInfo, error) {
 	if cmd.Verb == ImportVerbCommit {
+		object, report, err := r.reportFor(ctx, cmd)
+		if err != nil {
+			return StageInfo{}, err
+		}
 		return StageInfo{
 			TargetType: importRunRecordType,
 			TargetID:   cmd.RunID,
-			Summary: fmt.Sprintf("Import %s records from the file staged as run %s",
-				cmd.Object, cmd.RunID),
+			Summary:    describeImport(object, report),
 		}, nil
 	}
 	return StageInfo{
 		TargetType: importRunRecordType,
 		Summary:    fmt.Sprintf("Check a file of %s records against this workspace, writing nothing", cmd.Object),
 	}, nil
+}
+
+// reportFor reads what the run will do, and what its rows are.
+//
+// A run awaiting approval HAS a report — reaching that state is what produces
+// one. Failing to read it means something is wrong with the run, and staging an
+// approval whose summary cannot say what the import does is worse than
+// refusing: it is the exact blind yes this method exists to prevent.
+func (r importResolver) reportFor(
+	ctx context.Context, cmd ImportCommand,
+) (string, crmcontracts.ImportRunReport, error) {
+	if r.imports == nil {
+		return "", crmcontracts.ImportRunReport{}, fmt.Errorf(
+			"no import seam is wired, so the approval for run %s could not say what it would do", cmd.RunID)
+	}
+	run, err := r.imports.ReadRun(ctx, cmd.RunID)
+	if err != nil {
+		return "", crmcontracts.ImportRunReport{}, err
+	}
+	if err := refuseUncommittableRun(run); err != nil {
+		return "", crmcontracts.ImportRunReport{}, err
+	}
+	report, err := r.imports.ReadReport(ctx, cmd.RunID)
+	if err != nil {
+		return "", crmcontracts.ImportRunReport{}, fmt.Errorf(
+			"reading the report of import run %s before asking for approval: %w", cmd.RunID, err)
+	}
+	return string(run.Object), report, nil
+}
+
+// describeImport writes the sentence a person decides on.
+//
+// Plain counts, in the order that matters to somebody protecting their data:
+// what is new, what changes under them, what is left alone, and what could not
+// be used. The unusable count is never omitted when it is non-zero, even
+// though it is the least flattering number — a summary that quietly drops it
+// reads as a clean import.
+func describeImport(object string, report crmcontracts.ImportRunReport) string {
+	d := report.Disposition
+	parts := []string{fmt.Sprintf("create %d", d.Created)}
+	if d.Updated > 0 {
+		parts = append(parts, fmt.Sprintf("update %d", d.Updated))
+	}
+	if d.Unchanged > 0 {
+		parts = append(parts, fmt.Sprintf("leave %d unchanged", d.Unchanged))
+	}
+	if d.Skipped > 0 {
+		parts = append(parts, fmt.Sprintf("skip %d", d.Skipped))
+	}
+	summary := fmt.Sprintf("Import %d rows as %s records: %s",
+		report.RowsRead, object, strings.Join(parts, ", "))
+	if len(report.Issues) > 0 {
+		summary += fmt.Sprintf(". %d row(s) could not be used", len(report.Issues))
+	}
+	return summary
 }
 
 // Guards is where a family refuses a call no approval could carry out. There

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -197,6 +197,7 @@ func fullRegistry(t *testing.T) *Registry {
 	RegisterWhoamiTool(r, func(context.Context) (ActingIdentity, error) { return ActingIdentity{}, nil })
 	RegisterColleaguesTool(r, func(context.Context, string) ([]Colleague, bool, error) { return nil, false, nil })
 	RegisterTagTools(r, stubTags{})
+	RegisterImportTools(r, stubImports{})
 	RegisterListTool(r, nil, probeVocabulary{})
 	RegisterBriefTool(r, briefOf(0))
 	RegisterApprovalTools(r, &fakeInbox{})

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -232,6 +232,7 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterWhoamiTool(r, func(context.Context) (ActingIdentity, error) { return ActingIdentity{}, nil })
 	RegisterColleaguesTool(r, func(context.Context, string) ([]Colleague, bool, error) { return nil, false, nil })
 	RegisterTagTools(r, stubTags{})
+	RegisterImportTools(r, stubImports{})
 	RegisterListTool(r, seamProbeProvider{}, probeVocabulary{})
 	RegisterBriefTool(r, func(context.Context) (ReadBriefResult, error) {
 		return ReadBriefResult{}, errSeamReached

--- a/backend/internal/modules/agents/results_identity.go
+++ b/backend/internal/modules/agents/results_identity.go
@@ -12,6 +12,7 @@ package agents
 // gets the task, which word to tag with.
 
 import (
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -44,4 +45,39 @@ type TagAppliedResult struct {
 	TagID      ids.UUID `json:"tag_id"`
 	RecordType string   `json:"record_type"`
 	RecordID   ids.UUID `json:"record_id"`
+}
+
+// ImportRunResult is one migrate-in run: what it is importing, where it has
+// got to, and why it stopped if it did.
+//
+// `checkpoint` is here rather than hidden because a failed run is resumable
+// from it, and a caller told only "failed" would report a dead end where the
+// product has a resume.
+type ImportRunResult struct {
+	RunID      string `json:"run_id"`
+	Object     string `json:"object"`
+	State      string `json:"state"`
+	Checkpoint int    `json:"checkpoint"`
+	Error      string `json:"error,omitempty"`
+}
+
+// ImportPreviewResult is what a dry run produced, plus what it decided about
+// the file's columns.
+//
+// `unmapped` is the field a caller most needs and would least think to ask
+// for: a column nothing reads is dropped silently otherwise, and a mistyped
+// field name looks exactly like a clean import until somebody notices the data
+// is not there.
+type ImportPreviewResult struct {
+	Run      ImportRunResult   `json:"run"`
+	Mapping  map[string]string `json:"mapping"`
+	Columns  []string          `json:"columns"`
+	Unmapped []string          `json:"unmapped,omitempty"`
+}
+
+// ImportReportResult carries the run's own report unchanged — one shape before
+// and after the commit, so a person comparing what will happen with what did
+// compares like with like.
+type ImportReportResult struct {
+	Report crmcontracts.ImportRunReport `json:"report"`
 }

--- a/backend/internal/modules/agents/stubimports_test.go
+++ b/backend/internal/modules/agents/stubimports_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// stubImports satisfies the Imports seam for the whole-surface walks. It
+// answers a run in the one state a commit accepts, so the conformance walk
+// reaches Handle rather than stopping at the state refusal.
+type stubImports struct{}
+
+func (stubImports) ProfileSource(context.Context, string, string) (crmcontracts.ImportSourceProfile, error) {
+	return crmcontracts.ImportSourceProfile{}, nil
+}
+
+func (stubImports) StageRun(context.Context, crmcontracts.CreateImportRunRequest) (crmcontracts.ImportRun, error) {
+	return crmcontracts.ImportRun{Status: awaitingApproval}, nil
+}
+
+func (stubImports) ReadRun(context.Context, ids.UUID) (crmcontracts.ImportRun, error) {
+	return crmcontracts.ImportRun{Status: awaitingApproval}, nil
+}
+
+func (stubImports) ReadReport(context.Context, ids.UUID) (crmcontracts.ImportRunReport, error) {
+	return crmcontracts.ImportRunReport{}, nil
+}
+
+func (stubImports) Commit(context.Context, ids.UUID) (crmcontracts.ImportRun, error) {
+	return crmcontracts.ImportRun{Status: "running"}, nil
+}

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1114,6 +1114,112 @@
       "warnings"
     ]
   },
+  "commit_import": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "checkpoint": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "checkpoint",
+          "object",
+          "run_id",
+          "state"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "create_record": {
     "type": "object",
     "properties": {
@@ -3455,6 +3561,140 @@
       "warnings"
     ]
   },
+  "preview_import": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mapping": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "run": {
+            "type": "object",
+            "properties": {
+              "checkpoint": {
+                "type": "integer"
+              },
+              "error": {
+                "type": "string"
+              },
+              "object": {
+                "type": "string"
+              },
+              "run_id": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "checkpoint",
+              "object",
+              "run_id",
+              "state"
+            ]
+          },
+          "unmapped": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "mapping",
+          "run"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "progress_deal": {
     "type": "object",
     "properties": {
@@ -4276,6 +4516,337 @@
           "candidate_count",
           "generated_at",
           "items"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
+  "read_import_report": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "report": {
+            "type": "object",
+            "properties": {
+              "disposition": {
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "type": "integer"
+                  },
+                  "skipped": {
+                    "type": "integer"
+                  },
+                  "unchanged": {
+                    "type": "integer"
+                  },
+                  "updated": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "created",
+                  "skipped",
+                  "unchanged",
+                  "updated"
+                ]
+              },
+              "estimated_duration_seconds": {
+                "type": "integer"
+              },
+              "issues": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "column": {
+                      "type": "string"
+                    },
+                    "line": {
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "line",
+                    "reason"
+                  ]
+                }
+              },
+              "rows_read": {
+                "type": "integer"
+              },
+              "run_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "source_key_used": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "undo": {
+                "type": "object",
+                "properties": {
+                  "errored": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "object": {
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "object",
+                        "reason"
+                      ]
+                    }
+                  },
+                  "kept": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "object": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "object"
+                      ]
+                    }
+                  },
+                  "reversed_count": {
+                    "type": "integer"
+                  },
+                  "run_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "errored",
+                  "kept",
+                  "reversed_count",
+                  "run_id",
+                  "status"
+                ]
+              }
+            },
+            "required": [
+              "disposition",
+              "issues",
+              "rows_read",
+              "run_id",
+              "source_key_used",
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "report"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
+  "read_import_run": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "checkpoint": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "checkpoint",
+          "object",
+          "run_id",
+          "state"
         ]
       },
       "evidence": {

--- a/backend/internal/modules/agents/toolcopy_import.go
+++ b/backend/internal/modules/agents/toolcopy_import.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The copy for the import verbs. It carries one thing the schema cannot: that
+// a file of people becomes LEADS, not contacts. A caller picking `person` for
+// a prospect list would be picking a valid enum value and breaking ADR-0008's
+// anti-pollution rule at the same time.
+
+var previewImportCopy = toolCopy{
+	Purpose: "Bring a spreadsheet in: send the CSV as text and this checks every row " +
+		"against the workspace and reports what importing it would do.",
+	Limits:  "Writes nothing. People arrive as leads, so `object` is lead or organization.",
+	Instead: "create_record for one record you already know.",
+	Retain:  "run_id.",
+}
+
+var readImportRunCopy = toolCopy{
+	Purpose: "Where one import got to: awaiting approval, running, done, or stopped.",
+	Limits:  "A stopped run names the row it stopped at and can resume there.",
+}
+
+var readImportReportCopy = toolCopy{
+	Purpose: "What an import will do, or did: rows created, updated, failed, unusable.",
+	Limits:  "These counts are what a person approves. Same shape before and after.",
+}
+
+var commitImportCopy = toolCopy{
+	Purpose: "Write a checked import into the workspace, once a person approves.",
+	Limits:  "Only from awaiting_approval. Undoing one needs the web app.",
+	Instead: "read_import_report first; nobody should approve what they have not read.",
+}

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -88,15 +88,19 @@ const (
 	importObjectLead         = "lead"
 )
 
-// maxImportCSVChars caps the pasted file.
+// maxImportCSVBytes caps the pasted file.
 //
-// It is a character count rather than a byte count because that is what the
-// caller can measure before sending. The bound is well under the REST upload
-// limit (uploads.csv_import_mb, 10 MB by default): text travelling inside a
-// JSON tool argument rides the same request as the rest of the conversation,
-// and a file large enough to matter belongs on the upload door with a person
-// at it.
-const maxImportCSVChars = 1_000_000
+// BYTES, not characters — len() on a Go string counts bytes, and calling this
+// a character count would be a lie that matters: a UTF-8 file of German or
+// Vietnamese company names is refused sooner than the number suggests. The
+// refusal says bytes.
+//
+// The bound is well under the REST upload limit (uploads.csv_import_mb, 10 MB
+// by default) and under the MCP transport's own 8 MiB body: text travelling
+// inside a JSON tool argument rides the same request as the rest of the
+// conversation, and a file large enough to matter belongs on the upload door
+// with a person at it.
+const maxImportCSVBytes = 1_000_000
 
 type previewImport struct{ imports Imports }
 
@@ -132,11 +136,11 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 		return nil, &BadArgsError{Cause: errors.New(
 			"`csv` is empty; send the file's contents with its header row first")}
 	}
-	if len(args.CSV) > maxImportCSVChars {
+	if len(args.CSV) > maxImportCSVBytes {
 		return nil, &BadArgsError{Cause: fmt.Errorf(
-			"this file is %d characters and one pasted import takes at most %d; "+
+			"this file is %d bytes and one pasted import takes at most %d; "+
 				"upload it in the web app instead, or split it",
-			len(args.CSV), maxImportCSVChars)}
+			len(args.CSV), maxImportCSVBytes)}
 	}
 
 	profile, err := t.imports.ProfileSource(ctx, args.Object, args.CSV)
@@ -281,32 +285,17 @@ func (t commitImport) Spec() mcp.ToolSpec {
 	}
 }
 
-// StageInfo describes the approval a commit asks for.
-//
-// The run id is the whole target, deliberately: what a person approves is one
-// validated run, and the report they read belongs to that id. An approval that
-// named only "an import" could be redeemed against a different run.
+// StageInfo describes the approval a commit asks for, through the SAME
+// command the REST door builds — so the sentence a person decides on is
+// identical whichever door staged it.
 func (t commitImport) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
 	id, err := importRunArg(in)
 	if err != nil {
 		return StageInfo{}, err
 	}
-	// Read it BEFORE staging: a run that does not exist, or that is not
-	// awaiting approval, must refuse now rather than spend a person's approval
-	// on a call that dies when they grant it.
-	run, err := t.imports.ReadRun(ctx, id)
-	if err != nil {
-		return StageInfo{}, err
-	}
-	if err := refuseUncommittableRun(run); err != nil {
-		return StageInfo{}, err
-	}
-	return StageInfo{
-		Summary: fmt.Sprintf("Import %s records from the file staged as run %s",
-			string(run.Object), id),
-		TargetType: importRunRecordType,
-		TargetID:   id,
-	}, nil
+	return StageSubject(ctx, NewImportCall(t.imports, ImportCommand{
+		Verb: ImportVerbCommit, RunID: id,
+	}))
 }
 
 func (t commitImport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The import verbs: bringing a spreadsheet of records into the estate, which
+// the tool surface could not begin.
+//
+// Every import operation was human-only, so an assistant handed a CSV could
+// describe what to do with it and do none of it. The whole migrate-in flow —
+// the one a customer runs once, on their first day, with the most data at
+// stake — was reachable only by a person clicking through four screens.
+//
+// THE FILE ARRIVES AS TEXT, not as an upload. uploadImportSource is multipart
+// and stays human-only, because an assistant holding a spreadsheet's contents
+// cannot perform a file upload and asking it to construct a multipart body
+// would be a worse door than none. `preview_import` takes the CSV as a string
+// instead: the assistant already has the characters, and this is the shape it
+// can actually produce.
+//
+// THE DRY RUN IS NOT OPTIONAL AND CANNOT BE SKIPPED. preview_import writes no
+// domain rows by construction (AC-M5) — it validates the mapping against the
+// live estate and produces a report. commit_import is confirm-first and takes
+// a run id, so the thing a person approves is the run whose report they read.
+// There is no verb that imports without producing a report first, and adding
+// one would defeat the only review this flow has.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// Imports is the seam onto the migration module's CSV paths. The composition
+// root implements it over the same handlers the REST transport uses, so both
+// doors run one dry run and one commit.
+type Imports interface {
+	// ProfileSource stores CSV text and reads back what its columns contain,
+	// with a proposed mapping. The agent-shaped half of uploadImportSource.
+	ProfileSource(ctx context.Context, object, csv string) (crmcontracts.ImportSourceProfile, error)
+	// StageRun validates a mapping against the estate and parks the run for a
+	// human. Writes no domain rows.
+	StageRun(ctx context.Context, req crmcontracts.CreateImportRunRequest) (crmcontracts.ImportRun, error)
+	// ReadRun answers one run's lifecycle state.
+	ReadRun(ctx context.Context, id ids.UUID) (crmcontracts.ImportRun, error)
+	// ReadReport answers what the run will do, or did.
+	ReadReport(ctx context.Context, id ids.UUID) (crmcontracts.ImportRunReport, error)
+	// Commit approves a validated run and starts the write.
+	Commit(ctx context.Context, id ids.UUID) (crmcontracts.ImportRun, error)
+}
+
+// RegisterImportTools joins the import verbs to the surface.
+//
+// Unconditionally, unlike the tag and whoami registrars: the contract DECLARES
+// these four verbs, so a registry that skipped them would advertise something
+// tools/list cannot offer — the mismatch TestEveryDeclaredToolVerbIsRegistered
+// exists to catch. A deployment with no object store still serves them and
+// refuses the three that need the source file, naming what is missing.
+func RegisterImportTools(r *Registry, imports Imports) {
+	r.Register(previewImport{imports: imports})
+	r.Register(readImportRun{imports: imports})
+	r.Register(readImportReport{imports: imports})
+	r.Register(commitImport{imports: imports})
+}
+
+// importObjectEnum is what a file's rows may be, and it is SHORT on purpose.
+//
+// `person` and `deal` are not here, and the omission IS ADR-0008: a bulk file
+// of contacts lands as leads, which a human promotes, so machine-sourced rows
+// cannot be smuggled past the qualification step by picking an enum value. The
+// first cut of this tool listed all four, which would have advertised a door
+// the REST contract does not have — TestEveryToolEnumMatchesTheContractItMirrors
+// caught it, which is what that gate is for.
+var importObjectEnum = []string{importObjectOrganization, importObjectLead}
+
+// The two things a file's rows may be, spelled once. They mirror the
+// contract's ImportObject enum, and the tool's schema is built from them so
+// the two cannot drift.
+const (
+	importObjectOrganization = "organization"
+	importObjectLead         = "lead"
+)
+
+// maxImportCSVChars caps the pasted file.
+//
+// It is a character count rather than a byte count because that is what the
+// caller can measure before sending. The bound is well under the REST upload
+// limit (uploads.csv_import_mb, 10 MB by default): text travelling inside a
+// JSON tool argument rides the same request as the rest of the conversation,
+// and a file large enough to matter belongs on the upload door with a person
+// at it.
+const maxImportCSVChars = 1_000_000
+
+type previewImport struct{ imports Imports }
+
+func (t previewImport) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "preview_import", Title: "Preview an import", Version: toolVersionV1,
+		Description:   previewImportCopy.render(),
+		RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "createImportRun",
+		InputSchema: schema(`{"type":"object","required":["object","csv"],"properties":{
+			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `"]},
+			"csv":{"type":"string","description":"The file's contents, header row first."},
+			"mapping":{"type":"object","additionalProperties":{"type":"string"},
+			  "description":"Source column name → field name. Omit to accept the proposal this call would make."}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[ImportPreviewResult](),
+	}
+}
+
+func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args struct {
+		Object  string            `json:"object"`
+		CSV     string            `json:"csv"`
+		Mapping map[string]string `json:"mapping"`
+	}
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	if err := refuseUnimportableObject(args.Object); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(args.CSV) == "" {
+		return nil, &BadArgsError{Cause: errors.New(
+			"`csv` is empty; send the file's contents with its header row first")}
+	}
+	if len(args.CSV) > maxImportCSVChars {
+		return nil, &BadArgsError{Cause: fmt.Errorf(
+			"this file is %d characters and one pasted import takes at most %d; "+
+				"upload it in the web app instead, or split it",
+			len(args.CSV), maxImportCSVChars)}
+	}
+
+	profile, err := t.imports.ProfileSource(ctx, args.Object, args.CSV)
+	if err != nil {
+		return nil, err
+	}
+	// The caller's mapping wins where it names a column, and the proposal
+	// fills the rest. A caller that sends none gets the proposal whole —
+	// which is honest rather than convenient, because the report says what
+	// each column became and a person reads it before anything commits.
+	mapping := make(map[string]string, len(profile.SuggestedMapping))
+	for column, field := range profile.SuggestedMapping {
+		mapping[column] = field
+	}
+	for column, field := range args.Mapping {
+		mapping[column] = field
+	}
+
+	run, err := t.imports.StageRun(ctx, crmcontracts.CreateImportRunRequest{
+		Connector: crmcontracts.CreateImportRunRequestConnector(importConnectorCSV),
+		Object:    profile.Object,
+		SourceRef: profile.SourceRef,
+		Mapping:   mapping,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(ImportPreviewResult{
+		Run:      importRunResult(run),
+		Mapping:  mapping,
+		Columns:  columnNames(profile),
+		Unmapped: unmappedColumns(profile, mapping),
+	})
+}
+
+// importConnectorCSV is the connector a pasted file is: the same one the
+// upload door uses, because it IS the same path — only the way the bytes
+// arrived differs.
+const importConnectorCSV = "csv"
+
+// refuseUnimportableObject holds `object` to the vocabulary, naming the whole
+// of it rather than saying the value is invalid.
+func refuseUnimportableObject(object string) error {
+	for _, allowed := range importObjectEnum {
+		if object == allowed {
+			return nil
+		}
+	}
+	return &BadArgsError{Cause: fmt.Errorf("`object` must be one of %s",
+		strings.Join(importObjectEnum, ", "))}
+}
+
+// columnNames lists what the file actually contains, so a caller that guessed
+// a mapping can see the header it guessed against.
+func columnNames(p crmcontracts.ImportSourceProfile) []string {
+	out := make([]string, 0, len(p.Columns))
+	for _, c := range p.Columns {
+		out = append(out, c.Header)
+	}
+	return out
+}
+
+// unmappedColumns names the columns nothing will read.
+//
+// It is reported rather than refused: a file usually carries columns this
+// product has no field for, and dropping them is the normal outcome. What is
+// not acceptable is dropping them SILENTLY — a caller who mistyped a field
+// name would otherwise see a clean report and a column quietly missing.
+func unmappedColumns(p crmcontracts.ImportSourceProfile, mapping map[string]string) []string {
+	var out []string
+	for _, c := range p.Columns {
+		if field, ok := mapping[c.Header]; !ok || field == "" {
+			out = append(out, c.Header)
+		}
+	}
+	return out
+}
+
+type readImportRun struct{ imports Imports }
+
+func (t readImportRun) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "read_import_run", Title: "Read an import run", Version: toolVersionV1,
+		Description:   readImportRunCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp:    "getImportRun",
+		InputSchema:  schema(`{"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string","format":"uuid"}},"additionalProperties":false}`),
+		OutputSchema: schemaFor[ImportRunResult](),
+	}
+}
+
+func (t readImportRun) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	id, err := importRunArg(in)
+	if err != nil {
+		return nil, err
+	}
+	run, err := t.imports.ReadRun(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(importRunResult(run))
+}
+
+type readImportReport struct{ imports Imports }
+
+func (t readImportReport) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "read_import_report", Title: "Read an import report", Version: toolVersionV1,
+		Description:   readImportReportCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp:    "getImportRunReport",
+		InputSchema:  schema(`{"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string","format":"uuid"}},"additionalProperties":false}`),
+		OutputSchema: schemaFor[ImportReportResult](),
+	}
+}
+
+func (t readImportReport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	id, err := importRunArg(in)
+	if err != nil {
+		return nil, err
+	}
+	report, err := t.imports.ReadReport(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(ImportReportResult{Report: report})
+}
+
+type commitImport struct{ imports Imports }
+
+func (t commitImport) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "commit_import", Title: "Commit an import", Version: toolVersionV1,
+		Description:   commitImportCopy.render(),
+		RequiredScope: principal.ScopeWrite, Tier: mcp.TierConfirmationRequired,
+		OpenAPIOp: "approveImportRun",
+		InputSchema: schema(`{"type":"object","required":["run_id"],"properties":{
+			"run_id":{"type":"string","format":"uuid"},
+			"approval_id":{"type":"string","format":"uuid","description":"Set on retry after approval"}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[ImportRunResult](),
+	}
+}
+
+// StageInfo describes the approval a commit asks for.
+//
+// The run id is the whole target, deliberately: what a person approves is one
+// validated run, and the report they read belongs to that id. An approval that
+// named only "an import" could be redeemed against a different run.
+func (t commitImport) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
+	id, err := importRunArg(in)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	// Read it BEFORE staging: a run that does not exist, or that is not
+	// awaiting approval, must refuse now rather than spend a person's approval
+	// on a call that dies when they grant it.
+	run, err := t.imports.ReadRun(ctx, id)
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if err := refuseUncommittableRun(run); err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		Summary: fmt.Sprintf("Import %s records from the file staged as run %s",
+			string(run.Object), id),
+		TargetType: importRunRecordType,
+		TargetID:   id,
+	}, nil
+}
+
+func (t commitImport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	id, err := importRunArg(in)
+	if err != nil {
+		return nil, err
+	}
+	// Checked again on the approved retry. StageInfo's check is the courtesy
+	// that avoids spending an approval; this one is the rule, because Handle
+	// is what a granted approval re-enters and the run's state can have moved
+	// while the person was deciding.
+	run, err := t.imports.ReadRun(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := refuseUncommittableRun(run); err != nil {
+		return nil, err
+	}
+	committed, err := t.imports.Commit(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(importRunResult(committed))
+}
+
+// importRunRecordType is the word the contract's admission policy uses for an
+// import run, so a staged approval is row-scoped to the run it names.
+const importRunRecordType = "import_run"
+
+// awaitingApproval is the one state a commit may start from.
+const awaitingApproval = "awaiting_approval"
+
+// refuseUncommittableRun holds a commit to a run that has actually been
+// dry-run.
+//
+// This is G — the dry run stays mandatory — expressed where it cannot be
+// skipped: a run only reaches awaiting_approval by producing a report, so
+// requiring that state IS requiring the report. The refusal says which state
+// the run is in, because "already running" and "already finished" are the two
+// a caller most needs told apart.
+func refuseUncommittableRun(run crmcontracts.ImportRun) error {
+	if string(run.Status) == awaitingApproval {
+		return nil
+	}
+	return &BadArgsError{Cause: fmt.Errorf(
+		"import run %s is %s, and a commit starts only from %s — "+
+			"an import commits what a dry run reported, so there is always a report first",
+		run.Id, string(run.Status), awaitingApproval)}
+}
+
+// importRunArg reads the one argument every id-bearing import verb takes.
+func importRunArg(in json.RawMessage) (ids.UUID, error) {
+	var args struct {
+		RunID string `json:"run_id"`
+	}
+	if err := decodeArgs(in, &args); err != nil {
+		return ids.UUID{}, err
+	}
+	id, err := ids.Parse(args.RunID)
+	if err != nil {
+		return ids.UUID{}, &BadArgsError{Cause: errors.New(
+			"`run_id` must be the uuid preview_import answered with")}
+	}
+	return id, nil
+}
+
+// importRunResult reshapes one run for the wire.
+func importRunResult(run crmcontracts.ImportRun) ImportRunResult {
+	out := ImportRunResult{
+		RunID:      run.Id.String(),
+		Object:     string(run.Object),
+		State:      string(run.Status),
+		Checkpoint: run.Checkpoint,
+	}
+	if run.Error != nil {
+		out.Error = *run.Error
+	}
+	return out
+}

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// A commit starts only from awaiting_approval, which is how the mandatory dry
+// run is enforced: a run reaches that state ONLY by producing a report, so
+// requiring the state is requiring the report. There is no verb that imports
+// without one.
+func TestACommitRefusesARunThatHasNotBeenDryRun(t *testing.T) {
+	for _, status := range []string{"validating", "running", "complete", "failed", "undoing"} {
+		t.Run(status, func(t *testing.T) {
+			err := refuseUncommittableRun(crmcontracts.ImportRun{
+				Id:     openapi_types.UUID(ids.NewV7()),
+				Status: crmcontracts.ImportRunStatus(status),
+			})
+			if err == nil {
+				t.Fatalf("a %s run was accepted for commit; only awaiting_approval may commit", status)
+			}
+			if !strings.Contains(err.Error(), status) {
+				t.Errorf("the refusal does not say which state the run is in: %v", err)
+			}
+		})
+	}
+	if err := refuseUncommittableRun(crmcontracts.ImportRun{
+		Id: openapi_types.UUID(ids.NewV7()), Status: awaitingApproval,
+	}); err != nil {
+		t.Errorf("a dry-run run was refused: %v", err)
+	}
+}
+
+// A column nothing reads is reported, not dropped in silence.
+//
+// A caller who mistyped a field name would otherwise get a clean report and a
+// column quietly missing from every imported row — which looks exactly like a
+// successful import until somebody goes looking for the data.
+func TestUnmappedColumnsAreNamedRatherThanDroppedSilently(t *testing.T) {
+	profile := crmcontracts.ImportSourceProfile{Columns: []crmcontracts.ImportColumn{
+		{Header: "Company"}, {Header: "Website"}, {Header: "Internal Ref"},
+	}}
+	got := unmappedColumns(profile, map[string]string{
+		"Company": "display_name",
+		"Website": "", // mapped to nothing, which is the same as unmapped
+	})
+	want := map[string]bool{"Website": true, "Internal Ref": true}
+	if len(got) != len(want) {
+		t.Fatalf("unmapped = %v, want the two columns nothing reads", got)
+	}
+	for _, column := range got {
+		if !want[column] {
+			t.Errorf("%q was reported unmapped and it is mapped", column)
+		}
+	}
+}
+
+// `object` takes lead or organization. Not person, and not deal.
+//
+// This is ADR-0008 in the schema: a bulk file of contacts lands as leads, which
+// a human promotes, so machine-sourced rows cannot enter as contacts by the
+// choice of an enum value. It also has to match the REST contract's own enum,
+// which is what TestEveryToolEnumMatchesTheContractItMirrors holds it to.
+func TestAFileOfPeopleCannotBeImportedAsContacts(t *testing.T) {
+	for _, object := range []string{"person", "deal", "activity", ""} {
+		if err := refuseUnimportableObject(object); err == nil {
+			t.Errorf("`object` accepted %q; a file imports as lead or organization", object)
+		}
+	}
+	for _, object := range []string{importObjectLead, importObjectOrganization} {
+		if err := refuseUnimportableObject(object); err != nil {
+			t.Errorf("`object` refused %q: %v", object, err)
+		}
+	}
+}
+
+// An empty file is refused before anything is stored.
+func TestAnEmptyFileIsRefusedRatherThanStored(t *testing.T) {
+	var stored bool
+	_, err := previewImport{imports: recordingImports{stored: &stored}}.Handle(
+		context.Background(), json.RawMessage(`{"object":"lead","csv":"   \n  "}`))
+	if err == nil {
+		t.Fatal("an empty file was accepted")
+	}
+	if stored {
+		t.Error("an empty file reached the object store")
+	}
+}
+
+// The caller's mapping wins over the proposal, column by column, and the
+// proposal fills the rest — so a caller correcting one guess does not have to
+// restate the ones that were right.
+func TestACallersMappingOverridesTheProposalColumnByColumn(t *testing.T) {
+	out, err := previewImport{imports: recordingImports{
+		suggested: map[string]string{"Company": "legal_name", "Website": "domains"},
+	}}.Handle(context.Background(), json.RawMessage(
+		`{"object":"organization","csv":"Company,Website\nAcme,acme.test\n",`+
+			`"mapping":{"Company":"display_name"}}`))
+	if err != nil {
+		t.Fatalf("previewing: %v", err)
+	}
+	var got ImportPreviewResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if got.Mapping["Company"] != "display_name" {
+		t.Errorf("the caller's mapping lost to the proposal: Company = %q", got.Mapping["Company"])
+	}
+	if got.Mapping["Website"] != "domains" {
+		t.Errorf("the proposal did not fill an unstated column: Website = %q", got.Mapping["Website"])
+	}
+}
+
+type recordingImports struct {
+	stubImports
+	stored    *bool
+	suggested map[string]string
+}
+
+func (r recordingImports) ProfileSource(
+	_ context.Context, object, _ string,
+) (crmcontracts.ImportSourceProfile, error) {
+	if r.stored != nil {
+		*r.stored = true
+	}
+	return crmcontracts.ImportSourceProfile{
+		Object:           crmcontracts.ImportObject(object),
+		SuggestedMapping: r.suggested,
+	}, nil
+}

--- a/backend/internal/modules/agents/tools_import_test.go
+++ b/backend/internal/modules/agents/tools_import_test.go
@@ -6,6 +6,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -137,4 +138,57 @@ func (r recordingImports) ProfileSource(
 		Object:           crmcontracts.ImportObject(object),
 		SuggestedMapping: r.suggested,
 	}, nil
+}
+
+// The approval a person sees says what the import will DO.
+//
+// The inbox row is its summary — nothing renders the report beside it — so a
+// summary naming only the run id asks somebody to authorise a bulk write to
+// their estate without telling them what it does. They would be clicking yes
+// on a number they never saw.
+func TestTheApprovalSaysWhatTheImportWillDo(t *testing.T) {
+	got := describeImport("organization", crmcontracts.ImportRunReport{
+		RowsRead: 453,
+		Disposition: crmcontracts.ImportRunDisposition{
+			Created: 412, Updated: 38, Unchanged: 3,
+		},
+		Issues: []crmcontracts.ImportRowIssue{{}, {}},
+	})
+	for _, want := range []string{"453", "412", "38", "organization", "2 row(s) could not be used"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the summary %q does not carry %q", got, want)
+		}
+	}
+}
+
+// The unusable count is never quietly dropped: it is the least flattering
+// number in the report and the one a person most needs before saying yes.
+func TestACleanImportSaysNothingAboutUnusableRows(t *testing.T) {
+	got := describeImport("lead", crmcontracts.ImportRunReport{
+		RowsRead:    12,
+		Disposition: crmcontracts.ImportRunDisposition{Created: 12},
+	})
+	if strings.Contains(got, "could not be used") {
+		t.Errorf("a clean import reported unusable rows: %q", got)
+	}
+	if !strings.Contains(got, "create 12") {
+		t.Errorf("the summary %q does not say what it creates", got)
+	}
+}
+
+// A run whose report cannot be read stages NO approval. Refusing is better
+// than staging one whose summary cannot say what the import does — that is the
+// blind yes this whole path exists to prevent.
+func TestARunWhoseReportCannotBeReadStagesNoApproval(t *testing.T) {
+	_, err := importResolver{imports: reportlessImports{}}.Subject(
+		context.Background(), ImportCommand{Verb: ImportVerbCommit, RunID: ids.NewV7()})
+	if err == nil {
+		t.Fatal("an approval was staged for a run whose report could not be read")
+	}
+}
+
+type reportlessImports struct{ stubImports }
+
+func (reportlessImports) ReadReport(context.Context, ids.UUID) (crmcontracts.ImportRunReport, error) {
+	return crmcontracts.ImportRunReport{}, errors.New("the report is gone")
 }

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -29,6 +29,16 @@ import (
 // and a typo in any of them would silently ask for a grant nobody holds.
 const objectActivity = "activity"
 
+// targetImportRun is the staged target a migrate-in commit names, and the RBAC
+// object the migration module admits on (migration.ImportRunObject). One word
+// for both, spelled here rather than imported: approvals may not import a
+// module it governs.
+const targetImportRun = "import_run"
+
+// KindImportCommit is the approval a migrate-in commit stages. The kind IS the
+// tool verb, which is how every other confirm-first verb is keyed here.
+const KindImportCommit = "commit_import"
+
 // grantRequirement is one RBAC pair approving a staged kind requires. Named
 // rather than anonymous because the derivation below appends to the set and the
 // composition layer's satisfiability gate reads the objects back out of it.
@@ -73,6 +83,11 @@ var decisionGrants = map[string][]grantRequirement{
 	// gone, the message still held. selfOnlyKinds narrows it from "anyone
 	// holding that grant" to the one person whose message it is.
 	KindScheduledSendHeld: {{objectActivity, principal.ActionUpdate}},
+	// Committing an import writes the estate in bulk, so deciding one requires
+	// the same grant creating a run does. It is the CREATE grant rather than an
+	// update: an import creates records, and the person releasing it is
+	// authorising those creations, not editing a run.
+	KindImportCommit: {{targetImportRun, principal.ActionCreate}},
 	// A step-up requires NO object grant, and the empty slice is the decision
 	// rather than an omission. Releasing a volume window touches no record: it
 	// does not widen what the agent may read, only how much of what it may

--- a/backend/internal/modules/approvals/targetvisibility.go
+++ b/backend/internal/modules/approvals/targetvisibility.go
@@ -436,6 +436,12 @@ var existenceProbes = map[string]string{
 	targetOfferTemplate:       `SELECT EXISTS (SELECT 1 FROM offer_template WHERE id = $1 AND archived_at IS NULL)`,
 	targetWebhookSubscription: `SELECT EXISTS (SELECT 1 FROM webhook_subscription WHERE id = $1 AND archived_at IS NULL)`,
 	"custom_field":            `SELECT EXISTS (SELECT 1 FROM custom_field WHERE id = $1)`,
+	// An import run is workspace-shared work over the estate, with no owner and
+	// no row scope of its own — so the row half is existence alone, and the
+	// authority is the object-read floor plus the decision grants. There is no
+	// archived_at on the table: a run's history is its own status, and a
+	// finished one is still the thing an approval named.
+	targetImportRun: `SELECT EXISTS (SELECT 1 FROM import_run WHERE id = $1)`,
 }
 
 func targetExists(ctx context.Context, tx pgx.Tx, targetType string, targetID ids.UUID) (bool, error) {

--- a/backend/internal/modules/webhooks/approvalvisibility.go
+++ b/backend/internal/modules/webhooks/approvalvisibility.go
@@ -149,6 +149,10 @@ var sharedConfigExistence = map[string]string{
 	"offer_template":       `SELECT EXISTS (SELECT 1 FROM offer_template WHERE id = $1 AND archived_at IS NULL)`,
 	"webhook_subscription": `SELECT EXISTS (SELECT 1 FROM webhook_subscription WHERE id = $1 AND archived_at IS NULL)`,
 	"custom_field":         `SELECT EXISTS (SELECT 1 FROM custom_field WHERE id = $1)`,
+	// An import run carries no archived_at — a finished run is history, not a
+	// deleted row, and it is still the thing an approval named. Mirrors the
+	// inbox's own arm (approvals.existenceProbes).
+	"import_run": `SELECT EXISTS (SELECT 1 FROM import_run WHERE id = $1)`,
 }
 
 // approvalTargetRule names HOW a staged target type is scoped for the approval

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 51,
     "resources": 8,
-    "tool_catalog_bytes": 139763,
+    "tool_catalog_bytes": 139903,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 35717,
+    "approx_wire_tokens_total": 35752,
     "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
       "description_bytes": 34645,
       "input_schema_bytes": 30637,
-      "output_schema_bytes": 63486,
+      "output_schema_bytes": 63626,
       "description_plus_input_schema_bytes": 65282
     }
   },
@@ -127,6 +127,12 @@
                   },
                   "type": "array"
                 },
+                "sections_omitted": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "stakeholders": {
                   "items": {
                     "properties": {
@@ -155,6 +161,7 @@
                 "deal_id",
                 "our_side",
                 "risks",
+                "sections_omitted",
                 "stakeholders"
               ],
               "type": "object"
@@ -863,6 +870,9 @@
           "properties": {
             "data": {
               "properties": {
+                "coverage_withheld": {
+                  "type": "boolean"
+                },
                 "deals": {
                   "items": {
                     "properties": {
@@ -926,6 +936,7 @@
                 }
               },
               "required": [
+                "coverage_withheld",
                 "deals",
                 "deals_scanned",
                 "truncated"

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 47,
+    "tools": 51,
     "resources": 8,
-    "tool_catalog_bytes": 131572,
+    "tool_catalog_bytes": 139763,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 33670,
+    "approx_wire_tokens_total": 35717,
     "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 33621,
-      "input_schema_bytes": 29395,
-      "output_schema_bytes": 58335,
-      "description_plus_input_schema_bytes": 63016
+      "description_bytes": 34645,
+      "input_schema_bytes": 30637,
+      "output_schema_bytes": 63486,
+      "description_plus_input_schema_bytes": 65282
     }
   },
   "tools": {
@@ -127,12 +127,6 @@
                   },
                   "type": "array"
                 },
-                "sections_omitted": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
                 "stakeholders": {
                   "items": {
                     "properties": {
@@ -161,7 +155,6 @@
                 "deal_id",
                 "our_side",
                 "risks",
-                "sections_omitted",
                 "stakeholders"
               ],
               "type": "object"
@@ -870,9 +863,6 @@
           "properties": {
             "data": {
               "properties": {
-                "coverage_withheld": {
-                  "type": "boolean"
-                },
                 "deals": {
                   "items": {
                     "properties": {
@@ -936,7 +926,6 @@
                 }
               },
               "required": [
-                "coverage_withheld",
                 "deals",
                 "deals_scanned",
                 "truncated"
@@ -1547,6 +1536,145 @@
           "type": "object"
         },
         "title": "Check calendar availability"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": false,
+          "title": "Commit an import"
+        },
+        "description": "Write a checked import into the workspace, once a person approves. Only from awaiting_approval. Undoing one needs the web app. read_import_report first; nobody should approve what they have not read. (Governance: a person approves every call before it runs; requires passport scope \"write\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "approval_id": {
+              "description": "Set on retry after approval",
+              "format": "uuid",
+              "type": "string"
+            },
+            "idempotency_key": {
+              "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "run_id": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "required": [
+            "run_id"
+          ],
+          "type": "object"
+        },
+        "name": "commit_import",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "checkpoint": {
+                  "type": "integer"
+                },
+                "error": {
+                  "type": "string"
+                },
+                "object": {
+                  "type": "string"
+                },
+                "run_id": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "checkpoint",
+                "object",
+                "run_id",
+                "state"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Commit an import"
       },
       {
         "annotations": {
@@ -4566,6 +4694,183 @@
         "annotations": {
           "openWorldHint": false,
           "readOnlyHint": false,
+          "title": "Preview an import"
+        },
+        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. create_record for one record you already know. run_id. (Governance: runs immediately; requires passport scope \"write\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "csv": {
+              "description": "The file's contents, header row first.",
+              "type": "string"
+            },
+            "idempotency_key": {
+              "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "mapping": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Source column name → field name. Omit to accept the proposal this call would make.",
+              "type": "object"
+            },
+            "object": {
+              "enum": [
+                "organization",
+                "lead"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "object",
+            "csv"
+          ],
+          "type": "object"
+        },
+        "name": "preview_import",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "columns": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mapping": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "run": {
+                  "properties": {
+                    "checkpoint": {
+                      "type": "integer"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "object": {
+                      "type": "string"
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "checkpoint",
+                    "object",
+                    "run_id",
+                    "state"
+                  ],
+                  "type": "object"
+                },
+                "unmapped": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "columns",
+                "mapping",
+                "run"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Preview an import"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": false,
           "title": "Progress a deal with a note"
         },
         "description": "Move a deal to a new stage and leave a note on its timeline saying why, in one call. The move commits first and the note follows it, so a note that fails to write does not put the deal back — the answer says so, and the note is then log_activity's to retry. The note itself is optional. Same rules as the bare move otherwise: call list_pipelines for the id of the stage you are moving to, and moving onto or off a stage that closes a deal as won or lost is staged for a person to approve. Use advance_deal when there is genuinely nothing to say about the move, and log_activity when something happened but the deal did not move. Send if_version with the version you read of the deal; keep the staged approval id if a closing move is sent for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope \"write\".)",
@@ -5658,6 +5963,383 @@
           "type": "object"
         },
         "title": "Read the morning brief"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Read an import report"
+        },
+        "description": "What an import will do, or did: rows created, updated, failed, unusable. These counts are what a person approves. Same shape before and after. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "run_id": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "required": [
+            "run_id"
+          ],
+          "type": "object"
+        },
+        "name": "read_import_report",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "report": {
+                  "properties": {
+                    "disposition": {
+                      "properties": {
+                        "created": {
+                          "type": "integer"
+                        },
+                        "skipped": {
+                          "type": "integer"
+                        },
+                        "unchanged": {
+                          "type": "integer"
+                        },
+                        "updated": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "created",
+                        "skipped",
+                        "unchanged",
+                        "updated"
+                      ],
+                      "type": "object"
+                    },
+                    "estimated_duration_seconds": {
+                      "type": "integer"
+                    },
+                    "issues": {
+                      "items": {
+                        "properties": {
+                          "column": {
+                            "type": "string"
+                          },
+                          "line": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "line",
+                          "reason"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "rows_read": {
+                      "type": "integer"
+                    },
+                    "run_id": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "source_key_used": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "undo": {
+                      "properties": {
+                        "errored": {
+                          "items": {
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "object": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "object",
+                              "reason"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "kept": {
+                          "items": {
+                            "properties": {
+                              "id": {
+                                "format": "uuid",
+                                "type": "string"
+                              },
+                              "object": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "object"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "reversed_count": {
+                          "type": "integer"
+                        },
+                        "run_id": {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored",
+                        "kept",
+                        "reversed_count",
+                        "run_id",
+                        "status"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "disposition",
+                    "issues",
+                    "rows_read",
+                    "run_id",
+                    "source_key_used",
+                    "status"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "report"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Read an import report"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Read an import run"
+        },
+        "description": "Where one import got to: awaiting approval, running, done, or stopped. A stopped run names the row it stopped at and can resume there. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "run_id": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "required": [
+            "run_id"
+          ],
+          "type": "object"
+        },
+        "name": "read_import_run",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "checkpoint": {
+                  "type": "integer"
+                },
+                "error": {
+                  "type": "string"
+                },
+                "object": {
+                  "type": "string"
+                },
+                "run_id": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "checkpoint",
+                "object",
+                "run_id",
+                "state"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Read an import run"
       },
       {
         "annotations": {
@@ -8352,7 +9034,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":47,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_record\",\"relink_activity\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":51,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"relink_activity\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[{\"op\":\"within_radius\",\"answers\":\"distance_ranking_unavailable\",\"because\":\"records carry no normalized coordinates yet; ask for a city or region as an exact predicate instead.\"}]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, key?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, key?: string, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 51 |
 | Resources | 8 |
-| Tool catalog | 136.5 KB |
+| Tool catalog | 136.6 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 35717 |
+| Approx. wire tokens | 35752 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -28,7 +28,7 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 62.0 KB | 45% | **No** — a result's shape, never listed to a model |
+| Output schemas | 62.1 KB | 45% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 33.8 KB | 24% | Yes, every step |
 | Input schemas | 29.9 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 10.7 KB | 7% | Partly |
@@ -59,12 +59,12 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
-| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.6 KB |
+| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.7 KB |
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.3 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.3 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
 | [`archive_record`](#archive_record) | Archive a record |  |  | 2.3 KB |
-| [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.4 KB |
+| [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.5 KB |
 | [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.9 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.7 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
@@ -376,6 +376,12 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
           },
           "type": "array"
         },
+        "sections_omitted": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "stakeholders": {
           "items": {
             "properties": {
@@ -404,6 +410,7 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
         "deal_id",
         "our_side",
         "risks",
+        "sections_omitted",
         "stakeholders"
       ],
       "type": "object"
@@ -1162,6 +1169,9 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
   "properties": {
     "data": {
       "properties": {
+        "coverage_withheld": {
+          "type": "boolean"
+        },
         "deals": {
           "items": {
             "properties": {
@@ -1225,6 +1235,7 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
         }
       },
       "required": [
+        "coverage_withheld",
         "deals",
         "deals_scanned",
         "truncated"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 47 |
+| Tools | 51 |
 | Resources | 8 |
-| Tool catalog | 128.5 KB |
+| Tool catalog | 136.5 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 33670 |
+| Approx. wire tokens | 35717 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -28,11 +28,11 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 57.0 KB | 44% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 32.8 KB | 25% | Yes, every step |
-| Input schemas | 28.7 KB | 22% | Yes, every step |
-| _Names, annotations, punctuation_ | 10.0 KB | 7% | Partly |
-| **Description + input schema** | **61.5 KB** | **47%** | **the recurring cost** |
+| Output schemas | 62.0 KB | 45% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 33.8 KB | 24% | Yes, every step |
+| Input schemas | 29.9 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 10.7 KB | 7% | Partly |
+| **Description + input schema** | **63.8 KB** | **46%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -55,19 +55,20 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/handoff.html`](#handoff_view) — Delivery handoff
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 
-### Tools (47)
+### Tools (51)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
-| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.7 KB |
+| [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.6 KB |
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.3 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.3 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
 | [`archive_record`](#archive_record) | Archive a record |  |  | 2.3 KB |
-| [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.5 KB |
+| [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.4 KB |
 | [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.9 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.7 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
+| [`commit_import`](#commit_import) | Commit an import |  |  | 1.8 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 2.6 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 3.0 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 3.0 KB |
@@ -85,12 +86,15 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 3.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
+| [`preview_import`](#preview_import) | Preview an import |  |  | 2.3 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.1 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.5 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
 | [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.6 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
 | [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 2.8 KB |
+| [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.5 KB |
+| [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
 | [`read_record`](#read_record) | Read a record | yes |  | 1.9 KB |
 | [`relink_activity`](#relink_activity) | Re-associate an activity to a record |  |  | 2.3 KB |
 | [`remove_tag`](#remove_tag) | Take a tag off a record |  |  | 1.9 KB |
@@ -372,12 +376,6 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
           },
           "type": "array"
         },
-        "sections_omitted": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "stakeholders": {
           "items": {
             "properties": {
@@ -406,7 +404,6 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
         "deal_id",
         "our_side",
         "risks",
-        "sections_omitted",
         "stakeholders"
       ],
       "type": "object"
@@ -1165,9 +1162,6 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
   "properties": {
     "data": {
       "properties": {
-        "coverage_withheld": {
-          "type": "boolean"
-        },
         "deals": {
           "items": {
             "properties": {
@@ -1231,7 +1225,6 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
         }
       },
       "required": [
-        "coverage_withheld",
         "deals",
         "deals_scanned",
         "truncated"
@@ -1790,6 +1783,155 @@ Find when a host is free, so a time can be proposed to someone. It reads free/bu
       "required": [
         "slots",
         "truncated"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### commit_import
+
+**Commit an import**
+
+Write a checked import into the workspace, once a person approves. Only from awaiting_approval. Undoing one needs the web app. read_import_report first; nobody should approve what they have not read. (Governance: a person approves every call before it runs; requires passport scope "write".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "approval_id": {
+      "description": "Set on retry after approval",
+      "format": "uuid",
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+      "maxLength": 255,
+      "type": "string"
+    },
+    "run_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "run_id"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "checkpoint": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "checkpoint",
+        "object",
+        "run_id",
+        "state"
       ],
       "type": "object"
     },
@@ -5052,6 +5194,193 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
 
 </details>
 
+### preview_import
+
+**Preview an import**
+
+Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. create_record for one record you already know. run_id. (Governance: runs immediately; requires passport scope "write".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "csv": {
+      "description": "The file's contents, header row first.",
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+      "maxLength": 255,
+      "type": "string"
+    },
+    "mapping": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Source column name → field name. Omit to accept the proposal this call would make.",
+      "type": "object"
+    },
+    "object": {
+      "enum": [
+        "organization",
+        "lead"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "object",
+    "csv"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "columns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "run": {
+          "properties": {
+            "checkpoint": {
+              "type": "integer"
+            },
+            "error": {
+              "type": "string"
+            },
+            "object": {
+              "type": "string"
+            },
+            "run_id": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "checkpoint",
+            "object",
+            "run_id",
+            "state"
+          ],
+          "type": "object"
+        },
+        "unmapped": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "columns",
+        "mapping",
+        "run"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
 ### progress_deal
 
 **Progress a deal with a note**
@@ -6117,6 +6446,403 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
         "candidate_count",
         "generated_at",
         "items"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### read_import_report
+
+**Read an import report**
+
+What an import will do, or did: rows created, updated, failed, unusable. These counts are what a person approves. Same shape before and after. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "run_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "run_id"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "report": {
+          "properties": {
+            "disposition": {
+              "properties": {
+                "created": {
+                  "type": "integer"
+                },
+                "skipped": {
+                  "type": "integer"
+                },
+                "unchanged": {
+                  "type": "integer"
+                },
+                "updated": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "created",
+                "skipped",
+                "unchanged",
+                "updated"
+              ],
+              "type": "object"
+            },
+            "estimated_duration_seconds": {
+              "type": "integer"
+            },
+            "issues": {
+              "items": {
+                "properties": {
+                  "column": {
+                    "type": "string"
+                  },
+                  "line": {
+                    "type": "integer"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "line",
+                  "reason"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "rows_read": {
+              "type": "integer"
+            },
+            "run_id": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "source_key_used": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "undo": {
+              "properties": {
+                "errored": {
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "object": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "object",
+                      "reason"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "kept": {
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "object": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "object"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "reversed_count": {
+                  "type": "integer"
+                },
+                "run_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "errored",
+                "kept",
+                "reversed_count",
+                "run_id",
+                "status"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "disposition",
+            "issues",
+            "rows_read",
+            "run_id",
+            "source_key_used",
+            "status"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "report"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### read_import_run
+
+**Read an import run**
+
+Where one import got to: awaiting approval, running, done, or stopped. A stopped run names the row it stopped at and can resume there. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "run_id": {
+      "format": "uuid",
+      "type": "string"
+    }
+  },
+  "required": [
+    "run_id"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "checkpoint": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "checkpoint",
+        "object",
+        "run_id",
+        "state"
       ],
       "type": "object"
     },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16387,7 +16387,7 @@ export interface components {
              * @description The record the operation targets. A confirm-first operation that resolves a concrete {id} must name one, or the approval it stages cannot be row-scoped.
              * @enum {string}
              */
-            record_type?: "activity" | "app_user" | "commission" | "custom_field" | "data_subject_request" | "deal" | "lead" | "list" | "offer" | "offer_template" | "organization" | "overlay_connection" | "partner" | "person" | "product" | "project" | "quota" | "record_grant" | "relationship" | "saved_view" | "tag" | "team" | "webhook_subscription";
+            record_type?: "activity" | "app_user" | "commission" | "custom_field" | "data_subject_request" | "deal" | "import_run" | "lead" | "list" | "offer" | "offer_template" | "organization" | "overlay_connection" | "partner" | "person" | "product" | "project" | "quota" | "record_grant" | "relationship" | "saved_view" | "tag" | "team" | "webhook_subscription";
             /**
              * @description The autonomy tier, identical on REST and MCP (ADR-0055).
              * @enum {string}


### PR DESCRIPTION
Every import operation was human-only, so an assistant handed a CSV could
describe what to do with it and do none of it. The migrate-in flow — the one a
customer runs once, on their first day, with the most data at stake — was
reachable only by a person clicking through four screens. Four verbs open it:
preview_import, read_import_run, read_import_report, commit_import.

THE FILE ARRIVES AS TEXT. uploadImportSource is multipart and stays human-only,
because an assistant holding a spreadsheet's contents cannot perform a file
upload, and asking it to construct a multipart body would be a worse door than
none. preview_import takes the CSV as a string — the shape an assistant can
actually produce — capped at a million characters, well under the REST upload
limit, because text inside a tool argument rides the same request as the
conversation.

THE DRY RUN CANNOT BE SKIPPED, and that is what makes opening this safe.
preview_import writes no domain rows by construction (AC-M5): it validates the
mapping against the live estate and produces a report. commit_import is
confirm-first and takes a run id, so what a person approves is the run whose
report they read. A commit starts only from awaiting_approval, and a run
reaches that state only by producing a report — so requiring the state IS
requiring the report, checked at staging (so an approval is not spent on a
doomed call) and again in Handle (because an approved retry re-enters there and
the run can have moved).

`object` takes lead or organization. Not person, not deal — a bulk file of
contacts lands as leads, which a human promotes, so machine-sourced rows cannot
enter as contacts by the choice of an enum value (ADR-0008). The first cut
listed all four and TestEveryToolEnumMatchesTheContractItMirrors caught it,
which is exactly what that gate is for.

Unmapped columns are NAMED in the result rather than dropped in silence. A
caller who mistyped a field name would otherwise get a clean report and a
column quietly missing from every row — which looks like a successful import
until somebody goes looking for the data.

One seam, not two implementations. The tools delegate to the same handlers the
REST transport uses, because the dry run is the only review this flow gets and
two paths that both "validate a mapping" are two chances to disagree about what
an import will do — with the one a person read not being the one that ran. That
required extracting three transport-free halves from the existing handlers
(profileAndStore, stageRun, commitRun); the REST handlers now call them too.

The gates asked for the rest and named it precisely: import_run in the
admission-policy vocabulary, a REST command decoder for both mutating routes, a
visibility arm in approvals and its mirror in the webhook fan-out, a decision
grant, a two-door fixture, an unrunnable-call fixture, and a ratified note that
import_run carries no version pin — which is honest here, since the only
argument is the run id, so a drifted call is a different run and fails the
identical-call hash.

Human-only stays on two operations, each for its own reason: uploadImportSource
has no agent-shaped door, and undoImportRun reverses a committed estate-wide
write, which should not be reachable without a person present.

All three regenerations ran.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assistants can now preview and commit CSV imports over MCP with the same safety guarantees as REST. Approvals now summarize the dry‑run counts so a human sees exactly what will be written before approving.

- Adds MCP tools: `preview_import` (CSV text, ≤1 MiB), `read_import_run`, `read_import_report`, `commit_import`; all delegate to the REST handlers.
- `preview_import` checks authorization before touching storage; `uploadImportSource` remains human‑only multipart.
- Dry run is mandatory: commits start only from `awaiting_approval`. Staging reads the run’s report and writes the approval summary; unreadable/missing reports refuse staging.
- Object scope is `lead` or `organization` (ADR‑0008). Reports name unmapped CSV columns.
- Extracted transport‑free halves (`profileAndStore`, `stageRun`, `commitRun`) used by both doors.
- REST/MCP wiring: `createImportRun`/`getImportRun` now allow bearer auth; new approval kind `commit_import` and record type `import_run` with existence/visibility checks and webhook fan‑out. `import_run` is unpinned; identical‑call hash binds the run id.
- Schemas/docs regenerated; tests cover both doors (two‑door fixture, unrunnable‑call guard, conformance).

**Rollout**
- No data migration.
- Admission policy: grant `commit_import` if assistants may commit; preview/read tools are `auto_execute` and write no domain rows.
- Ensure an object store is configured for preview; the CSV size cap is in bytes.

<sup>Written for commit a4094cbc2064b4d37a0ad818699cd780a4b33e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive Deal Room state laboratory with responsive, accessible controls and contextual seller/buyer views.
  - Added CSV import workflows to preview mappings, inspect run status and reports, and commit approved imports.
  - Import previews identify unmapped columns, validate files, and summarize expected outcomes before changes are applied.
  - Import reports include row dispositions, issues, checkpoints, and undo information.
- **Documentation**
  - Updated MCP documentation and catalog with the new import tools and expanded deal progression details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->