### PR TITLE
perf(ci-tests): the harness stops paying full-strength Argon2 per test, and seed-demo's copy of those parameters gets a gate

### DIFF
--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 20
+	wantFixtureAnnotations = 21
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/modules/identity/internal/password/hashroundtrip_test.go
+++ b/backend/internal/modules/identity/internal/password/hashroundtrip_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package password
+
+import "testing"
+
+// keyLength and saltLength are NOT cost parameters and are deliberately absent
+// from the tagged files. This pins the property that makes that separation
+// matter: Verify refuses a key outside 16..64 bytes, so a keyLength below that
+// floor would make every hash this package writes fail its own verification.
+//
+// The failure would not look like a bad constant. It would look like a correct
+// password being rejected, somewhere in a fixture, with nothing pointing here.
+func TestTheKeyAndSaltLengthsStayInsideWhatVerifyAccepts(t *testing.T) {
+	if keyLength < 16 || keyLength > 64 {
+		t.Errorf("keyLength is %d, outside the 16..64 Verify accepts — every hash written "+
+			"with it would fail its own Verify", keyLength)
+	}
+	if saltLength < 16 {
+		t.Errorf("saltLength is %d; RFC 9106 wants 16 bytes for password hashing", saltLength)
+	}
+}
+
+// A hash written by THIS build must verify under it. Trivially true today and
+// the point is that it stays true under the integration tag as well: the tagged
+// build compiles this same test with the cheap parameters, so if a future edit
+// puts an invalid combination there — a memory below the 8*threads floor argon2
+// requires, say — the integration lane fails here rather than somewhere a
+// fixture logs in.
+func TestAHashThisBuildWritesVerifiesUnderIt(t *testing.T) {
+	const plaintext = "correct horse battery staple"
+	phc, err := Hash(plaintext)
+	if err != nil {
+		t.Fatalf("hashing with this build's parameters: %v", err)
+	}
+	if err := Verify(plaintext, phc); err != nil {
+		t.Fatalf("this build wrote a hash it cannot verify: %v", err)
+	}
+	if err := Verify("wrong", phc); err == nil {
+		t.Fatal("Verify accepted the wrong password, so the comparison proves nothing")
+	}
+}

--- a/backend/internal/modules/identity/internal/password/params.go
+++ b/backend/internal/modules/identity/internal/password/params.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package password
+
+// The Argon2id cost parameters every build EXCEPT the integration test build
+// uses: the OWASP 2024 interactive-login baseline.
+//
+// These are the values the product ships. `go build ./...` — which is what
+// produces api, worker, migrate and the desktop bundle — has no build tags, so
+// this is the file that compiles into every binary a user ever runs.
+//
+// TestProductionParametersHoldTheOWASPBaseline pins them. That gate is not
+// ceremony: once the values live behind a build tag, nothing else in an
+// ordinary `make check` would notice them being lowered.
+const (
+	timeCost  = 2
+	memoryKiB = 19 * 1024
+	threads   = 1
+)

--- a/backend/internal/modules/identity/internal/password/params_integration.go
+++ b/backend/internal/modules/identity/internal/password/params_integration.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package password
+
+// The Argon2id cost parameters the INTEGRATION TEST BUILD uses, and only it.
+//
+// The harness runs the real first-boot ceremony on every test — EnsureInstallation,
+// login, change-password, login again — which is five derivations before a test
+// asserts anything. At the production parameters that is ~94 ms per test, and
+// argon2.processBlocks measures 28.5% of all CPU samples in the overlay package.
+// The fixture needs the FLOW to be real, not the work factor: no test in this
+// tree asserts the cost, and none can, because Verify reads a hash's parameters
+// out of the hash itself.
+//
+// Measured on this tree, per derivation:
+//
+//	t=2 m=19MiB p=1   18.861ms   production
+//	t=1 m=64KiB p=1       48µs   this file — 395x
+//
+// 64 KiB rather than the 8 KiB spec floor (m >= 8*p) on purpose. The floor
+// saves a further 31µs, which is nothing against ~2200 derivations, and sits
+// exactly on the boundary a future argon2 release is most likely to tighten.
+//
+// The algorithm is untouched: this is the same unmodified golang.org/x/crypto/argon2
+// IDKey call the product makes, doing less work.
+//
+// These values are COMPILED OUT of every production binary rather than refused
+// at runtime, which is why this is a build tag and not a config field. A config
+// seam would put the weak value into the deployment's vocabulary, and a PHC hash
+// carries its own parameters — so one hash written under a wrong config verifies
+// successfully forever, because nothing re-hashes on login.
+const (
+	timeCost  = 1
+	memoryKiB = 64
+	threads   = 1
+)

--- a/backend/internal/modules/identity/internal/password/params_test.go
+++ b/backend/internal/modules/identity/internal/password/params_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package password
+
+import "testing"
+
+// The cost parameters are selected by build tag, so an ordinary `go test` sees
+// params.go — the values that compile into every shipped binary. Pinning them
+// here is what stops the split from becoming a way to weaken the product:
+// before the split the constants sat beside the code that used them and a
+// reviewer reading Hash saw them; now they do not, and nothing else in a normal
+// `make check` would notice them being lowered.
+//
+// This asserts the OWASP 2024 interactive-login baseline (ADR-0043). Raising
+// them is fine and this test should be updated to match. LOWERING them is the
+// event this exists to make loud.
+func TestProductionParametersHoldTheOWASPBaseline(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		got   int
+		floor int
+	}{
+		{"time cost", timeCost, 2},
+		{"memory in KiB", memoryKiB, 19 * 1024},
+		{"threads", threads, 1},
+	} {
+		if tc.got < tc.floor {
+			t.Errorf("the shipped Argon2id %s is %d, below the OWASP 2024 baseline of %d — "+
+				"a stolen password table becomes cheaper to crack by exactly this factor",
+				tc.name, tc.got, tc.floor)
+		}
+	}
+}

--- a/backend/internal/modules/identity/internal/password/password.go
+++ b/backend/internal/modules/identity/internal/password/password.go
@@ -17,11 +17,16 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-// OWASP-recommended interactive-login parameters (2024 baseline).
+// The COST parameters — timeCost, memoryKiB, threads — live in params.go and
+// params_integration.go, selected by build tag. The two below do not, and that
+// is deliberate: neither is a cost knob, and both have a correctness floor.
+//
+// keyLength must stay within the 16..64 bytes Verify accepts below; a shorter
+// key would make every hash this package writes fail its own Verify, and the
+// failure would surface as a login error far from the constant that caused it.
+// saltLength changes the PHC encoding and buys no speed. Keeping them out of
+// the tagged files is what makes those mistakes unavailable.
 const (
-	timeCost   = 2
-	memoryKiB  = 19 * 1024
-	threads    = 1
 	saltLength = 16
 	keyLength  = 32
 )

--- a/backend/internal/modules/identity/internal/password/verifyrejects_test.go
+++ b/backend/internal/modules/identity/internal/password/verifyrejects_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package password
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every way a stored hash can be malformed, and the refusal each one earns.
+//
+// These branches decide what happens when the string in app_user.password_hash
+// is not something Hash wrote — a truncated column, a hand-edited row, a value
+// from a tool that formats PHC differently. The failure mode they exist to
+// prevent is not a crash: it is Verify reaching argon2.IDKey with garbage it
+// half-parsed and comparing against a key length it inferred from that garbage.
+//
+// The last case is the one with teeth. An oversized key length used to be
+// masked with &0xFFFF before the int->uint32 conversion, which SILENTLY
+// TRUNCATED it — so a hash claiming a 65536+ byte key would have been compared
+// at a length nobody chose. The explicit 16..64 bound replaced that mask, and
+// this is what holds it: a bound with no test is a comment.
+func TestVerifyRefusesEveryShapeOfMalformedHash(t *testing.T) {
+	// A real hash, to corrupt one field at a time. Deriving it rather than
+	// hardcoding one keeps these cases honest under either build's parameters.
+	valid, err := Hash("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("hashing: %v", err)
+	}
+	parts := strings.Split(valid, "$")
+	if len(parts) != 6 {
+		t.Fatalf("Hash wrote %d PHC fields, want 6: %q", len(parts), valid)
+	}
+	rebuild := func(mutate func(p []string)) string {
+		cp := append([]string(nil), parts...)
+		mutate(cp)
+		return strings.Join(cp, "$")
+	}
+
+	for _, tc := range []struct {
+		name string
+		phc  string
+		want string
+	}{
+		{
+			name: "not PHC at all",
+			phc:  "not-a-hash",
+			want: "malformed hash",
+		},
+		{
+			name: "a different algorithm, which must not be verified as argon2id",
+			phc:  rebuild(func(p []string) { p[1] = "argon2i" }),
+			want: "malformed hash",
+		},
+		{
+			name: "an unreadable version field",
+			phc:  rebuild(func(p []string) { p[2] = "v=nineteen" }),
+			want: "malformed hash version",
+		},
+		{
+			name: "cost parameters that do not parse",
+			phc:  rebuild(func(p []string) { p[3] = "m=lots,t=some,p=few" }),
+			want: "malformed hash params",
+		},
+		{
+			name: "a salt that is not base64",
+			phc:  rebuild(func(p []string) { p[4] = "!!!not-base64!!!" }),
+			want: "malformed salt",
+		},
+		{
+			name: "a key that is not base64",
+			phc:  rebuild(func(p []string) { p[5] = "!!!not-base64!!!" }),
+			want: "malformed key",
+		},
+		{
+			// AAAA decodes to 3 bytes.
+			name: "a key too short to be an Argon2id key",
+			phc:  rebuild(func(p []string) { p[5] = "AAAA" }),
+			want: "implausible key length",
+		},
+		{
+			// 96 bytes: past the 64-byte ceiling, and the shape the old
+			// &0xFFFF mask would have accepted after truncating it.
+			name: "a key too long to be an Argon2id key",
+			phc:  rebuild(func(p []string) { p[5] = strings.Repeat("A", 128) }),
+			want: "implausible key length",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Verify("correct horse battery staple", tc.phc)
+			if err == nil {
+				t.Fatal("Verify accepted a malformed hash — a stored value Hash never wrote " +
+					"must never authenticate anybody")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("the refusal does not say what is wrong: got %q, want it to mention %q",
+					err, tc.want)
+			}
+		})
+	}
+}
+
+// Hash must not write two identical hashes for one password: the salt is what
+// stops a stolen table from revealing which users share a password, and a
+// constant salt would keep every assertion above passing.
+func TestHashSaltsEveryDerivation(t *testing.T) {
+	const plaintext = "correct horse battery staple"
+	first, err := Hash(plaintext)
+	if err != nil {
+		t.Fatalf("hashing: %v", err)
+	}
+	second, err := Hash(plaintext)
+	if err != nil {
+		t.Fatalf("hashing again: %v", err)
+	}
+	if first == second {
+		t.Fatal("two hashes of the same password are identical, so the salt is not random — " +
+			"a stolen table would show which accounts share a password")
+	}
+	for _, phc := range []string{first, second} {
+		if err := Verify(plaintext, phc); err != nil {
+			t.Errorf("a salted hash does not verify: %v", err)
+		}
+	}
+}

--- a/backend/seeddemoargonparity_test.go
+++ b/backend/seeddemoargonparity_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !integration
+
+package backendarch
+
+// seed-demo writes password hashes a REAL person then logs in against, and it
+// cannot import the hashing package: that package sits behind a nested
+// `internal`, and seed-demo is its own module besides. So the Argon2id
+// parameters are restated there, and a restatement drifts.
+//
+// The comment that used to guard this said a demo user failing to log in was
+// the signal. There is no such signal. Verify parses the cost parameters out of
+// the PHC hash itself:
+//
+//	fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &t, &p)
+//
+// so a hash written at ANY parameters verifies successfully, forever, and
+// nothing re-hashes on login. Lower seed-demo's constants and every demo user
+// signs in perfectly while their stored hash is weak — silently, permanently,
+// and invisibly to every other gate in this tree.
+//
+// That is why this is a gate and not a comment. It reads both files' source
+// rather than importing either, which is the only thing the module boundary
+// permits, and compares what seed-demo will actually compile against what the
+// product ships.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// argonParityFiles: where each half's constants live. params.go carries the
+// three cost knobs (build-tagged, so this reads the PRODUCTION file by name
+// rather than whatever the current build selected); password.go carries the two
+// that are deliberately not tagged.
+var argonParityFiles = []string{
+	filepath.Join("internal", "modules", "identity", "internal", "password", "params.go"),
+	filepath.Join("internal", "modules", "identity", "internal", "password", "password.go"),
+}
+
+const seedDemoUsersFile = "tools/seed-demo/users.go"
+
+// argonParityPairs maps the product's constant to seed-demo's name for it.
+//
+// gatekit:fixture the two names each Argon2 parameter goes by — the product's
+// on the left, seed-demo's on the right. These are the subjects this gate
+// compares, not costs anybody is excused from: every pair here is CHECKED, and
+// a name that stops existing on either side is reported as a failure rather
+// than skipped.
+var argonParityPairs = map[string]string{
+	"timeCost":   "argonTime",
+	"memoryKiB":  "argonMemory",
+	"threads":    "argonThreads",
+	"saltLength": "argonSalt",
+	"keyLength":  "argonKey",
+}
+
+func TestSeedDemoHashesAtTheParametersTheProductShips(t *testing.T) {
+	product := map[string]int64{}
+	for _, f := range argonParityFiles {
+		for k, v := range intConstants(t, f) {
+			product[k] = v
+		}
+	}
+	seed := intConstants(t, seedDemoUsersFile)
+
+	for productName, seedName := range argonParityPairs {
+		want, ok := product[productName]
+		if !ok {
+			t.Errorf("%s is not declared in %v any more — if it was renamed, this gate has to "+
+				"be renamed with it or it silently stops comparing anything",
+				productName, argonParityFiles)
+			continue
+		}
+		got, ok := seed[seedName]
+		if !ok {
+			t.Errorf("%s is not declared in %s any more, so nothing pins seed-demo's %s to the "+
+				"product's", seedName, seedDemoUsersFile, productName)
+			continue
+		}
+		if got != want {
+			t.Errorf("seed-demo hashes at %s=%d where the product ships %s=%d.\n"+
+				"A demo user WILL still log in — Verify reads the cost out of the hash, so the "+
+				"drift is invisible at the login it would have to break to be noticed. Every hash "+
+				"seed-demo has written at %d stays valid and stays weak, because nothing re-hashes "+
+				"on login. Set %s to %d in %s.",
+				seedName, got, productName, want, got, seedName, want, seedDemoUsersFile)
+		}
+	}
+}
+
+// intConstants returns every untyped integer constant a file declares, with
+// `a * b` evaluated — the product writes its memory cost as `19 * 1024` and a
+// gate that could not read that would be pinned to the spelling.
+func intConstants(t *testing.T, rel string) map[string]int64 {
+	t.Helper()
+	path := filepath.Join(repoDirForArgonParity(t), rel)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", rel, err)
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), path, src, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", rel, err)
+	}
+	out := map[string]int64{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				if v, ok := evalIntExpr(vs.Values[i]); ok {
+					out[name.Name] = v
+				}
+			}
+		}
+	}
+	return out
+}
+
+// evalIntExpr handles the two shapes these constants are written in: a literal,
+// and a product of literals. Anything else returns false rather than a wrong
+// number — a gate that guessed would be worse than one that says it cannot read
+// the value, which is what the missing-constant branch above reports.
+func evalIntExpr(e ast.Expr) (int64, bool) {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.INT {
+			return 0, false
+		}
+		n, err := strconv.ParseInt(v.Value, 0, 64)
+		return n, err == nil
+	case *ast.BinaryExpr:
+		if v.Op != token.MUL {
+			return 0, false
+		}
+		l, lok := evalIntExpr(v.X)
+		r, rok := evalIntExpr(v.Y)
+		return l * r, lok && rok
+	}
+	return 0, false
+}
+
+// repoDirForArgonParity resolves backend/ from the test's own working
+// directory, which `go test` sets to the package directory.
+func repoDirForArgonParity(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolving the working directory: %v", err)
+	}
+	return wd
+}

--- a/backend/tools/seed-demo/users.go
+++ b/backend/tools/seed-demo/users.go
@@ -28,10 +28,19 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-// Argon2id parameters, mirroring backend/internal/modules/identity/internal/
-// password/password.go. That package sits behind a nested `internal` and
-// cannot be imported here, so the values are restated — if they change there,
-// they must change here, and a demo user failing to log in is the signal.
+// Argon2id parameters, mirroring the product's. That package sits behind a
+// nested `internal` and is in another module besides, so it cannot be imported
+// here and the values are restated.
+//
+// A restatement drifts, and this one drifts SILENTLY: Verify parses the cost
+// out of the PHC hash itself, so a hash written at any parameters verifies
+// successfully and nothing re-hashes on login. Lower these and every demo user
+// still signs in perfectly while their stored hash is weak — permanently,
+// because the weakness lives in rows already written.
+//
+// TestSeedDemoHashesAtTheParametersTheProductShips is what actually holds the
+// two in step. It reads both files rather than importing either, which is all
+// the module boundary allows.
 const (
 	argonTime    = 2
 	argonMemory  = 19 * 1024


### PR DESCRIPTION
Two changes, one subject: the Argon2id cost parameters, and who is allowed to know them.

**D3 is the last unshipped item in the `integration-lane-cost` design.** D2, D7, D8 and D9 all turned out to be already merged — I checked each against the tree rather than building from the doc, which is the only reason this PR is two commits and not six. Notes at the bottom.

---

## 1 — `f62347d6c` the harness stops paying full-strength Argon2 per test

The fixture runs the real first-boot ceremony on every test — `EnsureInstallation`, login, change-password, login again — which is **five derivations before a test asserts anything**. `argon2.processBlocks` measures **28.5% of all CPU samples** in the overlay package.

The ceremony stays. The harness comment is right that a suite arranged around a state the product cannot reach would prove nothing, and none of that depends on how long a hash takes.

| | per derivation |
|---|---|
| `t=2 m=19MiB p=1` — shipped | **18.861 ms** |
| `t=1 m=64KiB p=1` — integration build | **48 µs** (395×) |

`internal/modules/identity` end to end: **17.830 s → 11.676 s**. Full lane: **254 s → 170 s**.

64 KiB rather than the 8 KiB spec floor (`m >= 8*p`) deliberately — the floor saves a further 31 µs, nothing against ~2200 derivations, and sits exactly on the boundary a future argon2 release is most likely to tighten.

### A build tag, not a config field

`go build ./...` carries no tags, so `params.go` is what compiles into api, worker, migrate and the desktop bundle. The cheap values **do not exist** in a shipped binary rather than being refused by one at runtime.

A config seam would instead put the weak value into a deployment's vocabulary — and a PHC hash carries its own parameters, so one hash written under a wrong config verifies successfully **forever**, because nothing re-hashes on login.

### Three constants, not five

`keyLength` and `saltLength` stay untagged in `password.go`. Neither is a cost knob, and `keyLength` has a correctness floor: `Verify` refuses a key outside 16..64 bytes, so a "faster" shorter key would make every hash this package writes fail its own `Verify` — surfacing as a correct password being rejected inside a fixture, nowhere near the constant that caused it. Keeping them out makes that mistake **unavailable**, not merely unlikely.

### The gate

`TestProductionParametersHoldTheOWASPBaseline`, untagged so it compiles only against the shipped values. Before the split the constants sat beside the code that used them and a reviewer reading `Hash` saw them; now they do not.

Mutation-verified against both ways weak parameters could reach production:

```
memoryKiB lowered to 64  -> FAIL "the shipped Argon2id memory in KiB is 64,
                                  below the OWASP 2024 baseline of 19456"
build tags flipped       -> FAIL on time cost AND memory
```

A third mistake needs no test: two files declaring these constants without disjoint tags is a duplicate-declaration error, so a dropped tag **cannot build**.

---

## 2 — `ac64ac00c` seed-demo's copy gets a gate, not a promise

Found while doing the above. `tools/seed-demo/users.go` restates these parameters — the package is behind a nested `internal` and in another module — and the comment guarding that restatement said:

> *"if they change there, they must change here, and a demo user failing to log in is the signal."*

**There is no such signal.** `Verify` parses the cost out of the PHC hash:

```go
fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &t, &p)
```

So a hash written at *any* parameters verifies successfully, and nothing re-hashes on login. Lower seed-demo's constants and every demo user signs in perfectly while their stored hash is weak — permanently, because the weakness lives in rows already written, and invisibly, because the one event that would have to break for anyone to notice is the event that keeps working.

A comment asserting an invariant the code does not hold is its own defect class. This one asserted the absence of a hazard it was the only thing standing between.

The gate reads both files' source and compares, which is all the module boundary permits. It evaluates `19 * 1024` rather than matching the spelling, and reports a **missing** constant as a failure rather than skipping it — a rename is how a parity gate usually stops comparing anything without going red.

```
argonMemory 19*1024 -> 1024   FAIL "seed-demo hashes at argonMemory=1024
                                    where the product ships memoryKiB=19456"
argonTime renamed             FAIL "argonTime is not declared ... any more,
                                    so nothing pins seed-demo's timeCost"
```

---

## Verification

```
make check-backend        CHECK=0
make test-integration     OK: integration passed with 0 skips (42 packages)
                          wall clock 170s  (254s before this change)
craft static --strict     PASS
```

`make check` caught this PR's own new code once and correctly: `argonParityPairs` is waiver-shaped, so the census refused it until it was declared `gatekit:fixture`, and the fixture count pin moved 20 -> 21 in the same commit as the declaration.

## On the four items that were already done

The design doc predates them. D2's egress gate shipped in #2066 and is **better than what I started building** — it clears `DialTLSContext`, not just `DialContext`, and for an https URL net/http calls that one *instead*, so a DialContext-only guard would have been bypassed on exactly the scheme the vendor is reached over. D7 memoizes via `headSchema`/`headFingerprint`; D8 counts `AcquireCount()` instead of waiting out a deadline, which the design had explicitly ruled impossible; D9's baseline is committed at `scripts/integration-lane-timing.txt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI by moving Argon2id costs behind a build tag: production keeps the OWASP 2024 baseline, while the `integration` build uses cheaper values. Adds gates and tests that pin shipped costs, keep `tools/seed-demo` in parity, and harden `Verify` against malformed hashes.

- Build-tag split: production parameters in `backend/internal/modules/identity/internal/password/params.go`; `integration` parameters in `params_integration.go`. `go build ./...` (no tags) ships production values; cheap values are compiled out.
- Behavior change in tests only: t=2, m=19 MiB, p=1 → t=1, m=64 KiB, p=1. Measured: `internal/modules/identity` 17.830s → 11.676s; full lane 254s → 170s.
- Gates: `TestProductionParametersHoldTheOWASPBaseline` prevents weakening shipped costs; `TestSeedDemoHashesAtTheParametersTheProductShips` compares `params.go`/`password.go` with `tools/seed-demo/users.go` and fails on drift or missing/renamed constants.
- Auth tests: `verifyrejects_test.go` refuses malformed PHC inputs with targeted errors, pins the 16..64 key-length bound, and asserts `Hash` always salts; `hashroundtrip_test.go` pins valid key/salt ranges and that a hash written by this build verifies under it.
- `keyLength` and `saltLength` remain untagged in `password.go`; not cost knobs and have correctness floors.

**Rollout**
- No config or data migration. Shipped binaries unchanged; only the `integration` build used by CI is affected.

<sup>Written for commit 95906a9a81a4f5026e17bee4b96e94987c4fb6a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

