### PR TITLE
fix(ci-tests): the voice lifecycle suite expects the source it will actually find (#2126)

### DIFF
--- a/backend/migrations/voice_profile_lifecycle_integration_test.go
+++ b/backend/migrations/voice_profile_lifecycle_integration_test.go
@@ -21,6 +21,24 @@ import (
 	"github.com/gradionhq/margince/backend/migrations"
 )
 
+// wantMigratedSource is the `source` these rows carry once the WHOLE core
+// namespace has been applied, which is what this suite does — it stops before
+// 0107, seeds a legacy installation, and then migrates all the way up.
+//
+// 0107's backfill stamps `ui`, and it is not the last word: the later
+// `source_names_the_origin` migration collapses `mcp` and `ui` into `manual` on
+// every table carrying the column, voice_profile, voice_corpus_source and
+// voice_profile_version among them. So `manual` is the value an upgraded
+// installation actually holds, and asserting `ui` asserts a vocabulary that no
+// longer exists at head.
+//
+// Named once, with that reason, because the obvious "fix" when this fails is to
+// change the migration back — and the collapse was deliberate. It was safe only
+// because the retrieval ranking that used to read this column had already moved
+// to `captured_by`; reversed, every agent-written note would have been promoted
+// to human-statement trust silently.
+const wantMigratedSource = "manual"
+
 func TestVoiceProfileLifecycleUpgradePreservesBuiltProfile(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	conn := connect(t, ownerDSN)
@@ -114,8 +132,8 @@ func assertMigratedVoiceCorpus(t *testing.T, conn *pgx.Conn, profileID, wantCont
 	if kind != "linkedin" || register != "social" {
 		t.Errorf("translated corpus vocabulary = (%q, %q), want (linkedin, social)", kind, register)
 	}
-	if source != "ui" || capturedBy != "system" {
-		t.Errorf("corpus provenance = (%q, %q), want (ui, system)", source, capturedBy)
+	if source != wantMigratedSource || capturedBy != "system" {
+		t.Errorf("corpus provenance = (%q, %q), want (%s, system)", source, capturedBy, wantMigratedSource)
 	}
 }
 
@@ -141,8 +159,9 @@ func assertMigratedVoiceProfile(t *testing.T, conn *pgx.Conn, profileID, ownerID
 	if sourceHash != wantSourceHash {
 		t.Errorf("active_source_hash = %q, want %q", sourceHash, wantSourceHash)
 	}
-	if source != "ui" || capturedBy != "system" || !builtAtPresent {
-		t.Errorf("profile backfill = source %q, captured_by %q, built_at %v; want ui, system, true", source, capturedBy, builtAtPresent)
+	if source != wantMigratedSource || capturedBy != "system" || !builtAtPresent {
+		t.Errorf("profile backfill = source %q, captured_by %q, built_at %v; want %s, system, true",
+			source, capturedBy, builtAtPresent, wantMigratedSource)
 	}
 }
 
@@ -168,8 +187,8 @@ func assertMigratedVoiceVersion(t *testing.T, conn *pgx.Conn, profileID string, 
 	if sourceHash != wantSourceHash || sourceCount != 1 {
 		t.Errorf("immutable version source snapshot = (%q, %d), want (%q, 1)", sourceHash, sourceCount, wantSourceHash)
 	}
-	if source != "ui" || capturedBy != "system" {
-		t.Errorf("immutable version provenance = (%q, %q), want (ui, system)", source, capturedBy)
+	if source != wantMigratedSource || capturedBy != "system" {
+		t.Errorf("immutable version provenance = (%q, %q), want (%s, system)", source, capturedBy, wantMigratedSource)
 	}
 }
 


### PR DESCRIPTION
Fixes #2126 — main is red for everybody on every branch, so this is deliberately the smallest change that makes it green.

## Which half was wrong

#2126 narrowed it to `core/1787315000_source_names_the_origin` and asked which side was stale. It is the **test**.

The suite stops before `0107`, seeds a legacy installation, and then migrates **all the way up**. So the value it reads is whatever the last migration to touch the column left there — and `0107`'s backfill of `ui` is not the last word. `source_names_the_origin` collapses `mcp` and `ui` into `manual` on every table carrying the column, including all three this suite asserts on:

```sql
UPDATE voice_profile         SET source = 'manual' WHERE source IN ('mcp', 'ui');
UPDATE voice_corpus_source   SET source = 'manual' WHERE source IN ('mcp', 'ui');
UPDATE voice_profile_version SET source = 'manual' WHERE source IN ('mcp', 'ui');
```

So `manual` is what an upgraded installation actually holds, and the assertions were naming a vocabulary that no longer exists at head. The migration is right; the expectation was left behind.

## Why the expected value is now a named const

Because the obvious reaction when this test fails is to change the migration back, and that would be the dangerous direction. The migration's own comment says the collapse was safe **only** because the retrieval ranking that used to read `source` had already moved to `captured_by`:

> Reversed, every agent-written note would have been promoted to human-statement trust silently.

A one-line diff swapping three string literals would have left the next reader with no way to know that. The const carries the reason, so the trap is visible at the point where somebody would otherwise fall into it.

## Verified

`scripts/test-integration-one.sh backend/migrations 'TestVoiceProfileLifecycleUpgradePreservesBuiltProfile'` → PASS, on a branch off `origin/main` with nothing else in it. It fails on `origin/main` unchanged, which is how #2126 was reproduced in the first place.

## Not addressed here

#2126's second finding — that `1787315000` is a hand-picked stamp roughly ten hours ahead of real UTC, so every migration authored since has to be stamped into the future to clear `check-migration-versions`, and the only reason nothing is red is the slack in `TestCoreMigrationVersionsAreUnixSecondsAfterTheClosedSequence`. That is a separate change (a rule that `make migrate-create` is the only way to stamp a core migration) and it should not ride a red-main fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by updating the voice lifecycle integration test to expect the final migrated source value. Previously the test expected source "ui"; now it expects "manual" because a later migration collapses "mcp" and "ui" into "manual", which is what an upgraded installation actually stores. No runtime behavior changes; only test expectations. Fixes #2126.

- Replaces "ui" literals with a named const (wantMigratedSource = "manual") to document the collapse and avoid regressions; the collapse is safe because retrieval ranking moved to `captured_by`.
- Confirms the suite seeds a legacy install and migrates fully, so assertions must reflect the last migration’s output. Verified the suite passes.

<sup>Written for commit 518bdb0fb45b182b54320d693afb38ef87af6b17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

