### PR TITLE
chore: remove the seed-demo binary I committed, and ignore both its paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,15 @@ coverage.out
 /backend/migrate
 /backend/mcp
 
-# Same for the tools module. `go build ./tools/seed-demo` from backend/ drops
-# an 18 MB binary here, which a `git add -A` will happily commit — it did once.
+# Same for the tools module, and BOTH paths it lands on: `go build ./tools/...`
+# from backend/ drops the binary at the first, `go build ./...` from
+# backend/tools/ drops it beside its own source at the second. A `git add -A`
+# will happily commit either — it has done both, the second time because only
+# the first was anchored here. An anchored rule is right for a build artifact
+# whose name collides with a package directory, so the two are listed rather
+# than loosened to a bare `seed-demo`.
 /backend/seed-demo
+/backend/tools/seed-demo/seed-demo
 
 # Session working notes — local only, not part of the published repo
 /review_*.md


### PR DESCRIPTION
**A 19 MB Mach-O executable is on `main`.** It came in with #2012. This removes
it and closes the gap that let it through.

## How it happened

I built the tools module from `backend/tools/` while fixing `seed-demo`'s own
SQL for the `app_user` column drop, and the `git add -A backend` that followed
swept the artifact in with the source.

## The rule that should have caught it

`.gitignore` had already anticipated this exact mistake. Its comment reads:

> `go build ./tools/seed-demo` from backend/ drops an 18 MB binary here, which a
> `git add -A` will happily commit — **it did once**.

But the rule was anchored at `/backend/seed-demo` — the path a build **from
`backend/`** produces. Building **from `backend/tools/`** drops it beside its own
source at `backend/tools/seed-demo/seed-demo`, which that anchor does not reach.
Both paths are listed now, and I verified it by reproducing the build and
confirming `git status` stays clean.

Still anchored rather than a bare `seed-demo`: the artifact's name collides with
its own package directory, so an unanchored pattern would match the source tree.

## What this does not fix

The blob stays in `main`'s object history. Removing a file does not purge it,
and purging would mean rewriting a shared branch — not a call this change should
make. What this fixes is the working tree, every future clone's checkout, and
the rule.

## How I found the rest

I swept every commit I authored in the last two days for non-source additions
and for any tracked blob over 500 KB. This was the only one — the other large
tracked files (`api_gen.go`, `schema.d.ts`, `crm.yaml`, the licensecheck wasm
module) are all intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a committed 19 MB `seed-demo` binary and tightens `.gitignore` to cover both build locations, preventing future accidental commits.

- Old: only `/backend/seed-demo` was ignored. New: also ignore `/backend/tools/seed-demo/seed-demo`; both patterns are anchored to avoid matching the source directory.
- History is unchanged; repository size is unaffected. Working trees and future clones stay clean.

<sup>Written for commit 3e5c13ca0067758b141aac7b4243fb4750e6d4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules for tools-related build outputs.
  * Prevented generated seed-demo binaries from appearing as untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->