### PR TITLE
fix(agents): four review findings on the merged archive change

### DIFF
--- a/backend/internal/compose/archivepin_integration_test.go
+++ b/backend/internal/compose/archivepin_integration_test.go
@@ -290,20 +290,7 @@ func archiveOverREST(as context.Context, t *testing.T, e *integration.Env,
 	return rec
 }
 
-// The geocode sidecar's cost is NOT measured here, and #2173 is why.
-//
-// This is where a fixture would go proving what `rowScopedFKDecisions`'s
-// waiver on organization_geocode_state.organization_id claims — that the
-// app.workspace_id predicate is what keeps the FK from being a cross-tenant
-// read. Writing it is how #2173 was found: `organization` has had no
-// workspace_id column since core 1787047322 dropped it (2026-08-18, ADR-0091
-// phase D), and geocode.go shipped three days later naming it in all three of
-// its statements. Every one fails with SQLSTATE 42703.
-//
-// So the fixture cannot exist yet, and shipping it anyway would be worse than
-// having none: it could not tell "the workspace guard refused" from "the query
-// cannot run", which means it would read GREEN exactly when the subject is most
-// broken. An inverted test, not a weak one.
-//
-// It goes in when #2173 lands. The waiver's own text needs revisiting then too
-// — its stated cost is currently unmeasurable rather than mis-stated.
+// No geocode fixture lives here. #2173 records why, and carries what a future
+// one has to prove: while organization.workspace_id is missing, a fixture
+// cannot tell "the workspace guard refused" from "the query cannot run", so it
+// would read GREEN exactly when the subject is most broken.

--- a/backend/internal/compose/archivepin_integration_test.go
+++ b/backend/internal/compose/archivepin_integration_test.go
@@ -221,11 +221,16 @@ func archivedAt(t *testing.T, e *integration.Env, table string, id ids.UUID) boo
 // closed on one door only.
 //
 // The agent gate forwards a released approval's version as the request's own
-// If-Match (compose/agentgatestaging.go), so an archive route that does not
-// DECLARE the parameter never parses it: the generated wrapper drops the
-// header, the handler passes nil, and the released archive runs unconditioned
-// exactly as before. Declaring it is what makes the forward mean something,
-// and only a request through the real handler proves the chain.
+// If-Match (compose/agentgatestaging.go). What left the archive unpinned was
+// not the contract: these handlers read the header straight off the request
+// with httperr.IfMatchVersion and ignore their Params struct entirely, so an
+// undeclared parameter would still have been parsed. It was the handler
+// passing a literal nil to the store.
+//
+// Declaring If-Match on the route is therefore about the CONTRACT telling the
+// truth — a client cannot be expected to send a precondition the API does not
+// advertise, and the 409 it can now provoke has to be a declared response.
+// Only a request through the real handler proves the chain either way.
 func TestTheRESTArchiveHonoursAStaleIfMatch(t *testing.T) {
 	e := integration.Setup(t)
 	native := NewProvider(e.Pool)
@@ -284,3 +289,21 @@ func archiveOverREST(as context.Context, t *testing.T, e *integration.Env,
 		crmcontracts.ArchivePersonParams{})
 	return rec
 }
+
+// The geocode sidecar's cost is NOT measured here, and #2173 is why.
+//
+// This is where a fixture would go proving what `rowScopedFKDecisions`'s
+// waiver on organization_geocode_state.organization_id claims — that the
+// app.workspace_id predicate is what keeps the FK from being a cross-tenant
+// read. Writing it is how #2173 was found: `organization` has had no
+// workspace_id column since core 1787047322 dropped it (2026-08-18, ADR-0091
+// phase D), and geocode.go shipped three days later naming it in all three of
+// its statements. Every one fails with SQLSTATE 42703.
+//
+// So the fixture cannot exist yet, and shipping it anyway would be worse than
+// having none: it could not tell "the workspace guard refused" from "the query
+// cannot run", which means it would read GREEN exactly when the subject is most
+// broken. An inverted test, not a weak one.
+//
+// It goes in when #2173 lands. The waiver's own text needs revisiting then too
+// — its stated cost is currently unmeasurable rather than mis-stated.

--- a/backend/internal/compose/dispatcherarchive.go
+++ b/backend/internal/compose/dispatcherarchive.go
@@ -60,10 +60,17 @@ func (d *Dispatcher) ArchivableTypes(ctx context.Context) ([]datasource.EntityTy
 // The egress backstop is deliberately NOT repeated here. It guards the WRITE,
 // and its own doc places it on updateInMode/archiveInMode precisely so the one
 // path that dispatches directly cannot slip underneath it; a third call site
-// would be a third thing to keep in step. Nor is one needed: a staging against
-// an overlay-served record is already refused earlier, by
-// refuseStagingElsewhere — a mirror read is Authoritative:false
-// (overlay/provider.go), and both answer the same unsupported-by-SoR sentinel.
+// would be a third thing to keep in step.
+//
+// What is NOT claimed, because it is not true: that a staging against an
+// overlay-served record is always refused earlier by refuseStagingElsewhere.
+// That holds only while the seam read and this refusal resolve the SAME mode,
+// and they do not — Dispatcher.Read answers from the cached mode (5s TTL, and
+// Invalidate reaches only the process that committed a flip) while this asks
+// isOverlayUncached. Inside that window, on a replica the invalidation never
+// reached, the read can route native and pass while this routes overlay. The
+// backstop on the write is what still catches it, which is the reason it stays
+// where its own doc puts it rather than being duplicated here.
 func (d *Dispatcher) RefuseArchive(ctx context.Context, ref datasource.EntityRef) error {
 	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {

--- a/backend/internal/compose/dispatcherarchive_test.go
+++ b/backend/internal/compose/dispatcherarchive_test.go
@@ -17,9 +17,12 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"slices"
+	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -55,20 +58,37 @@ func TestArchivableTypesAnswersForTheRoutedMode(t *testing.T) {
 }
 
 // The stage-time refusal routes by the same read, and reaches the overlay
-// provider rather than the nil native one.
+// provider's own work rather than the nil native one.
 //
-// The assertion is that it reaches a provider AT ALL — the error is overlay's
-// own (no mirror store is wired in this fixture), which is exactly the evidence
-// wanted: a question that had routed native would have panicked on nil.
+// The context carries a real actor with the delete grant, and that is the whole
+// design of this case rather than setup. Without one, overlay's RefuseArchive
+// refuses at its `auth.Require` and the test passes on "no actor bound to
+// context" — an error every path in the tree can raise, satisfying the
+// assertion by a mechanism upstream of the subject. What is wanted is the
+// refusal that proves the call got as far as overlay's OWN state: this fixture
+// wires no mirror store, so reaching that is reaching errNoMirrorStore.
 func TestRefuseArchiveRoutesByTheSameModeRead(t *testing.T) {
 	wsID := ids.NewV7()
 	d, calls := cachedModeDispatcher(wsID, modeNative)
-	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ctx := principal.WithActor(principal.WithWorkspaceID(context.Background(), wsID),
+		principal.Principal{
+			Type: principal.PrincipalHuman, ID: "archive-probe", SeatType: principal.SeatFull,
+			UserID: ids.NewV7(),
+			Permissions: principal.Permissions{
+				Objects: map[string]principal.ObjectGrant{"person": {Delete: true}},
+			},
+		})
 	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
 
-	if err := d.RefuseArchive(ctx, ref); err == nil {
+	err := d.RefuseArchive(ctx, ref)
+
+	if err == nil {
 		t.Fatal("RefuseArchive answered nil: it never reached a provider, so it refused nothing and " +
 			"a staging it should have stopped would proceed to a human")
+	}
+	if strings.Contains(err.Error(), "no actor bound") {
+		t.Fatalf("RefuseArchive stopped at its object gate (%v) — that refusal is upstream of "+
+			"everything this case is about, and it would pass whether or not the routing works", err)
 	}
 	if *calls == 0 {
 		t.Error("RefuseArchive answered from the cached mode; the refusals it reports belong to the " +
@@ -88,8 +108,15 @@ func TestRefuseArchiveRefusesATypeTheMirrorDoesNotArchive(t *testing.T) {
 	ctx := principal.WithWorkspaceID(context.Background(), wsID)
 	ref := datasource.EntityRef{Type: datasource.EntityProject, ID: ids.NewV7()}
 
-	if err := d.RefuseArchive(ctx, ref); err == nil {
-		t.Fatal("staging a project archive against an overlay workspace was not refused — overlay " +
-			"archives person, organization and deal, so this approval could never be carried out")
+	err := d.RefuseArchive(ctx, ref)
+
+	// The SENTINEL, not merely an error. This context binds no actor, so an
+	// assertion on "some error" is satisfied by overlay's object gate — a
+	// refusal that has nothing to do with which types the mirror archives and
+	// that would hold if the type check were deleted outright.
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("staging a project archive against an overlay workspace answered %v, want the "+
+			"unsupported-by-SoR refusal — overlay archives person, organization and deal, so this "+
+			"approval could never be carried out", err)
 	}
 }

--- a/backend/internal/compose/dispatcherarchive_test.go
+++ b/backend/internal/compose/dispatcherarchive_test.go
@@ -86,9 +86,12 @@ func TestRefuseArchiveRoutesByTheSameModeRead(t *testing.T) {
 		t.Fatal("RefuseArchive answered nil: it never reached a provider, so it refused nothing and " +
 			"a staging it should have stopped would proceed to a human")
 	}
-	if strings.Contains(err.Error(), "no actor bound") {
-		t.Fatalf("RefuseArchive stopped at its object gate (%v) — that refusal is upstream of "+
-			"everything this case is about, and it would pass whether or not the routing works", err)
+	// The refusal named in this case's own doc, not merely "not the upstream
+	// one": an assertion that only excludes today's impostor admits tomorrow's.
+	if !strings.Contains(err.Error(), "no mirror store") {
+		t.Fatalf("RefuseArchive answered %v, want overlay's own no-mirror-store refusal — anything "+
+			"else is a guard upstream of the routing this case exists to pin, and would hold "+
+			"whether or not the routing works", err)
 	}
 	if *calls == 0 {
 		t.Error("RefuseArchive answered from the cached mode; the refusals it reports belong to the " +
@@ -104,7 +107,10 @@ func TestRefuseArchiveRoutesByTheSameModeRead(t *testing.T) {
 // vocabulary would admit it here.
 func TestRefuseArchiveRefusesATypeTheMirrorDoesNotArchive(t *testing.T) {
 	wsID := ids.NewV7()
-	d, _ := cachedModeDispatcher(wsID, modeOverlay)
+	// modeNative, so the cached answer DISAGREES with the workspace row. Seeded
+	// as modeOverlay the two agree, and the case cannot observe which was read
+	// — measured: swapping RefuseArchive to the cached read left it green.
+	d, calls := cachedModeDispatcher(wsID, modeNative)
 	ctx := principal.WithWorkspaceID(context.Background(), wsID)
 	ref := datasource.EntityRef{Type: datasource.EntityProject, ID: ids.NewV7()}
 
@@ -118,5 +124,9 @@ func TestRefuseArchiveRefusesATypeTheMirrorDoesNotArchive(t *testing.T) {
 		t.Fatalf("staging a project archive against an overlay workspace answered %v, want the "+
 			"unsupported-by-SoR refusal — overlay archives person, organization and deal, so this "+
 			"approval could never be carried out", err)
+	}
+	if *calls == 0 {
+		t.Error("the refusal came from the cached mode, which disagrees with the workspace row here " +
+			"— the types a staging is judged against belong to the writer that will actually run")
 	}
 }

--- a/backend/internal/compose/dispatcherarchive_test.go
+++ b/backend/internal/compose/dispatcherarchive_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The archive's three questions all route by the SAME mode read.
+//
+// That is the property worth pinning rather than any one answer: an
+// installation whose mode says overlay must not have "what is archivable" or
+// "what would be refused" answered by the native provider while the write goes
+// to the mirror. A caller that got two of three from the wrong executor would
+// stage an archive the writer refuses — which is the failure this seam exists
+// to remove, reintroduced one layer down.
+//
+// The native provider is nil throughout, exactly as its sibling suite leaves
+// it: a question that wrongly routes native panics rather than quietly passing.
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// In overlay mode the archivable set is the MIRROR's three, not the native six.
+//
+// This is #2016 at the routing layer. The tool's own fallback list names what
+// native archives; asking the dispatcher is how an overlay installation learns
+// that project, relationship and activity are refused here.
+func TestArchivableTypesAnswersForTheRoutedMode(t *testing.T) {
+	wsID := ids.NewV7()
+	d, calls := cachedModeDispatcher(wsID, modeNative)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+
+	types, err := d.ArchivableTypes(ctx)
+	if err != nil {
+		t.Fatalf("asking the dispatcher what it archives answered %v", err)
+	}
+
+	want := []datasource.EntityType{
+		datasource.EntityDeal, datasource.EntityOrganization, datasource.EntityPerson,
+	}
+	if !slices.Equal(types, want) {
+		t.Errorf("the dispatcher archives %v, want the overlay set %v — answering the native six "+
+			"here admits three types this workspace's writer refuses, and the refusal then arrives "+
+			"after a human has released the approval", types, want)
+	}
+	if *calls == 0 {
+		t.Error("the answer came from the cached mode: which types are archivable is a fact about " +
+			"the mode this request runs in, and a stale entry answers for the wrong writer")
+	}
+}
+
+// The stage-time refusal routes by the same read, and reaches the overlay
+// provider rather than the nil native one.
+//
+// The assertion is that it reaches a provider AT ALL — the error is overlay's
+// own (no mirror store is wired in this fixture), which is exactly the evidence
+// wanted: a question that had routed native would have panicked on nil.
+func TestRefuseArchiveRoutesByTheSameModeRead(t *testing.T) {
+	wsID := ids.NewV7()
+	d, calls := cachedModeDispatcher(wsID, modeNative)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
+
+	if err := d.RefuseArchive(ctx, ref); err == nil {
+		t.Fatal("RefuseArchive answered nil: it never reached a provider, so it refused nothing and " +
+			"a staging it should have stopped would proceed to a human")
+	}
+	if *calls == 0 {
+		t.Error("RefuseArchive answered from the cached mode; the refusals it reports belong to the " +
+			"writer that will actually run, so the mode must be re-read")
+	}
+}
+
+// A type the ROUTED executor does not archive is refused by that executor, not
+// by a list this layer holds.
+//
+// `project` is archivable natively and is not in overlay's set, so it is the
+// one probe that tells the two apart — a dispatcher answering from the native
+// vocabulary would admit it here.
+func TestRefuseArchiveRefusesATypeTheMirrorDoesNotArchive(t *testing.T) {
+	wsID := ids.NewV7()
+	d, _ := cachedModeDispatcher(wsID, modeOverlay)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ref := datasource.EntityRef{Type: datasource.EntityProject, ID: ids.NewV7()}
+
+	if err := d.RefuseArchive(ctx, ref); err == nil {
+		t.Fatal("staging a project archive against an overlay workspace was not refused — overlay " +
+			"archives person, organization and deal, so this approval could never be carried out")
+	}
+}

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -300,6 +300,33 @@ func TestOverlayUpdateIgnoresIfMatch(t *testing.T) {
 	}
 }
 
+// The archive half of the same rule, and it had no gate in either direction:
+// #2142 made this route answer 422 on a stale If-Match and `make check` was
+// green; the revert restored 200 and `make check` was green again. Whichever
+// way the behaviour goes, nothing was watching it.
+//
+// A CALLER's header is what this pins. A released approval's pin travels in
+// the same header and is deliberately NOT ignored — that one is an
+// authorization binding rather than a client convenience, and
+// overlaywriteshadow.go answers the two separately.
+func TestOverlayArchiveIgnoresACallersIfMatch(t *testing.T) {
+	e := setupOverlayWrite(t)
+	e.seed(t, "person", "9104", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
+	id := firstListedID(t, e.AppEnv, "/v1/people")
+
+	var person crmcontracts.Person
+	status := e.Call(t, "DELETE", "/v1/people/"+id, nil,
+		map[string]string{"If-Match": "999"}, &person)
+	if status != http.StatusOK {
+		t.Fatalf("DELETE with a stale If-Match = %d, want 200 — a caller's precondition is accepted "+
+			"and discarded on the overlay path, the same answer PATCH gives it, and refusing one verb "+
+			"while ignoring the other tells one client two things about one record", status)
+	}
+	if person.ArchivedAt == nil {
+		t.Error("the archive itself did not apply: the header must be ignored, not the request")
+	}
+}
+
 // The write mapping carries only the fields it declares writable — here,
 // observed at the overlay REST surface's OWN honest limit: owner_id is a
 // valid, contract-writable UpdatePersonRequest field, but overlayWirePerson

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -190,16 +190,22 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		native()
 		return
 	}
-	// The caller's precondition travels with the write, exactly as it does on
-	// the native side. Reading the header and not forwarding it is the worse
-	// of the two answers available here: an overlay mirror carries no version
-	// column, so this installation cannot honour the condition — and a request
-	// that asks for one and is archived anyway has been told something false.
-	// Forwarding it lets the overlay provider refuse in its own words instead.
-	ifVersion, ok := httperr.IfMatchVersion(w, r)
-	if !ok {
-		return
-	}
+	// If-Match is accepted and discarded here, exactly as overlayUpdate's own
+	// doc says it is twenty lines above, and for the same reason: a mirror row
+	// carries no version to compare against.
+	//
+	// Forwarding it was tried and reverted. The pin reaches
+	// overlay.Provider.ArchiveAt, which refuses a version it cannot honour —
+	// correct on the seam, wrong through this door. It made one REST client
+	// carrying `If-Match` on every write get 200-and-ignored from
+	// PATCH /people/{id} and 422 from DELETE /people/{id}, on the same record
+	// in the same installation, for a request that archived successfully
+	// before. Two doors of one shadow may not answer a header two ways.
+	//
+	// The gap both verbs share — an overlay caller has no optimistic
+	// concurrency and gets no signal saying so — is one question, filed once,
+	// and closing it needs a version the caller can pin rather than a refusal
+	// on one verb.
 	ref := datasource.EntityRef{Type: et, ID: ids.UUID(id)}
 	rec, err := s.sorDispatch.Read(r.Context(), ref)
 	if err != nil {
@@ -207,7 +213,7 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		return
 	}
 	if _, err := s.sorDispatch.archiveInMode(r.Context(), bool(ov),
-		datasource.ArchiveInput{Ref: ref, IfVersion: ifVersion}); err != nil {
+		datasource.ArchiveInput{Ref: ref}); err != nil {
 		httperr.Write(w, r, err)
 		return
 	}

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -142,6 +142,31 @@ type archiveWire[Res any] struct {
 	markArchived func(*Res, time.Time)
 }
 
+// archivePrecondition answers which If-Match this request carries, and it is a
+// named function rather than three lines inline because the QUESTION is what
+// was got wrong twice: a caller's header and a released approval's pin arrive
+// identically and are not the same claim.
+//
+// Only the redeemed case yields a version. The unredeemed one answers nil even
+// when the caller sent a header — this shadow's documented answer to a
+// precondition a mirror row cannot evaluate.
+//
+// COVERAGE, stated because it is uneven and the uncovered arm is the important
+// one: the FALSE arm is gated by TestOverlayArchiveIgnoresACallersIfMatch. The
+// TRUE arm is not, and cannot be from outside package agents — the redeemed
+// marker is set only by RedeemAndMark and has no exported setter, which is the
+// right design (a test-only way to forge "a human approved this" is a worse
+// thing to own than an untested branch). Reaching it honestly needs a
+// staged-then-redeemed archive that routes overlay, and overlay staging is
+// refused by refuseStagingElsewhere except inside the mode-cache window
+// dispatcherarchive.go describes — which is the path this arm exists for.
+func archivePrecondition(w http.ResponseWriter, r *http.Request) (*int64, bool) {
+	if !agents.ApprovalRedeemed(r.Context()) {
+		return nil, true
+	}
+	return httperr.IfMatchVersion(w, r)
+}
+
 // overlayArchive serves one archive shadow: the native module handler off
 // overlay mode, otherwise a dispatched seam Archive answered with the
 // archived row's last-known state — the contract's own archive response
@@ -213,12 +238,9 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 	// The gap the caller's header leaves — an overlay client has no optimistic
 	// concurrency and no signal saying so — is one question about both verbs,
 	// and closing it needs a version the caller can pin.
-	var pin *int64
-	if agents.ApprovalRedeemed(r.Context()) {
-		var ok bool
-		if pin, ok = httperr.IfMatchVersion(w, r); !ok {
-			return
-		}
+	pin, ok := archivePrecondition(w, r)
+	if !ok {
+		return
 	}
 	ref := datasource.EntityRef{Type: et, ID: ids.UUID(id)}
 	rec, err := s.sorDispatch.Read(r.Context(), ref)

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -190,22 +191,35 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		native()
 		return
 	}
-	// If-Match is accepted and discarded here, exactly as overlayUpdate's own
-	// doc says it is twenty lines above, and for the same reason: a mirror row
-	// carries no version to compare against.
+	// A CALLER's If-Match and a released APPROVAL's pin arrive in the same
+	// header and are not the same thing, so they are not answered the same way.
 	//
-	// Forwarding it was tried and reverted. The pin reaches
-	// overlay.Provider.ArchiveAt, which refuses a version it cannot honour —
-	// correct on the seam, wrong through this door. It made one REST client
-	// carrying `If-Match` on every write get 200-and-ignored from
-	// PATCH /people/{id} and 422 from DELETE /people/{id}, on the same record
-	// in the same installation, for a request that archived successfully
-	// before. Two doors of one shadow may not answer a header two ways.
+	// A caller's precondition is a client convenience, and overlayUpdate's own
+	// doc twenty lines above states this shadow's answer to it: accepted and
+	// discarded, because a mirror row carries no version to compare against.
+	// Both verbs of one shadow owe a caller the same answer about one header —
+	// ignoring it on PATCH and refusing it on DELETE tells a client two things
+	// about one record.
 	//
-	// The gap both verbs share — an overlay caller has no optimistic
-	// concurrency and gets no signal saying so — is one question, filed once,
-	// and closing it needs a version the caller can pin rather than a refusal
-	// on one verb.
+	// A released approval's pin is an AUTHORIZATION BINDING. redeemIfPresented
+	// (agentgatestaging.go) sets the header from it precisely so the store
+	// re-checks the version inside the transaction that mutates, and discarding
+	// it would carry out an archive a human approved against a version nothing
+	// then verified — silently, where the caller's own header is merely
+	// ignored. So it is forwarded, and overlay refuses it in its own words: an
+	// approval this seam cannot honour must fail loudly rather than land
+	// unconditioned.
+	//
+	// The gap the caller's header leaves — an overlay client has no optimistic
+	// concurrency and no signal saying so — is one question about both verbs,
+	// and closing it needs a version the caller can pin.
+	var pin *int64
+	if agents.ApprovalRedeemed(r.Context()) {
+		var ok bool
+		if pin, ok = httperr.IfMatchVersion(w, r); !ok {
+			return
+		}
+	}
 	ref := datasource.EntityRef{Type: et, ID: ids.UUID(id)}
 	rec, err := s.sorDispatch.Read(r.Context(), ref)
 	if err != nil {
@@ -213,7 +227,7 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		return
 	}
 	if _, err := s.sorDispatch.archiveInMode(r.Context(), bool(ov),
-		datasource.ArchiveInput{Ref: ref}); err != nil {
+		datasource.ArchiveInput{Ref: ref, IfVersion: pin}); err != nil {
 		httperr.Write(w, r, err)
 		return
 	}

--- a/backend/internal/modules/agents/archiveauthority_test.go
+++ b/backend/internal/modules/agents/archiveauthority_test.go
@@ -34,15 +34,19 @@ import (
 // as a nil rather than as a passing test.
 type narrowArchiver struct {
 	datasource.SystemOfRecordProvider
-	refuse     error
-	types      []datasource.EntityType
-	archivedAt *datasource.ArchiveInput
+	refuse error
+	types  []datasource.EntityType
+	// heldElsewhere makes the record non-authoritative, so a case can put the
+	// system-of-record refusal and the executor refusal in play AT ONCE — which
+	// is the only way their order is observable.
+	heldElsewhere bool
+	archivedAt    *datasource.ArchiveInput
 }
 
 func (n *narrowArchiver) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
 	return datasource.Record{
 		Ref: ref, Fields: json.RawMessage(`{"name":"Acme"}`), Version: 4,
-		Freshness: datasource.FreshnessInfo{Authoritative: true},
+		Freshness: datasource.FreshnessInfo{Authoritative: !n.heldElsewhere},
 	}, nil
 }
 
@@ -199,10 +203,26 @@ func TestGuardsRefuseWhatTheExecutorsOwnProbesWouldRefuse(t *testing.T) {
 // probe ahead of refuseStagingElsewhere would replace a deliberate
 // unsupported-by-SoR refusal with whatever the probe happened to say.
 func TestTheHeldElsewhereRefusalStillWinsOverTheExecutorProbe(t *testing.T) {
-	provider := stubRecordProvider{rec: stagedRecord(datasource.EntityPerson, ids.NewV7(), false)}
+	// BOTH refusals are armed, and they answer DIFFERENT sentinels. That is the
+	// whole design of this case. A version using a stub whose executor probe
+	// answers nil, or one answering the same unsupported-by-SoR sentinel, passes
+	// with the two arms swapped — measured: inverting the order in Guards left
+	// the earlier version of this test green, because only one arm could speak.
+	provider := &narrowArchiver{
+		types:         threeTypes(),
+		heldElsewhere: true,
+		refuse:        apperrors.ErrPermissionDenied,
+	}
 	call := NewArchiveCall(provider, ArchiveCommand{RecordType: "person", ID: ids.NewV7()})
 
-	if err := call.Guards(context.Background()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+	err := call.Guards(context.Background())
+
+	if errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("the executor probe answered first (%v): a record held in another system of record "+
+			"has no local authority to ask about, so probing it is a question with no true answer — "+
+			"and the deliberate unsupported-by-SoR refusal is replaced by whatever the probe says", err)
+	}
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 		t.Fatalf("guarding a mirrored person answered %v, want the unsupported-by-SoR refusal to keep "+
 			"its place ahead of the executor probe", err)
 	}

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -160,12 +160,10 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 		"The row is created by enqueueGeocode inside UpdateOrganization's transaction, for the id that write was already addressing (people/organization.go), " +
 		"and touched afterwards only by AddressForGeocode and recordGeocodeAfter (people/geocode.go). " +
 		"The worker runs under the SYSTEM principal, which passes row scope, so what decides the tenant is an explicit app.workspace_id predicate rather than the job args. " +
-		"That predicate is present on the two statements that could DISCLOSE: AddressForGeocode's read joins the sidecar through organization and filters " +
-		"o.workspace_id, and recordGeocodeAfter's UPDATE organization carries the same clause. It is NOT present on the two INSERT ... ON CONFLICT statements " +
-		"that write the sidecar itself, and the table has no workspace column of its own (migration 1787320001), so a job carrying an organization id from another " +
-		"workspace would update zero organization rows and still write that organization's attempt ledger. That is a write, never a read, and it is latent — " +
-		"enqueueGeocode only ever mints the id its own workspace-checked write was addressing — but it is this exception's real cost and it is filed as #2167. " +
-		"Drop the workspace clause from AddressForGeocode and the FK becomes a cross-tenant READ with nothing else in the way.",
+		"Both entry points funnel through recordGeocodeAfter, whose FIRST statement is addressHashInTx — a read filtered on workspace_id that returns no rows for a " +
+		"foreign id, aborting the transaction before anything is written. The two INSERT ... ON CONFLICT statements on the sidecar itself carry no predicate and the " +
+		"table has no workspace column (migration 1787320001), but neither is reachable with an id from another workspace, so that is the shape of the exception " +
+		"rather than its cost. The cost is the read: drop the workspace clause from AddressForGeocode and the FK becomes a cross-tenant READ with nothing else in the way.",
 	"activity_link.activity_id":  "child row: written only inside LogActivity for the new activity",
 	"lead_score_history.lead_id": "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
 	// comms_outbound is delivery machinery for one activity, not a

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -159,11 +159,11 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"organization_geocode_state.organization_id": "child row: the sidecar for an organization's own coordinate lookup, and no caller ever names the organization it keys on. " +
 		"The row is created by enqueueGeocode inside UpdateOrganization's transaction, for the id that write was already addressing (people/organization.go), " +
 		"and touched afterwards only by AddressForGeocode and recordGeocodeAfter (people/geocode.go). " +
-		"The worker runs under the SYSTEM principal, which passes row scope, so what decides the tenant is an explicit app.workspace_id predicate rather than the job args. " +
-		"Both entry points funnel through recordGeocodeAfter, whose FIRST statement is addressHashInTx — a read filtered on workspace_id that returns no rows for a " +
-		"foreign id, aborting the transaction before anything is written. The two INSERT ... ON CONFLICT statements on the sidecar itself carry no predicate and the " +
-		"table has no workspace column (migration 1787320001), but neither is reachable with an id from another workspace, so that is the shape of the exception " +
-		"rather than its cost. The cost is the read: drop the workspace clause from AddressForGeocode and the FK becomes a cross-tenant READ with nothing else in the way.",
+		"WHAT THIS EXCEPTION RESTS ON IS CURRENTLY NON-EXECUTING, and that is the honest statement of its cost: all three of those statements filter " +
+		"organization.workspace_id, a column core 1787047322 dropped three days before geocode.go shipped, so every one fails with SQLSTATE 42703 (#2173). " +
+		"No read reaches this FK today because no read on this path runs at all. When #2173 is fixed the ADR-0091-consistent repair DELETES that predicate " +
+		"rather than restoring the column, at which point this reason is void and nothing here would fail — gatekit checks the key, never the rationale — so " +
+		"#2173 carries a note to revisit this entry, and it must be re-derived against whatever replaces the predicate rather than carried over.",
 	"activity_link.activity_id":  "child row: written only inside LogActivity for the new activity",
 	"lead_score_history.lead_id": "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
 	// comms_outbound is delivery machinery for one activity, not a


### PR DESCRIPTION
## Why

A third review pass over #2142's range, run **after it merged** because my own review turned out to be six commits stale — it had seen commit 1 of 7, and the 1047 insertions since included a public contract change. That gap was found by applying to my own work a check I had been carefully applying to CodeRabbit's.

Four findings. Two are text corrections; two are real.

## 1 · The overlay REST shadow answered one header two ways *(medium — a regression #2142 introduced)*

Forwarding `If-Match` into `archiveInMode` reached `overlay.Provider.ArchiveAt`, which **refuses** a version it cannot honour. Correct on the seam, wrong through that door:

| Same client, same record, same overlay installation | before #2142 | after #2142 |
|---|---|---|
| `PATCH /v1/people/{id}` with `If-Match: 7` | 200, header ignored | 200, header ignored |
| `DELETE /v1/people/{id}` with `If-Match: 7` | archived | **422** `unsupported_by_sor` |

And 422 is not among the responses `archivePerson` declares. `overlayUpdate`'s own doc twenty lines above already states the house answer — *"the header is accepted and discarded… State the consequence plainly rather than only the cause"* — so the archive now matches its sibling. The gap both verbs share is **one** question, not two divergent behaviours.

## 2 · The doc justifying a removed backstop rested on something unguaranteed *(low)*

#2142 dropped `refuseUngovernedAgentEgress` from `RefuseArchive`, arguing that `refuseStagingElsewhere` refuses an overlay staging first. That holds only while the seam read and the refusal resolve the **same mode** — and they do not: `Dispatcher.Read` uses the **cached** mode (5s TTL), `RefuseArchive` uses `isOverlayUncached`. Within 5s of a flip, on a replica the local `Invalidate` never reached, the read routes native and passes while the refusal routes overlay. The doc now claims only what is actually guaranteed.

## 3 · A comment named a mechanism that does not exist *(low)*

It said an undeclared contract parameter is never parsed, so the handler passes nil. **The handlers read the header directly** with `httperr.IfMatchVersion` and ignore their `Params` struct entirely — an undeclared parameter would still be parsed. What left the archive unpinned was the handler passing a literal `nil`. Declaring `If-Match` is about the contract telling the truth, and about `409` being a declared response.

This is the comment-asserts-a-false-invariant class this repo polices, committed inside a PR about that class.

## 4 · The geocode waiver overstated its cost — and measuring it found worse

Both entry points funnel through `recordGeocodeAfter`, whose **first** statement is a workspace-filtered read that aborts before either unguarded `INSERT`. The cross-tenant write I described in #2167 is unreachable; **#2167 closed as not-a-defect.**

That sentence has now been wrong twice in opposite directions in one afternoon, by two sessions reading carefully. So I went to *measure* it rather than read it again — and the fixture found **#2173**: `organization` has had no `workspace_id` column since core `1787047322` dropped it (2026-08-18), and `geocode.go` shipped **three days later** naming it in all three of its statements. Every one fails with `SQLSTATE 42703`. **The predicate this waiver rests on has never executed**, and geocoding is dead on `main`.

⚠️ **The fixture is parked, not shipped.** While the column is missing it cannot distinguish *"the workspace guard refused"* from *"the query cannot run"* — so it would read **green exactly when the subject is most broken**. That is an inverted test, not a weak one. The file says so, and it goes in when #2173 lands.

My first attempt at that fixture was itself a false pass — it drove a nonexistent org id, so the sidecar `INSERT` died on its own foreign key and the test agreed with a deliberately broken guard. Caught only by mutating.

## Also: the coverage SonarCloud was right about

Sonar reported new-code coverage at **70.8%** against an 80% bar on #2142. Not a required check, which is exactly why it was worth reading rather than merging past: **`ArchivableTypes` and `RefuseArchive` on the Dispatcher had ZERO coverage** — the two questions #2016 and #2014 turn on. An untested route there is how the answer comes from the native provider while the write goes to the mirror.

Three tests over the existing `cachedModeDispatcher` fixture, which leaves the native provider nil so a wrongly-routed question panics rather than quietly passing. Mutation-verified: routing `ArchivableTypes` to the other mode panics.

## Gates

`make check-backend` exit 0 · `craft static --strict` 0/0/0 · archive integration suites green against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns overlay archive semantics and closes a pinning gap: DELETE now ignores a caller’s If-Match like PATCH (200), while a redeemed approval’s version pin is still forwarded so the store can refuse stale approvals. Adds dispatcher tests to prove archive questions route by the current mode, not a stale cached one, and extracts `archivePrecondition` to separate caller headers from approval pins.

- Split header handling in `overlaywriteshadow.go`: ignore a caller `If-Match`; when `agents.ApprovalRedeemed` is set, forward the pin via `IfVersion` to the store. New `archivePrecondition` helper documents the untestable redeemed branch.
- Tests: `overlay_write_shadow_integration_test.go` adds DELETE-vs-If-Match gate; new `dispatcherarchive_test.go` pins that `ArchivableTypes` answers overlay’s three, `RefuseArchive` re-reads mode (not cache), and refusing `project` returns `apperrors.ErrUnsupportedBySoR` (native provider left nil to panic on misroutes).
- Docs and test hardening: clarify cache vs uncached mode in `dispatcherarchive.go` (write backstop stays); agents guard tests now assert distinct sentinels and ordering so “held elsewhere” beats the executor probe; update archive pin comments to reflect `httperr.IfMatchVersion`.
- Geocode waiver: note `organization.workspace_id` is missing and those statements do not execute (#2173); fixture remains parked until fixed.

**Rollout**
- No migrations or config. Overlay DELETE with caller `If-Match` now returns 200; approvals remain pinned and are refused when stale.

<sup>Written for commit aeda8a25e677a63675602e999afaf166b54af3df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

