### PR TITLE
refactor(ci): the two heaviest lanes become callable workflows

### DIFF
--- a/.github/workflows/_lane-frontend.yml
+++ b/.github/workflows/_lane-frontend.yml
@@ -1,0 +1,175 @@
+# The SPA lane, as a callable unit.
+#
+# Called by ci.yml. It carries NO `if:` of its own — the caller decides whether
+# this lane runs, which is what makes `needs.frontend.result == 'skipped'` mean
+# exactly one thing: the caller skipped it. See _lane-integration.yml for the
+# full reasoning; the short version is that an internal conditional would let a
+# job inside skip while the lane still reported success, and the `ci` aggregate
+# reads a skip as "this area was out of scope".
+#
+# The three jobs run CONCURRENTLY because they share no state. Serially the lane
+# was ~340s, of which vitest alone was ~207s, so the greps, the type gates and
+# the bundle all sat behind a test run that could not tell them anything. A Biome
+# failure now reports in about a minute instead of six.
+#
+# The suite itself is NOT split further. Sharding it would need the shards'
+# coverage merged, and the v8 provider enumerates a file's BRDA branch records
+# from the ranges that actually executed — so two shards that both load a file
+# describe its branches differently and the union inflates the denominator
+# (measured: 12979/16413 merged against a true 9667/11231). Line coverage merges
+# exactly; condition coverage does not, and a coverage number that is quietly
+# wrong is worse than a slower lane. Issue #966 carries the numbers and the
+# istanbul-provider fix that would unblock it.
+#
+# Every job sets `working-directory: .` for itself: a calling workflow's
+# `defaults` do not inherit, so nothing here may rely on ci.yml's.
+name: _lane-frontend
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  fe-quality:
+    name: fe-quality (ds gates + drift + biome + composed tsc)
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      # Go, in a FRONTEND job (ADR-0069). The composed SPA lane needs
+      # build/composition/frontend/ — which only gen-composition can produce.
+      # There is no Node-only shortcut: the registry is derived from the merged
+      # contracts, which the Go generator owns. Without a toolchain here the
+      # composed lane would have to be dropped from the merge gate, and the
+      # vanilla lane alone cannot catch a descriptor shape the SPA no longer
+      # compiles against. This is the only one of the three that composes, which
+      # is why the unit and bundle jobs below carry no Go setup.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - run: make fe-quality
+
+  fe-unit:
+    name: fe-unit (vitest + coverage)
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      # FE_COVERAGE=1 instruments the ONE vitest run this lane already performs,
+      # so the lcov the sonarcloud job downloads is a by-product of the run that
+      # decides the verdict rather than a second execution of the same suite.
+      - run: make fe-unit FE_COVERAGE=1
+      - name: Upload FE coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fe-coverage
+          path: frontend/coverage/lcov.info
+          if-no-files-found: ignore
+          retention-days: 1
+
+  fe-bundle:
+    name: fe-bundle (vite build + storybook)
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      # The production bundle and the Storybook catalog: a story that fails to
+      # compile or register is caught deterministically here. The change-scoped
+      # render capture (make fe-uat) stays a coordinator lane, not a required gate.
+      - run: make fe-bundle
+
+  # The fan-in. This job does no work — it exists to carry the verdict for the
+  # three jobs above, and its result is what the caller's `frontend` job reports
+  # and therefore what the `ci` aggregate reads.
+  #
+  # `always()` rather than the default, which is `success()` of every need: a job
+  # skipped because a dependency failed reports as SKIPPED, and a skip is what the
+  # aggregate reads as "legitimately out of scope". Left alone, a red unit suite
+  # would have merged. `!cancelled()` is not enough either — it is false for every
+  # job the moment a run is cancelled, so cancelling the workflow while the long
+  # unit job was still going would skip this check and green the lane. `always()`
+  # runs it in both cases, and the assertion below sees `cancelled` and fails.
+  frontend:
+    name: frontend (biome + vitest + tsc + build)
+    timeout-minutes: 20
+    needs: [fe-quality, fe-unit, fe-bundle]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      # Each result carries its own job name rather than being matched to a
+      # separate name list by position: two lists kept in step would silently
+      # stop checking a fourth lane that was added to one and not the other.
+      - name: Every frontend lane passed
+        env:
+          RESULTS: >-
+            fe-quality=${{ needs.fe-quality.result }}
+            fe-unit=${{ needs.fe-unit.result }}
+            fe-bundle=${{ needs.fe-bundle.result }}
+        run: |
+          set -euo pipefail
+          [ -n "${RESULTS// /}" ] || { echo "no lane results to check" >&2; exit 1; }
+          failed=""
+          for result in $RESULTS; do
+            case "$result" in
+              *=success) ;;
+              *) failed="$failed $result" ;;
+            esac
+          done
+          if [ -n "$failed" ]; then
+            echo "the frontend lane did not pass:$failed" >&2
+            exit 1
+          fi
+          echo "fe-quality, fe-unit and fe-bundle all passed"

--- a/.github/workflows/_lane-integration.yml
+++ b/.github/workflows/_lane-integration.yml
@@ -1,0 +1,254 @@
+# The real-Postgres lane, as a callable unit.
+#
+# Called by ci.yml. It carries NO `if:` of its own — the caller decides whether
+# this lane runs at all, and that is the whole point of the split: a lane's jobs
+# either all run or the lane is skipped, so `needs.<lane>.result == 'skipped'`
+# means exactly one thing (the caller skipped it) rather than "some job inside
+# quietly did not run". The `ci` aggregate reads that distinction and refuses a
+# skip on the merge queue, so an internal conditional here would reopen the
+# skip-as-pass hole one level down.
+#
+# `defaults.run.working-directory` does NOT inherit from a calling workflow, so
+# it is restated below. Without it every step would run from the repository root
+# and the Go jobs would fail to find their module.
+name: _lane-integration
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  # Sharded across independent runners. One runner already fans packages out
+  # onto per-package clone DBs, but the heaviest package (compose/integration,
+  # minutes of serial tests) floors any package-level split — so each shard runs
+  # a deterministic per-TEST slice of every package
+  # (scripts/test-integration-parallel.sh, INTEGRATION_SHARD) against its own
+  # Postgres/Redis/MinIO. The `integration` fan-in below reconciles the slices
+  # back into one verdict and one coverage profile.
+  #
+  # The caller runs this lane in parallel with the Go gate, not behind it: gating
+  # the longest lane on the build gate serialized the two slowest jobs and
+  # dominated PR wall-clock. A broken build is still caught by the Go gate
+  # itself, and sonarcloud gates its scan on that result directly.
+  integration-shards:
+    name: integration shard (${{ matrix.shard }}/${{ strategy.job-total }})
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      # A red shard must not cancel its siblings: one CI run should report
+      # every failing test, not the first shard to trip.
+      fail-fast: false
+      # Six, not twelve. The slice is per-TEST, so a shard's own tests are the
+      # small half of what it costs: measured on a green run, a shard spent ~146s
+      # restoring the build cache and ~275s compiling, against ~40s running the
+      # tests it was assigned. Twelve shards paid those fixed costs twelve times
+      # to divide the one cost that was already small.
+      #
+      # Halving doubles a shard's test slice — about +40s — and removes six
+      # cache-restore-plus-compile pairs, which is roughly half the lane's
+      # runner-minutes for about a minute of wall clock. Raise it again only
+      # against a measurement showing the TEST half has grown enough to matter;
+      # the compile half is addressed by building once rather than by sharding
+      # harder.
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      # The `integration` flavour: a shard compiles ~26 of the 31 tagged packages
+      # with `-tags=integration -cover -coverpkg=./...`, and because the slice is
+      # per-TEST rather than per-package, EVERY shard compiles nearly the whole
+      # lane. Sharding therefore divides the test execution N ways and
+      # multiplies the compile by N — which is why N is six rather than twelve
+      # (see the matrix above): past a point, another shard buys a smaller slice
+      # of the cheap half and pays another copy of the expensive one.
+      - name: Restore the Go build cache
+        id: go-cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: integration
+      # The same compose stack dev machines use (infra/docker-compose.dev.yml:
+      # Postgres + Redis + MinIO, digest-pinned there) plus scripts/db-init.sql
+      # for the cluster-level margince_app role — migration 0015 GRANTs to it,
+      # and the parallel lane's clones inherit those grants. One stack
+      # definition instead of hand-mirrored GH service containers; the lane's
+      # database admin goes through cmd/migrate's db verbs on the test DSN
+      # (scripts/lib-testdb.sh db_admin), so no host psql is assumed.
+      - name: Start the dev infra stack (compose + app role)
+        run: make db-up
+      # INTEGRATION_SHARD_OUT collects the slice manifests + binary coverage
+      # pods the fan-in reconciles and merges — so the scan is NOT a second
+      # Postgres/Redis/MinIO stack running the whole lane a second time.
+      - name: Integration shard (slice + coverage)
+        env:
+          INTEGRATION_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
+          INTEGRATION_SHARD_OUT: ${{ runner.temp }}/shard-out
+          # The tests are DB-bound, not CPU-bound: on the 4-core runner the
+          # nproc-derived default leaves the slice mostly waiting on Postgres.
+          INTEGRATION_JOBS: 16
+        run: make test-integration
+      # `!cancelled()` and not the default success(): a RED shard is exactly when
+      # somebody needs this artifact, and on failure the script writes the
+      # failing packages' logs + a failure-summary.txt into the same directory.
+      # Uploading only on green kept the evidence for the runs that did not need
+      # it and destroyed it with the runner for the runs that did.
+      - name: Upload the shard manifest + coverage pods
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-shard-${{ matrix.shard }}
+          path: ${{ runner.temp }}/shard-out
+          if-no-files-found: error
+          retention-days: 1
+
+  # Unit coverage for SonarCloud. The shards run only the integration-tagged
+  # packages, but the unit-only packages need a `-cover` pass of their own —
+  # otherwise SonarCloud sees them at a false ~0% new-code coverage and the
+  # gate fails on well-unit-tested code. Untagged tests never open a real DB
+  # (the test-lanes gate enforces it), so this pass needs no services; it runs
+  # beside the shards and the fan-in merges its pods with theirs.
+  #
+  # It lives in this lane rather than beside it because the fan-in is what
+  # consumes its pods: when the fan-in does not run, nothing ever reads them.
+  # Split across two scopes — this job on `backend`, the shards on `backend_db` —
+  # a rulebook-only change ran this job and then discarded its output.
+  integration-unit-coverage:
+    name: integration unit coverage
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Full history: this job runs the backend unit lane, which includes
+          # the RBAC legacy-cohort gates. Those derive the initial commit's
+          # object vocabulary and grants by reading 2cb50021 — a fixture the
+          # migration replay seeds from, so it must not be hand-editable. They
+          # FAIL on a shallow checkout rather than degrading to an empty cohort,
+          # because a gate that quietly checks nothing looks exactly like a
+          # passing one.
+          fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      # The `plain` flavour, not `integration`: this pass is untagged. Coverage
+      # instrumentation means its own package builds miss, but the dependency
+      # builds underneath — the bulk of a cold compile — hit.
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
+      - name: Unit tests with binary coverage
+        run: |
+          mkdir -p "$RUNNER_TEMP/covdata-unit"
+          go test ./... -cover -coverpkg=./... -covermode=atomic -args -test.gocoverdir="$RUNNER_TEMP/covdata-unit"
+      - name: Upload the unit coverage pods
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-covdata-unit
+          path: ${{ runner.temp }}/covdata-unit
+          if-no-files-found: error
+          retention-days: 1
+
+  # The fan-in: this is the result the caller's `integration` job reports, and
+  # therefore what the `ci` aggregate reads. It must RUN and FAIL when a shard
+  # fails — `needs` alone would leave it skipped, and a skipped required check
+  # counts as passing — hence the always() guard plus the explicit result
+  # assertion in the first step. Then it proves the slices add up
+  # (scripts/test-integration-reconcile.sh: every shard present, same discovery,
+  # union complete + disjoint) and merges every binary coverage pod (shards +
+  # unit) into the one text profile the sonarcloud job consumes.
+  integration:
+    name: integration (RLS + erasure + HTTP e2e)
+    timeout-minutes: 20
+    needs: [integration-shards, integration-unit-coverage]
+    # always(), and not !cancelled(): the latter is false for every job once a
+    # run is cancelled, so cancelling mid-lane would have skipped this check and
+    # greened it. The assertion below sees `cancelled` and fails on it.
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Every shard and the unit pass are green
+        working-directory: .
+        env:
+          SHARDS_RESULT: ${{ needs.integration-shards.result }}
+          UNIT_RESULT: ${{ needs.integration-unit-coverage.result }}
+        run: |
+          [ "$SHARDS_RESULT" = "success" ] || { echo "integration shards: $SHARDS_RESULT"; exit 1; }
+          [ "$UNIT_RESULT" = "success" ] || { echo "unit coverage pass: $UNIT_RESULT"; exit 1; }
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Download the shard + unit artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: integration-*
+          path: ${{ runner.temp }}/shards
+      - name: Reconcile the slices and merge coverage
+        working-directory: .
+        run: ./scripts/test-integration-reconcile.sh "$RUNNER_TEMP/shards" backend/coverage.out
+      - name: Upload Go coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-coverage
+          path: backend/coverage.out
+          if-no-files-found: ignore
+          retention-days: 1
+      # The extension migration gate (ADR-0069) — the ONE gate in the tier that
+      # is not textual: it applies each unit's migrations as that unit's own
+      # restricted ext_<name> role against a throwaway database and checks the
+      # resulting catalog against the allowlist.
+      #
+      # It lives HERE, on the integration lane, and not in check-backend where
+      # it started. From the first unit that ships a migrations/ layer the gate
+      # needs a cluster, and the Go gate is the fastest merge gate and
+      # container-free: arming it there would put a compose-stack start on every
+      # backend PR forever, to buy locality once. This lane is already the slow,
+      # cluster-bearing path.
+      #
+      # It ARMS ITSELF off the same condition the script tests, so the first
+      # migrations/ layer to land gets the cluster with no workflow edit and
+      # nobody having to remember. `make db-up` is the same compose stack the
+      # shards use (infra/docker-compose.dev.yml + scripts/db-init.sql for the
+      # cluster-level margince_app role migration 0015 GRANTs to), not a
+      # hand-mirrored service container. No margince_test template is built:
+      # the gate deliberately migrates a FRESH database under the root
+      # workspace rather than cloning the shared template, because a template
+      # migrated under the COMPOSED workspace already holds the very
+      # ext.ext_<name>_* objects the gate is about to apply.
+      #
+      # If the glob matches and the cluster is missing, the script FAILS with a
+      # named error rather than skipping — a gate that quietly checks nothing
+      # looks exactly like a passing one.
+      - name: Extension migration gate (armed by the tree)
+        working-directory: .
+        run: |
+          if ls -d extensions/*/migrations >/dev/null 2>&1; then
+            echo "an enabled unit declares migrations/ — starting the test cluster"
+            make db-up
+          else
+            echo "no enabled unit declares a migrations/ layer — the gate stays hermetic"
+          fi
+          make check-ext-migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,18 @@ jobs:
               - 'extensions/**'
               - 'fixtures/**'
               - 'composition/**'
-              # Only the merge gate itself. patch.yml and sbom.yml run no
+              # Only the merge gate itself. release.yml and sbom.yml run no
               # backend gate, so editing one cannot invalidate a gate result —
               # and each proves itself when it runs.
+              #
+              # The gate is three files now: this caller plus the lane workflows
+              # it invokes. The lanes are globbed rather than named one by one so
+              # a lane added later is covered the day it is committed — the same
+              # reason the classifier's other scopes are derived rather than
+              # listed, and the difference between a scope that stays honest and
+              # one that silently stops covering a new file.
               - '.github/workflows/ci.yml'
+              - '.github/workflows/_lane-*.yml'
               # The composite actions ci.yml calls. go-build-cache decides what
               # every Go job restores, so an edit to it changes what the gates
               # compile — the same claim on this scope that ci.yml itself has.
@@ -562,250 +570,27 @@ jobs:
         working-directory: .
         run: make check-host-ports
 
-  # The real-Postgres lane, sharded across independent runners. One runner
-  # already fans packages out onto per-package clone DBs, but the heaviest
-  # package (compose/integration, minutes of serial tests) floors any
-  # package-level split — so each shard runs a deterministic per-TEST slice of
-  # every package (scripts/test-integration-parallel.sh, INTEGRATION_SHARD)
-  # against its own Postgres/Redis/MinIO. The `integration` fan-in below
-  # reconciles the slices back into one verdict and one coverage profile.
+  # The real-Postgres lane. Its jobs live in
+  # .github/workflows/_lane-integration.yml — the shard matrix, the unit-coverage
+  # pass and the fan-in that reconciles them — because that cluster was a third of
+  # this file and none of it is edited when the merge gate changes.
   #
-  # Runs in parallel with deterministic-gates, not behind it: gating the
-  # longest lane on the build gate serialized the two slowest jobs and
-  # dominated PR wall-clock. Still backend-gated like deterministic-gates, so
-  # they skip together on non-backend PRs; a broken build is still caught by
-  # deterministic-gates itself, and sonarcloud gates its scan on that result
-  # directly (below) so a red build never posts a green coverage check.
-  integration-shards:
-    name: integration shard (${{ matrix.shard }}/${{ strategy.job-total }})
-    timeout-minutes: 30
-    needs: [changes]
-    # backend_db, not backend: this is the many-Postgres lane, and the two
-    # paths that differ (the agent rulebooks) cannot change what it proves.
-    # It moves in lockstep with the `integration` fan-in below, which asserts
-    # on this job's result and would read a skip as a failure if only one moved.
-    if: needs.changes.outputs.backend_db == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      # A red shard must not cancel its siblings: one CI run should report
-      # every failing test, not the first shard to trip.
-      fail-fast: false
-      # Six, not twelve. The slice is per-TEST, so a shard's own tests are the
-      # small half of what it costs: measured on a green run, a shard spent ~146s
-      # restoring the build cache and ~275s compiling, against ~40s running the
-      # tests it was assigned. Twelve shards paid those fixed costs twelve times
-      # to divide the one cost that was already small.
-      #
-      # Halving doubles a shard's test slice — about +40s — and removes six
-      # cache-restore-plus-compile pairs, which is roughly half the lane's
-      # runner-minutes for about a minute of wall clock. Raise it again only
-      # against a measurement showing the TEST half has grown enough to matter;
-      # the compile half is addressed by building once rather than by sharding
-      # harder.
-      matrix:
-        shard: [1, 2, 3, 4, 5, 6]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
-      # The `integration` flavour: a shard compiles ~26 of the 31 tagged packages
-      # with `-tags=integration -cover -coverpkg=./...`, and because the slice is
-      # per-TEST rather than per-package, EVERY shard compiles nearly the whole
-      # lane. Sharding therefore divides the test execution N ways and
-      # multiplies the compile by N — which is why N is six rather than twelve
-      # (see the matrix above): past a point, another shard buys a smaller slice
-      # of the cheap half and pays another copy of the expensive one.
-      - name: Restore the Go build cache
-        id: go-cache
-        uses: ./.github/actions/go-build-cache
-        with:
-          flavor: integration
-      # The same compose stack dev machines use (infra/docker-compose.dev.yml:
-      # Postgres + Redis + MinIO, digest-pinned there) plus scripts/db-init.sql
-      # for the cluster-level margince_app role — migration 0015 GRANTs to it,
-      # and the parallel lane's clones inherit those grants. One stack
-      # definition instead of hand-mirrored GH service containers; the lane's
-      # database admin goes through cmd/migrate's db verbs on the test DSN
-      # (scripts/lib-testdb.sh db_admin), so no host psql is assumed.
-      - name: Start the dev infra stack (compose + app role)
-        run: make db-up
-      # INTEGRATION_SHARD_OUT collects the slice manifests + binary coverage
-      # pods the fan-in reconciles and merges — so the scan is NOT a second
-      # Postgres/Redis/MinIO stack running the whole lane a second time.
-      - name: Integration shard (slice + coverage)
-        env:
-          INTEGRATION_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
-          INTEGRATION_SHARD_OUT: ${{ runner.temp }}/shard-out
-          # The tests are DB-bound, not CPU-bound: on the 4-core runner the
-          # nproc-derived default leaves the slice mostly waiting on Postgres.
-          INTEGRATION_JOBS: 16
-        run: make test-integration
-      # `!cancelled()` and not the default success(): a RED shard is exactly when
-      # somebody needs this artifact, and on failure the script writes the
-      # failing packages' logs + a failure-summary.txt into the same directory.
-      # Uploading only on green kept the evidence for the runs that did not need
-      # it and destroyed it with the runner for the runs that did.
-      - name: Upload the shard manifest + coverage pods
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integration-shard-${{ matrix.shard }}
-          path: ${{ runner.temp }}/shard-out
-          if-no-files-found: error
-          retention-days: 1
-
-  # Unit coverage for SonarCloud. The shards run only the integration-tagged
-  # packages, but the unit-only packages need a `-cover` pass of their own —
-  # otherwise SonarCloud sees them at a false ~0% new-code coverage and the
-  # gate fails on well-unit-tested code. Untagged tests never open a real DB
-  # (the test-lanes gate enforces it), so this pass needs no services; it runs
-  # beside the shards and the fan-in merges its pods with theirs.
-  integration-unit-coverage:
-    name: integration unit coverage
-    timeout-minutes: 30
-    needs: [changes]
-    if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history: this job runs the backend unit lane, which includes
-          # the RBAC legacy-cohort gates. Those derive the initial commit's
-          # object vocabulary and grants by reading 2cb50021 — a fixture the
-          # migration replay seeds from, so it must not be hand-editable. They
-          # FAIL on a shallow checkout rather than degrading to an empty cohort,
-          # because a gate that quietly checks nothing looks exactly like a
-          # passing one.
-          fetch-depth: 0
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
-      # The `plain` flavour, not `integration`: this pass is untagged. Coverage
-      # instrumentation means its own package builds miss, but the dependency
-      # builds underneath — the bulk of a cold compile — hit.
-      - name: Restore the Go build cache
-        uses: ./.github/actions/go-build-cache
-        with:
-          flavor: plain
-      - name: Unit tests with binary coverage
-        run: |
-          mkdir -p "$RUNNER_TEMP/covdata-unit"
-          go test ./... -cover -coverpkg=./... -covermode=atomic -args -test.gocoverdir="$RUNNER_TEMP/covdata-unit"
-      - name: Upload the unit coverage pods
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integration-covdata-unit
-          path: ${{ runner.temp }}/covdata-unit
-          if-no-files-found: error
-          retention-days: 1
-
-  # The fan-in: THIS is the required "integration" check, under the same name
-  # the single-runner lane carried, so branch protection needs no change. It
-  # must RUN and FAIL when a shard fails — `needs` alone would leave it
-  # skipped, and a skipped required check counts as passing — hence the
-  # !cancelled() guard plus the explicit result assertion in the first step.
-  # Then it proves the slices add up (scripts/test-integration-reconcile.sh:
-  # every shard present, same discovery, union complete + disjoint) and merges
-  # every binary coverage pod (shards + unit) into the one text profile the
-  # sonarcloud job consumes.
+  # The lane itself carries no conditional: this call site owns the decision,
+  # which is what makes `needs.integration.result == 'skipped'` mean "the caller
+  # skipped the whole lane" rather than "something inside it quietly did not run".
+  #
+  # backend_db, not backend: this is the many-Postgres lane, and the two paths
+  # that differ (the agent rulebooks) cannot change what it proves. The whole
+  # cluster moves together now — previously the unit-coverage pass hung off the
+  # wider `backend` scope, so a rulebook-only change ran it and then discarded its
+  # pods, because the fan-in that consumes them had skipped.
+  #
+  # Runs in parallel with the Go gate, not behind it: gating the longest lane on
+  # the build gate serialized the two slowest jobs and dominated PR wall-clock.
   integration:
-    name: integration (RLS + erasure + HTTP e2e)
-    timeout-minutes: 20
-    needs: [changes, integration-shards, integration-unit-coverage]
-    # `always()`, for the reason spelled out on the `frontend` fan-in below: a
-    # skipped required check counts as passing, and `!cancelled()` is false for
-    # every job once a run is cancelled — so cancelling mid-lane would have
-    # skipped this check and greened it. The assertion below sees `cancelled`.
-    #
-    # backend_db, in lockstep with integration-shards: the assertion below
-    # demands `success` from that job, so a run where the shards skipped and
-    # this did not would fail on the string "skipped" — a docs PR reported as
-    # a broken integration lane.
-    if: >-
-      always()
-      && needs.changes.outputs.backend_db == 'true'
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Every shard and the unit pass are green
-        working-directory: .
-        env:
-          SHARDS_RESULT: ${{ needs.integration-shards.result }}
-          UNIT_RESULT: ${{ needs.integration-unit-coverage.result }}
-        run: |
-          [ "$SHARDS_RESULT" = "success" ] || { echo "integration shards: $SHARDS_RESULT"; exit 1; }
-          [ "$UNIT_RESULT" = "success" ] || { echo "unit coverage pass: $UNIT_RESULT"; exit 1; }
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
-      - name: Download the shard + unit artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: integration-*
-          path: ${{ runner.temp }}/shards
-      - name: Reconcile the slices and merge coverage
-        working-directory: .
-        run: ./scripts/test-integration-reconcile.sh "$RUNNER_TEMP/shards" backend/coverage.out
-      - name: Upload Go coverage
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: go-coverage
-          path: backend/coverage.out
-          if-no-files-found: ignore
-          retention-days: 1
-      # The extension migration gate (ADR-0069) — the ONE gate in the tier that
-      # is not textual: it applies each unit's migrations as that unit's own
-      # restricted ext_<name> role against a throwaway database and checks the
-      # resulting catalog against the allowlist.
-      #
-      # It lives HERE, on the integration lane, and not in check-backend where
-      # it started. From the first unit that ships a migrations/ layer the gate
-      # needs a cluster, and deterministic-gates is the fastest merge gate and
-      # container-free: arming it there would put a compose-stack start on every
-      # backend PR forever, to buy locality once. This lane is already the slow,
-      # cluster-bearing path.
-      #
-      # It ARMS ITSELF off the same condition the script tests, so the first
-      # migrations/ layer to land gets the cluster with no workflow edit and
-      # nobody having to remember. `make db-up` is the same compose stack the
-      # shards use (infra/docker-compose.dev.yml + scripts/db-init.sql for the
-      # cluster-level margince_app role migration 0015 GRANTs to), not a
-      # hand-mirrored service container. No margince_test template is built:
-      # the gate deliberately migrates a FRESH database under the root
-      # workspace rather than cloning the shared template, because a template
-      # migrated under the COMPOSED workspace already holds the very
-      # ext.ext_<name>_* objects the gate is about to apply.
-      #
-      # If the glob matches and the cluster is missing, the script FAILS with a
-      # named error rather than skipping — a gate that quietly checks nothing
-      # looks exactly like a passing one.
-      - name: Extension migration gate (armed by the tree)
-        working-directory: .
-        run: |
-          if ls -d extensions/*/migrations >/dev/null 2>&1; then
-            echo "an enabled unit declares migrations/ — starting the test cluster"
-            make db-up
-          else
-            echo "no enabled unit declares a migrations/ layer — the gate stays hermetic"
-          fi
-          make check-ext-migrations
-
+    needs: [changes]
+    if: needs.changes.outputs.backend_db == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    uses: ./.github/workflows/_lane-integration.yml
 
   vuln:
     name: govulncheck
@@ -1115,174 +900,16 @@ jobs:
         if: failure()
         run: cat "$RUNNER_TEMP/api.log" || true
 
-  # The frontend lane, run as THREE jobs that start together. Serially it was
-  # ~340s, of which the vitest suite alone was ~207s: the cheap greps, the type
-  # gates and the bundle all sat behind a test run that could not tell them
-  # anything. They share no state, so they share no queue either, and a Biome
-  # failure now reports in about a minute instead of six.
+  # The SPA lane. Its four jobs live in
+  # .github/workflows/_lane-frontend.yml (fe-quality, fe-unit, fe-bundle and the
+  # fan-in that carries their verdict).
   #
-  # The suite itself is NOT split further. Sharding it would need the shards'
-  # coverage merged, and the v8 provider enumerates a file's BRDA branch records
-  # from the ranges that actually executed — so two shards that both load a file
-  # describe its branches differently and the union inflates the denominator
-  # (measured: 12979/16413 merged against a true 9667/11231). Line coverage
-  # merges exactly; condition coverage does not, and a coverage number that is
-  # quietly wrong is worse than a slower lane. Issue #966 carries the numbers
-  # and the istanbul-provider fix that would unblock it.
-  #
-  # `frontend` itself is the fan-in below — the name is a required status check,
-  # and it stays the one that reports.
-  fe-quality:
-    name: fe-quality (ds gates + drift + biome + composed tsc)
-    timeout-minutes: 20
-    needs: [changes]
-    if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        with:
-          version: 11
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      # Go, in a FRONTEND job (ADR-0069). The composed SPA lane needs
-      # build/composition/frontend/ — which only gen-composition can produce.
-      # There is no Node-only shortcut: the registry is derived from the merged
-      # contracts, which the Go generator owns. Without a toolchain here the
-      # composed lane would have to be dropped from the merge gate, and the
-      # vanilla lane alone cannot catch a descriptor shape the SPA no longer
-      # compiles against. This is the only one of the three that composes, which
-      # is why the unit and bundle jobs below carry no Go setup.
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
-      - run: make fe-quality
-
-  fe-unit:
-    name: fe-unit (vitest + coverage)
-    timeout-minutes: 20
-    needs: [changes]
-    if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        with:
-          version: 11
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      # FE_COVERAGE=1 instruments the ONE vitest run this lane already performs,
-      # so the lcov the sonarcloud job downloads is a by-product of the run that
-      # decides the verdict rather than a second execution of the same suite.
-      - run: make fe-unit FE_COVERAGE=1
-      - name: Upload FE coverage
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fe-coverage
-          path: frontend/coverage/lcov.info
-          if-no-files-found: ignore
-          retention-days: 1
-
-  fe-bundle:
-    name: fe-bundle (vite build + storybook)
-    timeout-minutes: 20
-    needs: [changes]
-    if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        with:
-          version: 11
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      # The production bundle and the Storybook catalog: a story that fails to
-      # compile or register is caught deterministically here. The change-scoped
-      # render capture (make fe-uat) stays a coordinator lane, not a required gate.
-      - run: make fe-bundle
-
-  # The fan-in. This job does no work — it exists to carry the name, because
-  # `frontend (biome + vitest + tsc + build)` is a REQUIRED status check and the
-  # three jobs above are not. Splitting the lane without it would retire the
-  # check every PR waits on.
-  #
-  # `always()` rather than the default, which is `success()` of every need: a job
-  # skipped because a dependency failed reports as SKIPPED, and GitHub counts a
-  # skipped required check as PASSING. Left alone, a red unit suite would have
-  # merged. `!cancelled()` is not enough either — it is false for every job the
-  # moment a run is cancelled, so cancelling the workflow while the long unit job
-  # was still going would skip this check and green the lane. `always()` runs it
-  # in both cases, and the assertion below sees `cancelled` and fails.
+  # As with the integration lane, the conditional lives HERE and not inside the
+  # lane, so a skip always means the caller skipped the lane.
   frontend:
-    name: frontend (biome + vitest + tsc + build)
-    timeout-minutes: 20
-    needs: [changes, fe-quality, fe-unit, fe-bundle]
-    if: >-
-      always()
-      && needs.changes.outputs.frontend == 'true'
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      # Each result carries its own job name rather than being matched to a
-      # separate name list by position: two lists kept in step would silently
-      # stop checking a fourth lane that was added to one and not the other.
-      - name: Every frontend lane passed
-        env:
-          RESULTS: >-
-            fe-quality=${{ needs.fe-quality.result }}
-            fe-unit=${{ needs.fe-unit.result }}
-            fe-bundle=${{ needs.fe-bundle.result }}
-        run: |
-          set -euo pipefail
-          [ -n "${RESULTS// /}" ] || { echo "no lane results to check" >&2; exit 1; }
-          failed=""
-          for result in $RESULTS; do
-            case "$result" in
-              *=success) ;;
-              *) failed="$failed $result" ;;
-            esac
-          done
-          if [ -n "$failed" ]; then
-            echo "the frontend lane did not pass:$failed" >&2
-            exit 1
-          fi
-          echo "fe-quality, fe-unit and fe-bundle all passed"
+    needs: [changes]
+    if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    uses: ./.github/workflows/_lane-frontend.yml
 
   # The UAT lane: the AC-<screen>-N screen-acceptance criteria as named
   # Playwright tests, plus the axe WCAG 2.2 AA gate, the 390px

--- a/backend/aggregategatereach_test.go
+++ b/backend/aggregategatereach_test.go
@@ -31,6 +31,7 @@ package backendarch
 // does not is a design question a reviewer can see.
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -128,4 +129,87 @@ func TestEveryAggregatedJobCanRunOnTheMergeQueue(t *testing.T) {
 // wrapped in the workflow.
 func normalizeCondition(cond string) string {
 	return strings.Join(strings.Fields(cond), " ")
+}
+
+// callerConcerns are the things a LANE must never decide for itself: which
+// scope the diff touched, and which event fired. Both belong to the call site.
+var callerConcerns = []string{
+	"needs.changes",
+	"github.event_name",
+	"github.event.pull_request",
+}
+
+// TestNoLaneWorkflowDecidesItsOwnScope holds the property that makes a lane's
+// result readable.
+//
+// `ci` refuses any result other than success on `merge_group`, and admits
+// `skipped` on a pull request. That only works because a lane is all-or-nothing:
+// `needs.<lane>.result == 'skipped'` has to mean "the caller skipped this lane",
+// full stop. Put a scope or event conditional on a job INSIDE a lane and the lane
+// can report `success` while a job in it never ran — the skip-as-pass hole the
+// aggregate exists to close, reopened one level down and invisible from the
+// caller, which sees only the lane's rolled-up result.
+//
+// WHAT THIS CATCHES: a lane job conditioned on the change classifier or on the
+// event, and a lane that is triggerable by anything other than `workflow_call`
+// (a lane with its own `pull_request` trigger would run outside the aggregate
+// entirely, reporting checks nothing gates on).
+//
+// WHAT THIS ALLOWS, deliberately: `if: always()` and step-level conditions. Those
+// are about upstream RESULTS inside the lane, not about whether the lane applies —
+// the fan-ins need `always()` precisely so a failed sibling cannot skip them into
+// a green.
+func TestNoLaneWorkflowDecidesItsOwnScope(t *testing.T) {
+	lanes, err := filepath.Glob(filepath.Join(workflowDir, "_lane-*.yml"))
+	if err != nil {
+		t.Fatalf("listing lane workflows: %v", err)
+	}
+	if len(lanes) == 0 {
+		t.Fatalf("no _lane-*.yml under %s; either the lanes were renamed — in which case the "+
+			"classifier glob in ci.yml needs the new spelling too — or this gate is checking nothing",
+			workflowDir)
+	}
+
+	for _, path := range lanes {
+		raw, err := os.ReadFile(path) // #nosec G304 -- a repo-relative path from the glob above
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		var wf struct {
+			// `on` is a YAML 1.1 boolean, which is why the workflow key decodes
+			// under `true` for some parsers; yaml.v3 keeps it a string.
+			On   map[string]yaml.Node `yaml:"on"`
+			Jobs map[string]struct {
+				If string `yaml:"if"`
+			} `yaml:"jobs"`
+		}
+		if err := yaml.Unmarshal(raw, &wf); err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		name := filepath.Base(path)
+
+		if len(wf.Jobs) == 0 {
+			t.Errorf("%s declares no jobs; this gate cannot see them, so it was about to pass "+
+				"without judging anything", name)
+			continue
+		}
+		for trigger := range wf.On {
+			if trigger != "workflow_call" {
+				t.Errorf("%s is triggered by %q as well as workflow_call — a lane that runs on its "+
+					"own reports checks the ci aggregate does not read", name, trigger)
+			}
+		}
+		for _, job := range slices.Sorted(maps.Keys(wf.Jobs)) {
+			cond := normalizeCondition(wf.Jobs[job].If)
+			for _, concern := range callerConcerns {
+				if strings.Contains(cond, concern) {
+					t.Errorf("%s: job %q conditions on %s — that is the CALL SITE's decision. "+
+						"A lane must be all-or-nothing, or needs.<lane>.result == 'skipped' stops "+
+						"meaning \"the caller skipped it\" and the aggregate can read a green lane "+
+						"that never ran a job. Move the condition to the `uses:` job in ci.yml.",
+						name, job, concern)
+				}
+			}
+		}
+	}
 }

--- a/backend/frontendlaneparity_test.go
+++ b/backend/frontendlaneparity_test.go
@@ -5,6 +5,7 @@ package backendarch
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -168,9 +169,54 @@ type workflow struct {
 // ciGateTargets is every make target invoked by a job the required fan-in
 // depends on. Parsed as YAML rather than grepped, so a commented-out step or a
 // job outside the fan-in's `needs` cannot pass for coverage.
+// gateWorkflowDeclaring finds the merge-gate workflow that declares `job`.
+//
+// The fan-in used to live in ci.yml; it now lives in the frontend lane that
+// ci.yml calls. Searching the workflow directory for whichever file declares the
+// job means this gate follows the next move too, instead of failing with
+// "the lane's work moved out from behind the required check" when the work is
+// exactly where it should be — one file over.
+func gateWorkflowDeclaring(t *testing.T, job string) string {
+	t.Helper()
+	paths, err := filepath.Glob("../.github/workflows/*.yml")
+	if err != nil {
+		t.Fatalf("listing workflows: %v", err)
+	}
+	var found []string
+	for _, path := range paths {
+		body, err := os.ReadFile(path) // #nosec G304 -- a repo-relative path from the glob above
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		var parsed workflow
+		if err := yaml.Unmarshal(body, &parsed); err != nil {
+			// A workflow this gate cannot parse is not necessarily the one it
+			// wants; the assertion below fails if none of them is.
+			continue
+		}
+		// The fan-in is the job that DOES the asserting, so it has steps. The
+		// caller carries a job of the same name that only delegates (`uses:`),
+		// with no steps of its own — matching that one would walk the caller's
+		// `needs` (the classifier) instead of the lane's three legs.
+		declared, ok := parsed.Jobs[job]
+		if ok && len(declared.Needs) > 0 && len(declared.Steps) > 0 {
+			found = append(found, path)
+		}
+	}
+	switch len(found) {
+	case 1:
+		return found[0]
+	case 0:
+		t.Fatalf("no workflow under ../.github/workflows declares a %q job with needs — the required check was renamed or retired, so nothing here gates the lane", job)
+	default:
+		t.Fatalf("%d workflows declare a %q fan-in (%s) — two definitions of one required check drift, and this gate cannot tell which one runs", len(found), job, strings.Join(found, ", "))
+	}
+	return ""
+}
+
 func ciGateTargets(t *testing.T, path string) []string {
 	t.Helper()
-	body, err := os.ReadFile(path)
+	body, err := os.ReadFile(path) // #nosec G304 -- a repo-relative workflow path
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)
 	}
@@ -203,7 +249,7 @@ func TestEveryLocalFrontendGateLegRunsInCI(t *testing.T) {
 	if len(local) < 2 {
 		t.Fatalf("%q reaches no other target — the local gate lost its legs, or this gate stopped being able to see them", localGateRoot)
 	}
-	ciRoots := ciGateTargets(t, "../.github/workflows/ci.yml")
+	ciRoots := ciGateTargets(t, gateWorkflowDeclaring(t, requiredFanInJob))
 	inCI := reachable(targets, ciRoots...)
 
 	for leg := range local {

--- a/backend/laneconnbudget_test.go
+++ b/backend/laneconnbudget_test.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -38,9 +39,13 @@ import (
 )
 
 const (
-	ciWorkflowPath  = "../.github/workflows/ci.yml"
-	laneScriptPath  = "../scripts/lib-testdb.sh"
-	composeInfraYML = "../infra/docker-compose.dev.yml"
+	ciWorkflowPath = "../.github/workflows/ci.yml"
+	// What the report calls the source of INTEGRATION_JOBS. It is read from the
+	// caller AND the lanes it invokes, so naming one file would send the reader
+	// to a file that may not hold the number.
+	gateWorkflowLabel = "../.github/workflows/{ci,_lane-*}.yml"
+	laneScriptPath    = "../scripts/lib-testdb.sh"
+	composeInfraYML   = "../infra/docker-compose.dev.yml"
 )
 
 // laneTerm reads one `NAME=<int>` assignment from the lane script. Anchored to
@@ -60,6 +65,36 @@ func laneTerm(t *testing.T, script, name string) int {
 	return n
 }
 
+// gateWorkflows returns the merge gate as one body of text: the caller plus every
+// lane workflow it invokes.
+//
+// The shard that sets INTEGRATION_JOBS moved out of ci.yml and into the
+// integration lane. Reading the whole gate rather than one file of it means this
+// arithmetic follows the declaration wherever it lives — the alternative is a
+// gate that fails because the number it needs is one file over, which reads as a
+// real finding and is not one.
+func gateWorkflows(t *testing.T) string {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(filepath.Dir(ciWorkflowPath), "ci.yml"))
+	if err != nil {
+		t.Fatalf("listing the gate caller: %v", err)
+	}
+	lanes, err := filepath.Glob(filepath.Join(filepath.Dir(ciWorkflowPath), "_lane-*.yml"))
+	if err != nil {
+		t.Fatalf("listing lane workflows: %v", err)
+	}
+	paths = append(paths, lanes...)
+	if len(paths) == 0 {
+		t.Fatalf("no merge-gate workflow found beside %s; this gate would read an empty string and its arithmetic would be silently smaller rather than wrong", ciWorkflowPath)
+	}
+	var joined strings.Builder
+	for _, path := range paths {
+		joined.WriteString(readRepoFile(t, path))
+		joined.WriteString("\n")
+	}
+	return joined.String()
+}
+
 // ciIntegrationJobs reads the INTEGRATION_JOBS the integration shard runs with.
 // It is read from the workflow rather than from the script's nproc-derived
 // default because CI is the environment that oversubscribes: the default is
@@ -69,11 +104,11 @@ func ciIntegrationJobs(t *testing.T, workflow string) int {
 	re := regexp.MustCompile(`(?m)^\s*INTEGRATION_JOBS:\s*(\d+)\s*$`)
 	m := re.FindStringSubmatch(workflow)
 	if m == nil {
-		t.Fatalf("%s sets no INTEGRATION_JOBS — this gate sizes the cluster for the concurrency CI actually uses, and cannot do that from a workflow that no longer names it", ciWorkflowPath)
+		t.Fatalf("the merge-gate workflows set no INTEGRATION_JOBS — this gate sizes the cluster for the concurrency CI actually uses, and cannot do that from a gate that no longer names it")
 	}
 	n, err := strconv.Atoi(m[1])
 	if err != nil || n <= 0 {
-		t.Fatalf("%s sets INTEGRATION_JOBS=%q, which is not a positive count", ciWorkflowPath, m[1])
+		t.Fatalf("the merge-gate workflows set INTEGRATION_JOBS=%q, which is not a positive count", m[1])
 	}
 	return n
 }
@@ -138,7 +173,7 @@ func fits(demand, maxConns int) bool { return demand <= maxConns }
 
 func TestTheLaneFitsInsideTheClusterItRunsAgainst(t *testing.T) {
 	script := readRepoFile(t, laneScriptPath)
-	jobs := ciIntegrationJobs(t, readRepoFile(t, ciWorkflowPath))
+	jobs := ciIntegrationJobs(t, gateWorkflows(t))
 	perPool := laneTerm(t, script, "LANE_POOL_MAX_CONNS")
 	perPackage := laneTerm(t, script, "LANE_CONNS_PER_PACKAGE")
 	fixed := laneTerm(t, script, "LANE_FIXED_CONNS")
@@ -167,7 +202,7 @@ Raise max_connections in %s to at least %d, or lower a term. Do not leave them
 apart: they were unrelated numbers once, and the lane failed at connect time in a
 different package set every run (#1109).`,
 			demand, composeInfraYML, maxConns,
-			jobs, ciWorkflowPath,
+			jobs, gateWorkflowLabel,
 			perPackage, laneScriptPath,
 			fixed, laneScriptPath,
 			demand, maxConns,

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -150,7 +150,7 @@ would report a documentation PR as a broken integration lane.
 
 | Scope | Paths | Gates |
 |---|---|---|
-| `backend_db` | `backend/**`, `infra/**/!(*.md)`, `go.work`, `go.work.sum`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/actions/**`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | the integration shards and the `integration` fan-in — every lane that opens a database |
+| `backend_db` | `backend/**`, `infra/**/!(*.md)`, `go.work`, `go.work.sum`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/workflows/_lane-*.yml` (the caller plus every lane it invokes — globbed so a lane added later is covered the day it lands), `.github/actions/**`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | the integration shards and the `integration` fan-in — every lane that opens a database |
 | `backend` | `backend_db` (by YAML anchor, so the two cannot drift) plus the agent rulebooks `AGENTS.md` and `CLAUDE.md` | Go build/gate, extension reference, craftsmanship, unit coverage, vuln |
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types), plus the composition inputs the lane now typechecks against — `extensions/**`, `fixtures/**`, `composition/**`, `backend/tools/gen-composition/**`, `Makefile` — and the install inputs `pnpm-lock.yaml` and `pnpm-workspace.yaml`, which decide *which* dependency the SPA builds on and which one `openapi-typescript` parses the contract with (`overrides` lives in the workspace file, so it resolves versions the lockfile then merely records) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
@@ -209,14 +209,18 @@ Consequences:
 
 ```
 changes ──┬─> deterministic-gates ──> craftsmanship
-          ├─> integration-shards (×12) ─────┬─> integration (fan-in) ──┐
-          ├─> integration-unit-coverage ────┘                          │
-          ├─> extension-reference ──────────────────────────────────┐  │
-          ├─> vuln                                                  │  │
-          ├─> license gate  (`deps` scope)                          │  │
-          ├─> frontend ──> uat                                      │  │
-          ├─> live-boot                                             │  │
-          v                                                         v  v
+          ├─> integration  →  _lane-integration.yml ────────────────┐
+          │                     integration-shards (×6) ──┐         │
+          │                     integration-unit-coverage ┴─> fan-in│
+          ├─> extension-reference ──────────────────────────────┐   │
+          ├─> vuln                                              │   │
+          ├─> license gate  (`deps` scope)                      │   │
+          ├─> frontend  →  _lane-frontend.yml ──> uat           │   │
+          │                  fe-quality ┐                       │   │
+          │                  fe-unit    ├─> fan-in              │   │
+          │                  fe-bundle  ┘                       │   │
+          ├─> live-boot                                         │   │
+          v                                                     v   v
  deterministic-gates + integration + extension-reference + frontend ──> sonarcloud
   dco            (independent — runs on merge_group too)
   craft-residue  (every non-draft change, independent)
@@ -227,6 +231,43 @@ changes ──┬─> deterministic-gates ──> craftsmanship
          integration, frontend, license-gate   (nine — vuln, live-boot and uat
          stay advisory and are NOT in the fan-in)
 ```
+
+### Two lanes are called, not inlined
+
+`integration` and `frontend` are `workflow_call` jobs: the caller decides whether
+the lane runs, and the lane's jobs live in
+[`_lane-integration.yml`](../.github/workflows/_lane-integration.yml) and
+[`_lane-frontend.yml`](../.github/workflows/_lane-frontend.yml). Those two
+clusters were a third of `ci.yml` — the six-way shard matrix, the coverage
+plumbing, the two fan-ins — and none of it is read when the merge gate itself
+changes.
+
+Both were already **fan-in contexts**, which is why they are the two that moved:
+`needs.integration.result` and `needs.frontend.result` mean exactly what they
+meant before, so the `ci` aggregate and the `sonarcloud` conditions are unchanged.
+Extracting a cluster whose members the aggregate names individually would have
+coarsened its verdict from "craftsmanship failed" to "the Go lane failed".
+
+**A lane carries no `if:` of its own.** The condition lives at the call site, and
+that is load-bearing rather than stylistic: it makes
+`needs.<lane>.result == 'skipped'` mean exactly one thing — the caller skipped the
+whole lane — which is the distinction the aggregate reads when it refuses a skip
+on the merge queue. An internal conditional would let a job inside skip while the
+lane still reported `success`, reopening the skip-as-pass hole one level down.
+
+**`defaults.run.working-directory` does not inherit** into a called workflow. Each
+lane restates it; without that, every step would run from the repository root.
+
+Check names inside a lane are reported as `<caller-job> / <lane-job>` — e.g.
+`integration / integration shard (3/6)`. Only `ci` is a required context, so no
+ruleset depends on those names.
+
+Why the pipeline stays **one caller** rather than splitting into `pr.yml` and
+`merge-queue.yml`: the `ci` aggregate is the single required check, and two
+callers would mean two definitions of it that must stay byte-identical or the two
+events gate differently. That is the "two hand-maintained copies of one list"
+shape this repository refuses everywhere else, and it would be guarding the one
+check everything depends on.
 
 Two deliberate shapes here. The Playwright `uat` lane is **fail-fast**: it
 starts only after the cheaper `frontend` gate (biome + vitest + tsc + build)
@@ -471,7 +512,10 @@ Wiring details:
 
 ## The other workflows
 
-`ci.yml` is the merge gate. Six workflows sit beside it, deliberately outside it:
+`ci.yml` is the merge gate, and `_lane-integration.yml` / `_lane-frontend.yml` are
+part of it — called by it, never triggered on their own (see
+[Two lanes are called](#two-lanes-are-called-not-inlined)). Six workflows sit
+beside the gate, deliberately outside it:
 
 - **`cache-warm.yml`** — the Go build cache's only writer, on `main` every three
   hours plus manual dispatch. **Gates nothing**: a red or cancelled run costs


### PR DESCRIPTION
Closes https://github.com/gradionhq/margince-poc-v1/issues/1982

## Why

`ci.yml` gates every merge and nobody could read it — **1,395 lines, 20 jobs**. The
integration and frontend clusters were a third of it and are not looked at when the
gate itself changes.

`ci.yml` is now **1,014 lines, 15 jobs**. The two clusters live in
`_lane-integration.yml` and `_lane-frontend.yml`, called via `workflow_call`.

## What is deliberately NOT in here

**No `pr.yml` / `merge-queue.yml` split**, which is what #1982 proposed. That shape
needs the `ci` job defined **twice** — the single required check, in two files,
which must stay byte-identical or the two events gate differently. That is the "two
hand-maintained copies of one list" shape this repository refuses everywhere else,
and it would be guarding the one check everything depends on. One caller, two called
lanes, gets the legibility win without it.

**Only the two clusters that were already fan-in contexts moved.**
`needs.integration.result` and `needs.frontend.result` mean exactly what they meant
before, so the `ci` aggregate and the `sonarcloud` conditions are **unchanged**.
Extracting, say, the Go cluster would have coarsened the aggregate's verdict from
"craftsmanship failed" to "the Go lane failed" — a legibility *regression* for
whoever reads the red check.

## The property that makes a lane safe

**A lane carries no condition of its own; the call site decides.** That is not
style. It keeps `needs.<lane>.result == 'skipped'` meaning exactly one thing — *the
caller skipped the whole lane* — which is the distinction the `ci` aggregate reads
when it refuses a skip on `merge_group`. An internal conditional would let a job
inside skip while the lane still reported `success`: the skip-as-pass hole, one
level down and invisible from the caller, which sees only the rolled-up result.

`TestNoLaneWorkflowDecidesItsOwnScope` holds it: a lane job may not condition on
`needs.changes`, `github.event_name` or `github.event.pull_request`, and a lane may
only be triggered by `workflow_call`. Mutation-checked by conditioning `fe-bundle`
on the classifier — it fails and names the file, the job and the fix.

`if: always()` and step-level conditions stay allowed: those are about upstream
*results* inside the lane, and the fan-ins need `always()` precisely so a failed
sibling cannot skip them into a green.

## Two existing gates caught this, and both are now derived

They read `ci.yml` by name and found their subject one file over:

- `TestEveryLocalFrontendGateLegRunsInCI` — walks the `frontend` fan-in's `needs`
- `TestTheLaneFitsInsideTheClusterItRunsAgainst` — reads `INTEGRATION_JOBS`

Both now discover the file from the workflow tree, so the next move does not break
them. The parity check needed one refinement: searching for "the workflow declaring
job `frontend`" matched **two** files — the lane's fan-in and the caller's
delegating job of the same name. It disambiguates on `steps`, because matching the
caller would have walked the classifier's `needs` and checked nothing. The
ambiguity assertion fired rather than silently picking one.

## Other fixes that fell out

- The classifier globs `.github/workflows/_lane-*.yml` rather than naming the two,
  so a lane added later is a gate input the day it lands. `ci-doc-parity` refused
  the undocumented path immediately, which is the gate working.
- `integration-unit-coverage` hung off the `backend` scope while the fan-in that
  consumes its pods hung off `backend_db` — a rulebook-only change ran that job and
  discarded its output. It is inside the lane now, so the two cannot diverge.

## Verification

`make check` green — **both halves, one run, real exit code 0**. That includes
`test-ci-verdict`, the three workflow fitness tests, `lint-modules`, `ci-doc-parity`
and `check-image-pins`.

**What local checks cannot prove:** GitHub's `workflow_call` wiring. Nothing on a
laptop exercises it. The first run on this PR is the first real evidence, and the
check names inside a lane will report as `<caller-job> / <lane-job>` (e.g.
`integration / integration shard (3/6)`).

## Note on the required check

`main-required-status-checks` is currently **disabled** — switched off yesterday so
a red `main` and a live merge queue would not block everyone. Nothing in this PR
changes that. Restoring `ci` as required (without the `merge_queue` rule) is the
follow-up, and it should happen only after a run here confirms the new wiring
reports.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the `integration` and `frontend` lanes from `ci.yml` into callable workflows to make the merge gate readable without changing what is gated. The `ci` aggregate and required-check behavior stay the same; only where the lane jobs live changes.

- Two new workflows: `_lane-integration.yml` (shards + unit-coverage + fan-in) and `_lane-frontend.yml` (fe-quality, fe-unit, fe-bundle + fan-in), invoked from `ci.yml` via `workflow_call`.
- Lanes carry no `if:`; the call site decides scope. This preserves “skip means caller skipped the whole lane.” Enforced by `TestNoLaneWorkflowDecidesItsOwnScope`; lanes are triggerable only by `workflow_call`.
- `needs.integration.result` and `needs.frontend.result` are unchanged; fan-ins still use `always()` to avoid skip-as-pass. Check names under lanes appear as `<caller> / <lane-job>`; only `ci` is required.
- `integration-unit-coverage` now lives inside the integration lane to match its fan-in scope.
- The change classifier now globs `.github/workflows/_lane-*.yml`; docs updated accordingly.
- Gates that read `ci.yml` now discover the declaring workflow: `TestEveryLocalFrontendGateLegRunsInCI` and `TestTheLaneFitsInsideTheClusterItRunsAgainst`.

**Rollout**
- First run on this PR verifies GitHub `workflow_call` wiring. After a green run, re-enable the `ci` required check in branch protection (without the `merge_queue` rule).

<sup>Written for commit bb1636545fd4352f348c3ccc539fc574c0584cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

