### PR TITLE
perf(frontend): the Core draws thirty times a second, not as fast as the display will go

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -725,9 +725,13 @@ test.describe("B-EP09.23: overlay mode", () => {
     await expect(name).toHaveValue("Fleet retrofit");
     await name.fill("Fleet retrofit — expanded scope");
     await page.getByRole("button", { name: "Speichern" }).click();
-    await expect(
-      page.getByText("Fleet retrofit — expanded scope"),
-    ).toBeVisible();
+    // The record's own heading, not any text on the page carrying the name: the
+    // agent line in the rail names what it is reading, so a bare text match
+    // finds the saved name twice and cannot say which one is the 360 rendering
+    // the write.
+    await expect(page.locator(".record-head h1")).toHaveText(
+      "Fleet retrofit — expanded scope",
+    );
   });
 
   test("AC-overlay-4: an unsupported verb explains itself rather than failing", async ({

--- a/frontend/src/app/agentrail-demo.test.tsx
+++ b/frontend/src/app/agentrail-demo.test.tsx
@@ -5,6 +5,7 @@
 
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Button } from "../design-system/atoms";
 import { useDemoRun } from "./agentrail-demo";
 
 // The scripted run is review scaffolding, and it is still code that runs in a
@@ -18,9 +19,7 @@ function Run() {
   const demo = useDemoRun();
   return (
     <div>
-      <button type="button" onClick={demo.toggle}>
-        toggle
-      </button>
+      <Button onClick={demo.toggle}>toggle</Button>
       <span data-testid="state">{demo.state ?? "-"}</span>
       <span data-testid="said">{demo.said ?? "-"}</span>
       <span data-testid="playing">{String(demo.playing)}</span>
@@ -30,10 +29,19 @@ function Run() {
 
 const shown = (id: string) => screen.getByTestId(id).textContent ?? "";
 
-/** Clicks the control the way the panel's own button does. */
+/**
+ * Clicks the control the way the panel's own button does.
+ *
+ * A bare dispatch inside `act`, not `userEvent`: user-event awaits its own
+ * `setTimeout` between the events of one click, and the run under test re-arms
+ * every beat from an effect. Handing user-event this suite's fake clock makes
+ * the two advance each other and the click never resolves. Nothing here turns
+ * on pointer or focus order — the subject is the beat chain — so the deciding
+ * property is that a click lands at a moment this test chose.
+ */
 function toggle() {
   act(() => {
-    screen.getByText("toggle").click();
+    screen.getByRole("button", { name: "toggle" }).click();
   });
 }
 

--- a/frontend/src/app/agentrail-demo.test.tsx
+++ b/frontend/src/app/agentrail-demo.test.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDemoRun } from "./agentrail-demo";
+
+// The scripted run is review scaffolding, and it is still code that runs in a
+// build somebody looks at. What these hold is the part a reviewer would be
+// misled by if it broke: that it PLAYS (the states change on their own rather
+// than sitting on the first beat), that it ENDS, and that stopping it leaves
+// the surface reporting what it actually read rather than the last invented
+// line.
+
+function Run() {
+  const demo = useDemoRun();
+  return (
+    <div>
+      <button type="button" onClick={demo.toggle}>
+        toggle
+      </button>
+      <span data-testid="state">{demo.state ?? "-"}</span>
+      <span data-testid="said">{demo.said ?? "-"}</span>
+      <span data-testid="playing">{String(demo.playing)}</span>
+    </div>
+  );
+}
+
+const shown = (id: string) => screen.getByTestId(id).textContent ?? "";
+
+/** Clicks the control the way the panel's own button does. */
+function toggle() {
+  act(() => {
+    screen.getByText("toggle").click();
+  });
+}
+
+/**
+ * Runs the clock forward, in slices.
+ *
+ * A beat arms the next one from an EFFECT, which React only runs once the
+ * commit for that beat has flushed. One long jump therefore fires a single
+ * timer and stops; the slices give each beat its commit before the next tick of
+ * the clock reaches it.
+ */
+function passes(ms: number) {
+  const SLICE = 50;
+  for (let spent = 0; spent < ms; spent += SLICE) {
+    act(() => {
+      vi.advanceTimersByTime(SLICE);
+    });
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useDemoRun", () => {
+  it("reports nothing at all until a reviewer asks for a run", () => {
+    render(<Run />);
+    expect(shown("playing")).toBe("false");
+    expect(shown("state")).toBe("-");
+    expect(shown("said")).toBe("-");
+  });
+
+  it("opens the run on intake, which is where the agent's own work starts", () => {
+    render(<Run />);
+    toggle();
+    expect(shown("playing")).toBe("true");
+    expect(shown("state")).toBe("ingest");
+    expect(shown("said")).toBe("Reading captured mail");
+  });
+
+  it("moves through the beats on its own, without another click", () => {
+    // The whole point of the control: a state a reviewer can only hold still is
+    // a state nobody can judge the motion of.
+    render(<Run />);
+    toggle();
+    const first = shown("said");
+    passes(1200);
+    expect(shown("said")).not.toBe(first);
+  });
+
+  it("reaches the working beats, so the run is not only intake", () => {
+    render(<Run />);
+    toggle();
+    passes(4000);
+    expect(shown("state")).toBe("working");
+  });
+
+  it("ends on its own and hands the surface back", () => {
+    // It must END. A run that left the section holding an invented state would
+    // make every later reading of that section a lie nobody could see.
+    render(<Run />);
+    toggle();
+    passes(60_000);
+    expect(shown("playing")).toBe("false");
+    expect(shown("state")).toBe("-");
+    expect(shown("said")).toBe("-");
+  });
+
+  it("stops the moment it is asked to, mid-run", () => {
+    render(<Run />);
+    toggle();
+    passes(1500);
+    expect(shown("playing")).toBe("true");
+    toggle();
+    expect(shown("playing")).toBe("false");
+    expect(shown("state")).toBe("-");
+  });
+
+  it("starts again from the top after it has been stopped", () => {
+    render(<Run />);
+    toggle();
+    passes(4000);
+    toggle();
+    toggle();
+    expect(shown("said")).toBe("Reading captured mail");
+  });
+
+  it("leaves no timer behind when it unmounts mid-run", () => {
+    // A beat that fires into an unmounted component is a React warning at best
+    // and a leak at worst, and this one re-arms itself on every beat.
+    const { unmount } = render(<Run />);
+    toggle();
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/frontend/src/app/agentrail-ticker.test.tsx
+++ b/frontend/src/app/agentrail-ticker.test.tsx
@@ -44,7 +44,7 @@ async function read(key: readonly unknown[], data: unknown) {
 }
 
 beforeEach(() => {
-  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.useFakeTimers();
   client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },

--- a/frontend/src/app/agentrail-ticker.test.tsx
+++ b/frontend/src/app/agentrail-ticker.test.tsx
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAgentTicker } from "./agentrail-ticker";
+
+// The line under the orb, as a unit. What it says is the product's own promise
+// about this surface: it names what THIS reader's tab is doing, it names the
+// record rather than the cache key, and it says nothing at all rather than
+// guessing. Each case here is one of those promises.
+
+function Ticker() {
+  const lines = useAgentTicker();
+  return <p data-testid="line">{lines[0]?.said ?? ""}</p>;
+}
+
+let client: QueryClient;
+
+function harness(children: ReactNode) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** The line the surface is showing right now, or "" while it shows none. */
+function line(): string {
+  return screen.getByTestId("line").textContent ?? "";
+}
+
+/**
+ * Drives one read to completion through the real cache.
+ *
+ * Through `fetchQuery` rather than a hand-built event: the ticker listens to the
+ * cache's own notifications, and a hand-fired event would prove only that the
+ * reducer works on the shape this test invented.
+ */
+async function read(key: readonly unknown[], data: unknown) {
+  await act(async () => {
+    await client.fetchQuery({ queryKey: [...key], queryFn: async () => data });
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  client.clear();
+  vi.useRealTimers();
+});
+
+describe("useAgentTicker", () => {
+  it("says nothing at all until something is read", () => {
+    render(harness(<Ticker />));
+    expect(line()).toBe("");
+  });
+
+  it("names a list read in the reader's own words, not the cache key's", async () => {
+    render(harness(<Ticker />));
+    await read(["deals"], { data: [] });
+    expect(line()).toBe("Reading the pipeline");
+  });
+
+  it("says nothing for a read that is plumbing rather than work", async () => {
+    // The session, the feature flags, the field catalog: a status line that
+    // narrated those would bury the two or three events a reader cares about.
+    render(harness(<Ticker />));
+    await read(["me"], { id: "u-1" });
+    expect(line()).toBe("");
+  });
+
+  it("names the record when the tab already knows what it is called", async () => {
+    render(harness(<Ticker />));
+    // The list the reader arrived from carried the name, which is the case that
+    // lets the record read be named the moment it starts.
+    await read(["organizations"], {
+      data: [{ id: "o-1", name: "zenloop" }],
+    });
+    await read(["organization360", "o-1"], { id: "o-1", name: "zenloop" });
+    expect(line()).toBe("Reading everything about zenloop");
+  });
+
+  it("says nothing for a record it cannot name yet, rather than naming its kind", async () => {
+    // "Reading a company" tells a reader nothing they cannot see from the page
+    // they are standing on, and printing it while the name is one moment away is
+    // worse than waiting that moment.
+    render(harness(<Ticker />));
+    await act(async () => {
+      client.getQueryCache().notify({
+        type: "updated",
+        query: client
+          .getQueryCache()
+          .build(client, { queryKey: ["organization360", "unknown-id"] }),
+        action: { type: "fetch" },
+      });
+    });
+    expect(line()).toBe("");
+  });
+
+  it("drops a line once its moment has passed", async () => {
+    render(harness(<Ticker />));
+    await read(["deals"], { data: [] });
+    expect(line()).toBe("Reading the pipeline");
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(line()).toBe("");
+  });
+
+  it("reports the newest thing first when two reads land together", async () => {
+    render(harness(<Ticker />));
+    await read(["deals"], { data: [] });
+    await read(["tasks"], { data: [] });
+    expect(line()).toBe("Reading your tasks");
+  });
+});

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -202,7 +202,9 @@
   /* The viewport cap is for a hero standing in a content column; the rail's own
      width and height are the only caps this one needs. */
   --coreCap: 100%;
-  --coreHalo: 0.4;
+  /* Most of the halo off. At this size the ball IS the signal, and a bloom wide
+     enough to suit a hero reaches the destinations above it. */
+  --coreHalo: 0.18;
   flex: none;
 }
 

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -566,14 +566,27 @@ describe("AgentRail", () => {
     ).toBe("true");
   });
 
-  // The state switcher is review-only scaffolding, and only renders behind
-  // the preview switch: it must be absent from every ordinary render.
-  it("carries no state switcher when the preview switch is off", async () => {
+  // The state switcher is review-only scaffolding, and it is ON by default
+  // while the surface is under design (app/ui-preview.ts). What has to stay
+  // true is that an installation can take it away, which is the posture this
+  // asserts: the switch turned off leaves no way to put the section into a
+  // state no read can reach.
+  it("carries no state switcher when the preview switch is turned off", async () => {
+    vi.stubEnv("VITE_UI_PREVIEW_TASKBAR", "0");
     const user = userEvent.setup();
     stubAgentRailApi();
     const { container } = render(ROUTE);
     await openPanel(user, container);
     expect(panel().querySelector(".archips")).toBeNull();
+  });
+
+  it("carries the state switcher by default, so a reviewer finds it without a flag", async () => {
+    const user = userEvent.setup();
+    stubAgentRailApi();
+    const { container } = render(ROUTE);
+    await openPanel(user, container);
+    expect(panel().querySelector(".archips")).toBeTruthy();
+    expect(screen.getByRole("button", { name: LABELS.runPlay })).toBeTruthy();
   });
 
   it("lets a review-only chip override the derived state with its invented line, once the preview switch is on", async () => {

--- a/frontend/src/app/ui-preview.ts
+++ b/frontend/src/app/ui-preview.ts
@@ -18,6 +18,7 @@ import type { components } from "../api/schema";
 
 // Both spellings, so a hurried demo command works either way.
 const isOn = (value: unknown) => value === "1" || value === "true";
+const isOff = (value: unknown) => value === "0" || value === "false";
 
 /**
  * `VITE_UI_PREVIEW_OIDC=1` — draw the federated sign-in buttons on the login
@@ -103,7 +104,13 @@ export function uiPreviewResetEnabled(): boolean {
  * switches above.
  */
 export function uiPreviewAgentStatesEnabled(): boolean {
-  return isOn(import.meta.env.VITE_UI_PREVIEW_TASKBAR);
+  // ON BY DEFAULT, unlike every other switch in this file, and deliberately so
+  // while the agent surface is being designed: the states are what is under
+  // review, and a reviewer opening the app should not have to know an
+  // environment variable to see them. `VITE_UI_PREVIEW_TASKBAR=0` takes them
+  // away, which is what an installation would set, and this default is the
+  // first thing to flip when the surface is settled.
+  return isOff(import.meta.env.VITE_UI_PREVIEW_TASKBAR) === false;
 }
 
 let warnedAgentStates = false;

--- a/frontend/src/design-system/margince-core-engine.ts
+++ b/frontend/src/design-system/margince-core-engine.ts
@@ -9,6 +9,7 @@ import {
   type CoreBehaviour,
   EASE,
   FEED_INGEST,
+  FRAME_MS,
   MAX_STEP,
   PHASE_SEED,
   rowFor,
@@ -126,6 +127,7 @@ function runCoreLoop(
   let paper = wanted.current.paper;
   let handle = 0;
   let last = 0;
+  let drawnAt = 0;
   let stopped = false;
 
   const measure = () => {
@@ -164,11 +166,26 @@ function runCoreLoop(
   });
 
   const tick = (now: number) => {
+    // The Core never truly rests: its quietest state still drifts, so this loop
+    // runs for as long as the app is open, on every screen. At the display's own
+    // rate that is a fragment-heavy shader redrawn sixty times a second forever,
+    // which costs a laptop real battery and costs a software renderer (CI, a
+    // machine with no GPU) enough to slow the page around it. The motion here is
+    // a slow drift, and a slow drift does not need every frame: the loop keeps
+    // asking the browser for one, and DRAWS on the ones far enough apart.
+    handle = requestAnimationFrame(tick);
+    if (now - drawnAt < FRAME_MS) {
+      return;
+    }
+    drawnAt = now;
     const drifting = advance(now);
     renderer.draw(shown());
-    // Scheduled AFTER the frame that decides it, so a park is a park: the next
-    // callback is never already in flight when the loop stops wanting one.
-    handle = drifting && !stopped ? requestAnimationFrame(tick) : 0;
+    // Parked only after the frame that decides it, so a park is a park: the
+    // next callback is never already in flight when the loop stops wanting one.
+    if (!drifting || stopped) {
+      cancelAnimationFrame(handle);
+      handle = 0;
+    }
   };
 
   const wake = () => {
@@ -177,6 +194,7 @@ function runCoreLoop(
     }
     measure();
     last = 0;
+    drawnAt = 0;
     handle = requestAnimationFrame(tick);
   };
 

--- a/frontend/src/design-system/margince-core-engine.ts
+++ b/frontend/src/design-system/margince-core-engine.ts
@@ -3,7 +3,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { MarginceCoreState } from "./margince-core";
-import { type CoreFrame, createCoreRenderer } from "./margince-core-gl";
+import {
+  type CoreFrame,
+  type CoreRenderer,
+  createCoreRenderer,
+} from "./margince-core-gl";
 import {
   asHero,
   type CoreBehaviour,
@@ -97,7 +101,7 @@ function step(dials: Dials, target: CoreBehaviour): boolean {
 }
 
 /** What the hook's callers can change under a running loop. */
-type Wanted = {
+export type Wanted = {
   behaviour: CoreBehaviour;
   paper: number;
 };
@@ -109,11 +113,24 @@ type Loop = Readonly<{
   stop: () => void;
 }>;
 
-function runCoreLoop(
+/**
+ * Where the pixels go.
+ *
+ * The GPU is the one true boundary this file has, and the loop's contract with
+ * it (one advance per frame, one draw per budget, a draw on the frame that
+ * parks) is a claim about timing that only a stand-in can be asked about: a
+ * real context reports how it looks, never how often it was asked.
+ */
+export type CoreRendererFactory = (
+  canvas: HTMLCanvasElement,
+) => CoreRenderer | null;
+
+export function runCoreLoop(
   canvas: HTMLCanvasElement,
   wanted: { current: Wanted },
+  makeRenderer: CoreRendererFactory = createCoreRenderer,
 ): Loop | null {
-  const renderer = createCoreRenderer(canvas);
+  const renderer = makeRenderer(canvas);
   if (!renderer) {
     return null;
   }

--- a/frontend/src/design-system/margince-core-engine.ts
+++ b/frontend/src/design-system/margince-core-engine.ts
@@ -173,13 +173,18 @@ function runCoreLoop(
     // machine with no GPU) enough to slow the page around it. The motion here is
     // a slow drift, and a slow drift does not need every frame: the loop keeps
     // asking the browser for one, and DRAWS on the ones far enough apart.
+    //
+    // The budget covers the DRAW alone. `advance` eases the dials one step per
+    // call, so skipping the call would stretch every transition by however much
+    // the display outruns the budget: the orb would take twice as long to reach
+    // a state on a 60 Hz screen as the motion is written for, which is a
+    // different animation rather than a cheaper one.
     handle = requestAnimationFrame(tick);
-    if (now - drawnAt < FRAME_MS) {
-      return;
-    }
-    drawnAt = now;
     const drifting = advance(now);
-    renderer.draw(shown());
+    if (now - drawnAt >= FRAME_MS || !drifting) {
+      drawnAt = now;
+      renderer.draw(shown());
+    }
     // Parked only after the frame that decides it, so a park is a park: the
     // next callback is never already in flight when the loop stops wanting one.
     if (!drifting || stopped) {

--- a/frontend/src/design-system/margince-core-loop.test.ts
+++ b/frontend/src/design-system/margince-core-loop.test.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runCoreLoop, type Wanted } from "./margince-core-engine";
+import type { CoreFrame, CoreRenderer } from "./margince-core-gl";
+import { FRAME_MS, rowFor } from "./margince-core-motion";
+
+// The draw loop's contract with the GPU, which is a contract about WHEN rather
+// than about pixels. `margince-core-engine.test.tsx` covers the same engine from
+// the outside, on a host with no WebGL2 at all, and can therefore say nothing
+// about a running loop: jsdom refuses the context, so no loop is ever built.
+// Here the context is stood in for, because a stand-in is the only thing that
+// can be asked how often it was drawn to. What it is NOT asked is how anything
+// looks: every expectation below is a count or a comparison between two runs of
+// the real code.
+
+/** A renderer that keeps every frame it was handed, and when. */
+function recorder(clock: () => number): CoreRenderer & {
+  frames: CoreFrame[];
+  at: number[];
+} {
+  const frames: CoreFrame[] = [];
+  const at: number[] = [];
+  return {
+    frames,
+    at,
+    resize: () => {},
+    draw: (frame) => {
+      // The engine hands out its own live dials object, so a stored reference
+      // would read the LAST frame's numbers from every slot in this array.
+      frames.push({ ...frame, tintCol: [...frame.tintCol] });
+      at.push(clock());
+    },
+    dispose: () => {},
+  };
+}
+
+/**
+ * Runs a loop for a stretch of time, granting frames at a fixed interval.
+ *
+ * The interval is the display's, which is the variable the budget exists to be
+ * independent of: a 60 Hz screen offers frames twice as often as a 30 Hz one and
+ * must still get the same animation out of the same wall-clock time.
+ */
+function runFor(
+  ms: number,
+  everyMs: number,
+  target: Wanted,
+): { frames: CoreFrame[]; at: number[]; parked: boolean } {
+  // jsdom's document reports no focus, and the loop parks on an unfocused
+  // window: without this it never asks for a frame at all, and every count
+  // below would be zero for a reason that has nothing to do with the budget.
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  const canvas = document.createElement("canvas");
+  let now = 0;
+  const renderer = recorder(() => now);
+  // The frames nobody has spent yet. A queue rather than one slot because the
+  // loop only ever holds one request at a time, and a queue that grows past one
+  // would be a defect this harness should not hide.
+  const asked: FrameRequestCallback[] = [];
+  vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+    asked.push(cb);
+    return asked.length;
+  });
+  vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation(() => {
+    asked.length = 0;
+  });
+
+  const wanted = { current: target };
+  const loop = runCoreLoop(canvas, wanted, () => renderer);
+  if (!loop) {
+    throw new Error("the loop refused a renderer that was handed to it");
+  }
+  // The mount draw is not part of what the budget governs, and counting it as
+  // one would make every draw total off by one.
+  const mounted = renderer.frames.length;
+
+  for (now = everyMs; now <= ms; now += everyMs) {
+    const frame = asked.shift();
+    if (!frame) {
+      break;
+    }
+    frame(now);
+  }
+  const parked = asked.length === 0;
+  loop.stop();
+  return {
+    frames: renderer.frames.slice(mounted),
+    at: renderer.at.slice(mounted),
+    parked,
+  };
+}
+
+/** A state that keeps drifting, so the loop under test never parks early. */
+const drifting = (): Wanted => ({ behaviour: rowFor("ingest"), paper: 0 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the Core's draw budget", () => {
+  it("draws about thirty times a second, not once per offered frame", () => {
+    // The whole point of the budget: a fragment-heavy shader on a 120 Hz panel
+    // costs four times what the motion needs, forever, on every screen.
+    const { frames } = runFor(1000, 1000 / 60, drifting());
+
+    expect(frames.length).toBeLessThan(40);
+    expect(frames.length).toBeGreaterThan(20);
+  });
+
+  it("never draws twice inside one budget window, at any offered rate", () => {
+    // The rule rather than a total, because a total is only the rule plus
+    // whichever rounding the offered interval happens to impose: a display that
+    // offers frames every 8ms cannot land a draw exactly on the budget, so it
+    // waits out the next whole offer. Both bounds together say the loop draws as
+    // soon as it may and never sooner.
+    // Whole milliseconds, so no case sits exactly on the budget: a 33.333ms
+    // offer against a 33.333ms budget decides on the last bit of a float, which
+    // is a property of the arithmetic rather than of the loop.
+    for (const everyMs of [8, 16, 40]) {
+      const { at } = runFor(1000, everyMs, drifting());
+      const gaps = at.slice(1).map((moment, i) => moment - (at[i] ?? 0));
+
+      expect(gaps.length).toBeGreaterThan(5);
+      for (const gap of gaps) {
+        expect(gap).toBeGreaterThanOrEqual(FRAME_MS);
+        expect(gap).toBeLessThan(FRAME_MS + everyMs);
+      }
+    }
+  });
+});
+
+describe("the Core's motion, against the budget", () => {
+  it("reaches the same point in the same time on a faster display", () => {
+    // The defect this case exists for: easing once per DRAW rather than once per
+    // frame made the orb take twice as long to reach a state on a 60 Hz screen
+    // as the table is written for. The two runs cover the same second of wall
+    // clock, so the last frame each drew has to describe the same object.
+    const slow = runFor(1000, 1000 / 30, drifting()).frames.at(-1);
+    const fast = runFor(1000, 1000 / 120, drifting()).frames.at(-1);
+    if (!slow || !fast) {
+      throw new Error("a drifting Core drew nothing over a whole second");
+    }
+
+    // Not equality: the two runs land their last frame at different moments
+    // inside the same second, and one eased step apart is the honest tolerance.
+    expect(fast.level).toBeCloseTo(slow.level, 2);
+    expect(fast.ingest).toBeCloseTo(slow.ingest, 2);
+    expect(fast.phase).toBeCloseTo(slow.phase, 1);
+  });
+
+  it("advances the phase under its own speed rather than by frame count", () => {
+    const { frames } = runFor(1000, 1000 / 60, drifting());
+    const first = frames[0];
+    const last = frames.at(-1);
+    if (!first || !last) {
+      throw new Error("a drifting Core drew nothing over a whole second");
+    }
+
+    expect(last.phase).toBeGreaterThan(first.phase);
+  });
+});
+
+describe("the Core's parking", () => {
+  it("draws the frame it parks on, so a settled orb is never a stale one", () => {
+    // A budget that skipped this frame would leave the last drawn position one
+    // step short of where the object came to rest, and nothing would ever
+    // correct it: the loop is parked, by definition.
+    const settled: Wanted = { behaviour: rowFor("idle"), paper: 0 };
+    const still: Wanted = {
+      behaviour: { ...settled.behaviour, speed: 0 },
+      paper: 0,
+    };
+    const { frames, parked } = runFor(1000, 1000 / 60, still);
+
+    expect(parked).toBe(true);
+    expect(frames.length).toBeGreaterThan(0);
+  });
+
+  it("keeps running while the state it was given still drifts", () => {
+    expect(runFor(1000, 1000 / 60, drifting()).parked).toBe(false);
+  });
+});

--- a/frontend/src/design-system/margince-core-motion.ts
+++ b/frontend/src/design-system/margince-core-motion.ts
@@ -121,6 +121,17 @@ export const EASE = {
   tintCol: 0.06,
 } as const;
 
+/**
+ * The least time between two drawn frames, in milliseconds.
+ *
+ * Thirty a second. The Core's fastest motion is a ribbon drifting across its own
+ * shell over seconds, so the frames between these are frames nobody can tell
+ * apart, and the loop runs for as long as the app is open on every screen. The
+ * phase is integrated from real elapsed time, so drawing half as often slows
+ * nothing down: it draws the same motion with half the work.
+ */
+export const FRAME_MS = 1000 / 30;
+
 /** The largest step the phase may take, in seconds of motion per frame. */
 export const MAX_STEP = 0.05;
 

--- a/frontend/src/design-system/margince-core-shader.ts
+++ b/frontend/src/design-system/margince-core-shader.ts
@@ -351,7 +351,7 @@ void main(){
   /* Tight and quiet: this is the light the ball throws, and a wide bloom on a
      surface that packs the Core next to other things is a smudge on them rather
      than an atmosphere around it. */
-  float glowA = (exp(-outer * 34.0) * 0.16 + exp(-outer * 9.0) * 0.03)
+  float glowA = (exp(-outer * 44.0) * 0.10 + exp(-outer * 14.0) * 0.018)
               * (0.60 + 0.40 * uLevel);
   float lit = 1.0 - uPaper;
   col   = mix(col, mix(glowTint, vec3(0.02, 0.06, 0.05), uPaper), (1.0 - alpha) * glowA);


### PR DESCRIPTION
Follow-up to #2011, which merged with two red checks: `uat` and SonarCloud's coverage gate. Both are addressed here, and the `uat` one was a real regression that PR introduced.

## The Core drew as fast as the display would go, forever

Its quietest state still drifts, so the loop never parks: a fragment-heavy shader redrawn sixty times a second, on every screen, for as long as the app is open. On a laptop that is continuous GPU load; on a machine with no GPU (CI, a VM) it is enough to slow the page around it.

Measured, not guessed — a worktree at `52bba8cfb^` against this branch:

| | record open (PERF-1) | full e2e suite |
|---|---|---|
| before #2011 | passes | 39.9s |
| #2011 as merged | **825ms** (budget 300ms) | 52.0s |
| this branch | passes | 46.8s |

I also checked the obvious suspect first and it was innocent: stubbing out the ticker's cache scan changed nothing, so the cost is the draw loop itself.

The fix is a frame budget: the loop still asks the browser for a frame and **draws** on the ones far enough apart. The phase is integrated from real elapsed time, so thirty frames is the same motion at half the work rather than slower motion. Thirty a second for a ribbon drifting across its own shell over seconds is well past what anyone can distinguish.

## The glow

Narrower and dimmer, at the shader's falloff and at `--coreHalo` both. At the size the rail gives the ball, a bloom scaled for a hero reached the destinations above it.

## The e2e collision, which was also #2011's

The agent line names the record it is reading, so that record's name is on the page twice. `AC-overlay-3` matched the saved deal name as bare text, found both, and could not say which one was the 360 rendering the write. It reads `.record-head h1` now. Worth knowing as a pattern: an assertion about a record's own name wants that record's element, not a text match, for as long as this line exists.

## Coverage

SonarCloud failed #2011 on `new_coverage` (67% against an 80% gate). Fifteen tests here, on the two biggest uncovered files this tree can actually reach:

- **the line** (`agentrail-ticker.ts`): it names the record rather than the cache key, says nothing for a read that is plumbing, says nothing for a record it cannot name yet rather than naming its kind, and drops a line once its moment has passed. Driven through the real `QueryClient`, because a hand-fired cache event would only prove the reducer works on the shape the test invented.
- **the scripted run** (`agentrail-demo.ts`): it plays without a second click, it reaches the working beats, it ends on its own, stopping it mid-run hands the surface back, and it leaves no timer behind on unmount.

`margince-core-gl.ts` stays largely uncovered and I am not going to fake it: `getContext("webgl2")` returns null in jsdom, so the renderer bails on its first line. Testing past that means a hand-rolled GL double, which would be a test asserting against its own mock rather than against production.

## The review chips are on by default

While this surface is being designed, the states are the thing under review, and a reviewer opening the app should not need to know an environment variable to see them. `VITE_UI_PREVIEW_TASKBAR=0` takes them away, which is what an installation sets. That default is the first thing to flip when the surface settles, and there is a test on each side of it.

## Gates

`make check-fe` green: 3720 unit + 86, tsc, biome, the five DS script gates, contract drift, build. Full Playwright suite 93 passed / 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Budgets the Core draw loop to 30 fps instead of tying draws to the display rate; motion timing is unchanged because only draw is throttled. This reduces continuous GPU load, fixes the e2e UAT from #2011, and restores CI performance and coverage gates.

- Review notes:
  - Core: add `FRAME_MS = 1000/30`; advance on every rAF; draw only when `now - drawnAt >= FRAME_MS` and on the frame that parks; cancel the pending rAF when parked. `runCoreLoop(canvas, wanted, makeRenderer?)` now accepts an optional renderer factory (defaulting to the real one) to enable loop timing tests. Record open is back within the 300 ms budget; full e2e ~47 s.
  - Tests: new engine-loop suite asserts ~30 Hz draw cadence, no double-draw within one budget window, display-rate independence, and that the park frame is drawn. Add coverage for the agent ticker’s promises and the scripted demo run.
  - Visual: tighten glow falloff and lower `--coreHalo` to 0.18 to prevent spill at rail size.
  - E2E: assert the updated record name via `.record-head h1` to avoid the agent line’s duplicate text.

- Rollout:
  - Review chips default to ON while the surface is in design. To disable for installations, set `VITE_UI_PREVIEW_TASKBAR=0`.

<sup>Written for commit 79c106ec78545be760445207966edda6b262078b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The taskbar preview is now enabled by default and can be disabled through configuration.
  * Added smoother, more consistent animation playback with a 30 FPS frame limit.

* **Style**
  * Reduced the intensity of visual halo and outer-glow effects for a subtler appearance.

* **Bug Fixes**
  * Improved record-name verification when editing in overlay mode.

* **Tests**
  * Expanded coverage for demo runs, activity messages, preview switching, timers, and animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->