### PR TITLE
fix(ci-tests): the sweep gate classifies the project clock it was handed

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -316,7 +316,13 @@ var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	"activity activity_refuse_restricted_mutation": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
 	// Not guards at all (migration 1787032690).
 	"activity_link activity_link_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the last_activity_at of the records the deleted link reached and refuses no delete; the sweep deletes those records too, so the recompute is discarded with them",
-	"relationship relationship_last_activity":   "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
+	// The same shape one column over (migration 1787320000): the project clock
+	// rather than the person/organization one. Recorded on its own line and not
+	// folded into the entry above, because this map is keyed on the PAIR for the
+	// reason its own comment gives — a table-keyed entry would ratify the next
+	// DELETE trigger on activity_link sight unseen, including one that blocks.
+	"activity_link activity_link_project_last_activity": "a clock-maintenance trigger, not a guard: it recomputes project.last_activity_at for the project the deleted link filed the activity against and refuses no delete; `project` is not preserved, so the sweep deletes those rows too and the recompute is discarded with them",
+	"relationship relationship_last_activity":           "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
 	// Also not a guard (migration 1787226902): BEFORE DELETE ON organization, it
 	// sets deal.partner_org_id and deal.partner_attribution to NULL so a deleted
 	// partner leaves no dangling attribution. It refuses no delete.


### PR DESCRIPTION
Closes #2133. **`main` is red without this** — every open PR's integration lane fails on something none of them changed.

## What is broken

`TestSweepTargetsCarryNoDeleteBlockingTrigger` has failed on a clean `origin/main` worktree since #2120 landed migration `1787320000_project_last_activity`:

```
datareset_integration_test.go:375: sweep target "activity_link" carries DELETE-firing
  trigger "activity_link_project_last_activity" — an append-only or otherwise protected
  table belongs in preservedResetTables; a row-conditional guard belongs in
  deleteGuardedSweepTargets, with what the reset owes it
```

The gate refuses any DELETE-firing trigger on a sweep target until somebody classifies it, which is the whole point of it: a delete guard the sweep does not know about either aborts the reset transaction at runtime or is wiped against its guard's intent. The new trigger was not classified.

## The classification

It is **not** a guard. `trg_activity_link_project_last_activity` never `RAISE`s — it calls `move_project_last_activity(OLD.project_id)` and returns NULL. `project` is not in `preservedResetTables`, so the sweep deletes those rows too and the recompute is discarded with them.

That is word for word the reasoning already on the record for the sibling entry on the same table, `activity_link activity_link_last_activity` (migration 1787032690).

It gets its own line rather than being folded into that entry, because the map is keyed on the `<table> <trigger>` PAIR for the reason its own comment gives: a table-keyed entry ratifies the *category*, and would clear the next DELETE trigger added to `activity_link` sight unseen — including one that really does block.

## Verified

```
make test-it DIR=backend/internal/compose RUN=TestSweepTargetsCarryNoDeleteBlockingTrigger
--- PASS (2.65s)

make test-it DIR=backend/internal/compose RUN='TestSweepTargets|TestPreserveSetIntegrity|TestDropReset'
--- PASS: TestPreserveSetIntegrity
--- PASS: TestDropResetCustomFieldColumns
--- PASS: TestSweepTargetsCarryNoDeleteBlockingTrigger
```

Before the change, on the same worktree at `origin/main`, the first of those fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies the DELETE-firing trigger `activity_link activity_link_project_last_activity` as non-guard clock maintenance in the sweep gate to unbreak CI. Previously, the gate rejected unclassified DELETE triggers on sweep targets and `TestSweepTargetsCarryNoDeleteBlockingTrigger` failed on `main`; now it passes with no change to reset behavior.

- Verify the trigger only recomputes `project.last_activity_at`, never RAISEs, and returns NULL.
- `project` is not in `preservedResetTables`, so the sweep deletes those rows and discards the recompute.
- Added as its own `<table> <trigger>` map entry to avoid auto-clearing future DELETE triggers on `activity_link`.
- No migrations or runtime behavior changes; this only fixes the test gate classification.

<sup>Written for commit 4983d4b4874919309991651c48401342e7c62b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

