### PR TITLE
docs(capture): the Telegram how-to is driven from the UI, not curl

### DIFF
--- a/docs/how-to/connect-telegram.md
+++ b/docs/how-to/connect-telegram.md
@@ -2,53 +2,56 @@
 
 Bind a Telegram bot so Margince captures the messages customers send it onto the timeline — creating
 people and activities through the one dedupe chokepoint — and so a rep can reply from that timeline.
-This guide is **UI-first**: you drive it from the app, with the equivalent `curl` shown alongside for
-scripting and verification. For the mental model on the inbound side — the connector seam, the one
-Sink, credential custody — read [explanation/capture-connectors.md](../explanation/capture-connectors.md);
-for the outbound half — the staging row, the gates, the dispatcher —
-[explanation/outbound-messaging.md](../explanation/outbound-messaging.md).
+Everything here is done in the app; the REST surface behind it is the contract
+(`backend/api/crm.yaml`, `/channel-connections*`), and nothing below requires you to call it by hand.
+For the mental model on the inbound side — the connector seam, the one Sink, credential custody — read
+[explanation/capture-connectors.md](../explanation/capture-connectors.md); for the outbound half — the
+staging row, the gates, the dispatcher — [explanation/outbound-messaging.md](../explanation/outbound-messaging.md).
 
 > **Single-organization installation.** One installation serves one organization; the server resolves
-> it itself, so no request selects a tenant — the `curl`s below carry only the session cookie.
-> ("Workspace" still names the internal RLS tenant these tables are scoped by.)
+> it itself, so nothing you do here selects a tenant. `channel_connection` carries no tenant column at
+> all (core `0282`), and core row-level security was retired in `0217` — "the bot" below means the one
+> installation's bot.
 
-## Which path do I want?
+## What kind of connection this is
 
-There is one path, and it is not a mailbox. A `capture_connection` models **one human's grant over
-their own mailbox**; a `channel_connection` is an **admin binding one bot on behalf of the whole
-workspace**. Three consequences, all of them load-bearing:
+A bot binding is **not** a mailbox. A mailbox (**Settings → Connections → Connected inboxes**) is one
+human's grant over their own mail; a Telegram bot is an **admin binding one bot for everybody**. Three
+consequences, all load-bearing:
 
-- **One live bot per workspace.** `uq_channel_connection_ws` is a partial unique index over the live
-  rows, and it exists because every outbound reply resolves the workspace's bot: with two live
-  bindings the send path refuses to guess, so a second bot would not add a channel — it would take
-  away the ability to reply on either.
+- **One live bot, full stop.** `uq_channel_connection_ws` is a partial unique index over the live rows,
+  keyed on `(provider)` since `0282`. Every outbound reply resolves the installation's bot, so with two
+  live bindings the send path refuses to guess: a second bot would not add a channel, it would remove
+  the ability to reply on either. The card enforces this in the UI too — the **Connect a Telegram bot**
+  action disappears once one is bound, leaving **Replace token** and **Disconnect** as the only verbs.
 - **Admin/ops bind it; everyone reads it.** The `channel_connection` RBAC object grants
-  create/update/delete to `admin` and `ops` only, while `manager`, `rep` and `read_only` all hold
-  read — a rep needs to know whether the channel is live before expecting a reply to arrive there.
-  Every operation is also `x-agent-access: human-only`: the bot token grants read of every message
-  the bot receives, so an agent must never be able to bind one on its own initiative.
+  create/update/delete to `admin` and `ops` only, while `management`, `manager`, `rep` and `read_only`
+  all hold read — a rep needs to know whether the channel is live before expecting a reply to arrive
+  there. Every operation is also `x-agent-access: human-only`: the bot token grants read of every
+  message the bot receives, so an agent must never bind one on its own initiative.
 - **The customer messages the bot first.** A Telegram bot cannot open a conversation. A person becomes
-  reachable only when an inbound message binds a `person_channel_identity` for them, so there is no
-  "message this person on Telegram" action that works before they have written to you.
+  reachable only when an inbound message binds a channel identity for them, which is why the composer's
+  **How to send** picker offers Telegram only for someone who already has a conversation on it — and
+  labels it *"Continues your Telegram conversation"* rather than pretending it could start one.
 
-Compared with a mailbox connector, what is *absent* is as important as what is present: no OAuth app,
+Compared with a mailbox connector, what is *absent* matters as much as what is present: no OAuth app,
 no consent redirect, no callback URI, and no inbound HTTP route at all — **ingress long-polls**, so
 this installation dials out and is never dialled.
 
-## Prerequisites
+## Before you start
 
 Two things, and nothing else:
 
-- **A bot token from BotFather.** Message [@BotFather](https://t.me/BotFather) on Telegram, `/newbot`,
-  and keep the token it issues. It has the shape `<bot id>:<secret>`; the connect surface shape-checks
-  that before spending a network call on it, so a pasted bot *username* or an empty box is refused
-  immediately.
+- **A bot token from BotFather.** Message [@BotFather](https://t.me/BotFather) on Telegram, send
+  `/newbot`, and keep the token it issues. It has the shape `<bot id>:<secret>`; the server shape-checks
+  that before spending a network call on it, so a pasted bot *username* comes back refused rather than
+  attempted.
 - **The vault key** — `MARGINCE_KEYVAULT_ROOT_KEY` (base64 of exactly 32 bytes), on **both** the api
   and the worker. The api seals the token on connect; the worker unseals it on every poll. Without a
-  vault the api still lists bindings, but every mutating path refuses by name
-  (`503 channel_credentials_not_configured`) rather than storing a token nothing could unseal, and the
-  worker registers **neither** Telegram job at all — `telegram_poll` and `telegram_poll_sweep` both
-  declare `registration: {when: [ChannelVault], absent: registers_nothing}`.
+  vault the card renders **"Messaging channels aren't configured in this deployment."** instead of a
+  connect action — the api refuses every mutating path by name rather than storing a token nothing
+  could unseal, and the worker registers **neither** Telegram job (`telegram_poll` and
+  `telegram_poll_sweep` both declare `registration: {when: [ChannelVault], absent: registers_nothing}`).
 
 ```sh
 export MARGINCE_KEYVAULT_ROOT_KEY="$(openssl rand -base64 32)"  # base64 of exactly 32 bytes
@@ -64,82 +67,62 @@ Explicitly **not** needed, and not read by this surface:
 | A callback / redirect URI | Same. `WithChannelSurface()` takes no deployment configuration at all. |
 | An inbound webhook route | The poller calls `getUpdates`; connect actively **clears** any webhook the bot arrives carrying, because Telegram refuses `getUpdates` while one is registered. |
 
-> **Restart after backend config.** The api is a compiled binary — setting the vault key needs
-> `make dev` again to take effect; Vite hot-reloads the SPA but not the Go api.
+> **Restart after setting the vault key.** The api is a compiled binary — `make dev` again for it to
+> take effect. Vite hot-reloads the SPA but not the Go api.
 
-## Connect from the UI
+## Connect
 
-1. Open the app and go to **Settings → Integrations**. Below the mailbox roster sits the **Telegram
-   bot** card ("One bot receives and sends messages for the whole workspace").
-2. Click **Connect a Telegram bot** and paste the BotFather token into the **Bot token** field (a
-   password input; the form never retains it after a failed submit).
-3. Submit. On success the modal shows **Connected as @yourbot** with a status badge, and the card's
-   roster re-reads `GET /channel-connections` to prove it rather than claiming a connection the server
-   did not confirm.
+1. **Settings → Connections.** The **Telegram bot** card sits below **Connected inboxes**, subtitled
+   *"One bot receives and sends messages for the whole organization."* With nothing bound, its roster
+   row reads *"No bot is connected yet."*
+2. Click **Connect a Telegram bot** in the card header.
+3. Paste the BotFather token into **Bot token** — a password field, hinted *"Paste the token BotFather
+   gave you when you created the bot. We seal it in the credential vault and never show it again."*
+   The form retains nothing after a failed submit, so a retry starts from an empty box.
+4. **Connect.** On success the modal reads **"Connected as @yourbot."** with a status badge and a
+   **Done** button. The card behind it re-reads the connection list to prove the binding rather than
+   claiming one the server did not confirm.
 
 The worker's `telegram_poll_sweep` dispatcher (every `30s`) picks the binding up on its next tick and
 long-polls it. The cursor starts at `0` — "whatever Telegram still holds" — so a freshly connected bot
 collects the messages already waiting for it.
 
-**A failed connect cannot leave a half-connected state.** `ChannelStore.Connect` runs a fixed order:
-`getMe` (validates the token, yields the bot id and @username) → `deleteWebhook` (clears any
-registration; `drop_pending_updates` is deliberately *not* sent, because those pending updates are the
-customer's messages) → seal the token in the vault → insert the row `connected` with a zero cursor, in
-**one transaction with its audit row**. Nothing follows that write — a poll dials out, so there is no
+**A failed connect cannot leave a half-connected state.** Connect runs a fixed order: `getMe`
+(validates the token, yields the bot id and @username) → `deleteWebhook` (clears any registration;
+`drop_pending_updates` is deliberately *not* sent, because those pending updates are the customer's
+messages) → seal the token in the vault → insert the row `connected` with a zero cursor, in **one
+transaction with its audit row**. Nothing follows that write — a poll dials out, so there is no
 registration to make and no flip to perform — which is why the schema's `pending` status is a value no
-server ever produces. A failure anywhere before the commit leaves nothing behind but a vault entry the
-path destroys itself on a lost uniqueness race.
+server ever produces (the UI still renders it as *"Pending — not yet confirmed live"* rather than as
+healthy, in case an older or foreign server ever sends one). A failure anywhere before the commit
+leaves nothing behind but a vault entry the path destroys itself on a lost uniqueness race.
 
-<details><summary>Same thing via <code>curl</code></summary>
+## What the card shows once it is bound
 
-Read the token **silently** so it never lands in your shell history or a process listing, mirroring
-the "never echoed back" guarantee:
+One row: **Telegram · @yourbot**, a status badge, and the two verbs that change it.
 
-```bash
-read -rsp 'BotFather token: ' BOT_TOKEN; echo    # silent — never echoed, never in history
-# The secret reaches jq on stdin, never on a command line: printf is a shell
-# builtin, so no process's argv ever holds it (a jq `--arg` would, and `ps` reads argv).
-printf '%s' "$BOT_TOKEN" \
-| jq -Rs '{provider:"telegram", botToken:.}' \
-| curl -X POST http://localhost:8080/v1/channel-connections \
-    --cookie 'crm_session=<session>' -H 'Content-Type: application/json' --data @- \
-| jq '{id, provider, channelId, channelLabel, status, version}'
-unset BOT_TOKEN
+| Badge | Status | Meaning |
+|---|---|---|
+| **Capturing** | `connected` | Live. Polled every dispatcher tick. |
+| **Needs reconnect** | `reauth_required` | Telegram refused the sealed token. No retry repairs it — **Replace token**. |
+| **Sync error** | `error` | Another consumer holds this bot's updates. Find and stop it (a second installation, a staging stack, an unrelated integration). |
+| **Disconnected** | `disconnected` | Archived. Filtered out of the roster. |
 
-curl --cookie 'crm_session=<session>' http://localhost:8080/v1/channel-connections \
-| jq '.data[] | {channelLabel, status}'
-```
-
-`201` carries the connected row. No read surface ever returns the token or its vault ref: the
-`ChannelConnection` shape carries `channelId` (the bot's global numeric id — the key) and
-`channelLabel` (the @username — display only, because a username is mutable and re-assignable).
-</details>
+Neither parked status is polled again until an operator acts — the due-scan selects only `connected`
+rows, which is what actually ends the retry loop. The reason is recorded in the audit trail's
+`poll_stopped_because`, because the row itself has no column for it.
 
 ## Rotate the token
 
-Rotating goes through `PATCH`, **in place** — never a disconnect/reconnect cycle. Click **Replace
-token** on the connection's row in **Settings → Integrations**, paste the new token, submit. The same
-modal serves both; the connection's current status stays visible while you do it, so a binding ingress
-has parked reads that way rather than silently as "connected".
+**Replace token** on the row, paste the new token, submit. The modal is titled **"Replace the bot
+token"** and keeps the connection's **current status badge visible** while you work — a binding ingress
+has parked must read that way here too, not silently as healthy just because an edit form opened on it.
 
-The replacement token is a live credential, so read it the same way you read the first one — on stdin,
-never on a command line where the shell history and `ps` would both keep it:
+Rotating goes **in place**; it is never a disconnect/reconnect cycle. What survives and what resets:
 
-```bash
-read -rsp 'New BotFather token: ' BOT_TOKEN; echo   # silent — never echoed, never in history
-printf '%s' "$BOT_TOKEN" \
-| jq -Rs '{botToken:.}' \
-| curl -X PATCH http://localhost:8080/v1/channel-connections/<id> \
-    --cookie 'crm_session=<session>' -H 'Content-Type: application/json' --data @- \
-| jq '{channelLabel, status, version}'
-unset BOT_TOKEN
-```
-
-What survives and what resets:
-
-- **The row survives, and with it every `person_channel_identity` binding and all captured history.**
-  Telegram user ids are global and `person_channel_identity`'s unique key omits the bot id, so
-  identities keep resolving across a rotation — even a swap to a *different* bot.
+- **The row survives, and with it every channel identity binding and all captured history.** Telegram
+  user ids are global and the identity's unique key omits the bot id, so identities keep resolving
+  across a rotation — even a swap to a *different* bot.
 - **The ingress cursor RESTARTS** (`poll_offset = 0`). `update_id` is a per-bot sequence, so inheriting
   the outgoing bot's position would ask the incoming bot for updates numbered beyond anything it has
   ever sent, and every message it had received would be skipped silently.
@@ -152,98 +135,81 @@ What survives and what resets:
 
 A rotation that lands while a poll or a send is mid-flight is fenced rather than raced: the poll's
 offset advance carries a `channel_id = <the bot it actually spoke to>` predicate, and the send path
-re-reads the binding's version immediately before spending the credential
-(`ErrChannelBindingReplaced` — transient, so the delivery re-resolves rather than parking).
+re-reads the binding's version immediately before spending the credential (a transient refusal, so the
+delivery re-resolves rather than parking).
 
 ## Disconnect
 
-**Settings → Integrations** → **Disconnect** on the row, then confirm. Three different things happen to
-three different kinds of state:
+**Disconnect** on the row, then confirm **"Disconnect this bot?"** — *"This deletes the stored token and
+stops checking the bot for new messages. Capture and sending stop immediately; everything already
+captured stays in your CRM."* Three kinds of state, three different outcomes:
 
 | | What happens |
 |---|---|
-| The binding row | **Archived**, status `disconnected`. Archiving is what actually stops ingress — the due-scan selects only live `connected` rows — and it frees both partial unique indexes, so the same bot (or another) can be connected here again later. |
+| The binding row | **Archived**, status `disconnected`. Archiving is what actually stops ingress — the due-scan selects only live `connected` rows — and it frees the live-row unique index, so the same bot (or another) can be connected here again later. |
 | The bot token | **Destroyed** in the vault. That is the custody guarantee: withdrawing a connection removes the credential, not just the row. |
 | Captured activities, people, channel identities | **Kept.** Disconnecting stops capture; it does not erase history. (Erasure is Art. 17's job — see [explanation/privacy-and-consent.md](../explanation/privacy-and-consent.md).) |
 
-```sh
-curl -X DELETE http://localhost:8080/v1/channel-connections/<id> \
-  --cookie 'crm_session=<session>' -i     # 204
-```
-
-Like connect and rotate, this needs the vault: without one it refuses
-`503 channel_credentials_not_configured` rather than archiving a row whose sealed token nothing could
-then destroy.
+Like connect and rotate, this needs the vault: without one it refuses rather than archiving a row whose
+sealed token nothing could then destroy.
 
 ## Verify end-to-end
 
-1. **The bot is bound.** **Settings → Integrations** shows a `telegram` row reading **connected**
-   (or `GET /channel-connections`).
+1. **The bot is bound.** **Settings → Connections** shows the Telegram row reading **Capturing**.
 2. **A customer message becomes an activity.** From a **second** Telegram account, open a private chat
-   with the bot and send a message. Within about one dispatcher tick it lands as an activity with
-   `kind: telegram`, `direction: inbound`, provenance-stamped `connector:telegram`. A message whose
-   payload is media with no words reads as a bracketed placeholder (`[photo]`, `[voice message]`) —
-   the customer did reach out, and the timeline says so.
+   with the bot and send a message. Within about one dispatcher tick it appears on the timeline as an
+   activity with `kind: message`, `channel_provider: telegram`, `direction: inbound`,
+   provenance-stamped `connector:telegram`. (`kind` stopped naming a transport in core `0251`/ADR-0107:
+   every captured channel message files as the one `message` kind, and which transport carried it is
+   `channel_provider` — so asking for Telegram means `channel_provider=telegram`.) A message whose
+   payload is media with no words reads as a bracketed placeholder (`[photo]`, `[voice message]`) — the
+   customer did reach out, and the timeline says so.
 3. **The person was auto-created.** The Sink routes the sender through the people module's **one dedupe
    chokepoint**, exactly as a mail counterparty goes through it. The person is deliberately
-   **ownerless**: a workspace bot acts for no one human, and `channel_connection.connected_by` is audit
+   **ownerless**: a workspace bot acts for no one human, and the connection's `connected_by` is audit
    only, so reusing the connecting admin as an owner is precisely what is refused. **No organization is
    derived** — a channel identity carries no mail domain to derive one from.
-4. **Grant consent, then reply from the timeline.** The send is default-deny per purpose, so record a
-   grant first (`POST /people/{id}/consent` with the `transactional` purpose id from
-   `GET /consent-purposes`), then use the reply box on the conversation.
-
-   ```sh
-   curl -X POST http://localhost:8080/v1/activities/<activity-id>/send-message \
-     --cookie 'crm_session=<session>' -H 'Content-Type: application/json' \
-     -d '{"body":"Thanks — looking into it now.","consent_purpose":"transactional"}' \
-   | jq '{id, kind, direction}'      # 202 Accepted; the outbound activity is the durable fact
-   ```
-
-   **The recipient is never named by the caller.** The `{id}` activity is the conversation being
-   answered; its `kind` names the medium; and the recipient is resolved server-side as the channel
-   identity of the person that conversation is with. `SendMessageRequest` carries only `body` and
-   `consent_purpose` — no addressee, no subject. A conversation that reaches nobody, or more than one
-   person, is refused (`422 person_unreachable` / `422 ambiguous_channel_recipient`) rather than
-   guessed at.
-5. **The reply is filed on the conversation it answers.** The outbound activity carries the anchor's
+4. **Grant consent.** Open the person, find the **Consent** section, and **Grant** the purpose you
+   intend to send under (some purposes need a double opt-in token first). Outbound is default-deny *per
+   purpose*: a grant for one purpose never authorizes another.
+5. **Reply from the timeline.** **Reply** on the inbound entry opens the composer with no Subject and
+   no Cc — a channel has neither — and asks for a **Consent purpose**. Confirm at **"Send this
+   message?"**: *"You are sending this message now. This is an outbound, irreversible action."*
+   - **The recipient is never named by you.** The entry you replied to *is* the conversation; its
+     `channel_provider` names the medium; the recipient is resolved server-side as the channel identity
+     of the person that conversation is with. The request carries only the body, the consent purpose,
+     and optionally attachments already in the record library (named by id, never uploaded here).
+   - Without a grant the send is suppressed and the composer says so — **"Send blocked — no consent"**,
+     with a **Review consent** link back to the person. That refusal is the whole reason the surface
+     shows a purpose picker at all.
+   - **Reply does not appear** for a person the channel cannot reach — an unbound identity, or one
+     Telegram has reported as blocking the bot. A button that could only fail is not offered.
+6. **The reply is filed on the conversation it answers.** The outbound activity carries the anchor's
    `thread_key`, which is what lets capture's reply detection match the customer's next inbound message
    against it and emit `engagement.reply` naming `telegram` as the channel.
-6. **The token is never echoed, and disconnect destroys it.** No read surface returns it — not the
-   list, not the connect response, not the audit trail (the audit images carry the provider, bot id,
-   label and status, never a vault ref).
+7. **The token is never echoed.** No read surface returns it — not the roster, not the connect
+   response, not the audit trail (the audit images carry the provider, bot id, label and status, never
+   a vault ref).
 
-## Failure modes
+## When connecting fails
 
-Every refusal below is RFC 7807 with a fixed detail; Telegram's own `description` text never reaches
-the wire — it rides the wrapped error that is logged server-side.
+Every refusal is RFC 7807 with a fixed `detail`, and the modal renders that `detail` verbatim in a
+danger callout rather than flattening it to "couldn't connect". Telegram's own `description` text never
+reaches the wire — it rides the wrapped error logged server-side. The `code` column is what you will
+find in a log or an audit row.
 
-| Status + `code` | What happened | What it calls for |
+| What the callout tells you | `code` (status) | What it calls for |
 |---|---|---|
-| `400 channel_token_rejected` | Telegram answered 401/404, or the value cannot be a BotFather token at all. | Check the token BotFather issued, and that it has not been revoked. |
-| `409 channel_workspace_already_bound` | This workspace already holds a live bot. | Disconnect it first, or `PATCH` its token to point it at a different bot. |
-| `409 conflict` | *That bot* is bound elsewhere in this installation. | Use a different bot. (Distinct from the row above on purpose — the remedies differ.) |
-| `409 version_skew` | A concurrent rotate/disconnect moved the row between your read and your write. | Re-read the connection and retry; nothing was written. |
-| `502 channel_provider_unreachable` | DNS/TCP/TLS/timeout, or a Telegram 5xx. | Nothing was changed — retry once the provider is back. |
-| `502 channel_provider_rejected` | Telegram understood the request and refused it on its own terms. | Nothing was changed — check the bot has not been restricted or deleted in BotFather. |
-| `503 channel_credentials_not_configured` | No vault is configured, so a token can be neither sealed nor destroyed. | Set `MARGINCE_KEYVAULT_ROOT_KEY` and restart. |
-| `503 channel_connections_not_configured` | This role composes no channel store (an honest answer, not a 500). | Reach the surface on a role that serves it — `cmd/api` composes it. |
-| `403 permission_denied` | A non-admin/ops principal tried to create, update or delete a binding. | Read is available to every role; binding is admin/ops. |
-| `404 not_found` | No live connection with that id in this workspace (existence-hiding — an archived one reads the same). | Re-read `GET /channel-connections`. |
-
-Two states ingress itself can park a binding in, both visible as the row's `status` and both requiring
-an operator:
-
-- **`reauth_required`** — Telegram refused the sealed token. No retry repairs it: an admin re-pastes a
-  token with **Replace token**.
-- **`error`** — another consumer holds this bot's updates. The poller establishes this rather than
-  inferring it: on Telegram's 409 it clears any registered webhook, re-asks with no long-poll interval,
-  and only parks if the refusal repeats against a bot that provably carries no webhook. Find and stop
-  the other consumer (a second installation, a staging stack, an unrelated integration).
-
-Neither status is polled again until an operator acts — the due-scan selects only `connected` rows,
-which is what actually ends the retry loop. The reason is recorded in the audit trail's
-`poll_stopped_because`, because the row itself has no column for it.
+| The token was refused, or cannot be a BotFather token at all | `channel_token_rejected` (400) | Check the token BotFather issued, and that it has not been revoked. |
+| A bot is already connected here | `channel_workspace_already_bound` (409) | Disconnect it first, or **Replace token** to point the existing binding at a different bot. |
+| Someone else changed this connection while you had it open | `version_skew` (409) | Re-open the card and retry; nothing was written. |
+| Telegram could not be reached | `channel_provider_unreachable` (502) | Nothing was changed — retry once the provider is back. |
+| Telegram understood the request and refused it | `channel_provider_rejected` (502) | Nothing was changed — check the bot has not been restricted or deleted in BotFather. |
+| No credential store is configured | `channel_credentials_not_configured` (503) | Set `MARGINCE_KEYVAULT_ROOT_KEY` and restart. |
+| Messaging channels aren't configured in this deployment | `channel_connections_not_configured` (503) | This process role composes no channel store — an honest answer, not a 500. `cmd/api` serves it. |
+| You may not change this | `permission_denied` (403) | Read is available to every role; binding is admin/ops. |
+| No such connection | `not_found` (404) | Existence-hiding — an archived binding reads the same. Re-open the card. |
+| — | `conflict` (409) | The provider is not one this binary implements, or some unique index other than the live-row rule refused the write. Only `telegram` is implemented; this is the honest fallback, not a second binding rule. |
 
 ## Limits
 
@@ -257,19 +223,18 @@ which is what actually ends the retry loop. The reason is recorded in the audit 
   uniqueness that satisfies Telegram's one-consumer rule is declared on the args type
   (`TelegramPollArgs.InsertOpts`), so no inserter can drop it by omission.
 - **A blocked bot is a recipient problem, not a credential problem.** Telegram answers `403` for "bot
-  was blocked by the user" and for a deactivated account; that maps to `ErrRecipientUnreachable`, and a
-  staged delivery **parks at once** rather than burning the retry ladder — the park reason says
-  retrying and reconnecting the channel both change nothing. Separately, Telegram reports the block as
-  a `my_chat_member` update, which sets `blocked_at` on the person's channel identity; from then on the
-  reply surface refuses with `422 person_unreachable` instead of offering a reply box that could only
-  fail. Unblocking clears it, ordered by the update's own `update_id` so two transitions cannot apply
+  was blocked by the user" and for a deactivated account; a staged delivery **parks at once** rather
+  than burning the retry ladder — the park reason says retrying and reconnecting the channel both
+  change nothing. Separately, Telegram reports the block as a `my_chat_member` update, which sets
+  `blocked_at` on the person's channel identity; from then on the **Reply** button is not offered at
+  all. Unblocking clears it, ordered by the update's own `update_id` so two transitions cannot apply
   backwards.
 - **Private chats only.** Group and supergroup messages are refused before anything is stored: a bot in
   a group runs in Telegram's default privacy mode and would see only fragments, and a reply resolves
   its recipient through the sender's *private* chat, so a group-filed message could never be answered
   where it came from.
-- **Media is named, not downloaded.** The body carries the text or the caption; a wordless message
-  reads as `[photo]` / `[document]` / `[attachment]`. Fetching the file itself is out of scope.
+- **Inbound media is named, not downloaded.** The body carries the text or the caption; a wordless
+  message reads as `[photo]` / `[document]` / `[attachment]`. Fetching the file itself is out of scope.
 - **A reply is not nested under a specific message.** The chat *is* the conversation, so an outbound
   channel delivery is staged unanchored rather than guessing at the capture provider's natural-key
   format.
@@ -282,7 +247,7 @@ which is what actually ends the retry loop. The reason is recorded in the audit 
 | Rotate + disconnect (in-place repoint, archive, credential destruction) | `backend/internal/modules/capture/channelconnedit.go` |
 | The `/channel-connections` transport + the wire-code mapping | `backend/internal/modules/capture/handlers_channel.go` |
 | The poller's reads/writes — due scan, poll target, cursor advance, park | `backend/internal/modules/capture/channelpoll.go` |
-| Send-side resolve of the workspace's bot + the replacement fence | `backend/internal/modules/capture/channelsend.go` |
+| Send-side resolve of the bot + the replacement fence | `backend/internal/modules/capture/channelsend.go` |
 | The channel counterparty auto-create + the erasure mutex | `backend/internal/modules/capture/sinkchannel.go` |
 | Bot API boundary, sentinels, token shape check | `backend/internal/modules/capture/telegram/api.go`, `auth.go` |
 | The pure update → activity mapping, and the membership (block/unblock) parse | `backend/internal/modules/capture/telegram/normalize.go`, `membership.go` |
@@ -293,7 +258,8 @@ which is what actually ends the retry loop. The reason is recorded in the audit 
 | The tables | `channel_connection` (0151), `person_channel_identity` (0152), `erasure_suppression` channel rows (0153), `comms_outbound`'s channel shape (0155/0156) |
 | The REST contract | `backend/api/crm.yaml` (`/channel-connections*`, `/activities/{id}/send-message`) |
 | The job declarations | `backend/api/jobs.yaml` (`telegram_poll_sweep`, `telegram_poll`, `telegram_ingest`) |
-| The connect UI | `frontend/src/screens/telegram-connect-form.tsx`, `connectors.tsx` |
+| The card, the connect/replace modal, and the status vocabulary | `frontend/src/screens/connectors.tsx`, `telegram-connect-form.tsx`, `connector-status.ts` |
+| The reply composer and the timeline **Reply** action | `frontend/src/screens/compose.tsx`, `persontransports.ts` |
 
 ## Where to go next
 


### PR DESCRIPTION
## What

`docs/how-to/connect-telegram.md` is rewritten as a UI-first guide. Every step is a click path with the copy the screen actually shows; the `curl` blocks are gone. The contract is still named for anyone scripting against it, but a reader never has to hand-assemble a request to bind a bot.

## Why now

Auditing the doc against the code turned up seven claims it had outlived — one of which sent the reader to the wrong screen, and another to look for a word the UI never prints.

| Claim | Reality |
|---|---|
| "Settings → **Integrations**" (4×) | `ConnectorsCard` renders in `ConnectionsTab` — the card is under **Settings → Connections** (`frontend/src/screens/settings.tsx:361`) |
| "a row reading **connected**" | The badge vocabulary is **Capturing / Needs reconnect / Sync error / Disconnected** (`connector-status.ts`) |
| activity `kind: telegram` (2×) | Core `0251`/ADR-0107 narrowed `kind` to `message`; the transport is `channel_provider` |
| `409 conflict` = "that bot is bound elsewhere" | `uq_channel_connection_bot` was dropped in `0282`; the surviving live-row rule subsumes it |
| `SendMessageRequest` carries "only `body` and `consent_purpose`" | It also takes `attachment_ids` |
| "workspace still names the internal RLS tenant" | RLS retired in `0217`; `0282` dropped `channel_connection`'s tenant column outright |
| RBAC read list | Was missing the `management` role (`docs/reference/rbac-matrix.md:69`) |

## Also new

- **A badge table.** The status vocabulary was a word in a sentence; it is now a section, because it is the first thing an operator reads off the card.
- **The failure table is re-keyed on what the callout says.** The modal renders the RFC 7807 `detail` verbatim, so that string is what an admin meets; the `code` (status) is demoted to a second column for log-reading.
- **Two behaviours a reader would otherwise meet blind.** `Reply` is not rendered at all for an unreachable person (`TimelineActions` returns `null`), so a missing button is the designed answer to a blocked bot. And a missing vault key shows as *"Messaging channels aren't configured in this deployment."* where the connect action sits.
- The reply half now describes the real surface end to end: **Reply** on the timeline entry → composer with no Subject/Cc and a **Consent purpose** picker → confirm *"Send this message?"*, with **"Send blocked — no consent"** and its **Review consent** link as the refusal.

## Kept

Everything a UI cannot tell you: connect's fixed ordering and its one-transaction write, why rotation resets the ingress cursor, credential destruction on disconnect, the poll/send fences, the job cadences, and every entry under Limits.

## Verification

Docs-only; no Go changed (`craft static: no changed Go files — ok`).

- `TestPublicTreeCitesNothingPrivate` — pass
- `TestSharedRulebookSectionsAreIdenticalInBothDocs` — pass
- The two tests that read `docs/how-to/` (`goversionpins`, `extensionsignored`) touch a different page; both pass
- Every relative link in the file resolves
- Each retained claim re-checked against its source — migrations `0151`/`0154`/`0251`/`0282`, `api/jobs.yaml` cadences, `httperr` code mapping, and the i18n strings the doc now quotes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites `docs/how-to/connect-telegram.md` as a UI-first guide and removes curl snippets to match the current product. This prevents wrong click paths and outdated guidance on statuses, RBAC, and request shapes.

- Moves navigation to Settings → Connections (card rendered by `ConnectorsCard` in `ConnectionsTab`) and uses the exact UI copy throughout.
- Updates status vocabulary and adds a badge table: Capturing / Needs reconnect / Sync error / Disconnected.
- Aligns contract details: captured activities are `kind: message` with `channel_provider=telegram`; send supports `attachment_ids`; removes the obsolete “409 = bot bound elsewhere” note after `0282` (live-row uniqueness is per workspace/provider via `uq_channel_connection_ws`).
- Fixes RBAC and tenancy notes: read includes `management`; binding is human-only; RLS retired and the tenant column dropped.
- Documents key UI behaviors: Reply hidden for unreachable people; missing vault renders “Messaging channels aren't configured in this deployment.”; composer requires a consent purpose and shows “Send blocked — no consent”; Replace token flow keeps current status visible; disconnect destroys the sealed token.
- Retains non-UI guarantees for operators: fixed connect ordering in one transaction; rotation resets the ingress cursor; poll/send fences; job cadences; limits. Docs-only; no migrations.

<sup>Written for commit 5dc691855a12980e37e215d933e032a9aae56cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

