### PR TITLE
fix(authz): the geocode sidecar's FK to organization is classified

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -156,6 +156,13 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"conversation_claim.task_activity_id":   "PENDING WRITER: no code writes this table yet. The task an extracted commitment creates is written through the tasks substrate's own gated path, and this entry is replaced with that gate when the routing edge lands",
 	// Owned child rows: the row is an attribute of its visible parent,
 	// written only through the parent's own gated paths.
+	"organization_geocode_state.organization_id": "child row: the sidecar for an organization's own coordinate lookup, and no caller ever names the organization it keys on. " +
+		"The row is created by enqueueGeocode inside UpdateOrganization's transaction, for the id that write was already addressing (people/organization.go), " +
+		"and touched afterwards only by AddressForGeocode and recordGeocodeAfter, which open with auth.Require on organization read and update. " +
+		"What decides the TENANT is not those gates: the worker runs under the SYSTEM principal, which passes row scope, so every query on this path " +
+		"carries an explicit app.workspace_id predicate rather than trusting the job args — geocode.go states the attack that closes, a job carrying " +
+		"workspace A with an organization id from workspace B. That predicate is the exception's whole cost: drop it from one query here and the FK " +
+		"becomes a cross-tenant read with nothing else in the way.",
 	"activity_link.activity_id":  "child row: written only inside LogActivity for the new activity",
 	"lead_score_history.lead_id": "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
 	// comms_outbound is delivery machinery for one activity, not a


### PR DESCRIPTION
Closes #2159. **`main` is red without this** — the second such break today, after #2134.

## What is broken

`TestFK_rowScopedTargetsHaveVisibilityDecision` fails on a clean `origin/main` worktree at `9d9820b6e`:

```
FK organization_geocode_state.organization_id -> organization has no visibility decision:
  a reference to a row-scoped record is a read of it — gate it (auth.EnsureLinkTarget)
  or classify it here
```

#2119 added the table; the FK was never classified. The gate exists so a new reference to a row-scoped record cannot arrive without somebody deciding what it discloses, and it did its job.

## The classification

It is a **child row**, and the entry records the reasoning `people/geocode.go` already states rather than inventing one:

- **No caller ever names the organization it keys on.** `enqueueGeocode` runs inside `UpdateOrganization`'s own transaction, for the id that write was already addressing (`people/organization.go:253`), and only when the patch actually moved the address.
- The two later touches, `AddressForGeocode` and `recordGeocodeAfter`, open with `auth.Require` on organization `read` and `update`.

**And the part those gates do not cover, which is the reason the entry is long.** The worker runs under the SYSTEM principal, which passes row scope — so the tenant authority on this path is the explicit `app.workspace_id` predicate every query carries, *not* the job args. `geocode.go` names the attack that closes: a job carrying workspace A with an organization id from workspace B would read and write B.

That predicate is the exception's whole cost, and the entry says so: drop it from one query on this path and the FK becomes a cross-tenant read with nothing else in the way. `gatekit` refuses a reason that does not state what the exception costs, which is the right bar here.

## Verified

```
make test-it DIR=backend/migrations RUN=TestFK_rowScopedTargetsHaveVisibilityDecision
--- PASS (1.27s)

make test-it DIR=backend/migrations RUN='TestFK_|TestSchema_'
3 passing, 0 failing
```

Before the change, on the same worktree at `origin/main`, the first of those fails.

## Note for the geocode author

I classified rather than gated, on the reading above. If the intent was for this path to take a per-caller visibility gate as well, say so on #2159 and this entry should be replaced with that gate — a waiver is a decision on the record, not a way to quiet a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies the `organization_geocode_state.organization_id` FK as a child-row exception so `gatekit`’s visibility gate passes. Main was failing `TestFK_rowScopedTargetsHaveVisibilityDecision`; this restores green without changing runtime behavior.

- Adds a `rowScopedFKDecisions` entry in `backend/migrations/schema_fitness_integration_test.go` describing why the FK is a child row.
- Old: FK unclassified, test failed. New: FK classified, `TestFK_rowScopedTargetsHaveVisibilityDecision` and `TestSchema_*` pass.
- Rationale: the row is created within `UpdateOrganization`’s transaction; later touches (`AddressForGeocode`, `recordGeocodeAfter`) require organization read/update via `auth.Require`. The worker runs as SYSTEM, so tenant isolation relies on an explicit `app.workspace_id` predicate in every query on this path; removing that predicate would permit a cross-tenant read/write.

<sup>Written for commit 380d91ba22a203df94571666f3228b9abd057629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

