### PR TITLE
feat(agents): list_tags, so a tag_id can be held before a word is coined

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -6122,6 +6122,11 @@ paths:
       tags: [Tags]
       operationId: listTags
       summary: List tags.
+      description: |
+        The workspace's tag vocabulary. Read it before applying one: apply_tag takes a tag_name and
+        creates the word when there is none, so a caller who cannot see the existing words invents a
+        near-duplicate — "K5 Conference" beside "K5 Conference 2026" — and the vocabulary stops being one.
+      x-mcp-tool: { verb: list_tags, record_type: tag, tier: auto_execute, scope: read }
       parameters:
         - $ref: '#/components/parameters/IncludeArchived'
       responses:

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -248,6 +248,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/scheduled-sends":                                            {Op: "listScheduledSends", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/scheduled-sends/{id}":                                       {Op: "getScheduledSend", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/search":                                                     {Op: "search", Access: "tool", Tool: "search_records", RecordType: "", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/tags":                                                       {Op: "listTags", Access: "tool", Tool: "list_tags", RecordType: "tag", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/users":                                                      {Op: "listUsers", Access: "tool", Tool: "list_colleagues", RecordType: "app_user", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/users/{id}/access":                                          {Op: "getUserAccess", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/voice-profiles":                                             {Op: "listVoiceProfiles", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/agenttooldescriptions_test.go
+++ b/backend/internal/compose/agenttooldescriptions_test.go
@@ -15,6 +15,7 @@ package compose
 // against a defect it cannot actually detect looks exactly like a passing one.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -359,4 +360,39 @@ func toolsListDescriptions(t *testing.T, registry *agents.Registry) map[string]s
 		out[tool.Name] = tool.Description
 	}
 	return out
+}
+
+// Every served schema is valid JSON and arrives compacted.
+//
+// schema() compacts what it is given because each InputSchema is rendered
+// verbatim into the listing that rides every run, and the literals are written
+// indented for the reader of the source. A source-level check cannot see the
+// thirteen schemas built by concatenation — they are only a schema once the
+// constants are joined — so this asserts on the SERVED specs, where both kinds
+// have become the same thing.
+//
+// The valid-JSON half matters because schema() passes a malformed literal
+// through untouched rather than failing: that keeps the mistake visible, and
+// this is the test it is visible to.
+func TestEverySchemaIsValidJSONAndArrivesCompacted(t *testing.T) {
+	for _, spec := range servedSurface(t).Specs() {
+		var shape any
+		if err := json.Unmarshal(spec.InputSchema, &shape); err != nil {
+			t.Errorf("%s: the input schema is not valid JSON: %v", spec.Name, err)
+			continue
+		}
+		// Compared against json.Compact rather than a re-marshal: Marshal also
+		// re-escapes (< > & become \u003c and friends), which changes the
+		// length without changing the whitespace this is about.
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, spec.InputSchema); err != nil {
+			t.Errorf("%s: the input schema does not compact: %v", spec.Name, err)
+			continue
+		}
+		if len(spec.InputSchema) != compact.Len() {
+			t.Errorf("%s: the served schema is %d bytes where its compact form is %d — "+
+				"the difference is whitespace, and it rides every prompt",
+				spec.Name, len(spec.InputSchema), compact.Len())
+		}
+	}
 }

--- a/backend/internal/compose/tagseam.go
+++ b/backend/internal/compose/tagseam.go
@@ -69,16 +69,16 @@ func (a tagAdapter) EnsureTag(ctx context.Context, name string) (ids.UUID, error
 // through: TagVocabulary was written for a caller outside that module and
 // this is the first one, so there is nothing here to translate beyond the
 // field names the wire uses.
-func (a tagAdapter) ListTags(ctx context.Context, includeArchived bool) ([]agents.Tag, error) {
-	rows, err := a.store.TagVocabulary(ctx, includeArchived)
+func (a tagAdapter) ListTags(ctx context.Context, includeArchived bool) ([]agents.Tag, bool, error) {
+	rows, truncated, err := a.store.TagVocabulary(ctx, includeArchived)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	out := make([]agents.Tag, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, agents.Tag{TagID: r.TagID, Name: r.Name, Color: r.Color, Archived: r.Archived})
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 func (a tagAdapter) EnsureTaggable(ctx context.Context, entityType string, entityID ids.UUID) error {

--- a/backend/internal/compose/tagseam.go
+++ b/backend/internal/compose/tagseam.go
@@ -65,6 +65,22 @@ func (a tagAdapter) EnsureTag(ctx context.Context, name string) (ids.UUID, error
 	return found, nil
 }
 
+// ListTags hands the collections module's own cross-module shape straight
+// through: TagVocabulary was written for a caller outside that module and
+// this is the first one, so there is nothing here to translate beyond the
+// field names the wire uses.
+func (a tagAdapter) ListTags(ctx context.Context, includeArchived bool) ([]agents.Tag, error) {
+	rows, err := a.store.TagVocabulary(ctx, includeArchived)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]agents.Tag, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, agents.Tag{TagID: r.TagID, Name: r.Name, Color: r.Color, Archived: r.Archived})
+	}
+	return out, nil
+}
+
 func (a tagAdapter) EnsureTaggable(ctx context.Context, entityType string, entityID ids.UUID) error {
 	return a.store.EnsureTaggable(ctx, entityType, entityID)
 }

--- a/backend/internal/modules/agents/results_identity.go
+++ b/backend/internal/modules/agents/results_identity.go
@@ -37,6 +37,16 @@ type ListColleaguesResult struct {
 	Truncated bool `json:"truncated,omitempty"`
 }
 
+// ListTagsResult is the workspace's tag vocabulary. Empty is a real answer —
+// a workspace that has coined no words yet — never an error.
+//
+// No `truncated` twin to ListColleaguesResult: the store caps its read at
+// 1000 words and a workspace vocabulary that long has a different problem
+// than a missing flag.
+type ListTagsResult struct {
+	Tags []Tag `json:"tags"`
+}
+
 // TagAppliedResult reports one tagging. `applied` is false for a removal,
 // which is the same shape rather than a second one: a caller that acted on a
 // record wants the record back either way.

--- a/backend/internal/modules/agents/results_identity.go
+++ b/backend/internal/modules/agents/results_identity.go
@@ -40,11 +40,14 @@ type ListColleaguesResult struct {
 // ListTagsResult is the workspace's tag vocabulary. Empty is a real answer —
 // a workspace that has coined no words yet — never an error.
 //
-// No `truncated` twin to ListColleaguesResult: the store caps its read at
-// 1000 words and a workspace vocabulary that long has a different problem
-// than a missing flag.
+// `truncated` is not optional decoration. The store caps its read, and the
+// caller's reason for reading is to find out whether a word already exists —
+// so a capped list presented as the whole vocabulary answers "no such tag" for
+// every word past the cap, and the caller coins the duplicate that reading the
+// vocabulary was meant to prevent.
 type ListTagsResult struct {
-	Tags []Tag `json:"tags"`
+	Tags      []Tag `json:"tags"`
+	Truncated bool  `json:"truncated,omitempty"`
 }
 
 // TagAppliedResult reports one tagging. `applied` is false for a removal,

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -2899,6 +2899,119 @@
       "warnings"
     ]
   },
+  "list_tags": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "archived": {
+                  "type": "boolean"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "tag_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "required": [
+                "name",
+                "tag_id"
+              ]
+            }
+          }
+        },
+        "required": [
+          "tags"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "log_activity": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -2929,6 +2929,9 @@
                 "tag_id"
               ]
             }
+          },
+          "truncated": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/backend/internal/modules/agents/toolcopy_tags.go
+++ b/backend/internal/modules/agents/toolcopy_tags.go
@@ -5,11 +5,16 @@ package agents
 
 // The tag verbs. Short on purpose: four tools ride every listing, and the tag
 // vocabulary is the simplest thing on this surface.
+var listTagsCopy = toolCopy{
+	Purpose: "The workspace's words for grouping records, with the tag_id apply_tag takes.",
+	Limits:  "Archived words come only on request and cannot be applied.",
+}
+
 var applyTagCopy = toolCopy{
-	Purpose: "Tag a person, company, deal or lead — by tag_id, or by tag_name, which reuses the " +
-		"workspace's word or adds it.",
-	Limits: "Applying the same tag twice is refused as a conflict. A name matches case-insensitively; " +
-		"a near-miss makes a NEW word, so prefer a tag_id you already hold.",
+	Purpose: "Tag a person, company, deal or lead by tag_id, or by tag_name, which reuses the " +
+		"workspace's word or coins it.",
+	Limits: "Prefer a tag_id from list_tags: a name matches case-insensitively, and a near-miss " +
+		"makes a NEW word. The same tag twice is a conflict.",
 }
 
 var removeTagCopy = toolCopy{

--- a/backend/internal/modules/agents/toolcopy_tags.go
+++ b/backend/internal/modules/agents/toolcopy_tags.go
@@ -7,7 +7,8 @@ package agents
 // vocabulary is the simplest thing on this surface.
 var listTagsCopy = toolCopy{
 	Purpose: "The workspace's words for grouping records, with the tag_id apply_tag takes.",
-	Limits:  "Archived words come only on request and cannot be applied.",
+	Limits: "Archived words come only on request and cannot be applied. `truncated` means the " +
+		"list was cut, so a word missing from it may still exist.",
 }
 
 var applyTagCopy = toolCopy{

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -12,6 +12,7 @@ package agents
 // provenance any more than a browser can.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -82,7 +83,26 @@ type FieldOwnership interface {
 	HumanOwnedConflicts(ctx context.Context, entityType string, id ids.UUID, patch json.RawMessage) ([]string, error)
 }
 
-func schema(s string) json.RawMessage { return json.RawMessage(s) }
+// schema turns a hand-written JSON schema into the wire form, COMPACTED.
+//
+// The compaction is not tidiness. Every spec's InputSchema is rendered
+// verbatim into the tool listing that rides every Surface-B prompt
+// (runner.ToolListing), so the tabs and newlines these literals are indented
+// with are paid for on every run — ~210 tokens across the core surface, out of
+// a listing already held to a two-thirds budget of the window.
+//
+// Doing it here rather than by unindenting forty literals keeps the source
+// readable: a schema stays legible where it is written, and costs nothing
+// where it is read. A literal that is not valid JSON is left exactly as it
+// was, so a malformed schema still fails the test that reads it rather than
+// being hidden by this.
+func schema(s string) json.RawMessage {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(s)); err != nil {
+		return json.RawMessage(s)
+	}
+	return json.RawMessage(compact.String())
+}
 
 // --- search_records (🟢 read) ---
 

--- a/backend/internal/modules/agents/tools_tags.go
+++ b/backend/internal/modules/agents/tools_tags.go
@@ -45,7 +45,7 @@ type Tags interface {
 	// ListTags answers the workspace's vocabulary, newest spelling rules and
 	// all. Read before applying: apply_tag creates the word it is given, so a
 	// caller who cannot see the existing ones coins near-duplicates.
-	ListTags(ctx context.Context, includeArchived bool) ([]Tag, error)
+	ListTags(ctx context.Context, includeArchived bool) (tags []Tag, truncated bool, err error)
 	// EnsureTaggable refuses a record the caller cannot tag, before a tag is
 	// created for it. Same check ApplyTag makes at the end of its own
 	// transaction; asked earlier so a failed apply leaves nothing behind.
@@ -109,7 +109,7 @@ func (t listTags) Handle(ctx context.Context, in json.RawMessage) (json.RawMessa
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	tags, err := t.tags.ListTags(ctx, args.IncludeArchived)
+	tags, truncated, err := t.tags.ListTags(ctx, args.IncludeArchived)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (t listTags) Handle(ctx context.Context, in json.RawMessage) (json.RawMessa
 	if tags == nil {
 		tags = []Tag{}
 	}
-	return json.Marshal(ListTagsResult{Tags: tags})
+	return json.Marshal(ListTagsResult{Tags: tags, Truncated: truncated})
 }
 
 // --- apply_tag / remove_tag (🟢 write) ---

--- a/backend/internal/modules/agents/tools_tags.go
+++ b/backend/internal/modules/agents/tools_tags.go
@@ -29,8 +29,23 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
+// Tag is one word in the workspace's vocabulary.
+type Tag struct {
+	TagID ids.UUID `json:"tag_id"`
+	Name  string   `json:"name"`
+	Color string   `json:"color,omitempty"`
+	// Archived says the word was retired. apply_tag will NOT reuse it — a
+	// name whose only holder is archived is a conflict, not a match — so a
+	// caller that cannot see this would read a refusal as a bug.
+	Archived bool `json:"archived,omitempty"`
+}
+
 // Tags is the seam onto the collections module's tag paths.
 type Tags interface {
+	// ListTags answers the workspace's vocabulary, newest spelling rules and
+	// all. Read before applying: apply_tag creates the word it is given, so a
+	// caller who cannot see the existing ones coins near-duplicates.
+	ListTags(ctx context.Context, includeArchived bool) ([]Tag, error)
 	// EnsureTaggable refuses a record the caller cannot tag, before a tag is
 	// created for it. Same check ApplyTag makes at the end of its own
 	// transaction; asked earlier so a failed apply leaves nothing behind.
@@ -53,6 +68,7 @@ func RegisterTagTools(r *Registry, tags Tags) {
 	if tags == nil {
 		return
 	}
+	r.Register(listTags{tags: tags})
 	r.Register(applyTag{tags: tags})
 	r.Register(removeTag{tags: tags})
 }
@@ -68,6 +84,44 @@ const taggingSchema = `{"type":"object","required":["record_type","record_id"],"
 	"tag_name":{"type":"string","maxLength":120,"description":"Instead of tag_id: the tag is created if the workspace has no such word"},
 	"record_type":{"type":"string","enum":` + tagTargetEnum + `},
 	"record_id":{"type":"string","format":"uuid"}},"additionalProperties":false}`
+
+// --- list_tags (🟢 read) ---
+
+type listTags struct{ tags Tags }
+
+func (t listTags) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "list_tags", Title: "List tags", Version: toolVersionV1,
+		Description:   listTagsCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "listTags",
+		InputSchema: schema(`{"type":"object","properties":{
+			"include_archived":{"type":"boolean","description":"Also list retired words; they cannot be applied"}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[ListTagsResult](),
+	}
+}
+
+func (t listTags) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args struct {
+		IncludeArchived bool `json:"include_archived"`
+	}
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	tags, err := t.tags.ListTags(ctx, args.IncludeArchived)
+	if err != nil {
+		return nil, err
+	}
+	// No noteEvidence, for the reason list_colleagues gives: a tag is
+	// vocabulary, not a record the answer rests on. Stamping one would put
+	// every word in the workspace into the evidence list of a call that only
+	// asked what the words are.
+	if tags == nil {
+		tags = []Tag{}
+	}
+	return json.Marshal(ListTagsResult{Tags: tags})
+}
 
 // --- apply_tag / remove_tag (🟢 write) ---
 

--- a/backend/internal/modules/agents/tools_tags_test.go
+++ b/backend/internal/modules/agents/tools_tags_test.go
@@ -19,13 +19,14 @@ type stubTags struct {
 	ensured          *string
 	vocabulary       []Tag
 	listedArchived   *bool
+	capped           bool
 }
 
-func (s stubTags) ListTags(_ context.Context, includeArchived bool) ([]Tag, error) {
+func (s stubTags) ListTags(_ context.Context, includeArchived bool) ([]Tag, bool, error) {
 	if s.listedArchived != nil {
 		*s.listedArchived = includeArchived
 	}
-	return s.vocabulary, nil
+	return s.vocabulary, s.capped, nil
 }
 
 func (stubTags) EnsureTaggable(context.Context, string, ids.UUID) error { return nil }
@@ -182,13 +183,10 @@ func (noSuchTag) FindTag(context.Context, string) (ids.UUID, bool, error) {
 // "K5 Conference" beside "K5 Conference 2026" is not two tags, it is a
 // vocabulary that has stopped being one.
 func TestTheVocabularyCanBeReadBeforeAWordIsCoined(t *testing.T) {
-	marketing, retired := ids.NewV7(), ids.NewV7()
+	marketing := ids.NewV7()
 	var askedForArchived bool
 	tool := listTags{tags: stubTags{
-		vocabulary: []Tag{
-			{TagID: marketing, Name: "K5 Conference 2026", Color: "#3366ff"},
-			{TagID: retired, Name: "Q1 Push", Archived: true},
-		},
+		vocabulary:     []Tag{{TagID: marketing, Name: "K5 Conference 2026", Color: "#3366ff"}},
 		listedArchived: &askedForArchived,
 	}}
 
@@ -200,19 +198,13 @@ func TestTheVocabularyCanBeReadBeforeAWordIsCoined(t *testing.T) {
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatalf("the answer does not decode: %v", err)
 	}
-	if len(got.Tags) != 2 {
-		t.Fatalf("listed %+v, want both words", got.Tags)
+	if len(got.Tags) != 1 {
+		t.Fatalf("listed %+v, want the workspace's word", got.Tags)
 	}
 	// The id is the whole point: it is what apply_tag takes, and a name-only
 	// answer would leave the caller guessing exactly as before.
 	if got.Tags[0].TagID != marketing || got.Tags[0].Name != "K5 Conference 2026" {
-		t.Errorf("the first word reads %+v, want the id apply_tag takes beside its name", got.Tags[0])
-	}
-	// Archived rides the row because apply_tag will NOT reuse a retired word —
-	// EnsureTag treats it as a conflict — so a caller shown one without the
-	// flag would read that refusal as a bug.
-	if !got.Tags[1].Archived {
-		t.Errorf("the retired word reads %+v, want it marked archived", got.Tags[1])
+		t.Errorf("the word reads %+v, want the id apply_tag takes beside its name", got.Tags[0])
 	}
 	if askedForArchived {
 		t.Error("the default asked the store for archived words; retired words are opt-in")
@@ -245,5 +237,68 @@ func TestAnEmptyVocabularyAnswersAsAList(t *testing.T) {
 	}
 	if !bytes.Contains(raw, []byte(`"tags":[]`)) {
 		t.Errorf("an empty workspace answered %s, want an empty list", raw)
+	}
+}
+
+// A retired word rides back MARKED. apply_tag will not reuse one — EnsureTag
+// treats a name whose only holder is archived as a conflict, deliberately, so
+// that retiring a word is not undone by a coincidence of spelling — and a
+// caller shown the word without the flag would read that refusal as a bug.
+func TestARetiredWordSaysSo(t *testing.T) {
+	retired := ids.NewV7()
+	tool := listTags{tags: stubTags{
+		vocabulary: []Tag{{TagID: retired, Name: "Q1 Push", Archived: true}},
+	}}
+	raw, err := tool.Handle(context.Background(), json.RawMessage(`{"include_archived":true}`))
+	if err != nil {
+		t.Fatalf("listing answered %v", err)
+	}
+	var got ListTagsResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("the answer does not decode: %v", err)
+	}
+	if len(got.Tags) != 1 || !got.Tags[0].Archived {
+		t.Errorf("listed %+v, want the retired word marked archived", got.Tags)
+	}
+}
+
+// A capped read SAYS it was capped, and this is the finding that makes the
+// tool honest rather than merely present.
+//
+// The store caps the vocabulary read, and the caller's whole reason for asking
+// is to learn whether a word already exists. A capped list handed over as the
+// vocabulary answers "no such tag" for everything past the cap — so the caller
+// coins the duplicate that reading the vocabulary was meant to prevent, and
+// nothing anywhere says why.
+func TestACappedVocabularySaysItIsCapped(t *testing.T) {
+	tool := listTags{tags: stubTags{
+		vocabulary: []Tag{{TagID: ids.NewV7(), Name: "Key Account"}},
+		capped:     true,
+	}}
+	raw, err := tool.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("listing answered %v", err)
+	}
+	var got ListTagsResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("the answer does not decode: %v", err)
+	}
+	if !got.Truncated {
+		t.Error("a capped read answered as the whole vocabulary; a caller past the cap " +
+			"is told a word does not exist when it does")
+	}
+}
+
+// The flag is absent when nothing was cut, so `truncated` means something when
+// it appears rather than riding every answer as noise.
+func TestAWholeVocabularyDoesNotClaimToBeCut(t *testing.T) {
+	raw, err := (listTags{tags: stubTags{
+		vocabulary: []Tag{{TagID: ids.NewV7(), Name: "Inbound"}},
+	}}).Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("listing answered %v", err)
+	}
+	if bytes.Contains(raw, []byte(`"truncated"`)) {
+		t.Errorf("a complete vocabulary answered %s, want no truncation flag", raw)
 	}
 }

--- a/backend/internal/modules/agents/tools_tags_test.go
+++ b/backend/internal/modules/agents/tools_tags_test.go
@@ -4,6 +4,7 @@
 package agents
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -16,6 +17,15 @@ import (
 type stubTags struct {
 	applied, removed *taggingArgs
 	ensured          *string
+	vocabulary       []Tag
+	listedArchived   *bool
+}
+
+func (s stubTags) ListTags(_ context.Context, includeArchived bool) ([]Tag, error) {
+	if s.listedArchived != nil {
+		*s.listedArchived = includeArchived
+	}
+	return s.vocabulary, nil
 }
 
 func (stubTags) EnsureTaggable(context.Context, string, ids.UUID) error { return nil }
@@ -162,4 +172,78 @@ type noSuchTag struct{ stubTags }
 
 func (noSuchTag) FindTag(context.Context, string) (ids.UUID, bool, error) {
 	return ids.UUID{}, false, nil
+}
+
+// The vocabulary had no door. apply_tag's own copy says to prefer a tag_id
+// "you already hold", and nothing on the surface could produce one: create was
+// human-only and the listing was declared by nobody. So the only reachable way
+// to tag was to pass a NAME, which creates the word when the workspace has no
+// such spelling — and a caller who cannot see the existing words guesses.
+// "K5 Conference" beside "K5 Conference 2026" is not two tags, it is a
+// vocabulary that has stopped being one.
+func TestTheVocabularyCanBeReadBeforeAWordIsCoined(t *testing.T) {
+	marketing, retired := ids.NewV7(), ids.NewV7()
+	var askedForArchived bool
+	tool := listTags{tags: stubTags{
+		vocabulary: []Tag{
+			{TagID: marketing, Name: "K5 Conference 2026", Color: "#3366ff"},
+			{TagID: retired, Name: "Q1 Push", Archived: true},
+		},
+		listedArchived: &askedForArchived,
+	}}
+
+	raw, err := tool.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("listing answered %v", err)
+	}
+	var got ListTagsResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("the answer does not decode: %v", err)
+	}
+	if len(got.Tags) != 2 {
+		t.Fatalf("listed %+v, want both words", got.Tags)
+	}
+	// The id is the whole point: it is what apply_tag takes, and a name-only
+	// answer would leave the caller guessing exactly as before.
+	if got.Tags[0].TagID != marketing || got.Tags[0].Name != "K5 Conference 2026" {
+		t.Errorf("the first word reads %+v, want the id apply_tag takes beside its name", got.Tags[0])
+	}
+	// Archived rides the row because apply_tag will NOT reuse a retired word —
+	// EnsureTag treats it as a conflict — so a caller shown one without the
+	// flag would read that refusal as a bug.
+	if !got.Tags[1].Archived {
+		t.Errorf("the retired word reads %+v, want it marked archived", got.Tags[1])
+	}
+	if askedForArchived {
+		t.Error("the default asked the store for archived words; retired words are opt-in")
+	}
+}
+
+// Opt-in, and it reaches the store rather than being filtered here: the store
+// is where `archived_at IS NULL` lives, and a second spelling of that rule in
+// this module is a second place for it to drift.
+func TestAskingForRetiredWordsReachesTheStore(t *testing.T) {
+	var askedForArchived bool
+	tool := listTags{tags: stubTags{listedArchived: &askedForArchived}}
+	if _, err := tool.Handle(context.Background(),
+		json.RawMessage(`{"include_archived":true}`)); err != nil {
+		t.Fatalf("listing answered %v", err)
+	}
+	if !askedForArchived {
+		t.Error("include_archived did not reach the store, so the argument is decoration")
+	}
+}
+
+// An empty workspace is an ANSWER, not an error, and it must decode as `[]`
+// rather than `null`: a caller handed null reads it as a failed read and says
+// the vocabulary could not be listed, when the truth is that nobody has coined
+// a word yet.
+func TestAnEmptyVocabularyAnswersAsAList(t *testing.T) {
+	raw, err := (listTags{tags: stubTags{}}).Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("listing answered %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"tags":[]`)) {
+		t.Errorf("an empty workspace answered %s, want an empty list", raw)
+	}
 }

--- a/backend/internal/modules/agents/tools_test.go
+++ b/backend/internal/modules/agents/tools_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import "testing"
+
+// Every spec's InputSchema is rendered VERBATIM into the tool listing that
+// rides every Surface-B prompt, so the indentation these literals are written
+// with is paid for on every run — ~210 tokens across the core surface, out of
+// a listing already held to two-thirds of the window.
+//
+// Compacting at the door rather than unindenting forty literals is what keeps
+// both true at once: a schema stays readable where it is written and costs
+// nothing where it is read. Without this, the next tool to be added has to buy
+// its own room by tightening somebody else's copy.
+func TestASchemaCostsNothingForBeingReadable(t *testing.T) {
+	got := string(schema(`{"type":"object","properties":{
+		"q":{"type":"string"}},
+		"additionalProperties":false}`))
+	want := `{"type":"object","properties":{"q":{"type":"string"}},"additionalProperties":false}`
+	if got != want {
+		t.Errorf("schema() rendered %s, want it compacted to %s", got, want)
+	}
+}
+
+// A literal that is not JSON is left exactly as written. Silently rewriting it
+// would hide the mistake from whichever test reads the schema next, which is
+// the one place it would otherwise be caught.
+func TestAMalformedSchemaIsLeftForTheTestThatReadsIt(t *testing.T) {
+	broken := `{"type":"object",`
+	if got := string(schema(broken)); got != broken {
+		t.Errorf("schema() rewrote a malformed literal to %s, want it untouched", got)
+	}
+}

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -309,20 +309,27 @@ func tagSummary(t tagRow) TagSummary {
 }
 
 // TagVocabulary lists the workspace's tags for a caller outside this module.
-func (s *Store) TagVocabulary(ctx context.Context, includeArchived bool) ([]TagSummary, error) {
+//
+// It reports TRUNCATION, because the read is capped at catalogCap and the
+// caller's whole reason for asking is to find out whether a word already
+// exists. A capped list handed over as if it were the vocabulary answers "no
+// such tag" for every word past the cap — the exact false negative that makes
+// a caller coin a duplicate, which is what reading the vocabulary was meant to
+// prevent.
+func (s *Store) TagVocabulary(ctx context.Context, includeArchived bool) ([]TagSummary, bool, error) {
 	filter := storekit.LiveOnly
 	if includeArchived {
 		filter = storekit.IncludeArchived
 	}
-	rows, _, err := s.ListTags(ctx, filter)
+	rows, truncated, err := s.ListTags(ctx, filter)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	out := make([]TagSummary, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, tagSummary(r))
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // NewTag creates one and answers it in the cross-module shape.

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 51,
+    "tools": 52,
     "resources": 8,
-    "tool_catalog_bytes": 139917,
+    "tool_catalog_bytes": 141455,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 35756,
+    "approx_wire_tokens_total": 36140,
     "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 34645,
-      "input_schema_bytes": 30637,
-      "output_schema_bytes": 63640,
-      "description_plus_input_schema_bytes": 65282
+      "description_bytes": 34820,
+      "input_schema_bytes": 30800,
+      "output_schema_bytes": 64671,
+      "description_plus_input_schema_bytes": 65620
     }
   },
   "tools": {
@@ -562,7 +562,7 @@
           "readOnlyHint": false,
           "title": "Apply a tag to a record"
         },
-        "description": "Tag a person, company, deal or lead — by tag_id, or by tag_name, which reuses the workspace's word or adds it. Applying the same tag twice is refused as a conflict. A name matches case-insensitively; a near-miss makes a NEW word, so prefer a tag_id you already hold. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Tag a person, company, deal or lead by tag_id, or by tag_name, which reuses the workspace's word or coins it. Prefer a tag_id from list_tags: a name matches case-insensitively, and a near-miss makes a NEW word. The same tag twice is a conflict. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -3821,6 +3821,139 @@
           "type": "object"
         },
         "title": "List records"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "List tags"
+        },
+        "description": "The workspace's words for grouping records, with the tag_id apply_tag takes. Archived words come only on request and cannot be applied. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "include_archived": {
+              "description": "Also list retired words; they cannot be applied",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "name": "list_tags",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "tags": {
+                  "items": {
+                    "properties": {
+                      "archived": {
+                        "type": "boolean"
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "tag_id"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "tags"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "List tags"
       },
       {
         "annotations": {
@@ -9047,7 +9180,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":51,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"relink_activity\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":52,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"relink_activity\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, key?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, key?: string, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 52,
     "resources": 8,
-    "tool_catalog_bytes": 141455,
+    "tool_catalog_bytes": 141565,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 36140,
+    "approx_wire_tokens_total": 36168,
     "largest_tool_bytes": 4709,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 34820,
+      "description_bytes": 34899,
       "input_schema_bytes": 30800,
-      "output_schema_bytes": 64671,
-      "description_plus_input_schema_bytes": 65620
+      "output_schema_bytes": 64702,
+      "description_plus_input_schema_bytes": 65699
     }
   },
   "tools": {
@@ -3828,7 +3828,7 @@
           "readOnlyHint": true,
           "title": "List tags"
         },
-        "description": "The workspace's words for grouping records, with the tag_id apply_tag takes. Archived words come only on request and cannot be applied. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "The workspace's words for grouping records, with the tag_id apply_tag takes. Archived words come only on request and cannot be applied. `truncated` means the list was cut, so a word missing from it may still exist. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -3868,6 +3868,9 @@
                     "type": "object"
                   },
                   "type": "array"
+                },
+                "truncated": {
+                  "type": "boolean"
                 }
               },
               "required": [

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 52 |
 | Resources | 8 |
-| Tool catalog | 138.1 KB |
+| Tool catalog | 138.2 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 36140 |
+| Approx. wire tokens | 36168 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,10 +29,10 @@ budget in `agenttooldescriptions_test.go`.
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
 | Output schemas | 63.2 KB | 45% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 34.0 KB | 24% | Yes, every step |
+| Descriptions (incl. governance clause) | 34.1 KB | 24% | Yes, every step |
 | Input schemas | 30.1 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 10.9 KB | 7% | Partly |
-| **Description + input schema** | **64.1 KB** | **46%** | **the recurring cost** |
+| **Description + input schema** | **64.2 KB** | **46%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -82,7 +82,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 1.9 KB |
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
-| [`list_tags`](#list_tags) | List tags | yes |  | 1.5 KB |
+| [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
 | [`log_activity`](#log_activity) | Log an activity |  |  | 3.2 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 3.0 KB |
@@ -4298,7 +4298,7 @@ Enumerate the people, organizations, deals, leads or projects that meet exact co
 
 **List tags**
 
-The workspace's words for grouping records, with the tag_id apply_tag takes. Archived words come only on request and cannot be applied. (Governance: runs immediately; requires passport scope "read".)
+The workspace's words for grouping records, with the tag_id apply_tag takes. Archived words come only on request and cannot be applied. `truncated` means the list was cut, so a word missing from it may still exist. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -4348,6 +4348,9 @@ The workspace's words for grouping records, with the tag_id apply_tag takes. Arc
             "type": "object"
           },
           "type": "array"
+        },
+        "truncated": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 51 |
+| Tools | 52 |
 | Resources | 8 |
-| Tool catalog | 136.6 KB |
+| Tool catalog | 138.1 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 35756 |
+| Approx. wire tokens | 36140 |
 | Largest tool | `run_report` (4.6 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -28,11 +28,11 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 62.1 KB | 45% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 33.8 KB | 24% | Yes, every step |
-| Input schemas | 29.9 KB | 21% | Yes, every step |
-| _Names, annotations, punctuation_ | 10.7 KB | 7% | Partly |
-| **Description + input schema** | **63.8 KB** | **46%** | **the recurring cost** |
+| Output schemas | 63.2 KB | 45% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 34.0 KB | 24% | Yes, every step |
+| Input schemas | 30.1 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 10.9 KB | 7% | Partly |
+| **Description + input schema** | **64.1 KB** | **46%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -55,7 +55,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/handoff.html`](#handoff_view) — Delivery handoff
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 
-### Tools (51)
+### Tools (52)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -82,6 +82,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 1.9 KB |
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
+| [`list_tags`](#list_tags) | List tags | yes |  | 1.5 KB |
 | [`log_activity`](#log_activity) | Log an activity |  |  | 3.2 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 3.0 KB |
@@ -831,7 +832,7 @@ Move a project to another phase — initiative, pursuing, delivering, closed. Th
 
 **Apply a tag to a record**
 
-Tag a person, company, deal or lead — by tag_id, or by tag_name, which reuses the workspace's word or adds it. Applying the same tag twice is refused as a conflict. A name matches case-insensitively; a near-miss makes a NEW word, so prefer a tag_id you already hold. (Governance: runs immediately; requires passport scope "write".)
+Tag a person, company, deal or lead by tag_id, or by tag_name, which reuses the workspace's word or coins it. Prefer a tag_id from list_tags: a name matches case-insensitively, and a near-miss makes a NEW word. The same tag twice is a conflict. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -4208,6 +4209,149 @@ Enumerate the people, organizations, deals, leads or projects that meet exact co
       },
       "required": [
         "records"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### list_tags
+
+**List tags**
+
+The workspace's words for grouping records, with the tag_id apply_tag takes. Archived words come only on request and cannot be applied. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "include_archived": {
+      "description": "Also list retired words; they cannot be applied",
+      "type": "boolean"
+    }
+  },
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "tags": {
+          "items": {
+            "properties": {
+              "archived": {
+                "type": "boolean"
+              },
+              "color": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tag_id": {
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "tag_id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "tags"
       ],
       "type": "object"
     },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3876,7 +3876,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List tags. */
+        /**
+         * List tags.
+         * @description The workspace's tag vocabulary. Read it before applying one: apply_tag takes a tag_name and
+         *     creates the word when there is none, so a caller who cannot see the existing words invents a
+         *     near-duplicate — "K5 Conference" beside "K5 Conference 2026" — and the vocabulary stops being one.
+         */
         get: operations["listTags"];
         put?: never;
         /** Create a tag. */


### PR DESCRIPTION
## What was wrong

`apply_tag`'s own description told the model to prefer a tag_id *"you already hold"* — and nothing on the surface could produce one. `createTag` is human-only by a deliberate decision (crm.yaml says why), and `listTags` was declared by nobody.

So the only reachable way to tag was to pass a **name**, which `apply_tag` creates when the workspace has no such spelling. A caller who cannot see the existing words guesses, and "K5 Conference" lands beside "K5 Conference 2026". That is not two tags; it is a vocabulary that has stopped being one.

## Reuse, not rebuild

Almost nothing new was needed. `collections.Store.TagVocabulary(ctx, includeArchived)` already answered this exact question in a cross-module shape — and had **zero callers**. The seam, the adapter and the store read were all in place. This declares the verb on the contract's existing `listTags` op and joins the two.

`create_tag` stays unbuilt on purpose: `apply_tag` already creates the word as part of the one act the caller asked for.

## The listing budget, and a fix that pays for itself

The new tool did not fit. `TestTheToolListingLeavesTheRunRoomInTheWindow` caps the core catalog at two-thirds of a 24000-token window, main sat just under it, and one more entry crossed the line.

Rather than buy room by tightening another tool's copy, `schema()` now runs `json.Compact` on what it is given. Every `InputSchema` is rendered **verbatim** into the listing that rides every Surface-B prompt, so the indentation ~40 hand-written literals carry was being paid for on every run — about **210 tokens of pure whitespace per prompt**.

Schemas stay readable where they are written and cost nothing where they are read. An invalid literal is passed through untouched, so a malformed schema still fails the test that reads it rather than being hidden.

## Verified live

Against a running stack, not just compiled:

- **66 tools served**, `list_tags` among them
- `list_tags` returns the four seeded tags with their ids and colors
- `apply_tag` with `tag_name: "K5 Conference 2026"` coins the word
- `list_tags` again shows it, with the id `apply_tag` takes

Probe tag archived afterwards; the dev database is as it was.

## Gates

`make check-backend` green · `make check-fe` green · `make craft-static` 0/0/0 · `rls-store-path` and `no-jurisdiction` OK.

All three regenerations in the same commit: `make gen`, `pnpm gen:api`, `-update-mcp-info` (51 → 52 tools), plus the `outputshapes.json` golden.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only `list_tags` tool so callers can fetch a `tag_id` before applying a tag and avoid coining near-duplicate names. Previously `apply_tag` often created a new word on a name miss; now callers list existing words and pass a `tag_id`, with truncation signaled when the vocabulary read is capped.

- Wires the store read (`TagVocabulary`) through the seam (`Tags.ListTags`) and adapter; returns `{tag_id, name, color, archived}` and carries `truncated` (absent when not cut). Defaults to exclude archived; `include_archived` is opt-in; empty answers are `[]`.
- Declares OpenAPI `listTags` with `x-mcp-tool`, adds `GET /v1/tags` policy mapping, registers the tool, updates `apply_tag` copy to prefer a `tag_id` from `list_tags`, and regenerates docs and frontend `schema.d.ts`.
- Compacts every tool input schema via `schema()` to keep the catalog under the window budget; malformed literals pass through unchanged. Adds tests for compaction and for `list_tags` behavior (truncation and archived semantics), and plumbs the truncation flag through store, seam, adapter, and result.
- No migrations or config changes. Required client action: call `list_tags`, then call `apply_tag` with `tag_id`.

<sup>Written for commit ea7a13479557317dc86d354d55bd382bb492e6b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only `list_tags` tool to view workspace tag vocabulary.
  * Supports optionally including archived tags.
  * Returns tag IDs, names, colors, and archive status, including valid empty results.

* **Improvements**
  * Clarified tag application guidance, including ID/name matching, case-insensitivity, near matches, and duplicate conflicts.
  * Updated the MCP tool catalog and reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->