### PR TITLE
fix(ci-tests): classify the project-clock trigger, which guards nothing

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -302,6 +302,17 @@ func TestDropResetCustomFieldColumns(t *testing.T) {
 // was written for AND every DELETE trigger added to that table afterwards,
 // including one that really does block. Each trigger earns its own line.
 var deleteGuardedSweepTargets = gatekit.Waive(map[string]string{
+	// Not a guard at all, which is a THIRD shape the catalog cannot show: this
+	// one is AFTER ... RETURN NULL, so it refuses nothing and cannot fail a
+	// DELETE. It recomputes project.last_activity_at from the live timeline when
+	// a link is written, moved or removed (core 1787320000).
+	//
+	// The sweep owes it nothing. project is a sweep target too, so a reset
+	// clears both tables and the clock it maintains has no row left to be wrong
+	// on. It is classified here rather than preserved because preserving
+	// activity_link would leave every activity's filing behind on a reset whose
+	// whole purpose is to clear them.
+	"activity_link activity_link_project_last_activity": "an AFTER trigger that returns NULL: it recomputes project.last_activity_at and refuses no delete, and project is swept alongside activity_link so the clock has nothing left to be wrong on",
 	// Not a protected table: the guard refuses a DELETE only while a row carries
 	// `restricted_at`, which is a statutory hold on that one record. Preserving
 	// `activity` would leave every conversation behind on a reset whose whole


### PR DESCRIPTION
**Main's integration lane is red** on
`TestSweepTargetsCarryNoDeleteBlockingTrigger`, and has been since
`core/1787320000` added `activity_link_project_last_activity` (#2120).

```
datareset_integration_test.go:375: sweep target "activity_link" carries
DELETE-firing trigger "activity_link_project_last_activity" — an append-only or
otherwise protected table belongs in preservedResetTables; a row-conditional
guard belongs in deleteGuardedSweepTargets, with what the reset owes it
```

## Neither of the gate's two homes fits, and that is the finding

The gate offers `preservedResetTables` (append-only table) or
`deleteGuardedSweepTargets` (row-conditional hold). This trigger is **a third
shape**:

```sql
AFTER INSERT OR UPDATE OR DELETE ON activity_link
FOR EACH ROW EXECUTE FUNCTION trg_activity_link_project_last_activity();
-- ... RETURN NULL;
```

`AFTER … RETURN NULL` — it refuses nothing and **cannot fail a DELETE**. It
recomputes `project.last_activity_at` from the live timeline when a link is
written, moved or removed. The gate reads only `tgtype` bit `0x08` and cannot
tell a recompute from a guard, which is precisely what the waiver map exists to
record.

## Why `deleteGuardedSweepTargets` and not `preservedResetTables`

Preserving `activity_link` would leave every activity's filing behind on a reset
whose whole purpose is to clear them.

**The sweep owes this trigger nothing**, and the entry says so: `project` is a
sweep target too, so a reset clears both tables and the clock it maintains has
no row left to be wrong on. That is stated explicitly because the neighbouring
waiver (`activity` / `restricted_at`) documents a *real* obligation the reset
will have to honour once #1557 lands — a reader has to be able to tell the two
apart at a glance.

## Verification

- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`
- `make check-backend` / `make craft-static` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red integration gate by classifying `activity_link_project_last_activity` as a non-guard trigger. Previously the gate flagged a DELETE-firing trigger on `activity_link`; now it is waived as an AFTER trigger that returns NULL and cannot block deletes, restoring green CI without runtime changes.

- Records the waiver under `deleteGuardedSweepTargets` instead of `preservedResetTables` to avoid preserving `activity_link` on reset.
- The sweep owes this trigger nothing: `project` is swept alongside `activity_link`, so the recomputed clock has no rows left to be wrong on.
- No migrations, no behavior changes, test-only configuration.

<sup>Written for commit 2d07a45aa533e2fcd2775299fd112a280b16d7cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

