### PR TITLE
docs(partners): a tutorial that follows one deal to the money it earns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ maps the codebase and links everything below.
 
 ### Tutorials — learn by doing
 - [getting-started.md](tutorials/getting-started.md) — clone → running instance with a bootstrapped workspace.
+- [run-a-partner-program.md](tutorials/run-a-partner-program.md) — follow one partner-sourced deal from the introduction to the commission it earns; no code.
 
 ### How-to — accomplish a task
 - [add-an-endpoint.md](how-to/add-an-endpoint.md) — add or change an API operation (contract → gen → handler).
@@ -36,7 +37,7 @@ maps the codebase and links everything below.
 - [register-a-webhook.md](how-to/register-a-webhook.md) — register an HTTPS endpoint for Standard-Webhooks-signed, retried outbound delivery of contract-generated event payloads (curl or Settings → Integrations), and verify/inspect/replay a delivery.
 - [add-an-extension.md](how-to/add-an-extension.md) — ship a stable-tier extension unit (a jurisdiction pack) under `extensions/`, composed and verified.
 - [work-your-pipeline.md](how-to/work-your-pipeline.md) — sell with Margince: move a deal, close it (and what winning one requires), stalled deals, saved views, bulk actions, and how to read the pipeline numbers; no code.
-- [set-up-a-partner-program.md](how-to/set-up-a-partner-program.md) — run a partner program from the UI: make a company a partner, what every field means, work the pipeline; no code.
+- [set-up-a-partner-program.md](how-to/set-up-a-partner-program.md) — the partner reference: what every field and every value means, and how to work the pipeline; no code. Learning it for the first time? [tutorials/run-a-partner-program.md](tutorials/run-a-partner-program.md) walks one deal end to end.
 - [build-the-desktop-app.md](how-to/build-the-desktop-app.md) — build the self-contained folder that runs the whole stack with no Docker, on macOS (`make desktop`) or Windows (`make desktop-win`), then run, configure and update an installation.
 
 ### Reference — look it up

--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -5,6 +5,11 @@ partners live in the app, how to make a company a partner, what every field on t
 and how to work the pipeline afterwards. The one thing you *cannot* do from the UI — changing
 the value lists themselves — is covered at the end.
 
+New to this? Start with
+[tutorials/run-a-partner-program.md](../tutorials/run-a-partner-program.md), which walks one
+deal from an introduction through to the commission it earns. This guide is the reference you
+come back to for what a particular field means.
+
 ## What a partner is in Margince
 
 A partner is not a separate record you create next to a company. It is an **extra layer on a
@@ -96,6 +101,14 @@ partners so filtering stays useful.
 - **The company page stays the home** — activities, people, and deals with a partner live on
   the company page like for any other company. The Partner tab is one more tab there, not a
   separate world.
+- **Two lists, two questions.** A company's **Deals** tab shows deals where it is the
+  *customer*. Its **Partner** tab shows **Deals they brought** — deals belonging to *other*
+  companies that came through this partner. A partner-sourced deal appears only in the second,
+  because the deal belongs to the customer.
+- **Commission** sits under that, one row per entry, naming the deal it was earned on. Entries
+  appear on their own when a partner-sourced deal is won; nobody creates them by hand. The
+  statuses (accrued → approved → paid, or reversed) are shown but **cannot yet be changed from
+  the app** — deciding a commission exists in the API only.
 - **A simple weekly loop:** filter the list for **Applied** and push certifications forward;
   scan for partners whose stage is behind reality and correct it; make sure every in-flight
   partner has a next step with a due date.
@@ -105,7 +118,8 @@ generic record tools, so an agent can find it, read it and see that it carries t
 relationship type — but `partner` is not yet one of the record types those tools accept, so the
 partner extension's own fields (tier, certification, relationship stage) are not readable or
 writable that way. A deal's partner and what that partner did for it ARE agent-visible, through
-the deal's own `partner_org_id` and `partner_attribution` fields.
+the deal's own `partner_org_id` and `partner_attribution` fields — readable, and settable both
+when an agent creates a deal and when it updates one.
 
 ## Changing the value lists themselves
 

--- a/docs/tutorials/run-a-partner-program.md
+++ b/docs/tutorials/run-a-partner-program.md
@@ -1,0 +1,163 @@
+# Run a partner program
+
+Some of your deals arrive because somebody else brought them. This tutorial follows one such
+deal from the introduction to the money owed, so that by the end you can answer the question a
+partner will eventually ask you: *what have we earned?*
+
+You will make a company a partner, attribute a deal to them, win it, and watch the commission
+appear on its own. It takes about fifteen minutes and touches four screens.
+
+This is a walkthrough, not a reference. Every field on the partner form, with its full
+vocabulary, is in [how-to/set-up-a-partner-program.md](../how-to/set-up-a-partner-program.md) —
+read that when you want the complete list; read this to learn the shape of the thing.
+
+**Before you start** you need a login and at least two companies in Margince: one that will be
+the partner, and one that will be the customer. That distinction is the whole idea, so it is
+worth being deliberate about it now.
+
+## The one idea worth getting straight
+
+A partner is **not** a customer who happens to be called a partner. In an ordinary deal there
+is one company: the one buying. In a partner-sourced deal there are two:
+
+- the **customer**, who is buying — the company the deal belongs to, and
+- the **partner**, who brought it — a different company, who earns a share.
+
+If both are the same company, something is wrong. That is a company buying for itself, not a
+partner bringing you business, and no commission is owed to anybody.
+
+Margince keeps them apart everywhere: a company's **Deals** tab lists deals where it is the
+*customer*, and its **Partner** tab lists deals it *brought*. Two different lists, two
+different questions, and a partner page where both are populated is a partner who both buys
+from you and sells for you.
+
+## 1. Make a company a partner
+
+Open the company that will be your partner — **Companies**, then pick it — and go to its
+**Partner** tab. A company that isn't a partner yet says **"Not a partner yet"** and offers
+**"Make this a partner"**.
+
+Fill in two things and leave the rest for now:
+
+- **Partner role** — the only required field. *Hosting* if they run the software for their
+  clients, *Consulting* if they advise clients and bring you in, *Strategic* for a wider
+  alliance.
+- **Margin tier** — the share they earn on deals they bring:
+
+  | Tier | Choose it when |
+  |---|---|
+  | **Intro (15%)** | they make the introduction and hand it over. |
+  | **Active Collab (20%)** | they work the opportunity alongside you. |
+  | **Partner closed (25%)** | they run the sale and close it themselves. |
+
+Save. The tab switches from the setup form to the partner record, and the company now appears
+under **Partners** in the Companies list header.
+
+**Leave the margin tier unset and no commission is ever calculated for them.** That is
+deliberate — a tier is a commercial agreement, and Margince will not invent one — but it means
+a partner you forgot to tier earns nothing while looking perfectly set up. If you take one
+thing from this tutorial, take that.
+
+## 2. Give them a deal
+
+Go to **Deals** and create one, or open a deal that already exists and edit it. Two fields
+matter here, and they only appear once at least one company is a partner:
+
+- **via Partner** — the partner who brought it. The list offers partners only, so you cannot
+  accidentally name an ordinary customer.
+- **What the partner did** — appears once you have picked a partner:
+  - **Brought us this deal (earns commission)** — they sourced it. This is what pays.
+  - **Helped on a deal we already had (no commission)** — they influenced it. Recorded, not
+    paid.
+
+Leave the second field alone and Margince treats the deal as *brought* — the common case, and
+the field says so.
+
+Set the **Company** to your *customer* and **via Partner** to your *partner*. Two different
+companies. Give it an amount and save.
+
+The deal now reads, under its name: **€10,000.00 · Northgate GmbH · via VietnamPartner JSC** —
+the value, the customer, and who brought it. The deals list can show the partner as a column
+too: open the column picker and add **via Partner**. (That column cannot be sorted yet; the
+API sorts by a fixed set of five fields that does not include it.)
+
+## 3. Win it
+
+Move the deal to **Won** the way you would any other — on the board, drag its card into the Won
+column and confirm.
+
+If the deal has no signed contract attached, Margince asks **"How was it won?"** before
+accepting it — *Verbally, in person or by phone*, *On a purchase order*, and so on. That answer
+is kept on the deal and counted in reports; it is not a commission question, and any of the
+options lets the win through.
+
+Nothing else is required of you. Behind the scenes the win is what triggers commission: a deal
+that was *brought* by a partner who *has* a margin tier produces a commission entry
+automatically, priced at that partner's tier against the deal's value at the moment it was won.
+It appears within a second or two — the calculation happens just after the win is recorded, not
+inside it, so give the page a refresh if the ledger looks empty.
+
+## 4. See what they earned
+
+Go back to the partner's company page and open its **Partner** tab. Two panels sit under the
+partner record:
+
+**Deals they brought** lists every deal attributed to them — open ones as well as won, sourced
+as well as influenced — with the customer each was brought for. This is their pipeline with
+you, and it is the only place those deals appear on this company's page: they belong to the
+customers, so the company's own **Deals** tab does not show them.
+
+**Commission** is the ledger: one row per entry, naming the deal it was earned on, the amount,
+the rate, and the deal value it was calculated from. A €10,000 deal for a partner on *Partner
+closed (25%)* shows **€2,500.00** — accrued.
+
+Both the deal name and the customer are links, so a figure can always be traced back to the
+work that produced it.
+
+## What the statuses mean
+
+A commission entry moves through four states:
+
+| Status | Meaning |
+|---|---|
+| **Accrued** | earned, not yet agreed. This is where every entry starts. |
+| **Approved** | somebody signed it off. |
+| **Paid** | the money went out. |
+| **Reversed** | the entry was cancelled — see below. |
+
+**Today the app shows these but cannot change them.** Approving and paying exist in the API and
+are not yet wired to buttons, so a ledger read from the Partner tab is a record of what is
+owed, not a place to settle it. Until that ships, treat the panel as the source of truth for
+*what was earned* and handle payment in whatever you use for payments.
+
+## When a won deal is reopened
+
+Reopen a won deal and its commission is **not deleted**. Margince adds a reversal row and marks
+the original as *Reversed*, leaving both visible. Win the deal again and a fresh entry accrues.
+
+That is the point of a ledger: it records what happened rather than what is currently true, so
+a partner asking "what happened to that one?" can be shown both halves. You will see three rows
+for a deal that was won, reopened, and won again — and that is correct, not a duplicate.
+
+The rate is frozen when an entry accrues. Re-tiering a partner changes what their *future*
+deals earn and never rewrites what a past one already did.
+
+## What is not here yet
+
+Worth knowing before you promise anything to a partner:
+
+- **No approve or pay buttons** — as above.
+- **No partner-facing view.** Partners cannot log in and see their own pipeline; everything
+  here is internal.
+- **Nothing enforces that a partner is a partner** on the API. The web form only offers real
+  partners, but a deal created through the API can name any company, and if that company has no
+  partner row it will never earn anything.
+- **Assistants can read a deal's partner** and what they did, but cannot yet read or change the
+  partner record itself — the tier, the certification, the stage.
+
+## Where next
+
+- Every field, with its full vocabulary and the ten relationship stages:
+  [how-to/set-up-a-partner-program.md](../how-to/set-up-a-partner-program.md).
+- Running deals in general, of which this is one flavour:
+  [how-to/work-your-pipeline.md](../how-to/work-your-pipeline.md).


### PR DESCRIPTION
The partner documentation was a field reference and nothing else — it explained every control on the setup form and never said what the feature is *for*. Somebody meeting it for the first time could fill in a partner record correctly and still not know that winning a deal pays anybody.

**New:** [docs/tutorials/run-a-partner-program.md](docs/tutorials/run-a-partner-program.md). It walks one deal: make a company a partner, attribute a deal to them, win it, read what they earned. It leads with the distinction the whole feature rests on — the customer buys, the partner brought it, two different companies — because getting that wrong is what makes the panels look broken.

It is honest about the edges, both of which are invisible from the UI:
- Approving and paying a commission exist in the API and are wired to no button, so the ledger records what is owed and cannot settle it.
- A partner with no margin tier earns nothing while looking perfectly set up.

**Also updated:** the how-to predated the commission ledger entirely, and described a partner's deals as living on the company page — the one place they do not appear. It now cross-links to the tutorial and covers the two panels.

Verified: every UI label quoted was checked against the i18n catalog (including catching that the deals-list column now reads "via Partner", not "Partner"), every link resolves, and the walkthrough was run end to end against a live stack — a €10,000 deal for a partner on *Partner closed (25%)* accrued €2,500 on the win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a step-by-step partner program tutorial and refreshes the how-to and docs index to orient first-time users. This clarifies customer vs partner, shows where partner-sourced deals and commission appear, and calls out current UI/API limits.

- New tutorial: docs/tutorials/run-a-partner-program.md. Walks making a company a partner, attributing a deal, winning it, and reading the commission. Explicitly notes that approve/pay are API-only and that no margin tier means no commission.
- How-to updated: fixes where partner-sourced deals appear (on the Partner tab only), adds a cross-link to the tutorial, and clarifies assistant visibility and setting `partner_org_id`/`partner_attribution`.
- README updated: adds the tutorial to Tutorials and reframes the partner how-to as a reference.
- Verify product details: the deals-list column label is “via Partner”; that column is not sortable; commission accrues on win and shows statuses that are not editable in the app; reopening a won deal creates a reversal; commission rate freezes at accrual. No migrations or rollout steps.

<sup>Written for commit ed005159d9a5b60e9a4b1d9b2f034bca611bdab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

