### PR TITLE
fix(deals): the partner fields ask only what applies

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1572,7 +1572,7 @@ export const de = {
   "deal.ownerKeep": "Aktuellen Inhaber behalten",
   "deal.ownerMe": "Mir zuweisen",
   "deal.ownerUnassign": "Zuweisung aufheben",
-  "deal.partnerOrg": "Partnerorganisation",
+  "deal.partnerOrg": "über Partner",
   "deal.forecastCategory": "Forecast-Kategorie",
   "deal.waitUntil": "Warten bis",
   "deal.fxBase": "Basis {value} · Kurs {rate} vom {date}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1576,7 +1576,7 @@ export const en = {
   "deal.ownerKeep": "Keep current owner",
   "deal.ownerMe": "Assign to me",
   "deal.ownerUnassign": "Unassign",
-  "deal.partnerOrg": "Partner organization",
+  "deal.partnerOrg": "via Partner",
   "deal.forecastCategory": "Forecast category",
   "deal.waitUntil": "Wait until",
   "deal.fxBase": "Base {value} · rate {rate} as of {date}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1563,7 +1563,7 @@ export const vi = {
   "deal.ownerKeep": "Giữ người phụ trách hiện tại",
   "deal.ownerMe": "Giao cho tôi",
   "deal.ownerUnassign": "Bỏ giao",
-  "deal.partnerOrg": "Tổ chức đối tác",
+  "deal.partnerOrg": "qua đối tác",
   "deal.forecastCategory": "Nhóm dự báo",
   "deal.waitUntil": "Chờ đến",
   "deal.fxBase": "Gốc {value} · tỷ giá {rate} tính đến {date}",

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -450,6 +450,27 @@ describe("a field that depends on another", () => {
     const sent = submittedValues(fields, { name: "x", cf_region: "APAC" });
     expect(sent.cf_region).toBe("APAC");
   });
+
+  // Withdrawing the question a value answered must not leave the answer
+  // waiting to be re-shown under a different one: naming partner A, saying
+  // what A did, clearing A and naming B would otherwise carry A's claim onto
+  // B — and "influenced" silently earns B nothing where the default pays.
+  it("does not carry an answer over to a different partner", () => {
+    // The state the form holds the moment A is cleared.
+    const cleared = submittedValues(fields, {
+      name: "x",
+      partner_org_id: "",
+      partner_attribution: "influenced",
+    });
+    expect(cleared.partner_attribution).toBe("");
+
+    // Naming B from that state starts the claim over rather than inheriting.
+    const withB = submittedValues(fields, {
+      ...cleared,
+      partner_org_id: "p-b",
+    });
+    expect(withB.partner_attribution).toBe("");
+  });
 });
 
 // The partner fields answer to whether this installation runs a partner

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -10,11 +10,14 @@ import {
 import userEvent from "@testing-library/user-event";
 import { type ReactNode, useLayoutEffect, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import {
   type CreateField,
   CreateRecordModal,
   splitMultiselectValue,
+  submittedValues,
+  visibleFields,
 } from "./create";
 import { DealsScreen } from "./deals";
 import { ContactsScreen } from "./people";
@@ -391,5 +394,136 @@ describe("deal create flow", () => {
       stage_id: "s1",
       source: "manual",
     });
+  });
+});
+
+// A field that only makes sense once another is answered. What a partner did
+// for a deal is a question ABOUT a partner, so it appears when one is named
+// and goes away when the choice is cleared.
+describe("a field that depends on another", () => {
+  const fields: CreateField[] = [
+    { key: "name", label: "create.dealName", required: true },
+    { key: "partner_org_id", label: "deal.partnerOrg", type: "select" },
+    {
+      key: "partner_attribution",
+      label: "deal.partnerAttribution",
+      type: "select",
+      showWhen: (values) => Boolean(values.partner_org_id),
+    },
+  ];
+
+  it("stays hidden until the field it depends on is answered", () => {
+    const shown = visibleFields(fields, { name: "x", partner_org_id: "" });
+    expect(shown.map((f) => f.key)).toEqual(["name", "partner_org_id"]);
+  });
+
+  it("appears once that field is answered", () => {
+    const shown = visibleFields(fields, { name: "x", partner_org_id: "p-1" });
+    expect(shown.map((f) => f.key)).toContain("partner_attribution");
+  });
+
+  // Answering a question and then withdrawing the one it depended on must not
+  // submit the orphaned answer: an attribution with no partner is refused by
+  // the server, and the reader did not ask to send it.
+  it("does not submit a value whose field went away", () => {
+    const sent = submittedValues(fields, {
+      name: "x",
+      partner_org_id: "",
+      partner_attribution: "influenced",
+    });
+    expect(sent.partner_attribution).toBe("");
+    expect(sent.name).toBe("x");
+  });
+
+  it("submits the value while its field is showing", () => {
+    const sent = submittedValues(fields, {
+      name: "x",
+      partner_org_id: "p-1",
+      partner_attribution: "influenced",
+    });
+    expect(sent.partner_attribution).toBe("influenced");
+  });
+
+  // A key the form never declared is a custom field, and blanking one the
+  // caller set would silently discard it.
+  it("leaves an undeclared value alone", () => {
+    const sent = submittedValues(fields, { name: "x", cf_region: "APAC" });
+    expect(sent.cf_region).toBe("APAC");
+  });
+});
+
+// The partner fields answer to whether this installation runs a partner
+// programme at all. "Has anybody been made a partner" is what decides it —
+// there is no separate switch — so an installation with no partners is not
+// asked a partner question.
+describe("the deal form's partner fields", () => {
+  const partnerRoutes = {
+    "GET /pipelines": () =>
+      jsonResponse({ data: [pipeline], page: { next_cursor: null } }),
+    "GET /organizations": () =>
+      jsonResponse({
+        data: [{ id: "o-1", display_name: "VietnamPartner JSC" }],
+        page: { next_cursor: null },
+      }),
+    "GET /partners": () =>
+      jsonResponse({
+        data: [{ organization_id: "o-1", margin_tier: "tier2_20" }],
+        page: { next_cursor: null },
+      }),
+  };
+
+  it("shows no partner fields when no company is a partner", async () => {
+    // Every unstubbed route answers an empty page, so /partners says none.
+    stubApi({
+      "GET /pipelines": () =>
+        jsonResponse({ data: [pipeline], page: { next_cursor: null } }),
+    });
+    render(<DealsScreen startCreating />);
+    await waitFor(() => expect(screen.getByLabelText("Stage *")).toBeTruthy());
+
+    expect(screen.queryByLabelText("via Partner")).toBeNull();
+    expect(screen.queryByLabelText("What the partner did")).toBeNull();
+  });
+
+  it("offers the partner once one exists, and asks what they did only after one is picked", async () => {
+    stubApi(partnerRoutes);
+    render(<DealsScreen startCreating />);
+    await waitFor(() => expect(screen.getByLabelText("Stage *")).toBeTruthy());
+
+    const user = userEvent.setup();
+    const partner = await screen.findByLabelText("via Partner");
+    // The claim is a question about a partner, so it is not asked before one
+    // is named.
+    expect(screen.queryByLabelText("What the partner did")).toBeNull();
+
+    await pickOption(user, partner, "VietnamPartner JSC");
+
+    expect(await screen.findByLabelText("What the partner did")).toBeTruthy();
+  });
+
+  // Only actual partners: the picker once listed every organization, which let
+  // a deal be attributed to an ordinary customer and silently never pay.
+  it("offers only companies that are partners", async () => {
+    stubApi({
+      ...partnerRoutes,
+      "GET /organizations": () =>
+        jsonResponse({
+          data: [
+            { id: "o-1", display_name: "VietnamPartner JSC" },
+            { id: "o-2", display_name: "Just A Customer" },
+          ],
+          page: { next_cursor: null },
+        }),
+    });
+    const user = userEvent.setup();
+    render(<DealsScreen startCreating />);
+    const partner = await screen.findByLabelText("via Partner");
+    await user.click(partner);
+
+    const offered = within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+    expect(offered).toContain("VietnamPartner JSC");
+    expect(offered).not.toContain("Just A Customer");
   });
 });

--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -559,6 +559,13 @@ export function RecordFormBody({
   // A field hidden by its own showWhen is absent from the form in every sense:
   // it neither renders nor holds Save hostage to a value nobody was asked for.
   const shown = visibleFields(fields, values);
+  // Writing a value must not resurrect an answer to a question that was
+  // withdrawn in between. Naming a partner, saying what they did, clearing the
+  // partner and naming a DIFFERENT one would otherwise carry the first
+  // partner's claim onto the second — and "influenced" silently earns them
+  // nothing where the default would have paid.
+  const setVisibleValues = (next: Record<string, string>) =>
+    setValues(submittedValues(fields, next));
   const requiredMissing = shown.some((field) => {
     if (field.type === "repeatable") {
       return !rowsRequirementMet(field, rows[field.key] ?? []);
@@ -600,7 +607,9 @@ export function RecordFormBody({
               field={field}
               formId={formId}
               value={values[field.key] ?? ""}
-              setValue={(next) => setValues({ ...values, [field.key]: next })}
+              setValue={(next) =>
+                setVisibleValues({ ...values, [field.key]: next })
+              }
             />
           );
         }
@@ -615,7 +624,7 @@ export function RecordFormBody({
                 field,
                 control,
                 values[field.key] ?? "",
-                (next) => setValues({ ...values, [field.key]: next }),
+                (next) => setVisibleValues({ ...values, [field.key]: next }),
                 t,
               )
             }

--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -89,7 +89,56 @@ export type CreateField = {
   toInput?: (raw: unknown) => string;
   // See SubField.step: a money field must declare its cents.
   step?: string;
+  /**
+   * Show this field only when the form's current values satisfy the predicate.
+   *
+   * For a field that is meaningless until another one is answered: what a
+   * partner did for a deal is a question about a partner, so asking it before
+   * one is named offers a choice with nothing to attach it to. A hidden field
+   * is also not required and not submitted — `visibleFields` is what both the
+   * render and the required check read, so the two cannot disagree and a form
+   * can never be blocked by a control nobody can see.
+   */
+  showWhen?: (values: Record<string, string>) => boolean;
 };
+
+/**
+ * The fields a form actually shows, given what has been filled in so far.
+ *
+ * One filter feeding both the render and the required check. A field hidden by
+ * `showWhen` is absent from the form in every sense a user can observe.
+ */
+export function visibleFields(
+  fields: CreateField[],
+  values: Record<string, string>,
+): CreateField[] {
+  return fields.filter((field) => field.showWhen?.(values) ?? true);
+}
+
+/**
+ * What the form sends: every value except those belonging to a field its own
+ * `showWhen` currently hides.
+ *
+ * A hidden field's value is blanked rather than carried. Answering a question
+ * and then withdrawing the one it depended on must not submit the orphaned
+ * answer — choosing a partner, saying what they did, then clearing the partner
+ * would otherwise send an attribution with nobody to attribute it to, which
+ * the server refuses. Blanked rather than dropped, because a scalar the form
+ * omits entirely leaves the stored value in place on an edit, and the reader
+ * asked for it to be gone.
+ */
+export function submittedValues(
+  fields: CreateField[],
+  values: Record<string, string>,
+): Record<string, string> {
+  const shown = new Set(visibleFields(fields, values).map((f) => f.key));
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    const declared = fields.some((f) => f.key === key);
+    out[key] = declared && !shown.has(key) ? "" : value;
+  }
+  return out;
+}
 
 // The label a top-level field shows: the literal labelText wins; otherwise the
 // i18n key. (Subfields are always core, so they keep using t(label) directly.)
@@ -507,7 +556,10 @@ export function RecordFormBody({
   const t = useT();
   const formId = useId();
 
-  const requiredMissing = fields.some((field) => {
+  // A field hidden by its own showWhen is absent from the form in every sense:
+  // it neither renders nor holds Save hostage to a value nobody was asked for.
+  const shown = visibleFields(fields, values);
+  const requiredMissing = shown.some((field) => {
     if (field.type === "repeatable") {
       return !rowsRequirementMet(field, rows[field.key] ?? []);
     }
@@ -518,11 +570,11 @@ export function RecordFormBody({
     <form
       onSubmit={(event) => {
         event.preventDefault();
-        onSubmit(values, rows);
+        onSubmit(submittedValues(fields, values), rows);
       }}
       className="form-stack"
     >
-      {fields.map((field) => {
+      {shown.map((field) => {
         if (field.divider) {
           return (
             <p className="form-divider t-label" key={field.key}>

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -534,6 +534,28 @@ describe("mapDealUpdate", () => {
     expect(body.expected_close_date).toBe("2026-09-01");
     expect(body.wait_until).toBeNull();
   });
+
+  // A withheld reference arrives as null with masked_fields naming it —
+  // deliberately, so a reader can tell "you may not see this" from "there is
+  // nothing here". The form has only the null, so sending it back would ask
+  // the server to clear a partner the reader never saw. Omitted means
+  // unchanged, which is the only honest patch for a field nobody was shown.
+  it("does not clear a partner it was never allowed to see", () => {
+    const body = mapDealUpdate(
+      { name: "Fleet retrofit", partner_org_id: "", partner_attribution: "" },
+      ["partner_org_id"],
+    );
+    expect("partner_org_id" in body).toBe(false);
+    // The attribution is withheld WITH its partner, so it goes too — returning
+    // half the pair would decide what a partner nobody could see is owed.
+    expect("partner_attribution" in body).toBe(false);
+    expect(body.name).toBe("Fleet retrofit");
+  });
+
+  it("still clears a partner the reader could see and chose to remove", () => {
+    const body = mapDealUpdate({ name: "x", partner_org_id: "" }, []);
+    expect(body.partner_org_id).toBeNull();
+  });
 });
 
 describe("mapDealCreate", () => {
@@ -1572,6 +1594,43 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     };
     expect(body.partner_org_id).toBe("p-offpage");
     expect(body.partner_attribution).toBe("sourced");
+  });
+
+  // Same guarantee when the partner list never arrives at all — a failed or
+  // still-pending /partners read must not read as "this deal has no partner".
+  it("keeps the partner when the partner list fails outright", async () => {
+    const user = userEvent.setup();
+    const patches: { body: unknown }[] = [];
+    const d = deal({
+      id: "x",
+      version: 4,
+      partner_org_id: "p-offpage",
+      partner_attribution: "influenced",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        if (request.url.includes("/partners")) {
+          return jsonResponse({ title: "Boom" }, 500);
+        }
+        return stubBackend([d], {
+          single: d,
+          onPatch: (body) => patches.push({ body }),
+        })(request);
+      }),
+    );
+
+    render(<DealScreen id="x" />);
+    await user.click(await screen.findByTestId("edit-record"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(patches.length).toBe(1));
+    const body = patches[0].body as {
+      partner_org_id: string | null;
+      partner_attribution: string | null;
+    };
+    expect(body.partner_org_id).toBe("p-offpage");
+    expect(body.partner_attribution).toBe("influenced");
   });
 
   // The facts run together without a separator: three adjacent spans in a

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1539,6 +1539,41 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     expect(screen.getByText("via")).toBeTruthy();
   });
 
+  // A form omits nothing the record already carries. The partner picker offers
+  // one capped page of partners, so a deal's own partner can be missing from
+  // it — and a select whose stored value is not an option shows blank, which
+  // on save clears the partner and the commission attribution with it.
+  it("keeps a partner the picker cannot reach, rather than clearing it on save", async () => {
+    const user = userEvent.setup();
+    const patches: { body: unknown }[] = [];
+    // Neither the org list ("Acme") nor the partner list holds p-offpage.
+    const d = deal({
+      id: "x",
+      version: 4,
+      partner_org_id: "p-offpage",
+      partner_attribution: "sourced",
+    });
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([d], {
+        single: d,
+        onPatch: (body) => patches.push({ body }),
+      }),
+    );
+
+    render(<DealScreen id="x" />);
+    await user.click(await screen.findByTestId("edit-record"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(patches.length).toBe(1));
+    const body = patches[0].body as {
+      partner_org_id: string | null;
+      partner_attribution: string | null;
+    };
+    expect(body.partner_org_id).toBe("p-offpage");
+    expect(body.partner_attribution).toBe("sourced");
+  });
+
   // The facts run together without a separator: three adjacent spans in a
   // plain text line rendered "€48,000.00Acme Corpvia Northgate", which is why
   // the partner looked missing on screen while every assertion about it passed.

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -439,17 +439,29 @@ function forecastCategory(v: string): UpdateDealRequest["forecast_category"] {
   }
 }
 
-// A blank scalar clears the field on the wire (explicit null); a set value
-// trims through. `amount` arrives in major units from the form, the wire is
-// minor units (deal creation applies the same conversion above).
+/**
+ * The edit form's values as a deal patch.
+ *
+ * A blank scalar clears the field on the wire (explicit null); a set value
+ * trims through. `amount` arrives in major units from the form, the wire is
+ * minor units (deal creation applies the same conversion above).
+ *
+ * `masked` names the fields THIS reader was not shown. A withheld reference
+ * arrives as null with `masked_fields` naming it — deliberately, so a reader
+ * can tell "you may not see this" from "there is nothing here" — but the form
+ * has only the null, and sending it back would ask the server to clear a
+ * partner the reader never saw and never touched. So a masked field is left
+ * out of the patch entirely: omitted means unchanged.
+ */
 export function mapDealUpdate(
   values: Record<string, unknown>,
+  masked: readonly string[] = [],
 ): UpdateDealRequest {
   const str = (v: unknown) => (typeof v === "string" ? v.trim() : "");
   const amount = str(values.amount);
   const owner = str(values.owner_id);
   const forecast = str(values.forecast_category);
-  return {
+  const patch: UpdateDealRequest = {
     name: str(values.name) || undefined,
     amount_minor: amount ? Math.round(Number(amount) * 100) : null,
     currency: str(values.currency) || undefined,
@@ -461,6 +473,34 @@ export function mapDealUpdate(
     expected_close_date: str(values.expected_close_date) || null,
     wait_until: str(values.wait_until) || null,
   };
+  return withoutMasked(patch, masked);
+}
+
+/**
+ * The patch minus every field the reader was not shown.
+ *
+ * `partner_org_id` carries its attribution: the server withholds the pair
+ * together, so returning one half of it would decide what a partner nobody
+ * could see is owed.
+ */
+function withoutMasked(
+  patch: UpdateDealRequest,
+  masked: readonly string[],
+): UpdateDealRequest {
+  if (masked.length === 0) {
+    return patch;
+  }
+  const out: Record<string, unknown> = { ...patch };
+  for (const field of masked) {
+    delete out[field];
+    if (field === "partner_org_id") {
+      delete out.partner_attribution;
+    }
+    if (field === "amount_minor") {
+      delete out.currency;
+    }
+  }
+  return out as UpdateDealRequest;
 }
 
 /**
@@ -2268,7 +2308,10 @@ function DealBadges({
               path: { id: deal.id },
               ...ifMatch(requireVersion(deal.version)),
             },
-            body: { ...mapDealUpdate(values), ...cf.toBody(values) },
+            body: {
+              ...mapDealUpdate(values, deal.masked_fields ?? []),
+              ...cf.toBody(values),
+            },
           });
           if (error) {
             throwProblem(error);

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -520,10 +520,91 @@ const ATTRIBUTION_OPTIONS: { value: string; label: MessageKey }[] = [
   { value: "influenced", label: "deal.attributionInfluenced" },
 ];
 
+/**
+ * The companies a deal may name as the partner who brought it.
+ *
+ * Only companies that ARE partners: the picker once offered every
+ * organization, which let a deal be attributed to an ordinary customer — and
+ * an attribution to a company with no partner row has no margin tier behind
+ * it, so it looks attributed and silently never earns anything.
+ *
+ * An empty list is also the answer to "is there a partner programme here": an
+ * installation that has never made a company a partner has no partner
+ * question to ask, and the two fields stay off the form entirely.
+ */
+export function usePartnerOptions(
+  orgs: { id: string; display_name: string }[],
+): { value: string; label: string }[] {
+  const partners = useQuery({
+    queryKey: ["partners", "options"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/partners", {
+        params: { query: { limit: 200 } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data;
+    },
+    staleTime: 60_000,
+  });
+  const named = new Map(orgs.map((org) => [org.id, org.display_name]));
+  return (partners.data ?? []).flatMap((partner) => {
+    const label = named.get(partner.organization_id);
+    // A partner whose organization the caller cannot read is left out rather
+    // than offered as a bare id: picking it would name a company the picker
+    // could not show them.
+    return label ? [{ value: partner.organization_id, label }] : [];
+  });
+}
+
+/**
+ * The two fields that record a deal coming through a partner, for both the
+ * create form and the edit form — one spelling, so the two cannot drift.
+ *
+ * Nothing at all when the installation has no partners: an empty picker asks a
+ * question with no answers in it, and a form that shows partner controls to a
+ * company running no partner programme is claiming a feature it does not have.
+ *
+ * The attribution follows the partner rather than standing beside it. What a
+ * partner DID is a question about a partner, so it appears once one is named
+ * and disappears when the choice is cleared — asking it first offers a claim
+ * with nobody to attach it to.
+ */
+function partnerFields(
+  t: (k: MessageKey) => string,
+  partnerOptions: { value: string; label: string }[],
+): CreateField[] {
+  if (partnerOptions.length === 0) {
+    return [];
+  }
+  return [
+    {
+      key: "partner_org_id",
+      label: "deal.partnerOrg",
+      type: "select",
+      options: partnerOptions,
+    },
+    // Commission accrues on "sourced" only, so this is the field that decides
+    // whether a win pays the partner.
+    {
+      key: "partner_attribution",
+      label: "deal.partnerAttribution",
+      type: "select",
+      showWhen: (values) => Boolean(values.partner_org_id),
+      options: ATTRIBUTION_OPTIONS.map((o) => ({
+        value: o.value,
+        label: t(o.label),
+      })),
+    },
+  ];
+}
+
 export function dealEditFields(
   t: (k: MessageKey) => string,
   opts: {
     orgs: { id: string; display_name: string }[];
+    partnerOptions: { value: string; label: string }[];
     me: string;
     currentOwner: string | null;
     currency: string;
@@ -566,23 +647,10 @@ export function dealEditFields(
       type: "select",
       options: orgOptions,
     },
-    {
-      key: "partner_org_id",
-      label: "deal.partnerOrg",
-      type: "select",
-      options: orgOptions,
-    },
-    // What that partner DID for the deal. Commission accrues on "sourced"
-    // only, so this is the field that decides whether a win pays them.
-    {
-      key: "partner_attribution",
-      label: "deal.partnerAttribution",
-      type: "select",
-      options: ATTRIBUTION_OPTIONS.map((o) => ({
-        value: o.value,
-        label: t(o.label),
-      })),
-    },
+    // Both partner fields are absent where no company has been made a partner:
+    // there is no partner programme to attribute anything to, and an empty
+    // picker is a question the reader cannot answer.
+    ...partnerFields(t, opts.partnerOptions),
     {
       key: "forecast_category",
       label: "deal.forecastCategory",
@@ -1212,6 +1280,8 @@ export function DealsScreen({
     },
   });
 
+  const partnerOptions = usePartnerOptions(orgsQuery.data?.data ?? []);
+
   const createDeal = async (values: Record<string, string>) => {
     const pipeline = effectivePipeline;
     if (!pipeline) {
@@ -1330,25 +1400,8 @@ export function DealsScreen({
         },
         // A deal brought by a partner is attributed at birth, not by editing
         // it afterwards: the win that pays them can come before anybody thinks
-        // to revisit the record, and commission accrues on "sourced" only.
-        {
-          key: "partner_org_id",
-          label: "deal.partnerOrg",
-          type: "select",
-          options: (orgsQuery.data?.data ?? []).map((org) => ({
-            value: org.id,
-            label: org.display_name,
-          })),
-        },
-        {
-          key: "partner_attribution",
-          label: "deal.partnerAttribution",
-          type: "select",
-          options: ATTRIBUTION_OPTIONS.map((o) => ({
-            value: o.value,
-            label: t(o.label),
-          })),
-        },
+        // to revisit the record.
+        ...partnerFields(t, partnerOptions),
         {
           key: "expected_close_date",
           label: "create.expectedClose",
@@ -2132,6 +2185,9 @@ function DealBadges({
 }>) {
   const t = useT();
   const cf = useObjectCustomFields("deal");
+  // Reads the same cached partner list the deals list built, so opening Edit
+  // costs no extra request.
+  const partnerOptions = usePartnerOptions(orgs);
   // The seam serves update and archive for a mirrored deal (write-back
   // projects onto the incumbent, overlay/provider_writes.go), so Edit and
   // Archive render in overlay too. Reopen and share stay hidden: reopen
@@ -2154,6 +2210,7 @@ function DealBadges({
         fields={[
           ...dealEditFields(t, {
             orgs,
+            partnerOptions,
             me: meId,
             currentOwner: deal.owner_id ?? null,
             // EMPTY, not a default. `dealEditFields` only uses this to put the

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -562,9 +562,16 @@ export function usePartnerOptions(
  * The two fields that record a deal coming through a partner, for both the
  * create form and the edit form — one spelling, so the two cannot drift.
  *
- * Nothing at all when the installation has no partners: an empty picker asks a
- * question with no answers in it, and a form that shows partner controls to a
- * company running no partner programme is claiming a feature it does not have.
+ * Nothing at all when the installation has no partners AND the deal names
+ * none: an empty picker asks a question with no answers in it, and a form that
+ * shows partner controls to a company running no partner programme is claiming
+ * a feature it does not have.
+ *
+ * `attributed` is what keeps that from eating data. A form omits nothing a
+ * record already carries: the pickable list is one capped page of companies, so
+ * a deal's own partner can be missing from it, and dropping the field would
+ * blank the stored partner the next time anybody edited anything else on the
+ * deal — taking the commission attribution with it, silently.
  *
  * The attribution follows the partner rather than standing beside it. What a
  * partner DID is a question about a partner, so it appears once one is named
@@ -574,16 +581,25 @@ export function usePartnerOptions(
 function partnerFields(
   t: (k: MessageKey) => string,
   partnerOptions: { value: string; label: string }[],
+  attributed?: { id: string; label: string },
 ): CreateField[] {
-  if (partnerOptions.length === 0) {
+  if (partnerOptions.length === 0 && !attributed) {
     return [];
   }
+  // The deal's own partner is always among the choices, even when the capped
+  // page of partners this form could offer does not include it. A select whose
+  // stored value is not an option shows blank, and saving that blank clears the
+  // partner nobody meant to touch.
+  const options =
+    attributed && !partnerOptions.some((o) => o.value === attributed.id)
+      ? [{ value: attributed.id, label: attributed.label }, ...partnerOptions]
+      : partnerOptions;
   return [
     {
       key: "partner_org_id",
       label: "deal.partnerOrg",
       type: "select",
-      options: partnerOptions,
+      options,
     },
     // Commission accrues on "sourced" only, so this is the field that decides
     // whether a win pays the partner.
@@ -600,11 +616,35 @@ function partnerFields(
   ];
 }
 
+/**
+ * The partner a deal already names, ready to stand as its own option.
+ *
+ * Falls back to the raw id when the org list cannot name it — an unreadable or
+ * off-page company. Ugly, and correct: the alternative is a blank select whose
+ * save clears an attribution the reader never touched.
+ */
+function attributedPartner(
+  deal: Deal,
+  orgs: { id: string; display_name: string }[],
+): { id: string; label: string } | undefined {
+  if (!deal.partner_org_id) {
+    return undefined;
+  }
+  const named = orgs.find((org) => org.id === deal.partner_org_id);
+  return {
+    id: deal.partner_org_id,
+    label: named?.display_name ?? deal.partner_org_id,
+  };
+}
+
 export function dealEditFields(
   t: (k: MessageKey) => string,
   opts: {
     orgs: { id: string; display_name: string }[];
     partnerOptions: { value: string; label: string }[];
+    // The partner this deal ALREADY names, when it names one. Keeps the field
+    // (and its stored value) on a form whose pickable list does not reach it.
+    attributedPartner?: { id: string; label: string };
     me: string;
     currentOwner: string | null;
     currency: string;
@@ -650,7 +690,7 @@ export function dealEditFields(
     // Both partner fields are absent where no company has been made a partner:
     // there is no partner programme to attribute anything to, and an empty
     // picker is a question the reader cannot answer.
-    ...partnerFields(t, opts.partnerOptions),
+    ...partnerFields(t, opts.partnerOptions, opts.attributedPartner),
     {
       key: "forecast_category",
       label: "deal.forecastCategory",
@@ -2211,6 +2251,7 @@ function DealBadges({
           ...dealEditFields(t, {
             orgs,
             partnerOptions,
+            attributedPartner: attributedPartner(deal, orgs),
             me: meId,
             currentOwner: deal.owner_id ?? null,
             // EMPTY, not a default. `dealEditFields` only uses this to put the

--- a/frontend/src/screens/partners.tsx
+++ b/frontend/src/screens/partners.tsx
@@ -473,6 +473,11 @@ export function PartnerTab({
       queryKey: ["organization", organizationId],
     });
     queryClient.invalidateQueries({ queryKey: ["organizations"] });
+    // The deal form asks this list whether a partner programme exists at all,
+    // so making the FIRST partner has to reach it — otherwise the partner
+    // fields stay absent from the deal form until the cache goes stale on its
+    // own, and the setting appears not to have taken.
+    queryClient.invalidateQueries({ queryKey: ["partners"] });
   }
 
   return (


### PR DESCRIPTION
The deal form's two partner fields now ask only what applies.

- **"via Partner"** replaces "Partner organization". The field answers where the deal came from, which is the sentence a reader is composing when they reach it.
- **What the partner did appears only once a partner is named.** It is a question about a partner, so asking it first offers a claim with nobody to attach it to. Clearing the partner takes the claim with it.
- **Both fields are absent where no company has been made a partner.** Whether anybody is a partner is what decides whether this installation runs a partner programme; there is no separate switch.
- **The picker offers partners, not every organization.** Naming an ordinary customer as the partner produced a deal that looked attributed and could never earn anything, because the margin tier commission reads lives on the partner row. This closes the frontend half of #2109.

`CreateField` gains `showWhen`, filtered once through `visibleFields` so the render and the required check cannot disagree — a form can never be held shut by a control nobody can see. Submit blanks a declared field its own condition hides, so an attribution with no partner is never sent.

Local gates green (`make check-fe`), 8 new tests, and both new rules mutation-checked: remove the empty-list guard or the `showWhen` and the tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes deal partner attribution conditional, partner-only, and safe to edit. Previously the form always showed partner fields, allowed any organization, and edits could silently drop or misapply attribution; now it shows “via Partner,” lists only partners, asks what the partner did only after a partner is chosen, clears the claim when the partner is cleared, and preserves an existing partner even if it’s off-page, unreadable, or the partner list fails.

- Adds `showWhen` to `CreateField`; `visibleFields` powers render/required; `submittedValues` blanks values for fields hidden by their own condition to avoid orphaned submissions.
- Introduces `usePartnerOptions` (reads `/partners`) and shared `partnerFields` for create/edit; hides partner controls when there are no partners; injects the deal’s partner via `attributedPartner` so edit cannot drop it.
- Update safety: `mapDealUpdate` omits fields listed in `masked_fields` (also drops `partner_attribution` with a masked `partner_org_id`, and `currency` with masked `amount_minor`) to prevent unintended clears.
- Invalidates the `partners` query after creating the first partner so the deal form shows the fields immediately.
- i18n label updated to “via Partner” in `en`, `de`, and `vi`. Tests cover visibility, submission blanking and carry-over prevention, partner-only options, and preserving withheld/off-page partners.

<sup>Written for commit f185cd845cd9cd9f9178c597b03a6a26540c5543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

