### PR TITLE
fix(ci-tests): classify the project last-activity trigger the reset sweeps

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -316,7 +316,14 @@ var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	"activity activity_refuse_restricted_mutation": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
 	// Not guards at all (migration 1787032690).
 	"activity_link activity_link_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the last_activity_at of the records the deleted link reached and refuses no delete; the sweep deletes those records too, so the recompute is discarded with them",
-	"relationship relationship_last_activity":   "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
+	// The second clock on the same table, added with project.last_activity_at.
+	// It is AFTER INSERT OR UPDATE OR DELETE and RETURNS NULL, so it cannot
+	// refuse a delete even in principle — an AFTER trigger's return value is
+	// discarded. Two entries for one table rather than one is the point of
+	// keying on `<table> <trigger>`: a waiver that said "activity_link is fine"
+	// would have cleared this trigger before anybody read it.
+	"activity_link activity_link_project_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the project's last_activity_at when a link that reached it is deleted, and being an AFTER trigger it refuses nothing; the sweep deletes those projects too, so the recompute is discarded with them",
+	"relationship relationship_last_activity":           "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
 	// Also not a guard (migration 1787226902): BEFORE DELETE ON organization, it
 	// sets deal.partner_org_id and deal.partner_attribution to NULL so a deleted
 	// partner leaves no dangling attribution. It refuses no delete.


### PR DESCRIPTION
`main` is red for every branch again — same gate as #2126/#2055, a new trigger.

```
sweep target "activity_link" carries DELETE-firing trigger "activity_link_project_last_activity"
```

Reproduced on a clean `origin/main` (`d902542`) with nothing else in the branch.

## It refuses nothing, and cannot

`core/1787320000_project_last_activity.up.sql`:

```sql
CREATE TRIGGER activity_link_project_last_activity
  AFTER INSERT OR UPDATE OR DELETE ON activity_link
  FOR EACH ROW EXECUTE FUNCTION trg_activity_link_project_last_activity();
```

`AFTER`, and the function `RETURN NULL`s. An AFTER trigger's return value is discarded, so it has no way to block a delete even in principle. What it does is recompute the project's `last_activity_at` when a link that reached it goes — and the sweep deletes those projects too, so the recompute is discarded with them. Identical shape to the clock on the same table one line above it in the waiver.

## Why two entries for one table is the right answer

This is the first trigger the `<table> <trigger>` rekeying from #2055 has caught, and it caught exactly what it was meant to. A waiver keyed on the table alone — saying "activity_link is fine" — would have cleared this trigger silently, before anybody looked at whether it was a guard or a clock. The rekeying is doing its job; it just means a new DELETE trigger on an already-waived table now needs its own line, which is the intended cost.

## Verified

`scripts/test-integration-one.sh backend/internal/compose 'TestSweepTargetsCarryNoDeleteBlockingTrigger'` → PASS on this branch, FAIL on `origin/main` unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by classifying the `activity_link_project_last_activity` trigger as a clock, not a delete guard, in the sweep gate. Previously the gate failed due to this unclassified trigger; now the sweep test passes without changing runtime behavior.

**Review notes**
- Add waiver for `<table> <trigger>` key `activity_link activity_link_project_last_activity`.
- Rationale: the trigger is AFTER INSERT/UPDATE/DELETE and RETURNS NULL, so it cannot block deletes; it only recomputes the project’s `last_activity_at`, which the sweep discards.
- Keep per-trigger classification on `activity_link`: both `activity_link_last_activity` and `activity_link_project_last_activity` are listed intentionally to avoid blanket table waivers.

<sup>Written for commit 7d5b4332075354fbf394ce3b2750069e33a5ac0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data reset handling so activity-related records can be deleted without unnecessary trigger-blocking errors.
  * Preserved existing behavior for relationship activity cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->