### PR TITLE
fix(records): geocoding names a column that was dropped before it shipped

### DIFF
--- a/backend/internal/modules/people/geocode.go
+++ b/backend/internal/modules/people/geocode.go
@@ -112,8 +112,7 @@ func (s *Store) AddressForGeocode(ctx context.Context, orgID ids.OrganizationID)
 			       coalesce(g.attempts, 0), g.next_attempt_at
 			  FROM organization o
 			  LEFT JOIN organization_geocode_state g ON g.organization_id = o.id
-			 WHERE o.id = $1 AND o.archived_at IS NULL
-			   AND o.workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, orgID).
+			 WHERE o.id = $1 AND o.archived_at IS NULL`, orgID).
 			Scan(&line1, &line2, &city, &region, &postal, &country, &currentHash, &status,
 				&attempts, &nextAttempt)
 	})
@@ -223,8 +222,7 @@ func addressHashInTx(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (
 		SELECT address_line1, address_line2, address_city, address_region,
 		       address_postal_code, address_country
 		  FROM organization
-		 WHERE id = $1 AND archived_at IS NULL
-		   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`, orgID).
+		 WHERE id = $1 AND archived_at IS NULL`, orgID).
 		Scan(&line1, &line2, &city, &region, &postal, &country); err != nil {
 		return "", fmt.Errorf("re-reading the address before recording its point: %w", err)
 	}
@@ -298,8 +296,7 @@ func (s *Store) recordGeocodeAfter(
 			UPDATE organization
 			   SET geocode_lat = $2, geocode_lon = $3, geocode_status = $4,
 			       geocode_provider = $5, geocode_input_hash = $6, geocoded_at = now()
-			 WHERE id = $1
-			   AND workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+			 WHERE id = $1`,
 			orgID, lat, lon, status, provider, inputHash); err != nil {
 			return fmt.Errorf("recording the geocode: %w", err)
 		}

--- a/backend/internal/modules/people/geocode_integration_test.go
+++ b/backend/internal/modules/people/geocode_integration_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// The geocode store's three statements, run against a real database.
+//
+// Every one of them named `organization.workspace_id` when the feature shipped,
+// three days after ADR-0091 §8 phase D dropped that column — so all three
+// failed at the first query, and geocoding an organization could never have
+// worked. Nothing caught it because geocode_test.go is a unit suite with no
+// database: it exercises the address-hashing and backoff arithmetic, which is
+// the half that needs no Postgres, and the SQL had never been executed at all.
+//
+// So this suite is deliberately shallow and deliberately WIDE. It asserts no
+// geocoding behaviour that the unit tests already cover; it exists so that each
+// statement is issued once against the schema it will meet in production, which
+// is the only thing that would have caught a column that is not there.
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestEveryGeocodeStatementRunsAgainstTheRealSchema(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Geocodable Gmbh", Source: "manual",
+		Address: &crmcontracts.Address{
+			Line1:      strPtr("Rosenthaler Str. 40"),
+			City:       strPtr("Berlin"),
+			PostalCode: strPtr("10178"),
+			Country:    strPtr("DE"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("seeding the organization to geocode: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	// 1. The read. It joins organization_geocode_state, which is the statement
+	//    the shipped bug failed on first.
+	addr, ok, err := e.store.AddressForGeocode(ctx, orgID)
+	if err != nil {
+		t.Fatalf("AddressForGeocode: %v", err)
+	}
+	if !ok {
+		t.Fatal("a company with a street address is not geocodable, so nothing downstream will ever ask a provider for its point")
+	}
+	if addr.Query == "" {
+		t.Error("the geocodable address carries an empty query; a provider cannot be asked for nothing")
+	}
+
+	// 2. The success write, which is also the re-read of the address hash: a
+	//    geocode that landed against a CHANGED address must not be recorded,
+	//    so RecordGeocode reads the hash back inside its own transaction.
+	lat, lon := 52.5244, 13.4105
+	if err := e.store.RecordGeocode(ctx, orgID, "ok", &lat, &lon, "fake", addr.InputHash); err != nil {
+		t.Fatalf("RecordGeocode: %v", err)
+	}
+
+	// The point is readable back, which is what makes the write above a write
+	// rather than a statement that merely did not error.
+	if status, lat, lon := readGeocode(t, e, orgID); status != "ok" || lat == nil || lon == nil {
+		t.Fatalf("after an ok geocode the organization reads status %q with point (%v, %v); want ok and a point", status, lat, lon)
+	}
+
+	// 3. The backoff write, on the same row, so the state table's upsert path
+	//    runs too. It records a FAILURE, so it is asserted as one rather than
+	//    with the success above — a backoff that left the point standing would
+	//    report a resolved address the provider never resolved.
+	if err := e.store.RecordGeocodeBackoff(ctx, orgID, addr.InputHash, 0); err != nil {
+		t.Fatalf("RecordGeocodeBackoff: %v", err)
+	}
+	if status, _, _ := readGeocode(t, e, orgID); status != "failed" {
+		t.Errorf("after a backoff the organization reads status %q, want failed", status)
+	}
+}
+
+// readGeocode reads the three columns the writes above are about, on the owner
+// pool, so the assertion does not depend on the store it is checking.
+func readGeocode(t *testing.T, e *dedupeEnv, orgID ids.OrganizationID) (status string, lat, lon *float64) {
+	t.Helper()
+	if err := e.store.db.Pool().QueryRow(context.Background(),
+		`SELECT coalesce(geocode_status, ''), geocode_lat, geocode_lon FROM organization WHERE id = $1`,
+		orgID).Scan(&status, &lat, &lon); err != nil {
+		t.Fatalf("reading the recorded geocode: %v", err)
+	}
+	return status, lat, lon
+}


### PR DESCRIPTION
Closes #2173.

**Geocoding an organization has never worked.** All three statements in
`people/geocode.go` predicate on `organization.workspace_id`, which ADR-0091 §8
phase D removed days before the feature landed:

```
AddressForGeocode: ERROR: column o.workspace_id does not exist (SQLSTATE 42703)
```

## Why nothing caught it

`geocode_test.go` is a **unit** suite with no database. It covers the
address-hashing and backoff arithmetic — the half that genuinely needs no
Postgres — and the SQL had simply never been executed against a schema.

So this fixes the predicates **and** adds a lane that issues each statement once
against the real schema. That suite is deliberately shallow and deliberately
wide: it asserts no geocoding behaviour the unit tests already prove, because
what was missing was never a case — it was a database.

I confirmed it catches the shipped bug by restoring one predicate and watching
it fail with the exact error above.

## Two things the lane found immediately

Both mine rather than the product's, and both are the kind of thing only a real
database says:

- the status vocabulary is `ok` / `failed` / `no_match` / `stale`, not the
  `resolved` I had assumed;
- **a backoff overwrites a success** — so the point is asserted after the
  success and the failure after the backoff, rather than assuming one survives
  the other.

## Verification

- `make check-backend` / `make craft-static` — green
- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove predicates on the dropped column `organization.workspace_id` from geocoding SQL and add an integration test that exercises all three geocode statements against the real schema. Previously every geocode call failed with “column o.workspace_id does not exist”; now the queries succeed and geocoding can record results.

- Review notes
  - Updated `backend/internal/modules/people/geocode.go` to remove `workspace_id` predicates from AddressForGeocode, address re-read, and geocode write; kept `id` and `archived_at` guards.
  - Added `backend/internal/modules/people/geocode_integration_test.go` (integration build tag) that seeds an organization, runs the read, a successful write, and a backoff write, and asserts the status transitions and stored point.
  - No migrations required; ADR-0091 had already removed the column.

<sup>Written for commit c5920e6210615d5a70194ca5647e0f8f86a530ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

