### PR TITLE
fix(ci): the voice lifecycle suite expects the vocabulary head actually holds

### DIFF
--- a/backend/migrations/voice_profile_lifecycle_integration_test.go
+++ b/backend/migrations/voice_profile_lifecycle_integration_test.go
@@ -98,6 +98,12 @@ func migrateToBeforeVoiceLifecycle(t *testing.T, conn *pgx.Conn) dbmigrate.Names
 	return core
 }
 
+// The three asserts below expect source = "manual", not the 'ui' that 0107's
+// own DEFAULT writes. This suite migrates a pre-0107 installation all the way to
+// HEAD, and core/1787315000_source_names_the_origin collapses 'ui' and 'mcp'
+// into 'manual' across all three voice tables — so 'manual' is what an
+// installation that took this upgrade path actually holds. Asserting 0107's
+// default would be asserting a value no migrated database ends up with.
 func assertMigratedVoiceCorpus(t *testing.T, conn *pgx.Conn, profileID, wantContentHash string) {
 	t.Helper()
 	var contentHash, kind, register, source, capturedBy string
@@ -114,8 +120,8 @@ func assertMigratedVoiceCorpus(t *testing.T, conn *pgx.Conn, profileID, wantCont
 	if kind != "linkedin" || register != "social" {
 		t.Errorf("translated corpus vocabulary = (%q, %q), want (linkedin, social)", kind, register)
 	}
-	if source != "ui" || capturedBy != "system" {
-		t.Errorf("corpus provenance = (%q, %q), want (ui, system)", source, capturedBy)
+	if source != "manual" || capturedBy != "system" {
+		t.Errorf("corpus provenance = (%q, %q), want (manual, system)", source, capturedBy)
 	}
 }
 
@@ -141,8 +147,8 @@ func assertMigratedVoiceProfile(t *testing.T, conn *pgx.Conn, profileID, ownerID
 	if sourceHash != wantSourceHash {
 		t.Errorf("active_source_hash = %q, want %q", sourceHash, wantSourceHash)
 	}
-	if source != "ui" || capturedBy != "system" || !builtAtPresent {
-		t.Errorf("profile backfill = source %q, captured_by %q, built_at %v; want ui, system, true", source, capturedBy, builtAtPresent)
+	if source != "manual" || capturedBy != "system" || !builtAtPresent {
+		t.Errorf("profile backfill = source %q, captured_by %q, built_at %v; want manual, system, true", source, capturedBy, builtAtPresent)
 	}
 }
 
@@ -168,8 +174,8 @@ func assertMigratedVoiceVersion(t *testing.T, conn *pgx.Conn, profileID string, 
 	if sourceHash != wantSourceHash || sourceCount != 1 {
 		t.Errorf("immutable version source snapshot = (%q, %d), want (%q, 1)", sourceHash, sourceCount, wantSourceHash)
 	}
-	if source != "ui" || capturedBy != "system" {
-		t.Errorf("immutable version provenance = (%q, %q), want (ui, system)", source, capturedBy)
+	if source != "manual" || capturedBy != "system" {
+		t.Errorf("immutable version provenance = (%q, %q), want (manual, system)", source, capturedBy)
 	}
 }
 


### PR DESCRIPTION
**Main's integration lane is red**, and has been since #2102 landed. This is the
fix. Closes the first half of #2126.

## What broke

`TestVoiceProfileLifecycleUpgradePreservesBuiltProfile` asserts `source = 'ui'`
on all three voice tables — which is what `core/0107`'s own `DEFAULT` writes.

But the suite seeds a **pre-0107** installation and migrates it to **head**, and
`core/1787315000_source_names_the_origin` (#2102) collapses `'ui'` and `'mcp'`
into `'manual'` across `voice_profile`, `voice_corpus_source` and
`voice_profile_version`. So `'ui'` is a value no migrated database ends up
holding, and the three assertions have failed for everybody on every branch
since.

```
voice_profile_lifecycle_integration_test.go:71: corpus provenance = ("manual", "system"), want (ui, system)
voice_profile_lifecycle_integration_test.go:72: profile backfill = source "manual", captured_by "system", built_at true; want ui, system, true
voice_profile_lifecycle_integration_test.go:73: immutable version provenance = ("manual", "system"), want (ui, system)
```

## The fix, and why it is not a weakened assertion

The expectation moves to `'manual'` **and says why in the code**. A bare value
change here reads exactly like somebody loosening a test to make it pass — so
the note names the migration that does the collapse and states the principle:
the suite exists to pin what an installation that took this upgrade path
actually holds, and asserting `0107`'s default would assert a value no migrated
database has.

## Still open on #2126

That migration is stamped **`1787315000`** — a round number, hand-picked rather
than `date +%s`, and roughly **ten hours ahead of real UTC** at the time of
writing. Every migration authored before then has to be stamped into the future
to clear `check-migration-versions`. It clears the clock check only because that
check has slack. Left on the issue as its own decision.

## Verification

- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`
- `make check-backend` / `make craft-static` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores green CI by aligning the voice lifecycle integration tests with the current migration behavior. Tests now expect source = "manual" (was "ui") across voice tables because `core/1787315000_source_names_the_origin` collapses "ui" and "mcp" into "manual" for upgraded installs.

- Updates assertions and messages in `backend/migrations/voice_profile_lifecycle_integration_test.go`; adds an inline note explaining the migration-driven expectation.
- No runtime changes; test-only fix. Partially addresses #2126 (timestamp follow-up remains).

<sup>Written for commit 5393e77471ea20eb407a5a0f82e18e98e8057df1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

