### PR TITLE
feat(records): any meeting can be briefed, and the brief cites its records

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1935,7 +1935,7 @@ export const de = {
   "today.source.nextSteps": "offene Aufgaben",
   "today.source.nextMeeting": "der Kalender",
   "today.source.deals": "Deals",
-  "today.meeting.prepare": "Termin vorbereiten",
+  "today.meeting.prepare": "An die Teilnehmer schreiben",
   "today.source.people": "die Kontakte",
   "today.source.standing": "wer am Zug ist und die Signale",
   "today.source.activities": "was gesprochen wurde",
@@ -5462,6 +5462,8 @@ export const de = {
   "person.research.evidenceOrOmit":
     "KI-unterstützt · nur mit Beleg · ausschließlich öffentliche Informationen",
   "person.meeting.title": "Meeting-Briefing",
+  "person.meeting.brief": "Briefing öffnen",
+  "person.meeting.empty": "Zu diesem Meeting ist noch nichts erfasst.",
   "person.meeting.loading": "Briefing wird zusammengestellt…",
   "person.meeting.assembledNow":
     "Soeben aus den aktuellen Daten zusammengestellt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1963,7 +1963,7 @@ export const en = {
   "today.source.nextSteps": "open tasks",
   "today.source.nextMeeting": "the calendar",
   "today.source.deals": "deals",
-  "today.meeting.prepare": "Prepare meeting",
+  "today.meeting.prepare": "Write to the room",
   "today.source.people": "the contacts",
   "today.source.standing": "whose move it is and the signals",
   "today.source.activities": "what was said",
@@ -5515,6 +5515,8 @@ export const en = {
   "person.research.evidenceOrOmit":
     "AI-assisted · evidence-or-omit · public information only",
   "person.meeting.title": "Meeting brief",
+  "person.meeting.brief": "Brief me",
+  "person.meeting.empty": "There is nothing recorded for this meeting yet.",
   "person.meeting.loading": "Assembling the brief…",
   "person.meeting.assembledNow": "Assembled just now, from the latest data",
   "person.meeting.header": "At a glance",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1918,7 +1918,7 @@ export const vi = {
   "today.source.nextSteps": "công việc đang mở",
   "today.source.nextMeeting": "lịch",
   "today.source.deals": "deal",
-  "today.meeting.prepare": "Chuẩn bị cuộc họp",
+  "today.meeting.prepare": "Viết cho người tham dự",
   "today.source.people": "các liên hệ",
   "today.source.standing": "phía nào cần hành động và các tín hiệu",
   "today.source.activities": "những gì đã trao đổi",
@@ -5413,6 +5413,8 @@ export const vi = {
   "person.research.evidenceOrOmit":
     "Có hỗ trợ AI · có bằng chứng hoặc bỏ qua · chỉ thông tin công khai",
   "person.meeting.title": "Tóm tắt cuộc họp",
+  "person.meeting.brief": "Xem tóm tắt",
+  "person.meeting.empty": "Chưa có gì được ghi lại cho cuộc họp này.",
   "person.meeting.loading": "Đang tổng hợp bản tóm tắt…",
   "person.meeting.assembledNow": "Vừa được tổng hợp từ dữ liệu mới nhất",
   "person.meeting.header": "Tổng quan",

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -516,7 +516,7 @@ describe("the context line, and which record each reading picks", () => {
   // The MOVES half of the merged brief: a booked meeting's own verb renders
   // as a full-bleed row alongside whatever advice the account has, rather
   // than as a sidebar button beside the context tiles.
-  it("offers to prepare a booked meeting as a move row", () => {
+  it("offers to write to the room of a booked meeting as a move row", () => {
     const prepared = vi.fn();
     show(
       {
@@ -530,7 +530,11 @@ describe("the context line, and which record each reading picks", () => {
       },
       { onPrepareMeeting: prepared },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Prepare meeting" }));
+    // The verb names what the button does. It opens the COMPOSER anchored on
+    // the meeting, and there is no meeting brief on the account page to open —
+    // a button reading "Prepare meeting" promised one and delivered a mail
+    // form.
+    fireEvent.click(screen.getByRole("button", { name: "Write to the room" }));
     expect(prepared).toHaveBeenCalledWith("a-1");
   });
 

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -1611,16 +1611,22 @@ export function ChannelReplyAction({
 // `links` to gate on regardless. It is offered unconditionally.
 //
 // It owns the two open states so the timeline mapper stays presentational.
+//
+// `extra` is how a surface adds a verb only it can serve — the person page's
+// meeting brief opens a drawer this file cannot see. It renders before Relink
+// so the row's own subject-matter verbs lead and the corrective ones follow.
 export function TimelineActions({
   activity,
   entityType,
   entityId,
   personId,
+  extra,
 }: Readonly<{
   activity: Activity;
   entityType: RelinkKind;
   entityId: string;
   personId?: string;
+  extra?: (activity: Activity) => ReactNode;
 }>) {
   const t = useT();
   const [relink, setRelink] = useState(false);
@@ -1634,6 +1640,7 @@ export function TimelineActions({
         entityId={entityId}
         personId={personId}
       />
+      {extra?.(activity)}
       <Button small onClick={() => setRelink(true)}>
         {t("compose.relink")}
       </Button>

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -10,12 +10,15 @@ import {
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { ENTITY, isEntityKind } from "../app/entity";
+import { navigate } from "../app/router";
 import { Badge, Button, Modal, TextInput } from "../design-system/atoms";
 import { RichText } from "../design-system/richtext";
 import { Select } from "../design-system/select";
 import { webUrl } from "../format/weburl";
 import { useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
+import { SentenceList } from "./company360";
 import { refusalOf, SendRefusal, scheduleFields } from "./compose";
 import { useConsentPurposes } from "./consent";
 import { PersonProviderSection } from "./personprovider";
@@ -973,6 +976,16 @@ export function PersonResearchDrawer({
 
 // --- The meeting brief -----------------------------------------------------
 
+// A cited deal or contact goes to its own screen. The brief's other citation
+// kind is the meeting activity itself, which has no screen and is rendered
+// flat by the shared Citations — so this is only ever called for the two that
+// route, and an unroutable kind is left where it is rather than guessed at.
+function openCitedRecord(entityType: string, entityId: string) {
+  if (isEntityKind(entityType)) {
+    navigate(ENTITY[entityType].route(entityId));
+  }
+}
+
 export function PersonMeetingBrief({
   activityId,
   open,
@@ -1017,6 +1030,16 @@ export function PersonMeetingBrief({
         {brief.isLoading && (
           <p className="pe-prose">{t("person.meeting.loading")}</p>
         )}
+        {/* A failed read says so here rather than throwing the whole page to
+            the error boundary: the reader is minutes from a room, and losing
+            the record behind the drawer costs them the context they opened it
+            for. */}
+        {brief.isError && (
+          <p className="pe-prose">{problemMessageOf(brief.error, t)}</p>
+        )}
+        {brief.isSuccess && brief.data.sections.length === 0 && (
+          <p className="pe-prose">{t("person.meeting.empty")}</p>
+        )}
         {brief.data?.sections.map((section) => (
           <section className="pe-brief-section" key={section.kind}>
             {/* h3 for the same reason as the composer's own section above: the
@@ -1024,11 +1047,14 @@ export function PersonMeetingBrief({
             <h3 className="pe-section-title">
               {t(`person.meeting.${section.kind}` as never)}
             </h3>
-            {section.sentences.map((sentence) => (
-              <p className="pe-prose" key={sentence.text}>
-                {sentence.text}
-              </p>
-            ))}
+            {/* The account brief's own renderer. The meeting brief carries the
+                same sentence shape — text, nature, evidence — and rendering it
+                a second way here is how one product grows two spellings of a
+                citation. */}
+            <SentenceList
+              sentences={section.sentences}
+              onOpenRecord={openCitedRecord}
+            />
           </section>
         ))}
       </div>

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -385,3 +385,78 @@ describe("the page's one primary action", () => {
     expect(screen.queryByText(CONSENT_REFUSED)).toBeNull();
   });
 });
+
+// The seam the meeting brief regressed at: the page decides WHICH meeting the
+// drawer briefs. Mounting the tab alone proves only that a callback fires with
+// an id — the page could still ignore it and ask for the next meeting, which
+// is exactly the bug the drawer used to have. So this asserts the URL that
+// actually goes out.
+describe("which meeting the brief drawer asks about", () => {
+  const heldMeeting = {
+    id: "a-held",
+    kind: "meeting" as const,
+    subject: "Depot walkthrough",
+    occurred_at: "2026-08-09T08:00:00Z",
+    is_done: false,
+    ...CAPTURED,
+  };
+
+  const withMeetings: Person360 = {
+    ...view,
+    activities: { data: [heldMeeting], page: { has_more: false } },
+    next_meeting: {
+      activity_id: "a-booked",
+      starts_at: "2026-08-20T13:00:00Z",
+      subject: "Contract review",
+      participants: [{ person_id: "p-1", full_name: "Dana Buyer" }],
+    },
+  };
+
+  it("requests the brief for the meeting the reader picked", async () => {
+    const asked: string[] = [];
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"], activity: ["read"] }),
+      "GET /people/p-1/360": () => jsonResponse(withMeetings),
+      "GET /people/p-1/brief": () =>
+        jsonResponse({
+          person_id: "p-1",
+          sentences: [],
+          generated_by: "rules",
+        }),
+      "GET /people/p-1/consent/guard": () =>
+        jsonResponse({ person_id: "p-1", entries: [] }),
+      "GET /channel-providers": () => jsonResponse({ data: [] }),
+      "GET /activities/a-held/meeting-brief": () => {
+        asked.push("a-held");
+        return jsonResponse({
+          activity_id: "a-held",
+          generated_at: "2026-08-13T09:00:00Z",
+          generated_by: "deterministic",
+          sections: [],
+        });
+      },
+      "GET /activities/a-booked/meeting-brief": () => {
+        asked.push("a-booked");
+        return jsonResponse({
+          activity_id: "a-booked",
+          generated_at: "2026-08-13T09:00:00Z",
+          generated_by: "deterministic",
+          sections: [],
+        });
+      },
+    });
+    render(
+      <StoryProviders>
+        <PersonPageV2 id="p-1" tab="meetings" />
+      </StoryProviders>,
+    );
+
+    const actions = await screen.findAllByRole("button", { name: "Brief me" });
+    // The booked meeting leads the tab and the held one follows it, so the
+    // second verb is the one that used to be unreachable.
+    await userEvent.setup().click(actions[1]);
+
+    await waitFor(() => expect(asked.length).toBe(1));
+    expect(asked).toEqual(["a-held"]);
+  });
+});

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -108,14 +108,26 @@ function PersonTabPanel({
   tab,
   personId,
   view,
-}: Readonly<{ tab: PersonTab; personId: string; view: Person360 }>) {
+  onBriefMeeting,
+}: Readonly<{
+  tab: PersonTab;
+  personId: string;
+  view: Person360;
+  onBriefMeeting: (activityId: string) => void;
+}>) {
   switch (tab) {
     case "timeline":
-      return <PersonTimelineTab personId={personId} view={view} />;
+      return (
+        <PersonTimelineTab
+          personId={personId}
+          view={view}
+          onBriefMeeting={onBriefMeeting}
+        />
+      );
     case "deals":
       return <PersonDealsTab view={view} />;
     case "meetings":
-      return <PersonMeetingsTab view={view} />;
+      return <PersonMeetingsTab view={view} onBriefMeeting={onBriefMeeting} />;
     case "research":
       return <PersonResearchTab view={view} />;
     case "documents":
@@ -250,7 +262,15 @@ export function PersonPageV2({
         setDrawer("research");
         return;
       case "meeting_brief":
-        setDrawer("meeting");
+        // The prep moment is raised off the next meeting, so that is the one
+        // it briefs. An action naming its own activity is honoured over the
+        // page's, because a moment about a different meeting must not open a
+        // brief about this one.
+        setDrawer(
+          meetingDrawer(
+            destination.entity_id ?? view.data.next_meeting?.activity_id,
+          ),
+        );
         return;
       case "record":
         if (destination.entity_id) {
@@ -348,7 +368,12 @@ export function PersonPageV2({
           </div>
         )}
 
-        <PersonTabPanel tab={tab} personId={id} view={view.data} />
+        <PersonTabPanel
+          tab={tab}
+          personId={id}
+          view={view.data}
+          onBriefMeeting={(activityId) => setDrawer(meetingDrawer(activityId))}
+        />
         <PersonComposer
           personId={id}
           view={view.data}
@@ -365,8 +390,8 @@ export function PersonPageV2({
           onClose={() => setDrawer(null)}
         />
         <PersonMeetingBrief
-          activityId={view.data.next_meeting?.activity_id ?? null}
-          open={drawer === "meeting"}
+          activityId={briefingMeeting(drawer)}
+          open={briefingMeeting(drawer) !== null}
           onClose={() => setDrawer(null)}
         />
       </RecordView>
@@ -376,7 +401,30 @@ export function PersonPageV2({
 
 // Which drawer is open. Null is the ordinary state — the page is the thing the
 // reader is looking at, and a drawer is a detour from it.
-type Drawer = "composer" | "research" | "meeting" | null;
+//
+// The meeting brief names the meeting it is briefing. It used to be a bare
+// "meeting" that always read `next_meeting`, which made a working feature
+// reachable only for the soonest meeting and only while the prep moment was
+// live — every other meeting on the record had a brief the backend would
+// happily assemble and no way to ask for it.
+type Drawer =
+  | "composer"
+  | "research"
+  | { kind: "meeting"; activityId: string }
+  | null;
+
+// The brief the prep moment opens is the one for the next meeting; a timeline
+// row names its own. Both go through here so the drawer has one shape.
+function meetingDrawer(activityId: string | null | undefined): Drawer {
+  return activityId ? { kind: "meeting", activityId } : null;
+}
+
+// Which meeting the open drawer is briefing, or null when it is not the brief.
+function briefingMeeting(drawer: Drawer): string | null {
+  return typeof drawer === "object" && drawer?.kind === "meeting"
+    ? drawer.activityId
+    : null;
+}
 
 // The header's second line: what this person does, and where. The company is a
 // link because it is a record of its own, not a label.

--- a/frontend/src/screens/persontabs.test.tsx
+++ b/frontend/src/screens/persontabs.test.tsx
@@ -184,6 +184,37 @@ describe("the meetings tab", () => {
     expect(briefed.length).toBe(1);
   });
 
+  it("offers no brief for a meeting the reader may find but not read", () => {
+    // The timeline carries discoverable-but-withheld rows on purpose, so the
+    // reader knows a conversation happened. The brief endpoint applies the
+    // stricter content gate, so a verb here would promise what their own grant
+    // refuses — and answer 404 when they took it up.
+    const withWithheld: Person360 = {
+      ...view,
+      activities: {
+        data: [
+          activity({
+            id: "a-secret",
+            kind: "meeting",
+            subject: "Board session",
+            occurred_at: "2026-08-10T08:00:00Z",
+            content_state: "withheld",
+          }),
+        ],
+        page: { has_more: false },
+      },
+      next_meeting: undefined,
+    };
+    withProviders(
+      <PersonMeetingsTab view={withWithheld} onBriefMeeting={() => {}} />,
+    );
+    // The row is DRAWN — the reader learns a meeting happened — and carries no
+    // verb. Asserting the subject would be wrong: a withheld row redacts it,
+    // which is the whole point of the state.
+    expect(screen.queryByText(/Nothing logged/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Brief me" })).toBeNull();
+  });
+
   it("offers no brief when the surface cannot open one", () => {
     // Without the callback the verb would be a button that does nothing, which
     // teaches a reader the feature is broken rather than absent.

--- a/frontend/src/screens/persontabs.test.tsx
+++ b/frontend/src/screens/persontabs.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../api/schema";
@@ -164,5 +165,45 @@ describe("the meetings tab", () => {
     // filter that let it through here would make this tab a second, worse
     // spelling of that one.
     expect(screen.queryByText("Fleet renewal")).toBeNull();
+  });
+
+  it("offers a brief for the booked meeting and for one already held", async () => {
+    // The backend assembles a brief for ANY meeting activity. Reaching it only
+    // through the next meeting's prep moment left every other meeting on the
+    // record with a brief nothing could ask for.
+    const briefed: string[] = [];
+    withProviders(
+      <PersonMeetingsTab
+        view={view}
+        onBriefMeeting={(id) => briefed.push(id)}
+      />,
+    );
+    const actions = screen.getAllByRole("button", { name: "Brief me" });
+    expect(actions.length).toBe(2);
+    await userEvent.setup().click(actions[0]);
+    expect(briefed.length).toBe(1);
+  });
+
+  it("offers no brief when the surface cannot open one", () => {
+    // Without the callback the verb would be a button that does nothing, which
+    // teaches a reader the feature is broken rather than absent.
+    withProviders(<PersonMeetingsTab view={view} />);
+    expect(screen.queryByRole("button", { name: "Brief me" })).toBeNull();
+  });
+
+  it("names the meeting the reader picked, not the soonest one", async () => {
+    // The defect this replaces: the drawer always read next_meeting, so a
+    // brief opened from a past meeting described a different room.
+    const briefed: string[] = [];
+    withProviders(
+      <PersonMeetingsTab
+        view={view}
+        onBriefMeeting={(id) => briefed.push(id)}
+      />,
+    );
+    const actions = screen.getAllByRole("button", { name: "Brief me" });
+    // The booked meeting leads the tab; the held one follows it.
+    await userEvent.setup().click(actions[1]);
+    expect(briefed).toEqual(["a-2"]);
   });
 });

--- a/frontend/src/screens/persontabs.tsx
+++ b/frontend/src/screens/persontabs.tsx
@@ -1,7 +1,7 @@
 import type { components } from "../api/schema";
 import { navigate } from "../app/router";
 import { activityTimeline } from "../design-system/activitytimeline";
-import { Avatar } from "../design-system/atoms";
+import { Avatar, Button } from "../design-system/atoms";
 import { GroupedTimelineList } from "../design-system/composed";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
@@ -14,6 +14,7 @@ import { formatDateTime } from "../format/format";
 import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { useViewerId } from "./common";
+import { TimelineActions } from "./compose";
 import { PersonCommercialCard, readableRole } from "./personcards";
 import {
   CHRONOLOGY_EMPTY_KEYS,
@@ -55,7 +56,15 @@ export function PersonTimelineTab({
   personId,
   view,
   loading = false,
-}: Readonly<{ personId: string; view?: Person360; loading?: boolean }>) {
+  onBriefMeeting,
+}: Readonly<{
+  personId: string;
+  view?: Person360;
+  loading?: boolean;
+  // Opens the pre-meeting brief for one meeting row. The drawer lives on the
+  // page, so the tab asks rather than renders it.
+  onBriefMeeting?: (activityId: string) => void;
+}>) {
   const t = useT();
   const [filter, setFilter] = useChronologyFilter(personId);
   const logged = view?.activities?.data ?? [];
@@ -66,6 +75,20 @@ export function PersonTimelineTab({
     filter,
     activities: logged,
     activitiesHaveMore: hasMore,
+    renderActions: (activity) => (
+      <TimelineActions
+        activity={activity}
+        entityType="person"
+        entityId={personId}
+        personId={personId}
+        extra={(row) => (
+          <MeetingBriefAction
+            activityId={row.kind === "meeting" ? row.id : null}
+            onBriefMeeting={onBriefMeeting}
+          />
+        )}
+      />
+    ),
   });
   return (
     <Panel
@@ -198,6 +221,31 @@ export function PersonDealsTab({
 
 // --- Meetings ---------------------------------------------------------------
 
+// The brief verb for one meeting, booked or already held — the backend
+// assembles a brief for any meeting activity, and reading one afterwards is
+// how a reader recovers what a room agreed.
+//
+// It narrows the id in one place, where the caller's optional prop and the
+// record's nullable field can both be checked: absent when either is missing,
+// which is the same "no brief to open" answer arriving from two directions.
+function MeetingBriefAction({
+  activityId,
+  onBriefMeeting,
+}: Readonly<{
+  activityId: string | null | undefined;
+  onBriefMeeting?: (activityId: string) => void;
+}>) {
+  const t = useT();
+  if (!activityId || !onBriefMeeting) {
+    return null;
+  }
+  return (
+    <Button small onClick={() => onBriefMeeting(activityId)}>
+      {t("person.meeting.brief")}
+    </Button>
+  );
+}
+
 /**
  * PersonMeetingsTab puts the meeting that has not happened yet above the ones
  * that have. The booked meeting is the server's own next-meeting read, taken
@@ -207,7 +255,12 @@ export function PersonDealsTab({
 export function PersonMeetingsTab({
   view,
   loading = false,
-}: Readonly<{ view?: Person360; loading?: boolean }>) {
+  onBriefMeeting,
+}: Readonly<{
+  view?: Person360;
+  loading?: boolean;
+  onBriefMeeting?: (activityId: string) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const viewerId = useViewerId();
@@ -245,6 +298,10 @@ export function PersonMeetingsTab({
                 <p className="pe-brief-line">
                   {formatDateTime(next.starts_at, locale, RECORD_ZONE)}
                 </p>
+                <MeetingBriefAction
+                  activityId={next.activity_id}
+                  onBriefMeeting={onBriefMeeting}
+                />
                 {next.participants && next.participants.length > 0 && (
                   <>
                     <Eyebrow as="h3">
@@ -276,7 +333,15 @@ export function PersonMeetingsTab({
             emptyLabel={t("person.meetings.noneLogged")}
           >
             <GroupedTimelineList
-              groups={groupChronology(activityTimeline(met, viewerId), hasMore)}
+              groups={groupChronology(
+                activityTimeline(met, viewerId, (activity) => (
+                  <MeetingBriefAction
+                    activityId={activity.id}
+                    onBriefMeeting={onBriefMeeting}
+                  />
+                )),
+                hasMore,
+              )}
               zone={RECORD_ZONE}
             />
           </SurfaceState>

--- a/frontend/src/screens/persontabs.tsx
+++ b/frontend/src/screens/persontabs.tsx
@@ -82,10 +82,7 @@ export function PersonTimelineTab({
         entityId={personId}
         personId={personId}
         extra={(row) => (
-          <MeetingBriefAction
-            activityId={row.kind === "meeting" ? row.id : null}
-            onBriefMeeting={onBriefMeeting}
-          />
+          <MeetingBriefAction activity={row} onBriefMeeting={onBriefMeeting} />
         )}
       />
     ),
@@ -225,20 +222,32 @@ export function PersonDealsTab({
 // assembles a brief for any meeting activity, and reading one afterwards is
 // how a reader recovers what a room agreed.
 //
-// It narrows the id in one place, where the caller's optional prop and the
-// record's nullable field can both be checked: absent when either is missing,
-// which is the same "no brief to open" answer arriving from two directions.
+// Every reason NOT to offer it is decided here rather than at each call site,
+// because a third caller that forgets one of them ships a button that fails:
+//
+//   - no id, or a surface with no drawer to open — nothing to ask for.
+//   - a row that is not a meeting — the endpoint answers 404 for any other
+//     kind, by design.
+//   - a meeting the reader may DISCOVER but not READ. The timeline carries
+//     those deliberately, as `content_state: "withheld"`, so the reader knows
+//     a conversation happened without seeing it. The brief endpoint applies
+//     the stricter content gate, so offering the verb here would promise a
+//     reader something their own grant refuses.
 function MeetingBriefAction({
-  activityId,
+  activity,
   onBriefMeeting,
 }: Readonly<{
-  activityId: string | null | undefined;
+  activity: Pick<Activity, "id" | "kind" | "content_state"> | undefined;
   onBriefMeeting?: (activityId: string) => void;
 }>) {
   const t = useT();
-  if (!activityId || !onBriefMeeting) {
+  if (!activity?.id || !onBriefMeeting) {
     return null;
   }
+  if (activity.kind !== "meeting" || activity.content_state === "withheld") {
+    return null;
+  }
+  const activityId = activity.id;
   return (
     <Button small onClick={() => onBriefMeeting(activityId)}>
       {t("person.meeting.brief")}
@@ -264,8 +273,15 @@ export function PersonMeetingsTab({
   const t = useT();
   const { locale } = useLocale();
   const viewerId = useViewerId();
+  // The booked meeting is drawn above, from the server's own next-meeting
+  // read. It is also an activity, so an unfiltered list draws it a second time
+  // under "already held" — which was merely untidy while the rows were inert
+  // and becomes two identical brief buttons for one room now that they carry a
+  // verb.
+  const booked = view?.next_meeting?.activity_id;
   const met = (view?.activities?.data ?? []).filter(
-    (activity: Activity) => activity.kind === "meeting",
+    (activity: Activity) =>
+      activity.kind === "meeting" && activity.id !== booked,
   );
   const hasMore = view?.activities?.page.has_more ?? false;
   const past = sectionState(
@@ -298,8 +314,13 @@ export function PersonMeetingsTab({
                 <p className="pe-brief-line">
                   {formatDateTime(next.starts_at, locale, RECORD_ZONE)}
                 </p>
+                {/* next_meeting carries no content_state because the 360
+                    withholds the whole section rather than a redacted row, so
+                    a booked meeting the reader can see here is one they can
+                    read. The kind is stated for the same reason: this section
+                    IS the meeting. */}
                 <MeetingBriefAction
-                  activityId={next.activity_id}
+                  activity={{ id: next.activity_id, kind: "meeting" }}
                   onBriefMeeting={onBriefMeeting}
                 />
                 {next.participants && next.participants.length > 0 && (
@@ -336,7 +357,7 @@ export function PersonMeetingsTab({
               groups={groupChronology(
                 activityTimeline(met, viewerId, (activity) => (
                   <MeetingBriefAction
-                    activityId={activity.id}
+                    activity={activity}
                     onBriefMeeting={onBriefMeeting}
                   />
                 )),


### PR DESCRIPTION
Three defects in the pre-meeting brief, all pre-existing, all found while planning project scope for it.

## You could only ever brief the next meeting

The drawer was hardwired to `next_meeting`, and the only way in was the `meeting_prep` moment — which fires only inside **72 hours**. Clicking any other meeting could not open a brief, and outside that window there was no path at all. The backend has always accepted any meeting's activity id.

The drawer now carries the meeting it is briefing. The Meetings tab offers the verb on the booked meeting and on every one already held; the timeline offers it on meeting rows through a new `extra` slot on `TimelineActions`.

## The citations were computed and thrown away

Every sentence carries `evidence` with entity ids, and the backend drops any sentence whose citations do not resolve — `doc.go` is built around "every sentence is cited or dropped". The drawer rendered `sentence.text` into a `<p>` and never read `evidence`. `nature` was ignored too, so an assessment looked identical to a fact.

It now renders through **`SentenceList`**, the account brief's own renderer, which already does both. Writing a second one here is how a product grows two spellings of a citation. Cited deals and contacts route to their screens; the meeting activity itself renders flat, which the shared `Citations` already decided and documents.

## No error state, no empty state

A failed read relied on the error boundary, taking the record behind the drawer with it — the reader is minutes from a room. A brief whose sections all dropped out rendered a blank body between the title and the footer. Both now say what happened.

## Also

`Prepare meeting` on the account page is wired to `onCompose` and opens the composer. There is no account-side brief for it to open, so the label now says what the button does.

## Verification

- `make check-fe` green, `make craft-static` clean (0/0/0).
- Three new tests in `persontabs.test.tsx`.
- **Mutation-checked**: regressing the row action to always pass `next_meeting` fails "names the meeting the reader picked, not the soonest one" — the exact defect this fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Any meeting can be briefed, and the brief cites its records. Previously only the next meeting’s 72‑hour prep moment opened a plain‑text brief; now the drawer targets the selected meeting, “Brief me” appears on booked and past meetings, and the verb hides on discoverable‑but‑withheld rows.

- Drawer carries { kind: "meeting", activityId }. The prep moment still opens the next meeting; Meetings and timeline rows pass their own id. The page honors an action’s meeting id over the page default.
- Renders via `SentenceList`: cited deals/contacts navigate to their records; unresolved citations drop the sentence; judgments are distinct from facts.
- Error and empty states render inline in the drawer, not via the page’s error boundary.
- Timeline and Meetings: `TimelineActions` accepts an `extra` slot; `MeetingBriefAction` centralizes gating (only meetings, not withheld, requires a handler). The Meetings tab removes the booked meeting from the past list to avoid duplicate verbs.
- Account page button now reads “Write to the room” and opens the composer.
- Tests cover verb presence in Meetings, correct meeting targeting, withheld gating, absence without a handler, and a page‑level assertion that the brief requests the meeting the reader picked; i18n updated (en/de/vi).

<sup>Written for commit d2965b40a5df4e716184ed4f1a7de8c18bc94b41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

