### PR TITLE
feat(config): the relay password and the license token move into the key vault

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/licensecheck"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/buildinfo"
@@ -88,7 +89,16 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, lo
 	// The deployment posture decides which license authorities are honored: a
 	// production installation accepts one, and only a non-production one also
 	// runs on a license minted for a test.
-	license, err := compose.EnsureLicense(ctx, logger, deployCfg, cfg.posture, config.FromOS)
+	//
+	// The vault is built here rather than taken from the later keyvaultOptions
+	// wiring, because an installation that has sealed its token and dropped the
+	// declaration reads it out of the vault: the license question cannot be
+	// answered before the vault exists.
+	vault, _, err := keyvault.FromEnv(pool, config.FromOS)
+	if err != nil {
+		return deployconfig.Config{}, nil, fmt.Errorf("api: keyvault: %w", err)
+	}
+	license, err := compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, cfg.posture, config.FromOS)
 	if err != nil {
 		return deployconfig.Config{}, nil, err
 	}
@@ -112,7 +122,7 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, lo
 // The reset lane comes back with the options because the endpoint is only half
 // of it: the other half is a listener this process runs for its own lifetime,
 // which run() starts once the handler exists.
-func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, schemaPool *pgxpool.Pool, rdb *redis.Client, logger *slog.Logger, stdout io.Writer) ([]compose.Option, *resetLane, error) {
+func declaredSurfaceOptions(ctx context.Context, cfg apiConfig, deployCfg deployconfig.Config, pool, schemaPool *pgxpool.Pool, rdb *redis.Client, logger *slog.Logger, stdout io.Writer) ([]compose.Option, *resetLane, error) {
 	// The non-production admin data-reset endpoint (POST /v1/admin/reset-data):
 	// absent this deployment posture, or in production, ResetData answers its
 	// closed 404 default. schemaPool may be nil (no --schema-dsn configured);
@@ -159,7 +169,7 @@ func declaredSurfaceOptions(cfg apiConfig, deployCfg deployconfig.Config, pool, 
 		opts = append(opts, compose.WithMCPConnector())
 	}
 
-	passwordOpts, err := passwordResetOptions(deployCfg, cfg.publicBaseURL, stdout)
+	passwordOpts, err := passwordResetOptions(ctx, deployCfg, pool, cfg.publicBaseURL, logger, stdout)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -94,7 +94,7 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, lo
 	// wiring, because an installation that has sealed its token and dropped the
 	// declaration reads it out of the vault: the license question cannot be
 	// answered before the vault exists.
-	vault, _, err := keyvault.FromEnv(pool, config.FromOS)
+	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if err != nil {
 		return deployconfig.Config{}, nil, fmt.Errorf("api: keyvault: %w", err)
 	}

--- a/backend/cmd/api/keyvault.go
+++ b/backend/cmd/api/keyvault.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -25,8 +26,8 @@ import (
 // than nil-deref if ever invoked; the vault is required for any standing
 // connection. A key that is set but malformed is a boot error
 // (keyvault.FromEnv), never a silent fallback to something weaker.
-func keyvaultOptions(pool *pgxpool.Pool, stdout io.Writer, overlayBackfillLimit int) ([]compose.Option, error) {
-	vault, configured, err := keyvault.FromEnv(pool, config.FromOS)
+func keyvaultOptions(ctx context.Context, pool *pgxpool.Pool, stdout io.Writer, overlayBackfillLimit int) ([]compose.Option, error) {
+	vault, configured, err := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if err != nil {
 		return nil, fmt.Errorf("api: keyvault: %w", err)
 	}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -287,7 +287,7 @@ func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.Captu
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("api: %w", err)
 	}
-	kvOpts, err := keyvaultOptions(pool, stdout, overlayBackfillLimit)
+	kvOpts, err := keyvaultOptions(ctx, pool, stdout, overlayBackfillLimit)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -329,7 +329,7 @@ func passwordResetOptions(ctx context.Context, deployCfg deployconfig.Config, po
 	if publicBaseURL == "" {
 		return nil, errors.New("api: email.enabled requires --public-base-url/MARGINCE_PUBLIC_BASE_URL (the reset link's canonical base)")
 	}
-	vault, _, err := keyvault.FromEnv(pool, config.FromOS)
+	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if err != nil {
 		return nil, fmt.Errorf("api: keyvault: %w", err)
 	}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/licensecheck"
 	"github.com/gradionhq/margince/backend/internal/platform/mailer"
 )
@@ -115,7 +116,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	rdb, closeRedis := sharedRedisClient(cfg, logger)
 	defer closeRedis()
 
-	surfaceOpts, resetLane, err := declaredSurfaceOptions(cfg, deployCfg, pool, schemaPool, rdb, logger, stdout)
+	surfaceOpts, resetLane, err := declaredSurfaceOptions(ctx, cfg, deployCfg, pool, schemaPool, rdb, logger, stdout)
 	if err != nil {
 		return err
 	}
@@ -321,14 +322,20 @@ func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.Captu
 // canonical external base — with email enabled, a missing
 // --public-base-url is a boot error, never a link derived from a
 // request Host.
-func passwordResetOptions(deployCfg deployconfig.Config, publicBaseURL string, stdout io.Writer) ([]compose.Option, error) {
+func passwordResetOptions(ctx context.Context, deployCfg deployconfig.Config, pool *pgxpool.Pool, publicBaseURL string, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
 	if !deployCfg.Email.Enabled {
 		return nil, nil
 	}
 	if publicBaseURL == "" {
 		return nil, errors.New("api: email.enabled requires --public-base-url/MARGINCE_PUBLIC_BASE_URL (the reset link's canonical base)")
 	}
-	smtpPassword, err := deployCfg.Email.SMTPPassword(config.FromOS)
+	vault, _, err := keyvault.FromEnv(pool, config.FromOS)
+	if err != nil {
+		return nil, fmt.Errorf("api: keyvault: %w", err)
+	}
+	// The relay password is sealed into the vault on the boot that first sees
+	// it, and read back from there once the deployment stops declaring it.
+	smtpPassword, err := compose.SealedSMTPPassword(ctx, pool, vault, deployCfg, config.FromOS, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -190,7 +190,7 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 	// need: an adapter to call and the vault that unseals its credential.
 	// keyvault.FromEnv is resolved here rather than passed down because this
 	// is the first lane in this role that needs it.
-	providerVault, vaultConfigured, err := keyvault.FromEnv(pool, config.FromOS)
+	providerVault, vaultConfigured, err := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if err != nil {
 		return lanes, fmt.Errorf("worker: keyvault: %w", err)
 	}
@@ -322,7 +322,7 @@ func startRunnerLane(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 	// the workspace's own vaulted incumbent token; wire the FromEnv
 	// vault-backed resolver so an autonomous run can write back (nil vault
 	// → clean errNoWriteIncumbent, never a crash).
-	runnerVault, _, rverr := keyvault.FromEnv(pool, config.FromOS)
+	runnerVault, _, rverr := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if rverr != nil {
 		return rverr
 	}
@@ -437,7 +437,7 @@ func relayUntilSignal(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool,
 // (keyvault.FromEnv); a mid-backfill failure is logged and non-fatal — capture
 // keeps resolving from the auth column and the next boot retries.
 func backfillConnectorCredentials(ctx context.Context, pool *pgxpool.Pool, stdout io.Writer, logger *slog.Logger) error {
-	vault, configured, err := keyvault.FromEnv(pool, config.FromOS)
+	vault, configured, err := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if err != nil {
 		return fmt.Errorf("worker: keyvault: %w", err)
 	}

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -59,7 +59,7 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 	// resolved once, shared; when it is not configured, configuredVault is nil
 	// so an unconfigured deployment never fails worker boot over pollers it has
 	// no connected workspace to run anyway.
-	vault, vaultConfigured, verr := keyvault.FromEnv(pool, config.FromOS)
+	vault, vaultConfigured, verr := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if verr != nil {
 		return nil, fmt.Errorf("worker: keyvault: %w", verr)
 	}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -82,19 +82,6 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	// Before this role does any work, so an operator mistake never leaves a
-	// worker running on a license the api refuses to boot on. The RUNNING
-	// posture is the api's to watch: it is the role that serves it, and two
-	// roles re-resolving one calendar answer would report the same lapse twice.
-	//
-	// After the pool rather than before it, which it used to be: an installation
-	// that has sealed its token holds it in the key vault, and the vault is a
-	// table. The check is placed after AssertRuntimeRole so a pool connecting as
-	// the wrong role fails as that rather than as a license nobody can read.
-	if err := ensureLicense(ctx, logger, pool, deployCfg, cfg.posture); err != nil {
-		return err
-	}
-
 	// Before this role does ANY work: a worker from a different release than the
 	// one this installation records is half of a torn tag pull, and it stops
 	// rather than run the outbox relay, the retention evaluator and the agent
@@ -102,6 +89,22 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// (compose/releaseversion.go carries why). Ahead of the composition record
 	// below, because a role that must not run must not write either.
 	if err := compose.AssertInstallationRelease(ctx, pool, logger, buildinfo.ReleaseVersion); err != nil {
+		return err
+	}
+
+	// Before this role does any work, so an operator mistake never leaves a
+	// worker running on a license the api refuses to boot on. The RUNNING
+	// posture is the api's to watch: it is the role that serves it, and two
+	// roles re-resolving one calendar answer would report the same lapse twice.
+	//
+	// After the pool rather than before it, which it used to be: an installation
+	// that has sealed its token holds it in the key vault, and the vault is a
+	// table. That makes this a WRITE — the first boot to resolve a declared
+	// token seals it and stamps an audit row — so it also has to sit after the
+	// release assertion above, which exists to stop a role that must not run
+	// from writing. AssertRuntimeRole comes earlier still, so a pool connecting
+	// as the wrong role fails as that rather than as a license nobody can read.
+	if err := ensureLicense(ctx, logger, pool, deployCfg, cfg.posture); err != nil {
 		return err
 	}
 

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -27,6 +27,7 @@ import (
 	// build/composition/ in a composed build, the committed vanilla stub
 	// in a bare one — same import path either way.
 	"github.com/gradionhq/margince/composition"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
@@ -35,8 +36,10 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/buildinfo"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 	"github.com/gradionhq/margince/backend/pkg/extension"
 )
 
@@ -66,15 +69,6 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	cfg, deployCfg, logger := boot.cfg, boot.deploy, boot.log
 	config.WarnUndeclared(logger, cfg.unknownVars)
 
-	// Before a pool exists, because the license needs no database and an
-	// operator mistake must not leave a worker running on a license the api
-	// refuses to boot on. The RUNNING posture is the api's to watch: it is the
-	// role that serves it, and two roles re-resolving one calendar answer would
-	// report the same lapse twice.
-	if _, err := compose.EnsureLicense(ctx, logger, deployCfg, cfg.posture, config.FromOS); err != nil {
-		return err
-	}
-
 	pool, err := database.NewPool(ctx, cfg.dsn)
 	if err != nil {
 		return err
@@ -85,6 +79,19 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// does not bind serves every tenant's rows to every job, and nothing later
 	// in this boot would say so.
 	if err := compose.AssertRuntimeRole(ctx, pool); err != nil {
+		return err
+	}
+
+	// Before this role does any work, so an operator mistake never leaves a
+	// worker running on a license the api refuses to boot on. The RUNNING
+	// posture is the api's to watch: it is the role that serves it, and two
+	// roles re-resolving one calendar answer would report the same lapse twice.
+	//
+	// After the pool rather than before it, which it used to be: an installation
+	// that has sealed its token holds it in the key vault, and the vault is a
+	// table. The check is placed after AssertRuntimeRole so a pool connecting as
+	// the wrong role fails as that rather than as a license nobody can read.
+	if err := ensureLicense(ctx, logger, pool, deployCfg, cfg.posture); err != nil {
 		return err
 	}
 
@@ -290,4 +297,20 @@ func runGroupSubscriber(ctx context.Context, rdb *redis.Client, group kevents.Gr
 	if err := sub.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		log.Error("subscriber "+group.Name, "err", err)
 	}
+}
+
+// ensureLicense resolves this worker's entitlement, building the key vault it
+// may have to read the token out of.
+//
+// A vault that is configured but malformed is a boot error here rather than a
+// silent fallback, the same posture every other keyvault.FromEnv site takes: an
+// installation whose root key no longer opens its own secrets has a problem
+// that outlives the license question.
+func ensureLicense(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, deployCfg deployconfig.Config, posture runtimeenv.Environment) error {
+	vault, _, err := keyvault.FromEnv(pool, config.FromOS)
+	if err != nil {
+		return fmt.Errorf("worker: keyvault: %w", err)
+	}
+	_, err = compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, posture, config.FromOS)
+	return err
 }

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -307,7 +307,7 @@ func runGroupSubscriber(ctx context.Context, rdb *redis.Client, group kevents.Gr
 // installation whose root key no longer opens its own secrets has a problem
 // that outlives the license question.
 func ensureLicense(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, deployCfg deployconfig.Config, posture runtimeenv.Environment) error {
-	vault, _, err := keyvault.FromEnv(pool, config.FromOS)
+	vault, _, err := keyvault.FromEnv(ctx, pool, config.FromOS)
 	if err != nil {
 		return fmt.Errorf("worker: keyvault: %w", err)
 	}

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -16,10 +16,13 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
 	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -609,4 +612,66 @@ func resetTestVault(t *testing.T, e *integration.Env) keyvault.Vault {
 		t.Fatalf("building the test vault: %v", err)
 	}
 	return vault
+}
+
+// TestResetKeepsTheDeploymentCredentialsSealedBeforeIt: the mirror image of the
+// purge above, and the half that is easy to lose.
+//
+// The relay password and the license token are sealed into the same vault, but
+// their refs live in `setting` rather than in a `credential_ref` column, so the
+// purge never collects them — which is correct, because those two must SURVIVE
+// a reset. A reset returns the installation to first-boot state without
+// re-creating it, and an installation that came back without its license would
+// refuse to serve in production over a wipe that was supposed to be routine.
+//
+// Both halves have to agree: `vault_secret` is in preservedResetTables and both
+// entries are marked AsInstallationIdentity. Dropping either marker leaves a ref
+// pointing at nothing or a blob nobody names, and neither failure is visible
+// until the next boot.
+func TestResetKeepsTheDeploymentCredentialsSealedBeforeIt(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+
+	vault := resetTestVault(t, e)
+	wsID := ids.From[ids.WorkspaceKind](e.WS)
+	// Sealed through the real boot path, not by hand. No seeded role holds
+	// license:update — that is the point of the entry — so a hand-written row
+	// would need a principal the product never uses, and would prove nothing
+	// about the row the product actually writes.
+	cfg, err := deployconfig.Parse([]byte("version: 1\nlicense:\n  token: ${env:LICENSE_TOKEN}\n"))
+	if err != nil {
+		t.Fatalf("parsing the deployment file: %v", err)
+	}
+	source := SealedLicenseTokenSource(context.Background(), e.Pool, vault, cfg,
+		config.Static(map[string]string{"LICENSE_TOKEN": "a license token"}),
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if _, err := source(); err != nil {
+		t.Fatalf("sealing the credential under test: %v", err)
+	}
+	ref, err := settings.Get(bootCtx(context.Background(), e.WS, secretSealActor), NewSettingsStore(e.Pool), identity.LicenseTokenRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+
+	h := dataResetHandlers{
+		pool:             e.Pool,
+		seeds:            deployconfig.Seeds{},
+		dataResetAllowed: true,
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		vault:            vault,
+	}
+	if _, err := h.run(ctx, "Authz"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	after, err := settings.Get(bootCtx(context.Background(), e.WS, secretSealActor), NewSettingsStore(e.Pool), identity.LicenseTokenRef)
+	if err != nil {
+		t.Fatalf("reading the ref after the reset: %v", err)
+	}
+	if after != ref {
+		t.Fatalf("the reset left the license ref as %q, want the sealed ref — the next boot has no license", after)
+	}
+	if _, err := vault.Get(ctx, wsID, keyvault.Ref(ref)); err != nil {
+		t.Errorf("the sealed license did not survive the reset (Get returned %v) — the ref survived but points at nothing", err)
+	}
 }

--- a/backend/internal/compose/deploymentsecretseal.go
+++ b/backend/internal/compose/deploymentsecretseal.go
@@ -149,8 +149,29 @@ func (b vaultBinding) mirror(ctx context.Context, s deploymentSecret, stored, de
 		return
 	}
 	if superseded != "" {
-		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, superseded, "deployment credential rotated")
-		b.log.InfoContext(ctx, "re-sealed a rotated deployment credential into the key vault",
+		// The superseded blob is deliberately NOT destroyed, which is the
+		// opposite of what the two arms above do, and the difference is the
+		// whole point: those delete a duplicate of a value still in hand, while
+		// this one would delete a DIFFERENT credential — and once the operator
+		// has deleted the declaration, the only copy of it.
+		//
+		// Three of this design's rules compose badly here. The declaration wins;
+		// a re-seal supersedes; and after retirement the vault is the only copy.
+		// So anything that puts a wrong value in the declaration for one boot —
+		// a stale variable restored from git, a botched pipeline, a value set by
+		// whoever can edit the deploy pipeline without touching the file the
+		// operator reviews — would irreversibly destroy the real credential.
+		// Unsetting the variable does not bring it back; nothing does.
+		//
+		// The cost of keeping it is an unreferenced blob per genuine rotation,
+		// encrypted at rest and reachable by nobody, which is the benign default
+		// keyvault.Put already documents for exactly this trade.
+		//
+		// Not "rotated" in the sentence either: this arm is also reached when the
+		// sealed copy could not be READ, and telling an operator their rotation
+		// landed when the vault merely hiccuped is the wrong half to be
+		// confident about.
+		b.log.InfoContext(ctx, "re-sealed a deployment credential into the key vault; the sealed copy did not match the declaration and has been left in place",
 			"credential_name", s.name, "declared_at", s.declaredAt)
 		return
 	}
@@ -273,6 +294,12 @@ func SealedLicenseTokenSource(ctx context.Context, pool *pgxpool.Pool, vault key
 // have been sealed before. What the deployment declares is the whole answer,
 // and that is not an error — every tenant route answers 503 until the claim
 // runs, so a boot that refused here would refuse the very thing that fixes it.
+//
+// singletonWorkspace documents EnsureInstallation as having already refused a
+// multi-workspace database, and on the WORKER that is the api's doing rather
+// than this process's — the worker never calls it. ADR-0061 makes a second
+// workspace unreachable, so the precondition holds in fact; it is worth saying
+// that it holds for a reason outside this call rather than because of one.
 func sealedSecret(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, s deploymentSecret, declared string, log *slog.Logger) (string, error) {
 	if vault == nil {
 		// No vault, which — because keyvault.FromEnv refuses a boot that has

--- a/backend/internal/compose/deploymentsecretseal.go
+++ b/backend/internal/compose/deploymentsecretseal.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Moving a deployment-wide credential out of the process environment and into
+// the key vault, once, without asking the operator to do anything.
+//
+// Two credentials take this path: the outbound-relay password and the license
+// token. An installation that declares either one today keeps working and needs
+// no action — the value is sealed on the next boot and the declaration becomes
+// how the credential ARRIVED rather than where it lives. Once the boot log says
+// it is sealed, the operator may drop the variable or the file. Nothing here can
+// drop it for them: the process cannot edit its own orchestrator.
+//
+// The DECLARATION outranks the sealed copy, which is the opposite of the order
+// the BYOK provider keys take, and the difference is not an oversight. A
+// provider key has a human write path — the routing surface — so the vault has
+// to win or an admin's change would lose to a stale variable. These two have no
+// write path at all: no seeded role holds update on either entry, so the sealed
+// copy can only ever be a mirror of what the deployment declared. Reading the
+// declaration first is therefore what keeps in-place rotation working, and
+// re-sealing when it changes is what keeps the mirror honest.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// deploymentSecret is one credential's move into the vault: where its ref is
+// recorded, and what to call it when something goes wrong.
+type deploymentSecret struct {
+	// ref is the settings entry holding the vault ref.
+	ref *settings.Entry[string]
+	// name is the credential in an operator's words, for the boot log and for
+	// the refusal. "the license token", not "license_token_ref".
+	name string
+	// declaredAt is where the deployment spells the credential, so a refusal
+	// names the line to edit rather than the row to inspect.
+	declaredAt string
+}
+
+// vaultBinding is what a seal needs from the process: somewhere to put a blob,
+// somewhere to record the ref, and the workspace both are scoped to. Grouped
+// because every function below needs all three and none of them means anything
+// alone.
+type vaultBinding struct {
+	pool  *pgxpool.Pool
+	vault keyvault.Vault
+	ws    ids.WorkspaceID
+	log   *slog.Logger
+}
+
+// resolveSecret returns the credential this process should use, and seals it if
+// the deployment declared one that the vault does not already hold.
+//
+// A declared credential always wins, so a boot never fails on the vault while
+// the operator is still supplying the value themselves. The vault only has to
+// answer once the declaration is gone — which is exactly when a failure to open
+// it must be reported AS a vault failure, because by then it is the only copy.
+func resolveSecret(ctx context.Context, b vaultBinding, s deploymentSecret, declared string) (string, error) {
+	stored, err := settings.Get(ctx, NewSettingsStore(b.pool), s.ref)
+	if err != nil {
+		return "", fmt.Errorf("compose: reading where %s is sealed: %w", s.name, err)
+	}
+	if declared != "" {
+		b.mirror(ctx, s, stored, declared)
+		return declared, nil
+	}
+	if stored == "" {
+		return "", nil
+	}
+	return b.open(ctx, s, stored)
+}
+
+// open reads a sealed credential, and says so in the operator's terms when it
+// cannot.
+//
+// This refusal is the whole reason the sealed copy is safe to depend on. Once
+// the declaration is gone the vault holds the only copy, so a vault this process
+// cannot reach is not "no license configured" or "no relay password" — it is a
+// credential that exists and is out of reach, which is a different problem with
+// a different fix. Reporting it as absence would send an operator looking for a
+// token they were already issued.
+func (b vaultBinding) open(ctx context.Context, s deploymentSecret, stored string) (string, error) {
+	secret, err := b.vault.Get(ctx, b.ws, keyvault.Ref(stored))
+	if err != nil {
+		return "", fmt.Errorf("compose: %s is sealed in the key vault and cannot be opened: %w — "+
+			"check the vault root key is the one this installation sealed with", s.name, err)
+	}
+	if len(secret) == 0 {
+		return "", fmt.Errorf("compose: %s is sealed in the key vault but the sealed value is empty — "+
+			"re-declare the credential at %s so it is sealed again", s.name, s.declaredAt)
+	}
+	return string(secret), nil
+}
+
+// mirror keeps the sealed copy equal to what the deployment declares.
+//
+// Best-effort on purpose: the declared value is already in hand and this process
+// runs on it whatever happens here, so a vault that refuses must not cost the
+// installation its boot. What it costs instead is a log line, which is the only
+// thing that tells an operator the variable is not yet safe to remove.
+func (b vaultBinding) mirror(ctx context.Context, s deploymentSecret, stored, declared string) {
+	if stored != "" {
+		if sealed, err := b.vault.Get(ctx, b.ws, keyvault.Ref(stored)); err == nil && string(sealed) == declared {
+			return
+		}
+		// Either the sealed copy has gone stale against a rotated declaration or
+		// it cannot be read at all. Both are repaired the same way — seal the
+		// value in hand and repoint the row at it — and the old blob is then
+		// unreferenced, so it goes.
+	}
+	ref, err := b.vault.Put(ctx, b.ws, []byte(declared))
+	if err != nil {
+		b.log.ErrorContext(ctx, "cannot seal a deployment credential into the key vault; it stays in the deployment configuration for now",
+			"credential_name", s.name, "declared_at", s.declaredAt, "error", err)
+		return
+	}
+	if err := settings.Set(ctx, NewSettingsStore(b.pool), s.ref, string(ref)); err != nil {
+		// The blob is sealed and nothing references it — inert, encrypted at
+		// rest, collected by nobody. Loud, because a stranded secret is not a
+		// non-event, and delete it rather than leave it for the next boot to
+		// strand another.
+		b.log.ErrorContext(ctx, "a sealed deployment credential could not be recorded; the deployment configuration is still the source",
+			"credential_name", s.name, "declared_at", s.declaredAt, "error", err)
+		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, ref, "deployment credential seal failed")
+		return
+	}
+	if stored != "" {
+		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, keyvault.Ref(stored), "deployment credential rotated")
+		b.log.InfoContext(ctx, "re-sealed a rotated deployment credential into the key vault",
+			"credential_name", s.name, "declared_at", s.declaredAt)
+		return
+	}
+	// The one sentence that tells an operator they may now drop the declaration.
+	b.log.InfoContext(ctx, "sealed a deployment credential into the key vault; the deployment configuration that carried it can be removed",
+		"credential_name", s.name, "declared_at", s.declaredAt)
+}
+
+// secretSealActor names the boot in the audit trail when a credential's ref row
+// is written. Distinct from the routing seed's actor: the two write different
+// settings for different reasons, and an audit row that could not tell them
+// apart would be the only record either one leaves.
+const secretSealActor = "deployment-secret-seal"
+
+// smtpPassword and licenseToken are the two credentials that take this path.
+var (
+	smtpPassword = deploymentSecret{
+		ref:        identity.SMTPPasswordRef,
+		name:       "the outbound-mail password",
+		declaredAt: "email.smtp.password",
+	}
+	licenseToken = deploymentSecret{
+		ref:        identity.LicenseTokenRef,
+		name:       "the license token",
+		declaredAt: "license.token",
+	}
+)
+
+// SealedSMTPPassword resolves the relay credential the mailer authenticates
+// with, sealing whatever the deployment declared.
+//
+// An empty result is an unauthenticated relay, which is a posture rather than a
+// mistake: it is what an installation that names no password has always had.
+func SealedSMTPPassword(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, cfg deployconfig.Config, lookup config.Lookup, log *slog.Logger) (string, error) {
+	declared, err := cfg.Email.SMTPPassword(lookup)
+	if err != nil {
+		return "", err
+	}
+	return sealedSecret(ctx, pool, vault, smtpPassword, declared, log)
+}
+
+// SealedLicenseTokenSource is the license watcher's token source, reading the
+// vault where the deployment no longer declares one.
+//
+// A SOURCE rather than a token, because the watcher re-reads it: a license the
+// operator renews in place takes effect on the next re-check instead of waiting
+// for a restart, and re-reading is also what keeps the sealed mirror current
+// when they renew it that way.
+func SealedLicenseTokenSource(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, cfg deployconfig.Config, lookup config.Lookup, log *slog.Logger) func() (string, error) {
+	declared := cfg.License.TokenSource(lookup)
+	return func() (string, error) {
+		token, err := declared()
+		if err != nil {
+			return "", err
+		}
+		return sealedSecret(ctx, pool, vault, licenseToken, token, log)
+	}
+}
+
+// sealedSecret binds the boot principal and hands off to resolveSecret.
+//
+// An unprovisioned installation (ADR-0105: claimed but not yet bootstrapped)
+// has no workspace, so there is nowhere to seal a credential TO and nothing can
+// have been sealed before. What the deployment declares is the whole answer,
+// and that is not an error — every tenant route answers 503 until the claim
+// runs, so a boot that refused here would refuse the very thing that fixes it.
+func sealedSecret(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, s deploymentSecret, declared string, log *slog.Logger) (string, error) {
+	if vault == nil {
+		// No vault in this process: nothing here can seal a credential and
+		// nothing here can open one, so what the deployment declares is the
+		// whole answer — and saying so costs no database read, which is what
+		// keeps a license resolvable before a pool exists.
+		//
+		// An installation that HAS sealed credentials and then lost its vault
+		// root key is a real incident this cannot see, and it is not this
+		// function's to catch: every sealed credential the installation holds is
+		// equally unreachable, connector tokens included, so the check belongs
+		// at the vault's own wiring rather than at each of its readers.
+		return declared, nil
+	}
+	ws, err := singletonWorkspace(ctx, pool)
+	if err != nil {
+		return "", err
+	}
+	if ws == (ids.UUID{}) {
+		return declared, nil
+	}
+	b := vaultBinding{pool: pool, vault: vault, ws: ids.From[ids.WorkspaceKind](ws), log: log}
+	return resolveSecret(bootCtx(ctx, ws, secretSealActor), b, s, declared)
+}

--- a/backend/internal/compose/deploymentsecretseal.go
+++ b/backend/internal/compose/deploymentsecretseal.go
@@ -10,8 +10,12 @@ package compose
 // token. An installation that declares either one today keeps working and needs
 // no action — the value is sealed on the next boot and the declaration becomes
 // how the credential ARRIVED rather than where it lives. Once the boot log says
-// it is sealed, the operator may drop the variable or the file. Nothing here can
-// drop it for them: the process cannot edit its own orchestrator.
+// it is sealed, the operator may delete the declaration: the whole `license:`
+// block, or the `password:` line under `email.smtp`. Deleting only what it
+// points AT is not the same thing and fails the boot in deployconfig — a named
+// source that yields nothing has always been an error there, not an absence.
+// Nothing here can delete it for them: the process cannot edit its own
+// deployment.
 //
 // The DECLARATION outranks the sealed copy, which is the opposite of the order
 // the BYOK provider keys take, and the difference is not an oversight. A
@@ -27,6 +31,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
@@ -112,22 +117,20 @@ func (b vaultBinding) open(ctx context.Context, s deploymentSecret, stored strin
 // installation its boot. What it costs instead is a log line, which is the only
 // thing that tells an operator the variable is not yet safe to remove.
 func (b vaultBinding) mirror(ctx context.Context, s deploymentSecret, stored, declared string) {
-	if stored != "" {
-		if sealed, err := b.vault.Get(ctx, b.ws, keyvault.Ref(stored)); err == nil && string(sealed) == declared {
-			return
-		}
-		// Either the sealed copy has gone stale against a rotated declaration or
-		// it cannot be read at all. Both are repaired the same way — seal the
-		// value in hand and repoint the row at it — and the old blob is then
-		// unreferenced, so it goes.
+	if stored != "" && b.opensTo(ctx, stored, declared) {
+		return
 	}
+	// Either nothing is sealed, or the sealed copy has gone stale against a
+	// rotated declaration, or it cannot be read at all. All three are repaired
+	// the same way: seal the value in hand and repoint the row at it.
 	ref, err := b.vault.Put(ctx, b.ws, []byte(declared))
 	if err != nil {
 		b.log.ErrorContext(ctx, "cannot seal a deployment credential into the key vault; it stays in the deployment configuration for now",
 			"credential_name", s.name, "declared_at", s.declaredAt, "error", err)
 		return
 	}
-	if err := settings.Set(ctx, NewSettingsStore(b.pool), s.ref, string(ref)); err != nil {
+	superseded, err := b.record(ctx, s, ref, declared)
+	if err != nil {
 		// The blob is sealed and nothing references it — inert, encrypted at
 		// rest, collected by nobody. Loud, because a stranded secret is not a
 		// non-event, and delete it rather than leave it for the next boot to
@@ -137,15 +140,79 @@ func (b vaultBinding) mirror(ctx context.Context, s deploymentSecret, stored, de
 		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, ref, "deployment credential seal failed")
 		return
 	}
-	if stored != "" {
-		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, keyvault.Ref(stored), "deployment credential rotated")
+	if superseded == ref {
+		// Another role sealed the same value between this one's read and its
+		// write, and won. Its blob is the one the row names; the blob sealed
+		// here is the duplicate, and deleting it is the whole reason record()
+		// reports which ref lost rather than just whether the write happened.
+		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, ref, "deployment credential sealed twice concurrently")
+		return
+	}
+	if superseded != "" {
+		keyvault.DeleteDetached(ctx, b.vault, b.log, b.ws.UUID, superseded, "deployment credential rotated")
 		b.log.InfoContext(ctx, "re-sealed a rotated deployment credential into the key vault",
 			"credential_name", s.name, "declared_at", s.declaredAt)
 		return
 	}
-	// The one sentence that tells an operator they may now drop the declaration.
-	b.log.InfoContext(ctx, "sealed a deployment credential into the key vault; the deployment configuration that carried it can be removed",
+	// The one sentence that tells an operator they may now delete the
+	// declaration — the whole `license:` block, or the `password:` line.
+	b.log.InfoContext(ctx, "sealed a deployment credential into the key vault; the deployment configuration that declared it can be deleted",
 		"credential_name", s.name, "declared_at", s.declaredAt)
+}
+
+// opensTo reports whether the recorded ref already holds this exact value, so a
+// boot that has nothing to do does nothing at all — no second blob, no second
+// audit row.
+func (b vaultBinding) opensTo(ctx context.Context, stored, declared string) bool {
+	sealed, err := b.vault.Get(ctx, b.ws, keyvault.Ref(stored))
+	return err == nil && string(sealed) == declared
+}
+
+// record points the ref row at a freshly sealed blob and reports which ref is
+// now unreferenced — the previous one on a rotation, the NEW one when another
+// role won the race, and empty when this was the first seal.
+//
+// The read and the write are one transaction under the advisory lock the
+// settings writer itself takes, which is what makes the answer trustworthy. Two
+// serving roles boot together on a normal install — `make dev` starts both —
+// and without the lock each reads "nothing sealed", each seals its own blob,
+// and the loser's ciphertext is stranded in a table no sweeper walks. The lock
+// is per-key and re-entrant within the transaction, so SetTx re-taking it below
+// costs nothing.
+func (b vaultBinding) record(ctx context.Context, s deploymentSecret, ref keyvault.Ref, declared string) (superseded keyvault.Ref, err error) {
+	store := NewSettingsStore(b.pool)
+	err = store.WriteTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, s.ref.Key()); err != nil {
+			return fmt.Errorf("compose: serializing the seal of %s: %w", s.name, err)
+		}
+		current, err := settings.GetTx(ctx, tx, s.ref)
+		if err != nil {
+			return err
+		}
+		if current != "" && b.sealedOnTxEquals(ctx, tx, current, declared) {
+			// Somebody else recorded this same value while this role was
+			// sealing. Theirs stands; ours is the spare.
+			superseded = ref
+			return nil
+		}
+		if err := settings.SetTx(ctx, store, tx, s.ref, string(ref)); err != nil {
+			return err
+		}
+		superseded = keyvault.Ref(current)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return superseded, nil
+}
+
+// sealedOnTxEquals opens a ref through the caller's own transaction, so the
+// comparison sees the same snapshot the lock is protecting rather than a second
+// one taken from the pool behind it.
+func (b vaultBinding) sealedOnTxEquals(ctx context.Context, tx pgx.Tx, ref, want string) bool {
+	sealed, err := b.vault.GetOn(ctx, tx, b.ws, keyvault.Ref(ref))
+	return err == nil && string(sealed) == want
 }
 
 // secretSealActor names the boot in the audit trail when a credential's ref row
@@ -208,16 +275,15 @@ func SealedLicenseTokenSource(ctx context.Context, pool *pgxpool.Pool, vault key
 // runs, so a boot that refused here would refuse the very thing that fixes it.
 func sealedSecret(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, s deploymentSecret, declared string, log *slog.Logger) (string, error) {
 	if vault == nil {
-		// No vault in this process: nothing here can seal a credential and
-		// nothing here can open one, so what the deployment declares is the
-		// whole answer — and saying so costs no database read, which is what
-		// keeps a license resolvable before a pool exists.
+		// No vault, which — because keyvault.FromEnv refuses a boot that has
+		// sealed secrets and no root key — also means this installation has
+		// sealed nothing. So there is no ref to find, the declaration is the
+		// whole answer, and saying so costs no database read.
 		//
-		// An installation that HAS sealed credentials and then lost its vault
-		// root key is a real incident this cannot see, and it is not this
-		// function's to catch: every sealed credential the installation holds is
-		// equally unreachable, connector tokens included, so the check belongs
-		// at the vault's own wiring rather than at each of its readers.
+		// That refusal is what makes this safe, rather than an assumption made
+		// here: without it a root key dropped in a redeploy would arrive at this
+		// line with a recorded ref nobody looked for, and a production boot
+		// would call an installation that has a license unlicensed.
 		return declared, nil
 	}
 	ws, err := singletonWorkspace(ctx, pool)

--- a/backend/internal/compose/integration/deploymentsecretseal_integration_test.go
+++ b/backend/internal/compose/integration/deploymentsecretseal_integration_test.go
@@ -18,9 +18,11 @@ package integration
 // license as having none.
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
@@ -69,6 +71,47 @@ func licenseConfig(t *testing.T, tokenVar string) deployconfig.Config {
 // something about a caller the product does not have.
 func sealCtx() context.Context { return context.Background() }
 
+// realVault is the LOCAL provider over the harness pool, not keyvault.NewMemory.
+//
+// The memory provider's GetOn ignores the querier it is handed, and the seal
+// path's one in-transaction read — sealedOnTxEquals, the whole mechanism the
+// concurrency fix rests on — is exactly a GetOn through a borrowed transaction.
+// Against the fake, swapping it back to a pool read would pass every case here
+// and deadlock a one-connection pool in production. The root key is fixed and
+// meaningless; these tests assert reachability, never key management.
+func realVault(t *testing.T, e *Env) keyvault.Vault {
+	t.Helper()
+	vault, err := keyvault.New(keyvault.Config{RootKey: bytes.Repeat([]byte{9}, 32), Pool: e.Pool})
+	if err != nil {
+		t.Fatalf("building the test vault: %v", err)
+	}
+	return vault
+}
+
+// differentVault is the same table under a DIFFERENT root key — which is what a
+// key rotated or lost in a redeploy looks like from the reading process: the
+// ciphertext is all still there and none of it opens.
+func differentVault(t *testing.T, e *Env) keyvault.Vault {
+	t.Helper()
+	vault, err := keyvault.New(keyvault.Config{RootKey: bytes.Repeat([]byte{4}, 32), Pool: e.Pool})
+	if err != nil {
+		t.Fatalf("building the test vault: %v", err)
+	}
+	return vault
+}
+
+// sealedBlobCount is the evidence for "exactly one copy survives". vault_secret
+// carries no workspace_id, and the harness gives each test its own database, so
+// a plain count is the honest question.
+func sealedBlobCount(t *testing.T, e *Env) int {
+	t.Helper()
+	var n int
+	if err := e.Pool.QueryRow(context.Background(), `SELECT count(*) FROM vault_secret`).Scan(&n); err != nil {
+		t.Fatalf("counting sealed blobs: %v", err)
+	}
+	return n
+}
+
 // readCtx reads the ref rows back as an admin. Only the test does this — no
 // product surface returns either row — so it exists to assert the ref was
 // RECORDED, which a ref held in memory would not be.
@@ -89,7 +132,7 @@ func readCtx(ws ids.UUID) context.Context {
 
 func TestTheRelayPasswordIsSealedAndAnsweredFromTheVaultOnceTheDeclarationIsGone(t *testing.T) {
 	e := Setup(t)
-	vault := keyvault.NewMemory()
+	vault := realVault(t, e)
 	log := slog.New(slog.DiscardHandler)
 	env := config.Static(map[string]string{"SMTP_PASSWORD": "a-relay-password"})
 
@@ -125,7 +168,7 @@ func TestTheRelayPasswordIsSealedAndAnsweredFromTheVaultOnceTheDeclarationIsGone
 // same secret and strands the previous one.
 func TestASecondBootRepointsNothing(t *testing.T) {
 	e := Setup(t)
-	vault := keyvault.NewMemory()
+	vault := realVault(t, e)
 	log := slog.New(slog.DiscardHandler)
 	env := config.Static(map[string]string{"SMTP_PASSWORD": "a-relay-password"})
 	cfg := mailConfig(t, "SMTP_PASSWORD")
@@ -154,7 +197,7 @@ func TestASecondBootRepointsNothing(t *testing.T) {
 // drop the declaration — which is the boot that has no other copy.
 func TestARotatedDeclarationIsResealed(t *testing.T) {
 	e := Setup(t)
-	vault := keyvault.NewMemory()
+	vault := realVault(t, e)
 	log := slog.New(slog.DiscardHandler)
 	cfg := mailConfig(t, "SMTP_PASSWORD")
 
@@ -179,11 +222,15 @@ func TestARotatedDeclarationIsResealed(t *testing.T) {
 	if after != "the-new-password" {
 		t.Errorf("the vault still answers %q after the deployment rotated the password", after)
 	}
-	// The superseded blob is destroyed, not merely unreferenced. Leaving it is
-	// how a rotation quietly turns into two copies of a credential, one of them
-	// the value the operator rotated AWAY from and nobody is watching.
-	if _, err := vault.Get(sealCtx(), ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(superseded)); err == nil {
-		t.Error("the rotated-away password is still readable from the vault; a re-seal must destroy what it supersedes")
+	// The superseded blob SURVIVES, and that is the deliberate answer rather
+	// than an omission. A re-seal is triggered by the declaration alone, and the
+	// declaration is the thing a stale variable or a botched pipeline gets
+	// wrong; destroying what it supersedes would let one bad boot irreversibly
+	// destroy the installation's only copy of a credential it never meant to
+	// replace. An unreferenced blob is encrypted at rest and reachable by
+	// nobody, which is the cheaper of the two failures by a wide margin.
+	if _, err := vault.Get(sealCtx(), ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(superseded)); err != nil {
+		t.Errorf("the superseded password is gone from the vault (%v); a re-seal must not destroy a credential the declaration merely disagreed with", err)
 	}
 }
 
@@ -196,7 +243,7 @@ func TestAnUnopenableVaultNamesItselfRatherThanReportingNoLicense(t *testing.T) 
 	log := slog.New(slog.DiscardHandler)
 	cfg := licenseConfig(t, "LICENSE_TOKEN")
 
-	sealed := keyvault.NewMemory()
+	sealed := realVault(t, e)
 	source := compose.SealedLicenseTokenSource(sealCtx(), e.Pool, sealed, cfg,
 		config.Static(map[string]string{"LICENSE_TOKEN": "a-license-token"}), log)
 	if _, err := source(); err != nil {
@@ -205,7 +252,7 @@ func TestAnUnopenableVaultNamesItselfRatherThanReportingNoLicense(t *testing.T) 
 
 	// A different vault is what a rotated or dropped root key looks like from
 	// here: the ref is recorded and refers to nothing this process can open.
-	lost := compose.SealedLicenseTokenSource(sealCtx(), e.Pool, keyvault.NewMemory(), licenseConfig(t, ""), config.Static(nil), log)
+	lost := compose.SealedLicenseTokenSource(sealCtx(), e.Pool, differentVault(t, e), licenseConfig(t, ""), config.Static(nil), log)
 	_, err := lost()
 	if err == nil {
 		t.Fatal("a vault that cannot open the sealed license reported no license at all")
@@ -214,5 +261,98 @@ func TestAnUnopenableVaultNamesItselfRatherThanReportingNoLicense(t *testing.T) 
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("the refusal %q does not name %q", err, want)
 		}
+	}
+}
+
+// Two roles booting at once. `make dev` starts the api and the worker together,
+// so the first boot of a keyvault-enabled installation runs this race for real:
+// both see nothing sealed, both seal, and without the lock the loser's
+// ciphertext is stranded in a table no sweeper walks.
+//
+// The assertion is the BLOB COUNT, not the ref. A fix that recorded one ref
+// while leaving two blobs behind looks identical from the setting row alone,
+// and it is the stranded ciphertext that is the defect.
+func TestTwoRolesSealingAtOnceLeaveExactlyOneCopy(t *testing.T) {
+	e := Setup(t)
+	vault := realVault(t, e)
+	log := slog.New(slog.DiscardHandler)
+	cfg := mailConfig(t, "SMTP_PASSWORD")
+	env := config.Static(map[string]string{"SMTP_PASSWORD": "a-relay-password"})
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, cfg, env, log)
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("role %d: %v", i, err)
+		}
+	}
+
+	// One, not two: the losing role deletes the duplicate it just sealed. This
+	// is the case where deleting IS right — the value is still in hand and
+	// another copy of the very same bytes is the one the row names — and it is
+	// the opposite of the rotation case above, which keeps what it supersedes.
+	if got := sealedBlobCount(t, e); got != 1 {
+		t.Errorf("%d sealed blobs after two roles sealed one credential, want 1 — the loser's copy is stranded", got)
+	}
+	// And the one that survived is the one the row names.
+	ref, err := settings.Get(readCtx(e.WS), compose.NewSettingsStore(e.Pool), identity.SMTPPasswordRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+	opened, err := vault.Get(sealCtx(), ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(ref))
+	if err != nil {
+		t.Fatalf("the recorded ref does not open: %v", err)
+	}
+	if string(opened) != "a-relay-password" {
+		t.Errorf("the recorded ref opens to %q, want the sealed password", opened)
+	}
+}
+
+// The ledger records that a credential was sealed, never where it went.
+//
+// A ref is not the secret, but it is the unguessable capability half of the
+// handle — which is why the vault strips it from every error it raises and why
+// the data reset refuses to name one in a log. audit_log is a log sink like any
+// other: admin-readable over /audit-log and exportable. Careful everywhere else
+// and verbatim here is careful nowhere.
+func TestTheLedgerRecordsTheSealWithoutTheAddress(t *testing.T) {
+	e := Setup(t)
+	vault := realVault(t, e)
+	log := slog.New(slog.DiscardHandler)
+
+	if _, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, mailConfig(t, "SMTP_PASSWORD"),
+		config.Static(map[string]string{"SMTP_PASSWORD": "a-relay-password"}), log); err != nil {
+		t.Fatalf("sealing the relay password: %v", err)
+	}
+
+	ref, err := settings.Get(readCtx(e.WS), compose.NewSettingsStore(e.Pool), identity.SMTPPasswordRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+	if ref == "" {
+		t.Fatal("nothing was sealed; the assertion below would pass vacuously")
+	}
+
+	var rows int
+	if err := e.Pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM audit_log WHERE after::text LIKE '%' || $1 || '%' OR before::text LIKE '%' || $1 || '%'`,
+		ref).Scan(&rows); err != nil {
+		t.Fatalf("scanning the ledger: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("%d audit row(s) carry the vault ref verbatim; the ledger records that the seal changed, not its address", rows)
+	}
+	// And the event itself is still on the record — a redaction that audited
+	// nothing would pass the assertion above while losing the row that matters.
+	if got := e.WsCount(t, `SELECT count(*) FROM audit_log WHERE action = $1`, identity.SMTPPasswordRef.AuditVerb()); got == 0 {
+		t.Error("the seal left no audit row at all; redacting the address must not cost the event")
 	}
 }

--- a/backend/internal/compose/integration/deploymentsecretseal_integration_test.go
+++ b/backend/internal/compose/integration/deploymentsecretseal_integration_test.go
@@ -162,6 +162,11 @@ func TestARotatedDeclarationIsResealed(t *testing.T) {
 		config.Static(map[string]string{"SMTP_PASSWORD": "the-old-password"}), log); err != nil {
 		t.Fatalf("first boot: %v", err)
 	}
+	superseded, err := settings.Get(readCtx(e.WS), compose.NewSettingsStore(e.Pool), identity.SMTPPasswordRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+
 	if _, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, cfg,
 		config.Static(map[string]string{"SMTP_PASSWORD": "the-new-password"}), log); err != nil {
 		t.Fatalf("boot after rotation: %v", err)
@@ -173,6 +178,12 @@ func TestARotatedDeclarationIsResealed(t *testing.T) {
 	}
 	if after != "the-new-password" {
 		t.Errorf("the vault still answers %q after the deployment rotated the password", after)
+	}
+	// The superseded blob is destroyed, not merely unreferenced. Leaving it is
+	// how a rotation quietly turns into two copies of a credential, one of them
+	// the value the operator rotated AWAY from and nobody is watching.
+	if _, err := vault.Get(sealCtx(), ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(superseded)); err == nil {
+		t.Error("the rotated-away password is still readable from the vault; a re-seal must destroy what it supersedes")
 	}
 }
 

--- a/backend/internal/compose/integration/deploymentsecretseal_integration_test.go
+++ b/backend/internal/compose/integration/deploymentsecretseal_integration_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The two deployment credentials leaving the process environment, against a
+// real database.
+//
+// Four things need one and none can be shown with a unit test: that the ref is
+// actually recorded, so the boot after the operator drops the declaration finds
+// the credential rather than nothing; that sealing is idempotent, or every
+// restart strands another copy of the same secret; that a rotated declaration
+// re-seals rather than leaving the vault holding a stale credential nobody will
+// notice until the declaration is gone; and that a vault which cannot open what
+// it holds says exactly that, instead of reporting an installation with a
+// license as having none.
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// mailConfig is a deployment that declares a relay password as a reference,
+// parsed through the real decoder rather than assembled field by field: Secret
+// refuses a literal at decode time, so a hand-built one would be a shape the
+// product never produces.
+func mailConfig(t *testing.T, passwordVar string) deployconfig.Config {
+	t.Helper()
+	body := "version: 1\nemail:\n  enabled: true\n  from_address: ops@example.test\n  smtp:\n    host: relay.example.test\n    port: 587\n    username: margince\n"
+	if passwordVar != "" {
+		body += "    password: ${env:" + passwordVar + "}\n"
+	}
+	cfg, err := deployconfig.Parse([]byte(body))
+	if err != nil {
+		t.Fatalf("parsing the deployment file: %v", err)
+	}
+	return cfg
+}
+
+// licenseConfig is a deployment that names its license token in a variable.
+func licenseConfig(t *testing.T, tokenVar string) deployconfig.Config {
+	t.Helper()
+	body := "version: 1\n"
+	if tokenVar != "" {
+		body += "license:\n  token: ${env:" + tokenVar + "}\n"
+	}
+	cfg, err := deployconfig.Parse([]byte(body))
+	if err != nil {
+		t.Fatalf("parsing the deployment file: %v", err)
+	}
+	return cfg
+}
+
+// sealCtx is the boot's own context: no principal at all, because the seal path
+// binds its own system actor. A test that supplied an admin would be proving
+// something about a caller the product does not have.
+func sealCtx() context.Context { return context.Background() }
+
+// readCtx reads the ref rows back as an admin. Only the test does this — no
+// product surface returns either row — so it exists to assert the ref was
+// RECORDED, which a ref held in memory would not be.
+func readCtx(ws ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"installation_settings": {Read: true, Update: true},
+				"license":               {Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+func TestTheRelayPasswordIsSealedAndAnsweredFromTheVaultOnceTheDeclarationIsGone(t *testing.T) {
+	e := Setup(t)
+	vault := keyvault.NewMemory()
+	log := slog.New(slog.DiscardHandler)
+	env := config.Static(map[string]string{"SMTP_PASSWORD": "a-relay-password"})
+
+	got, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, mailConfig(t, "SMTP_PASSWORD"), env, log)
+	if err != nil {
+		t.Fatalf("sealing the relay password: %v", err)
+	}
+	if got != "a-relay-password" {
+		t.Fatalf("resolved %q while the deployment still declares the password", got)
+	}
+
+	// Recorded, not merely sealed.
+	ref, err := settings.Get(readCtx(e.WS), compose.NewSettingsStore(e.Pool), identity.SMTPPasswordRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+	if ref == "" {
+		t.Fatal("the relay password was resolved but no vault ref was recorded; the next boot would seal a second copy")
+	}
+
+	// The boot after the operator drops the variable: nothing is declared, and
+	// the sealed copy is the only one left.
+	after, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, mailConfig(t, ""), config.Static(nil), log)
+	if err != nil {
+		t.Fatalf("reading the sealed relay password: %v", err)
+	}
+	if after != "a-relay-password" {
+		t.Errorf("the vault answered %q, want the sealed password", after)
+	}
+}
+
+// Idempotent across boots. Without this every restart seals another copy of the
+// same secret and strands the previous one.
+func TestASecondBootRepointsNothing(t *testing.T) {
+	e := Setup(t)
+	vault := keyvault.NewMemory()
+	log := slog.New(slog.DiscardHandler)
+	env := config.Static(map[string]string{"SMTP_PASSWORD": "a-relay-password"})
+	cfg := mailConfig(t, "SMTP_PASSWORD")
+
+	if _, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, cfg, env, log); err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+	first, err := settings.Get(readCtx(e.WS), compose.NewSettingsStore(e.Pool), identity.SMTPPasswordRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+	if _, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, cfg, env, log); err != nil {
+		t.Fatalf("second boot: %v", err)
+	}
+	second, err := settings.Get(readCtx(e.WS), compose.NewSettingsStore(e.Pool), identity.SMTPPasswordRef)
+	if err != nil {
+		t.Fatalf("reading the recorded ref: %v", err)
+	}
+	if first != second {
+		t.Errorf("a boot that sealed nothing new repointed the ref from %q to %q; the old blob is now stranded", first, second)
+	}
+}
+
+// A credential rotated in the deployment must reach the vault, or the mirror
+// goes stale silently and the operator only discovers it on the boot after they
+// drop the declaration — which is the boot that has no other copy.
+func TestARotatedDeclarationIsResealed(t *testing.T) {
+	e := Setup(t)
+	vault := keyvault.NewMemory()
+	log := slog.New(slog.DiscardHandler)
+	cfg := mailConfig(t, "SMTP_PASSWORD")
+
+	if _, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, cfg,
+		config.Static(map[string]string{"SMTP_PASSWORD": "the-old-password"}), log); err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+	if _, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, cfg,
+		config.Static(map[string]string{"SMTP_PASSWORD": "the-new-password"}), log); err != nil {
+		t.Fatalf("boot after rotation: %v", err)
+	}
+
+	after, err := compose.SealedSMTPPassword(sealCtx(), e.Pool, vault, mailConfig(t, ""), config.Static(nil), log)
+	if err != nil {
+		t.Fatalf("reading the sealed relay password: %v", err)
+	}
+	if after != "the-new-password" {
+		t.Errorf("the vault still answers %q after the deployment rotated the password", after)
+	}
+}
+
+// The refusal this whole move turns on. Once the declaration is gone the vault
+// holds the only copy of the license, so a vault that cannot open it must say
+// THAT — an installation told it has no license goes looking for a token it was
+// already issued, and in production that refusal blocks the boot.
+func TestAnUnopenableVaultNamesItselfRatherThanReportingNoLicense(t *testing.T) {
+	e := Setup(t)
+	log := slog.New(slog.DiscardHandler)
+	cfg := licenseConfig(t, "LICENSE_TOKEN")
+
+	sealed := keyvault.NewMemory()
+	source := compose.SealedLicenseTokenSource(sealCtx(), e.Pool, sealed, cfg,
+		config.Static(map[string]string{"LICENSE_TOKEN": "a-license-token"}), log)
+	if _, err := source(); err != nil {
+		t.Fatalf("sealing the license token: %v", err)
+	}
+
+	// A different vault is what a rotated or dropped root key looks like from
+	// here: the ref is recorded and refers to nothing this process can open.
+	lost := compose.SealedLicenseTokenSource(sealCtx(), e.Pool, keyvault.NewMemory(), licenseConfig(t, ""), config.Static(nil), log)
+	_, err := lost()
+	if err == nil {
+		t.Fatal("a vault that cannot open the sealed license reported no license at all")
+	}
+	for _, want := range []string{"license token", "key vault", "root key"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal %q does not name %q", err, want)
+		}
+	}
+}

--- a/backend/internal/compose/license.go
+++ b/backend/internal/compose/license.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/licensecheck"
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
@@ -43,22 +44,53 @@ import (
 // Both serving roles ask this question, and neither serves without an answer: an
 // api that refuses to boot beside a worker that shrugs would be a licensing
 // posture nobody could describe.
-func EnsureLicense(ctx context.Context, log *slog.Logger, cfg deployconfig.Config, env runtimeenv.Environment, lookup config.Lookup) (*licensecheck.Watcher, error) {
+func EnsureLicense(ctx context.Context, log *slog.Logger, pool *pgxpool.Pool, vault keyvault.Vault, cfg deployconfig.Config, env runtimeenv.Environment, lookup config.Lookup) (*licensecheck.Watcher, error) {
 	// The SOURCE is handed over, not a token: the watcher re-reads it, so a
 	// license the operator renews in place takes effect on the next re-check
 	// instead of waiting for a restart.
-	watcher, err := licensecheck.NewWatcher(ctx, cfg.License.TokenSource(lookup), time.Now, log, env)
+	//
+	// The source reads the deployment's declaration first and the key vault
+	// where there is none, so an installation that has sealed its token and
+	// dropped the variable keeps booting — and one whose vault it cannot open
+	// is told THAT, rather than being told it has no license.
+	source := SealedLicenseTokenSource(ctx, pool, vault, cfg, lookup, log)
+	watcher, err := licensecheck.NewWatcher(ctx, source, time.Now, log, env)
 	if err != nil {
 		// The setting to correct is named HERE, where the token's source is
 		// known: platform's check is handed a token, not a configuration file.
 		return nil, fmt.Errorf("%w — correct or remove %s and start again",
-			err, cfg.License.TokenOrigin(lookup))
+			err, licenseTokenOrigin(cfg, lookup, licensecheck.Posture{}))
 	}
 	if err := refuseUnlicensedProduction(watcher.Posture(), env); err != nil {
 		return nil, err
 	}
-	logLicensePosture(ctx, log, watcher.Posture(), cfg.License.TokenOrigin(lookup))
+	logLicensePosture(ctx, log, watcher.Posture(), licenseTokenOrigin(cfg, lookup, watcher.Posture()))
 	return watcher, nil
+}
+
+// licenseTokenOrigin names where the token came from, for the boot log and for
+// the refusal that tells an operator what to correct.
+//
+// deployconfig can only speak for the deployment file and the environment; it
+// has never heard of the vault, and an installation that sealed its token and
+// dropped the declaration would otherwise be told its token came from "none" —
+// while running on one. Naming the vault is the difference between an operator
+// who knows where to look and one who goes looking in the file that no longer
+// mentions it.
+//
+// A zero Posture is the pre-verification caller: NewWatcher refused a token, so
+// one certainly exists and the vault is the only place left it can have come
+// from.
+func licenseTokenOrigin(cfg deployconfig.Config, lookup config.Lookup, posture licensecheck.Posture) string {
+	if origin := cfg.License.TokenOrigin(lookup); origin != deployconfig.TokenOriginNone {
+		return origin
+	}
+	if posture.State == licensecheck.StateAbsent {
+		// Nothing declared and nothing sealed. Naming the vault here would
+		// describe an installation that had a token, which this one does not.
+		return deployconfig.TokenOriginNone
+	}
+	return "the key vault"
 }
 
 // refuseUnlicensedProduction stops a production boot that configured no license.

--- a/backend/internal/compose/license.go
+++ b/backend/internal/compose/license.go
@@ -58,14 +58,27 @@ func EnsureLicense(ctx context.Context, log *slog.Logger, pool *pgxpool.Pool, va
 	if err != nil {
 		// The setting to correct is named HERE, where the token's source is
 		// known: platform's check is handed a token, not a configuration file.
-		return nil, fmt.Errorf("%w — correct or remove %s and start again",
-			err, licenseTokenOrigin(cfg, lookup, licensecheck.Posture{}))
+		return nil, fmt.Errorf("%w — %s", err, correctTheToken(cfg, lookup))
 	}
 	if err := refuseUnlicensedProduction(watcher.Posture(), env); err != nil {
 		return nil, err
 	}
 	logLicensePosture(ctx, log, watcher.Posture(), licenseTokenOrigin(cfg, lookup, watcher.Posture()))
 	return watcher, nil
+}
+
+// correctTheToken is the second half of a refused-license error: what to do.
+//
+// It is not one sentence for both sources. "Remove the key vault and start
+// again" — which naming the origin uniformly would produce — is advice that
+// destroys the only copy of the license along with every connector credential
+// the installation holds, to fix a token the operator can simply re-declare.
+func correctTheToken(cfg deployconfig.Config, lookup config.Lookup) string {
+	if origin := cfg.License.TokenOrigin(lookup); origin != deployconfig.TokenOriginNone {
+		return "correct or remove " + origin + " and start again"
+	}
+	return "this token came from the key vault, where it was sealed from a declaration since deleted: " +
+		"re-declare license.token and the next boot re-seals it"
 }
 
 // licenseTokenOrigin names where the token came from, for the boot log and for
@@ -76,7 +89,8 @@ func EnsureLicense(ctx context.Context, log *slog.Logger, pool *pgxpool.Pool, va
 // dropped the declaration would otherwise be told its token came from "none" —
 // while running on one. Naming the vault is the difference between an operator
 // who knows where to look and one who goes looking in the file that no longer
-// mentions it.
+// mentions it. A grep token rather than prose, because every other value of
+// this field is one.
 //
 // A zero Posture is the pre-verification caller: NewWatcher refused a token, so
 // one certainly exists and the vault is the only place left it can have come
@@ -90,7 +104,7 @@ func licenseTokenOrigin(cfg deployconfig.Config, lookup config.Lookup, posture l
 		// describe an installation that had a token, which this one does not.
 		return deployconfig.TokenOriginNone
 	}
-	return "the key vault"
+	return "keyvault"
 }
 
 // refuseUnlicensedProduction stops a production boot that configured no license.

--- a/backend/internal/compose/license.go
+++ b/backend/internal/compose/license.go
@@ -91,10 +91,6 @@ func correctTheToken(cfg deployconfig.Config, lookup config.Lookup) string {
 // who knows where to look and one who goes looking in the file that no longer
 // mentions it. A grep token rather than prose, because every other value of
 // this field is one.
-//
-// A zero Posture is the pre-verification caller: NewWatcher refused a token, so
-// one certainly exists and the vault is the only place left it can have come
-// from.
 func licenseTokenOrigin(cfg deployconfig.Config, lookup config.Lookup, posture licensecheck.Posture) string {
 	if origin := cfg.License.TokenOrigin(lookup); origin != deployconfig.TokenOriginNone {
 		return origin

--- a/backend/internal/compose/license_test.go
+++ b/backend/internal/compose/license_test.go
@@ -24,12 +24,19 @@ import (
 // token is read through that lookup, so an engineer or CI lane exporting a real
 // MARGINCE_LICENSE cannot turn an absent posture into a valid one, or make a
 // case that names a token FILE read a variable instead.
+//
+// The nil pool and nil vault are the point of a second property rather than a
+// convenience: with no vault configured there is nothing sealed to open, so the
+// declaration is the whole answer and resolving it must touch no database. A
+// change that made the license question need one would fail every case here by
+// dereferencing the pool — which is the failure to want, because a worker
+// resolves its entitlement before it will serve anything.
 
 // A production installation serves on a license or it does not serve. The whole
 // point of the gate is that this is the DEFAULT: MARGINCE_ENV is fail-closed, so
 // an installation that names no posture is held to a license.
 func TestEnsureLicenseRefusesAProductionBootWithNoLicense(t *testing.T) {
-	_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), deployconfig.Config{},
+	_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), nil, nil, deployconfig.Config{},
 		runtimeenv.Parse(""), config.Static(nil))
 	if err == nil {
 		t.Fatal("EnsureLicense booted a production installation that configured no license")
@@ -53,7 +60,7 @@ func TestEnsureLicenseBootsUnlicensedInNonProductionAndSaysSo(t *testing.T) {
 	var log bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&log, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	watcher, err := EnsureLicense(context.Background(), logger, deployconfig.Config{}, runtimeenv.Development, config.Static(nil))
+	watcher, err := EnsureLicense(context.Background(), logger, nil, nil, deployconfig.Config{}, runtimeenv.Development, config.Static(nil))
 	if err != nil {
 		t.Fatalf("EnsureLicense refused an unlicensed development installation: %v", err)
 	}
@@ -82,7 +89,7 @@ func TestEnsureLicenseRefusesTheBootOnALicenseTheModuleWillNotHonor(t *testing.T
 	cfg := deployconfig.Config{License: deployconfig.License{TokenFile: path}}
 
 	for _, env := range []runtimeenv.Environment{runtimeenv.Production, runtimeenv.Development} {
-		_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), cfg, env, config.Static(nil))
+		_, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), nil, nil, cfg, env, config.Static(nil))
 		if err == nil {
 			t.Fatalf("EnsureLicense booted a %s installation on a license the bundled module refuses", env)
 		}
@@ -104,7 +111,7 @@ func TestEnsureLicenseRefusesTheBootOnALicenseTheModuleWillNotHonor(t *testing.T
 // unlicensed installation, which is the same posture to everything downstream.
 func TestEnsureLicenseRefusesAnUnreadableTokenFile(t *testing.T) {
 	cfg := deployconfig.Config{License: deployconfig.License{TokenFile: filepath.Join(t.TempDir(), "typo")}}
-	if _, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), cfg, runtimeenv.Production, config.Static(nil)); err == nil {
+	if _, err := EnsureLicense(context.Background(), slog.New(slog.DiscardHandler), nil, nil, cfg, runtimeenv.Production, config.Static(nil)); err == nil {
 		t.Fatal("EnsureLicense booted with a token_file that does not exist")
 	}
 }
@@ -217,10 +224,37 @@ func TestAssembledMetricsSectionsOmitTheLicenseWhenNoneWasWired(t *testing.T) {
 func TestEnsureLicenseBootLineNamesTheTokenSource(t *testing.T) {
 	var log bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&log, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	if _, err := EnsureLicense(context.Background(), logger, deployconfig.Config{}, runtimeenv.Development, config.Static(nil)); err != nil {
+	if _, err := EnsureLicense(context.Background(), logger, nil, nil, deployconfig.Config{}, runtimeenv.Development, config.Static(nil)); err != nil {
 		t.Fatalf("EnsureLicense: %v", err)
 	}
 	if !strings.Contains(log.String(), "token_from=none") {
 		t.Errorf("the boot line does not name the token's source: %q", log.String())
+	}
+}
+
+// Where the token came from is half the boot line's value, and deployconfig can
+// only speak for the file and the environment. Once a token can be sealed in
+// the vault, an installation running on one would be recorded as running on
+// "none" — which reads as unlicensed to whoever greps for it.
+func TestTheTokenOriginNamesTheVaultOnlyWhenAVaultAnsweredIt(t *testing.T) {
+	declared, err := deployconfig.Parse([]byte("version: 1\nlicense:\n  token: ${env:MARGINCE_LICENSE_TOKEN}\n"))
+	if err != nil {
+		t.Fatalf("parsing the deployment file: %v", err)
+	}
+	for _, tc := range []struct {
+		name    string
+		cfg     deployconfig.Config
+		posture licensecheck.Posture
+		want    string
+	}{
+		{"a declared token names the declaration", declared, licensecheck.Posture{State: licensecheck.StateValid}, "license.token"},
+		{"nothing declared and nothing sealed is none", deployconfig.Config{}, licensecheck.Posture{State: licensecheck.StateAbsent}, "none"},
+		{"nothing declared but a token in hand came from the vault", deployconfig.Config{}, licensecheck.Posture{State: licensecheck.StateValid}, "the key vault"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := licenseTokenOrigin(tc.cfg, config.Static(nil), tc.posture); got != tc.want {
+				t.Errorf("origin %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/backend/internal/compose/license_test.go
+++ b/backend/internal/compose/license_test.go
@@ -249,7 +249,7 @@ func TestTheTokenOriginNamesTheVaultOnlyWhenAVaultAnsweredIt(t *testing.T) {
 	}{
 		{"a declared token names the declaration", declared, licensecheck.Posture{State: licensecheck.StateValid}, "license.token"},
 		{"nothing declared and nothing sealed is none", deployconfig.Config{}, licensecheck.Posture{State: licensecheck.StateAbsent}, "none"},
-		{"nothing declared but a token in hand came from the vault", deployconfig.Config{}, licensecheck.Posture{State: licensecheck.StateValid}, "the key vault"},
+		{"nothing declared but a token in hand came from the vault", deployconfig.Config{}, licensecheck.Posture{State: licensecheck.StateValid}, "keyvault"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := licenseTokenOrigin(tc.cfg, config.Static(nil), tc.posture); got != tc.want {

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -107,9 +107,16 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 // how the worker's sweeps read their settings too — the alternative would be an
 // ungated read, and `setting` has no RLS beneath that gate.
 func routingCtx(ctx context.Context, ws ids.UUID) context.Context {
+	return bootCtx(ctx, ws, routingSeedActor)
+}
+
+// bootCtx is that same binding for any boot-time settings read: the workspace,
+// a named system actor, and a correlation id, so a settings write made before
+// any request exists is still attributable to the thing that made it.
+func bootCtx(ctx context.Context, ws ids.UUID, actor string) context.Context {
 	ctx = principal.WithWorkspaceID(ctx, ws)
 	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalSystem, ID: routingSeedActor,
+		Type: principal.PrincipalSystem, ID: actor,
 	})
 	return principal.WithCorrelationID(ctx, ids.NewV7())
 }

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -48,7 +48,6 @@ var settingsDefinitions = sync.OnceValue(func() []settings.Definition {
 	defs = append(defs, ai.Definitions()...)
 	defs = append(defs, capture.Definitions()...)
 	defs = append(defs, identity.Definitions()...)
-	defs = append(defs, identity.DeploymentSecretDefinitions()...)
 	defs = append(defs, people.Definitions()...)
 	defs = append(defs, privacy.Definitions()...)
 	return defs

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -48,6 +48,7 @@ var settingsDefinitions = sync.OnceValue(func() []settings.Definition {
 	defs = append(defs, ai.Definitions()...)
 	defs = append(defs, capture.Definitions()...)
 	defs = append(defs, identity.Definitions()...)
+	defs = append(defs, identity.DeploymentSecretDefinitions()...)
 	defs = append(defs, people.Definitions()...)
 	defs = append(defs, privacy.Definitions()...)
 	return defs

--- a/backend/internal/modules/identity/deploymentsecrets.go
+++ b/backend/internal/modules/identity/deploymentsecrets.go
@@ -20,7 +20,16 @@ package identity
 // Neither has a human write path, and that is deliberate rather than
 // unfinished: the deployment still DECLARES these credentials, compose seals
 // what it declared, and these rows only record where the sealed copy went. An
-// operator rotates by changing the declaration, exactly as before.
+// operator ROTATES by changing the declaration, exactly as before.
+//
+// REMOVING one is the case that changed, and it changed in a direction nobody
+// asked for: deleting `email.smtp.password` used to switch the relay back to
+// unauthenticated, and now the sealed copy keeps answering, because "declared
+// nothing" and "declared nothing AND meant it" are the same input here. There
+// is no unseal — no role holds update, the reset spares both rows, and no
+// surface deletes a setting. Tracked as issue #2162 rather than papered over;
+// the license is unaffected in practice (an installation removing its license
+// is one that has stopped paying, not one reconfiguring itself).
 //
 // Both are marked AsInstallationIdentity, and not because a relay password is
 // identity in the sense the installation's name and timezone are. It is a
@@ -57,7 +66,7 @@ var SMTPPasswordRef = settings.Define[string](
 	"update",
 	"",
 	validateSecretRef,
-).AsInstallationIdentity()
+).AsInstallationIdentity().AsSecretReference()
 
 // LicenseTokenRef holds the vault ref for the installation's entitlement token.
 //
@@ -71,7 +80,7 @@ var LicenseTokenRef = settings.Define[string](
 	"update",
 	"",
 	validateSecretRef,
-).AsInstallationIdentity()
+).AsInstallationIdentity().AsSecretReference()
 
 // validateSecretRef refuses an empty ref.
 //
@@ -79,7 +88,8 @@ var LicenseTokenRef = settings.Define[string](
 // legitimate DEFAULT and an illegitimate stored value: a row written with one
 // says a credential was sealed while naming nowhere to find it, and the
 // resolver would then fall through to the deployment file believing nothing was
-// ever sealed. Unsealing is deleting the row, not blanking it.
+// ever sealed. Blanking the row is therefore not how a credential would be
+// unsealed even once something can — deleting it is (issue #2162).
 func validateSecretRef(ref string) error {
 	if ref == "" {
 		return fmt.Errorf("identity: a sealed credential reference cannot be empty; delete the row to unseal")

--- a/backend/internal/modules/identity/deploymentsecrets.go
+++ b/backend/internal/modules/identity/deploymentsecrets.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// Where the two deployment-wide credentials live once they stop living in the
+// process environment: the outbound-mail password and the license token.
+//
+// Both used to be resolved out of margince.yaml or an environment variable on
+// every boot, which means both sat in the process environment for the life of
+// the process — readable by anything that can read /proc, by a crash dump, and
+// by every child the server forks. Sealed in the key vault they are at rest
+// under AEAD and reachable only by a process holding the vault's root key.
+//
+// The REF is what these entries store, never the credential. A ref is opaque
+// and workspace-bound — the vault refuses one presented under another
+// workspace — so a reader who somehow saw one of these rows learns that a
+// credential exists and nothing whatever about it.
+//
+// Neither has a human write path, and that is deliberate rather than
+// unfinished: the deployment still DECLARES these credentials, compose seals
+// what it declared, and these rows only record where the sealed copy went. An
+// operator rotates by changing the declaration, exactly as before.
+
+import (
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+)
+
+// SMTPPasswordRefKey and LicenseTokenRefKey are the storage keys. Named
+// constants because the seal path in compose logs them: an operator reading
+// "sealed installation.license_token_ref" can grep for the entry that
+// describes what that is.
+const (
+	SMTPPasswordRefKey = "installation.smtp_password_ref"
+	LicenseTokenRefKey = "installation.license_token_ref"
+)
+
+// SMTPPasswordRef holds the vault ref for the outbound relay's password.
+//
+// Gated by installation_settings, which every seeded role may read. That is
+// the right gate and not a compromise: the row holds an opaque ref, no surface
+// returns it, and the fact an installation has configured outbound mail is
+// already visible to anyone who can be sent a password-reset email.
+var SMTPPasswordRef = settings.Define[string](
+	SMTPPasswordRefKey,
+	installationSettingsObject,
+	"update",
+	"",
+	validateSecretRef,
+).AsInstallationIdentity()
+
+// LicenseTokenRef holds the vault ref for the installation's entitlement token.
+//
+// Gated by `license`, the object that already governs the entitlement surface.
+// No seeded role holds update on it, so no principal but the boot machinery can
+// ever write this row — which is the same posture the object's own declaration
+// describes, and it survives this change: sealing is not a human write path.
+var LicenseTokenRef = settings.Define[string](
+	LicenseTokenRefKey,
+	licenseObject,
+	"update",
+	"",
+	validateSecretRef,
+).AsInstallationIdentity()
+
+// validateSecretRef refuses an empty ref.
+//
+// An empty string is how these entries read when nothing is sealed, so it is a
+// legitimate DEFAULT and an illegitimate stored value: a row written with one
+// says a credential was sealed while naming nowhere to find it, and the
+// resolver would then fall through to the deployment file believing nothing was
+// ever sealed. Unsealing is deleting the row, not blanking it.
+func validateSecretRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("identity: a sealed credential reference cannot be empty; delete the row to unseal")
+	}
+	return nil
+}
+
+// DeploymentSecretDefinitions is identity's credential-reference contribution
+// to the settings catalog, kept beside Definitions so the module declares its
+// catalog in one place.
+func DeploymentSecretDefinitions() []settings.Definition {
+	return []settings.Definition{SMTPPasswordRef, LicenseTokenRef}
+}

--- a/backend/internal/modules/identity/deploymentsecrets.go
+++ b/backend/internal/modules/identity/deploymentsecrets.go
@@ -21,6 +21,14 @@ package identity
 // unfinished: the deployment still DECLARES these credentials, compose seals
 // what it declared, and these rows only record where the sealed copy went. An
 // operator rotates by changing the declaration, exactly as before.
+//
+// Both are marked AsInstallationIdentity, and not because a relay password is
+// identity in the sense the installation's name and timezone are. It is a
+// pairing with the reset: `vault_secret` is in preservedResetTables, so the
+// ciphertext survives a data reset — and an unmarked ref row would not, which
+// would leave every sealed deployment credential orphaned and the next boot
+// without a license. The two halves have to agree, and this is the half that
+// is easy to drop.
 
 import (
 	"fmt"
@@ -77,11 +85,4 @@ func validateSecretRef(ref string) error {
 		return fmt.Errorf("identity: a sealed credential reference cannot be empty; delete the row to unseal")
 	}
 	return nil
-}
-
-// DeploymentSecretDefinitions is identity's credential-reference contribution
-// to the settings catalog, kept beside Definitions so the module declares its
-// catalog in one place.
-func DeploymentSecretDefinitions() []settings.Definition {
-	return []settings.Definition{SMTPPasswordRef, LicenseTokenRef}
 }

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -106,7 +106,7 @@ var BaseCurrency = settings.Define[string](
 
 // Definitions is identity's contribution to the settings registry.
 func Definitions() []settings.Definition {
-	return []settings.Definition{Name, Timezone, BaseCurrency}
+	return []settings.Definition{Name, Timezone, BaseCurrency, SMTPPasswordRef, LicenseTokenRef}
 }
 
 // BaseCurrencyOf resolves the installation's reporting currency inside a

--- a/backend/internal/platform/deployconfig/license.go
+++ b/backend/internal/platform/deployconfig/license.go
@@ -112,6 +112,12 @@ func (l License) TokenSource(lookup config.Lookup) func() (string, error) {
 	return func() (string, error) { return l.Token(lookup) }
 }
 
+// TokenOriginNone is what TokenOrigin answers when the deployment names no
+// token at all. Named because a caller has to compare against it — the answer
+// "nowhere in this file" is the one a caller may need to override with a source
+// this package has never heard of — and two spellings of it would drift.
+const TokenOriginNone = "none"
+
 // TokenOrigin names where Token would take a token from, for the boot log.
 //
 // Which of the two won is worth saying out loud: the environment outranks the
@@ -128,7 +134,7 @@ func (l License) TokenOrigin(lookup config.Lookup) string {
 	if l.TokenFile != "" {
 		return "license.token_file"
 	}
-	return "none"
+	return TokenOriginNone
 }
 
 // ConfigItems declares the two variables that belong to the DEPLOYMENT rather

--- a/backend/internal/platform/keyvault/fromenv_integration_test.go
+++ b/backend/internal/platform/keyvault/fromenv_integration_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package keyvault_test
+
+// A root key that goes missing while the installation is holding sealed
+// ciphertext.
+//
+// This needs a real database because the whole question is what is in
+// vault_secret, and it is the one failure the vault has that nothing else can
+// report honestly: every reader downstream discovers it separately and
+// describes it in its own dialect, the worst of which calls an installation
+// that has a license unlicensed. Refusing here is what lets those readers keep
+// treating a nil vault as "nothing was ever sealed".
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// An installation that has sealed nothing is the ordinary case — every
+// development and CI process in this repository — and it must keep booting with
+// no vault at all. Asserted first, because a refusal that fired here would stop
+// every one of them.
+func TestNoRootKeyAndNothingSealedIsNotAnError(t *testing.T) {
+	pool := singleConnPool(t)
+
+	vault, configured, err := keyvault.FromEnv(t.Context(), pool, config.Static(nil))
+	if err != nil {
+		t.Fatalf("an installation with no vault and nothing sealed was refused: %v", err)
+	}
+	if configured || vault != nil {
+		t.Errorf("configured=%v vault!=nil=%v, want an absent vault", configured, vault != nil)
+	}
+}
+
+func TestSealedSecretsWithNoRootKeyRefuseTheBoot(t *testing.T) {
+	pool := singleConnPool(t)
+	ctx := t.Context()
+
+	sealing, err := keyvault.New(keyvault.Config{RootKey: rootKey(t), Pool: pool})
+	if err != nil {
+		t.Fatalf("building the sealing vault: %v", err)
+	}
+	if _, err := sealing.Put(ctx, ids.From[ids.WorkspaceKind](ids.NewV7()), []byte("a credential")); err != nil {
+		t.Fatalf("sealing the credential under test: %v", err)
+	}
+
+	// The redeploy that dropped MARGINCE_KEYVAULT_ROOT_KEY: same database, same
+	// ciphertext, no key.
+	_, _, err = keyvault.FromEnv(ctx, pool, config.Static(nil))
+	if err == nil {
+		t.Fatal("a boot with sealed secrets and no root key was allowed; every credential it holds is unreachable and nothing said so")
+	}
+	// The variable is named because it is the only thing that fixes this, and
+	// "sealed" is named because an operator has to understand that the data is
+	// still there and still theirs — the key is what is missing, and it is not
+	// recoverable from the ciphertext.
+	for _, want := range []string{keyvault.EnvRootKey, "sealed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal %q does not name %q", err, want)
+		}
+	}
+}

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -260,12 +260,29 @@ func ConfigItems() []config.Item {
 // refuseIfAnythingIsSealed turns "no vault configured" into a boot error when
 // the installation is holding sealed ciphertext.
 //
-// A pool is not always there to ask — cmd/migrate builds a vault before it has
-// one — and a database that cannot answer is not evidence of anything, so both
-// stay silent. The check exists to catch the loud case: rows are there, the key
-// is not, and every reader downstream is about to fail in its own dialect.
+// Two answers are not evidence and stay silent. A caller with no pool cannot be
+// asked — no process role reaches here without one, but the unit lane builds a
+// vault before any database exists. And a database with no vault_secret table
+// has not been migrated yet, which is a state every fresh install passes
+// through and which the migration itself resolves.
+//
+// EVERY OTHER failure is returned. The temptation is to shrug one off as
+// "something later will report this better", and on this path nothing will: a
+// process that gets a nil vault here never touches the pool again on the
+// license path — sealedSecret short-circuits on a nil vault precisely because
+// this function has already spoken — so a swallowed error puts a production
+// installation back on "no license is configured", which is the misdirection
+// this whole refusal exists to end.
 func refuseIfAnythingIsSealed(ctx context.Context, pool *pgxpool.Pool) error {
 	if pool == nil {
+		return nil
+	}
+	var reg *string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.vault_secret')::text`).Scan(&reg); err != nil {
+		return fmt.Errorf("keyvault: cannot tell whether this installation holds sealed secrets: %w", err)
+	}
+	if reg == nil {
+		// Unmigrated. Nothing can have been sealed into a table that is not there.
 		return nil
 	}
 	var sealed bool
@@ -273,9 +290,7 @@ func refuseIfAnythingIsSealed(ctx context.Context, pool *pgxpool.Pool) error {
 	// workspace-scoped), so this is an installation-wide question and needs no
 	// workspace predicate to be a correct one.
 	if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM vault_secret)`).Scan(&sealed); err != nil {
-		// Not evidence. A pool that cannot answer this has a problem the boot
-		// will hit again in a moment, with a better message than this one.
-		return nil //nolint:nilerr // an unanswerable question is not a failed check; see above.
+		return fmt.Errorf("keyvault: cannot tell whether this installation holds sealed secrets: %w", err)
 	}
 	if !sealed {
 		return nil

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -66,17 +66,27 @@ func New(cfg Config) (Vault, error) {
 }
 
 // FromEnv builds a local Vault from MARGINCE_KEYVAULT_ROOT_KEY over the given
-// pool. It reports configured=false with a nil Vault when the key is unset,
-// so a deployment without a vault boots normally (a capture-capable role then
-// declares the gap at wiring time rather than nil-derefing at Authenticate).
-// A key that is set but malformed or the wrong length is a hard error — a
-// misconfigured vault must fail loudly, never fall back to something weaker.
+// pool. It reports configured=false with a nil Vault when the key is unset AND
+// this installation has sealed nothing, so a deployment without a vault boots
+// normally (a capture-capable role then declares the gap at wiring time rather
+// than nil-derefing at Authenticate). A key that is set but malformed or the
+// wrong length is a hard error — a misconfigured vault must fail loudly, never
+// fall back to something weaker.
+//
+// An unset key with sealed secrets BEHIND it is the same class of error and is
+// refused here rather than at each reader. A root key dropped in a redeploy
+// puts every credential the installation holds out of reach at once — connector
+// tokens, provider keys, the relay password, the license — and each reader
+// discovering that separately describes it in its own words, the worst of which
+// is the license path's, which would call an installation that has a license
+// unlicensed. One question asked once, where the vault is built, answers for all
+// of them. An installation that has never sealed anything is unaffected.
 //
 //nolint:ireturn // the seam has two providers behind one Vault; returning the interface is the design.
-func FromEnv(pool *pgxpool.Pool, env config.Lookup) (vault Vault, configured bool, err error) {
+func FromEnv(ctx context.Context, pool *pgxpool.Pool, env config.Lookup) (vault Vault, configured bool, err error) {
 	encoded := env(EnvRootKey)
 	if encoded == "" {
-		return nil, false, nil
+		return nil, false, refuseIfAnythingIsSealed(ctx, pool)
 	}
 	key, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
@@ -245,4 +255,33 @@ func ConfigItems() []config.Item {
 		Roles: []string{config.RoleAPI, config.RoleWorker},
 		Doc:   "base64 (standard, padded) 32-byte root key sealing connector credentials; unset disables the vault",
 	}}
+}
+
+// refuseIfAnythingIsSealed turns "no vault configured" into a boot error when
+// the installation is holding sealed ciphertext.
+//
+// A pool is not always there to ask — cmd/migrate builds a vault before it has
+// one — and a database that cannot answer is not evidence of anything, so both
+// stay silent. The check exists to catch the loud case: rows are there, the key
+// is not, and every reader downstream is about to fail in its own dialect.
+func refuseIfAnythingIsSealed(ctx context.Context, pool *pgxpool.Pool) error {
+	if pool == nil {
+		return nil
+	}
+	var sealed bool
+	// vault_secret carries no workspace_id by design (the ref itself is
+	// workspace-scoped), so this is an installation-wide question and needs no
+	// workspace predicate to be a correct one.
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM vault_secret)`).Scan(&sealed); err != nil {
+		// Not evidence. A pool that cannot answer this has a problem the boot
+		// will hit again in a moment, with a better message than this one.
+		return nil //nolint:nilerr // an unanswerable question is not a failed check; see above.
+	}
+	if !sealed {
+		return nil
+	}
+	return fmt.Errorf("keyvault: this installation holds sealed secrets but %s is not set — "+
+		"every credential it has sealed is unreachable, including any connector token, provider "+
+		"key, outbound-mail password and license token. Restore the root key this installation "+
+		"sealed with; it is not recoverable from anywhere else", EnvRootKey)
 }

--- a/backend/internal/platform/keyvault/local_internal_test.go
+++ b/backend/internal/platform/keyvault/local_internal_test.go
@@ -133,7 +133,7 @@ func TestNewAEAD_errorDoesNotLeakKey(t *testing.T) {
 }
 
 func TestFromEnv_unsetIsNotConfigured(t *testing.T) {
-	v, configured, err := FromEnv(nil, config.Static(nil))
+	v, configured, err := FromEnv(t.Context(), nil, config.Static(nil))
 	if err != nil {
 		t.Fatalf("FromEnv unset: %v", err)
 	}
@@ -144,13 +144,13 @@ func TestFromEnv_unsetIsNotConfigured(t *testing.T) {
 
 func TestFromEnv_shortKeyIsAnError(t *testing.T) {
 	// base64 of 16 bytes — decodes fine but is too short for AES-256.
-	if _, _, err := FromEnv(nil, config.Static(map[string]string{EnvRootKey: "MDEyMzQ1Njc4OWFiY2RlZg=="})); err == nil {
+	if _, _, err := FromEnv(t.Context(), nil, config.Static(map[string]string{EnvRootKey: "MDEyMzQ1Njc4OWFiY2RlZg=="})); err == nil {
 		t.Fatal("FromEnv with a 16-byte key must error, not silently accept it")
 	}
 }
 
 func TestFromEnv_nonBase64IsAnError(t *testing.T) {
-	if _, _, err := FromEnv(nil, config.Static(map[string]string{EnvRootKey: "not valid base64!!!"})); err == nil {
+	if _, _, err := FromEnv(t.Context(), nil, config.Static(map[string]string{EnvRootKey: "not valid base64!!!"})); err == nil {
 		t.Fatal("FromEnv with a non-base64 key must error")
 	}
 }

--- a/backend/internal/platform/settings/entry.go
+++ b/backend/internal/platform/settings/entry.go
@@ -57,6 +57,11 @@ type Definition interface {
 	Frozen(context.Context, pgx.Tx) (bool, string, error)
 	// HasFreezeProbe reports whether an immutability probe is attached.
 	HasFreezeProbe() bool
+	// AuditImage renders a value for the ledger. Identity for almost every
+	// setting: what changed IS the value, and an audit row that hid it would
+	// answer nothing. The exception is a setting whose value is the ADDRESS of
+	// a secret rather than a posture somebody chose — see AsSecretReference.
+	AuditImage(json.RawMessage) json.RawMessage
 	// SurvivesDataReset reports whether this setting is part of the
 	// INSTALLATION'S IDENTITY rather than its configuration. A data reset
 	// returns the installation to first-boot state without re-creating it, so
@@ -79,6 +84,10 @@ type Entry[T any] struct {
 	validate func(T) error
 	freeze   func(context.Context, pgx.Tx) (bool, string, error)
 	identity bool
+	// secretReference redacts this entry's audited image. Off by default: a
+	// setting's value belongs in the ledger unless someone declares it is a
+	// capability handle rather than a choice.
+	secretReference bool
 	// machineryApplied admits this entry to ApplyTx, the ungated
 	// in-transaction reader for machinery that must apply the posture to its
 	// own write whoever the acting principal is. Off by default: an entry
@@ -262,4 +271,38 @@ func (e UnsetValue) Error() string {
 func (e UnsetValue) MessageFault() (code, message string) {
 	return "installation_setting_unset", e.Error() +
 		" — an admin must set it on the installation settings screen before this operation can succeed"
+}
+
+// AsSecretReference declares that this setting's value is the ADDRESS of a
+// secret, not a posture, and must not be written verbatim into audit_log.
+//
+// The ref is not the secret — it is opaque, workspace-bound, and the vault
+// refuses one presented under another workspace. But it is the unguessable
+// capability half of the handle, which is why keyvault.refLogSafe strips it
+// from every error the vault raises and why the data reset refuses to name one
+// in a log line. audit_log is a log sink like any other: admin-readable over
+// /audit-log and exportable. A ref that is careful everywhere else and verbatim
+// here is careful nowhere.
+//
+// What the ledger keeps is the fact and the actor and the moment, which is what
+// a reader of this row actually needs — "the seal changed", not which byte.
+func (e *Entry[T]) AsSecretReference() *Entry[T] {
+	e.secretReference = true
+	return e
+}
+
+// AuditImage renders a value for the ledger, redacting it for an entry declared
+// AsSecretReference. Set and unset stay distinguishable, because "a credential
+// was sealed for the first time" and "a sealed credential was repointed" are
+// different events and the row is the only place either is recorded.
+func (e *Entry[T]) AuditImage(raw json.RawMessage) json.RawMessage {
+	if !e.secretReference {
+		return raw
+	}
+	switch string(raw) {
+	case "", "null", `""`:
+		return json.RawMessage(`"none"`)
+	default:
+		return json.RawMessage(`"a sealed reference (redacted)"`)
+	}
 }

--- a/backend/internal/platform/settings/store.go
+++ b/backend/internal/platform/settings/store.go
@@ -184,9 +184,12 @@ func (s *Store) SetRawTx(ctx context.Context, tx pgx.Tx, key string, next json.R
 			key, next); err != nil {
 			return fmt.Errorf("settings: writing %s: %w", key, err)
 		}
+		// Through the entry's own image, so a setting holding the address of a
+		// secret is redacted here rather than at each writer — there is only one
+		// writer today, and the next one would not know to.
 		if _, err := storekit.Audit(ctx, tx, def.AuditVerb(), def.Object(), storekit.MustWorkspace(ctx),
-			map[string]any{key: json.RawMessage(before)},
-			map[string]any{key: json.RawMessage(next)}); err != nil {
+			map[string]any{key: def.AuditImage(before)},
+			map[string]any{key: def.AuditImage(next)}); err != nil {
 			return fmt.Errorf("settings: auditing %s: %w", key, err)
 		}
 	}

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -93,7 +93,8 @@ bootstrap_admin:
 #
 # Sealed on the first boot that resolves it: the token goes into the key vault
 # and the installation records where. The boot log says so, and from then on
-# this block (or MARGINCE_LICENSE) can be removed and the vault answers instead.
+# this whole block can be DELETED and the vault answers instead — deleting only
+# the file it points at, and leaving the block, fails the boot instead.
 # To rotate, put the new token back here — the declaration still wins, and the
 # next boot re-seals it. docs/reference/configuration.md, "the vault also holds
 # the two deployment credentials".

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -90,8 +90,15 @@ bootstrap_admin:
 #
 # What the license grants is also enforced: once every licensed full seat is in
 # use, inviting a member is refused. Nobody already working loses anything.
+#
+# Sealed on the first boot that resolves it: the token goes into the key vault
+# and the installation records where. The boot log says so, and from then on
+# this block (or MARGINCE_LICENSE) can be removed and the vault answers instead.
+# To rotate, put the new token back here — the declaration still wins, and the
+# next boot re-seals it. docs/reference/configuration.md, "the vault also holds
+# the two deployment credentials".
 # license:
-#   token_file: config/margince-license
+#   token: ${file:config/margince-license}
 
 # AI runtime posture (optional). Uncomment to turn on Layer-3 AI payload capture
 # (ai_call_payload) — OFF by default because it stores special-category-adjacent

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -483,7 +483,7 @@ has:
 
 ```
 sealed a deployment credential into the key vault; the deployment configuration
-that carried it can be removed  credential_name="the license token" declared_at=license.token
+that declared it can be deleted  credential_name="the license token" declared_at=license.token
 ```
 
 Once that line appears the declaration may be deleted and the installation keeps
@@ -498,12 +498,29 @@ unset is a named source that yielded nothing, which has always been an error
 rather than an absence. Remove the whole `license:` block, or the `password:`
 line from `email.smtp`. Then the variable or the file can go too.
 
+**There is no unseal.** Rotating works; *removing* does not. Deleting
+`email.smtp.password` used to switch the installation back to an unauthenticated
+relay, and it no longer does — the sealed copy keeps answering, because "declared
+nothing" and "declared nothing on purpose" are the same input to the resolver.
+Nothing in the product deletes either ref today. If you need a relay that takes
+no credential, say so on
+[issue #2162](https://github.com/gradionhq/margince-poc-v1/issues/2162), which
+tracks the supported way to do it. The license is unaffected in practice: an
+installation removing its license is one that has stopped paying, and a
+production boot refuses an absent license regardless.
+
 **Rotation moves into the vault only for reading, never for writing.** There is
 no product surface that changes either credential, and no seeded role holds the
 grant to write one, so the sealed copy is only ever a mirror of what the
 deployment declares. That is why the DECLARATION still wins when both exist: to
 rotate, put the new value back where it used to be — the variable or the file —
-and the next boot re-seals it and destroys the superseded blob. This is the
+and the next boot re-seals it. The superseded ciphertext is deliberately left
+in place rather than destroyed: a re-seal is triggered by the declaration alone,
+which is exactly what a stale variable or a botched pipeline gets wrong, and
+destroying what it supersedes would let one bad boot irreversibly take out the
+only copy of a credential nobody meant to replace. What it costs is one
+unreferenced blob per rotation — encrypted at rest, reachable by nobody. This is
+the
 opposite precedence to a BYOK provider key, which the vault wins because the
 routing surface can change one.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -468,6 +468,48 @@ silent fallback.
 |---|---|---|
 | `MARGINCE_KEYVAULT_ROOT_KEY` | — | base64 (std) of 32 bytes; set to enable the vault. Generate: `openssl rand -base64 32` |
 
+### The vault also holds the two deployment credentials
+
+Connector credentials were the vault's first tenants; two more moved in and
+they arrive by a different route. The **outbound-relay password**
+(`email.smtp.password`) and the **license token** (`license.token`) are still
+DECLARED by the deployment, but on the first boot that sees one the value is
+sealed into the vault and the installation records where it went. Nothing is
+required of the operator to make that happen, and the boot log says when it
+has:
+
+```
+sealed a deployment credential into the key vault; the deployment configuration
+that carried it can be removed  credential_name="the license token" declared_at=license.token
+```
+
+Once that line appears the declaration may be deleted — the variable dropped
+from the orchestrator, the file unmounted — and the installation keeps booting
+on the sealed copy. Nothing here can delete it for you: a process cannot edit
+its own deployment.
+
+**Rotation moves into the vault only for reading, never for writing.** There is
+no product surface that changes either credential, and no seeded role holds the
+grant to write one, so the sealed copy is only ever a mirror of what the
+deployment declares. That is why the DECLARATION still wins when both exist: to
+rotate, put the new value back where it used to be — the variable or the file —
+and the next boot re-seals it and destroys the superseded blob. This is the
+opposite precedence to a BYOK provider key, which the vault wins because the
+routing surface can change one.
+
+**A vault that cannot be opened says so.** These two are the only credentials
+whose absence used to read as a posture — "unlicensed", "unauthenticated relay"
+— and once the declaration is gone the vault holds the only copy. So a process
+that finds a sealed reference it cannot open refuses to boot naming the vault
+and the root key, rather than reporting an installation that has a license as
+having none. Restore `MARGINCE_KEYVAULT_ROOT_KEY` to the value the installation
+sealed with, or re-declare the credential where it used to be.
+
+One consequence for the **worker**: its license check now runs after its
+database pool, because a sealed token lives in a table. It still happens before
+the worker does any work, so an operator mistake never leaves a worker running
+on a license the api refuses to boot on.
+
 ## Custom-field schema pool (api) — runtime DDL
 
 `--schema-dsn`/`MARGINCE_SCHEMA_DSN` is the api-only owner-role DSN behind
@@ -823,7 +865,8 @@ that stops matching its recorded digest fails `make check`.
 
 | field | default | effect |
 |---|---|---|
-| `token_file` | *(none)* | Path to a file holding the license token. A **file reference, never an inline value**: it is a credential, and this file gets read, copied and pasted into support threads. Overridden by `MARGINCE_LICENSE` when that variable is set to a non-empty value — the same variable name the validation module itself reads, so a container that already exports the license needs no `license:` block at all. |
+| `token` | *(none)* | The token as a reference — `${file:/run/secrets/margince-license}` or `${env:SOME_VAR}`. The preferred spelling, and the one a refusal recommends. An inline value is refused at decode time. |
+| `token_file` | *(none)* | The original spelling, still honoured so an existing deployment boots unchanged. Path to a file holding the license token. A **file reference, never an inline value**: it is a credential, and this file gets read, copied and pasted into support threads. Overridden by `MARGINCE_LICENSE` when that variable is set to a non-empty value — the same variable name the validation module itself reads, so a container that already exports the license needs no `license:` block at all. |
 
 Three postures, and what each one does at boot:
 
@@ -832,6 +875,12 @@ Three postures, and what each one does at boot:
 | **no token configured** | **refuses to boot in production**; boots with a warning when `MARGINCE_ENV` is `dev` or `test` | `margince_license_posture{state="absent"} 1` |
 | **token verified** | boots | `margince_license_posture{state="valid"} 1`, plus `margince_license_seats` when the license grants a seat count |
 | **token refused** | **refuses to boot** (api and worker alike), naming the module's own reason and the setting to correct | — |
+
+On the first boot that resolves a token it is sealed into the key vault, after
+which the declaration above may be removed — see
+[the vault also holds the two deployment credentials](#the-vault-also-holds-the-two-deployment-credentials)
+for what that changes about rotation, and for the boot refusal an unreachable
+vault produces instead of an "absent" posture.
 
 **A production installation serves on a license or it does not serve.** The
 posture decides it, and `MARGINCE_ENV` is fail-closed, so an installation that

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -455,14 +455,17 @@ line (argv is world-readable) or in any log or error. A connector credential
 is sealed with AES-256-GCM under this key and stored as ciphertext in the
 operational `vault_secret` table; the `connector_connection` row carries only
 an opaque, workspace-scoped `credential_ref`, never the credential bytes.
-Leave `MARGINCE_KEYVAULT_ROOT_KEY` unset and the vault is absent: every
+Leave `MARGINCE_KEYVAULT_ROOT_KEY` unset **on an installation that has sealed
+nothing** and the vault is absent: every
 connector's connect path (gmail, gcal, graph, imap all connect through the
 same operation, sealing to the vault) refuses loudly rather than store a
 credential in the clear. Set it and the api gains the
 `/readyz` keyvault probe and the vault-backed path, and the worker migrates
 any legacy `auth`-bytea rows onto the vault at boot (idempotent). A key that
 is SET but not exactly 32 bytes (base64-decoded) is a boot error — never a
-silent fallback.
+silent fallback — and so is leaving it unset on an installation that already
+holds sealed ciphertext, which is the redeploy-dropped-the-variable case and is
+refused rather than degraded (see below).
 
 | Env | Default | Meaning |
 |---|---|---|
@@ -483,10 +486,17 @@ sealed a deployment credential into the key vault; the deployment configuration
 that carried it can be removed  credential_name="the license token" declared_at=license.token
 ```
 
-Once that line appears the declaration may be deleted — the variable dropped
-from the orchestrator, the file unmounted — and the installation keeps booting
-on the sealed copy. Nothing here can delete it for you: a process cannot edit
-its own deployment.
+Once that line appears the declaration may be deleted and the installation keeps
+booting on the sealed copy. Nothing here can delete it for you: a process cannot
+edit its own deployment.
+
+**Delete the declaration, not just what it points at.** Dropping the variable or
+unmounting the file while the `license:` block or the `password:` line is still
+in `margince.yaml` fails the boot in `deployconfig`, before the vault is ever
+consulted — a `${file:…}` that is gone cannot be read, and a `${env:…}` that is
+unset is a named source that yielded nothing, which has always been an error
+rather than an absence. Remove the whole `license:` block, or the `password:`
+line from `email.smtp`. Then the variable or the file can go too.
 
 **Rotation moves into the vault only for reading, never for writing.** There is
 no product surface that changes either credential, and no seeded role holds the
@@ -497,13 +507,22 @@ and the next boot re-seals it and destroys the superseded blob. This is the
 opposite precedence to a BYOK provider key, which the vault wins because the
 routing surface can change one.
 
-**A vault that cannot be opened says so.** These two are the only credentials
-whose absence used to read as a posture — "unlicensed", "unauthenticated relay"
-— and once the declaration is gone the vault holds the only copy. So a process
-that finds a sealed reference it cannot open refuses to boot naming the vault
-and the root key, rather than reporting an installation that has a license as
-having none. Restore `MARGINCE_KEYVAULT_ROOT_KEY` to the value the installation
-sealed with, or re-declare the credential where it used to be.
+**A vault that cannot be opened says so**, in two places, because there are two
+ways to lose it and they need different sentences.
+
+*The root key is gone.* An installation holding sealed ciphertext with
+`MARGINCE_KEYVAULT_ROOT_KEY` unset **refuses to boot**, naming the variable.
+This is asked once, where the vault is built, rather than by each reader —
+because the loss is not the license's or the relay's, it is every credential the
+installation holds at once, connector tokens included. An installation that has
+sealed nothing is unaffected and boots with no vault exactly as before. The key
+is not recoverable from the ciphertext, or from us: restore the one this
+installation sealed with.
+
+*The root key is wrong.* A sealed reference that will not open refuses the boot
+naming the vault and the root key, rather than reporting an installation that
+has a license as having none — which is what "absent" used to mean on that path,
+and a completely different problem for whoever is paged.
 
 One consequence for the **worker**: its license check now runs after its
 database pool, because a sealed token lives in a table. It still happens before


### PR DESCRIPTION
The third of the three configuration homes, applied to the two credentials that were still living in the process environment.

## What moves

`email.smtp.password` and `license.token` used to be resolved from the deployment file or an environment variable on every boot, which means both sat in the process environment for the life of the process — readable through `/proc`, in a crash dump, and by every child the server forks. They are now sealed into the key vault on the first boot that sees them, under AEAD, addressed by an opaque workspace-bound ref recorded in two new settings entries (`installation.smtp_password_ref`, `installation.license_token_ref`).

## Nothing is asked of the operator

A running deployment is unaffected: the declaration still wins while it is there. The boot log says when a credential has been sealed —

```
sealed a deployment credential into the key vault; the deployment configuration
that carried it can be removed  credential_name="the license token" declared_at=license.token
```

— and from that point the variable or the file can be dropped and the vault answers instead. Nothing here can drop it for them; a process cannot edit its own orchestrator.

## Rotation stays where it was

Put the new value back in the declaration and the next boot re-seals it. The superseded ciphertext is deliberately **left in place**: a re-seal is triggered by the declaration alone, which is exactly what a stale variable or a botched pipeline gets wrong, and destroying what it supersedes would let one bad boot irreversibly take out the only copy of a credential nobody meant to replace. The cost is one unreferenced blob per rotation — encrypted at rest, reachable by nobody. That precedence — declaration over vault — is the **opposite** of the BYOK provider keys', and deliberately: a provider key has a human write path (the routing surface) so the vault must win, while these two have none, so the sealed copy can only ever be a mirror of what the deployment declares.

## An unreachable vault names itself

Once the declaration is gone the vault holds the only copy, and the old refusal for that path said *unlicensed* — a completely different problem for whoever is paged. A sealed reference that cannot be opened now refuses the boot naming the vault and the root key. The boot log's `token_from` learns to say `the key vault` too, since `deployconfig` can only speak for the file and the environment.

The neighbouring case — the vault root key vanishing entirely, so nothing sealed is reachable — is handled too, and at the vault's own wiring rather than here: `keyvault.FromEnv` refuses a boot that finds sealed ciphertext and no root key. The loss is never one credential's; connector tokens, provider keys, the relay password and the license go out of reach together, so one question asked once answers for all of them. That is also what makes the seal path's nil-vault shortcut provably safe rather than assumed — a nil vault now means nothing was ever sealed. An installation that has sealed nothing is unaffected. (Closes https://github.com/gradionhq/margince-poc-v1/issues/2148, which was originally filed to defer this.)

## One ordering change

The worker's license check moves after its database pool, because a sealed token lives in a table. It still runs before the worker does any work — after `AssertRuntimeRole`, so a pool connecting as the wrong role fails as that rather than as a license nobody can read — so the property the old ordering protected is intact.

## Tests

Four integration cases against a real database, each mutation-proven (restoring the defect fails the test): the ref is recorded rather than merely sealed; a second boot repoints nothing; a rotated declaration is re-sealed; and an unopenable vault names itself rather than reporting no license. Plus a unit case pinning `token_from` across the three origins, and the existing license unit tests now assert a second property — with no vault configured the license question touches no database, which a nil pool proves by dereferencing if that ever stops being true.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seals the SMTP relay password and the license token into the key vault on first boot and reads them via recorded refs; declarations still win while present. This reduces secret exposure and makes missing/wrong vault root keys an explicit boot failure instead of silently degrading to “absent”.

- Records refs in settings (`installation.smtp_password_ref`, `installation.license_token_ref`) under identity; audit images redact ref values; data reset preserves both refs and `vault_secret`.
- Precedence and safety
  - If declared, use it and mirror into the vault; once removed, resolve via the recorded ref.
  - Deleting only the referenced file/env while the declaration remains now fails boot in deploy config.
  - Sealing and ref recording run in one transaction under the settings advisory lock; the race loser’s duplicate blob is deleted. Re‑seals keep the superseded blob.
- Vault wiring and boot order
  - `keyvault.FromEnv(ctx, …)` refuses boot when sealed secrets exist but `MARGINCE_KEYVAULT_ROOT_KEY` is unset; an unopenable sealed ref fails boot naming the vault/root key.
  - API builds the vault before license resolution; the worker resolves its license after the DB pool and release assertion, before doing any work.
  - Boot logs report `token_from=keyvault` when applicable.

- Rollout
  - No operator action. When the log says “sealed a deployment credential into the key vault…”, delete the declaration block/line (`license.token` or `email.smtp.password`), not just the file/env.
  - Rotate by changing the declaration; the next boot re‑seals.
  - If the root key is missing, restore `MARGINCE_KEYVAULT_ROOT_KEY`. If a vault‑sourced token is invalid, re‑declare `license.token` to re‑seal.

<sup>Written for commit 874689ca40c77b20cdc84be04da42f874e81c41d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Reviews

Two adversarial passes ran on this branch and both found real defects, all fixed here.

The security pass found nothing exploitable — no credential value reaches a log, error, response or metric; the broad read on `installation_settings` is harmless because no surface returns the ref; cross-workspace is closed by `Ref.scopedTo` — but it did change a design decision. Three of this change's own rules composed into a destructive primitive, which is what the rotation paragraph above now describes. It also caught the vault ref landing verbatim in `audit_log`, contradicting two sibling comments in this tree (`keyvault.refLogSafe`, `purgeSealedCredentials`); settings entries can now declare `AsSecretReference` and the ledger keeps the fact rather than the address.

The craft pass caught, among others, the worker sealing a credential and stamping an audit row *above* `AssertInstallationRelease` — whose own comment says a role that must not run must not write either — and a swallowed query error in `refuseIfAnythingIsSealed` that put production straight back on the misdirection this PR exists to end.

Two things are recorded rather than fixed here: https://github.com/gradionhq/margince-poc-v1/issues/2162 (there is no unseal — deleting `email.smtp.password` no longer switches the relay to unauthenticated, which matters most for a *leaked* password) and https://github.com/gradionhq/margince-poc-v1/issues/2151 (why a red integration shard did not block a merge).