### PR TITLE
fix(authz): the installation-claim credential's lifecycle is recorded

### DIFF
--- a/backend/internal/modules/identity/setuptoken.go
+++ b/backend/internal/modules/identity/setuptoken.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // ErrSetupTokenMismatch means a claim presented a token that is not the
@@ -75,25 +76,28 @@ const (
 	replaceOutstanding outstandingPolicy = true
 )
 
-// No audit_log or event_outbox row accompanies these writes, which is the one
-// place in this package the standard write shape does not reach.
+// The lifecycle writes a system_log row for every act: minting a token,
+// retiring an outstanding one, and — through the claim — spending it. It writes
+// no audit_log or event_outbox row, and that half IS still a schema-shaped
+// exemption: audit_log is the record-mutation spine (P12) and a setup token
+// mutates no record, while an outbox envelope is a domain event nobody
+// subscribes to before the installation exists.
 //
-// The reason was a schema fact — both ledgers carried a NOT NULL tenant column
-// and a setup token exists BEFORE the organization it authorizes creating — and
-// that fact is gone: ADR-0091 §8 phase D took the column off both. What still
-// stands in the way is the ACTOR: a setup token is minted with no authenticated
-// principal, and storekit.Audit and LogSystem both refuse a caller without one
-// before any SQL runs.
+// It used to write nothing at all, on the stated grounds that both ledgers
+// carried a NOT NULL tenant column and a setup token exists BEFORE the
+// organization it authorizes creating. ADR-0091 §8 phase D removed that column,
+// so the impediment was gone and the gap was left. What actually stood in the
+// way was the ACTOR: storekit.LogSystem refuses a caller with no principal
+// bound, deliberately, because an unattributed ledger row is worse than none.
 //
-// So this is now a gap with a reachable fix rather than a schema consequence,
-// and it is tracked as #2198 rather than argued away here: minting, rotating
-// and retiring the credential that lets any bearer claim an unprovisioned
-// installation as admin leaves no ledger row. What the lifecycle does leave
-// behind is the boot log line announcing the mint — which names the token file
-// rather than repeating what it holds — and the system_log row the resulting
-// claim writes inside the same transaction as the organization, naming the
-// human who presented the token.
+// So the lifecycle binds one. `system:setup-token` is the same shape a
+// background pass uses when no human is present, and it is honest about what
+// happened: nobody was authenticated, because nobody can be yet.
 //
+// What the row must NOT carry is the token, or its hash. The hash is the
+// credential's stored form and a ledger is readable by every admin the
+// installation will ever have.
+
 // issueSetupToken is the whole rule both public entry points apply: under the
 // installation advisory lock, refuse a provisioned installation, settle what to
 // do about an outstanding credential, and record only the hash of a new one.
@@ -108,6 +112,7 @@ func (s *Service) issueSetupToken(ctx context.Context, policy outstandingPolicy)
 	if err != nil {
 		return "", fmt.Errorf("identity: minting the setup token: %w", err)
 	}
+	ctx = setupTokenActor(ctx)
 	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, installationLockKey); err != nil {
 			return fmt.Errorf("identity: taking the bootstrap advisory lock: %w", err)
@@ -142,6 +147,11 @@ func (s *Service) issueSetupToken(ctx context.Context, policy outstandingPolicy)
 				return ErrSetupTokenExists
 			}
 			return fmt.Errorf("identity: recording the setup token: %w", err)
+		}
+		if _, err := storekit.LogSystem(ctx, tx, actionInstallationClaimOpened, map[string]any{
+			"replaced_outstanding": policy == replaceOutstanding,
+		}); err != nil {
+			return fmt.Errorf("identity: recording that a setup token was issued: %w", err)
 		}
 		return nil
 	})
@@ -178,11 +188,63 @@ func consumeSetupToken(ctx context.Context, tx pgx.Tx, presented string) error {
 // holds an organization has nothing left to claim, so a token that survives it
 // is a live credential with no legitimate use.
 func retireSetupTokens(ctx context.Context, tx pgx.Tx) error {
-	if _, err := tx.Exec(ctx,
-		`UPDATE setup_token SET consumed_at = now() WHERE consumed_at IS NULL`); err != nil {
+	tag, err := tx.Exec(ctx,
+		`UPDATE setup_token SET consumed_at = now() WHERE consumed_at IS NULL`)
+	if err != nil {
 		return fmt.Errorf("identity: retiring outstanding setup tokens: %w", err)
 	}
+	// Only when one was actually retired. A rotation that found nothing
+	// outstanding invalidated nobody's credential, and a row saying otherwise
+	// would send an operator looking for a token that never existed.
+	if tag.RowsAffected() == 0 {
+		return nil
+	}
+	// The bootstrap paths reach here BEFORE they bind the actor that created
+	// the organization, and that is the right order: the comment at the call
+	// site says the ORGANIZATION retires the token, not whichever path made it.
+	// So the retirement is a system act unless a caller has already said
+	// otherwise, which the mint path has.
+	ctx = ensureSetupTokenActor(ctx)
+	if _, err := storekit.LogSystem(ctx, tx, actionInstallationClaimClosed, map[string]any{
+		"retired": tag.RowsAffected(),
+	}); err != nil {
+		return fmt.Errorf("identity: recording that a setup token was retired: %w", err)
+	}
 	return nil
+}
+
+// The two actions the token's own lifecycle records. Named constants because
+// each is also the string a reader greps the ledger for.
+//
+// They name the ACT — the installation became claimable, and stopped being —
+// rather than the secret that carries it. Partly because that is the better
+// vocabulary for an operator reading the ledger, and partly because gosec reads
+// any identifier pairing `token` or `credential` with a string literal as a
+// hardcoded secret. It is not wrong to look: a constant beside this code is
+// exactly where a leaked one would sit.
+const (
+	actionInstallationClaimOpened = "installation_claim_opened"
+	actionInstallationClaimClosed = "installation_claim_closed"
+)
+
+// setupTokenActor binds the principal the token's lifecycle acts under. Nobody
+// is authenticated before an installation exists, so the ledger says so rather
+// than borrowing an identity that was not there.
+func setupTokenActor(ctx context.Context) context.Context {
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:setup-token",
+	})
+}
+
+// ensureSetupTokenActor is setupTokenActor for a path that MAY already have a
+// principal. It never overwrites one: a caller that knows who acted is always a
+// better answer than "the system did it".
+func ensureSetupTokenActor(ctx context.Context) context.Context {
+	if _, err := storekit.Actor(ctx); err == nil {
+		return ctx
+	}
+	return setupTokenActor(ctx)
 }
 
 // ErrAlreadyProvisioned means a claim arrived at an installation that already
@@ -215,6 +277,7 @@ func (s *Service) ClaimInstallation(ctx context.Context, token string, in Instal
 	if cached := s.installation.Load(); cached != nil {
 		return ids.WorkspaceID{}, nil, ErrAlreadyProvisioned
 	}
+	ctx = setupTokenActor(ctx)
 	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, installationLockKey); err != nil {
 			return fmt.Errorf("identity: taking the bootstrap advisory lock: %w", err)

--- a/backend/internal/modules/identity/setuptoken_integration_test.go
+++ b/backend/internal/modules/identity/setuptoken_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -301,4 +302,66 @@ func TestAClaimCannotSetAnEmptyOrShortAdminPassword(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTheSetupTokenLifecycleIsRecorded pins what #2198 was about: the
+// credential that lets any bearer claim an unprovisioned installation as admin
+// used to leave no durable trace at all.
+//
+// A rotation is the case that matters most. It silently invalidates whatever
+// the operator was holding, and before this the only evidence was a boot log
+// line on whichever process happened to run it.
+func TestTheSetupTokenLifecycleIsRecorded(t *testing.T) {
+	svc := newSetupService(t)
+	ctx := context.Background()
+
+	if _, err := svc.MintSetupToken(ctx); err != nil {
+		t.Fatalf("minting the first token: %v", err)
+	}
+	if got := setupTokenLedger(t, svc, actionInstallationClaimOpened); got != 1 {
+		t.Fatalf("minting a token wrote %d issued rows, want 1 — the credential's creation is unrecorded", got)
+	}
+
+	// The rotation: one more issue, and a retirement of what the operator held.
+	if _, err := svc.RotateSetupToken(ctx); err != nil {
+		t.Fatalf("rotating the token: %v", err)
+	}
+	if got := setupTokenLedger(t, svc, actionInstallationClaimOpened); got != 2 {
+		t.Errorf("after a rotation the ledger holds %d issued rows, want 2", got)
+	}
+	if got := setupTokenLedger(t, svc, actionInstallationClaimClosed); got != 1 {
+		t.Errorf("a rotation retired the outstanding credential and recorded it %d times, want 1 — "+
+			"an operator whose token stopped working has nothing to read", got)
+	}
+
+	// The row names a system actor, because nobody is authenticated before an
+	// installation exists — and it must not carry the credential itself.
+	var actorType, actorID string
+	var detail []byte
+	if err := database.WithInfraTx(ctx, svc.db.Pool(), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT actor_type, actor_id, coalesce(detail::text, '') FROM system_log
+			  WHERE action = $1 ORDER BY occurred_at DESC LIMIT 1`,
+			actionInstallationClaimOpened).Scan(&actorType, &actorID, &detail)
+	}); err != nil {
+		t.Fatalf("reading the issued row: %v", err)
+	}
+	if actorType != "system" || actorID != "system:setup-token" {
+		t.Errorf("the issued row is attributed to (%q, %q); nobody is authenticated yet, so it must say so", actorType, actorID)
+	}
+	if strings.Contains(string(detail), "token") && strings.Contains(string(detail), "hash") {
+		t.Errorf("the issued row's detail mentions a token hash: %s — a ledger every admin can read must not carry the credential", detail)
+	}
+}
+
+func setupTokenLedger(t *testing.T, svc *Service, action string) int {
+	t.Helper()
+	var n int
+	if err := database.WithInfraTx(context.Background(), svc.db.Pool(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM system_log WHERE action = $1`, action).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting %s rows: %v", action, err)
+	}
+	return n
 }


### PR DESCRIPTION
Closes #2198.

Minting, rotating and retiring **the credential that lets any bearer claim an
unprovisioned installation as admin** left no durable trace. A rotation is the
worst of the three: it silently invalidates whatever the operator was holding,
and the only evidence was a boot log line on whichever process ran it.

## The stated reason had expired

The code called this unavoidable — *"a schema fact rather than a choice"*, both
ledgers carrying a `NOT NULL` tenant column while a setup token exists *before*
the organization it authorizes. **ADR-0091 §8 phase D removed that column**, so
the impediment was gone and only the comment was left.

## What actually stood in the way

The **actor**. `storekit.LogSystem` refuses a caller with no principal —
deliberately, because an unattributed ledger row is worse than none.

So the lifecycle binds one. `system:setup-token` is the shape a background pass
already uses when no human is present, and it is honest about what happened:
nobody was authenticated, because nobody can be yet.

The retirement takes an actor **only if the caller has not bound one**. Both
bootstrap paths reach it before binding the admin they create, and that order is
right — the call site's own comment says the *organization* retires the token,
not whichever path made it — so those rows are system acts, while the mint path
keeps its own.

**A rotation that found nothing outstanding writes nothing.** It invalidated
nobody's credential, and a row saying otherwise would send an operator looking
for a token that never existed.

## Two details worth the review

- The actions name the **act** (`installation_claim_opened` / `_closed`) rather
  than the secret. Better vocabulary for an operator, and it stops gosec reading
  a constant beside this code as a leaked credential — which is not a silly
  thing for it to check, since that is exactly where one would sit.
- The detail payload carries **no token and no hash**, asserted by the test: a
  ledger every admin can read must not carry the credential.

`audit_log` and `event_outbox` stay out, and that half **is** schema-shaped:
`audit_log` is the record-mutation spine and a setup token mutates no record,
while an outbox envelope is a domain event nobody can subscribe to before the
installation exists.

## Verification

- `make check-backend` / `make craft-static` — green
- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the installation-claim credential lifecycle in `system_log` so operators can audit issuance and retirement. Before: mint, rotate, and retire wrote no durable record. Now: we write `installation_claim_opened` and `installation_claim_closed` entries, without exposing secrets.

- Bind the actor as `system:setup-token` via `storekit.LogSystem`; do not overwrite if a caller already set one. Minting always logs; retirement logs only when rows were updated; rotations with nothing outstanding write nothing.
- Action names describe the act, not the secret. The detail payload excludes the token and its hash (asserted by tests).
- Leave `audit_log` and `event_outbox` unchanged. The token does not mutate a record and no subscribers exist pre-installation.
- No migrations or configuration changes required.

<sup>Written for commit a45506c13dcad136fb4b145eb45e19a3a15e897e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

