### PR TITLE
fix(contract): regenerate the frontend type for the deal update partner field

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -13273,7 +13273,10 @@ export interface components {
             currency?: string | null;
             /** Format: uuid */
             organization_id?: string | null;
-            /** Format: uuid */
+            /**
+             * Format: uuid
+             * @description The partner who brought this deal. The org must have a live `partner` row (else 422 `not_a_partner`), and the caller must be able to read it. Null clears the attribution.
+             */
             partner_org_id?: string | null;
             /**
              * @description `sourced` or `influenced`. Naming a partner without this field attributes the deal `sourced`; an attribution for a deal naming no partner is refused 422.


### PR DESCRIPTION
`main` is failing `check-contract-frontend-drift`.

The description added to `UpdateDealRequest.partner_org_id` in #2154 reached `crm.yaml`, but its generated TypeScript did not — the regenerated file was staged before that contract edit and never re-staged after it. So main carries a contract and a `schema.d.ts` that disagree, which is exactly what that gate exists to catch.

One regenerated file, no hand edits. Verified: the gate goes from FAIL to `OK — 2 generated contract artifact(s) regenerated and unchanged`, and `make check-fe` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings `frontend/src/api/schema.d.ts` back in sync with `crm.yaml` by regenerating the missing doc for `UpdateDealRequest.partner_org_id`. Previously the doc was absent in the generated TypeScript, causing `check-contract-frontend-drift` to fail; now the doc is present and the gate passes. No runtime behavior changes.

- One regenerated file; no hand edits.
- Doc now states: partner org must have a live `partner` row (else 422 `not_a_partner`), caller must be able to read it, and null clears attribution.
- CI: `check-contract-frontend-drift` OK and `make check-fe` green.

<sup>Written for commit 5fae3ba60854924821d60d799e1189d7b5bbfac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

