### PR TITLE
fix(ci-tests): the vocabulary gate follows within_radius, and main is green again

### DIFF
--- a/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
@@ -86,11 +86,32 @@ func TestTheComposedMCPMountPublishesTheQueryVocabulary(t *testing.T) {
 		t.Error("the published deal vocabulary has no derived organization hop")
 	}
 
-	// The declared-but-unanswerable operator arrives declared (SEARCH-AC-17).
-	if !slices.ContainsFunc(doc.Unavailable, func(u vocabularyUnavailable) bool {
-		return u.Op == "within_radius" && u.Answers == search.CodeDistanceRankingUnavailable
+	// within_radius ANSWERS now (#2171: a company carries coordinates), so the
+	// deployment-wide unavailable list is empty and the operator is published
+	// where a caller can find it. SEARCH-AC-17's guarantee is unchanged and
+	// this is still the test of it — a caller must be able to tell an operator
+	// that works from one that does not — but the two halves have swapped,
+	// so asserting the old half would now pin the wrong answer.
+	if slices.ContainsFunc(doc.Unavailable, func(u vocabularyUnavailable) bool {
+		return u.Op == search.OpWithinRadius
 	}) {
-		t.Error("within_radius is not published as unavailable, so a caller cannot tell it apart from one that works")
+		t.Error("within_radius is still published as unavailable; it answers for a locatable target, and declaring it broken sends a caller to a text match on a city name instead")
+	}
+	// The other half: it has to be REACHABLE, or "not declared unavailable"
+	// would be satisfied by an operator nobody can discover.
+	org := targetVocabulary(t, doc, "organization")
+	if !slices.ContainsFunc(org.Fields, func(f vocabularyField) bool {
+		return slices.Contains(f.Ops, search.OpWithinRadius)
+	}) {
+		t.Error("no organization field publishes within_radius, so the operator answers but no caller can find it")
+	}
+	// And it stays absent where it cannot be answered at all: a deal is never
+	// anywhere, which is a fact about the record type rather than about this
+	// deployment, so it is refused per call rather than declared here.
+	if slices.ContainsFunc(deal.Fields, func(f vocabularyField) bool {
+		return slices.Contains(f.Ops, search.OpWithinRadius)
+	}) {
+		t.Error("the deal vocabulary publishes within_radius; a deal is never anywhere, so offering it invites a query that can only be refused")
 	}
 }
 
@@ -230,9 +251,17 @@ func readVocabulary(e *apptest.AppEnv, t *testing.T, bearer string) vocabularyDo
 // the custom-field test, a workspace column) plus a derived hop.
 func dealVocabulary(t *testing.T, doc vocabularyDoc) vocabularyTarget {
 	t.Helper()
-	i := slices.IndexFunc(doc.Targets, func(target vocabularyTarget) bool { return target.Target == "deal" })
+	return targetVocabulary(t, doc, "deal")
+}
+
+// targetVocabulary is the published entry for one record type, or a fatal
+// naming the one that is missing — an absent target would otherwise make every
+// assertion about its fields pass against a zero value.
+func targetVocabulary(t *testing.T, doc vocabularyDoc, target string) vocabularyTarget {
+	t.Helper()
+	i := slices.IndexFunc(doc.Targets, func(candidate vocabularyTarget) bool { return candidate.Target == target })
 	if i < 0 {
-		t.Fatal(`the published vocabulary has no "deal" target`)
+		t.Fatalf("the published vocabulary has no %q target", target)
 	}
 	return doc.Targets[i]
 }


### PR DESCRIPTION
`main` is red — the third breakage today, and the third found by an unrelated PR going red rather than by its own.

https://github.com/gradionhq/margince-poc-v1/pull/2171 made `within_radius` answer for a locatable target and emptied the deployment-wide unavailable list. That is the right change and `queryschema.go` documents it well at the point it happens. What it did not carry along is the MCP wiring test, which still asserted the *old* half — that the operator arrives **declared unavailable** — so `TestTheComposedMCPMountPublishesTheQueryVocabulary` has failed on `main`'s tip ever since.

Reproduced against `origin/main` in a clean worktree:

```
--- FAIL: TestTheComposedMCPMountPublishesTheQueryVocabulary (3.62s)
    queryvocabulary_integration_test.go:93: within_radius is not published as unavailable,
    so a caller cannot tell it apart from one that works
```

## The fix is not "delete the assertion"

SEARCH-AC-17's guarantee is unchanged — *a caller must be able to tell an operator that works from one that does not.* What changed is which half of it `within_radius` sits on. So the case asserts the other half, and it takes three assertions where there was one, because "not declared unavailable" is trivially satisfied by an operator nobody can discover:

1. it is **not** in the unavailable list, since it answers;
2. an `organization` field **publishes** it, so a caller can find it;
3. a `deal` field **does not** — a deal is never anywhere, and unlike the geocoding question that is a fact about the record type rather than about the deployment, so it is refused per call. Offering it would invite a query that can only ever be refused.

## Verified, not assumed

Both directions were mutation-checked: re-declaring the operator unavailable (the pre-#2171 state) fails assertion 1, and making `KindGeo` publish no operators fails assertion 2. `make check` exits 0 and `craft-static` is 4×PASS.

No product code changes — the gate was wrong about the product, not the other way round.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red build by updating the MCP vocabulary test to match `within_radius` now answering for locatable targets. Previously the test required the operator to be declared unavailable; now it requires the operator to not appear in the unavailable list, to be discoverable on `organization`, and to remain absent on `deal`.

- No product code changes; only updates `backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go`.
- Preserves SEARCH-AC-17: callers can tell working operators from non-working ones.
- Test fails if `within_radius` is re-declared unavailable or if geo stops publishing it, guarding against regressions.

<sup>Written for commit 11000dfb501fa3c9bd68df4fe75c078a337ce3b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that `within_radius` is available for organization fields.
  * Verified that `within_radius` is not listed as unavailable for deployments.
  * Confirmed that `within_radius` is not advertised for deals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->