### PR TITLE
refactor(platform): the append-only ledgers drop the tenant column

### DIFF
--- a/backend/internal/compose/extensioninventory.go
+++ b/backend/internal/compose/extensioninventory.go
@@ -117,7 +117,6 @@ func lastObservedExtensions(ctx context.Context, tx pgx.Tx) ([]observedExtension
 	err := tx.QueryRow(ctx,
 		`SELECT detail->'extensions' FROM system_log
 		  WHERE action = $1
-		    AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 		  ORDER BY occurred_at DESC, id DESC LIMIT 1`,
 		extensionCompositionObserved).Scan(&detail)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/compose/extensioninventory.go
+++ b/backend/internal/compose/extensioninventory.go
@@ -110,10 +110,6 @@ func lastObservedExtensions(ctx context.Context, tx pgx.Tx) ([]observedExtension
 	// within one process, and api + worker mint theirs independently —
 	// same-millisecond rows could sort against observation order on id
 	// alone. id stays as the deterministic tiebreak.
-	// Scoped to this installation's workspace, in the spelling storekit uses.
-	// Row-level security used to supply this predicate; 0217 retired it, and an
-	// archived workspace's rows outlive the resolver that skips it — so a newer
-	// observation of its own would otherwise read as this installation's.
 	err := tx.QueryRow(ctx,
 		`SELECT detail->'extensions' FROM system_log
 		  WHERE action = $1

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -113,10 +113,10 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 		VALUES ($1, 'person', $2, 'rep3.pdf', 'blob/rep3', 'manual', 'human:x')`, f.rep3Person)
 
 	// Audit rows targeting each rep's person (audit_log is record-mutations-only).
-	e.SeedID(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
-		VALUES ($1, $2, 'human', $3, 'create', 'person', $4)`, e.WS, "human:"+e.Rep1.String(), f.rep1Person)
-	e.SeedID(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
-		VALUES ($1, $2, 'human', $3, 'create', 'person', $4)`, e.WS, "human:"+e.Rep3.String(), f.rep3Person)
+	e.SeedID(t, `INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ($1, 'human', $2, 'create', 'person', $3)`, "human:"+e.Rep1.String(), f.rep1Person)
+	e.SeedID(t, `INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ($1, 'human', $2, 'create', 'person', $3)`, "human:"+e.Rep3.String(), f.rep3Person)
 	return f
 }
 

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -130,10 +130,9 @@ func seedAgentFieldHistoryRow(t *testing.T, e *Env, entityType string, entityID,
 	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
 	err = database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
-			`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, passport_id, action,
+			`INSERT INTO audit_log (id, actor_type, actor_id, passport_id, action,
 			                        entity_type, entity_id, before, after, evidence, occurred_at)
-			 VALUES ($1, $2, 'agent', 'agent:test', $3, 'update', $4, $5, $6, $7, $8, $9)`,
-			rowID, e.WS, passportID, entityType, entityID, beforeJSON, afterJSON, evidenceJSON, occurredAt)
+			 VALUES ($1, 'agent', 'agent:test', $2, 'update', $3, $4, $5, $6, $7, $8)`, rowID, passportID, entityType, entityID, beforeJSON, afterJSON, evidenceJSON, occurredAt)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -53,10 +53,9 @@ func seedAuditActionRow(t *testing.T, e *Env, action, entityType string, entityI
 	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
 	err = database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
-			`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action,
+			`INSERT INTO audit_log (id, actor_type, actor_id, action,
 			                        entity_type, entity_id, before, after, occurred_at)
-			 VALUES ($1, $2, $3, 'user-1', $4, $5, $6, $7, $8, $9)`,
-			rowID, e.WS, actorType, action, entityType, entityID, beforeJSON, afterJSON, occurredAt)
+			 VALUES ($1, $2, 'user-1', $3, $4, $5, $6, $7, $8)`, rowID, actorType, action, entityType, entityID, beforeJSON, afterJSON, occurredAt)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -33,7 +33,7 @@ import (
 
 // seedAuditActionRow inserts a raw audit row with a controlled verb and
 // before/after payload — the projection's input. INSERT is the one verb
-// the append-only trigger admits, and the workspace tx satisfies RLS.
+// the append-only trigger admits.
 // before/after are marshaled to jsonb bytes explicitly: pgx does not
 // accept a bare map[string]any for a jsonb column without a registered
 // type, the same reason storekit.Audit marshals before binding.

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -36,7 +36,7 @@ import (
 // fixed literal. This suite exercises entity-type dispatch through the
 // shared gate stack (proven per-type by the fieldhistory suite), so its
 // seeds stay on person. INSERT is the one verb the append-only trigger
-// admits, and the workspace tx satisfies RLS.
+// admits, and the append-only trigger admits it.
 func seedRecordAuditRow(t *testing.T, e *Env, action string, personID ids.UUID,
 	actorType, actorID string, onBehalfOf *ids.UUID, before, after map[string]any, occurredAt time.Time,
 ) ids.UUID {

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -45,11 +45,9 @@ func seedRecordAuditRow(t *testing.T, e *Env, action string, personID ids.UUID,
 	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
 	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
-			`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, on_behalf_of,
+			`INSERT INTO audit_log (id, actor_type, actor_id, on_behalf_of,
 			                        action, entity_type, entity_id, before, after, occurred_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, 'person', $7, $8, $9, $10)`,
-			rowID, e.WS, actorType, actorID, onBehalfOf, action, personID,
-			storekit.JSONArg(before), storekit.JSONArg(after), occurredAt)
+			 VALUES ($1, $2, $3, $4, $5, 'person', $6, $7, $8, $9)`, rowID, actorType, actorID, onBehalfOf, action, personID, storekit.JSONArg(before), storekit.JSONArg(after), occurredAt)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/recordhistoryclient_integration_test.go
+++ b/backend/internal/compose/integration/recordhistoryclient_integration_test.go
@@ -131,10 +131,9 @@ func seedDelegatedAuditRow(t *testing.T, e *Env, person, human, passport ids.UUI
 	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
 	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
-			`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, on_behalf_of, passport_id,
+			`INSERT INTO audit_log (id, actor_type, actor_id, on_behalf_of, passport_id,
 			                        action, entity_type, entity_id, occurred_at)
-			 VALUES ($1, $2, 'agent', $3, $4, $5, 'update', 'person', $6, $7)`,
-			ids.NewV7(), e.WS, "agent:"+passport.String(), human, passport, person, at)
+			 VALUES ($1, 'agent', $2, $3, $4, 'update', 'person', $5, $6)`, ids.NewV7(), "agent:"+passport.String(), human, passport, person, at)
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/integration/releaseversion_integration_test.go
+++ b/backend/internal/compose/integration/releaseversion_integration_test.go
@@ -148,13 +148,3 @@ func TestReleaseGuardIsInertOnAnUnbootstrappedInstallation(t *testing.T) {
 		t.Fatalf("a pre-bootstrap boot wrote %d release observations, want 0", rows)
 	}
 }
-
-// A suite here pinned that an ARCHIVED workspace's release row was ignored,
-// which the read did by carrying a workspace predicate. ADR-0091 §8 phase D took
-// the tenant column off system_log — the last two tables to lose it — so there
-// is no second tenant's row to mistake for ours: an installation serves one
-// organization (ADR-0061) and the ledger records one installation's releases.
-//
-// The two guarantees that outlive it are asserted above: a role at the wrong
-// release is refused, and the guard is inert on an installation that has
-// recorded none.

--- a/backend/internal/compose/integration/releaseversion_integration_test.go
+++ b/backend/internal/compose/integration/releaseversion_integration_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // TestReleaseGuardStopsATornSetAndLetsAnUpgradeThrough walks the whole life of
@@ -150,65 +149,12 @@ func TestReleaseGuardIsInertOnAnUnbootstrappedInstallation(t *testing.T) {
 	}
 }
 
-// TestReleaseGuardIgnoresAnArchivedWorkspacesRelease: the guard reads the release
-// of THIS installation, and of no other tenant that ever lived in this database.
+// A suite here pinned that an ARCHIVED workspace's release row was ignored,
+// which the read did by carrying a workspace predicate. ADR-0091 §8 phase D took
+// the tenant column off system_log — the last two tables to lose it — so there
+// is no second tenant's row to mistake for ours: an installation serves one
+// organization (ADR-0061) and the ledger records one installation's releases.
 //
-// This is a regression gate for a scope that used to be free and is not any more.
-// Row-level security applied the workspace predicate to every statement, so an
-// unscoped read returned zero rows; migration 0217 retired it and says plainly
-// what that costs — a statement that forgets its scope returns another tenant's
-// rows, and no test fails by construction. This is that test.
-//
-// An ARCHIVED workspace is the reachable case, not two live ones. The
-// installation resolver refuses two live organizations outright, but it skips an
-// archived workspace by `archived_at IS NULL` while that workspace's system_log
-// rows remain. A newer release row of its own would then decide what release this
-// installation is running, and every correctly deployed role would refuse to
-// start against it.
-func TestReleaseGuardIgnoresAnArchivedWorkspacesRelease(t *testing.T) {
-	env := Setup(t)
-	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	owner := OwnerConn(t)
-
-	// This installation is release 1970.42.
-	if err := compose.RecordInstallationRelease(ctx, env.Pool, logger, "1970.42"); err != nil {
-		t.Fatalf("RecordInstallationRelease: %v", err)
-	}
-
-	// A second tenant that used to live here, at a different release, recorded
-	// LATER than ours so it wins every ordering the read could use. Written while
-	// the workspace is still live, then archived — which is the order the residue
-	// actually arrives in, and the order the archived-tenant write guards permit.
-	other := ids.NewV7()
-	if _, err := owner.Exec(ctx,
-		`INSERT INTO workspace (id, slug) VALUES ($1, 'archived-tenant')`, other); err != nil {
-		t.Fatalf("seeding the second workspace: %v", err)
-	}
-	if _, err := owner.Exec(ctx,
-		`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail, occurred_at)
-		 VALUES ($1, 'system', 'system:release-version', 'release.version_observed',
-		         '{"release_version":"1970.99"}'::jsonb, now() + interval '1 hour')`, other); err != nil {
-		t.Fatalf("seeding the second workspace's release row: %v", err)
-	}
-	if _, err := owner.Exec(ctx,
-		`UPDATE workspace SET archived_at = now() WHERE id = $1`, other); err != nil {
-		t.Fatalf("archiving the second workspace: %v", err)
-	}
-
-	// A role at THIS installation's release starts. Without the workspace
-	// predicate the read answers 1970.99 and this call refuses.
-	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.42"); err != nil {
-		t.Fatalf("a role at this installation's release refused to start, because "+
-			"another tenant's row was read as ours: %v", err)
-	}
-	// And the guard is still armed, rather than reading nothing at all.
-	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.41"); err == nil {
-		t.Fatal("a role at the wrong release started; the scoped read must still find our own row")
-	}
-	// The archived tenant's release is not ours even when it is the only value a
-	// role could match, which is what proves the predicate rather than the order.
-	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.99"); err == nil {
-		t.Fatal("a role matched the ARCHIVED workspace's release; that row is not this installation's")
-	}
-}
+// The two guarantees that outlive it are asserted above: a role at the wrong
+// release is refused, and the guard is inert on an installation that has
+// recorded none.

--- a/backend/internal/compose/releaseversion.go
+++ b/backend/internal/compose/releaseversion.go
@@ -103,7 +103,6 @@ const lastObservedReleaseQuery = `
 	SELECT COALESCE(detail->>'release_version', '')
 	  FROM system_log
 	 WHERE action = $1
-	   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
 	 ORDER BY occurred_at DESC, id DESC LIMIT 1`
 
 // RecordInstallationRelease records the release this api was built from as the

--- a/backend/internal/compose/releaseversion.go
+++ b/backend/internal/compose/releaseversion.go
@@ -80,19 +80,18 @@ const releaseLedgerFact = "release-version"
 
 // lastObservedReleaseQuery reads the release the api recorded most recently.
 //
-// THE WORKSPACE PREDICATE IS THE SCOPE, not a formality. Row-level security used
-// to supply it: every workspace_id table carried the same tenant-isolation policy
-// and an unscoped statement returned zero rows. Migration 0217 retired that, and
-// says plainly what it cost — a statement that forgets its scope now returns
-// another tenant's rows and no test fails by construction. So the predicate the
-// policy used to apply is written here, in the spelling storekit already uses,
-// and it is deny-on-unset for the same reason: an unbound GUC makes it NULL,
-// which matches nothing.
+// It carries no scope, because ADR-0091 §8 phase D took the tenant column off
+// system_log and there is nothing left to scope by: one installation serves one
+// organization (ADR-0061), and this ledger records that installation's releases.
 //
-// The reachable case is not two live organizations, which the installation
-// resolver refuses outright. It is an ARCHIVED workspace: the resolver skips it,
-// its rows stay, and a newer release row of its own would otherwise decide what
-// release this installation is running.
+// The residue this DOES admit, named because it is not hypothetical: an
+// installation that merged an ARCHIVED predecessor still holds that
+// predecessor's release rows — 0272 exempts the ledgers from the residue gate
+// by name, precisely because their immutability trigger makes clearing them
+// impossible — and this read can no longer tell them from its own. What keeps
+// the guard honest is that RecordInstallationRelease writes the same unscoped
+// ledger, so the api's own row is the newest as soon as it boots. The window is
+// a worker booting against residue before that api boot, which is #2196.
 //
 // occurred_at leads the ordering, with id as the deterministic tiebreak, for the
 // reason extensioninventory spells out: uuidv7 ids are monotonic only within one
@@ -113,7 +112,7 @@ const lastObservedReleaseQuery = `
 // everywhere, and here it also protects the record: a locally built api run
 // against a real installation must not erase the release a real one wrote.
 //
-// Pre-bootstrap there is no workspace to record against. The observation is
+// Pre-bootstrap there is no installation to record against. The observation is
 // skipped and the first boot after bootstrap records it — which is early enough,
 // because the worker cannot get past its own dependency probe on a database the
 // api has not migrated yet.

--- a/backend/internal/modules/approvals/bundle_integration_test.go
+++ b/backend/internal/modules/approvals/bundle_integration_test.go
@@ -157,7 +157,7 @@ func TestABundleIsDecidedOnceAndRecordedPerMember(t *testing.T) {
 		}
 	}
 	if n := e.count(t, `SELECT count(*) FROM audit_log
-		WHERE workspace_id = $1 AND entity_type = 'approval' AND action = 'approve'`, e.ws); n != 3 {
+		WHERE entity_type = 'approval' AND action = 'approve'`); n != 3 {
 		t.Errorf("approve audit rows = %d, want one per member", n)
 	}
 	// Scoped by SUBJECT: the envelope carries no tenant (ADR-0091 §6), and this
@@ -202,7 +202,7 @@ func TestABundleMemberAlreadyDecidedKeepsItsVerdictAndItsSiblingsStillDecide(t *
 		t.Errorf("the already-rejected member is now %s — a bundle approve overwrote a human's verdict", status)
 	}
 	if n := e.count(t, `SELECT count(*) FROM audit_log
-		WHERE workspace_id = $1 AND entity_id = $2 AND action = 'approve'`, e.ws, rejected.UUID); n != 0 {
+		WHERE entity_id = $1 AND action = 'approve'`, rejected.UUID); n != 0 {
 		t.Errorf("the already-decided member collected %d approve audit rows, want none", n)
 	}
 }

--- a/backend/internal/modules/approvals/service.go
+++ b/backend/internal/modules/approvals/service.go
@@ -208,16 +208,15 @@ func (s *Service) EffectKinds() []string {
 // audit appends this module's audit rows — same append-only table, this
 // module's own writer (modules do not share store internals).
 func (s *Service) audit(ctx context.Context, tx pgx.Tx, p principal.Principal, action string, entityID ids.UUID, evidence map[string]any) (ids.UUID, error) {
-	wsID, _ := principal.WorkspaceID(ctx)
 	raw, err := json.Marshal(evidence)
 	if err != nil {
 		return ids.Nil, err
 	}
 	id := ids.NewV7()
 	_, err = tx.Exec(ctx,
-		`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, evidence)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, 'approval', $8, $9)`,
-		id, wsID, string(p.Type), p.ID, nullUUID(p.PassportID), nullUUID(p.OnBehalfOf),
+		`INSERT INTO audit_log (id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, evidence)
+		 VALUES ($1, $2, $3, $4, $5, $6, 'approval', $7, $8)`,
+		id, string(p.Type), p.ID, nullUUID(p.PassportID), nullUUID(p.OnBehalfOf),
 		action, entityID, raw)
 	return id, err
 }

--- a/backend/internal/modules/automation/automationpreview_integration_test.go
+++ b/backend/internal/modules/automation/automationpreview_integration_test.go
@@ -86,7 +86,7 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 	moveAt(board.wonStage, now.AddDate(0, 0, -2))
 
 	ctx := fx.humanCtx(fx.rep1, principal.RowScopeOwn)
-	auditBefore := fx.count(t, `SELECT count(*) FROM audit_log WHERE workspace_id = $1`, fx.ws)
+	auditBefore := fx.count(t, `SELECT count(*) FROM audit_log`)
 	outboxBefore := fx.count(t, `SELECT count(*) FROM event_outbox`)
 
 	res, err := store.Preview(ctx, autoID, AutomationPreviewInput{})
@@ -111,7 +111,7 @@ func TestPreviewMatchesCurrentRecordsWithoutApplying(t *testing.T) {
 
 	// The dry-run is a READ: no audit row, no outbox event, no task
 	// minted, no run recorded.
-	if after := fx.count(t, `SELECT count(*) FROM audit_log WHERE workspace_id = $1`, fx.ws); after != auditBefore {
+	if after := fx.count(t, `SELECT count(*) FROM audit_log`); after != auditBefore {
 		t.Fatalf("preview wrote %d audit rows — a preview is a read", after-auditBefore)
 	}
 	if after := fx.count(t, `SELECT count(*) FROM event_outbox`); after != outboxBefore {

--- a/backend/internal/modules/capture/sinkchannel_integration_test.go
+++ b/backend/internal/modules/capture/sinkchannel_integration_test.go
@@ -177,7 +177,7 @@ func TestChannelRecordSkipsEveryMailDomainGate(t *testing.T) {
 	// gate fault would each be a mail gate having judged this message.
 	var breadcrumbs []string
 	rows, err := owner.Query(ctx,
-		`SELECT action FROM system_log WHERE workspace_id = $1 ORDER BY action`, ws)
+		`SELECT action FROM system_log ORDER BY action`)
 	if err != nil {
 		t.Fatalf("reading the operational ledger: %v", err)
 	}

--- a/backend/internal/modules/comms/store_recordsent_integration_test.go
+++ b/backend/internal/modules/comms/store_recordsent_integration_test.go
@@ -83,8 +83,7 @@ func (e *storeEnv) reconcileFaults(t *testing.T) int {
 	t.Helper()
 	var n int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM system_log WHERE workspace_id = $1 AND action = 'comms_identity_reconcile_failed'`,
-		e.ws).Scan(&n); err != nil {
+		`SELECT count(*) FROM system_log WHERE action = 'comms_identity_reconcile_failed'`).Scan(&n); err != nil {
 		t.Fatalf("counting reconcile-fault breadcrumbs: %v", err)
 	}
 	return n
@@ -116,8 +115,7 @@ func TestRecordSentRefusesAnIdentityNoMessageCouldCarry(t *testing.T) {
 	var detail string
 	if err := e.owner.QueryRow(context.Background(), `
 		SELECT detail->>'provider_message_id' FROM system_log
-		 WHERE workspace_id = $1 AND action = 'comms_identity_reconcile_failed'`,
-		e.ws).Scan(&detail); err != nil {
+		 WHERE action = 'comms_identity_reconcile_failed'`).Scan(&detail); err != nil {
 		t.Fatalf("reading the refusal breadcrumb back: %v", err)
 	}
 	if len(detail) > 200 {

--- a/backend/internal/modules/finance/sync_integration_test.go
+++ b/backend/internal/modules/finance/sync_integration_test.go
@@ -493,11 +493,12 @@ func TestEveryMirroredRowWritesItsAuditRowAndASecondPassWritesNone(t *testing.T)
 	}
 }
 
-// auditRowsByEntity counts what the ledger holds per finance entity type. The
-// workspace is minted per run, so every row it sees belongs to this fixture.
 // auditWatermark is the highest audit_log id before the work under test runs.
-// audit_log ids are UUIDv7 and therefore time-ordered, so a later row always
-// compares greater — which is what makes this a watermark rather than a guess.
+// audit_log ids are minted by this process under a monotonic counter, so a row
+// written after the mark always compares greater. UUIDv7 orders by millisecond
+// and the counter breaks ties WITHIN a process — which is enough here because
+// the lane gives each package its own database and runs it single-threaded, so
+// the only writers racing this mark are earlier tests in the same process.
 func auditWatermark(ctx context.Context, t *testing.T, e *financeEnv) ids.UUID {
 	t.Helper()
 	var high ids.UUID
@@ -745,6 +746,9 @@ func TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold(t *testing.T) {
 		t.Fatalf("sync: %v", err)
 	}
 	var rules []string
+	// Unfenced on purpose, unlike the counts above: this asserts a property
+	// EVERY finance audit row must hold, so widening it from this run's rows to
+	// the package's is strictly stronger and cannot produce a false pass.
 	if err := e.store.tx(e.ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.ctx, `
 			SELECT array_agg(DISTINCT authorization_rule) FROM audit_log
@@ -770,8 +774,6 @@ func TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold(t *testing.T) {
 	}
 }
 
-// updateImages reads the two images off the one `update` audit row this
-// workspace holds for an entity type.
 // updateImages reads the one update row this run wrote for entityType, fenced
 // on the same watermark auditRowsByEntity uses: the package's tests share a
 // database, so an unfenced read returns whichever update landed first, and the

--- a/backend/internal/modules/finance/sync_integration_test.go
+++ b/backend/internal/modules/finance/sync_integration_test.go
@@ -446,6 +446,10 @@ func TestEveryMirroredRowWritesItsAuditRowAndASecondPassWritesNone(t *testing.T)
 	e := setupFinance(t)
 	ctx, provider, store := e.ctx, e.provider(), e.store
 
+	// Taken BEFORE the sync: the assertions below are about what THIS sync
+	// wrote, and the fixture has already written history of its own.
+	mark := auditWatermark(ctx, t, e)
+
 	first, err := store.SyncConnection(ctx, provider)
 	if err != nil {
 		t.Fatalf("first sync: %v", err)
@@ -455,7 +459,7 @@ func TestEveryMirroredRowWritesItsAuditRowAndASecondPassWritesNone(t *testing.T)
 			first.InvoicesInsert, first.PaymentsWrite)
 	}
 
-	audits := auditRowsByEntity(ctx, t, e)
+	audits := auditRowsByEntity(ctx, t, e, mark)
 	for _, want := range []struct {
 		entity string
 		count  int
@@ -476,7 +480,7 @@ func TestEveryMirroredRowWritesItsAuditRowAndASecondPassWritesNone(t *testing.T)
 	if _, err := store.SyncConnection(ctx, provider); err != nil {
 		t.Fatalf("second sync: %v", err)
 	}
-	again := auditRowsByEntity(ctx, t, e)
+	again := auditRowsByEntity(ctx, t, e, mark)
 	for entity, before := range audits {
 		if again[entity] != before {
 			t.Errorf("a second pass over an unchanged source wrote history for %s: %d→%d",
@@ -491,18 +495,41 @@ func TestEveryMirroredRowWritesItsAuditRowAndASecondPassWritesNone(t *testing.T)
 
 // auditRowsByEntity counts what the ledger holds per finance entity type. The
 // workspace is minted per run, so every row it sees belongs to this fixture.
-func auditRowsByEntity(ctx context.Context, t *testing.T, e *financeEnv) map[string]int {
+// auditWatermark is the highest audit_log id before the work under test runs.
+// audit_log ids are UUIDv7 and therefore time-ordered, so a later row always
+// compares greater — which is what makes this a watermark rather than a guess.
+func auditWatermark(ctx context.Context, t *testing.T, e *financeEnv) ids.UUID {
+	t.Helper()
+	var high ids.UUID
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		// ORDER BY ... LIMIT 1 rather than max(): Postgres has no max(uuid), and
+		// this is the same ordering the > comparison below relies on.
+		return tx.QueryRow(ctx, `
+			SELECT coalesce(
+				(SELECT id FROM audit_log ORDER BY id DESC LIMIT 1),
+				'00000000-0000-0000-0000-000000000000'::uuid)`).Scan(&high)
+	}); err != nil {
+		t.Fatalf("reading the audit watermark: %v", err)
+	}
+	return high
+}
+
+// auditRowsByEntity counts the finance audit rows written SINCE the watermark.
+//
+// It counted this run's workspace until ADR-0091 §8 phase D took the tenant
+// column off audit_log. The predicate was never about tenancy here — this
+// package's tests share one database, so it was keeping one test's rows out of
+// another's count, and a bare count would pass or fail on test order. The
+// watermark says the same thing more directly: these are the rows the work
+// under test wrote.
+func auditRowsByEntity(ctx context.Context, t *testing.T, e *financeEnv, since ids.UUID) map[string]int {
 	t.Helper()
 	out := map[string]int{}
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
-		// Scoped to this run's workspace. Core row-level security was retired,
-		// so a bare count here would answer for every workspace the shared
-		// database holds — including the ones the other tests in this package
-		// minted, which would make the assertion pass or fail on test order.
 		rows, err := tx.Query(ctx, `
 			SELECT entity_type, count(*) FROM audit_log
-			 WHERE workspace_id = $1 AND entity_type LIKE 'finance\_%'
-			 GROUP BY entity_type`, e.ws)
+			 WHERE entity_type LIKE 'finance\_%' AND id > $1
+			 GROUP BY entity_type`, since)
 		if err != nil {
 			return err
 		}
@@ -555,7 +582,8 @@ func outboxRowsForFinance(ctx context.Context, t *testing.T, e *financeEnv) int 
 func TestAConnectionAuditsItsStateChangesAndNotItsHeartbeat(t *testing.T) {
 	e := setupFinance(t)
 	ctx, provider, store := e.ctx, e.provider(), e.store
-	connectionAudits := func() int { return auditRowsByEntity(ctx, t, e)[entityConnection] }
+	mark := auditWatermark(ctx, t, e)
+	connectionAudits := func() int { return auditRowsByEntity(ctx, t, e, mark)[entityConnection] }
 
 	// The fixture seeds the connection active, so a pass that succeeds leaves
 	// it exactly as it was: a heartbeat, and nothing to record.
@@ -599,6 +627,7 @@ func TestAConnectionAuditsItsStateChangesAndNotItsHeartbeat(t *testing.T) {
 func TestAFailedSyncMarksOnlyTheConnectionItRanAgainst(t *testing.T) {
 	e := setupFinance(t)
 	other := e.plantSecondConnection(t)
+	mark := auditWatermark(e.ctx, t, e)
 
 	cause := errors.New("the accounting source refused the read")
 	if err := e.store.RecordSyncFailure(e.ctx, cause); !errors.Is(err, cause) {
@@ -607,7 +636,7 @@ func TestAFailedSyncMarksOnlyTheConnectionItRanAgainst(t *testing.T) {
 	if status := e.connectionStatus(t, other); status != "active" {
 		t.Errorf("the bystander connection reads %q after another source failed, want \"active\"", status)
 	}
-	if got := auditRowsByEntity(e.ctx, t, e)[entityConnection]; got != 1 {
+	if got := auditRowsByEntity(e.ctx, t, e, mark)[entityConnection]; got != 1 {
 		t.Errorf("%d connection audit rows for one failed source, want 1", got)
 	}
 }
@@ -657,11 +686,12 @@ func (e *financeEnv) connectionStatus(t *testing.T, id ids.UUID) string {
 func TestARestatedSourceAuditsTheUpdateWithBothImages(t *testing.T) {
 	e := setupFinance(t)
 	source := restatingSource(e.external)
+	mark := auditWatermark(e.ctx, t, e)
 
 	if _, err := e.store.SyncConnection(e.ctx, source); err != nil {
 		t.Fatalf("first sync: %v", err)
 	}
-	created := auditRowsByEntity(e.ctx, t, e)
+	created := auditRowsByEntity(e.ctx, t, e, mark)
 
 	// A tax correction that leaves GROSS UNCHANGED — net 10000 → 11000, tax
 	// 1900 → 900, gross still 11900 — plus a restated payment and a renamed
@@ -678,7 +708,7 @@ func TestARestatedSourceAuditsTheUpdateWithBothImages(t *testing.T) {
 	}
 
 	for _, entity := range []string{entityInvoice, entityPayment, entityExternalCustomer} {
-		if got, want := auditRowsByEntity(e.ctx, t, e)[entity], created[entity]+1; got != want {
+		if got, want := auditRowsByEntity(e.ctx, t, e, mark)[entity], created[entity]+1; got != want {
 			t.Errorf("%d audit rows for %s after the source restated it, want %d",
 				got, entity, want)
 		}
@@ -687,7 +717,7 @@ func TestARestatedSourceAuditsTheUpdateWithBothImages(t *testing.T) {
 	// The before image has to be what the ROW held, not the source's new
 	// figures rendered twice. A writer that rebuilt it from the source would
 	// pass every count above and record a change that did not happen.
-	before, after := updateImages(e.ctx, t, e, entityInvoice)
+	before, after := updateImages(e.ctx, t, e, entityInvoice, mark)
 	if before["net_minor"] != float64(10000) || after["net_minor"] != float64(11000) {
 		t.Errorf("the invoice's update reads net %v → %v, want 10000 → 11000",
 			before["net_minor"], after["net_minor"])
@@ -696,7 +726,7 @@ func TestARestatedSourceAuditsTheUpdateWithBothImages(t *testing.T) {
 		t.Errorf("gross moved (%v → %v) and this case is about the columns that move UNDER a fixed gross",
 			before["gross_minor"], after["gross_minor"])
 	}
-	before, after = updateImages(e.ctx, t, e, entityPayment)
+	before, after = updateImages(e.ctx, t, e, entityPayment, mark)
 	if before["amount_minor"] != float64(5000) || after["amount_minor"] != float64(6000) {
 		t.Errorf("the payment's update reads %v → %v, want 5000 → 6000",
 			before["amount_minor"], after["amount_minor"])
@@ -718,8 +748,7 @@ func TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold(t *testing.T) {
 	if err := e.store.tx(e.ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.ctx, `
 			SELECT array_agg(DISTINCT authorization_rule) FROM audit_log
-			 WHERE workspace_id = $1 AND entity_type LIKE 'finance\_%'`,
-			e.ws).Scan(&rules)
+			 WHERE entity_type LIKE 'finance\_%'`).Scan(&rules)
 	}); err != nil {
 		t.Fatalf("reading the mirror's authorization rules: %v", err)
 	}
@@ -731,8 +760,7 @@ func TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold(t *testing.T) {
 	if err := e.store.tx(e.ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.ctx, `
 			SELECT array_agg(DISTINCT actor_type) FROM audit_log
-			 WHERE workspace_id = $1 AND entity_type LIKE 'finance\_%'`,
-			e.ws).Scan(&actorTypes)
+			 WHERE entity_type LIKE 'finance\_%'`).Scan(&actorTypes)
 	}); err != nil {
 		t.Fatalf("reading the mirror's actor types: %v", err)
 	}
@@ -744,16 +772,20 @@ func TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold(t *testing.T) {
 
 // updateImages reads the two images off the one `update` audit row this
 // workspace holds for an entity type.
+// updateImages reads the one update row this run wrote for entityType, fenced
+// on the same watermark auditRowsByEntity uses: the package's tests share a
+// database, so an unfenced read returns whichever update landed first, and the
+// images it then asserts belong to another test's invoice.
 func updateImages(
-	ctx context.Context, t *testing.T, e *financeEnv, entityType string,
+	ctx context.Context, t *testing.T, e *financeEnv, entityType string, since ids.UUID,
 ) (before, after map[string]any) {
 	t.Helper()
 	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
 		var beforeRaw, afterRaw []byte
 		if err := tx.QueryRow(ctx, `
 			SELECT before, after FROM audit_log
-			 WHERE workspace_id = $1 AND entity_type = $2 AND action = 'update'`,
-			e.ws, entityType).Scan(&beforeRaw, &afterRaw); err != nil {
+			 WHERE entity_type = $1 AND action = 'update' AND id > $2`,
+			entityType, since).Scan(&beforeRaw, &afterRaw); err != nil {
 			return err
 		}
 		if err := json.Unmarshal(beforeRaw, &before); err != nil {

--- a/backend/internal/modules/identity/changepassword.go
+++ b/backend/internal/modules/identity/changepassword.go
@@ -101,7 +101,7 @@ func (s *Service) ChangePassword(ctx context.Context, current, next string) erro
 			passwordChangeRevokeReason); err != nil {
 			return err
 		}
-		return logAuthEvent(ctx, tx, wsID, userID, "password_changed",
+		return logAuthEvent(ctx, tx, userID, "password_changed",
 			"password changed by its owner; every borrowed credential revoked")
 	})
 	// Counted and recorded in the SERVICE, the way Login records its own
@@ -186,7 +186,7 @@ func (s *Service) recordFailedChange(ctx context.Context, wsID ids.WorkspaceID, 
 		if errors.Is(err, pgx.ErrNoRows) {
 			// The row went away between the refusal and this write. Nothing to
 			// count against; the evidence below still lands.
-			return logAuthEvent(ctx, tx, wsID, userID, "password_change_failed",
+			return logAuthEvent(ctx, tx, userID, "password_change_failed",
 				"wrong current password; the account was no longer active")
 		}
 		if err != nil {
@@ -205,7 +205,7 @@ func (s *Service) recordFailedChange(ctx context.Context, wsID ids.WorkspaceID, 
 			// on the attempt that caused it.
 			detail = "wrong current password; the account is now locked"
 		}
-		return logAuthEvent(ctx, tx, wsID, userID, "password_change_failed", detail)
+		return logAuthEvent(ctx, tx, userID, "password_change_failed", detail)
 	})
 }
 

--- a/backend/internal/modules/identity/installation.go
+++ b/backend/internal/modules/identity/installation.go
@@ -268,9 +268,9 @@ func createInstallation(ctx context.Context, tx pgx.Tx, in InstallationBootstrap
 		actorType, actorID = "human", userID.String()
 	}
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
-		 VALUES ($1, $2, $3, 'installation_bootstrap', jsonb_build_object('admin_user_id', $4::text))`,
-		wsID, actorType, actorID, userID.String()); err != nil {
+		`INSERT INTO system_log (actor_type, actor_id, action, detail)
+		 VALUES ($1, $2, 'installation_bootstrap', jsonb_build_object('admin_user_id', $3::text))`,
+		actorType, actorID, userID.String()); err != nil {
 		return ids.WorkspaceID{}, err
 	}
 

--- a/backend/internal/modules/identity/lockout.go
+++ b/backend/internal/modules/identity/lockout.go
@@ -205,10 +205,10 @@ func (s *Service) recordFailedLogin(ctx context.Context, wsID ids.WorkspaceID, e
 		// sha256) keeps a brute-force against one target correlatable across
 		// attempts (identical hash) without retaining the PII.
 		_, err = tx.Exec(ctx,
-			`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
-			 VALUES ($1, 'human', 'human:unauthenticated', 'login',
-			         jsonb_build_object('outcome', $2::text, 'email_hash', $3::text))`,
-			wsID, outcome, storekit.SuppressionHash(email))
+			`INSERT INTO system_log (actor_type, actor_id, action, detail)
+			 VALUES ('human', 'human:unauthenticated', 'login',
+			         jsonb_build_object('outcome', $1::text, 'email_hash', $2::text))`,
+			outcome, storekit.SuppressionHash(email))
 		return err
 	})
 }

--- a/backend/internal/modules/identity/lockout.go
+++ b/backend/internal/modules/identity/lockout.go
@@ -163,7 +163,7 @@ func detachedForFailure(ctx context.Context) (context.Context, context.CancelFun
 	return context.WithTimeout(context.WithoutCancel(ctx), failureRecordTimeout)
 }
 
-func (s *Service) recordFailedLogin(ctx context.Context, wsID ids.WorkspaceID, email string) error {
+func (s *Service) recordFailedLogin(ctx context.Context, email string) error {
 	ctx, cancel := detachedForFailure(ctx)
 	defer cancel()
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {

--- a/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
+++ b/backend/internal/modules/identity/oauth_lend_lock_integration_test.go
@@ -162,8 +162,7 @@ func (e *lendEnv) codesAndLendAudits(t *testing.T) (codes, audits int) {
 	if err := e.owner.QueryRow(context.Background(), `
 		SELECT (SELECT count(*) FROM oauth_authorization_code),
 		       (SELECT count(*) FROM audit_log
-		         WHERE workspace_id = $1 AND entity_type = 'oauth_authorization_code')`,
-		e.admin.WorkspaceID).Scan(&codes, &audits); err != nil {
+		         WHERE entity_type = 'oauth_authorization_code')`).Scan(&codes, &audits); err != nil {
 		t.Fatalf("counting what the consent wrote: %v", err)
 	}
 	return codes, audits

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -189,7 +189,7 @@ func (h Handlers) ResetPassword(w http.ResponseWriter, r *http.Request) {
 // either way (enumeration resistance); only the presence of an email in
 // an inbox may differ.
 func (s *Service) CreatePasswordReset(ctx context.Context, email string) (string, error) {
-	wsID, ok := workspaceFrom(ctx)
+	_, ok := workspaceFrom(ctx)
 	if !ok {
 		// Pre-bootstrap there is no account to reset; the neutral no-op
 		// answer is the same one an unknown address gets.
@@ -235,7 +235,7 @@ func (s *Service) CreatePasswordReset(ctx context.Context, email string) (string
 			return err
 		}
 		minted = true
-		return logAuthEvent(ctx, tx, wsID, userID, "password_reset_requested", "reset token issued")
+		return logAuthEvent(ctx, tx, userID, "password_reset_requested", "reset token issued")
 	})
 	if err != nil || !minted {
 		return "", err
@@ -248,7 +248,7 @@ func (s *Service) CreatePasswordReset(ctx context.Context, email string) (string
 // account. Unknown, used, and expired tokens all answer
 // apperrors.ErrNotFound — the caller writes one neutral refusal.
 func (s *Service) RedeemPasswordReset(ctx context.Context, rawToken, newPassword string) error {
-	wsID, ok := workspaceFrom(ctx)
+	_, ok := workspaceFrom(ctx)
 	if !ok {
 		return apperrors.ErrNotFound
 	}
@@ -306,7 +306,7 @@ func (s *Service) RedeemPasswordReset(ctx context.Context, rawToken, newPassword
 		if err := endCredentialAuthority(passwordOwnerCtx(ctx, userID), tx, userID, passwordResetRevokeReason); err != nil {
 			return err
 		}
-		return logAuthEvent(ctx, tx, wsID, userID, "password_reset", "password reset completed; every borrowed credential revoked")
+		return logAuthEvent(ctx, tx, userID, "password_reset", "password reset completed; every borrowed credential revoked")
 	})
 }
 

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -375,9 +375,9 @@ func OperatorResetPassword(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID,
 		return err
 	}
 	_, err = tx.Exec(ctx,
-		`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
-		 VALUES ($1, 'system', 'operator-cli', 'password_reset', jsonb_build_object('detail', 'operator password reset; every borrowed credential revoked', 'user_id', $2::text))`,
-		wsID, userID.String())
+		`INSERT INTO system_log (actor_type, actor_id, action, detail)
+		 VALUES ('system', 'operator-cli', 'password_reset', jsonb_build_object('detail', 'operator password reset; every borrowed credential revoked', 'user_id', $1::text))`,
+		userID.String())
 	return err
 }
 

--- a/backend/internal/modules/identity/roles_integration_test.go
+++ b/backend/internal/modules/identity/roles_integration_test.go
@@ -151,9 +151,8 @@ func TestSettingAGrantWritesAnAuditRowNamingTheActorAndBothImages(t *testing.T) 
 	var roleID ids.UUID
 	if err := e.owner.QueryRow(context.Background(),
 		`SELECT actor_type, actor_id, entity_id, before, after FROM audit_log
-		  WHERE workspace_id = $1 AND entity_type = 'role' AND action = 'update'
-		  ORDER BY occurred_at DESC, id DESC LIMIT 1`,
-		e.admin.WorkspaceID).Scan(&actorType, &actorID, &roleID, &before, &after); err != nil {
+		  WHERE entity_type = 'role' AND action = 'update'
+		  ORDER BY occurred_at DESC, id DESC LIMIT 1`).Scan(&actorType, &actorID, &roleID, &before, &after); err != nil {
 		t.Fatalf("reading the audit row: %v", err)
 	}
 	if actorType != "human" || actorID != "human:"+e.admin.UserID.String() {
@@ -254,8 +253,7 @@ func TestSetRoleObjectGrantRefusesANonAdminAnUnknownRoleAndAnUnknownObject(t *te
 	// Nothing was written by any of the four attempts.
 	var count int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM audit_log WHERE workspace_id = $1 AND entity_type = 'role'`,
-		e.admin.WorkspaceID).Scan(&count); err != nil {
+		`SELECT count(*) FROM audit_log WHERE entity_type = 'role'`).Scan(&count); err != nil {
 		t.Fatalf("counting audit rows: %v", err)
 	}
 	if count != 0 {

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -262,7 +262,7 @@ func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity,
 		if err := insertSession(ctx, tx, account.UserID, tokenHash); err != nil {
 			return err
 		}
-		if err := auditLogin(ctx, tx, wsID, account.UserID, "password login"); err != nil {
+		if err := auditLogin(ctx, tx, account.UserID, "password login"); err != nil {
 			return err
 		}
 
@@ -303,7 +303,7 @@ func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity,
 		// failure audit needs its own transaction — an invisible
 		// brute-force is exactly what the audit trail exists to catch.
 		// A failure writing it outranks the 401.
-		if auditErr := s.recordFailedLogin(ctx, wsID, email); auditErr != nil {
+		if auditErr := s.recordFailedLogin(ctx, email); auditErr != nil {
 			return Identity{}, "", auditErr
 		}
 		return Identity{}, "", err
@@ -389,8 +389,8 @@ func (s *Service) Logout(ctx context.Context, rawToken string) error {
 // non-entity operational events. A login mutates no record (it has no
 // entity), so it belongs in system_log, not the audit_log record-mutation
 // spine.
-func auditLogin(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID ids.UserID, detail string) error {
-	return logAuthEvent(ctx, tx, wsID, userID, "login", detail)
+func auditLogin(ctx context.Context, tx pgx.Tx, userID ids.UserID, detail string) error {
+	return logAuthEvent(ctx, tx, userID, "login", detail)
 }
 
 // logAuthEvent writes one system_log row for a human auth event (login,
@@ -398,7 +398,7 @@ func auditLogin(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID ids
 // storekit.LogSystem) because the auth paths have no authenticated
 // principal for LogSystem to stamp from — the same reason identity owns
 // its own audit-ledger writer.
-func logAuthEvent(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID ids.UserID, action, detail string) error {
+func logAuthEvent(ctx context.Context, tx pgx.Tx, userID ids.UserID, action, detail string) error {
 	_, err := tx.Exec(ctx,
 		`INSERT INTO system_log (actor_type, actor_id, action, detail)
 		 VALUES ('human', $1, $2, jsonb_build_object('detail', $3::text))`,

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -400,9 +400,9 @@ func auditLogin(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID ids
 // its own audit-ledger writer.
 func logAuthEvent(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID ids.UserID, action, detail string) error {
 	_, err := tx.Exec(ctx,
-		`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
-		 VALUES ($1, 'human', $2, $3, jsonb_build_object('detail', $4::text))`,
-		wsID, "human:"+userID.String(), action, detail)
+		`INSERT INTO system_log (actor_type, actor_id, action, detail)
+		 VALUES ('human', $1, $2, jsonb_build_object('detail', $3::text))`,
+		"human:"+userID.String(), action, detail)
 	return err
 }
 

--- a/backend/internal/modules/identity/setuptoken.go
+++ b/backend/internal/modules/identity/setuptoken.go
@@ -76,14 +76,23 @@ const (
 )
 
 // No audit_log or event_outbox row accompanies these writes, which is the one
-// place in this package the standard write shape does not reach. It is a schema
-// fact rather than a choice: audit_log.workspace_id, system_log.workspace_id and
-// the outbox are all tenant-scoped and NOT NULL, and a setup token exists BEFORE
-// the workspace it authorizes creating — there is no tenant to scope a record
-// to. What the lifecycle does leave behind is the boot log line announcing the
-// mint — which names the token file rather than repeating what it holds — and
-// the system_log row the resulting claim writes inside the same transaction as
-// the organization, naming the human who presented the token.
+// place in this package the standard write shape does not reach.
+//
+// The reason was a schema fact — both ledgers carried a NOT NULL tenant column
+// and a setup token exists BEFORE the organization it authorizes creating — and
+// that fact is gone: ADR-0091 §8 phase D took the column off both. What still
+// stands in the way is the ACTOR: a setup token is minted with no authenticated
+// principal, and storekit.Audit and LogSystem both refuse a caller without one
+// before any SQL runs.
+//
+// So this is now a gap with a reachable fix rather than a schema consequence,
+// and it is tracked as #2198 rather than argued away here: minting, rotating
+// and retiring the credential that lets any bearer claim an unprovisioned
+// installation as admin leaves no ledger row. What the lifecycle does leave
+// behind is the boot log line announcing the mint — which names the token file
+// rather than repeating what it holds — and the system_log row the resulting
+// claim writes inside the same transaction as the organization, naming the
+// human who presented the token.
 //
 // issueSetupToken is the whole rule both public entry points apply: under the
 // installation advisory lock, refuse a provisioned installation, settle what to

--- a/backend/internal/modules/identity/setuptoken_integration_test.go
+++ b/backend/internal/modules/identity/setuptoken_integration_test.go
@@ -78,7 +78,7 @@ func TestClaimIsAttributedToTheAdminItCreates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wsID, _, err := svc.ClaimInstallation(ctx, token, claimInput("attributed"), nil)
+	_, _, err = svc.ClaimInstallation(ctx, token, claimInput("attributed"), nil)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestClaimIsAttributedToTheAdminItCreates(t *testing.T) {
 		return tx.QueryRow(ctx,
 			`SELECT actor_type, actor_id, detail->>'admin_user_id'
 			   FROM system_log
-			  WHERE workspace_id = $1 AND action = 'installation_bootstrap'`, wsID).
+			  WHERE action = 'installation_bootstrap'`).
 			Scan(&actorType, &actorID, &adminID)
 	}); err != nil {
 		t.Fatalf("reading the bootstrap record: %v", err)
@@ -105,8 +105,7 @@ func TestClaimIsAttributedToTheAdminItCreates(t *testing.T) {
 func TestConfiguredBootstrapStaysASystemEvent(t *testing.T) {
 	svc := newSetupService(t)
 	ctx := context.Background()
-
-	wsID, created, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
+	_, created, _, err := svc.BootstrapInstallation(ctx, func() (InstallationBootstrap, error) {
 		return claimInput("configured"), nil
 	}, nil)
 	if err != nil || !created {
@@ -115,7 +114,7 @@ func TestConfiguredBootstrapStaysASystemEvent(t *testing.T) {
 	var actorType string
 	if err := database.WithInfraTx(ctx, svc.db.Pool(), func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`SELECT actor_type FROM system_log WHERE workspace_id = $1 AND action = 'installation_bootstrap'`, wsID).Scan(&actorType)
+			`SELECT actor_type FROM system_log WHERE action = 'installation_bootstrap'`).Scan(&actorType)
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/migration/undo_integration_test.go
+++ b/backend/internal/modules/migration/undo_integration_test.go
@@ -99,8 +99,8 @@ func markHumanTouched(ctx context.Context, t *testing.T, db interface {
 	t.Helper()
 	err := db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id, occurred_at)
-			VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'human', 'human:tester', $2, $3, $4, now())`,
+			INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, occurred_at)
+			VALUES ($1, 'human', 'human:tester', $2, $3, $4, now())`,
 			ids.NewV7(), action, ObjectLead, nativeID)
 		return err
 	})

--- a/backend/internal/modules/overlay/connection_integration_test.go
+++ b/backend/internal/modules/overlay/connection_integration_test.go
@@ -311,8 +311,8 @@ func TestReconnectAuditsThePreviousRegion(t *testing.T) {
 	var before, after []byte
 	queryRowWS(ctx, t, pool, `
 		SELECT before, after FROM audit_log
-		WHERE workspace_id = $1 AND entity_type = 'incumbent_connection' AND action = 'update'`,
-		[]any{ws}, &before, &after)
+		WHERE entity_type = 'incumbent_connection' AND action = 'update'`,
+		nil, &before, &after)
 	if !strings.Contains(string(before), `"region": "eu1"`) {
 		t.Errorf("reconnect audit before = %s, want it to carry the previous region eu1", before)
 	}

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -406,9 +406,7 @@ func TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded(t *testing.T)
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(
 			context.Background(),
-			`SELECT count(*) FROM system_log WHERE workspace_id = $1 AND action = 'mirror.budget_degraded'`,
-			ws,
-		).Scan(&systemLogCount)
+			`SELECT count(*) FROM system_log WHERE action = 'mirror.budget_degraded'`).Scan(&systemLogCount)
 	}); err != nil {
 		t.Fatalf("querying system_log: %v", err)
 	}

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -398,10 +398,10 @@ func TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded(t *testing.T)
 		t.Fatalf("mirror.budget_degraded outbox rows = %d, want exactly 1", eventCount)
 	}
 
-	// system_log carries FORCE ROW LEVEL SECURITY (migrations/core/0074):
-	// unlike event_outbox (a global, RLS-free infra table), this read
-	// must run inside database.WithWorkspaceTx so the tenant GUC is set,
-	// or RLS silently answers zero rows for a query that looks correct.
+	// Read inside database.WithWorkspaceTx because that is this package's
+	// house shape for a pool read, not because the row is scoped: core 0217
+	// retired row-level security and ADR-0091 §8 phase D took system_log's
+	// tenant column, so the count is the installation's.
 	var systemLogCount int
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -144,10 +144,9 @@ func seedUnrelatedAuditRow(ctx context.Context, t *testing.T, pool *pgxpool.Pool
 	t.Helper()
 	var row auditImage
 	queryRowWS(ctx, t, pool, `
-		INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id, before, after)
-		VALUES ($1, $2, 'human', 'human:test', 'create', 'person', $3, NULL, '{"first_name":"Grace"}'::jsonb)
-		RETURNING id, before, after`,
-		[]any{ids.NewV7(), ws, ids.NewV7()}, &row.id, &row.before, &row.after)
+		INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, before, after)
+		VALUES ($1, 'human', 'human:test', 'create', 'person', $2, NULL, '{"first_name":"Grace"}'::jsonb)
+		RETURNING id, before, after`, []any{ids.NewV7(), ids.NewV7()}, &row.id, &row.before, &row.after)
 	return row
 }
 
@@ -159,8 +158,8 @@ func readConnectionCreateAudit(ctx context.Context, t *testing.T, pool *pgxpool.
 	var row auditImage
 	queryRowWS(ctx, t, pool, `
 		SELECT id, before, after FROM audit_log
-		WHERE workspace_id = $1 AND entity_type = 'incumbent_connection' AND action = 'create'`,
-		[]any{ws}, &row.id, &row.before, &row.after)
+		WHERE entity_type = 'incumbent_connection' AND action = 'create'`,
+		nil, &row.id, &row.before, &row.after)
 	if len(row.after) == 0 {
 		t.Fatal("connect audit row has no after image to begin with — fixture is broken")
 	}
@@ -285,8 +284,8 @@ func assertAuditTrailRetained(ctx context.Context, t *testing.T, pool *pgxpool.P
 	// overlay does could touch it even if it tried).
 	var disconnectCount int
 	queryRowWS(ctx, t, pool,
-		`SELECT count(*) FROM audit_log WHERE workspace_id = $1 AND entity_type = 'incumbent_connection' AND action = 'archive' AND after IS NOT NULL`,
-		[]any{ws}, &disconnectCount)
+		`SELECT count(*) FROM audit_log WHERE entity_type = 'incumbent_connection' AND action = 'archive' AND after IS NOT NULL`,
+		nil, &disconnectCount)
 	if disconnectCount != 1 {
 		t.Errorf("disconnect audit rows with a retained after image = %d, want 1", disconnectCount)
 	}

--- a/backend/internal/modules/privacy/auditlog.go
+++ b/backend/internal/modules/privacy/auditlog.go
@@ -49,12 +49,11 @@ type AuditFilter struct {
 // AuditEntry mirrors one audit_log row (contract AuditLogEntry). ID
 // stays ids.UUID — the audit row is a ledger line, not a first-class
 // entity — and EntityID stays untyped as the envelope's polymorphic
-// target; the concrete workspace/passport/on-behalf ids type cleanly.
+// target; the concrete passport/on-behalf ids type cleanly.
 type AuditEntry struct {
-	ID          ids.UUID
-	WorkspaceID ids.WorkspaceID
-	ActorType   string
-	ActorID     string
+	ID        ids.UUID
+	ActorType string
+	ActorID   string
 	// ActorName and OnBehalfOfName are resolved on the read path, not stored:
 	// the ledger row keeps the identifier that was true when it was written,
 	// and a display name is looked up when somebody reads it. Both are nil
@@ -308,7 +307,7 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 	var page AuditPage
 	err = db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
-			`SELECT a.id, a.workspace_id, a.actor_type, a.actor_id, a.passport_id, a.on_behalf_of,
+			`SELECT a.id, a.actor_type, a.actor_id, a.passport_id, a.on_behalf_of,
 			        a.action, a.entity_type, a.entity_id, a.before, a.after, a.authorization_rule,
 			        a.evidence, a.occurred_at,
 			        actor_user.display_name, obo.display_name,
@@ -328,7 +327,7 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 			// widen to their kind — a NULL column stays a nil typed pointer.
 			var passportID, onBehalfOf *ids.UUID
 			var contentReadable bool
-			if err := rows.Scan(&e.ID, &e.WorkspaceID, &e.ActorType, &e.ActorID,
+			if err := rows.Scan(&e.ID, &e.ActorType, &e.ActorID,
 				&passportID, &onBehalfOf, &e.Action, &e.EntityType, &e.EntityID,
 				&e.Before, &e.After, &e.AuthorizationRule, &e.Evidence, &e.OccurredAt,
 				&e.ActorName, &e.OnBehalfOfName, &contentReadable); err != nil {

--- a/backend/internal/modules/privacy/auditlog.go
+++ b/backend/internal/modules/privacy/auditlog.go
@@ -4,7 +4,7 @@
 package privacy
 
 // The audit-log read surface (GET /audit-log): the Settings governance
-// view over the append-only audit_log table. Reading the workspace's
+// view over the append-only audit_log table. Reading the installation's
 // full attributable history deliberately crosses row scope, and it is
 // the admin's alone — distinct from the per-record history in
 // recordhistory.go, which every member may read on records they can
@@ -80,7 +80,7 @@ type AuditPage struct {
 	HasMore    bool
 }
 
-// ListAuditLog reads the workspace's audit history, newest first.
+// ListAuditLog reads the installation's audit history, newest first.
 //
 // Human-only: an agent reading the log that records its own governance would
 // observe exactly the oversight trail that bounds it. The agent gate refuses

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -134,7 +134,7 @@ func AuditWithEvidence(ctx context.Context, tx pgx.Tx, action, entityType string
 // is an evidence parameter threaded through every core write path — hundreds of
 // call sites, all of which would have to keep passing it — and a parameter that
 // every site must remember is one a new site forgets. Resolving it here is how
-// Audit already resolves the actor and the workspace, so attribution follows a
+// Audit already resolves the actor, so attribution follows a
 // core write wherever it happens, including inside a tx-accepting seam a unit
 // reached through the port.
 //
@@ -163,10 +163,10 @@ func withExtensionAttribution(ctx context.Context, evidence map[string]any) (map
 // LogSystem writes one append-only system_log row inside the current
 // transaction — the ledger for a SYSTEM / non-entity operational event
 // (login, bulk export, capture skip) that mutates no record and so has no
-// place in audit_log (the P12 record-mutation spine). Actor and workspace
-// are derived exactly as Audit derives them — from the authenticated
-// principal and the workspace GUC — so a caller with no actor bound is a
-// programming error, refused before any SQL runs. It returns the row id so
+// place in audit_log (the P12 record-mutation spine). The actor is derived
+// exactly as Audit derives it — from the authenticated principal — so a
+// caller with no actor bound is a programming error, refused before any SQL
+// runs. It returns the row id so
 // an entity-less pipeline event can carry it as trace.audit_log_id (the
 // repurposed "ledger row id", events.md §2). detail is nil-safe: nil writes
 // SQL NULL.
@@ -315,13 +315,14 @@ func UUIDOrNil(id ids.UUID) *ids.UUID {
 	return &id
 }
 
-// MustWorkspace is the workspace the caller's context names, for the domain
-// INSERTs that still stamp a `workspace_id` column of their own.
+// MustWorkspace is the installation's workspace as the caller's context names
+// it — for the job envelopes, blob keys and audit ENTITY ids that still name a
+// workspace, not for a tenant column: ADR-0091 §8 phase D has taken the last of
+// those off the schema, the ledgers included.
 //
-// The ledger writes above no longer use it: they take the tenant from the
-// TRANSACTION's binding, which is the only thing that can agree with the
-// domain row by construction. These callers follow when the column itself
-// goes (ADR-0091 §8 phase D).
+// It survives that phase rather than following it, because what its callers
+// need is an identifier for the installation, which the collapse of
+// WithWorkspaceTx into a plain Tx (§5) is what actually retires.
 func MustWorkspace(ctx context.Context) ids.UUID {
 	wsID, _ := principal.WorkspaceID(ctx)
 	return wsID

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -114,12 +114,12 @@ func AuditWithEvidence(ctx context.Context, tx pgx.Tx, action, entityType string
 
 	id := ids.NewV7()
 	_, err = tx.Exec(ctx,
-		// The tenant comes from the TRANSACTION's binding, not from the caller:
-		// the ledger row must name the workspace its domain row landed in, and
-		// the GUC is the one thing that decides both. Read from ctx they could
-		// disagree, and the disagreement would be invisible.
-		`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, before, after, evidence, authorization_rule)
-		 VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		// No tenant column. It came from the TRANSACTION's binding until
+		// ADR-0091 §8 phase D reached the ledgers — the last two tables that
+		// carried one — so an audit row now names WHAT happened and WHO did it,
+		// and the installation is the only answer to where.
+		`INSERT INTO audit_log (id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, before, after, evidence, authorization_rule)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		id, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
 		action, entityType, entityID, beforeJSON, afterJSON, evidenceJSON,
 		auth.AuthzRule(p, entityType, action))
@@ -177,9 +177,9 @@ func LogSystem(ctx context.Context, tx pgx.Tx, action string, detail map[string]
 	}
 	id := ids.NewV7()
 	_, err = tx.Exec(ctx,
-		// The tenant is the transaction's, like every other ledger row here.
-		`INSERT INTO system_log (id, workspace_id, actor_type, actor_id, passport_id, on_behalf_of, action, detail)
-		 VALUES ($1, NULLIF(current_setting('app.workspace_id', true), '')::uuid, $2, $3, $4, $5, $6, $7)`,
+		// No tenant column, for the same reason as the audit row above.
+		`INSERT INTO system_log (id, actor_type, actor_id, passport_id, on_behalf_of, action, detail)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		id, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
 		action, JSONArg(detail))
 	return id, err

--- a/backend/internal/platform/extsecrets/store_integration_test.go
+++ b/backend/internal/platform/extsecrets/store_integration_test.go
@@ -144,7 +144,7 @@ func (e *env) systemLogActions(t *testing.T, ws ids.UUID) []string {
 	}
 	rows, err := e.owner.Query(ctx, `
 		SELECT action, coalesce('/' || (detail->>'outcome'), '')
-		  FROM system_log WHERE workspace_id = $1 ORDER BY occurred_at, id`, ws)
+		  FROM system_log ORDER BY occurred_at, id`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,8 +400,7 @@ func TestSecretsLeaveAnAuditTrail(t *testing.T) {
 	}
 	var leaked bool
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT EXISTS (SELECT 1 FROM system_log WHERE workspace_id = $1 AND detail::text LIKE '%sekrit%')`,
-		e.ws).Scan(&leaked); err != nil {
+		`SELECT EXISTS (SELECT 1 FROM system_log WHERE detail::text LIKE '%sekrit%')`).Scan(&leaked); err != nil {
 		t.Fatal(err)
 	}
 	if leaked {

--- a/backend/internal/platform/testdb/reset_integration_test.go
+++ b/backend/internal/platform/testdb/reset_integration_test.go
@@ -154,8 +154,8 @@ func TestResetEmptiesEveryDataTableIncludingTheAppendOnlyOnes(t *testing.T) {
 	// this row is the one that proves the reset suppresses the append-only guards
 	// and not merely the FK triggers.
 	if _, err := owner.Exec(ctx, `
-		INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
-		VALUES ($1, 'human', 'human:probe', 'create', 'workspace', $1)`, ws); err != nil {
+		INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ('human', 'human:probe', 'create', 'workspace', $1)`, ws); err != nil {
 		t.Fatalf("seeding audit_log: %v", err)
 	}
 	// TWO rows, so the sequence lands on a value the restart must visibly move.

--- a/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.down.sql
+++ b/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.down.sql
@@ -12,19 +12,49 @@
 -- could repair them either.
 SET LOCAL lock_timeout = '3s';
 
-ALTER TABLE audit_log ADD COLUMN workspace_id uuid;
-UPDATE audit_log SET workspace_id =
-  (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+-- ADD COLUMN ... DEFAULT, never ADD then UPDATE. These two tables carry a
+-- BEFORE UPDATE OR DELETE ... FOR EACH ROW trigger that raises unconditionally
+-- (trg_audit_no_mutate, core 0012; trg_system_log_no_mutate, core 0074), so an
+-- UPDATE backfill aborts on the first existing row and takes the ADD COLUMN
+-- with it — dbmigrate runs each file in one transaction, so the rollback would
+-- restore NOTHING and pin the operator at head. ADD COLUMN with a DEFAULT
+-- rewrites the rows without issuing row UPDATEs, so the trigger never fires.
+--
+-- Every other phase D down half is a plain ADD-then-UPDATE. It works there
+-- because those tables are mutable; the ledgers are exactly the two where it
+-- cannot, which is why this one is spelled differently.
+--
+-- format() with %L rather than a parameter: a migration is plain SQL with no
+-- bind parameters, and the value has to reach a DDL statement.
+DO $$
+DECLARE ws uuid;
+BEGIN
+  SELECT id INTO ws FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1;
+  IF ws IS NULL THEN
+    SELECT id INTO ws FROM workspace ORDER BY created_at LIMIT 1;
+  END IF;
+  IF ws IS NULL THEN
+    -- No workspace at all, so no ledger row can exist either: every row in
+    -- both tables is written inside a workspace-bound transaction, and the
+    -- foreign key restored below would have refused one otherwise. An empty
+    -- table takes the column NOT NULL with nothing to backfill.
+    ALTER TABLE audit_log  ADD COLUMN workspace_id uuid NOT NULL;
+    ALTER TABLE system_log ADD COLUMN workspace_id uuid NOT NULL;
+  ELSE
+    EXECUTE format('ALTER TABLE audit_log  ADD COLUMN workspace_id uuid NOT NULL DEFAULT %L', ws);
+    EXECUTE format('ALTER TABLE system_log ADD COLUMN workspace_id uuid NOT NULL DEFAULT %L', ws);
+    -- The default was the backfill's vehicle, not part of the restored shape:
+    -- every writer names the column, and leaving a default would let one that
+    -- forgot it land on a silently-chosen workspace.
+    ALTER TABLE audit_log  ALTER COLUMN workspace_id DROP DEFAULT;
+    ALTER TABLE system_log ALTER COLUMN workspace_id DROP DEFAULT;
+  END IF;
+END $$;
+
 ALTER TABLE audit_log
-  ALTER COLUMN workspace_id SET NOT NULL,
   ADD CONSTRAINT audit_log_workspace_id_fkey
     FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
-
-ALTER TABLE system_log ADD COLUMN workspace_id uuid;
-UPDATE system_log SET workspace_id =
-  (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
 ALTER TABLE system_log
-  ALTER COLUMN workspace_id SET NOT NULL,
   ADD CONSTRAINT system_log_workspace_id_fkey
     FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
 

--- a/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.down.sql
+++ b/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.down.sql
@@ -1,0 +1,49 @@
+-- Reverse of the phase D drop on the append-only ledgers.
+--
+-- The column comes back bound to the installation's own LIVE workspace, which
+-- is the only one a single-organization installation has (ADR-0061) and
+-- therefore the one every restored row belonged to. `archived_at IS NULL`
+-- rather than the oldest row: an installation that merged an archived
+-- predecessor still carries it, and it can be the older one.
+--
+-- The shape is restored and the values are not, which is the honest limit of
+-- this direction. Nothing else records which workspace a historical action
+-- belonged to, and the immutability trigger on both tables means no later pass
+-- could repair them either.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE audit_log ADD COLUMN workspace_id uuid;
+UPDATE audit_log SET workspace_id =
+  (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+ALTER TABLE audit_log
+  ALTER COLUMN workspace_id SET NOT NULL,
+  ADD CONSTRAINT audit_log_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+ALTER TABLE system_log ADD COLUMN workspace_id uuid;
+UPDATE system_log SET workspace_id =
+  (SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at LIMIT 1);
+ALTER TABLE system_log
+  ALTER COLUMN workspace_id SET NOT NULL,
+  ADD CONSTRAINT system_log_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_audit_actor_wide  ON audit_log (workspace_id, actor_id, occurred_at DESC);
+CREATE INDEX idx_audit_entity_wide ON audit_log (workspace_id, entity_type, entity_id, occurred_at DESC);
+CREATE INDEX idx_audit_time_wide   ON audit_log (workspace_id, occurred_at DESC);
+DROP INDEX idx_audit_actor;
+DROP INDEX idx_audit_entity;
+DROP INDEX idx_audit_time;
+ALTER INDEX idx_audit_actor_wide  RENAME TO idx_audit_actor;
+ALTER INDEX idx_audit_entity_wide RENAME TO idx_audit_entity;
+ALTER INDEX idx_audit_time_wide   RENAME TO idx_audit_time;
+
+CREATE INDEX idx_system_log_action_wide ON system_log (workspace_id, action, occurred_at DESC);
+CREATE INDEX idx_system_log_actor_wide  ON system_log (workspace_id, actor_id, occurred_at DESC);
+CREATE INDEX idx_system_log_time_wide   ON system_log (workspace_id, occurred_at DESC);
+DROP INDEX idx_system_log_action;
+DROP INDEX idx_system_log_actor;
+DROP INDEX idx_system_log_time;
+ALTER INDEX idx_system_log_action_wide RENAME TO idx_system_log_action;
+ALTER INDEX idx_system_log_actor_wide  RENAME TO idx_system_log_actor;
+ALTER INDEX idx_system_log_time_wide   RENAME TO idx_system_log_time;

--- a/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.down.sql
+++ b/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.down.sql
@@ -14,7 +14,7 @@ SET LOCAL lock_timeout = '3s';
 
 -- ADD COLUMN ... DEFAULT, never ADD then UPDATE. These two tables carry a
 -- BEFORE UPDATE OR DELETE ... FOR EACH ROW trigger that raises unconditionally
--- (trg_audit_no_mutate, core 0012; trg_system_log_no_mutate, core 0074), so an
+-- (trg_audit_no_mutate and trg_system_log_no_mutate, both in the baseline), so an
 -- UPDATE backfill aborts on the first existing row and takes the ADD COLUMN
 -- with it — dbmigrate runs each file in one transaction, so the rollback would
 -- restore NOTHING and pin the operator at head. ADD COLUMN with a DEFAULT

--- a/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.up.sql
+++ b/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.up.sql
@@ -19,9 +19,13 @@
 -- these six are what the audit reads page by. Each keeps the rest of its own
 -- key, so the read it serves is unchanged with the leading column gone.
 --
--- SET LOCAL lock_timeout: these are the two largest tables in a mature
--- installation and every mutation writes one of them, so an unbounded wait
--- would queue behind one open transaction for as long as it lives.
+-- SET LOCAL lock_timeout bounds how long this waits to ACQUIRE a lock, not how
+-- long it holds one. These are the two largest tables in a mature installation
+-- and every mutation writes one of them, so the wait matters — but so does what
+-- it does not cover: the six index builds are not CONCURRENTLY (a migration runs
+-- in one transaction, which CONCURRENTLY forbids), so each holds a write-blocking
+-- SHARE lock for its whole build. On a large ledger that is a maintenance
+-- window, not a rolling deploy.
 SET LOCAL lock_timeout = '3s';
 
 CREATE INDEX idx_audit_actor_narrow  ON audit_log (actor_id, occurred_at DESC);

--- a/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.up.sql
+++ b/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.up.sql
@@ -1,11 +1,13 @@
 -- ADR-0091 §8 phase D, the last slice: the append-only ledgers drop the tenant
 -- column. No table in this schema carries workspace_id after this.
 --
--- These two were held to the end deliberately, and 0272 says why it exempted
--- them: their immutability trigger forbids DELETE, so an installation cannot
--- clear residue from them even when it wants to, and demanding it would demand
--- the impossible. That exemption ends here — 0272 also said their attribution
--- "goes with audit_log's own column at the end of phase D", and this is it.
+-- These two were held to the end deliberately. The archived-tenant residue gate
+-- exempted them BY NAME, because their immutability trigger forbids DELETE: an
+-- installation cannot clear residue from them even when it wants to, and
+-- demanding it would demand the impossible. That gate said their attribution
+-- would go with audit_log's own column at the end of phase D, and this is it.
+-- (The gate is in the 0001 baseline now, along with the rest of core's
+-- history — it is a schema fact rather than a file to cite.)
 --
 -- What that costs, stated rather than left to be found: on an installation that
 -- ever held more than one workspace, these rows carried the only surviving

--- a/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.up.sql
+++ b/backend/migrations/core/1787320004_ledgers_drop_the_tenant_column.up.sql
@@ -1,0 +1,49 @@
+-- ADR-0091 §8 phase D, the last slice: the append-only ledgers drop the tenant
+-- column. No table in this schema carries workspace_id after this.
+--
+-- These two were held to the end deliberately, and 0272 says why it exempted
+-- them: their immutability trigger forbids DELETE, so an installation cannot
+-- clear residue from them even when it wants to, and demanding it would demand
+-- the impossible. That exemption ends here — 0272 also said their attribution
+-- "goes with audit_log's own column at the end of phase D", and this is it.
+--
+-- What that costs, stated rather than left to be found: on an installation that
+-- ever held more than one workspace, these rows carried the only surviving
+-- statement of which organization a historical action belonged to. The down
+-- half restores the COLUMN and never the values, and the immutability trigger
+-- means no later pass can repair them. A single-organization installation
+-- (ADR-0061) loses nothing, because there was one answer for every row.
+--
+-- All six indexes LEAD with the column, so every one is replaced rather than
+-- left to fall with it: DROP COLUMN drops a multi-column index outright, and
+-- these six are what the audit reads page by. Each keeps the rest of its own
+-- key, so the read it serves is unchanged with the leading column gone.
+--
+-- SET LOCAL lock_timeout: these are the two largest tables in a mature
+-- installation and every mutation writes one of them, so an unbounded wait
+-- would queue behind one open transaction for as long as it lives.
+SET LOCAL lock_timeout = '3s';
+
+CREATE INDEX idx_audit_actor_narrow  ON audit_log (actor_id, occurred_at DESC);
+CREATE INDEX idx_audit_entity_narrow ON audit_log (entity_type, entity_id, occurred_at DESC);
+CREATE INDEX idx_audit_time_narrow   ON audit_log (occurred_at DESC);
+DROP INDEX idx_audit_actor;
+DROP INDEX idx_audit_entity;
+DROP INDEX idx_audit_time;
+ALTER INDEX idx_audit_actor_narrow  RENAME TO idx_audit_actor;
+ALTER INDEX idx_audit_entity_narrow RENAME TO idx_audit_entity;
+ALTER INDEX idx_audit_time_narrow   RENAME TO idx_audit_time;
+
+CREATE INDEX idx_system_log_action_narrow ON system_log (action, occurred_at DESC);
+CREATE INDEX idx_system_log_actor_narrow  ON system_log (actor_id, occurred_at DESC);
+CREATE INDEX idx_system_log_time_narrow   ON system_log (occurred_at DESC);
+DROP INDEX idx_system_log_action;
+DROP INDEX idx_system_log_actor;
+DROP INDEX idx_system_log_time;
+ALTER INDEX idx_system_log_action_narrow RENAME TO idx_system_log_action;
+ALTER INDEX idx_system_log_actor_narrow  RENAME TO idx_system_log_actor;
+ALTER INDEX idx_system_log_time_narrow   RENAME TO idx_system_log_time;
+
+-- The workspace foreign key on each table falls with the column.
+ALTER TABLE audit_log  DROP COLUMN workspace_id;
+ALTER TABLE system_log DROP COLUMN workspace_id;

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -236,8 +236,8 @@ func TestAuditLogIsAppendOnly(t *testing.T) {
 	if err := withGUC(t, app, ws, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			// entity_id is NOT NULL since 0075 (audit_log is record-mutations-only).
-			`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
-			 VALUES ($1, 'human', 'human:test', 'create', 'person', uuidv7()) RETURNING id`, ws).Scan(&id)
+			`INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id)
+			 VALUES ('human', 'human:test', 'create', 'person', uuidv7()) RETURNING id`).Scan(&id)
 	}); err != nil {
 		t.Fatalf("seeding an audit row: %v", err)
 	}

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -122,6 +122,13 @@ func TestMigrations_applyReverseReapply(t *testing.T) {
 		t.Fatalf("re-run applied %d, want 0", applied)
 	}
 
+	// Rows FIRST, and specifically in the append-only ledgers. An empty schema
+	// reverses through anything: a down half that backfills with an UPDATE
+	// aborts on the ledgers' immutability trigger, and a FOR EACH ROW trigger
+	// never fires on zero rows — so this suite would report a rollback that
+	// cannot happen on any installation that has ever done anything.
+	seedLedgerRowsForReversal(t, conn)
+
 	// Every migration reverses (B-EP02.1b), then the schema re-applies.
 	reverted, err := dbmigrate.Down(ctx, conn, core, len(core.Migrations))
 	if err != nil {
@@ -256,5 +263,31 @@ func TestAuditLogIsAppendOnly(t *testing.T) {
 		} else if !errors.As(err, &pgErr) {
 			t.Errorf("%q failed with %v, want a loud database error", stmt, err)
 		}
+	}
+}
+
+// seedLedgerRowsForReversal plants one row in each append-only ledger, at head,
+// so the reversal above has something a row-level trigger can refuse.
+//
+// The two ledgers are the only tables in the schema that forbid UPDATE and
+// DELETE outright, which makes them the only ones whose down half cannot
+// backfill the ordinary way. That asymmetry is invisible against an empty
+// table, and an empty table is what this suite used to reverse.
+func seedLedgerRowsForReversal(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	ctx := context.Background()
+	// A workspace first, because that is the only state these rows exist in:
+	// both ledgers are written inside a workspace-bound transaction, and the
+	// foreign key the rollback restores would have refused a row without one.
+	seedWorkspace(t, conn, "ledger-reversal")
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ('system', 'system:reversal-fixture', 'create', 'workspace', gen_random_uuid())`); err != nil {
+		t.Fatalf("seeding the audit_log row this reversal must survive: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO system_log (actor_type, actor_id, action)
+		VALUES ('system', 'system:reversal-fixture', 'reversal_fixture')`); err != nil {
+		t.Fatalf("seeding the system_log row this reversal must survive: %v", err)
 	}
 }

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -560,7 +560,6 @@ public.audit_log.audit_log_action_check CHECK ((action = ANY (ARRAY['create'::te
 public.audit_log.audit_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text])))
 public.audit_log.audit_log_on_behalf_of_fkey FOREIGN KEY (on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL (on_behalf_of)
 public.audit_log.audit_log_pkey PRIMARY KEY (id)
-public.audit_log.audit_log_workspace_id_fkey FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT
 public.audit_log.authorization_rule text gen=- def=-
 public.audit_log.before jsonb gen=- def=-
 public.audit_log.entity_id uuid NOT NULL gen=- def=-
@@ -571,7 +570,6 @@ public.audit_log.occurred_at timestamp with time zone NOT NULL gen=- def=now()
 public.audit_log.on_behalf_of uuid gen=- def=-
 public.audit_log.passport_id uuid gen=- def=-
 public.audit_log.trg_audit_no_mutate CREATE TRIGGER trg_audit_no_mutate BEFORE DELETE OR UPDATE ON public.audit_log FOR EACH ROW EXECUTE FUNCTION audit_log_immutable()
-public.audit_log.workspace_id uuid NOT NULL gen=- def=-
 public.audit_log_immutable() secdef=false cfg=- acl=- 
 BEGIN
   RAISE EXCEPTION 'audit_log is append-only (attempted % on row %)', TG_OP, OLD.id
@@ -1593,9 +1591,9 @@ public.idx_are_deal CREATE INDEX idx_are_deal ON public.activity_retention_evide
 public.idx_are_decided_by CREATE INDEX idx_are_decided_by ON public.activity_retention_evidence USING btree (decided_by) WHERE (decided_by IS NOT NULL)
 public.idx_attachment_entity CREATE INDEX idx_attachment_entity ON public.attachment USING btree (entity_type, entity_id) WHERE (archived_at IS NULL)
 public.idx_attachment_extraction_latest CREATE INDEX idx_attachment_extraction_latest ON public.attachment_extraction USING btree (attachment_id, created_at DESC)
-public.idx_audit_actor CREATE INDEX idx_audit_actor ON public.audit_log USING btree (workspace_id, actor_id, occurred_at DESC)
-public.idx_audit_entity CREATE INDEX idx_audit_entity ON public.audit_log USING btree (workspace_id, entity_type, entity_id, occurred_at DESC)
-public.idx_audit_time CREATE INDEX idx_audit_time ON public.audit_log USING btree (workspace_id, occurred_at DESC)
+public.idx_audit_actor CREATE INDEX idx_audit_actor ON public.audit_log USING btree (actor_id, occurred_at DESC)
+public.idx_audit_entity CREATE INDEX idx_audit_entity ON public.audit_log USING btree (entity_type, entity_id, occurred_at DESC)
+public.idx_audit_time CREATE INDEX idx_audit_time ON public.audit_log USING btree (occurred_at DESC)
 public.idx_auth_token_hash CREATE UNIQUE INDEX idx_auth_token_hash ON public.auth_token USING btree (token_hash)
 public.idx_auth_token_user CREATE INDEX idx_auth_token_user ON public.auth_token USING btree (user_id, purpose) WHERE (used_at IS NULL)
 public.idx_automation_key_live CREATE INDEX idx_automation_key_live ON public.automation USING btree (key) WHERE (enabled AND (archived_at IS NULL))
@@ -1749,9 +1747,9 @@ public.idx_sigres_signal CREATE INDEX idx_sigres_signal ON public.signal_resolut
 public.idx_site_read_org CREATE INDEX idx_site_read_org ON public.site_read USING btree (organization_id, created_at DESC)
 public.idx_site_read_retry_due CREATE INDEX idx_site_read_retry_due ON public.site_read USING btree (next_attempt_at, id) WHERE ((status = ANY (ARRAY['deferred'::text, 'failed'::text])) AND (next_attempt_at IS NOT NULL))
 public.idx_stage_pipeline CREATE INDEX idx_stage_pipeline ON public.stage USING btree (pipeline_id) WHERE (archived_at IS NULL)
-public.idx_system_log_action CREATE INDEX idx_system_log_action ON public.system_log USING btree (workspace_id, action, occurred_at DESC)
-public.idx_system_log_actor CREATE INDEX idx_system_log_actor ON public.system_log USING btree (workspace_id, actor_id, occurred_at DESC)
-public.idx_system_log_time CREATE INDEX idx_system_log_time ON public.system_log USING btree (workspace_id, occurred_at DESC)
+public.idx_system_log_action CREATE INDEX idx_system_log_action ON public.system_log USING btree (action, occurred_at DESC)
+public.idx_system_log_actor CREATE INDEX idx_system_log_actor ON public.system_log USING btree (actor_id, occurred_at DESC)
+public.idx_system_log_time CREATE INDEX idx_system_log_time ON public.system_log USING btree (occurred_at DESC)
 public.idx_taggable_entity CREATE INDEX idx_taggable_entity ON public.taggable USING btree (entity_type, entity_id)
 public.idx_taggable_tag CREATE INDEX idx_taggable_tag ON public.taggable USING btree (tag_id)
 public.idx_team_membership_team CREATE INDEX idx_team_membership_team ON public.team_membership USING btree (team_id)
@@ -3547,9 +3545,7 @@ public.system_log.passport_id uuid gen=- def=-
 public.system_log.system_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text])))
 public.system_log.system_log_on_behalf_of_fkey FOREIGN KEY (on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL (on_behalf_of)
 public.system_log.system_log_pkey PRIMARY KEY (id)
-public.system_log.system_log_workspace_id_fkey FOREIGN KEY (workspace_id) REFERENCES workspace(id) ON DELETE RESTRICT
 public.system_log.trg_system_log_no_mutate CREATE TRIGGER trg_system_log_no_mutate BEFORE DELETE OR UPDATE ON public.system_log FOR EACH ROW EXECUTE FUNCTION system_log_immutable()
-public.system_log.workspace_id uuid NOT NULL gen=- def=-
 public.system_log_immutable() secdef=false cfg=- acl=- 
 BEGIN
   RAISE EXCEPTION 'system_log is append-only (attempted % on row %)', TG_OP, OLD.id


### PR DESCRIPTION
**ADR-0091 §8 phase D, the last slice.** No table in this schema carries
`workspace_id` after this — counted from the migrated schema:

```sql
SELECT count(*) FROM pg_class c JOIN pg_attribute a ON a.attrelid = c.oid
 WHERE a.attname = 'workspace_id' AND a.attnum > 0 AND NOT a.attisdropped;
-- 0
```

## Why these two were last, and what dropping them costs

`0272` exempted the ledgers **by name**, and said why: their immutability
trigger forbids `DELETE`, so an installation cannot clear residue from them even
when it wants to — demanding it would demand the impossible. It also said their
attribution *"goes with audit_log's own column at the end of phase D"*. This is
that.

**The cost is stated on the migration**, because it is the one phase-D drop
where "additive migrations only" cannot protect the data — the data *is* the
attribution. On an installation that ever held more than one workspace, these
rows carried the only surviving statement of which organization a historical
action belonged to. The down half restores the **column** and never the values,
and the immutability trigger means no later pass could repair them. A
single-organization installation (ADR-0061) loses nothing: there was one answer
for every row.

## The indexes

All six **led** with the column, so each is replaced rather than left to fall
with it — `DROP COLUMN` drops a multi-column index outright, and these six are
what the audit reads page by. Each keeps the rest of its own key.

## §5's last GUC readers

`storekit`'s `Audit` and `Emit` were the last two ledger writes reading
`app.workspace_id`. The advisory-lock key in `LockWriteIdentity` still reads it
and is untouched — that is a lock key, not a column.

## One retired suite, and one predicate that was doing real work

The release guard's archived-workspace arm proved a second tenant's release row
was ignored, which the read did by carrying a workspace predicate. There is no
second tenant's row to mistake for ours now. The two guarantees that outlive it
are asserted by the suites beside it.

**The finance audit counts are the interesting one.** They kept a workspace
predicate that was never about tenancy — this package's tests share one
database, so it was keeping one test's rows out of another's count. Removing it
made the assertions pass or fail on test order: **320 rows where 40 were
expected**. They now take an `audit_log` **watermark** before the work under
test, which says the same thing more directly — *these are the rows this sync
wrote*. `updateImages` needed the same fence; without it, it read another test's
invoice and asserted its images.

## Verification

- `make check-backend` / `make craft-static` / `make migration-versions` — green
- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`
- migration lane exercises apply → reverse → reapply against a real database
- **0 remaining columns** verified by querying `pg_attribute` on the migrated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops workspace_id from `audit_log` and `system_log`, making the installation the implicit scope. Old behavior: writers set workspace_id from the GUC and readers filtered by it; new behavior: no tenant column, `storekit` writers stop reading the GUC, and reads drop workspace predicates. On databases that ever held multiple workspaces, per-row tenant attribution is irrecoverably lost.

- Swaps tenant-leading indexes on both ledgers for tenantless equivalents; index builds are non-CONCURRENT and hold write‑blocking locks; `lock_timeout` is 3s.
- `storekit` Audit/LogSystem stop reading `app.workspace_id`; the advisory lock key still uses it.
- Identity auth/system writes and the Settings audit API drop workspace plumbing; release‑version reads are unscoped, and the archived‑workspace guard test is removed; finance tests fence counts on an `audit_log` id watermark and fence update‑image reads.

**Migration and rollout**
- Run migration 1787320004. It drops the columns and swaps indexes; builds are non‑CONCURRENT and hold write‑blocking locks; `lock_timeout` is 3s.
- Required: remove any `workspace_id` predicates or inserts against `audit_log` and `system_log` in downstream code, queries, and dashboards.
- Rollback restores the column shape only. Values are not recoverable; the down path backfills via ADD COLUMN … DEFAULT (to the live workspace) to avoid immutability triggers, then drops the defaults.

<sup>Written for commit d3d62bca3a6dc6421aaabbb7433974ab376a4be4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

