### PR TITLE
fix(deals): a deal may only name a company that is a partner

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18971,7 +18971,7 @@ components:
         amount_minor: { type: [integer, 'null'], format: int64 }
         currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
         organization_id: { type: [string, 'null'], format: uuid }
-        partner_org_id: { type: [string, 'null'], format: uuid }
+        partner_org_id: { type: [string, 'null'], format: uuid, description: 'The partner who brought this deal. The org must have a live `partner` row (else 422 `not_a_partner`), and the caller must be able to read it. Null clears the attribution.' }
         partner_attribution:
           type: [string, 'null']
           enum: [sourced, influenced, null]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18889,7 +18889,7 @@ components:
         pipeline_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent''s own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).' }
         stage_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null stage FK; must belong to pipeline_id. Overlay mode: NULL (see pipeline_id; the incumbent dealstage id rides `raw`, OVA-MAP-6).' }
         organization_id: { type: [string, 'null'], format: uuid, description: 'Primary org; never a raw lead. Null when the caller may not read that organization, in which case `masked_fields` names it.' }
-        partner_org_id: { type: [string, 'null'], format: uuid, description: 'Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row. Null when the caller may not read that organization, in which case `masked_fields` names it.' }
+        partner_org_id: { type: [string, 'null'], format: uuid, description: 'Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a live `partner` row — naming one that does not is refused 422 (`not_a_partner`), because commission prices from the margin tier on that row, and an attribution without one could never earn anything. Null when the caller may not read that organization, in which case `masked_fields` names it.' }
         partner_attribution:
           type: [string, 'null']
           enum: [sourced, influenced, null]
@@ -18950,7 +18950,7 @@ components:
         pipeline_id: { type: string, format: uuid }
         stage_id: { type: string, format: uuid }
         organization_id: { type: [string, 'null'], format: uuid }
-        partner_org_id: { type: [string, 'null'], format: uuid, description: 'The partner this deal is attributed to at birth. The org must have a `partner` row, and the caller must be able to read it.' }
+        partner_org_id: { type: [string, 'null'], format: uuid, description: 'The partner this deal is attributed to at birth. The org must have a live `partner` row (else 422 `not_a_partner`), and the caller must be able to read it.' }
         partner_attribution:
           type: [string, 'null']
           enum: [sourced, influenced, null]

--- a/backend/internal/compose/installseam/installseam.go
+++ b/backend/internal/compose/installseam/installseam.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 )
 
 // Deals is the installation seam the deals module reads through.
@@ -27,5 +28,8 @@ func Deals() deals.Installation {
 		// activities owns `activity`, so the stamp's write lives there and the
 		// edge is injected here (ADR-0054).
 		StampCorrespondence: activities.StampCorrespondenceForDeal,
+		// people owns `partner`, so the "is this company a partner" read lives
+		// there and the edge is injected here for the same reason.
+		EnsurePartner: people.EnsureOrganizationIsPartner,
 	}
 }

--- a/backend/internal/compose/integration/authority_scope_integration_test.go
+++ b/backend/internal/compose/integration/authority_scope_integration_test.go
@@ -57,8 +57,13 @@ func TestFKTargetsRequireRowScopeVisibility(t *testing.T) {
 	foreignOrg := e.SeedOrg(t, "Their Org", &e.Rep3) // capture-private to Rep3
 	e.MakeCapturePrivate(t, "organization", foreignOrg, e.Rep3)
 	visibleOrg := e.SeedOrg(t, "Our Org", &e.Rep1) // rep1's own
+	// A partner the rep CAN see, for the admit case: naming a partner needs
+	// the target to be visible AND to actually be a partner, and this test is
+	// about the first of those.
+	visiblePartner := e.SeedPartnerOrg(t, "Our Partner", nil, &e.Rep1)
 	foreignOrgID := ids.From[ids.OrganizationKind](foreignOrg)
 	visibleOrgID := ids.From[ids.OrganizationKind](visibleOrg)
+	visiblePartnerID := ids.From[ids.OrganizationKind](visiblePartner)
 	myDeal := ids.From[ids.DealKind](e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1))
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, repPermsWithOrg())
 
@@ -99,7 +104,7 @@ func TestFKTargetsRequireRowScopeVisibility(t *testing.T) {
 		t.Errorf("UpdateDeal attaching own-team organization → %v, want ok", err)
 	}
 	if _, err := e.Deals.CreateDeal(rep, deals.CreateDealInput{
-		Name: "Partner deal", PipelineID: pipeline, StageID: open, PartnerOrganizationID: &visibleOrgID,
+		Name: "Partner deal", PipelineID: pipeline, StageID: open, PartnerOrganizationID: &visiblePartnerID,
 	}); err != nil {
 		t.Errorf("CreateDeal naming a visible partner → %v, want ok", err)
 	}

--- a/backend/internal/compose/integration/dealpartnerattribution_integration_test.go
+++ b/backend/internal/compose/integration/dealpartnerattribution_integration_test.go
@@ -40,7 +40,7 @@ func execDirect(t *testing.T, e *Env, sql string, args ...any) error {
 func seedDealWithPartner(t *testing.T, e *Env) (ids.DealID, ids.OrganizationID) {
 	t.Helper()
 	pipeline, open, _ := DealFixture(t, e)
-	partnerOrg := orgIDOf(e.SeedOrg(t, "Northgate Partners", nil))
+	partnerOrg := orgIDOf(e.SeedPartnerOrg(t, "Northgate Partners", nil, nil))
 	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Northgate rollout", pipeline, open, &e.Rep1))
 	if _, err := e.Deals.UpdateDeal(e.Admin(), deal, deals.UpdateDealInput{
 		PartnerOrganizationID: &partnerOrg,

--- a/backend/internal/compose/integration/dealreferences_integration_test.go
+++ b/backend/internal/compose/integration/dealreferences_integration_test.go
@@ -40,7 +40,7 @@ func seedDealReferenceFixture(t *testing.T, e *Env) dealReferenceFixture {
 	// EnsureLinkTarget gate; capture privacy lands afterwards, which is the
 	// order a connector-captured contact reaches this state in anyway.
 	privateOrg := e.SeedOrg(t, "Meridian Labs", &e.Rep3)
-	partnerOrg := e.SeedOrg(t, "Northgate Partners", &e.Rep3)
+	partnerOrg := e.SeedPartnerOrg(t, "Northgate Partners", nil, &e.Rep3)
 	openOrg := e.SeedOrg(t, "Kestrel Foods", nil)
 
 	hiddenRefs := ids.From[ids.DealKind](e.SeedDeal(t, "Meridian renewal", pipeline, open, &e.Rep1))

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -266,6 +266,43 @@ func (e *Env) SeedOrg(t *testing.T, name string, owner *ids.UUID) ids.UUID {
 	return ids.UUID(org.Id)
 }
 
+// SeedPartnerOrg creates an organization and gives it a partner programme, so
+// a deal may name it.
+//
+// A deal's partner must BE a partner (the store refuses any other company,
+// because commission prices from the margin tier on that row). A fixture that
+// pointed a deal at a plain organization was writing a row the product itself
+// will not write, which is the shape of test that proves nothing.
+//
+// The tier is optional: a partner with none is a real and common state — the
+// arrangement exists, the rate has not been agreed — and accrual treats it as
+// earning nothing rather than as an error.
+func (e *Env) SeedPartnerOrg(t *testing.T, name string, tier *string, owner *ids.UUID) ids.UUID {
+	t.Helper()
+	org := e.SeedOrg(t, name, owner)
+	// The harness's AdminPerms deliberately carries no `partner` grant, so the
+	// seeding acts as a seat that has one. Borrowing the caller's context would
+	// make every suite that seeds a partner grow a permission it is not testing.
+	seeder := e.As(e.AdminUser, nil, principal.Permissions{
+		RoleKeys: []string{"admin"},
+		Objects: map[string]principal.ObjectGrant{
+			"partner": {Create: true, Read: true, Update: true},
+			// Becoming a partner also stamps the organization's relationship
+			// types, so the seat needs the company as well as the programme.
+			objOrg: {Read: true, Update: true},
+		},
+		RowScope: principal.RowScopeAll,
+	})
+	if _, err := e.People.UpsertPartner(seeder, people.UpsertPartnerInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		PartnerRole:    "consulting",
+		MarginTier:     tier,
+	}); err != nil {
+		t.Fatalf("giving %s a partner programme: %v", name, err)
+	}
+	return org
+}
+
 // SeedOrgAs creates an ownerless organization in a SECOND workspace, under
 // that workspace's own context — unlike SeedOrg, which always writes the
 // harness's primary workspace as e.Admin().

--- a/backend/internal/compose/integration/partnerattributiontarget_integration_test.go
+++ b/backend/internal/compose/integration/partnerattributiontarget_integration_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A deal may only be attributed to a company that IS a partner.
+//
+// The commission ledger prices from the partner row's margin tier, so a deal
+// pointed at an ordinary customer reads as credited and can never earn
+// anything — the failure is silent, which is what makes it worth a gate rather
+// than a note. Both write paths carry it, because a rule one verb enforces and
+// the other does not is not a rule.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestADealMayOnlyNameARealPartner(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	admin := e.As(e.AdminUser, nil, commissionAdminPerms)
+
+	// Two ordinary companies. One is made a partner; the other stays a plain
+	// customer, which is exactly what somebody picks by mistake.
+	partnerOrg := orgIDOf(e.SeedOrg(t, "Northgate Partners", nil))
+	plainOrg := orgIDOf(e.SeedOrg(t, "Just A Customer", nil))
+	tier := "tier2_20"
+	if _, err := e.People.UpsertPartner(admin, people.UpsertPartnerInput{
+		OrganizationID: partnerOrg,
+		PartnerRole:    "consulting",
+		MarginTier:     &tier,
+	}); err != nil {
+		t.Fatalf("making the organization a partner: %v", err)
+	}
+
+	t.Run("create refuses a company that is not a partner", func(t *testing.T) {
+		_, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+			Name: "Misattributed", PipelineID: pipeline, StageID: open, Source: "ui",
+			PartnerOrganizationID: &plainOrg,
+		})
+		var notPartner *people.NotAPartnerError
+		if !errors.As(err, &notPartner) {
+			t.Fatalf("CreateDeal naming a non-partner → %v, want NotAPartnerError", err)
+		}
+		// The refusal names the field the caller can act on, and says what to
+		// do — a bare 422 would leave them guessing which of two org fields
+		// was wrong.
+		field, code, _ := notPartner.FieldFault()
+		if field != "partner_org_id" || code != "not_a_partner" {
+			t.Errorf("fault = (%s, %s), want (partner_org_id, not_a_partner)", field, code)
+		}
+	})
+
+	t.Run("update refuses a company that is not a partner", func(t *testing.T) {
+		deal := ids.From[ids.DealKind](e.SeedDeal(t, "Repointed", pipeline, open, &e.Rep1))
+		_, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{
+			PartnerOrganizationID: &plainOrg,
+		})
+		var notPartner *people.NotAPartnerError
+		if !errors.As(err, &notPartner) {
+			t.Fatalf("UpdateDeal naming a non-partner → %v, want NotAPartnerError", err)
+		}
+	})
+
+	// The gate narrows what may be named; it does not break the feature. A
+	// refusal test that never admits anything passes just as happily against an
+	// authority that refuses everyone.
+	t.Run("both paths still accept a real partner", func(t *testing.T) {
+		created, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+			Name: "Sourced properly", PipelineID: pipeline, StageID: open, Source: "ui",
+			PartnerOrganizationID: &partnerOrg,
+		})
+		if err != nil {
+			t.Fatalf("CreateDeal naming a real partner → %v, want ok", err)
+		}
+		if created.PartnerOrgId == nil {
+			t.Error("the partner named at birth did not reach the row")
+		}
+
+		deal := ids.From[ids.DealKind](e.SeedDeal(t, "Repointed properly", pipeline, open, &e.Rep1))
+		updated, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{
+			PartnerOrganizationID: &partnerOrg,
+		})
+		if err != nil {
+			t.Fatalf("UpdateDeal naming a real partner → %v, want ok", err)
+		}
+		if updated.PartnerOrgId == nil {
+			t.Error("the partner named on update did not reach the row")
+		}
+	})
+}

--- a/backend/internal/compose/integration/partnerattributiontarget_integration_test.go
+++ b/backend/internal/compose/integration/partnerattributiontarget_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -95,4 +96,53 @@ func TestADealMayOnlyNameARealPartner(t *testing.T) {
 			t.Error("the partner named on update did not reach the row")
 		}
 	})
+}
+
+// Merging one company into another repoints its deals' partners with raw SQL,
+// outside the store and so outside the check above. That is safe only because
+// the merge carries the partner row to the survivor as well — this holds it to
+// that, because a merge that moved the deals and left the programme behind
+// would orphan every attribution silently, which is the exact failure the
+// check exists to prevent.
+func TestMergingAPartnerLeavesItsDealsNamingAPartner(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	admin := e.As(e.AdminUser, nil, commissionAdminPerms)
+
+	tier := "tier2_20"
+	source := e.SeedPartnerOrg(t, "Partner Source", &tier, nil)
+	target := e.SeedOrg(t, "Plain Target", nil)
+	sourceID := ids.From[ids.OrganizationKind](source)
+
+	deal := ids.From[ids.DealKind](e.SeedDeal(t, "Sourced by the merged partner", pipeline, open, &e.Rep1))
+	if _, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{
+		PartnerOrganizationID: &sourceID,
+	}); err != nil {
+		t.Fatalf("attributing the deal to the source partner: %v", err)
+	}
+
+	if _, err := e.People.MergeOrganization(e.Admin(), orgIDOf(source), orgIDOf(target)); err != nil {
+		t.Fatalf("merging the partner into the plain company: %v", err)
+	}
+
+	// The deal now names the survivor, and the survivor carries the programme
+	// — so the attribution the merge produced is one the store would accept.
+	moved, err := e.Deals.GetDeal(admin, deal, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("reading the merged deal: %v", err)
+	}
+	if moved.PartnerOrgId == nil || ids.UUID(*moved.PartnerOrgId) != target {
+		t.Fatalf("partner = %v, want the survivor %v", moved.PartnerOrgId, target)
+	}
+
+	// The survivor is asked through the store rather than by reading the table:
+	// re-naming it must be ACCEPTED, which is the same question the check asks
+	// and the one that matters — a merge that left an attribution the product
+	// would now refuse has broken the invariant even if the row looks fine.
+	survivor := orgIDOf(target)
+	if _, err := e.Deals.UpdateDeal(admin, deal, deals.UpdateDealInput{
+		PartnerOrganizationID: &survivor,
+	}); err != nil {
+		t.Errorf("re-naming the survivor as partner → %v; the merge left an attribution the store refuses", err)
+	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21275,12 +21275,14 @@ type UpdateDealRequest struct {
 	OwnerId        *openapi_types.UUID `json:"owner_id,omitempty"`
 
 	// PartnerAttribution `sourced` or `influenced`. Naming a partner without this field attributes the deal `sourced`; an attribution for a deal naming no partner is refused 422.
-	PartnerAttribution   *UpdateDealRequestPartnerAttribution `json:"partner_attribution,omitempty"`
-	PartnerOrgId         *openapi_types.UUID                  `json:"partner_org_id,omitempty"`
-	ProjectId            *openapi_types.UUID                  `json:"project_id,omitempty"`
-	Status               *UpdateDealRequestStatus             `json:"status,omitempty"`
-	WaitUntil            *openapi_types.Date                  `json:"wait_until,omitempty"`
-	AdditionalProperties map[string]interface{}               `json:"-"`
+	PartnerAttribution *UpdateDealRequestPartnerAttribution `json:"partner_attribution,omitempty"`
+
+	// PartnerOrgId The partner who brought this deal. The org must have a live `partner` row (else 422 `not_a_partner`), and the caller must be able to read it. Null clears the attribution.
+	PartnerOrgId         *openapi_types.UUID      `json:"partner_org_id,omitempty"`
+	ProjectId            *openapi_types.UUID      `json:"project_id,omitempty"`
+	Status               *UpdateDealRequestStatus `json:"status,omitempty"`
+	WaitUntil            *openapi_types.Date      `json:"wait_until,omitempty"`
+	AdditionalProperties map[string]interface{}   `json:"-"`
 }
 
 // UpdateDealRequestForecastCategory defines model for UpdateDealRequest.ForecastCategory.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14136,7 +14136,7 @@ type CreateDealRequest struct {
 	// PartnerAttribution `sourced` or `influenced`. Naming a partner without this field attributes the deal `sourced`; an attribution for a deal naming no partner is refused 422.
 	PartnerAttribution *CreateDealRequestPartnerAttribution `json:"partner_attribution,omitempty"`
 
-	// PartnerOrgId The partner this deal is attributed to at birth. The org must have a `partner` row, and the caller must be able to read it.
+	// PartnerOrgId The partner this deal is attributed to at birth. The org must have a live `partner` row (else 422 `not_a_partner`), and the caller must be able to read it.
 	PartnerOrgId *openapi_types.UUID `json:"partner_org_id,omitempty"`
 	PipelineId   openapi_types.UUID  `json:"pipeline_id"`
 
@@ -14678,7 +14678,7 @@ type Deal struct {
 	// PartnerAttribution What the partner named by `partner_org_id` did: `sourced` (brought the deal) or `influenced` (helped one we had). Travels with the partner — naming a partner defaults it to `sourced`. Commission accrues on `sourced` only.
 	PartnerAttribution *DealPartnerAttribution `json:"partner_attribution,omitempty"`
 
-	// PartnerOrgId Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row. Null when the caller may not read that organization, in which case `masked_fields` names it.
+	// PartnerOrgId Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a live `partner` row — naming one that does not is refused 422 (`not_a_partner`), because commission prices from the margin tier on that row, and an attribution without one could never earn anything. Null when the caller may not read that organization, in which case `masked_fields` names it.
 	PartnerOrgId *openapi_types.UUID `json:"partner_org_id,omitempty"`
 
 	// PipelineId Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent's own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -99,7 +99,7 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 	if in.Currency != nil {
 		p.Set("currency", current.Currency, *in.Currency)
 	}
-	if err := applyDealLinkPatches(ctx, tx, current, in, p); err != nil {
+	if err := applyDealLinkPatches(ctx, tx, current, in, p, s.installation.EnsurePartner); err != nil {
 		return nil, err
 	}
 	if in.ExpectedClose != nil {
@@ -133,6 +133,7 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 // disclosing that the row exists.
 func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
 	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
+	ensurePartner EnsurePartner,
 ) error {
 	if in.OrganizationID != nil {
 		if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.OrganizationID.UUID); err != nil {
@@ -149,7 +150,7 @@ func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
 		}
 		p.Set("project_id", current.ProjectId, *in.ProjectID)
 	}
-	return applyPartnerAttributionPatch(ctx, tx, current, in, p)
+	return applyPartnerAttributionPatch(ctx, tx, current, in, p, ensurePartner)
 }
 
 // applyPartnerAttributionPatch writes the partner link and what that partner
@@ -165,6 +166,7 @@ func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
 // leaves the link alone and moves only the claim.
 func applyPartnerAttributionPatch(ctx context.Context, tx pgx.Tx,
 	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch,
+	ensurePartner EnsurePartner,
 ) error {
 	if in.PartnerAttribution != nil {
 		if err := validPartnerAttribution(*in.PartnerAttribution); err != nil {
@@ -191,6 +193,11 @@ func applyPartnerAttributionPatch(ctx context.Context, tx pgx.Tx,
 		return nil
 	}
 	if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.PartnerOrganizationID.UUID); err != nil {
+		return err
+	}
+	// Visible is not enough: it must actually BE a partner, or the deal reads
+	// as credited to somebody the accrual can never price.
+	if err := ensurePartner(ctx, tx, *in.PartnerOrganizationID); err != nil {
 		return err
 	}
 	p.Set("partner_org_id", current.PartnerOrgId, *in.PartnerOrganizationID)

--- a/backend/internal/modules/deals/deal_create.go
+++ b/backend/internal/modules/deals/deal_create.go
@@ -255,6 +255,14 @@ func (s *Store) createDealInTx(ctx context.Context, tx pgx.Tx, in CreateDealInpu
 	if err := ensureBirthLinksVisible(ctx, tx, in); err != nil {
 		return crmcontracts.Deal{}, err
 	}
+	// Visible is not enough for the partner: it must actually BE one, or the
+	// deal reads as credited and can never earn anything (the accrual prices
+	// from the partner row's margin tier).
+	if in.PartnerOrganizationID != nil {
+		if err := s.installation.EnsurePartner(ctx, tx, *in.PartnerOrganizationID); err != nil {
+			return crmcontracts.Deal{}, err
+		}
+	}
 
 	id := ids.New[ids.DealKind]()
 	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{

--- a/backend/internal/modules/deals/fxrate_store_test.go
+++ b/backend/internal/modules/deals/fxrate_store_test.go
@@ -118,8 +118,9 @@ func TestEveryUninjectedInstallationSeamRefuses(t *testing.T) {
 	for i := range inst.NumField() {
 		field := inst.Type().Field(i).Name
 		t.Run(field, func(t *testing.T) {
-			// Two seam shapes live on this struct: the InstallationValue
-			// readers, and StampCorrespondence, which writes. Both must refuse
+			// Three seam shapes live on this struct: the InstallationValue
+			// readers, StampCorrespondence, which writes, and EnsurePartner,
+			// which refuses an attribution. Each must refuse
 			// when un-injected, so the test calls whichever this field is
 			// rather than asserting one shape and skipping the other — a
 			// skipped field is a seam nobody proved fails closed.
@@ -135,6 +136,11 @@ func TestEveryUninjectedInstallationSeamRefuses(t *testing.T) {
 					t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
 				}
 				err = seam(context.Background(), nil, ids.DealID{}, BasisDealWon)
+			case EnsurePartner:
+				if seam == nil {
+					t.Fatalf("%s is nil after orRefusing; an un-injected seam must refuse, not panic", field)
+				}
+				err = seam(context.Background(), nil, ids.OrganizationID{})
 			default:
 				t.Fatalf("%s is neither seam shape; teach this test how to call it", field)
 			}

--- a/backend/internal/modules/deals/partner_attribution_test.go
+++ b/backend/internal/modules/deals/partner_attribution_test.go
@@ -10,11 +10,13 @@ package deals
 // constraint violation.
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -40,6 +42,18 @@ func TestMigrationAdmitsExactlyTheAttributionsTheStoreAccepts(t *testing.T) {
 	}
 	if err := validPartnerAttribution("partner_of"); err == nil {
 		t.Error("a value outside the two-word vocabulary was accepted; the CHECK would reject the row")
+	}
+}
+
+// unreachablePartnerCheck is the seam for a path that must not reach it: every
+// case below is refused, or leaves the pair alone, BEFORE the partner is
+// resolved. A call here means the refusal moved after the database read it was
+// meant to happen instead of.
+func unreachablePartnerCheck(t *testing.T) EnsurePartner {
+	t.Helper()
+	return func(context.Context, pgx.Tx, ids.OrganizationID) error {
+		t.Error("the partner check ran on a path that never names a valid partner")
+		return nil
 	}
 }
 
@@ -122,7 +136,7 @@ func TestAttributionWithoutAPartnerIsRefused(t *testing.T) {
 	sourced := attributionSourced
 	in := UpdateDealInput{PartnerAttribution: &sourced}
 
-	err := applyPartnerAttributionPatch(t.Context(), nil, crmcontracts.Deal{}, in, p)
+	err := applyPartnerAttributionPatch(t.Context(), nil, crmcontracts.Deal{}, in, p, unreachablePartnerCheck(t))
 
 	var unpaired *PartnerAttributionUnpairedError
 	if !errors.As(err, &unpaired) {
@@ -144,7 +158,7 @@ func TestAnUnknownAttributionIsRefusedBeforeTheDatabaseSeesIt(t *testing.T) {
 	// does not depend on a transaction being present.
 	in := UpdateDealInput{PartnerAttribution: &bogus}
 
-	err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), in, p)
+	err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), in, p, unreachablePartnerCheck(t))
 
 	var invalid *PartnerAttributionValueError
 	if !errors.As(err, &invalid) {
@@ -161,7 +175,7 @@ func TestAnUnknownAttributionIsRefusedBeforeTheDatabaseSeesIt(t *testing.T) {
 func TestTouchingNeitherHalfLeavesThePairAlone(t *testing.T) {
 	p := storekit.NewPatch()
 
-	if err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), UpdateDealInput{}, p); err != nil {
+	if err := applyPartnerAttributionPatch(t.Context(), nil, dealNamingPartner(attributionSourced), UpdateDealInput{}, p, unreachablePartnerCheck(t)); err != nil {
 		t.Fatalf("an update naming neither half: %v", err)
 	}
 	if len(p.After()) != 0 {

--- a/backend/internal/modules/deals/store.go
+++ b/backend/internal/modules/deals/store.go
@@ -71,7 +71,16 @@ type Installation struct {
 	// WithX setter because every construction site already passes this struct,
 	// and a seam a caller can forget is one that silently stops shielding.
 	StampCorrespondence StampCorrespondence
+	// EnsurePartner refuses a partner_org_id that names a company with no
+	// partner programme. `people` owns that table, so the edge is injected
+	// here rather than read across the module boundary (ADR-0054).
+	EnsurePartner EnsurePartner
 }
+
+// EnsurePartner answers whether an organization may be named as a deal's
+// partner, inside the caller's own transaction so the answer cannot go stale
+// between the check and the write.
+type EnsurePartner func(ctx context.Context, tx pgx.Tx, organizationID ids.OrganizationID) error
 
 // NewStore binds the store to the pool every tenant query runs through, and
 // to the seam that answers the installation's own values.
@@ -100,7 +109,21 @@ func (i Installation) orRefusing() Installation {
 	if i.StampCorrespondence == nil {
 		i.StampCorrespondence = refusingStamp()
 	}
+	if i.EnsurePartner == nil {
+		i.EnsurePartner = refusingEnsurePartner()
+	}
 	return i
+}
+
+// refusingEnsurePartner is what an un-injected partner check becomes: it
+// refuses every attribution rather than admitting every one. A seam that failed
+// OPEN here would silently restore the hole it exists to close.
+func refusingEnsurePartner() EnsurePartner {
+	return func(context.Context, pgx.Tx, ids.OrganizationID) error {
+		return errors.New("deals: the EnsurePartner seam was not injected; " +
+			"construct this store with installseam.Deals(), which binds people's " +
+			"EnsureOrganizationIsPartner")
+	}
 }
 
 func refusing(field string) InstallationValue {

--- a/backend/internal/modules/people/partner_attribution_target.go
+++ b/backend/internal/modules/people/partner_attribution_target.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The check a deal runs before it names a partner: does this organization
+// actually have a partner programme? It lives here because `people` owns the
+// `partner` table, and the deals module reaches it through the installation
+// seam compose wires (ADR-0054) rather than reading a sibling's table.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// EnsureOrganizationIsPartner refuses an organization that carries no partner
+// row, inside the caller's own transaction.
+//
+// A deal's partner is what the commission ledger prices from: accrual reads the
+// margin tier off the partner row, so an attribution to a company that is not a
+// partner produces a deal that LOOKS credited and can never earn anything. The
+// contract has always said the target "must have a `partner` row"; this is what
+// makes that true rather than aspirational.
+//
+// It runs in the caller's transaction so the answer cannot go stale between the
+// check and the write — a partner archived in the moment between the two would
+// otherwise leave exactly the row this refuses.
+//
+// Archived partners are refused with the same answer as absent ones. A
+// programme that has been retired is not one a NEW deal may be attributed to,
+// and the deals already pointing at it keep their attribution untouched.
+func EnsureOrganizationIsPartner(ctx context.Context, tx pgx.Tx, organizationID ids.OrganizationID) error {
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM partner
+		                 WHERE organization_id = $1 AND archived_at IS NULL)`,
+		organizationID).Scan(&exists); err != nil {
+		return fmt.Errorf("check organization is a partner: %w", err)
+	}
+	if !exists {
+		return &NotAPartnerError{}
+	}
+	return nil
+}
+
+// NotAPartnerError maps to 422: the organization exists and the caller may read
+// it, but it carries no partner programme to attribute a deal to.
+//
+// Separate from a not-found: the caller named a real company they can see, and
+// telling them "no such organization" would send them looking for the wrong
+// problem. What they need to hear is that this company is not a partner yet,
+// and what to do about it.
+type NotAPartnerError struct{}
+
+func (e *NotAPartnerError) Error() string {
+	return "partner_org_id must name a company that is a partner — set up its partner programme first, or clear the field"
+}
+
+// FieldFault names the wire field the refusal belongs to.
+func (e *NotAPartnerError) FieldFault() (field, code, message string) {
+	return "partner_org_id", "not_a_partner", e.Error()
+}

--- a/backend/internal/modules/people/partner_attribution_target.go
+++ b/backend/internal/modules/people/partner_attribution_target.go
@@ -26,9 +26,15 @@ import (
 // contract has always said the target "must have a `partner` row"; this is what
 // makes that true rather than aspirational.
 //
-// It runs in the caller's transaction so the answer cannot go stale between the
-// check and the write — a partner archived in the moment between the two would
-// otherwise leave exactly the row this refuses.
+// The row is LOCKED, not merely read. Running in the caller's transaction is
+// not enough on its own: a plain SELECT takes no lock, so an archive could
+// commit between the check and the write and leave a fresh deal naming an
+// archived partner — the state this exists to refuse. FOR KEY SHARE is the
+// weakest lock that conflicts with the archive's own write, so an unrelated
+// edit to the partner (a tier change, a stage move) still runs alongside a deal
+// being attributed. Whichever side takes it first the outcome is right: the
+// archive waits and then sees the deal, or this check waits and re-evaluates
+// against the committed archived_at and refuses.
 //
 // Archived partners are refused with the same answer as absent ones. A
 // programme that has been retired is not one a NEW deal may be attributed to,
@@ -37,7 +43,8 @@ func EnsureOrganizationIsPartner(ctx context.Context, tx pgx.Tx, organizationID 
 	var exists bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM partner
-		                 WHERE organization_id = $1 AND archived_at IS NULL)`,
+		                 WHERE organization_id = $1 AND archived_at IS NULL
+		                 FOR KEY SHARE)`,
 		organizationID).Scan(&exists); err != nil {
 		return fmt.Errorf("check organization is a partner: %w", err)
 	}

--- a/backend/migrations/core/1787320002_orphaned_partner_attributions_are_cleared.down.sql
+++ b/backend/migrations/core/1787320002_orphaned_partner_attributions_are_cleared.down.sql
@@ -1,0 +1,7 @@
+-- Irreversible by nature: the rows this cleared named companies that are not
+-- partners, and the values are not recorded anywhere this migration could read
+-- them back from. The audit log holds the history for anyone who needs it.
+--
+-- Down is a no-op rather than an error so a rollback of the surrounding release
+-- is not blocked by a data repair that cannot be undone.
+SELECT 1;

--- a/backend/migrations/core/1787320002_orphaned_partner_attributions_are_cleared.up.sql
+++ b/backend/migrations/core/1787320002_orphaned_partner_attributions_are_cleared.up.sql
@@ -1,0 +1,27 @@
+-- A deal may only name a company that is a partner. New writes are refused by
+-- the store; this reaches the rows written before that check existed.
+--
+-- An attribution to a company with no live partner row could never earn
+-- anything: commission prices from the margin tier on that row, so accrual
+-- finds no tier and records a skip. The deal reads as credited on every screen
+-- and pays nobody — and because the store now refuses that shape, the field
+-- could not be corrected in place either.
+--
+-- Both halves are cleared together: deal_partner_attribution_pairing admits the
+-- columns populated together or not at all, so clearing one alone would leave a
+-- row the constraint rejects.
+--
+-- What is NOT done here: nothing is invented. A deal whose partner was never
+-- set up keeps its history in the audit log, and the attribution can be made
+-- again once that company has a partner programme.
+
+SET LOCAL lock_timeout = '5s';
+
+UPDATE deal
+   SET partner_org_id = NULL,
+       partner_attribution = NULL
+ WHERE partner_org_id IS NOT NULL
+   AND NOT EXISTS (
+         SELECT 1 FROM partner
+          WHERE partner.organization_id = deal.partner_org_id
+            AND partner.archived_at IS NULL);

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -13161,7 +13161,7 @@ export interface components {
             organization_id?: string | null;
             /**
              * Format: uuid
-             * @description Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row. Null when the caller may not read that organization, in which case `masked_fields` names it.
+             * @description Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a live `partner` row — naming one that does not is refused 422 (`not_a_partner`), because commission prices from the margin tier on that row, and an attribution without one could never earn anything. Null when the caller may not read that organization, in which case `masked_fields` names it.
              */
             partner_org_id?: string | null;
             /**
@@ -13242,7 +13242,7 @@ export interface components {
             organization_id?: string | null;
             /**
              * Format: uuid
-             * @description The partner this deal is attributed to at birth. The org must have a `partner` row, and the caller must be able to read it.
+             * @description The partner this deal is attributed to at birth. The org must have a live `partner` row (else 422 `not_a_partner`), and the caller must be able to read it.
              */
             partner_org_id?: string | null;
             /**


### PR DESCRIPTION
Closes #2109.

The contract has always said `partner_org_id` must name an org with a `partner` row. Nothing enforced it, so a deal could be attributed to an ordinary customer — and **the failure was silent**, which is what made it worth closing rather than documenting. Commission prices from the margin tier on the partner row, so an attribution to a company without one reaches accrual, finds no tier, and records a skip. The deal reads as credited on every screen and can never earn anything.

Both write paths now refuse with a 422 that names the field and says what to do:

> partner_org_id must name a company that is a partner — set up its partner programme first, or clear the field

A company the caller cannot see still answers **not-found**, because visibility is checked before the partner row and existence-hiding outranks a more specific message.

**Where the check lives.** `people` owns the `partner` table, so the check is theirs and reaches deals through the installation seam compose wires — the same shape the correspondence stamp already uses. Un-injected it **refuses** rather than admits, and the existing seam fitness function proves that from the struct, so the next seam added cannot quietly fail open.

**Seven existing integration fixtures** pointed deals at plain organizations, which is a row the product will no longer write. They seed through a new harness helper that makes a real partner instead.

Verified: full backend gate, `make check-fe`, the whole `compose/integration` lane plus the deals and people lanes, and live against a dev stack — 422 for a non-partner, 201 for a real one. Both refusals mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses partner attribution to non-partner organizations and repairs existing orphaned attributions. Previously, `partner_org_id` accepted any visible org; accrual then found no margin tier and skipped commission while the deal appeared credited. Now create and update refuse with 422 and a field fault; a migration clears old invalid pairs.

- Behavior: 422 with field `partner_org_id` and code `not_a_partner` when the named org lacks a live partner row; archived partners are treated as non-partners; a non-visible org still returns not-found first. Update may set `partner_org_id` to null to clear attribution.
- Notes:
  - One-time migration clears `partner_org_id` and `partner_attribution` on deals naming a non-partner; no data is invented and audit history remains; rollback is a no-op.
  - The partner check now locks the partner row (`FOR KEY SHARE`) inside the caller’s transaction to avoid races with archive.
  - The check lives in `people.EnsureOrganizationIsPartner` and is injected as `installseam.Deals().EnsurePartner`; un-injected seams refuse closed. API/docs and generated types now document 422 on both create and update.
  - Fixtures use `SeedPartnerOrg`; integration tests cover refusal/admit and verify org merge leaves deals naming a still-valid partner.

<sup>Written for commit 7a299044a64b08a9ac8bb6553aaea6a8b25c2cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

