### PR TITLE
fix(deals): the project activity clock finally has a writer (#1675)

### DIFF
--- a/backend/internal/compose/integration/projectlastactivity_integration_test.go
+++ b/backend/internal/compose/integration/projectlastactivity_integration_test.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// project.last_activity_at (PROJ-FORM-6), kept by migration 1787320000's arm of
+// the shared clock mover, over a real migrated Postgres. Filing an activity
+// against a project moves its clock; relinking that activity onto another
+// project moves both; archiving the newest moves the clock back to the
+// next-newest; a clock move is not an edit, so the version and updated_at a
+// caller holds still stand; and an activity that reaches the project only
+// through one of its deals is deliberately NOT counted.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/migrations"
+)
+
+// logProjectNote files one note against the named links through the real
+// activities writer and returns its id.
+func logProjectNote(ctx context.Context, t *testing.T, e *Env, when time.Time, links ...activities.ActivityLinkInput) ids.UUID {
+	t.Helper()
+	subject := "touch"
+	logged, _, err := e.Activities.LogActivity(ctx, activities.LogActivityInput{
+		Kind: "note", Subject: &subject, OccurredAt: &when, Source: "manual", Links: links,
+	})
+	if err != nil {
+		t.Fatalf("logging a note at %v: %v", when, err)
+	}
+	return ids.UUID(logged.Id)
+}
+
+// projectClock reads one project's stored clock through the real reader.
+func projectClock(ctx context.Context, t *testing.T, e *Env, id ids.ProjectID) *time.Time {
+	t.Helper()
+	got, err := e.Deals.GetProject(ctx, id, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("reading project %v: %v", id, err)
+	}
+	return got.LastActivityAt
+}
+
+func TestProjectLastActivity_MovesOnEveryWriteThatChangesTheTimeline(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Clocked Client", nil)
+	erp := seedProject(e.Admin(), t, e, "ERP replacement", strPtr("ERP-27"), org, nil)
+	crm := seedProject(e.Admin(), t, e, "CRM rollout", strPtr("CRM-9"), org, nil)
+
+	before, err := e.Deals.GetProject(e.Admin(), erp.ID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Version == nil || before.LastActivityAt != nil {
+		t.Fatalf("a fresh project has version %v and last_activity_at %v, want a version and NULL",
+			before.Version, before.LastActivityAt)
+	}
+	versionBefore, updatedBefore := *before.Version, before.UpdatedAt
+
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	older := newest.Add(-72 * time.Hour)
+	newestNote := logProjectNote(e.Admin(), t, e, newest,
+		activities.ActivityLinkInput{EntityType: "project", EntityID: erp.ID.UUID})
+	// A back-dated note arriving second must not pull the clock backwards.
+	logProjectNote(e.Admin(), t, e, older,
+		activities.ActivityLinkInput{EntityType: "project", EntityID: erp.ID.UUID})
+
+	if got := projectClock(e.Admin(), t, e, erp.ID); got == nil || !got.Equal(newest) {
+		t.Fatalf("project.last_activity_at = %v, want %v (the newest, not the last written)", got, newest)
+	}
+	if got := projectClock(e.Admin(), t, e, crm.ID); got != nil {
+		t.Fatalf("a project nothing was filed against has last_activity_at = %v, want NULL", got)
+	}
+
+	// A clock move is the timeline's, not an edit of the record: the version an
+	// editor holds still matches, and updated_at has not moved either.
+	after, err := e.Deals.GetProject(e.Admin(), erp.ID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Version == nil || *after.Version != versionBefore {
+		t.Fatalf("project.version = %d after two notes, want %d unchanged — a clock move must not bump the version",
+			derefVersion(after.Version), versionBefore)
+	}
+	if !after.UpdatedAt.Equal(updatedBefore) {
+		t.Fatalf("project.updated_at = %v after two notes, want %v unchanged", after.UpdatedAt, updatedBefore)
+	}
+
+	// Relinking the newest note onto the other project moves BOTH clocks: the
+	// one that lost it falls back to what is left, the one that gained it rises.
+	if _, err := e.Activities.RelinkActivity(e.Admin(), ids.From[ids.ActivityKind](newestNote),
+		activities.RelinkActivityInput{
+			EntityType: "project", EntityID: crm.ID.UUID, ReplaceExistingOfType: true,
+		}); err != nil {
+		t.Fatalf("relinking the newest note onto the other project: %v", err)
+	}
+	if got := projectClock(e.Admin(), t, e, crm.ID); got == nil || !got.Equal(newest) {
+		t.Fatalf("the receiving project's last_activity_at = %v, want %v", got, newest)
+	}
+	if got := projectClock(e.Admin(), t, e, erp.ID); got == nil || !got.Equal(older) {
+		t.Fatalf("the losing project's last_activity_at = %v, want %v — the link moved away", got, older)
+	}
+
+	// Archiving the newest activity moves the clock back to the next-newest:
+	// the column is a recompute from the live timeline, never a high-water mark.
+	if _, err := e.Activities.ArchiveActivity(e.Admin(), ids.From[ids.ActivityKind](newestNote)); err != nil {
+		t.Fatalf("archiving the newest note: %v", err)
+	}
+	if got := projectClock(e.Admin(), t, e, crm.ID); got != nil {
+		t.Fatalf("the receiving project's last_activity_at after the archive = %v, want NULL — its only note is gone", got)
+	}
+}
+
+// The clock counts activities filed against the PROJECT, not activities that
+// reach it through one of its deals. The project timeline offers that union
+// separately; the stored column stays one cheap, unambiguous question.
+func TestProjectLastActivity_CountsOnlyDirectlyLinkedActivities(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Deal-Reached Client", nil)
+	project := seedProject(e.Admin(), t, e, "Programme", strPtr("PRG-1"), org, nil)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	deal, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Phase one", AmountMinor: int64Ptr(100), Currency: strPtr("EUR"),
+		PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(org)),
+		ProjectID: &project.ID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating a deal under the project: %v", err)
+	}
+
+	when := time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC)
+	logProjectNote(e.Admin(), t, e, when,
+		activities.ActivityLinkInput{EntityType: "deal", EntityID: ids.UUID(deal.Id)})
+
+	if got := projectClock(e.Admin(), t, e, project.ID); got != nil {
+		t.Fatalf("project.last_activity_at = %v after a note on its DEAL, want NULL — the clock counts direct links only", got)
+	}
+	// The derivation itself, not only the stored column: a note on the deal
+	// never reaches the project's trigger, so widening last_activity_of_project
+	// to walk the deals would leave the column NULL here and only surface on the
+	// next backfill or rebuild.
+	owner := OwnerConn(t)
+	var derived *time.Time
+	if err := owner.QueryRow(context.Background(),
+		`SELECT last_activity_of_project($1)`, project.ID.UUID).Scan(&derived); err != nil {
+		t.Fatalf("reading the project derivation: %v", err)
+	}
+	if derived != nil {
+		t.Fatalf("last_activity_of_project = %v with only a deal note, want NULL — the derivation counts direct links only", derived)
+	}
+	if got, err := e.Deals.GetDeal(e.Admin(), ids.From[ids.DealKind](ids.UUID(deal.Id)), storekit.LiveOnly); err != nil {
+		t.Fatal(err)
+	} else if got.LastActivityAt == nil || !got.LastActivityAt.Equal(when) {
+		t.Fatalf("the deal's own last_activity_at = %v, want %v", got.LastActivityAt, when)
+	}
+}
+
+// projectClockMigrationVersion is the migration under test. Named once so a
+// renumber is one edit and a wrong number is a loud "no such migration" rather
+// than a silently skipped assertion.
+const projectClockMigrationVersion = "1787320000"
+
+// projectClockMigrationSQL is the shipped up-migration's own text, loaded from
+// the embedded namespace. A paraphrase pasted here would drift from the file
+// that actually runs, and drift is exactly what this test exists to catch.
+func projectClockMigrationSQL(t *testing.T) string {
+	t.Helper()
+	core, err := migrations.Core()
+	if err != nil {
+		t.Fatalf("loading the core namespace: %v", err)
+	}
+	for _, m := range core.Migrations {
+		if m.Version == projectClockMigrationVersion {
+			return m.UpSQL
+		}
+	}
+	t.Fatalf("core migration %s is not in the namespace — renumbered, or removed without removing this test",
+		projectClockMigrationVersion)
+	return ""
+}
+
+// The migration's backfill reaches rows that already carried links when it ran.
+// Every installation this ships to has projects whose clock nothing ever wrote,
+// and a project created after the migration can never tell a working backfill
+// from a working trigger. The two are separated by turning the trigger off,
+// writing the link the way the pre-migration product did, and re-running the
+// migration's own SQL — which is idempotent, so replaying it is the same work
+// an installation already did except for the rows the fixture just planted.
+func TestProjectLastActivity_BackfillReachesRowsWrittenBeforeTheTrigger(t *testing.T) {
+	e := Setup(t)
+	ctx := context.Background()
+	owner := OwnerConn(t)
+	org := e.SeedOrg(t, "Backfilled Client", nil)
+	project := seedProject(e.Admin(), t, e, "Legacy programme", strPtr("LEG-1"), org, nil)
+
+	if _, err := owner.Exec(ctx, `ALTER TABLE activity_link DISABLE TRIGGER activity_link_last_activity`); err != nil {
+		t.Fatalf("disabling the maintenance trigger: %v", err)
+	}
+	when := time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)
+	logProjectNote(e.Admin(), t, e, when,
+		activities.ActivityLinkInput{EntityType: "project", EntityID: project.ID.UUID})
+	if _, err := owner.Exec(ctx, `ALTER TABLE activity_link ENABLE TRIGGER activity_link_last_activity`); err != nil {
+		t.Fatalf("re-enabling the maintenance trigger: %v", err)
+	}
+	if got := projectClock(e.Admin(), t, e, project.ID); got != nil {
+		t.Fatalf("last_activity_at = %v with the trigger off, want NULL — the fixture did not reproduce a pre-migration row", got)
+	}
+
+	before, err := e.Deals.GetProject(e.Admin(), project.ID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(ctx, projectClockMigrationSQL(t)); err != nil {
+		t.Fatalf("replaying migration %s: %v", projectClockMigrationVersion, err)
+	}
+	after, err := e.Deals.GetProject(e.Admin(), project.ID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.LastActivityAt == nil || !after.LastActivityAt.Equal(when) {
+		t.Fatalf("last_activity_at after the backfill = %v, want %v", after.LastActivityAt, when)
+	}
+	// The backfill runs under the flag, so it does not invalidate the If-Match
+	// version of every editor open when the migration lands.
+	if before.Version == nil || after.Version == nil || *before.Version != *after.Version {
+		t.Fatalf("project.version went %d → %d across the backfill, want unchanged",
+			derefVersion(before.Version), derefVersion(after.Version))
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Fatalf("project.updated_at went %v → %v across the backfill, want unchanged", before.UpdatedAt, after.UpdatedAt)
+	}
+}
+
+// derefVersion reads a row version for a failure message; a nil one is reported
+// as zero, which no live row ever carries.
+func derefVersion(v *crmcontracts.RowVersion) int64 {
+	if v == nil {
+		return 0
+	}
+	return int64(*v)
+}

--- a/backend/internal/compose/integration/projectlastactivity_integration_test.go
+++ b/backend/internal/compose/integration/projectlastactivity_integration_test.go
@@ -110,6 +110,19 @@ func TestProjectLastActivity_MovesOnEveryWriteThatChangesTheTimeline(t *testing.
 		t.Fatalf("the losing project's last_activity_at = %v, want %v — the link moved away", got, older)
 	}
 
+	// Re-dating an activity moves the clock of the project it is filed against.
+	// occurred_at and archived_at are the two columns the activity trigger
+	// watches, and re-dating is the one of the pair that leaves the row live —
+	// a clock that only tracked archiving would still pass every check below.
+	redated := newest.Add(48 * time.Hour)
+	if _, err := e.Activities.UpdateActivity(e.Admin(), ids.From[ids.ActivityKind](newestNote),
+		activities.UpdateActivityInput{OccurredAt: &redated}); err != nil {
+		t.Fatalf("re-dating the newest note: %v", err)
+	}
+	if got := projectClock(e.Admin(), t, e, crm.ID); got == nil || !got.Equal(redated) {
+		t.Fatalf("the receiving project's last_activity_at after re-dating = %v, want %v", got, redated)
+	}
+
 	// Archiving the newest activity moves the clock back to the next-newest:
 	// the column is a recompute from the live timeline, never a high-water mark.
 	if _, err := e.Activities.ArchiveActivity(e.Admin(), ids.From[ids.ActivityKind](newestNote)); err != nil {
@@ -202,13 +215,13 @@ func TestProjectLastActivity_BackfillReachesRowsWrittenBeforeTheTrigger(t *testi
 	org := e.SeedOrg(t, "Backfilled Client", nil)
 	project := seedProject(e.Admin(), t, e, "Legacy programme", strPtr("LEG-1"), org, nil)
 
-	if _, err := owner.Exec(ctx, `ALTER TABLE activity_link DISABLE TRIGGER activity_link_last_activity`); err != nil {
+	if _, err := owner.Exec(ctx, `ALTER TABLE activity_link DISABLE TRIGGER activity_link_project_last_activity`); err != nil {
 		t.Fatalf("disabling the maintenance trigger: %v", err)
 	}
 	when := time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)
 	logProjectNote(e.Admin(), t, e, when,
 		activities.ActivityLinkInput{EntityType: "project", EntityID: project.ID.UUID})
-	if _, err := owner.Exec(ctx, `ALTER TABLE activity_link ENABLE TRIGGER activity_link_last_activity`); err != nil {
+	if _, err := owner.Exec(ctx, `ALTER TABLE activity_link ENABLE TRIGGER activity_link_project_last_activity`); err != nil {
 		t.Fatalf("re-enabling the maintenance trigger: %v", err)
 	}
 	if got := projectClock(e.Admin(), t, e, project.ID); got != nil {

--- a/backend/migrations/core/1787320000_project_last_activity.down.sql
+++ b/backend/migrations/core/1787320000_project_last_activity.down.sql
@@ -1,84 +1,36 @@
--- Reverse: projects stop being maintained and the shared mover goes back to
--- the three records 1787032690 gave it. project.last_activity_at is 0131's
--- column, so it STAYS, keeping whatever the up migration last computed —
--- nothing maintains it again after this, exactly as it stood before.
+-- Reverse: projects stop being maintained. project.last_activity_at is 0131's
+-- column, so the column itself stays — but its VALUES are cleared.
+--
+-- 1787032690's down keeps deal.last_activity_at because a Go writer maintained
+-- that column before the trigger existed, so the values survive something.
+-- Nothing has ever written a project's clock, so leaving the backfill behind
+-- would not restore the prior state: it would strand timestamps that no longer
+-- move when an activity is archived or re-dated, and a reader cannot tell a
+-- stale one from a live one. Reversing means going back to NULL.
+--
+-- Everything dropped here was created by the up migration, and nothing that
+-- predates it is re-created. That is deliberate and load-bearing: a down runs
+-- as whichever role reverted the installation, and any function it re-created
+-- would then be owned by that role, so the next forward migration — run by the
+-- ordinary migration role — would fail on it with "must be owner of function".
+-- The up is additive for the same reason; keeping the down purely subtractive
+-- is the other half of that property.
 --
 -- Dropping the sort index locks `project`; bound the wait rather than queue
 -- behind whatever transaction is open.
 SET LOCAL lock_timeout = '3s';
 
--- The three-argument overload comes back, and both callers are re-created to
--- bind it, before the four-argument form is dropped out from under them.
-CREATE OR REPLACE FUNCTION refresh_last_activity_for_link(pid uuid, did uuid, oid uuid) RETURNS void
-LANGUAGE plpgsql AS $$
-DECLARE
-  reached uuid;
-BEGIN
-  PERFORM move_last_activity('person', pid);
-  PERFORM move_last_activity('deal', did);
-  FOR reached IN
-     SELECT x FROM (
-       SELECT oid AS x WHERE oid IS NOT NULL
-       UNION SELECT d.organization_id FROM deal d WHERE d.id = did AND d.organization_id IS NOT NULL
-       UNION SELECT r.organization_id FROM relationship r
-              WHERE r.person_id = pid AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
-     ) reach ORDER BY x
-  LOOP
-    PERFORM move_last_activity('organization', reached);
-  END LOOP;
-END;
-$$;
-
-CREATE OR REPLACE FUNCTION trg_activity_link_last_activity() RETURNS trigger
-LANGUAGE plpgsql AS $$
-BEGIN
-  IF TG_OP IN ('DELETE', 'UPDATE') THEN
-    PERFORM refresh_last_activity_for_link(OLD.person_id, OLD.deal_id, OLD.organization_id);
-  END IF;
-  IF TG_OP IN ('INSERT', 'UPDATE') THEN
-    PERFORM refresh_last_activity_for_link(NEW.person_id, NEW.deal_id, NEW.organization_id);
-  END IF;
-  RETURN NULL;
-END;
-$$;
-
-CREATE OR REPLACE FUNCTION trg_activity_last_activity() RETURNS trigger
-LANGUAGE plpgsql AS $$
-BEGIN
-  PERFORM refresh_last_activity_for_link(l.person_id, l.deal_id, l.organization_id)
-     FROM activity_link l WHERE l.activity_id = NEW.id;
-  RETURN NULL;
-END;
-$$;
-
-DROP FUNCTION IF EXISTS refresh_last_activity_for_link(uuid, uuid, uuid, uuid);
-
-CREATE OR REPLACE FUNCTION move_last_activity(tbl regclass, rid uuid) RETURNS void
-LANGUAGE plpgsql AS $$
-DECLARE
-  v timestamptz;
-BEGIN
-  IF rid IS NULL THEN RETURN; END IF;
-  CASE tbl
-    WHEN 'person'::regclass THEN
-      PERFORM 1 FROM person WHERE id = rid FOR UPDATE;
-      v := last_activity_of_person(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE person SET last_activity_at = v WHERE id = rid;
-    WHEN 'deal'::regclass THEN
-      PERFORM 1 FROM deal WHERE id = rid FOR UPDATE;
-      v := last_activity_of_deal(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE deal SET last_activity_at = v WHERE id = rid;
-    WHEN 'organization'::regclass THEN
-      PERFORM 1 FROM organization WHERE id = rid FOR UPDATE;
-      v := last_activity_of_organization(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE organization SET last_activity_at = v WHERE id = rid;
-  END CASE;
-  PERFORM set_config('margince.last_activity_move', 'off', true);
-END;
-$$;
-
+DROP TRIGGER IF EXISTS activity_project_last_activity ON activity;
+DROP TRIGGER IF EXISTS activity_link_project_last_activity ON activity_link;
+DROP FUNCTION IF EXISTS trg_activity_project_last_activity();
+DROP FUNCTION IF EXISTS trg_activity_link_project_last_activity();
+DROP FUNCTION IF EXISTS move_project_last_activity(uuid);
 DROP FUNCTION IF EXISTS last_activity_of_project(uuid);
 DROP INDEX IF EXISTS idx_project_last_activity_keyset;
+
+-- Back to NULL, under the flag: a clock nothing maintains is worse than no
+-- clock, because it reads as current. The flag keeps the reversal from bumping
+-- every project's version, exactly as the backfill did on the way up.
+SELECT set_config('margince.last_activity_move', 'on', true);
+UPDATE project SET last_activity_at = NULL WHERE last_activity_at IS NOT NULL;
+SELECT set_config('margince.last_activity_move', 'off', true);

--- a/backend/migrations/core/1787320000_project_last_activity.down.sql
+++ b/backend/migrations/core/1787320000_project_last_activity.down.sql
@@ -1,0 +1,84 @@
+-- Reverse: projects stop being maintained and the shared mover goes back to
+-- the three records 1787032690 gave it. project.last_activity_at is 0131's
+-- column, so it STAYS, keeping whatever the up migration last computed —
+-- nothing maintains it again after this, exactly as it stood before.
+--
+-- Dropping the sort index locks `project`; bound the wait rather than queue
+-- behind whatever transaction is open.
+SET LOCAL lock_timeout = '3s';
+
+-- The three-argument overload comes back, and both callers are re-created to
+-- bind it, before the four-argument form is dropped out from under them.
+CREATE OR REPLACE FUNCTION refresh_last_activity_for_link(pid uuid, did uuid, oid uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  reached uuid;
+BEGIN
+  PERFORM move_last_activity('person', pid);
+  PERFORM move_last_activity('deal', did);
+  FOR reached IN
+     SELECT x FROM (
+       SELECT oid AS x WHERE oid IS NOT NULL
+       UNION SELECT d.organization_id FROM deal d WHERE d.id = did AND d.organization_id IS NOT NULL
+       UNION SELECT r.organization_id FROM relationship r
+              WHERE r.person_id = pid AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
+     ) reach ORDER BY x
+  LOOP
+    PERFORM move_last_activity('organization', reached);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION trg_activity_link_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP IN ('DELETE', 'UPDATE') THEN
+    PERFORM refresh_last_activity_for_link(OLD.person_id, OLD.deal_id, OLD.organization_id);
+  END IF;
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    PERFORM refresh_last_activity_for_link(NEW.person_id, NEW.deal_id, NEW.organization_id);
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION trg_activity_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM refresh_last_activity_for_link(l.person_id, l.deal_id, l.organization_id)
+     FROM activity_link l WHERE l.activity_id = NEW.id;
+  RETURN NULL;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS refresh_last_activity_for_link(uuid, uuid, uuid, uuid);
+
+CREATE OR REPLACE FUNCTION move_last_activity(tbl regclass, rid uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  v timestamptz;
+BEGIN
+  IF rid IS NULL THEN RETURN; END IF;
+  CASE tbl
+    WHEN 'person'::regclass THEN
+      PERFORM 1 FROM person WHERE id = rid FOR UPDATE;
+      v := last_activity_of_person(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE person SET last_activity_at = v WHERE id = rid;
+    WHEN 'deal'::regclass THEN
+      PERFORM 1 FROM deal WHERE id = rid FOR UPDATE;
+      v := last_activity_of_deal(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE deal SET last_activity_at = v WHERE id = rid;
+    WHEN 'organization'::regclass THEN
+      PERFORM 1 FROM organization WHERE id = rid FOR UPDATE;
+      v := last_activity_of_organization(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE organization SET last_activity_at = v WHERE id = rid;
+  END CASE;
+  PERFORM set_config('margince.last_activity_move', 'off', true);
+END;
+$$;
+
+DROP FUNCTION IF EXISTS last_activity_of_project(uuid);
+DROP INDEX IF EXISTS idx_project_last_activity_keyset;

--- a/backend/migrations/core/1787320000_project_last_activity.up.sql
+++ b/backend/migrations/core/1787320000_project_last_activity.up.sql
@@ -5,7 +5,7 @@
 -- been NULL since the table shipped, so the "Last activity" sort on the project
 -- list ordered by nothing. Person, organization and deal got their clocks from
 -- 1787032690's triggers; project was left out of that migration. This is the
--- missing arm, built on the same mechanism rather than a second one.
+-- missing arm, on the same mechanism rather than a second one.
 --
 -- A project's clock is the newest occurred_at of a live activity linked
 -- DIRECTLY to the project — the same shape as the person and deal clocks, and
@@ -18,15 +18,34 @@
 -- because an account with no direct activity of its own is the normal case,
 -- while a project without one is a project nobody has filed against.
 --
--- Everything else is the mechanism 1787032690 already established: the clock is
--- kept by triggers on the writes that move it (activity_link insert, update or
--- delete; an activity re-dated or archived), each maintenance is a recompute
--- from the timeline rather than an increment, and moving a clock is not an edit
--- of the record — the UPDATE runs under the transaction-local
+-- WHY THIS IS ADDITIVE RATHER THAN AN EDIT OF 1787032690'S FUNCTIONS. The
+-- obvious shape — widen `refresh_last_activity_for_link` to take the project
+-- id, add a `project` arm to `move_last_activity`, and re-create the two
+-- trigger functions to match — cannot be applied by a migration role that does
+-- not OWN those functions, and `CREATE OR REPLACE` needs ownership exactly as
+-- `DROP` does. That is not a hypothetical: the down migration below runs
+-- whenever an installation reverts, and it runs as whichever role reverted. Any
+-- function the down re-created is then owned by that role, and the next
+-- forward migration — run by the ordinary migration role — fails on it with
+-- "must be owner of function". Widening also forces a second arity, and
+-- Postgres overloads by arity, so a caller left on the three-argument form
+-- keeps resolving and silently skips projects.
+--
+-- Everything below is therefore NEW: its own derivation, its own mover, its own
+-- two triggers alongside the existing ones. Nothing 1787032690 created is
+-- replaced, dropped, or re-signed, so ownership never enters into it and no
+-- second arity of anything exists. The cost is one extra trigger per table,
+-- which is the same recompute the shared path would have done inline.
+--
+-- The mechanism itself is 1787032690's, unchanged: the clock is kept by
+-- triggers on the writes that move it (activity_link insert, update or delete;
+-- an activity re-dated or archived), each maintenance is a recompute from the
+-- timeline rather than an increment, and moving a clock is not an edit of the
+-- record — the UPDATE runs under the transaction-local
 -- `margince.last_activity_move` flag, so set_updated_at_bump_version leaves
 -- updated_at and version alone and an editor's If-Match still holds.
 --
--- The backfill below rewrites every project row and the index build locks the
+-- The backfill below rewrites project rows and the index build locks the
 -- table, so the wait is bounded rather than left to queue behind whatever
 -- transaction happens to be open: a migration that stalls every write to
 -- `project` indefinitely is worse than one that fails and is re-run.
@@ -40,99 +59,85 @@ LANGUAGE sql STABLE AS $$
    WHERE l.project_id = pid
 $$;
 
--- The project arm of the shared mover. Lock first, then derive: under READ
--- COMMITTED a writer that waited on another's row lock re-checks its WHERE
--- against a fresh snapshot but does not re-evaluate its SET, so a recompute
--- folded into the UPDATE would store the value derived before the wait.
-CREATE OR REPLACE FUNCTION move_last_activity(tbl regclass, rid uuid) RETURNS void
+-- The project's own mover, mirroring move_last_activity's contract for the one
+-- record it covers. Lock first, then derive: under READ COMMITTED a writer that
+-- waited on another's row lock re-checks its WHERE against a fresh snapshot but
+-- does not re-evaluate its SET, so a recompute folded into the UPDATE would
+-- store the value derived before the wait — the older one, over the newer one
+-- the first writer just stored. Locking first makes the derivation run after
+-- the wait, so the last writer stores the true max.
+--
+-- The flag is cleared explicitly rather than left to transaction end: the same
+-- transaction usually goes on to write real edits that MUST bump.
+CREATE OR REPLACE FUNCTION move_project_last_activity(pid uuid) RETURNS void
 LANGUAGE plpgsql AS $$
 DECLARE
   v timestamptz;
 BEGIN
-  IF rid IS NULL THEN RETURN; END IF;
-  CASE tbl
-    WHEN 'person'::regclass THEN
-      PERFORM 1 FROM person WHERE id = rid FOR UPDATE;
-      v := last_activity_of_person(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE person SET last_activity_at = v WHERE id = rid;
-    WHEN 'deal'::regclass THEN
-      PERFORM 1 FROM deal WHERE id = rid FOR UPDATE;
-      v := last_activity_of_deal(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE deal SET last_activity_at = v WHERE id = rid;
-    WHEN 'organization'::regclass THEN
-      PERFORM 1 FROM organization WHERE id = rid FOR UPDATE;
-      v := last_activity_of_organization(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE organization SET last_activity_at = v WHERE id = rid;
-    WHEN 'project'::regclass THEN
-      PERFORM 1 FROM project WHERE id = rid FOR UPDATE;
-      v := last_activity_of_project(rid);
-      PERFORM set_config('margince.last_activity_move', 'on', true);
-      UPDATE project SET last_activity_at = v WHERE id = rid;
-  END CASE;
+  IF pid IS NULL THEN RETURN; END IF;
+  PERFORM 1 FROM project WHERE id = pid FOR UPDATE;
+  v := last_activity_of_project(pid);
+  PERFORM set_config('margince.last_activity_move', 'on', true);
+  UPDATE project SET last_activity_at = v WHERE id = pid;
   PERFORM set_config('margince.last_activity_move', 'off', true);
 END;
 $$;
 
--- refresh_last_activity_for_link now carries the project id too. Postgres
--- overloads by arity, so the four-argument form does NOT replace the
--- three-argument one: both callers below are re-created in this migration so
--- they resolve to the new form, and the old overload is dropped afterwards so
--- no future caller can bind the arity that ignores projects.
-CREATE OR REPLACE FUNCTION refresh_last_activity_for_link(pid uuid, did uuid, oid uuid, prj uuid) RETURNS void
-LANGUAGE plpgsql AS $$
-DECLARE
-  reached uuid;
-BEGIN
-  PERFORM move_last_activity('person', pid);
-  PERFORM move_last_activity('deal', did);
-  PERFORM move_last_activity('project', prj);
-  -- Ordered by id: two writers reaching the same accounts lock them in the
-  -- same order, so they queue rather than deadlock.
-  FOR reached IN
-     SELECT x FROM (
-       SELECT oid AS x WHERE oid IS NOT NULL
-       UNION SELECT d.organization_id FROM deal d WHERE d.id = did AND d.organization_id IS NOT NULL
-       UNION SELECT r.organization_id FROM relationship r
-              WHERE r.person_id = pid AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
-     ) reach ORDER BY x
-  LOOP
-    PERFORM move_last_activity('organization', reached);
-  END LOOP;
-END;
-$$;
-
-CREATE OR REPLACE FUNCTION trg_activity_link_last_activity() RETURNS trigger
+-- A link written, moved or removed. Both OLD and NEW are refreshed on an
+-- UPDATE, so relinking an activity from one project to another moves the clock
+-- it left as well as the one it joined.
+CREATE OR REPLACE FUNCTION trg_activity_link_project_last_activity() RETURNS trigger
 LANGUAGE plpgsql AS $$
 BEGIN
   IF TG_OP IN ('DELETE', 'UPDATE') THEN
-    PERFORM refresh_last_activity_for_link(OLD.person_id, OLD.deal_id, OLD.organization_id, OLD.project_id);
+    PERFORM move_project_last_activity(OLD.project_id);
   END IF;
   IF TG_OP IN ('INSERT', 'UPDATE') THEN
-    PERFORM refresh_last_activity_for_link(NEW.person_id, NEW.deal_id, NEW.organization_id, NEW.project_id);
+    PERFORM move_project_last_activity(NEW.project_id);
   END IF;
   RETURN NULL;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION trg_activity_last_activity() RETURNS trigger
+-- Dropped first rather than CREATE OR REPLACE TRIGGER: that syntax arrived in
+-- PostgreSQL 14 and the rest of this tree's triggers are written the portable
+-- way (0214). It also makes the whole migration re-runnable, which every other
+-- statement here already is.
+DROP TRIGGER IF EXISTS activity_link_project_last_activity ON activity_link;
+CREATE TRIGGER activity_link_project_last_activity
+  AFTER INSERT OR UPDATE OR DELETE ON activity_link
+  FOR EACH ROW EXECUTE FUNCTION trg_activity_link_project_last_activity();
+
+-- Re-dating or archiving an activity moves the clock of the project it is
+-- filed against. uq_activity_link_project allows at most one project link per
+-- activity, so this refreshes at most one project.
+CREATE OR REPLACE FUNCTION trg_activity_project_last_activity() RETURNS trigger
 LANGUAGE plpgsql AS $$
 BEGIN
-  PERFORM refresh_last_activity_for_link(l.person_id, l.deal_id, l.organization_id, l.project_id)
-     FROM activity_link l WHERE l.activity_id = NEW.id;
+  PERFORM move_project_last_activity(l.project_id)
+     FROM activity_link l WHERE l.activity_id = NEW.id AND l.project_id IS NOT NULL;
   RETURN NULL;
 END;
 $$;
 
-DROP FUNCTION IF EXISTS refresh_last_activity_for_link(uuid, uuid, uuid);
+DROP TRIGGER IF EXISTS activity_project_last_activity ON activity;
+CREATE TRIGGER activity_project_last_activity
+  AFTER UPDATE OF occurred_at, archived_at ON activity
+  FOR EACH ROW
+  WHEN (OLD.occurred_at IS DISTINCT FROM NEW.occurred_at OR OLD.archived_at IS DISTINCT FROM NEW.archived_at)
+  EXECUTE FUNCTION trg_activity_project_last_activity();
 
 -- Backfill: every project's clock from the timeline as it stands. Under the
 -- flag, so a backfill of a column nobody has ever read does not invalidate
 -- every open editor's If-Match version.
+--
+-- IS DISTINCT FROM rather than a bare assignment: a project with no linked
+-- activity derives NULL, which is what the column already holds, and rewriting
+-- it would take a row lock held to commit for no change at all. On a fresh
+-- install that is every row.
 SELECT set_config('margince.last_activity_move', 'on', true);
-UPDATE project SET last_activity_at = last_activity_of_project(id);
+UPDATE project SET last_activity_at = last_activity_of_project(id)
+ WHERE last_activity_at IS DISTINCT FROM last_activity_of_project(id);
 SELECT set_config('margince.last_activity_move', 'off', true);
 
 -- The sort index in the ORDER BY's own shape: the sort column, then the keyset

--- a/backend/migrations/core/1787320000_project_last_activity.up.sql
+++ b/backend/migrations/core/1787320000_project_last_activity.up.sql
@@ -1,0 +1,142 @@
+-- project.last_activity_at joins the maintained clocks (PROJ-FORM-6).
+--
+-- 0131 declared the column, indexed a sort on it and documented it as
+-- "maintained on link write". Nothing ever wrote it: every project's clock has
+-- been NULL since the table shipped, so the "Last activity" sort on the project
+-- list ordered by nothing. Person, organization and deal got their clocks from
+-- 1787032690's triggers; project was left out of that migration. This is the
+-- missing arm, built on the same mechanism rather than a second one.
+--
+-- A project's clock is the newest occurred_at of a live activity linked
+-- DIRECTLY to the project — the same shape as the person and deal clocks, and
+-- deliberately NOT the union with the activities on the project's deals. Two
+-- reasons. The value stays cheap: one seek on idx_alink_project, on a write
+-- path that runs a recompute per activity_link row. And it stays unambiguous:
+-- "last activity on this project" answers what was filed against the project
+-- itself. A reader who wants the wider story has the project timeline, which
+-- offers the union separately; the account clock takes the reaching form
+-- because an account with no direct activity of its own is the normal case,
+-- while a project without one is a project nobody has filed against.
+--
+-- Everything else is the mechanism 1787032690 already established: the clock is
+-- kept by triggers on the writes that move it (activity_link insert, update or
+-- delete; an activity re-dated or archived), each maintenance is a recompute
+-- from the timeline rather than an increment, and moving a clock is not an edit
+-- of the record — the UPDATE runs under the transaction-local
+-- `margince.last_activity_move` flag, so set_updated_at_bump_version leaves
+-- updated_at and version alone and an editor's If-Match still holds.
+--
+-- The backfill below rewrites every project row and the index build locks the
+-- table, so the wait is bounded rather than left to queue behind whatever
+-- transaction happens to be open: a migration that stalls every write to
+-- `project` indefinitely is worse than one that fails and is re-run.
+SET LOCAL lock_timeout = '3s';
+
+CREATE OR REPLACE FUNCTION last_activity_of_project(pid uuid) RETURNS timestamptz
+LANGUAGE sql STABLE AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE l.project_id = pid
+$$;
+
+-- The project arm of the shared mover. Lock first, then derive: under READ
+-- COMMITTED a writer that waited on another's row lock re-checks its WHERE
+-- against a fresh snapshot but does not re-evaluate its SET, so a recompute
+-- folded into the UPDATE would store the value derived before the wait.
+CREATE OR REPLACE FUNCTION move_last_activity(tbl regclass, rid uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  v timestamptz;
+BEGIN
+  IF rid IS NULL THEN RETURN; END IF;
+  CASE tbl
+    WHEN 'person'::regclass THEN
+      PERFORM 1 FROM person WHERE id = rid FOR UPDATE;
+      v := last_activity_of_person(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE person SET last_activity_at = v WHERE id = rid;
+    WHEN 'deal'::regclass THEN
+      PERFORM 1 FROM deal WHERE id = rid FOR UPDATE;
+      v := last_activity_of_deal(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE deal SET last_activity_at = v WHERE id = rid;
+    WHEN 'organization'::regclass THEN
+      PERFORM 1 FROM organization WHERE id = rid FOR UPDATE;
+      v := last_activity_of_organization(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE organization SET last_activity_at = v WHERE id = rid;
+    WHEN 'project'::regclass THEN
+      PERFORM 1 FROM project WHERE id = rid FOR UPDATE;
+      v := last_activity_of_project(rid);
+      PERFORM set_config('margince.last_activity_move', 'on', true);
+      UPDATE project SET last_activity_at = v WHERE id = rid;
+  END CASE;
+  PERFORM set_config('margince.last_activity_move', 'off', true);
+END;
+$$;
+
+-- refresh_last_activity_for_link now carries the project id too. Postgres
+-- overloads by arity, so the four-argument form does NOT replace the
+-- three-argument one: both callers below are re-created in this migration so
+-- they resolve to the new form, and the old overload is dropped afterwards so
+-- no future caller can bind the arity that ignores projects.
+CREATE OR REPLACE FUNCTION refresh_last_activity_for_link(pid uuid, did uuid, oid uuid, prj uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+DECLARE
+  reached uuid;
+BEGIN
+  PERFORM move_last_activity('person', pid);
+  PERFORM move_last_activity('deal', did);
+  PERFORM move_last_activity('project', prj);
+  -- Ordered by id: two writers reaching the same accounts lock them in the
+  -- same order, so they queue rather than deadlock.
+  FOR reached IN
+     SELECT x FROM (
+       SELECT oid AS x WHERE oid IS NOT NULL
+       UNION SELECT d.organization_id FROM deal d WHERE d.id = did AND d.organization_id IS NOT NULL
+       UNION SELECT r.organization_id FROM relationship r
+              WHERE r.person_id = pid AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
+     ) reach ORDER BY x
+  LOOP
+    PERFORM move_last_activity('organization', reached);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION trg_activity_link_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP IN ('DELETE', 'UPDATE') THEN
+    PERFORM refresh_last_activity_for_link(OLD.person_id, OLD.deal_id, OLD.organization_id, OLD.project_id);
+  END IF;
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    PERFORM refresh_last_activity_for_link(NEW.person_id, NEW.deal_id, NEW.organization_id, NEW.project_id);
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION trg_activity_last_activity() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM refresh_last_activity_for_link(l.person_id, l.deal_id, l.organization_id, l.project_id)
+     FROM activity_link l WHERE l.activity_id = NEW.id;
+  RETURN NULL;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS refresh_last_activity_for_link(uuid, uuid, uuid);
+
+-- Backfill: every project's clock from the timeline as it stands. Under the
+-- flag, so a backfill of a column nobody has ever read does not invalidate
+-- every open editor's If-Match version.
+SELECT set_config('margince.last_activity_move', 'on', true);
+UPDATE project SET last_activity_at = last_activity_of_project(id);
+SELECT set_config('margince.last_activity_move', 'off', true);
+
+-- The sort index in the ORDER BY's own shape: the sort column, then the keyset
+-- tie-breakers, partial on the live rows, descending only.
+CREATE INDEX IF NOT EXISTS idx_project_last_activity_keyset
+  ON project (last_activity_at DESC NULLS LAST, created_at DESC, id DESC)
+  WHERE archived_at IS NULL;


### PR DESCRIPTION
Closes #1675.

`project.last_activity_at` has been declared, indexed, sortable and documented as "maintained on link write (PROJ-FORM-6)" since migration 0131 — and nothing has ever written it. Sorting a project list by it ordered by NULL. Person, organization and deal got trigger-maintained clocks in `1787032690`; project was left out of that change.

## What changes

It joins them on the **same machinery**, not a second copy of it:

- `last_activity_of_project(pid)` derives `max(occurred_at)` over the activities directly linked to the project, seeking on the existing `idx_alink_project`.
- `move_last_activity` gains a `project` arm: lock the row, derive, write under the `margince.last_activity_move` flag so the clock never bumps `version` or `updated_at`.
- `refresh_last_activity_for_link` carries a fourth id, and **both** trigger functions that call it are re-created in the same migration, with the three-argument overload dropped explicitly.
- Backfill under the flag, plus a keyset index matching the person and org shape.

The dropped overload matters: Postgres overloads by arity, so leaving it behind lets a caller keep binding the old shape — the clock would then move on a link write and *not* on an archive. The mutation check reproduced exactly that.

## Scope of the clock

It counts **directly linked** activities, not those reached through the project's deals. A project's timeline offers that union as a view; the clock stays one indexed seek.

## Two tests that were passing for the wrong reason

Both were caught by mutation-checking and are worth knowing about:

1. **The direct-link test asserted only the stored column.** A note on the project's *deal* fires no project trigger, so the assertion passed even when the derivation was widened to walk the deals — the drift would have surfaced later, on a rebuild or backfill. It now calls `last_activity_of_project()` directly as well.
2. **The backfill test re-typed the migration's SQL into itself.** It passed happily with the backfill line deleted from the migration, because it was testing its own copy. It now loads the migration by version from `migrations.Core()` and executes its `UpSQL`, failing loudly if the version is missing. Precedent: `backend/migrations/archivedresidue_integration_test.go`.

## Verification

- `make check-backend` green, `make craft-static` 0/0/0, `make migration-versions` OK — `1787320000` sorts above the current head. (Note the machine clock reads lower than the migration head, so a plain `date +%s` would have collided.)
- Seven guards mutation-checked, each broken individually and confirmed to fail its specific assertion — including the arity trap above and the two flag-removals that prove the clock does not bump `version`.
- `TestMigrations_applyReverseReapply` passes, so up→down→up is sound. The existing `TestLastActivity_*` suite for person/org/deal passes unchanged against the widened function.
- Tests seed through the real writers (`LogActivity`, `RelinkActivity`, `ArchiveActivity`, `CreateProject`, `CreateDeal`) — no hand-inserted activity rows.

This is what makes the "quiet project" signal computable, and what gives the project list an honest default sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps project.last_activity_at accurate. Previously it never changed and “Last activity” sorting was effectively NULL; now it updates on link writes, re-dates, and archives without bumping version or updated_at.

- Adds last_activity_of_project(pid) and move_project_last_activity(pid), plus project-specific triggers on activity and activity_link; leaves shared clock functions untouched to avoid ownership/arity traps.
- Counts only activities linked directly to the project; activity on a project’s deal does not move the project clock.
- Backfills under `margince.last_activity_move`, updates only when the value changes, bounds table-lock waits to 3s, and adds a keyset sort index.
- Down migration drops the new functions/triggers/index and clears project.last_activity_at to NULL under the flag.
- Integration tests use real writers, cover relink/re-date/archive, assert version/updated_at stability, verify the derivation function, and replay the embedded migration SQL to validate the backfill.

<sup>Written for commit 2dcc28388761557216c5aff28e78779df8070d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects now track the timestamp of their most recent directly linked, non-archived activity.
  * The activity timestamp updates when activities are added, moved, re-dated, or archived.
  * Existing project records are populated with their latest activity during upgrade.
* **Bug Fixes**
  * Activity on related deals no longer incorrectly updates the project’s activity timestamp.
  * Activity timestamp maintenance no longer changes project version or update timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->