### PR TITLE
fix(ci-tests): the vocabulary test asserts the operator answers, not that it cannot

### DIFF
--- a/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/queryvocabulary_integration_test.go
@@ -86,11 +86,26 @@ func TestTheComposedMCPMountPublishesTheQueryVocabulary(t *testing.T) {
 		t.Error("the published deal vocabulary has no derived organization hop")
 	}
 
-	// The declared-but-unanswerable operator arrives declared (SEARCH-AC-17).
-	if !slices.ContainsFunc(doc.Unavailable, func(u vocabularyUnavailable) bool {
-		return u.Op == "within_radius" && u.Answers == search.CodeDistanceRankingUnavailable
+	// SEARCH-AC-17 inverted, which is what #2171 earned. within_radius was
+	// declared permanently unavailable while no record carried coordinates;
+	// companies are geocoded on ingestion now, so the operator ANSWERS — and
+	// declaring it unavailable would send a caller to a text match on a city
+	// name, the exact wrong answer the declaration existed to prevent.
+	//
+	// Both halves, because either alone passes for the wrong reason: an empty
+	// unavailable list would also be produced by dropping the operator
+	// altogether, and a published operator would also appear if the deployment
+	// still refused it.
+	if slices.ContainsFunc(doc.Unavailable, func(u vocabularyUnavailable) bool {
+		return u.Op == "within_radius"
 	}) {
-		t.Error("within_radius is not published as unavailable, so a caller cannot tell it apart from one that works")
+		t.Errorf("within_radius is still published as unavailable, so a caller is told to avoid an operator that answers: %+v", doc.Unavailable)
+	}
+	org := targetVocabulary(t, doc, "organization")
+	if !slices.ContainsFunc(org.Fields, func(f vocabularyField) bool {
+		return f.Kind == "geo" && slices.Contains(f.Ops, "within_radius")
+	}) {
+		t.Errorf("the organization vocabulary offers no geo field admitting within_radius, so nothing tells a caller the operator is theirs to use: %+v", org.Fields)
 	}
 }
 
@@ -230,9 +245,16 @@ func readVocabulary(e *apptest.AppEnv, t *testing.T, bearer string) vocabularyDo
 // the custom-field test, a workspace column) plus a derived hop.
 func dealVocabulary(t *testing.T, doc vocabularyDoc) vocabularyTarget {
 	t.Helper()
-	i := slices.IndexFunc(doc.Targets, func(target vocabularyTarget) bool { return target.Target == "deal" })
+	return targetVocabulary(t, doc, "deal")
+}
+
+// targetVocabulary reads one published target by name, failing where the reason
+// is legible rather than leaving a later assertion to inspect a zero value.
+func targetVocabulary(t *testing.T, doc vocabularyDoc, name string) vocabularyTarget {
+	t.Helper()
+	i := slices.IndexFunc(doc.Targets, func(target vocabularyTarget) bool { return target.Target == name })
 	if i < 0 {
-		t.Fatal(`the published vocabulary has no "deal" target`)
+		t.Fatalf("the published vocabulary has no %q target", name)
 	}
 	return doc.Targets[i]
 }


### PR DESCRIPTION
**Main's integration lane is red** on
`TestTheComposedMCPMountPublishesTheQueryVocabulary`, and has been since #2171.
Closes #2179.

```
queryvocabulary_integration_test.go:93: within_radius is not published as
unavailable, so a caller cannot tell it apart from one that works
```

## The production code is right; the assertion went stale

#2171 emptied the published `unavailable` list **on purpose**, and says why at
the field:

> within_radius used to be declared permanently unavailable here because no
> record carried coordinates; companies do now, so the operator answers for them.

The test still asserts the old SEARCH-AC-17 shape. Declaring an operator
unavailable *when it works* sends a caller to a text match on a city name —
which is precisely the wrong answer that declaration existed to prevent. So the
test now pins the inverse.

## Both halves, because either alone passes for the wrong reason

- an **empty unavailable list** is also what dropping the operator altogether
  would produce;
- a **published operator** would also appear if the deployment still refused it.

So it asserts `within_radius` is absent from `unavailable` **and** that the
`organization` target offers a geo field admitting it.

`dealVocabulary`'s lookup becomes `targetVocabulary`, keyed by name — the new
assertion needs the organization target, and a second copy of a four-line
`IndexFunc` is how a file grows two spellings of one thing.

## Verification

- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`
- `make check-backend` / `make craft-static` — green

This is the last thing standing between #2136 (removing the 19 MB binary from
`main`) and a green lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the query vocabulary integration test to reflect that `within_radius` now answers due to geocoded companies, fixing the red integration lane. Previously the test expected `within_radius` in the published `unavailable` list (SEARCH-AC-17); it now asserts the operator is absent from `unavailable` and that the `organization` vocabulary exposes a `geo` field admitting `within_radius`.

- Production behavior is unchanged; this corrects stale assertions only.
- Adds `targetVocabulary(name)` and has `dealVocabulary` delegate to it to fetch targets by name.
- Asserts both absence from `unavailable` and presence on the `organization` `geo` field to prevent false positives.

<sup>Written for commit 433417af8f4fde25559a5e9ee22a0c68a4ed4974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

