### PR TITLE
feat(deals): winning a deal starts delivery on the project it belongs to

### DIFF
--- a/backend/internal/compose/integration/project_closewon_integration_test.go
+++ b/backend/internal/compose/integration/project_closewon_integration_test.go
@@ -20,11 +20,16 @@ package integration
 // closed and restart work already under way.
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // closeWonFixture is one project on one company, plus a deal pointing at it
@@ -268,5 +273,286 @@ func TestReWinningADealWritesNoSecondTransition(t *testing.T) {
 		  WHERE envelope->>'type' = 'project.phase_changed' AND envelope->'entity'->>'id' = $1::text`,
 		f.project); n != 1 {
 		t.Errorf("project.phase_changed events = %d after two wins, want exactly 1", n)
+	}
+}
+
+// Re-asserting the won stage must not drive the project anywhere. The bridge
+// is gated on the deal actually BECOMING won, not on the status it ends up
+// with — otherwise anyone who can advance the deal can force the project back
+// to delivering after a project-authorized human moved it on, repeatedly, and
+// without needing to see the project at all.
+//
+// The previous replay test cannot catch this: it never moves the project away
+// from delivering between the two wins, so a bridge that re-ran would write
+// nothing either way and pass.
+func TestReAssertingAWonStageDoesNotDriveTheProjectBack(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Data platform")
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("win the deal: %v", err)
+	}
+	if got := phaseOf(t, e, f.project); got != deals.PhaseDelivering {
+		t.Fatalf("phase = %s after the win, want %s", got, deals.PhaseDelivering)
+	}
+
+	// Somebody with authority over the project deliberately moves it back —
+	// the scope was cut, delivery has not started after all.
+	if _, err := e.Deals.AdvanceProjectPhase(e.Admin(), f.project, deals.AdvanceProjectPhaseInput{
+		ToPhase: deals.PhasePursuing,
+	}); err != nil {
+		t.Fatalf("move the project back to pursuing: %v", err)
+	}
+
+	// The deal owner re-asserts the stage the deal is already on. Nothing
+	// about the deal changes, so nothing about the project may change either.
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("re-assert the won stage: %v", err)
+	}
+
+	if got := phaseOf(t, e, f.project); got != deals.PhasePursuing {
+		t.Errorf("phase = %s — re-asserting the win overrode a deliberate move to %s",
+			got, deals.PhasePursuing)
+	}
+	if n := deliveringHistoryCount(t, e, f.project); n != 1 {
+		t.Errorf("delivering history rows = %d, want the 1 the real win wrote", n)
+	}
+}
+
+// A project carries several deals over years. When two of them win, the first
+// starts delivery and the second finds work already under way — one
+// transition, not two. Sequential wins are the case a user actually hits; the
+// concurrent shape is held by the row lock the bridge takes before it decides.
+func TestTwoDealsWinningOnOneProjectProduceOneTransition(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, won := DealFixture(t, e)
+	org := e.SeedOrg(t, "BAER Pharma", nil)
+	p := seedProject(e.Admin(), t, e, "Multi-phase programme", nil, org, nil)
+
+	orgID := orgIDOf(org)
+	var wonDeals []ids.DealID
+	for _, name := range []string{"Phase one", "Phase two"} {
+		d, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+			Name: name, PipelineID: pipeline, StageID: open,
+			OrganizationID: &orgID, ProjectID: &p.ID, Source: "manual",
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		wonDeals = append(wonDeals, ids.From[ids.DealKind](ids.UUID(d.Id)))
+	}
+	for i, deal := range wonDeals {
+		if _, err := e.Deals.AdvanceDeal(e.Admin(), deal, wonInput(won)); err != nil {
+			t.Fatalf("win deal %d: %v", i+1, err)
+		}
+	}
+
+	if n := deliveringHistoryCount(t, e, p.ID); n != 1 {
+		t.Errorf("delivering history rows = %d after two deals won, want exactly 1", n)
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'project.phase_changed' AND envelope->'entity'->>'id' = $1::text`,
+		p.ID); n != 1 {
+		t.Errorf("project.phase_changed events = %d, want exactly 1", n)
+	}
+}
+
+// Winning a deal whose project was archived is a no-op, not a failure. Failing
+// would roll back the win itself over somebody else's archive — a deal that
+// cannot be closed because an unrelated grouping was tidied away.
+func TestWinningADealWhoseProjectWasArchivedStillWins(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Retired programme")
+
+	if _, err := e.Deals.ArchiveProject(e.Admin(), f.project, nil); err != nil {
+		t.Fatalf("archive the project: %v", err)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("the win was rolled back by an archived project: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM deal WHERE id = $1 AND status = 'won'`, f.deal); n != 1 {
+		t.Error("the deal did not end up won")
+	}
+	if n := deliveringHistoryCount(t, e, f.project); n != 0 {
+		t.Errorf("delivering history rows = %d, want 0 — an archived project is not resurrected", n)
+	}
+}
+
+// waitForBlockedOnProject blocks until some other backend is WAITING on a row
+// lock held against the project — the observable proof that the win reached
+// LockRow and parked, rather than the test merely getting there first.
+//
+// It asks Postgres for the fact instead of sleeping: pg_locks names the
+// waiter, so there is no timing assumption to tune. Failing here is the signal
+// the race test exists to give — a bridge that takes no lock never parks, so
+// the wait times out and the test fails rather than silently proving nothing.
+func waitForBlockedOn(ctx context.Context, t *testing.T, probe pgx.Tx, holderPID int) {
+	t.Helper()
+	// Paced with a ticker rather than spun: this loop and the win it watches
+	// compete for the same processor, and a tight loop is one of the ways a
+	// loaded runner starves the very writer whose progress it waits on.
+	pace := time.NewTicker(25 * time.Millisecond)
+	defer pace.Stop()
+	budget, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	for {
+		blocked, err := blockedBy(budget, probe, holderPID)
+		if err != nil && budget.Err() == nil {
+			t.Fatalf("probing for a backend blocked on the project row: %v", err)
+		}
+		if blocked {
+			return
+		}
+		select {
+		case <-pace.C:
+		case <-budget.Done():
+			t.Fatal("no backend ever blocked on the held project row — the delivery bridge " +
+				"decided its transition without taking the lock, so this run proves nothing")
+		}
+	}
+}
+
+// blockedBy asks whether any backend in this database is waiting on the
+// holder. pg_blocking_pids answers the question directly, so nothing here has
+// to reason about which lock shape Postgres reports mid-queue.
+//
+// The snapshot is cleared first because pg_stat_activity is materialized once
+// per transaction and cached until it ends: a probe running inside the holder's
+// long transaction would otherwise keep answering from the view it had before
+// the win's connection existed, and never see the waiter at all.
+func blockedBy(ctx context.Context, probe pgx.Tx, holderPID int) (bool, error) {
+	if _, err := probe.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+		return false, err
+	}
+	var blocked bool
+	err := probe.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM pg_stat_activity a
+		   WHERE a.datname = current_database() AND $1 = ANY (pg_blocking_pids(a.pid)))`,
+		holderPID).Scan(&blocked)
+	return blocked, err
+}
+
+// The race the row lock exists to close, forced rather than hoped for.
+//
+// A sequential test cannot see this: swap the lock for a plain read and every
+// other test in this file still passes. So this one holds the project row from
+// a second transaction, starts the win (which must block on the lock rather
+// than reading a stale phase), closes the project, and commits. The win then
+// acquires the lock and must read the CLOSED phase — not the `pursuing` it
+// would have seen had it decided before locking.
+//
+// Without the lock the win reads pursuing, writes phase=delivering over the
+// committed close, and — because its stale snapshot carried no closed_reason —
+// never clears that column, leaving a delivering project that still explains
+// why it was closed.
+func TestTheDeliveryTransitionDecidesUnderTheProjectLock(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Contended programme")
+	if _, err := e.Deals.AdvanceProjectPhase(e.Admin(), f.project, deals.AdvanceProjectPhaseInput{
+		ToPhase: deals.PhasePursuing,
+	}); err != nil {
+		t.Fatalf("move the project to pursuing: %v", err)
+	}
+
+	// Held from its own transaction, so the win below cannot pass LockRow
+	// until this one commits. No sleep decides the ordering — the lock does.
+	holderCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	holder, err := e.Pool.Begin(holderCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := holder.Exec(holderCtx,
+		`SELECT set_config('app.workspace_id', $1::text, true)`, e.WS); err != nil {
+		t.Fatal(err)
+	}
+	var holderPID int
+	if err := holder.QueryRow(holderCtx,
+		`SELECT id, pg_backend_pid() FROM project WHERE id = $1 FOR UPDATE`,
+		f.project).Scan(new(ids.UUID), &holderPID); err != nil {
+		t.Fatal(err)
+	}
+
+	winErr := make(chan error, 1)
+	go func() {
+		_, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage))
+		winErr <- err
+	}()
+
+	// Wait until the win is genuinely PARKED behind this holder, asked of
+	// Postgres rather than assumed after a sleep. Without this the close can
+	// commit before the win has even opened its transaction, and the test
+	// would pass against a bridge that holds no lock at all.
+	waitForBlockedOn(holderCtx, t, holder, holderPID)
+
+	// The close commits while the win is parked on the lock, so the phase the
+	// win eventually reads is one that did not exist when it started.
+	closeReason := "Cancelled before delivery."
+	if _, err := holder.Exec(holderCtx,
+		`UPDATE project SET phase = $2, closed_reason = $3, version = version + 1 WHERE id = $1`,
+		f.project, deals.PhaseClosed, closeReason); err != nil {
+		t.Fatal(err)
+	}
+	if err := holder.Commit(holderCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-winErr; err != nil {
+		t.Fatalf("the win failed against a concurrently closed project: %v", err)
+	}
+
+	if got := phaseOf(t, e, f.project); got != deals.PhaseClosed {
+		t.Errorf("phase = %s — the win decided on a phase read before it held the lock", got)
+	}
+	if n := deliveringHistoryCount(t, e, f.project); n != 0 {
+		t.Errorf("delivering history rows = %d, want 0 — the close won the race", n)
+	}
+	got, err := e.Deals.GetProject(e.Admin(), f.project, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ClosedReason == nil || *got.ClosedReason != closeReason {
+		t.Errorf("closed_reason = %v, want the concurrent close's reason intact", got.ClosedReason)
+	}
+}
+
+// The audit row must not claim an authorization that never happened. This path
+// is admitted by deal.update and deliberately skips the project's row scope,
+// but audit_log.authorization_rule is derived from the entity and action and
+// so always reads `project.update`. The evidence column is what makes the
+// ledger honest, and its absence is exactly the silent overclaim.
+func TestTheDeliveryTransitionRecordsWhatActuallyAuthorizedIt(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Attribution")
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("win the deal: %v", err)
+	}
+
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM audit_log
+		  WHERE entity_type = 'project' AND entity_id = $1 AND action = 'advance_phase'
+		    AND evidence->>'authorized_by' = 'deal.update'
+		    AND evidence->>'project_row_scope' = 'not_checked'
+		    AND evidence->>'transition_trigger' = 'deal_won'`,
+		f.project); n != 1 {
+		t.Errorf("delivery audit rows naming their real authority = %d, want 1", n)
+	}
+
+	// And a human-driven advance, which DID check project.update, carries no
+	// such evidence — the marker means something only if it is not on every row.
+	if _, err := e.Deals.AdvanceProjectPhase(e.Admin(), f.project, deals.AdvanceProjectPhaseInput{
+		ToPhase: deals.PhaseClosed, Reason: strPtr("Delivered."),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM audit_log
+		  WHERE entity_type = 'project' AND entity_id = $1 AND action = 'advance_phase'
+		    AND after->>'phase' = $2 AND evidence->'authorized_by' IS NOT NULL`,
+		f.project, deals.PhaseClosed); n != 0 {
+		t.Errorf("human-driven advances carrying the cross-scope marker = %d, want 0", n)
 	}
 }

--- a/backend/internal/compose/integration/project_closewon_integration_test.go
+++ b/backend/internal/compose/integration/project_closewon_integration_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Winning a deal starts the delivery it was sold for.
+//
+// The project already exists when the deal is won — it has been accumulating
+// since `initiative` — so the win is a transition, not a birth. These tests
+// drive the REAL winning transition through the deals store and seed the
+// project through the REAL project writer, because the whole claim is that the
+// phase move commits with the win: a hand-written phase column would prove the
+// column exists and nothing about the writer.
+//
+// The guards matter more than the happy path. A project carries several deals
+// over years, phase movement is free-form in both directions, and a naive
+// "won implies delivering" would re-open engagements somebody deliberately
+// closed and restart work already under way.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// closeWonFixture is one project on one company, plus a deal pointing at it
+// and the won stage that deal is advanced onto.
+type closeWonFixture struct {
+	project  ids.ProjectID
+	deal     ids.DealID
+	wonStage ids.StageID
+}
+
+// seedCloseWonFixture builds the fixture through the real writers: the real
+// project store creates the project (so its birth history row is the writer's,
+// not a fixture's), and the real deal store creates the deal pointing at it.
+func seedCloseWonFixture(t *testing.T, e *Env, projectName string) closeWonFixture {
+	t.Helper()
+	pipeline, open, won := DealFixture(t, e)
+	org := e.SeedOrg(t, "BAER Pharma", nil)
+	p := seedProject(e.Admin(), t, e, projectName, nil, org, nil)
+
+	orgID := orgIDOf(org)
+	d, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: projectName + " phase one", PipelineID: pipeline, StageID: open,
+		OrganizationID: &orgID, ProjectID: &p.ID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create the deal on the project: %v", err)
+	}
+	return closeWonFixture{
+		project:  p.ID,
+		deal:     ids.From[ids.DealKind](ids.UUID(d.Id)),
+		wonStage: won,
+	}
+}
+
+// deliveringHistoryCount counts the transitions recorded INTO delivering —
+// the number that must not grow when a guard refuses to move the project.
+func deliveringHistoryCount(t *testing.T, e *Env, project ids.ProjectID) int {
+	t.Helper()
+	return e.WsCount(t,
+		`SELECT count(*) FROM project_phase_history WHERE project_id = $1 AND to_phase = $2`,
+		project, deals.PhaseDelivering)
+}
+
+// phaseOf reads the project's phase back through the real read path.
+func phaseOf(t *testing.T, e *Env, project ids.ProjectID) string {
+	t.Helper()
+	got, err := e.Deals.GetProject(e.Admin(), project, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("read project %s: %v", project.UUID, err)
+	}
+	if got.Phase == nil {
+		t.Fatalf("project %s came back with no phase", project.UUID)
+	}
+	return string(*got.Phase)
+}
+
+// The bridge itself: a deal won on a project that is being pursued moves that
+// project into delivering, with the history row and the first-class event that
+// every other phase move writes — because it goes through the same path.
+func TestWinningADealStartsDeliveryOnItsProject(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "ERP replacement")
+
+	// Pursuing is where a project sits while its deal is in flight, so that is
+	// the state the win actually finds in the field.
+	if _, err := e.Deals.AdvanceProjectPhase(e.Admin(), f.project, deals.AdvanceProjectPhaseInput{
+		ToPhase: deals.PhasePursuing,
+	}); err != nil {
+		t.Fatalf("move the project to pursuing: %v", err)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("win the deal: %v", err)
+	}
+
+	if got := phaseOf(t, e, f.project); got != deals.PhaseDelivering {
+		t.Errorf("phase = %s after the win, want %s", got, deals.PhaseDelivering)
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM project_phase_history
+		  WHERE project_id = $1 AND from_phase = $2 AND to_phase = $3`,
+		f.project, deals.PhasePursuing, deals.PhaseDelivering); n != 1 {
+		t.Errorf("pursuing→delivering history rows = %d, want exactly 1", n)
+	}
+	// The event is asserted on its payload, not merely on its type: the
+	// pursuing move in the setup published one too, so a type-only count would
+	// pass on the wrong event.
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'project.phase_changed'
+		    AND envelope->'entity'->>'id' = $1::text
+		    AND envelope->'payload'->>'from_phase' = $2
+		    AND envelope->'payload'->>'to_phase' = $3`,
+		f.project, deals.PhasePursuing, deals.PhaseDelivering); n != 1 {
+		t.Errorf("pursuing→delivering events = %d, want exactly 1", n)
+	}
+	// The audit row is the other half of the write shape, and the transition
+	// must carry the same action a human-driven advance carries — a reader
+	// filtering the log for phase moves must find this one.
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM audit_log
+		  WHERE entity_type = 'project' AND entity_id = $1 AND action = 'advance_phase'
+		    AND after->>'phase' = $2`,
+		f.project, deals.PhaseDelivering); n != 1 {
+		t.Errorf("advance_phase audit rows into delivering = %d, want exactly 1", n)
+	}
+}
+
+// A project still at the head of the ladder when its deal lands moves too:
+// initiative is where a project is born, and a deal can be won off one that
+// never passed through pursuing.
+func TestWinningADealStartsDeliveryFromInitiativeToo(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Validation")
+
+	if got := phaseOf(t, e, f.project); got != deals.PhaseInitiative {
+		t.Fatalf("the fixture project starts at %s, want %s", got, deals.PhaseInitiative)
+	}
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("win the deal: %v", err)
+	}
+	if got := phaseOf(t, e, f.project); got != deals.PhaseDelivering {
+		t.Errorf("phase = %s after the win, want %s", got, deals.PhaseDelivering)
+	}
+}
+
+// A second deal landing on work already under way is not a transition. Writing
+// one would claim a restart that never happened, and every "when did delivery
+// begin" answer derived from the history would move to the later date.
+func TestWinningADealOnAnAlreadyDeliveringProjectWritesNothing(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Rollout")
+
+	if _, err := e.Deals.AdvanceProjectPhase(e.Admin(), f.project, deals.AdvanceProjectPhaseInput{
+		ToPhase: deals.PhaseDelivering,
+	}); err != nil {
+		t.Fatalf("move the project to delivering: %v", err)
+	}
+	before := deliveringHistoryCount(t, e, f.project)
+	if before != 1 {
+		t.Fatalf("the setup wrote %d delivering rows, want 1", before)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("win the deal: %v", err)
+	}
+
+	if got := deliveringHistoryCount(t, e, f.project); got != before {
+		t.Errorf("delivering history rows = %d after the win, want %d — a no-op writes nothing", got, before)
+	}
+	if got := phaseOf(t, e, f.project); got != deals.PhaseDelivering {
+		t.Errorf("phase = %s, want it left at %s", got, deals.PhaseDelivering)
+	}
+}
+
+// The guard that matters most: a renewal closing in year three must NOT
+// silently re-open an engagement somebody deliberately ended with a reason.
+// Re-opening is a human decision made with that reason in hand, and this path
+// has none to offer.
+func TestWinningADealDoesNotReopenAClosedProject(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Support retainer")
+
+	reason := "Delivered and signed off."
+	if _, err := e.Deals.AdvanceProjectPhase(e.Admin(), f.project, deals.AdvanceProjectPhaseInput{
+		ToPhase: deals.PhaseClosed, Reason: &reason,
+	}); err != nil {
+		t.Fatalf("close the project: %v", err)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+		t.Fatalf("winning a renewal on a closed project must still succeed: %v", err)
+	}
+
+	if got := phaseOf(t, e, f.project); got != deals.PhaseClosed {
+		t.Errorf("phase = %s after the renewal win, want it left %s", got, deals.PhaseClosed)
+	}
+	if n := deliveringHistoryCount(t, e, f.project); n != 0 {
+		t.Errorf("delivering history rows = %d, want 0 — the close was deliberate", n)
+	}
+	// And the close's own explanation survives: a re-open through the ordinary
+	// path clears it, so a lingering reason would be evidence the guard leaked.
+	got, err := e.Deals.GetProject(e.Admin(), f.project, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ClosedReason == nil || *got.ClosedReason != reason {
+		t.Errorf("closed_reason = %v, want it untouched", got.ClosedReason)
+	}
+}
+
+// A deal with no project has nothing to advance. Creating one, and guessing
+// which existing project a projectless deal meant, are separate questions.
+func TestWinningAProjectlessDealTouchesNoProject(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, won := DealFixture(t, e)
+	org := e.SeedOrg(t, "BAER Pharma", nil)
+	// A live project on the same company that the win must not reach for.
+	bystander := seedProject(e.Admin(), t, e, "Unrelated work", nil, org, nil)
+
+	orgID := orgIDOf(org)
+	d, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "No project", PipelineID: pipeline, StageID: open,
+		OrganizationID: &orgID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), ids.From[ids.DealKind](ids.UUID(d.Id)), wonInput(won)); err != nil {
+		t.Fatalf("win the projectless deal: %v", err)
+	}
+
+	if got := phaseOf(t, e, bystander.ID); got != deals.PhaseInitiative {
+		t.Errorf("the bystander project moved to %s — a projectless win reached for it", got)
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM project_phase_history WHERE to_phase = $1`, deals.PhaseDelivering); n != 0 {
+		t.Errorf("delivering history rows = %d workspace-wide, want 0", n)
+	}
+}
+
+// Re-winning a deal already sitting on its won stage runs the win branch
+// again. The project is delivering by then, so the phase guard must absorb it:
+// a second transition would record a restart nobody performed.
+func TestReWinningADealWritesNoSecondTransition(t *testing.T) {
+	e := Setup(t)
+	f := seedCloseWonFixture(t, e, "Migration")
+
+	for round := 1; round <= 2; round++ {
+		if _, err := e.Deals.AdvanceDeal(e.Admin(), f.deal, wonInput(f.wonStage)); err != nil {
+			t.Fatalf("win round %d: %v", round, err)
+		}
+	}
+
+	if n := deliveringHistoryCount(t, e, f.project); n != 1 {
+		t.Errorf("delivering history rows = %d after two wins, want exactly 1", n)
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'project.phase_changed' AND envelope->'entity'->>'id' = $1::text`,
+		f.project); n != 1 {
+		t.Errorf("project.phase_changed events = %d after two wins, want exactly 1", n)
+	}
+}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -154,13 +154,27 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 			if err := s.stampCorrespondence(ctx, tx, id, BasisDealWon); err != nil {
 				return fmt.Errorf("stamp won deal's correspondence: %w", err)
 			}
-			// And it starts the delivery it was sold for. In the same
-			// transaction so a won deal and a project still reading as
-			// "pursuing" can never be observed together — see
+			// And a deal that BECOMES won starts the delivery it was sold for,
+			// in the same transaction, so a won deal and a project still
+			// reading as "pursuing" can never be observed together. See
 			// project_delivery.go for which projects this moves and which it
 			// deliberately leaves alone.
-			if err := startDeliveryForWonDeal(ctx, tx, current.ProjectId, by); err != nil {
-				return fmt.Errorf("start delivery on the won deal's project: %w", err)
+			//
+			// Gated on the transition, not on the resulting status, and that
+			// is a security boundary rather than an optimization. The stamp
+			// above may re-run freely because it is monotonic; this is not. A
+			// caller who re-asserts the won stage on an already-won deal must
+			// not thereby drive the project — which they may have no authority
+			// to see, let alone write — back to `delivering` after somebody
+			// deliberately moved it elsewhere.
+			//
+			// The patch is what says whether the status actually moved:
+			// stageTransitionPatch sets the column only when it differs from
+			// what the deal already had, so its presence IS the transition.
+			if _, becameWon := p.After()["status"]; becameWon {
+				if err := startDeliveryForWonDeal(ctx, tx, id, by); err != nil {
+					return fmt.Errorf("start delivery on the won deal's project: %w", err)
+				}
 			}
 		}
 		if out, err = readDealForCaller(ctx, tx, id, storekit.LiveOnly, active); err != nil {

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -154,6 +154,14 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 			if err := s.stampCorrespondence(ctx, tx, id, BasisDealWon); err != nil {
 				return fmt.Errorf("stamp won deal's correspondence: %w", err)
 			}
+			// And it starts the delivery it was sold for. In the same
+			// transaction so a won deal and a project still reading as
+			// "pursuing" can never be observed together — see
+			// project_delivery.go for which projects this moves and which it
+			// deliberately leaves alone.
+			if err := startDeliveryForWonDeal(ctx, tx, current.ProjectId, by); err != nil {
+				return fmt.Errorf("start delivery on the won deal's project: %w", err)
+			}
 		}
 		if out, err = readDealForCaller(ctx, tx, id, storekit.LiveOnly, active); err != nil {
 			return fmt.Errorf("read advanced deal: %w", err)

--- a/backend/internal/modules/deals/project_advance.go
+++ b/backend/internal/modules/deals/project_advance.go
@@ -58,6 +58,15 @@ func (s *Store) AdvanceProjectPhase(ctx context.Context, id ids.ProjectID, in Ad
 		if err := auth.EnsureWritable(ctx, tx, projectObject, id.UUID); err != nil {
 			return err
 		}
+		// The row is locked BEFORE the phase is read, so the phase this
+		// transition is derived from cannot change under it. An If-Match
+		// caller keeps the optimistic CAS instead: ApplyGuarded answers
+		// version skew, which is the refusal that caller asked for.
+		if in.IfVersion == nil {
+			if _, err := storekit.LockRow(ctx, tx, projectObject, id.UUID, storekit.LiveOnly); err != nil {
+				return err
+			}
+		}
 		// A decision read, not a wire read — no custom columns needed.
 		current, err := readProject(ctx, tx, id, storekit.LiveOnly, nil)
 		if err != nil {
@@ -74,7 +83,7 @@ func (s *Store) AdvanceProjectPhase(ctx context.Context, id ids.ProjectID, in Ad
 		// history row for it would inflate the record with movement that
 		// never happened.
 		if fromPhase != in.ToPhase {
-			if err := recordPhaseTransition(ctx, tx, id, current, fromPhase, in, by); err != nil {
+			if err := recordPhaseTransition(ctx, tx, id, current, fromPhase, in, by, nil); err != nil {
 				return err
 			}
 		}
@@ -89,8 +98,20 @@ func (s *Store) AdvanceProjectPhase(ctx context.Context, id ids.ProjectID, in Ad
 // recordPhaseTransition applies the row change, appends its history row and
 // emits the first-class event — the three writes that must land together or
 // not at all, which is the whole reason this verb exists apart from update.
+//
+// Callers must already hold the project row (LockRow, or an If-Match version
+// on the input) and must have read `current` under it: the patch below carries
+// a before-image, so a snapshot taken before the lock would overwrite a
+// concurrent writer's change with stale values.
+//
+// evidence records what authorized the write when it was NOT the caller's own
+// project.update grant. audit_log.authorization_rule is derived from the entity
+// and action, so it always reads `project.update`; a path that was admitted by
+// something else must say so here or the ledger claims a check that never ran.
+// nil is the ordinary case — a human advancing a project they may write.
 func recordPhaseTransition(ctx context.Context, tx pgx.Tx, id ids.ProjectID,
 	current crmcontracts.Project, fromPhase string, in AdvanceProjectPhaseInput, by string,
+	evidence map[string]any,
 ) error {
 	p := storekit.NewPatch()
 	p.Set("phase", fromPhase, in.ToPhase)
@@ -117,7 +138,8 @@ func recordPhaseTransition(ctx context.Context, tx pgx.Tx, id ids.ProjectID,
 		return fmt.Errorf("record project phase history: %w", err)
 	}
 
-	auditID, err := storekit.Audit(ctx, tx, "advance_phase", projectObject, id.UUID, p.Before(), p.After())
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, "advance_phase", projectObject, id.UUID,
+		p.Before(), p.After(), evidence)
 	if err != nil {
 		return fmt.Errorf("audit project advance: %w", err)
 	}

--- a/backend/internal/modules/deals/project_delivery.go
+++ b/backend/internal/modules/deals/project_delivery.go
@@ -19,6 +19,12 @@ package deals
 // deals owns both records, so this needs no seam — it calls the same
 // recordPhaseTransition every human-driven phase move goes through, which is
 // what keeps the phase, its history row and project.phase_changed inseparable.
+//
+// Every guard here decides UNDER the project's row lock. A guard that reads
+// the phase before locking is a check-then-act race: the window between the
+// read and the write is long enough for a human to close the project, and the
+// stale patch would then reinstate `delivering` over their close and append a
+// history row for a transition that never happened.
 
 import (
 	"context"
@@ -26,7 +32,6 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -41,6 +46,18 @@ const PhasePursuing = "pursuing"
 // not sought.
 const PhaseDelivering = "delivering"
 
+// deliveryEvidence is what the audit row records in place of a project.update
+// check that never ran. audit_log.authorization_rule is derived from the
+// entity and action, so this row reads `project.update` whatever the caller
+// actually held — and on this path the caller was admitted by deal.update and
+// the project's own row scope was deliberately not consulted. Saying so in
+// evidence is the only way the ledger stops overclaiming.
+var deliveryEvidence = map[string]any{
+	"authorized_by":      "deal.update",
+	"project_row_scope":  "not_checked",
+	"transition_trigger": "deal_won",
+}
+
 // startDeliveryForWonDeal advances the project a just-won deal belongs to into
 // `delivering`, inside the transaction that won it. Every case it declines to
 // act on is a legitimate state of the world rather than a failure, so it
@@ -53,6 +70,9 @@ const PhaseDelivering = "delivering"
 //   - the deal names no project — nothing to advance. Creating one, and
 //     guessing which existing one a projectless deal meant, are separate
 //     questions with their own answers.
+//   - the project is archived — the grouping was ended deliberately, and a
+//     win does not resurrect it. A no-op, never an error: failing here would
+//     roll back the win itself over somebody else's archive.
 //   - the project is already `delivering` — a second deal landing on work
 //     already under way is not a transition, and recording one would claim a
 //     restart that never happened.
@@ -68,22 +88,34 @@ const PhaseDelivering = "delivering"
 // authorizes the correspondence stamp: a rep closing their own deal must not
 // have the win refused because the delivery project belongs to another team.
 // changed_by records the human who won, because that is who caused it — there
-// is no separate system principal here to invent.
-func startDeliveryForWonDeal(ctx context.Context, tx pgx.Tx, projectID *openapi_types.UUID, by string) error {
-	if projectID == nil {
-		return nil
+// is no separate system principal here to invent. The audit row carries
+// deliveryEvidence so the ledger names that authority rather than implying a
+// project grant.
+//
+// dealID must name a deal row this transaction already holds: the project
+// pointer is re-read from it here rather than taken from a pre-lock snapshot,
+// because a concurrent edit that repoints the deal from one project to another
+// would otherwise send this advance at the project the deal no longer names.
+func startDeliveryForWonDeal(ctx context.Context, tx pgx.Tx, dealID ids.DealID, by string) error {
+	projectID, err := lockedDealProject(ctx, tx, dealID)
+	if err != nil || projectID == nil {
+		return err
 	}
-	id := ids.From[ids.ProjectKind](ids.UUID(*projectID))
+	id := ids.From[ids.ProjectKind](*projectID)
+	// The lock comes FIRST and the phase is read under it, so the decision
+	// below cannot go stale between reading and writing. A row the filter
+	// cannot resolve is an archived project, which is a no-op.
+	if _, err := storekit.LockRow(ctx, tx, projectObject, id.UUID, storekit.LiveOnly); err != nil {
+		if errors.Is(err, apperrors.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("lock the won deal's project: %w", err)
+	}
 	// A decision read, not a wire read — no custom columns needed, and the
 	// project this deal already points at needs no row-scope probe: the FK
 	// proves it is in this workspace, and the caller's authority came from the
 	// deal.
 	current, err := readProject(ctx, tx, id, storekit.LiveOnly, nil)
-	if errors.Is(err, apperrors.ErrNotFound) {
-		// The deal points at an archived project. The grouping was ended
-		// deliberately; the win does not resurrect it.
-		return nil
-	}
 	if err != nil {
 		return fmt.Errorf("read the won deal's project: %w", err)
 	}
@@ -95,5 +127,18 @@ func startDeliveryForWonDeal(ctx context.Context, tx pgx.Tx, projectID *openapi_
 		return nil
 	}
 	return recordPhaseTransition(ctx, tx, id, current, fromPhase,
-		AdvanceProjectPhaseInput{ToPhase: PhaseDelivering}, by)
+		AdvanceProjectPhaseInput{ToPhase: PhaseDelivering}, by, deliveryEvidence)
+}
+
+// lockedDealProject reads the project pointer off a deal row the caller's
+// transaction already holds — the win path calls this only after its patch has
+// applied, and applying is what takes the lock. Nil means the deal names no
+// project.
+func lockedDealProject(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (*ids.UUID, error) {
+	var projectID *ids.UUID
+	if err := tx.QueryRow(ctx,
+		`SELECT project_id FROM deal WHERE id = $1`, dealID).Scan(&projectID); err != nil {
+		return nil, fmt.Errorf("read the won deal's project pointer: %w", err)
+	}
+	return projectID, nil
 }

--- a/backend/internal/modules/deals/project_delivery.go
+++ b/backend/internal/modules/deals/project_delivery.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Winning a deal starts the delivery it was sold for.
+//
+// A project is not born when a deal is won — it exists from `initiative`, is
+// already accumulating conversations and leads while the deal is still being
+// pursued, and outlives the deal that funded this round of it. So the win is a
+// TRANSITION on a project that is already there, not the project's creation.
+//
+// It runs INSIDE the transaction that wins the deal, for the same reason the
+// correspondence stamp does: a phase move that landed afterwards would leave a
+// window in which the deal reads as won and the project still reads as being
+// pursued, and every dashboard and brief that joins the two would report the
+// contradiction as fact. The two states are one fact and they commit together.
+//
+// deals owns both records, so this needs no seam — it calls the same
+// recordPhaseTransition every human-driven phase move goes through, which is
+// what keeps the phase, its history row and project.phase_changed inseparable.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// PhasePursuing is the phase a project sits in while a deal for it is in
+// flight — the one the win moves it out of.
+const PhasePursuing = "pursuing"
+
+// PhaseDelivering is where a won deal puts its project: the work is now owed,
+// not sought.
+const PhaseDelivering = "delivering"
+
+// startDeliveryForWonDeal advances the project a just-won deal belongs to into
+// `delivering`, inside the transaction that won it. Every case it declines to
+// act on is a legitimate state of the world rather than a failure, so it
+// returns only an error: there is no outcome the win path would do anything
+// differently about.
+//
+// The advance is deliberately narrow, because a project carries several deals
+// over years and a naive "won implies delivering" would rewrite history:
+//
+//   - the deal names no project — nothing to advance. Creating one, and
+//     guessing which existing one a projectless deal meant, are separate
+//     questions with their own answers.
+//   - the project is already `delivering` — a second deal landing on work
+//     already under way is not a transition, and recording one would claim a
+//     restart that never happened.
+//   - the project is `closed` — a renewal that closes in year three must not
+//     silently re-open an engagement somebody deliberately ended. Re-opening
+//     is a decision a human makes with the reason in hand, and this path has
+//     no reason to offer; it does nothing and leaves the two states honestly
+//     disagreeing, which is visible, rather than acting and being wrong
+//     invisibly.
+//
+// The move is not gated on the caller's write authority over the project. The
+// human's authority to win the deal is what authorizes it, exactly as it
+// authorizes the correspondence stamp: a rep closing their own deal must not
+// have the win refused because the delivery project belongs to another team.
+// changed_by records the human who won, because that is who caused it — there
+// is no separate system principal here to invent.
+func startDeliveryForWonDeal(ctx context.Context, tx pgx.Tx, projectID *openapi_types.UUID, by string) error {
+	if projectID == nil {
+		return nil
+	}
+	id := ids.From[ids.ProjectKind](ids.UUID(*projectID))
+	// A decision read, not a wire read — no custom columns needed, and the
+	// project this deal already points at needs no row-scope probe: the FK
+	// proves it is in this workspace, and the caller's authority came from the
+	// deal.
+	current, err := readProject(ctx, tx, id, storekit.LiveOnly, nil)
+	if errors.Is(err, apperrors.ErrNotFound) {
+		// The deal points at an archived project. The grouping was ended
+		// deliberately; the win does not resurrect it.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read the won deal's project: %w", err)
+	}
+	if current.Phase == nil {
+		return fmt.Errorf("project %s has no phase", id.UUID)
+	}
+	fromPhase := string(*current.Phase)
+	if fromPhase != PhaseInitiative && fromPhase != PhasePursuing {
+		return nil
+	}
+	return recordPhaseTransition(ctx, tx, id, current, fromPhase,
+		AdvanceProjectPhaseInput{ToPhase: PhaseDelivering}, by)
+}


### PR DESCRIPTION
A project exists from the `initiative` phase and outlives the deal that paid for it, so closed-won is not the project's birth — it is the moment the work changes character. Until now nothing marked that moment: a deal went to won and its project sat in `pursuing` forever.

## What changes

The win moves the project to `delivering`, **in the same transaction**, so a won deal and its project can never disagree about where the work stands. It goes through `recordPhaseTransition` — the same path a human advance takes — so the phase history row, the `advance_phase` audit row and the `project.phase_changed` event all land exactly as they otherwise would.

## The guards are the point

A project carries several deals over years, and the phase ladder moves in both directions. A naive "won ⇒ delivering" would let a renewal closing in year three silently reopen an engagement somebody deliberately closed.

| Project state | What happens |
|---|---|
| `initiative` or `pursuing` | advances to `delivering` |
| already `delivering` | nothing, not even a history row |
| `closed` | nothing — reopening is a human's decision |
| deal has no project | nothing |
| project archived | nothing |

The archived case is the same reasoning: the grouping was ended on purpose and a win must not resurrect it — nor should a deal become un-winnable because someone archived its project.

## One judgement call worth reviewing

**No row-scope gate on the project**, following the `stampCorrespondence` precedent in the same branch: the human's authority to win the deal is what authorizes its consequences. Gating here would roll the entire win back with a 403/404 for a rep whose delivery project belongs to another team. The reasoning is in the function's doc comment.

Creating a project when the deal has none, and the sole-open-project probe, are deliberately **not** here — they need the prompt UI to be honest about ambiguity.

## Verification

- `make check-backend` green, `make craft-static` 0/0/0, `rls-store-path` clean.
- 6 integration tests seeded through the real writers (`CreateProject`, `CreateDeal`, `AdvanceDeal`) — no hand-inserted rows. Event and audit assertions match on payload (`from_phase`/`to_phase`), not just event type, so they cannot pass on the wrong row.
- Every guard mutation-checked: removing the phase guard fails 3 tests, removing the call fails 3, removing the nil-project guard panics.

Note: 7 tests in `compose/integration` fail on this machine (`TestRecordHistory*`, `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas`) with `column oc.workspace_id does not exist` — a stale test template. Verified identical on a clean tree with a fresh template name; unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Winning a deal now advances its project to delivering in the same transaction, under the project row lock, so the deal and project cannot disagree or race. Previously a won deal could leave its project in pursuing; now initiative/pursuing moves to delivering with consistent history, `advance_phase` audit, and `project.phase_changed` event.

- Triggers from `deals.AdvanceDeal` only when a deal becomes won; re-asserting a won stage does nothing.
- Runs `startDeliveryForWonDeal` → `recordPhaseTransition`; locks the project row before reading phase and reads the project ID from the locked deal row to avoid repointing races. Archived projects are a no-op (the win still commits).
- Guards: initiative or pursuing → delivering; already delivering, closed, archived, or no project → no-op. Idempotent across re-winning and multiple deals winning on the same project (one transition).
- No project row-scope gate; `changed_by` is the closer. Audit uses `AuditWithEvidence` noting authorized_by=deal.update, project_row_scope=not_checked, transition_trigger=deal_won.
- `AdvanceProjectPhase` now decides under lock unless an `IfVersion` CAS is provided.
- Adds integration tests for the transition, guards, re-asserted stages, two-wins-one-project, row-lock race, and audit evidence.

<sup>Written for commit 89ad8fc635d76e76a0fd2b299692c7614b4c0e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

