### PR TITLE
fix(records): the merge refusal names projects to a caller with no sight of one

### DIFF
--- a/backend/internal/compose/integration/project_integration_test.go
+++ b/backend/internal/compose/integration/project_integration_test.go
@@ -596,6 +596,53 @@ func TestTheMergeRefusalNamesTheProjectsTheCallerCanSee(t *testing.T) {
 	}
 }
 
+// The other half of the same rule: naming a project is a read of it, so a
+// caller who never held project.read is refused the merge WITHOUT the names.
+//
+// The merge entry point gates on organization.update alone, so this seat is a
+// real one — a rep who may tidy up duplicate companies and has no business
+// with the delivery side. Row scope does not narrow a project any more, but
+// the object grant is a separate gate, and the counts are what tells this
+// caller the work exists without telling them what it is called.
+func TestTheMergeRefusalWithholdsProjectNamesFromACallerWithoutTheGrant(t *testing.T) {
+	e := Setup(t)
+	source := e.SeedOrg(t, "Kepler GmbH", &e.Rep1)
+	target := e.SeedOrg(t, "Kepler AG", &e.Rep1)
+	seedProject(e.Admin(), t, e, "Secret migration", nil, source, &e.Rep1)
+	seedProject(e.Admin(), t, e, "Secret rollout", nil, target, &e.Rep1)
+
+	// Everything the merge itself demands, and no project grant at all.
+	ungranted := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"organization":          {Read: true, Update: true, Delete: true},
+			"person":                {Read: true, Update: true},
+			"installation_settings": {Read: true},
+		},
+		RowScope: principal.RowScopeOwn,
+	})
+
+	_, err := e.People.MergeOrganization(ungranted, orgIDOf(source), orgIDOf(target))
+	var both *people.BothCompaniesCarryProjectsError
+	if !errors.As(err, &both) {
+		t.Fatalf("the merge produced %v, want a refusal — work the caller cannot see still blocks it", err)
+	}
+	// Still refused, and still on the true counts: the decision is unscoped.
+	if both.SourceCount != 1 || both.TargetCount != 1 {
+		t.Errorf("counted %d and %d live projects, want one each", both.SourceCount, both.TargetCount)
+	}
+	if len(both.Source) != 0 || len(both.Target) != 0 {
+		t.Errorf("the refusal named %v and %v to a caller holding no project grant", both.Source, both.Target)
+	}
+	// And no name reaches the rendered message either, which is what the
+	// handler puts on the wire as the 409 detail.
+	for _, name := range []string{"Secret migration", "Secret rollout"} {
+		if strings.Contains(err.Error(), name) {
+			t.Errorf("the refusal message discloses %q to a caller holding no project grant: %v", name, err)
+		}
+	}
+}
+
 // An activity's visibility DERIVES from its links, so replacing one is not a
 // harmless association edit: cut the link a team sees the activity through
 // and the activity leaves their world. Relink therefore replaces only what

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -353,19 +353,20 @@ func relinkOrgEdges(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.Organ
 // naming a project is a read of it, so the refusal lists only the ones this
 // caller may already see and counts the rest.
 func refuseWhenBothCarryProjects(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.OrganizationID) error {
+	// Naming a project is a read of it, and the merge entry point checks only
+	// organization.update — nothing on this path has asked for project.read.
+	// Row scope no longer narrows a project (no own/team arm in platform/auth
+	// tableclass.go, and migration 1787320003 narrowed project.visibility to
+	// 'workspace'), but the OBJECT grant is a separate gate and a seat can
+	// hold organization.update with no sight of a project at all. So the
+	// naming asks for the grant it actually needs, and a caller without it is
+	// still refused the merge — on counts, which say the work exists without
+	// saying whose it is or what it is called.
+	mayName := auth.Require(ctx, "project", principal.ActionRead) == nil
+
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	sourcePos, targetPos := arg(sourceID), arg(targetID)
-	// Naming a project is a read of it, and every seat holding the object
-	// grant reads every project: no own/team arm (platform/auth
-	// tableclass.go) and no capture privacy, since migration 1787320003
-	// narrowed project.visibility to 'workspace'. So the refusal names both
-	// sides in full. It used to carry a per-row visibility flag and withhold
-	// the names it answered false for; that branch could no longer fire, and a
-	// withholding arm that never withholds reads as a protection while proving
-	// nothing. If a project ever becomes scoped again, the arm comes back
-	// WITH the scope — TestEveryTableThatCanHoldAnOwnerRowIsOwnerPrivate is
-	// what refuses the half-change.
 	rows, err := tx.Query(ctx, storekit.SQLf(`
 		SELECT organization_id, name FROM project
 		WHERE organization_id IN ($%d, $%d) AND archived_at IS NULL
@@ -387,7 +388,9 @@ func refuseWhenBothCarryProjects(ctx context.Context, tx pgx.Tx, sourceID, targe
 			side, names = &refusal.SourceCount, &refusal.Source
 		}
 		*side++
-		*names = append(*names, name)
+		if mayName {
+			*names = append(*names, name)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return err


### PR DESCRIPTION
Merging two companies that both carry live work is refused, and the refusal names the projects so a human can act on it. **It named them to anyone.**

The merge path checks `organization:update` and nothing on it has ever asked for `project:read`, so a seat holding no project grant at all received both name lists on the wire — `source_projects` and `target_projects` in the 409 body (`people/handlers.go:101`).

## The fix

The naming asks for the grant it needs. One line:

```go
mayName := auth.Require(ctx, "project", principal.ActionRead) == nil
```

**The decision to refuse stays unscoped.** Every live project on both sides still counts, so work the caller cannot see still blocks the merge — that split is the whole point. Only the names are withheld. A caller without the grant gets a 409 with true counts and no names, which says the work exists without saying whose it is or what it is called.

Nothing needed adding: `BothCompaniesCarryProjectsError` already carried `SourceCount`/`TargetCount` alongside the name slices, and `mergeSideSummary` already renders the empty case as "work you cannot see". The shape was built for this and was simply unreachable.

## Why the comment it replaces is worth reading

#2152 (mine, earlier today) removed a per-row visibility flag here on the grounds that "every seat holding the object grant reads every project". That is true — and irrelevant. It is an argument about **row scope**, which no longer narrows a project after that PR. The **object grant** is a separate gate, and this path skips it. Row scope stopped being the thing standing between a caller and a project name, and nothing took its place.

The removal was right about the flag being dead and wrong about the property being safe. Two comments asserted the scoped behaviour that no longer existed; both are replaced.

## Verification

- `make check-backend` green, `make craft-static` 0/0/0, `rls-store-path` clean, `compose/integration` zero failures.
- New: `TestTheMergeRefusalWithholdsProjectNamesFromACallerWithoutTheGrant` — a rep with organization read/update/delete and **no** project grant; merge still refused, counts correct, both name slices empty, and neither name appears in the error string the handler ships as the 409 detail.
- Mutation-checked both directions: forcing `mayName := true` reproduces the bug verbatim in the failure output; forcing it `false` fails the two pre-existing tests that prove a granted caller still gets names.

Found by the background security review on #2152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops disclosing project names to callers without `project.read` when refusing a merge of two companies that both have live projects. Previously, anyone with `organization.update` received source/target project names in the 409; now names appear only with `project.read`, while the refusal decision and counts are unchanged.

**Review notes**
- Names are included only if `auth.Require(ctx, "project", principal.ActionRead) == nil`; refusal still counts all live projects on both sides.
- For callers without the grant: `source_projects` and `target_projects` are empty; `SourceCount`/`TargetCount` remain accurate; the 409 detail omits names.
- Added test `TestTheMergeRefusalWithholdsProjectNamesFromACallerWithoutTheGrant`; existing tests confirm granted callers still see names.
- No migrations or config changes; clients relying on names without `project.read` must handle empty name lists.

<sup>Written for commit 9c67cc7a4e7e0c03cd7051a42c67bdff801cbd79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

