### PR TITLE
feat(ci): main's breakage is found in two hours and named, not in a day

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -1,0 +1,194 @@
+# Is main red RIGHT NOW, and whose commit made it so.
+#
+# main receives ~85 merges a day and a merge can land over a red required check —
+# a repository-role bypass is deliberate here, so that will keep happening and
+# this workflow does nothing to prevent it. What it changes is the DELAY: without
+# it, a breakage on main is discovered when somebody else's unrelated pull request
+# goes red for reasons they did not cause, which is both slow and lands the cost on
+# the wrong person. The nightly lane in scheduled.yml answers the same question
+# once a day; at eight merges an hour that is a working day of exposure.
+#
+# So this runs every two hours and, when it finds main broken, files ONE issue per
+# broken lane naming the commits that landed since the last green run and who
+# authored them. The point is attribution and speed, not prevention.
+#
+# It is NOT a gate. Nothing here blocks a merge, and it never will: the required
+# check is `ci` on the pull request, and this workflow reports on a tree that has
+# already landed.
+#
+# The cadence is the one knob. Every two hours costs ~11 jobs a run against a
+# 20-concurrent org ceiling that the pull-request lanes also queue in, and narrows
+# the suspect range to roughly a dozen commits. Tighten the cron if a dozen is too
+# many to bisect; it is one line.
+name: main-health
+
+on:
+  schedule:
+    # :17 rather than :00 — the top of the hour is when every other cron in every
+    # other repository fires, and this lane competes for the same runner pool.
+    - cron: "17 */2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One run at a time, and never cancelled. A cancelled run answers nothing, and two
+# concurrent runs would both report the same breakage under the same issue title.
+# If a run is still going when the next fires, main is slow rather than broken and
+# the answer is worth waiting for.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  # The no-database half of the merge gate, run against main's tip unconditionally.
+  # Unconditionally is the whole point: the classifier that makes a pull request
+  # cheap is exactly what let a docs-only commit report green over a broken tree.
+  gates:
+    name: backend gate (main)
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The RBAC legacy-cohort gates read an early commit as a fixture and
+          # fail rather than degrade on a shallow checkout.
+          fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+        with:
+          flavor: plain
+      # The gate binaries are NOT covered by the Go caches: setup-go caches
+      # ~/go/pkg/mod and ~/.cache/go-build, not the tools installed into ~/go/bin.
+      # cache-warm.yml shipped without these three steps and failed every run on
+      # "golangci-lint not found" before compiling anything, which is the one thing
+      # it existed to do. Same lane, same requirement, so the same three steps.
+      - name: Cache the gate binaries
+        id: gate-binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/bin
+          key: gate-binaries-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.mod', 'backend/Makefile') }}
+      - name: Install the pinned gate binaries
+        if: steps.gate-binaries.outputs.cache-hit != 'true'
+        working-directory: .
+        run: make tools
+      - name: Gate binaries onto PATH
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
+      - name: Backend merge gate (make check-backend)
+        working-directory: .
+        env:
+          CONTRACT_BREAKING_REQUIRE_BASE: "1"
+          MIGRATION_VERSIONS_REQUIRE_BASE: "1"
+        run: make check-backend
+
+  # The real-Postgres lane, called rather than copied. Every schema fitness gate
+  # that has broken main recently lives here and nowhere else — an unratified
+  # DELETE trigger, a foreign key with no visibility decision — so a health check
+  # without a database would have missed every one of them.
+  integration:
+    uses: ./.github/workflows/_lane-integration.yml
+
+  # main's SonarCloud analysis, published from here.
+  #
+  # Nothing else publishes it. The push-to-main scan is gone (the merge queue was
+  # meant to gate before the merge instead), and the merge_group scan that replaced
+  # it only runs while the queue rule is enabled — which it is not. A stored
+  # analysis does not disappear when it stops being refreshed, it FREEZES, and the
+  # nightly quality-gate job reads ?branch=main and reports that frozen verdict as
+  # though it were current. Publishing here makes main's reading independent of
+  # whether the queue is on.
+  sonar:
+    name: sonarcloud (main)
+    timeout-minutes: 30
+    needs: [integration]
+    # Only on a green lane, and only with the coverage in hand. The scanner's Zero
+    # Coverage Sensor scores every executable line it holds no report for as
+    # UNCOVERED, so a scan without the Go profile publishes the tree at 0% rather
+    # than declining to answer — and measuring nothing is not a measurement of zero.
+    if: needs.integration.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: https://sonarcloud.io
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Full history so the scanner can attribute blame and compute new code.
+          fetch-depth: 0
+      - name: Download Go coverage
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: go-coverage
+          path: backend
+      - name: SonarCloud scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        with:
+          args: -Dsonar.branch.name=main
+      - name: No token yet — scan skipped
+        if: ${{ env.SONAR_TOKEN == '' }}
+        run: echo "SONAR_TOKEN not set; main's analysis was not refreshed by this run."
+
+  # Say what broke and who landed it. This is the job the whole workflow exists
+  # for: a red lane nobody is told about is the state we already had.
+  report:
+    name: report
+    timeout-minutes: 10
+    needs: [gates, integration]
+    if: >-
+      !cancelled()
+      && (needs.gates.result == 'failure' || needs.integration.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      # To find this workflow's last GREEN run, which is what bounds the suspect
+      # range. Without it the report can say "main is red" but not "since when".
+      actions: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The whole history, because the range starts at the last green run's
+          # commit — which may be many merges back.
+          fetch-depth: 0
+      # The suspect range: everything that landed since this workflow last passed.
+      # It is an over-approximation on purpose. Naming a dozen commits that might
+      # be responsible is useful; naming none, or guessing one, is not.
+      - name: Commits since the last green health check
+        id: range
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: ./scripts/main-health-range.sh
+      - name: File or update an issue per broken lane
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAIN_GATES_RESULT: ${{ needs.gates.result }}
+          MAIN_INTEGRATION_RESULT: ${{ needs.integration.result }}
+          MAIN_SUSPECTS: ${{ steps.range.outputs.suspects }}
+        run: ./scripts/scheduled-report.sh

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -514,7 +514,7 @@ Wiring details:
 
 `ci.yml` is the merge gate, and `_lane-integration.yml` / `_lane-frontend.yml` are
 part of it — called by it, never triggered on their own (see
-[Two lanes are called](#two-lanes-are-called-not-inlined)). Six workflows sit
+[Two lanes are called](#two-lanes-are-called-not-inlined)). Seven workflows sit
 beside the gate, deliberately outside it:
 
 - **`cache-warm.yml`** — the Go build cache's only writer, on `main` every three
@@ -526,6 +526,32 @@ beside the gate, deliberately outside it:
   branch plus the default branch, and a queue ref is throwaway). See
   [The shared Go build cache](#the-shared-go-build-cache) for why it is scheduled
   rather than per-push.
+
+- **`main-health.yml`** — every two hours on `main`: the backend gate plus the
+  real-Postgres lane (called, not copied — it `uses:` `_lane-integration.yml`),
+  and `main`'s SonarCloud analysis published from the coverage that lane produces.
+  **It is not a gate and never will be**: it reports on a tree that has already
+  landed.
+
+  It exists because of a deliberate asymmetry. A merge can land over a red `ci` —
+  a repository-role bypass is sanctioned here, to keep the fastest contributor
+  fast — so breakage on `main` will keep happening and nothing in this workflow
+  tries to prevent it. What it changes is the **delay and the attribution**:
+  without it, a breakage is discovered when somebody else's unrelated pull request
+  goes red for a reason they did not cause. On failure it files one issue per
+  broken lane carrying the commits that landed since the health check was last
+  green, with authors ([`scripts/main-health-range.sh`](../scripts/main-health-range.sh)).
+  That range is a deliberate over-approximation: naming a dozen candidates is
+  useful, guessing one sends the wrong person looking.
+
+  It is also the **only** publisher of `main`'s SonarCloud analysis. The
+  push-to-`main` scan is gone and the `merge_group` scan that replaced it only
+  runs while the queue rule is enabled, which it is not — and a stored analysis
+  does not vanish when it stops being refreshed, it FREEZES, while the nightly
+  quality-gate job goes on reporting that frozen verdict as current.
+
+  The cadence is the knob: two hours costs ~11 jobs a run and narrows the suspect
+  range to roughly a dozen commits at eight merges an hour.
 
 - **`scheduled.yml`** — daily on `main`, the checks whose answer changes when
   nothing is being merged. `ci.yml` asks "is this diff sound?" and runs because a

--- a/scripts/main-health-range.sh
+++ b/scripts/main-health-range.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# main-health-range.sh — the commits that could have broken main, and who wrote them.
+#
+# A health check that only says "main is red" leaves the same investigation the red
+# check on somebody else's pull request already forced: bisect, or ask around. The
+# range this prints is what turns that into a name and a commit.
+#
+# It is bounded by this workflow's last GREEN run, so it is an OVER-approximation:
+# every commit that landed since main was last known good. That is deliberate.
+# Naming a dozen commits, one of which is responsible, is useful; naming one by
+# guessing is worse than naming none, because it sends the wrong person looking.
+#
+# WHAT THIS CATCHES: the window. Not the culprit.
+#
+# WHAT IT DOES NOT DO, deliberately: bisect. Halving the range means re-running the
+# lane per step, and the lane is ~20 minutes — an hour of runners to save a reader
+# thirty seconds of `git log`. The range plus the failing test name has been enough
+# every time this has happened so far.
+set -euo pipefail
+
+# No apostrophes in these messages: inside ${VAR:?word} bash parses the word, so a
+# lone ' opens a quote that never closes and the parse error surfaces dozens of
+# lines later, pointing at innocent code.
+: "${GH_TOKEN:?the range lookup needs a token to read the history of this workflow}"
+: "${REPO:?REPO must name the repository}"
+: "${GITHUB_OUTPUT:?this script writes its answer to the step output}"
+
+# How many commits to name when there is no green run to bound the range — a first
+# run, or a workflow renamed. Enough to be a lead, few enough to read.
+FALLBACK_COMMITS=15
+
+# The last run of THIS workflow that passed. `--status success` is the workflow
+# conclusion, so a run whose report job filed an issue is not green and does not
+# bound the range: the window stays open until main is actually fixed, which is the
+# behaviour that matters when a breakage survives several health checks.
+last_green="$(gh run list \
+  --repo "$REPO" \
+  --workflow main-health.yml \
+  --status success \
+  --limit 1 \
+  --json headSha \
+  --jq '.[0].headSha // empty' 2>/dev/null || true)"
+
+range=""
+if [ -n "$last_green" ] && git cat-file -e "$last_green^{commit}" 2>/dev/null; then
+  range="$last_green..HEAD"
+  bound="since the last green health check ($(git rev-parse --short "$last_green"))"
+else
+  # No green run on record, or its commit is not in this checkout's history —
+  # a force-push, a renamed workflow, or the first ever run. Say which, rather
+  # than printing a range that quietly means something else.
+  range="-n $FALLBACK_COMMITS HEAD"
+  bound="the last $FALLBACK_COMMITS commits (no green health check on record to bound the range)"
+fi
+
+# %h short sha, %an author, %s subject. git log takes the range unquoted in the
+# fallback case because it is two arguments there, not one.
+#
+# The markdown backtick around the sha comes from printf rather than being typed:
+# a literal backtick inside a double-quoted command substitution is still command
+# substitution to bash, and the parse error it produces points at a line well past
+# the one that caused it. Octal 140 is the character, with none of that.
+bt="$(printf '\140')"
+# shellcheck disable=SC2086 -- $range is deliberately word-split; see above.
+commits="$(git log $range --no-merges --format='- %h %an — %s' | sed -E "s/^- ([0-9a-f]+) /- ${bt}\1${bt} /" || true)"
+
+if [ -z "$commits" ]; then
+  commits="_no commits in the range — the breakage predates it, or the range could not be computed._"
+fi
+
+count="$(printf '%s\n' "$commits" | grep -c '^- ' || true)"
+
+# Written as a heredoc-delimited multiline output: a bare `name=value` truncates at
+# the first newline, which would reduce the whole range to one commit and read as a
+# confident single suspect.
+{
+  echo "suspects<<MAIN_HEALTH_RANGE"
+  echo "Landed on \`main\` $bound — $count commit(s), one of which is the likely cause:"
+  echo
+  printf '%s\n' "$commits"
+  echo "MAIN_HEALTH_RANGE"
+} >>"$GITHUB_OUTPUT"
+
+echo "range: $bound - $count commit(s)"

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scheduled-report.sh — turn a failing scheduled check into a durable issue.
 #
-# Called only when something in .github/workflows/scheduled.yml failed. A red
+# Called when a check in scheduled.yml OR main-health.yml failed. A red
 # scheduled run notifies essentially nobody by default, which is the whole reason
 # these checks moved off the PR path in the first place: nothing was going to make
 # someone look. An issue is the artifact that survives until it is closed.
@@ -186,6 +186,53 @@ the \`go-build-\` prefix changed, teach the script the new shape —
 \`scripts/test-reap-build-caches.sh\` covers both refusals.
 
 Inspect without deleting anything: \`DRY_RUN=1 scripts/reap-build-caches.sh\`."\
+    || unreported=1
+fi
+
+# --- main-health.yml -----------------------------------------------------------
+#
+# The two arms below are filed by the two-hourly health check rather than the daily
+# lane, and they are the ones that carry a SUSPECT RANGE. That is the whole reason
+# that workflow exists: a merge can land over a red `ci` here (a repository-role
+# bypass is deliberate), so the question is never "how do we stop it" but "how
+# quickly does somebody learn, and whose commit was it". Naming the window is what
+# turns a red lane on an unrelated pull request into a fixable finding.
+#
+# MAIN_SUSPECTS is an over-approximation — every commit since the health check was
+# last green. Printed as-is rather than narrowed: a guessed culprit sends the wrong
+# person looking, which is worse than a dozen candidates and a failing test name.
+
+if [ "${MAIN_GATES_RESULT:-}" = "failure" ]; then
+  report "main is red: the backend gate fails on the tip" bug \
+"\`make check-backend\` failed against \`main\` on the two-hourly health check:
+$RUN_URL
+
+This is the no-database half of the merge gate, re-run unconditionally. That
+matters: the classifier that makes a pull request cheap is exactly what let a
+docs-only commit report green over a broken tree, so \`main\`'s last-known-green
+is not evidence \`main\` is green.
+
+${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
+
+Reproduce locally on \`main\` with \`make check-backend\`."\
+    || unreported=1
+fi
+
+if [ "${MAIN_INTEGRATION_RESULT:-}" = "failure" ]; then
+  report "main is red: the integration lane fails on the tip" bug \
+"The real-Postgres lane failed against \`main\` on the two-hourly health check:
+$RUN_URL
+
+Every schema fitness gate lives in this lane and nowhere else — an unratified
+DELETE trigger on a sweep target, a foreign key with no visibility decision — and
+that family is what has broken \`main\` repeatedly. The failing test names which
+one; the run above has the shard log.
+
+${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
+
+Reproduce locally with \`make db-up && make test-integration\` on \`main\`. Until
+this is fixed, every other pull request inherits the failure through its merge
+commit and reads as red for a reason its author did not cause."\
     || unreported=1
 fi
 

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -44,6 +44,10 @@ case "$1 ${2:-}" in
 "issue create")
 	for i in $(seq 1 $#); do
 		if [ "${!i}" = "--title" ]; then j=$((i + 1)); echo "create ${!j}" >>"$ACTION_LOG"; fi
+		# The body is recorded, not just the title: an arm that files the right
+		# issue with the wrong contents is indistinguishable from a working one
+		# unless something reads what it wrote.
+		if [ "${!i}" = "--body" ] && [ -n "${BODY_LOG:-}" ]; then j=$((i + 1)); printf '%s' "${!j}" >>"$BODY_LOG"; fi
 	done
 	;;
 *) echo "unexpected gh call: $*" >&2; exit 1 ;;
@@ -111,6 +115,57 @@ expect "duplicates already filed: the oldest keeps the discussion" \
 expect "a similar title is a different finding" \
 	"create $GATE_TITLE" \
 	"$(printf '55\tSonarCloud quality gate is not green on staging\n')"
+
+# --- main-health arms ----------------------------------------------------------
+#
+# The health check's whole value is the SUSPECT RANGE it carries: "main is red" was
+# already knowable from any other pull request going red. So the assertion is not
+# just that an issue is filed — it is that the range reaches the body. A reporter
+# that filed the issue and dropped MAIN_SUSPECTS would look identical from the
+# outside and be worth nothing.
+
+readonly HEALTH_TITLE="main is red: the integration lane fails on the tip"
+readonly SUSPECTS="- \`deadbeef\` Some Author — the commit that did it"
+
+# expect_health <name> <expected-actions> <suspects>
+expect_health() {
+	local name="$1" want="$2" suspects="$3" out status got body
+	export ACTION_LOG="$stub_dir/actions"
+	export BODY_LOG="$stub_dir/body"
+	: >"$ACTION_LOG"
+	: >"$BODY_LOG"
+	set +e
+	out="$(OPEN_TITLES="" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
+		MAIN_INTEGRATION_RESULT=failure MAIN_SUSPECTS="$suspects" \
+		"$root/scripts/scheduled-report.sh" 2>&1)"
+	status=$?
+	set -e
+	got="$(paste -sd, - <"$ACTION_LOG")"
+	body="$(cat "$BODY_LOG" 2>/dev/null || true)"
+
+	if [ "$status" -ne 0 ] || [ "$got" != "$want" ]; then
+		echo "FAIL: $name"
+		echo "  exit    want 0 got $status"
+		echo "  actions want '$want' got '$got'"
+		printf '  output: %s\n' "$out" | head -5
+		failures=$((failures + 1))
+		return
+	fi
+	if [ -n "$suspects" ] && ! printf '%s' "$body" | grep -qF -- "deadbeef"; then
+		echo "FAIL: $name — the issue was filed but the suspect range never reached its body"
+		failures=$((failures + 1))
+		return
+	fi
+	echo "ok: $name"
+}
+
+expect_health "a red integration lane on main is filed with its suspect range" \
+	"create $HEALTH_TITLE" "$SUSPECTS"
+
+# No range computed is a degraded report, not a silent one: the issue still has to
+# exist, because "main is red" is worth filing even when the window is unknown.
+expect_health "a red lane with no range still files" \
+	"create $HEALTH_TITLE" ""
 
 if [ "$failures" -ne 0 ]; then
 	echo "FAIL: $failures case(s)" >&2


### PR DESCRIPTION
## Why

A merge can land on `main` over a red `ci` — a repository-role bypass is sanctioned
here, deliberately, so the fastest contributor stays fast. **Nothing in this PR
tries to prevent that, and nothing here is a gate.** What it changes is how long a
breakage goes unnoticed, and whether anyone can tell whose commit it was.

Today a breakage on `main` is discovered when somebody *else's* unrelated pull
request goes red for a reason its author did not cause. That is slow, and the cost
lands on the wrong person. The nightly lane asks the same question once a day —
at eight merges an hour, a working day of exposure.

## What it does

**`main-health.yml`, every two hours** against `main`'s tip:

- the backend gate, unconditionally (no classifier — that is exactly what let a
  docs-only commit report green over a broken tree)
- the real-Postgres lane, **called not copied**: `uses: _lane-integration.yml`,
  which the Stage 2 refactor made possible

The database half is not optional. Every schema fitness gate that has broken `main`
recently lives *only* there — an unratified DELETE trigger on a sweep target, a
foreign key with no visibility decision — and a health check without a cluster
would have missed all five occurrences
([#1588](https://github.com/gradionhq/margince-poc-v1/issues/1588),
[#1682](https://github.com/gradionhq/margince-poc-v1/issues/1682),
[#2046](https://github.com/gradionhq/margince-poc-v1/issues/2046),
[#2058](https://github.com/gradionhq/margince-poc-v1/issues/2058), and today's).

## The part that unblocks people

On failure it files **one issue per broken lane, carrying the suspect range**:

```
Landed on `main` since the last green health check (0a475573) — 12 commit(s),
one of which is the likely cause:

- `69329499` LarsGradion — fix(deals): the project activity clock finally has a writer
- ...
```

Bounded by this workflow's last **green** run, so the window stays open until
`main` is actually fixed rather than resetting on each re-failure.

The range is a deliberate over-approximation. Naming a dozen candidates is useful;
guessing one sends the wrong person looking. It does **not** bisect: halving a
~20-minute lane spends an hour of runners to save thirty seconds of `git log`, and
the range plus the failing test name has been enough every time so far.

The integration issue also says plainly that every other pull request is
inheriting the failure through its merge commit — so five people do not each
independently debug the same trigger.

## It also unfreezes main's SonarCloud analysis

Same workflow, because it is the same prerequisite: a periodic run against `main`
that produces coverage.

Nothing else publishes `main`'s analysis any more. The push-to-`main` scan went
with the merge queue, and the `merge_group` scan that replaced it only runs while
the queue rule is enabled — which it is not. **A stored analysis does not vanish
when it stops being refreshed, it freezes**, and `scheduled.yml`'s quality-gate job
reads `?branch=main` and reports that frozen verdict as though it were current.

Publishing from the coverage this lane already produces makes `main`'s reading
independent of whether the queue is ever turned back on. Guarded on a green lane:
the Zero Coverage Sensor scores lines it holds no report for as *uncovered*, and
measuring nothing is not a measurement of zero.

## Verification

`make check` green — both halves, one run, exit 0, zero FAIL lines.

- `scripts/main-health-range.sh` exercised against real history; multiline
  `GITHUB_OUTPUT` framing so the range is not truncated to a single commit (which
  would read as a confident single suspect)
- Two new reporter arms **tested**, and the test asserts the range reaches the
  issue **body** — not merely that an issue was filed. An arm that files the right
  title with the range dropped is otherwise indistinguishable from a working one.
  Mutation-checked by removing `MAIN_SUSPECTS`: the assertion fails, and the
  legitimate no-range case still passes.
- The gate-binary cache-and-install steps are copied on purpose: their absence is
  exactly why `cache-warm.yml` failed every run on `golangci-lint not found`
  before compiling anything
  ([#2080](https://github.com/gradionhq/margince-poc-v1/pull/2080)).

## The knob

Two hours costs ~11 jobs a run and narrows the suspect range to roughly a dozen
commits. It is one cron line. Tighten it if a dozen is too many to read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finds and names breakage on `main` within two hours and refreshes `main`’s SonarCloud analysis, without changing PR gates. Previously we learned `main` was broken from unrelated PRs or a nightly run; now a scheduled health check runs, attributes the window of suspects, and only then publishes analysis.

- Add `main-health.yml`: runs every 2 hours with single-run concurrency; executes the backend gate and calls `_lane-integration.yml` (not copied). It is not a gate and does not alter required PR checks.
- On failure, files one issue per broken lane with a suspect range bounded by this workflow’s last green run. The range comes from `scripts/main-health-range.sh` and is reported via `scripts/scheduled-report.sh`.
- Publish SonarCloud for `main` here only when the integration lane is green; set `SONAR_TOKEN` to enable, otherwise the scan is skipped.
- Extend `scripts/scheduled-report.sh` with two `main-health` reporting arms; `scripts/test-scheduled-report.sh` asserts the suspect range reaches the issue body.
- Document the new workflow in `infra/ci-pipeline.md`.

<sup>Written for commit 57106008312a2d27182010dbfba1fc56c3c64e88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

