### PR TITLE
fix(capture): a sent email files under the deal the rep grounded it in

### DIFF
--- a/frontend/src/screens/compose-links.test.tsx
+++ b/frontend/src/screens/compose-links.test.tsx
@@ -204,32 +204,77 @@ describe("what a sent message files under", () => {
     ]);
   });
 
-  it("never repeats a record the page is already anchored on", async () => {
+  it("keeps a deal whose id happens to match the company's", async () => {
+    // A link is identified by its TYPE and its id together, which is how the
+    // server identifies one. Two records of different kinds live in different
+    // tables and may hold the same uuid; collapsing them on the id alone would
+    // drop the deal here, and the message would be missing from its timeline
+    // with nothing to say why. The shared id is the whole point of the case.
     const sent = stubRoutes({
       "POST /emails": () => jsonResponse(SENT_ACTIVITY, 202),
+      "GET /organizations/shared-id/360": () =>
+        jsonResponse({
+          organization: { id: "shared-id", name: "Acme" },
+          people: { data: [{ person_id: "per-1", full_name: "Dieter Klein" }] },
+          deals: { data: [{ deal_id: "shared-id", name: "Acme Renewal" }] },
+        }),
     });
     render(
       <ComposeModal
         entityType="organization"
-        entityId="org-1"
+        entityId="shared-id"
         personId="per-1"
         open
         onClose={vi.fn()}
       />,
     );
 
-    await screen.findByLabelText("Draft to");
-    // Re-picking the contact the composer opened on is a no-op the rep can
-    // perform, and it must not produce the same person twice on the wire.
-    await pickBy("Draft to", "Dieter Klein");
+    await screen.findByLabelText("Related to");
+    await pickBy("Related to", "Acme Renewal");
     await fillBody();
     await pickBy("Consent purpose", "Deal messages");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(linksOf(sent)).toBeDefined());
-    const ids = (linksOf(sent) as { entity_id: string }[]).map(
-      (l) => l.entity_id,
+    expect(linksOf(sent)).toEqual([
+      { entity_type: "organization", entity_id: "shared-id" },
+      { entity_type: "person", entity_id: "per-1" },
+      { entity_type: "deal", entity_id: "shared-id" },
+    ]);
+  });
+
+  it("files a reply under its own record and adds nothing the rep did not pick", async () => {
+    // A reply grounds on the thread, not the account: the rep chose nothing,
+    // and the recipient is already a participant on the activity being
+    // answered. Anchored sends go to the activity's own endpoint, so the
+    // composed links never reach the wire at all.
+    const sent = stubRoutes({
+      "POST /activities/act-1/send-email": () =>
+        jsonResponse(SENT_ACTIVITY, 202),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="per-1"
+        personId="per-1"
+        open
+        onClose={vi.fn()}
+      />,
     );
-    expect(new Set(ids).size).toBe(ids.length);
+
+    await screen.findByPlaceholderText("Subject");
+    await fillBody();
+    await pickBy("Consent purpose", "Deal messages");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(
+        sent.some((r) => r.key === "POST /activities/act-1/send-email"),
+      ).toBe(true),
+    );
+    // The account-started endpoint is the only one that takes links, and a
+    // reply must never reach it.
+    expect(sent.some((r) => r.key === "POST /emails")).toBe(false);
   });
 });

--- a/frontend/src/screens/compose-links.test.tsx
+++ b/frontend/src/screens/compose-links.test.tsx
@@ -1,0 +1,235 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+
+// What a sent message files under.
+//
+// The grounding controls and the attribution are one statement: a rep who picks
+// "Related to → Acme Renewal" has said what the message is about, and a send
+// that files only under the page's own record throws that away. These tests
+// assert the request body, because the links array IS the contract.
+
+type Sent = { key: string; body: unknown };
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+// The account view the grounding selects are populated from: one contact and
+// two open deals, so a pick is a real choice rather than the only option.
+const ORG_VIEW = {
+  organization: { id: "org-1", name: "Acme" },
+  people: {
+    data: [
+      { person_id: "per-1", full_name: "Dieter Klein" },
+      { person_id: "per-2", full_name: "Sara Vogel" },
+    ],
+  },
+  deals: {
+    data: [
+      { deal_id: "deal-1", name: "Acme Renewal" },
+      { deal_id: "deal-2", name: "Acme Expansion" },
+    ],
+  },
+};
+
+const SENT_ACTIVITY = {
+  id: "act-9",
+  kind: "email",
+  subject: "Hello",
+  occurred_at: "2026-07-01T00:00:00Z",
+  is_done: false,
+  source: "manual",
+  captured_by: "human:u1",
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+};
+
+function stubRoutes(
+  overrides: Record<string, () => Response | Promise<Response>> = {},
+) {
+  const sent: Sent[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.clone().json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      sent.push({ key, body });
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
+      if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      if (key === "GET /organizations/org-1/360") return jsonResponse(ORG_VIEW);
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// The account-started composer carries three dropdowns (recipient, deal,
+// purpose), so each pick names the one it means rather than taking the only
+// combobox on screen.
+async function pickBy(labelText: string, option: string) {
+  const select = screen.getByLabelText(labelText);
+  await pickOption(userEvent.setup(), select, option);
+}
+
+async function fillBody() {
+  await userEvent.type(screen.getByLabelText("To"), "dieter@acme.test");
+  await userEvent.tab();
+  await userEvent.type(screen.getByPlaceholderText("Subject"), "Hello");
+  await userEvent.type(screen.getByPlaceholderText("Body"), "Body content");
+}
+
+function linksOf(sent: Sent[]) {
+  const req = sent.find((r) => r.key === "POST /emails");
+  return (req?.body as { links?: unknown[] } | undefined)?.links;
+}
+
+describe("what a sent message files under", () => {
+  it("sends the deal the rep grounded the draft in, not only the page", async () => {
+    const sent = stubRoutes({
+      "POST /emails": () => jsonResponse(SENT_ACTIVITY, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        personId="per-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByLabelText("Related to");
+    await pickBy("Related to", "Acme Renewal");
+    await fillBody();
+    await pickBy("Consent purpose", "Deal messages");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(linksOf(sent)).toBeDefined());
+    // The deal is the assertion that fails without the fix: before it, the
+    // send carried the organization alone and the deal's timeline never saw
+    // the message the rep wrote about it.
+    expect(linksOf(sent)).toEqual([
+      { entity_type: "organization", entity_id: "org-1" },
+      { entity_type: "person", entity_id: "per-1" },
+      { entity_type: "deal", entity_id: "deal-1" },
+    ]);
+  });
+
+  it("files under the page and the recipient when no deal was chosen", async () => {
+    const sent = stubRoutes({
+      "POST /emails": () => jsonResponse(SENT_ACTIVITY, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        personId="per-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByLabelText("Related to");
+    await fillBody();
+    await pickBy("Consent purpose", "Deal messages");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(linksOf(sent)).toBeDefined());
+    // An unchosen deal is absent, not an empty entry: "no deal" is a real
+    // answer and must not file the message under a blank id.
+    expect(linksOf(sent)).toEqual([
+      { entity_type: "organization", entity_id: "org-1" },
+      { entity_type: "person", entity_id: "per-1" },
+    ]);
+  });
+
+  it("never repeats a record the page is already anchored on", async () => {
+    const sent = stubRoutes({
+      "POST /emails": () => jsonResponse(SENT_ACTIVITY, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        personId="per-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByLabelText("Draft to");
+    // Re-picking the contact the composer opened on is a no-op the rep can
+    // perform, and it must not produce the same person twice on the wire.
+    await pickBy("Draft to", "Dieter Klein");
+    await fillBody();
+    await pickBy("Consent purpose", "Deal messages");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(linksOf(sent)).toBeDefined());
+    const ids = (linksOf(sent) as { entity_id: string }[]).map(
+      (l) => l.entity_id,
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -357,6 +357,44 @@ function useAccountGrounding(
   };
 }
 
+// What a sent message files under: the page it was written from, and every
+// record the rep named while writing it.
+//
+// The anchor alone is not enough. A rep who picks "Related to → Acme Renewal"
+// has said what the message is about, and a send that files only under the
+// organization loses that: the deal's own timeline never sees the message, and
+// nothing downstream can attribute the correspondence to the work it belongs
+// to. The grounding choices ARE the attribution — they are the same statement,
+// so they travel together.
+//
+// Duplicates are dropped rather than sent twice: on a person page the anchor
+// and the recipient are the same record, and the link table treats a repeat as
+// a conflict rather than a no-op.
+//
+// `chosen` is null on a reply, whose links are the thread's own business: the
+// rep picked nothing, and the recipient is already a participant on the
+// activity being answered.
+function composedLinks(
+  anchor: { entityType: RelinkKind; entityId: string },
+  chosen: { recipientId: string; dealId: string } | null,
+): { entity_type: RelinkKind; entity_id: string }[] {
+  const links: { entity_type: RelinkKind; entity_id: string }[] = [
+    { entity_type: anchor.entityType, entity_id: anchor.entityId },
+  ];
+  if (!chosen) {
+    return links;
+  }
+  const add = (kind: RelinkKind, id: string) => {
+    if (!id || links.some((l) => l.entity_id === id)) {
+      return;
+    }
+    links.push({ entity_type: kind, entity_id: id });
+  };
+  add("person", chosen.recipientId);
+  add("deal", chosen.dealId);
+  return links;
+}
+
 // A freeform email-chip input: typed address + Enter/comma (or blur) adds a
 // chip, the X icon removes it. No client-side email regex beyond type=email —
 // the server is the authority (422 on a malformed address), so this never
@@ -1244,7 +1282,12 @@ export function ComposeModal({
         isChannelReply,
         mail,
         channelBody: { body, consent_purpose: purpose },
-        links: [{ entity_type: entityType, entity_id: entityId }],
+        links: composedLinks(
+          { entityType, entityId },
+          groundable
+            ? { recipientId: account.recipientId, dealId: account.dealId }
+            : null,
+        ),
       });
       if (response.status === 501) return { sent: false as const };
       // Only a real 202 is a send. openapi-fetch returns a falsy `error` for a

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -369,7 +369,11 @@ function useAccountGrounding(
 //
 // Duplicates are dropped rather than sent twice: on a person page the anchor
 // and the recipient are the same record, and the link table treats a repeat as
-// a conflict rather than a no-op.
+// a conflict rather than a no-op. A link is identified by BOTH of its fields,
+// the way the server identifies it — matching on the id alone would drop a
+// legitimate second link whenever two records of different kinds happened to
+// share a uuid, and the message would then be missing from that record's
+// timeline with nothing to say why.
 //
 // `chosen` is null on a reply, whose links are the thread's own business: the
 // rep picked nothing, and the recipient is already a participant on the
@@ -385,7 +389,10 @@ function composedLinks(
     return links;
   }
   const add = (kind: RelinkKind, id: string) => {
-    if (!id || links.some((l) => l.entity_id === id)) {
+    const already = links.some(
+      (l) => l.entity_type === kind && l.entity_id === id,
+    );
+    if (!id || already) {
       return;
     }
     links.push({ entity_type: kind, entity_id: id });


### PR DESCRIPTION
Picking **Related to → Acme Renewal** in the composer grounded the draft's prose in that deal and then sent a message linked to the organization alone. The deal's timeline never saw it, so correspondence a rep had explicitly attributed was lost to every downstream reader.

The grounding choices and the attribution are one statement. `composedLinks` now builds the wire links from the page anchor plus the recipient and the deal the rep named, dropping a repeat rather than sending a record twice — on a person page the anchor and the recipient are the same row, and the link table treats a duplicate as a conflict.

A reply passes no choices: the rep picked nothing, and the recipient is already a participant on the activity being answered. That path is unchanged.

## Verification

- `make check-fe` green, `make check-backend` green, `make craft-static` clean (0 blocker / 0 major / 0 minor).
- Three new tests in `frontend/src/screens/compose-links.test.tsx`, asserting the request body because the links array *is* the contract.
- **Mutation-checked**: reverting the fix to the old hardcoded single link fails two of the three, so they prove the behaviour rather than passing for the wrong reason.

Closes #2092

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emails sent from the composer now file under the selected deal as well as the page anchor. Previously we linked only to the organization, so the deal timeline missed the message.

- `composedLinks` builds links from the page anchor, the recipient, and the selected deal; it de-duplicates by (entity_type, entity_id) to avoid conflicts while preserving cross-type records that share an id.
- When no deal is selected, we link only to the anchor and recipient; replies use the activity endpoint and send no links.
- Tests assert the `links` request body, including a shared-id org/deal case and a reply path; no API/DB changes. Addresses #2092.

<sup>Written for commit 6e8d1afffb5487e0adbea794653a96815290c90e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

