### PR TITLE
fix(authz): boot names what an archived organization left behind

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -49,6 +49,9 @@ func recordBootLedger(
 	if err := compose.RecordInstallationRelease(ctx, pool, logger, buildinfo.ReleaseVersion); err != nil {
 		return err
 	}
+	if err := compose.WarnOnArchivedPredecessor(ctx, pool, logger); err != nil {
+		return err
+	}
 	return compose.RecordComposition(ctx, pool, logger, extensions)
 }
 

--- a/backend/internal/compose/archivedpredecessor.go
+++ b/backend/internal/compose/archivedpredecessor.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// An installation that archived a predecessor organization is carrying that
+// organization's rows, and since ADR-0091 §8 phase D nothing can tell them from
+// its own.
+//
+// This is stated at boot because it CANNOT be detected any other way. While the
+// record tables carried a tenant column, a gate could count an archived
+// workspace's rows and refuse; it ran once, at its ordered position, and the
+// operator cleared or accepted what it named. After the column is gone the rows
+// are indistinguishable by construction — there is no residue query left to
+// write. What survives is the one fact that says a merge was possible at all:
+// an archived workspace row.
+//
+// So this WARNS and does not refuse. Refusing would take down installations
+// that archived a predecessor, were told to, accepted the merge and have been
+// serving correctly ever since — punishing them for a decision the product
+// asked them to make. What an operator gets instead is the sentence nobody said
+// at the time: the merge folded credentials and role grants, not just records.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// WarnOnArchivedPredecessor says, once per boot, what an archived organization
+// left behind in this installation.
+func WarnOnArchivedPredecessor(ctx context.Context, pool *pgxpool.Pool, log *slog.Logger) error {
+	var archived int
+	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM workspace WHERE archived_at IS NOT NULL`).Scan(&archived)
+	}); err != nil {
+		return fmt.Errorf("compose: checking for an archived predecessor organization: %w", err)
+	}
+	if archived == 0 {
+		return nil
+	}
+	log.Warn("this installation carries an archived organization's rows, and they are no longer distinguishable from its own",
+		"archived_organizations", archived,
+		"what_merged", "login credentials, sessions and RBAC grants — not only records",
+		"what_to_check", "the roster and every role assignment: a seat from the archived organization "+
+			"authenticates here and holds whatever role it held there",
+		"why_now", "ADR-0091 §8 phase D removed the tenant column, so no query can separate the two")
+	return nil
+}

--- a/backend/internal/compose/integration/archivedpredecessor_integration_test.go
+++ b/backend/internal/compose/integration/archivedpredecessor_integration_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The boot warning is the ONLY thing that can still say a merge happened.
+//
+// While the record tables carried a tenant column, a gate counted an archived
+// workspace's rows and refused. After ADR-0091 §8 phase D the rows are
+// indistinguishable by construction, so there is no residue query left — the
+// surviving signal is the archived workspace row itself, and this suite pins
+// that it is read and said out loud.
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestBootSaysNothingWhenNoOrganizationWasArchived(t *testing.T) {
+	env := Setup(t)
+	var out bytes.Buffer
+
+	if err := compose.WarnOnArchivedPredecessor(context.Background(), env.Pool,
+		slog.New(slog.NewTextHandler(&out, nil))); err != nil {
+		t.Fatalf("WarnOnArchivedPredecessor: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("a clean installation was warned about a merge that never happened:\n%s", out.String())
+	}
+}
+
+func TestBootNamesWhatAnArchivedOrganizationLeftBehind(t *testing.T) {
+	env := Setup(t)
+	ctx := context.Background()
+
+	if _, err := OwnerConn(t).Exec(ctx,
+		`INSERT INTO workspace (id, slug, archived_at) VALUES ($1, $2, now())`,
+		ids.NewV7(), "predecessor"); err != nil {
+		t.Fatalf("seeding the archived predecessor: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := compose.WarnOnArchivedPredecessor(ctx, env.Pool,
+		slog.New(slog.NewTextHandler(&out, nil))); err != nil {
+		t.Fatalf("WarnOnArchivedPredecessor: %v", err)
+	}
+	said := out.String()
+	if said == "" {
+		t.Fatal("an installation carrying an archived organization's rows was told nothing; " +
+			"no other query can find them, so this line is the whole notice")
+	}
+	// What it says matters more than that it said something: an operator who
+	// reads "records merged" will not go and look at the roster.
+	for _, want := range []string{"credentials", "RBAC grants"} {
+		if !strings.Contains(said, want) {
+			t.Errorf("the warning does not mention %q, so it reads as a records-only merge:\n%s", want, said)
+		}
+	}
+	if !strings.Contains(said, "WARN") {
+		t.Errorf("the notice is not at WARN, so a log pipeline filters it away:\n%s", said)
+	}
+}

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -85,6 +85,10 @@ var ratifiedFleetScans = map[string]ratifiedFleetScan{
 		1,
 		"boot path: resolves the singleton organization and refuses to serve when a second exists (ADR-0061 §3) — it IS the workspace authority, not a consumer of it",
 	},
+	"internal/compose/archivedpredecessor.go": {
+		1,
+		"boot path, and it counts ARCHIVED workspaces rather than enumerating live ones: an archived organization's rows merged into this installation when ADR-0091 §8 phase D took the tenant column, and that row is the only surviving evidence a merge happened. It reads the count to say so once and does no tenant work at all",
+	},
 	"internal/modules/capture/registry_connections.go": {
 		1,
 		"collectDue, the due-scan BOTH capture dispatchers drive (gmail_sync via DueConnections, gmail_watch_renew via DueWatches): it enumerates to find due connections it then enqueues one job each for, which is the target shape, not the anti-pattern",


### PR DESCRIPTION
Closes #2026.

An installation that archived a predecessor is carrying that organization's
rows, and since ADR-0091 §8 phase D **nothing can tell them from its own**. The
merge folds **login credentials, sessions and RBAC grants** — not only records —
and the gate that used to guard this said neither half.

## Why this is at boot and not a query somebody runs

While the record tables carried a tenant column, a gate could count an archived
workspace's rows and refuse. It ran **once**, at its ordered position, so an
operator who archived *after* it got nothing.

After the column is gone the rows are **indistinguishable by construction** —
there is no residue query left to write. What survives is the one fact that says
a merge was possible at all: an archived `workspace` row. So that is what this
reads.

## Why it warns rather than refuses

Refusing would take down installations that archived a predecessor **because the
product told them to**, accepted the merge, and have served correctly ever
since. That punishes them for a decision the product asked them to make.

What an operator gets instead is the sentence nobody said at the time, plus
where to look: the roster, where a seat from the archived organization
authenticates and holds whatever role it held there.

I'd flag this as the judgment call in the PR. If you'd rather it refuse and
force an explicit acknowledgement, that is a one-line change — but it should be
a deliberate decision, not something I make on your behalf.

## The test asserts what it says

Not that it said something. An operator who reads "records merged" will not go
and check the roster, so the test pins that the words `credentials` and `RBAC
grants` are both present — and that it is at `WARN`, because a log pipeline
filters anything quieter.

## One gate caught it, correctly

`TestFleetEnumerationOnlyAtRatifiedSites` refused this for reading the workspace
table. It is ratified with the reason: it counts **archived** rows rather than
enumerating live ones, and does no tenant work.

## Verification

- `make check-backend` / `make craft-static` — green
- `make test-integration` — `OK: integration passed with 0 skips (42 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns once at boot when an installation carries rows from an archived predecessor organization, which became indistinguishable after ADR-0091 §8 phase D removed the tenant column. Old behavior: the boot path did not surface this and a prior gate could refuse based on tenant-scoped counts; new behavior: a WARN log at boot names that the merge included credentials, sessions, and RBAC grants, without blocking startup.

- Calls `compose.WarnOnArchivedPredecessor` during boot; counts archived workspaces and, when present, emits a WARN with guidance to check the roster and role assignments.
- Adds integration tests covering the clean case (no log) and asserting the warning content includes “credentials” and “RBAC grants” and is at WARN level.
- Ratifies the fleet-scan exception: counting archived workspaces at boot is allowed and performs no tenant work.

<sup>Written for commit bc9d42e9e1d0f32d468581a3a5a92ce44d388d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup now warns when archived workspaces are detected.
  * Warnings identify potentially merged credentials, sessions, and access permissions that can no longer be separated.

* **Bug Fixes**
  * Boot recording now stops if the archived-workspace check encounters an error.

* **Tests**
  * Added coverage for installations with and without archived workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->