### PR TITLE
fix(platform): a boot observation says which installation made it

### DIFF
--- a/backend/internal/compose/bootscope.go
+++ b/backend/internal/compose/bootscope.go
@@ -71,3 +71,26 @@ func bootLedgerScope(ctx context.Context, pool *pgxpool.Pool, actor string) (con
 const bootLedgerLock = `
 	SELECT pg_advisory_xact_lock(
 		hashtext($1 || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`
+
+// installationMarker identifies THIS installation inside a boot observation's
+// detail payload.
+//
+// The ledgers lost their tenant column in ADR-0091 §8 phase D, and the boot
+// facts are read back with "the newest row wins". That is right for an
+// installation reading its own history and wrong for one carrying an archived
+// predecessor's: the residue gate exempts the ledgers by name, because their
+// immutability trigger makes clearing them impossible, so those rows are still
+// there and the read can no longer tell them apart.
+//
+// So the observation says which installation made it. A row without the marker
+// is not assumed to be ours — it predates this and may be a predecessor's — and
+// the reader treats "no marked row" the same way it treats "nothing recorded":
+// the comparison is disabled, which is the posture buildinfo already takes for
+// an unstamped binary.
+func installationMarker(ctx context.Context) string {
+	wsID, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return ""
+	}
+	return wsID.String()
+}

--- a/backend/internal/compose/extensioninventory.go
+++ b/backend/internal/compose/extensioninventory.go
@@ -82,7 +82,8 @@ func ObserveExtensionInventory(ctx context.Context, pool *pgxpool.Pool, log *slo
 			return nil
 		}
 		_, err = storekit.LogSystem(ctx, tx, extensionCompositionObserved, map[string]any{
-			"extensions": current,
+			"extensions":   current,
+			"installation": installationMarker(ctx),
 		})
 		if err != nil {
 			return err
@@ -112,9 +113,9 @@ func lastObservedExtensions(ctx context.Context, tx pgx.Tx) ([]observedExtension
 	// alone. id stays as the deterministic tiebreak.
 	err := tx.QueryRow(ctx,
 		`SELECT detail->'extensions' FROM system_log
-		  WHERE action = $1
+		  WHERE action = $1 AND detail->>'installation' = $2
 		  ORDER BY occurred_at DESC, id DESC LIMIT 1`,
-		extensionCompositionObserved).Scan(&detail)
+		extensionCompositionObserved, installationMarker(ctx)).Scan(&detail)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}

--- a/backend/internal/compose/integration/releaseversion_integration_test.go
+++ b/backend/internal/compose/integration/releaseversion_integration_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // TestReleaseGuardStopsATornSetAndLetsAnUpgradeThrough walks the whole life of
@@ -146,5 +147,50 @@ func TestReleaseGuardIsInertOnAnUnbootstrappedInstallation(t *testing.T) {
 	}
 	if rows != 0 {
 		t.Fatalf("a pre-bootstrap boot wrote %d release observations, want 0", rows)
+	}
+}
+
+// TestReleaseGuardIgnoresAPredecessorsRelease is the property a workspace
+// predicate used to give and the installation marker gives now.
+//
+// An installation that merged an archived predecessor still holds that
+// predecessor's release rows: the ledgers are exempt from the archived-residue
+// gate BY NAME, because their immutability trigger makes clearing them
+// impossible. So the rows are there, they can be newer than ours by occurred_at,
+// and before the marker the guard read one of them as this installation's — a
+// worker would refuse to start against a release nobody here is running.
+func TestReleaseGuardIgnoresAPredecessorsRelease(t *testing.T) {
+	env := Setup(t)
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	if err := compose.RecordInstallationRelease(ctx, env.Pool, logger, "1970.42"); err != nil {
+		t.Fatalf("recording this installation's release: %v", err)
+	}
+
+	// The predecessor's row, written directly because no live code can produce
+	// one any more — an installation records only under its own marker. Stamped
+	// an hour AHEAD so it wins every ordering the read could use, which is what
+	// makes this about the marker rather than about occurred_at.
+	if _, err := OwnerConn(t).Exec(ctx, `
+		INSERT INTO system_log (actor_type, actor_id, action, detail, occurred_at)
+		VALUES ('system', 'system:release-version', 'release.version_observed',
+		        jsonb_build_object('release_version', '1970.99', 'installation', $1::text),
+		        now() + interval '1 hour')`, ids.NewV7()); err != nil {
+		t.Fatalf("seeding the predecessor's release row: %v", err)
+	}
+
+	// A role at THIS installation's release still starts.
+	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.42"); err != nil {
+		t.Fatalf("a role at this installation's release refused to start, so a predecessor's row was read as ours: %v", err)
+	}
+	// The guard is still armed rather than reading nothing at all.
+	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.41"); err == nil {
+		t.Fatal("a role at the wrong release started; the marked read must still find our own row")
+	}
+	// And the predecessor's release is not ours even though it is the newest
+	// row in the ledger — which is what proves the marker rather than the order.
+	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.99"); err == nil {
+		t.Fatal("a role matched the PREDECESSOR's release; that row is not this installation's")
 	}
 }

--- a/backend/internal/compose/releaseversion.go
+++ b/backend/internal/compose/releaseversion.go
@@ -101,7 +101,7 @@ const releaseLedgerFact = "release-version"
 const lastObservedReleaseQuery = `
 	SELECT COALESCE(detail->>'release_version', '')
 	  FROM system_log
-	 WHERE action = $1
+	 WHERE action = $1 AND detail->>'installation' = $2
 	 ORDER BY occurred_at DESC, id DESC LIMIT 1`
 
 // RecordInstallationRelease records the release this api was built from as the
@@ -153,6 +153,7 @@ func RecordInstallationRelease(ctx context.Context, pool *pgxpool.Pool, log *slo
 		}
 		if _, err := storekit.LogSystem(ctx, tx, installationReleaseObserved, map[string]any{
 			"release_version": version,
+			"installation":    installationMarker(ctx),
 		}); err != nil {
 			return err
 		}
@@ -244,12 +245,18 @@ func refuseMixedRelease(mine, installation string) error {
 		mine, installation)
 }
 
-// lastObservedRelease reads the release the api recorded most recently; no
-// record yet reads as the empty string, which every caller treats as "nothing to
-// compare" rather than as a value.
+// lastObservedRelease reads the release THIS installation's api recorded most
+// recently; no such record reads as the empty string, which every caller treats
+// as "nothing to compare" rather than as a value.
+//
+// Scoped to the installation marker rather than to the newest row of all: an
+// installation that merged an archived predecessor still holds that
+// predecessor's release rows, and the ledgers are exempt from the residue gate
+// because their immutability trigger makes clearing them impossible.
 func lastObservedRelease(ctx context.Context, tx pgx.Tx) (string, error) {
 	var version string
-	err := tx.QueryRow(ctx, lastObservedReleaseQuery, installationReleaseObserved).Scan(&version)
+	err := tx.QueryRow(ctx, lastObservedReleaseQuery,
+		installationReleaseObserved, installationMarker(ctx)).Scan(&version)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", nil
 	}


### PR DESCRIPTION
Closes #2196.

The two boot facts — the installation's release and its extension composition —
are read back with **"newest row wins"**. That was right while `system_log`
carried a workspace column, and wrong the moment ADR-0091 §8 phase D took it: an
installation that merged an archived predecessor **still holds that
predecessor's rows**, because the ledgers are exempt from the archived-residue
gate BY NAME — their immutability trigger makes clearing them impossible.

So a predecessor's release row, newer by `occurred_at`, reads as this
installation's, and a worker refuses to start against a release nobody here is
running. Permanently, in a crash loop.

## The fix

The observation now carries **which installation made it**, and the read filters
on that. A row *without* the marker is not assumed to be ours — it predates this
change and may be a predecessor's — so "no marked row" is treated exactly like
"nothing recorded": the comparison is disabled, which is the posture
`buildinfo` already takes for an unstamped binary.

The guard is therefore inert between deploying this and the next api boot, which
is the same deploy. **Failing open there is deliberate**: the alternative is
comparing against a row nobody can attribute.

## The test is the one #2193 retired

It was retired because the property was no longer expressible — there was no
predicate left to prove. It is expressible again, so it is back. It stamps the
predecessor's row an hour **ahead**, so that row wins every ordering the read
could use: that is what makes it a test of the marker rather than of
`occurred_at`.

Verified by reverting the filter and watching it fail with the real crash-loop
message:

```
this role is release "1970.42" but this installation runs release "1970.99"
```

`extensioninventory` had the identical shape and gets the identical fix.

## Verification

- `make check-backend` / `make craft-static` — green
- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes boot observations to the active installation by writing an installation marker and filtering reads by it. This prevents workers from crash-looping after a predecessor merge where “newest row wins” attributed the predecessor’s release to this installation.

- Writes include "installation" in release and extension-composition observations, and reads filter on it; unmarked rows are treated as “nothing recorded” so the guard is inert until the next API boot.
- Touches `backend/internal/compose/releaseversion.go`, `backend/internal/compose/extensioninventory.go`, and adds `installationMarker` in `backend/internal/compose/bootscope.go`.
- Restores the predecessor-ignore property with an integration test that seeds a newer predecessor row and verifies the guard only matches this installation.
- Rollout: no data migration. Expect one fail-open boot window; the next boot writes marked rows and re-arms the guard.

<sup>Written for commit c9a0dbcf6596dec199b764bbfb8b1ad340419723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

