### PR TITLE
fix(ci-tests): the reset gate knows about the project clock, and main is green again

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -316,7 +316,11 @@ var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
 	"activity activity_refuse_restricted_mutation": "a row-conditional statutory hold, not a protected store: preserving it would leave every activity behind on a reset meant to clear them, and no writer can set the restriction yet (#1557) — when one lands the reset must lift before it sweeps",
 	// Not guards at all (migration 1787032690).
 	"activity_link activity_link_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the last_activity_at of the records the deleted link reached and refuses no delete; the sweep deletes those records too, so the recompute is discarded with them",
-	"relationship relationship_last_activity":   "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
+	// The project arm of the same clock, on the same table (migration
+	// 1787320000). A second trigger rather than a fourth id inside the one
+	// above, so it needs its own entry — and it earns it the same way.
+	"activity_link activity_link_project_last_activity": "a clock-maintenance trigger, not a guard: it recomputes the project's last_activity_at when a link is written, moved or removed, and refuses no delete; `project` is swept too, so the recompute is discarded with it",
+	"relationship relationship_last_activity":           "a clock-maintenance trigger, not a guard: it recomputes the employer's last_activity_at and refuses no delete",
 	// Also not a guard (migration 1787226902): BEFORE DELETE ON organization, it
 	// sets deal.partner_org_id and deal.partner_attribution to NULL so a deleted
 	// partner leaves no dangling attribution. It refuses no delete.


### PR DESCRIPTION
`main` is red. https://github.com/gradionhq/margince-poc-v1/pull/2120 added `activity_link_project_last_activity` — a second clock-maintenance trigger on `activity_link`, this one for `project.last_activity_at`. `TestSweepTargetsCarryNoDeleteBlockingTrigger` scans every data-reset sweep target for DELETE-firing triggers and fails on any it has not been told about, so the gate went red on the merge and has stayed red since.

Reproduced against `origin/main` in a clean worktree:

```
--- FAIL: TestSweepTargetsCarryNoDeleteBlockingTrigger (2.65s)
    datareset_integration_test.go:375: sweep target "activity_link" carries DELETE-firing trigger
    "activity_link_project_last_activity" — an append-only or otherwise protected table belongs in
    preservedResetTables; a row-conditional guard belongs in deleteGuardedSweepTargets, with what
    the reset owes it
```

## The fix

It is the same shape as `activity_link_last_activity` sitting immediately above it in the map: `AFTER INSERT OR UPDATE OR DELETE`, returns `NULL`, refuses no delete, and only recomputes a clock. So it is registered the same way, with why it is safe rather than merely that it is — and the claim is checked rather than assumed: `project` is a sweep target and is **not** in `preservedResetTables`, so the row the recompute writes to is deleted in the same transaction.

No product code changes. The gate is the thing that was wrong about the schema, not the schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores green on main by teaching the data-reset gate about the new activity_link_project_last_activity trigger. Previously the gate treated it as a DELETE-blocking guard; now it is registered as clock maintenance that refuses no delete, so TestSweepTargetsCarryNoDeleteBlockingTrigger passes.

- Registers "activity_link activity_link_project_last_activity" in deleteGuardedSweepTargets as a non-guard clock-maintenance trigger, mirroring the existing last-activity clock on the same table.
- Confirms project is a sweep target and not in preservedResetTables; recomputed last_activity_at is deleted in the same transaction, so the trigger cannot block deletes.

<sup>Written for commit 497514a60618deb2d97316f2e3454bbd8887c8a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

