### PR TITLE
fix(lists): a late chip option keeps the reader on their page

### DIFF
--- a/backend/internal/modules/agents/tools_intents_dates_test.go
+++ b/backend/internal/modules/agents/tools_intents_dates_test.go
@@ -26,8 +26,10 @@ func TestAnAssembledContextCarriesWhenEachThingHappened(t *testing.T) {
 	got := assembledContext(context.Background(), retrieval.Context{
 		Anchor: datasource.EntityRef{Type: datasource.EntityOrganization, ID: ids.NewV7()},
 		Sections: []retrieval.Section{{Name: "recent", Items: []retrieval.Item{
-			{Ref: datasource.EntityRef{Type: datasource.EntityActivity, ID: activity},
-				Summary: "Zu viele Ansprechpartner", OccurredAt: when},
+			{
+				Ref:     datasource.EntityRef{Type: datasource.EntityActivity, ID: activity},
+				Summary: "Zu viele Ansprechpartner", OccurredAt: when,
+			},
 			// A person is not an event and carries no date; a zero one would
 			// render as 0001-01-01 rather than as absent.
 			{Ref: datasource.EntityRef{Type: datasource.EntityPerson, ID: person}, Summary: "Andrea"},

--- a/backend/internal/modules/agents/tools_intents_dates_test.go
+++ b/backend/internal/modules/agents/tools_intents_dates_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/retrieval"
+)
+
+// A briefing states a date from the RECORD, not from what a note recalls.
+//
+// The retriever always knew when each touch happened — occurred_at orders the
+// timeline — but the answer dropped it, so the only dates a reader could see
+// were the ones written inside note prose. A loss post-mortem written months
+// later said "im Oktober" for an email dated 2025-09-13, and a briefing built
+// on the prose alone repeats that to the customer. The date now rides the item.
+func TestAnAssembledContextCarriesWhenEachThingHappened(t *testing.T) {
+	when := time.Date(2025, 9, 13, 9, 30, 0, 0, time.UTC)
+	activity, person := ids.NewV7(), ids.NewV7()
+	got := assembledContext(context.Background(), retrieval.Context{
+		Anchor: datasource.EntityRef{Type: datasource.EntityOrganization, ID: ids.NewV7()},
+		Sections: []retrieval.Section{{Name: "recent", Items: []retrieval.Item{
+			{Ref: datasource.EntityRef{Type: datasource.EntityActivity, ID: activity},
+				Summary: "Zu viele Ansprechpartner", OccurredAt: when},
+			// A person is not an event and carries no date; a zero one would
+			// render as 0001-01-01 rather than as absent.
+			{Ref: datasource.EntityRef{Type: datasource.EntityPerson, ID: person}, Summary: "Andrea"},
+		}}},
+	})
+	if len(got.Sections) != 1 || len(got.Sections[0].Items) != 2 {
+		t.Fatalf("assembled %+v, want one section of two items", got.Sections)
+	}
+	event, contact := got.Sections[0].Items[0], got.Sections[0].Items[1]
+	if event.OccurredAt == nil || !event.OccurredAt.Equal(when) {
+		t.Errorf("the event carries occurred_at %v, want %v — without it a reader can only "+
+			"take dates from the prose", event.OccurredAt, when)
+	}
+	if contact.OccurredAt != nil {
+		t.Errorf("a person carries occurred_at %v, want it absent", contact.OccurredAt)
+	}
+}

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -291,6 +291,7 @@ export function ListTable<Row>({
   views = [],
   activeView = 0,
   onViewChange,
+  scopeKey = "",
   action,
   caption,
   note,
@@ -361,6 +362,14 @@ export function ListTable<Row>({
   archived?: { checked: boolean; onChange: (next: boolean) => void };
   views?: readonly ListView[];
   activeView?: number;
+  /**
+   * What this list is reading, when the screen narrows it by something that is
+   * NOT a chip or a filter. Deals is the case: the pipeline picker is screen
+   * state, so switching it changes the whole result set while `chosen` and the
+   * filters stay exactly as they were. Page 2 of one pipeline is not page 2 of
+   * another, so the reader must land on page 1 — and only the screen knows it.
+   */
+  scopeKey?: string;
   onViewChange?: (index: number) => void;
   /** The one primary action for this surface, e.g. "New contact". */
   action?: ReactNode;
@@ -607,6 +616,7 @@ export function ListTable<Row>({
       perPage,
       sort?.value,
       archived?.checked,
+      scopeKey,
     ],
   );
 

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -286,6 +286,7 @@ export function ListTable<Row>({
   sort,
   chips = [],
   chosen = EMPTY_FILTERS,
+  narrowKey,
   onChipChange,
   archived,
   views = [],
@@ -357,6 +358,19 @@ export function ListTable<Row>({
   sort?: SortControl;
   chips?: readonly ListChip[];
   chosen?: Readonly<Record<string, string>>;
+  /**
+   * What the list is narrowed BY, serialized — the reset trigger, separate
+   * from `chosen`, which is what the DIALS show.
+   *
+   * They are two jobs and they cannot share one value. `chosen` must always be
+   * current or a dial renders the wrong label; the reset must fire only when
+   * the answer changes, or an option arriving late throws the reader off their
+   * page. Keying the reset on `chosen` forces one to break the other.
+   *
+   * Defaults to `chosen` for the callers whose dials are all declared up front
+   * and therefore cannot drift apart.
+   */
+  narrowKey?: string;
   /** Called with "" to clear. */
   onChipChange?: (key: string, value: string) => void;
   archived?: { checked: boolean; onChange: (next: boolean) => void };
@@ -611,7 +625,7 @@ export function ListTable<Row>({
     () => setPage(1),
     [
       search?.value,
-      chosen,
+      narrowKey ?? chosen,
       activeView,
       perPage,
       sort?.value,

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1636,6 +1636,10 @@ export function DealsScreen({
           searchable={false}
           action={createAction}
           tools={tableTools}
+          // The pipeline picker is screen state, not a filter, so switching it
+          // changes every row without touching `filters`. Naming it here is
+          // what puts the reader back on page 1.
+          scopeKey={effectivePipeline?.id ?? ""}
           dataChips={dealChips}
           dataViews={savedViews}
           selection={{

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -118,6 +118,7 @@ function ListTableHarness({
   dataViews,
   dataChips,
   scopeKey,
+  initialFilters,
 }: Readonly<{
   fetchPage: (
     query: ListQuery,
@@ -129,10 +130,12 @@ function ListTableHarness({
   dataViews?: readonly ListView[];
   dataChips?: readonly ListChip[];
   scopeKey?: string;
+  initialFilters?: Readonly<Record<string, string>>;
 }>) {
   const state = useListQuery<Row>({
     key: "list-table-harness",
     initialSort: "-created_at",
+    initialFilters,
     fetchPage,
   });
   return (
@@ -753,5 +756,100 @@ describe("a scope the chips cannot see", () => {
 
     await user.click(screen.getByRole("button", { name: "other pipeline" }));
     await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
+  });
+});
+
+describe("a late option that matches a filter already set", () => {
+  it("still keeps the reader on their page", async () => {
+    const user = userEvent.setup();
+    const page = (from: number) => ({
+      data: Array.from({ length: 25 }, (_, i) => ({
+        id: `r-${from + i}`,
+        name: `Row ${from + i}`,
+      })),
+      page: { next_cursor: `c-${from + 25}`, has_more: true },
+    });
+    let served = 0;
+    const fetchPage = vi.fn(async (_query: ListQuery, _cursor: string | null) =>
+      page(25 * served++),
+    );
+    // The harder half of the same bug. A saved view restores
+    // `owner_team_id=t-9` before the roster has answered, so the filter is
+    // already set when the matching option finally arrives. chosenFor then
+    // gains the chip's own key — the chosen RESULT changes shape — even
+    // though the query, and therefore every row, is exactly what it was.
+    function LateMatchingOption() {
+      const [teamKnown, setTeamKnown] = useState(false);
+      const chip = {
+        key: "owner",
+        label: "Owner",
+        allLabel: "Any owner",
+        options: teamKnown
+          ? [{ value: "owner_team_id:t-9", label: "Team Neukunden" }]
+          : [],
+      };
+      return (
+        <>
+          <button type="button" onClick={() => setTeamKnown(true)}>
+            roster answers
+          </button>
+          <ListTableHarness
+            fetchPage={fetchPage}
+            dataChips={[chip]}
+            initialFilters={{ owner_team_id: "t-9" }}
+          />
+        </>
+      );
+    }
+    render(<LateMatchingOption />);
+    await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "roster answers" }));
+    await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
+    expect(screen.queryByText("Row 0")).toBeNull();
+  });
+});
+
+describe("a late option that matches a filter already set", () => {
+  it("shows the chip as chosen once the option arrives", async () => {
+    const user = userEvent.setup();
+    const fetchPage = vi.fn(async (_query: ListQuery, _cursor: string | null) =>
+      emptyPage(),
+    );
+    // The display half of the same moment. Keeping the reader in place must not
+    // cost them the truth about what the list is narrowed BY: once the roster
+    // answers, the dial has to read "Team Neukunden", not "Any owner".
+    function LateMatchingOption() {
+      const [teamKnown, setTeamKnown] = useState(false);
+      const chip = {
+        key: "owner",
+        label: "Owner",
+        allLabel: "Any owner",
+        options: teamKnown
+          ? [{ value: "owner_team_id:t-9", label: "Team Neukunden" }]
+          : [],
+      };
+      return (
+        <>
+          <button type="button" onClick={() => setTeamKnown(true)}>
+            roster answers
+          </button>
+          <ListTableHarness
+            fetchPage={fetchPage}
+            dataChips={[chip]}
+            initialFilters={{ owner_team_id: "t-9" }}
+          />
+        </>
+      );
+    }
+    render(<LateMatchingOption />);
+    await user.click(screen.getByRole("button", { name: "roster answers" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("group", { name: "Owner: Team Neukunden" }),
+      ).toBeTruthy(),
+    );
   });
 });

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -117,6 +117,7 @@ function ListTableHarness({
   views,
   dataViews,
   dataChips,
+  scopeKey,
 }: Readonly<{
   fetchPage: (
     query: ListQuery,
@@ -127,6 +128,7 @@ function ListTableHarness({
   views?: readonly ViewSpec[];
   dataViews?: readonly ListView[];
   dataChips?: readonly ListChip[];
+  scopeKey?: string;
 }>) {
   const state = useListQuery<Row>({
     key: "list-table-harness",
@@ -151,6 +153,7 @@ function ListTableHarness({
       views={views}
       dataViews={dataViews}
       action={action}
+      scopeKey={scopeKey}
     />
   );
 }
@@ -711,5 +714,44 @@ describe("a chip whose options arrive late", () => {
     await user.click(screen.getByRole("button", { name: "roster answers" }));
     await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
     expect(screen.queryByText("Row 0")).toBeNull();
+  });
+});
+
+describe("a scope the chips cannot see", () => {
+  it("puts the reader back on page 1 when it changes", async () => {
+    const user = userEvent.setup();
+    const page = (from: number) => ({
+      data: Array.from({ length: 25 }, (_, i) => ({
+        id: `r-${from + i}`,
+        name: `Row ${from + i}`,
+      })),
+      page: { next_cursor: `c-${from + 25}`, has_more: true },
+    });
+    let served = 0;
+    const fetchPage = vi.fn(async (_query: ListQuery, _cursor: string | null) =>
+      page(25 * served++),
+    );
+    // Deals stands behind this: its pipeline picker is screen state, so
+    // switching pipelines leaves `filters` and every chip exactly as they
+    // were while the rows change completely. Page 2 of one pipeline is not
+    // page 2 of another, so the reader must not be left standing on it.
+    function ScopedList() {
+      const [pipeline, setPipeline] = useState("p-1");
+      return (
+        <>
+          <button type="button" onClick={() => setPipeline("p-2")}>
+            other pipeline
+          </button>
+          <ListTableHarness fetchPage={fetchPage} scopeKey={pipeline} />
+        </>
+      );
+    }
+    render(<ScopedList />);
+    await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "other pipeline" }));
+    await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
   });
 });

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -9,7 +9,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ListChip, ListView } from "../design-system/listsurface";
 import { pickOption } from "../design-system/select-testing";
@@ -657,5 +657,59 @@ describe("two chips on one list", () => {
       ),
     );
     expect(fetchPage.mock.calls.at(-1)?.[0].filters.unassigned).toBe("true");
+  });
+});
+
+describe("a chip whose options arrive late", () => {
+  it("does not throw the reader back to page 1", async () => {
+    const user = userEvent.setup();
+    const page = (from: number) => ({
+      data: Array.from({ length: 25 }, (_, i) => ({
+        id: `r-${from + i}`,
+        name: `Row ${from + i}`,
+      })),
+      page: { next_cursor: `c-${from + 25}`, has_more: true },
+    });
+    let served = 0;
+    const fetchPage = vi.fn(async (_query: ListQuery, _cursor: string | null) =>
+      page(25 * served++),
+    );
+    const option = (value: string, label: string) => ({ value, label });
+    // The owner dial names the viewer's teams, which arrive on their OWN query.
+    // This stands in for that: the roster answers after the list has rendered,
+    // and the chip gains an option without the reader touching anything.
+    function LateChips() {
+      const [teamKnown, setTeamKnown] = useState(false);
+      const chip = {
+        key: "owner",
+        label: "Owner",
+        allLabel: "Any owner",
+        options: [
+          option("owner_id:u-1", "My records"),
+          ...(teamKnown ? [option("owner_team_id:t-9", "Team Neukunden")] : []),
+          option("unassigned:true", "Unassigned"),
+        ],
+      };
+      return (
+        <>
+          <button type="button" onClick={() => setTeamKnown(true)}>
+            roster answers
+          </button>
+          <ListTableHarness fetchPage={fetchPage} dataChips={[chip]} />
+        </>
+      );
+    }
+    render(<LateChips />);
+    await waitFor(() => expect(screen.getByText("Row 0")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: /Next/ }));
+    await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
+
+    // The reader did not touch a filter, so the page they are on must survive.
+    // A list that jumps back to the top because a picker finished loading loses
+    // the reader's place for a reason they cannot see.
+    await user.click(screen.getByRole("button", { name: "roster answers" }));
+    await waitFor(() => expect(screen.getByText("Row 25")).toBeTruthy());
+    expect(screen.queryByText("Row 0")).toBeNull();
   });
 });

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -4,7 +4,6 @@ import {
   type ReactNode,
   type SetStateAction,
   useEffect,
-  useMemo,
   useState,
 } from "react";
 import { FIRST_PAGE } from "../api/client";
@@ -313,19 +312,35 @@ export function ListTable<Row>({
     ...chips.map((chip) => translateChip(chip, t)),
     ...dataChips,
   ];
-  // Keyed on the RESULT, not on the chips that produced it. The table treats a
-  // new `chosen` identity as the reader narrowing the list and resets to page
-  // 1, so this identity must change only when what is chosen changes.
+  // Keyed on the FILTERS, which are what the list actually reads. The table
+  // treats a new `chosen` identity as the reader narrowing the list and resets
+  // to page 1, so this identity must change only when the answer changes.
   //
-  // Keying on the chip options instead made the roster do it: the owner dial
-  // names the viewer's teams, which arrive on their own query, so a chip gained
-  // an option seconds after the list rendered and threw the reader from page 2
-  // back to page 1 — for a reason they could not see, having touched nothing.
-  // A late option changes what the dial OFFERS, never what is currently chosen.
-  const nextChosen = chosenFor(allChips, query.filters);
-  const chosenKey = JSON.stringify(nextChosen);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the serialized result, which is what makes the identity stable
-  const chosen = useMemo(() => nextChosen, [chosenKey]);
+  // Keying on the chip options made the roster do it: the owner dial names the
+  // viewer's teams, which arrive on their own query, so a chip gained an option
+  // seconds after the list rendered and threw the reader from page 2 back to
+  // page 1 — for a reason they could not see, having touched nothing.
+  //
+  // Keying on chosenFor's RESULT is not enough either, and the saved views are
+  // why. A restored view sets `owner_team_id=t-9` before the roster answers, so
+  // the filter is already there when the matching option arrives; chosenFor
+  // then adds the chip's own key and the result changes shape while the query,
+  // and every row, stays exactly as it was.
+  //
+  // The filters are the honest signal: the fetch reads them and nothing else,
+  // so an identity that follows them resets when the rows change and never
+  // otherwise. What a dial OFFERS is presentation, and presentation must not
+  // move the reader.
+  // Sorted, so re-picking the same value cannot reorder the object and read as
+  // a change: setFilter deletes a composite param and re-adds it, which moves
+  // its insertion order without moving what it selects.
+  const narrowKey = JSON.stringify(
+    Object.entries(query.filters).sort(([a], [b]) => a.localeCompare(b)),
+  );
+  // Rebuilt every render, on purpose: a dial must show what is chosen the
+  // moment its options arrive. Nothing resets on this — `narrowKey` is the
+  // trigger — so a fresh object here costs nothing.
+  const chosen = chosenFor(allChips, query.filters);
 
   // A functional updater reads the query at commit time, not at the time the
   // timer was scheduled: a concurrent sort/filter/includeArchived change
@@ -443,6 +458,7 @@ export function ListTable<Row>({
           : [...views.map((spec) => translateView(spec, t)), ...dataViews]
       }
       activeView={view}
+      narrowKey={narrowKey}
       scopeKey={scopeKey}
       onViewChange={setPicked}
       archived={

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -304,20 +304,19 @@ export function ListTable<Row>({
     ...chips.map((chip) => translateChip(chip, t)),
     ...dataChips,
   ];
-  // Carries the chip KEYS and the grouping, not just a flat list of values:
-  // chosenFor reads both, so two different chip sets that happen to share the
-  // same values must not produce the same key. JSON, rather than a join on a
-  // separator — any separator can appear inside a value, and then ["a","b"]
-  // and ["a<sep>b"] are indistinguishable.
-  const chipOptionKey = JSON.stringify(
-    allChips.map((chip) => [chip.key, chip.options.map((o) => o.value)]),
-  );
-  const filterKey = JSON.stringify(query.filters);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the values the arrays carry, which is what makes the identity stable
-  const chosen = useMemo(
-    () => chosenFor(allChips, query.filters),
-    [chipOptionKey, filterKey],
-  );
+  // Keyed on the RESULT, not on the chips that produced it. The table treats a
+  // new `chosen` identity as the reader narrowing the list and resets to page
+  // 1, so this identity must change only when what is chosen changes.
+  //
+  // Keying on the chip options instead made the roster do it: the owner dial
+  // names the viewer's teams, which arrive on their own query, so a chip gained
+  // an option seconds after the list rendered and threw the reader from page 2
+  // back to page 1 — for a reason they could not see, having touched nothing.
+  // A late option changes what the dial OFFERS, never what is currently chosen.
+  const nextChosen = chosenFor(allChips, query.filters);
+  const chosenKey = JSON.stringify(nextChosen);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the serialized result, which is what makes the identity stable
+  const chosen = useMemo(() => nextChosen, [chosenKey]);
 
   // A functional updater reads the query at commit time, not at the time the
   // timer was scheduled: a concurrent sort/filter/includeArchived change

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -206,6 +206,7 @@ export function ListTable<Row>({
   showArchivedToggle = true,
   tools,
   emptyNote,
+  scopeKey,
   body,
   bodyOwnsPaging = false,
   selection,
@@ -262,6 +263,14 @@ export function ListTable<Row>({
    * way back to everything. Overlay's own note wins when both apply.
    */
   emptyNote?: ReactNode;
+  /**
+   * What this list is reading, when the screen narrows it by something that is
+   * neither a chip nor a filter — passed straight to the surface, which resets
+   * the reader to page 1 when it changes. Deals is the case: its pipeline
+   * picker is screen state, so switching pipelines leaves `filters` untouched
+   * while the result set changes entirely.
+   */
+  scopeKey?: string;
 }>): ReactNode {
   const t = useT();
   // Overlay reads a mirror that cannot sort or filter (the server 422s those
@@ -434,6 +443,7 @@ export function ListTable<Row>({
           : [...views.map((spec) => translateView(spec, t)), ...dataViews]
       }
       activeView={view}
+      scopeKey={scopeKey}
       onViewChange={setPicked}
       archived={
         showArchivedToggle


### PR DESCRIPTION
## What was wrong

The owner dial names the viewer's teams, which arrive on their **own** query. So the chip gains an option seconds after the list has already rendered.

The table read that as the reader narrowing the list and reset to page 1. A reader sitting on page 2 was thrown back to page 1 having touched nothing, for a reason they could not see.

## The fix

The `chosen` memo was keyed on the chip **options** — which is exactly what changes when the roster answers. Key it on the chosen **result** instead. A late option changes what the dial offers, never what is currently chosen, so the identity no longer moves.

## Test

`listquery.test.tsx` gains "a chip whose options arrive late". It drives the real sequence: render, page forward to Row 25, then let the roster answer. On the previous keying it fails — the list snaps back to Row 0.

Verified both ways on today's main: test alone against unmodified source fails, fix applied makes all 19 pass.

## Provenance

This fix was written in an earlier session and left uncommitted in a worktree that was 249 commits behind main. It was nearly discarded during cleanup. Rebased onto current main, where the bug is still live.

`make check-fe` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents lists from snapping back to page 1 when chip options arrive late, while still resetting on real scope changes. Also pins that briefings use record dates for events.

- Separates display from reset: recomputes `chosen` every render so chip labels update immediately; introduces `narrowKey`, serialized from sorted `filters`, to trigger pagination reset only when the actual filter set changes.
- Adds optional `scopeKey` to `ListTable`; `DealsScreen` passes the pipeline id so switching pipelines resets to page 1.
- Tests cover: late options (including ones matching already-set filters) do not reset the page; labels update when options arrive; scope changes reset to page 1.
- Backend adds a test ensuring an assembled briefing context carries `occurred_at` for events and omits it for non-events.

<sup>Written for commit 9876b903208f098f99fa7896e7b06d71b6d851e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented paginated lists from resetting to the first page when filter options load asynchronously.
  * Preserved the current results position when late-arriving filter choices do not change the active filters.

* **Tests**
  * Added coverage for maintaining pagination when filter options become available after initial loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->