### PR TITLE
feat(records): a context read can be narrowed to one body of work

### DIFF
--- a/backend/internal/compose/integration/activity_projectscope_integration_test.go
+++ b/backend/internal/compose/integration/activity_projectscope_integration_test.go
@@ -5,120 +5,175 @@
 
 package integration
 
-// Narrowing a timeline read to ONE body of work.
+// Narrowing a read to ONE body of work, on both surfaces that carry it: the
+// timeline list, and the context walk every assembled picture is built from.
 //
-// The rule is exclusion rather than selection, and the negative half is the
-// one worth testing: a scope that only proved the wanted rows appear would
-// pass against a filter that does nothing at all. So every case here asserts
-// what is ABSENT as well as what is present.
+// The rule is "filed under this project, or filed under none". The NEGATIVE
+// half is what these prove — a test asserting only that the wanted rows appear
+// would pass against a filter that does nothing at all, which is the failure
+// mode a predicate like this actually has.
 
 import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/retrieval"
 )
 
-// projectScopeFixture is one account running two engagements plus ordinary
-// correspondence that belongs to neither — the shape the exclusion exists for.
-type projectScopeFixture struct {
-	org     ids.UUID
+// scopeFixture is one account running two engagements, plus ordinary
+// correspondence belonging to neither — the shape the rule exists for.
+type scopeFixture struct {
 	person  ids.UUID
 	erp     ids.ProjectID
-	migrate ids.ProjectID
-	onERP   ids.UUID
-	onOther ids.UUID
-	unfiled ids.UUID
+	onERP   string
+	onOther string
+	unfiled string
 }
 
-func seedTwoProjectAccount(t *testing.T, e *Env) projectScopeFixture {
+// Everything here is written by the REAL writers — CreateProject, LogActivity
+// and RelinkActivity — each through its own authority check and the audit +
+// outbox write shape. Hand-inserted rows would let the filter pass over a row
+// shape production never produces.
+func seedTwoEngagementAccount(t *testing.T, e *Env) scopeFixture {
 	t.Helper()
-	owner := OwnerConn(t)
+	admin := e.Admin()
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	person := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 
-	newProject := func(name string) ids.UUID {
-		return SeedIDRow(t, owner, `INSERT INTO project (id, owner_id, name, organization_id, source, captured_by)
-			VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, e.Rep1, name, org)
+	newProject := func(name, key string) ids.ProjectID {
+		p, err := e.Deals.CreateProject(admin, deals.CreateProjectInput{
+			Name: name, Key: &key, OrganizationID: orgIDOf(org), Source: "manual",
+		})
+		if err != nil {
+			t.Fatalf("create project %q: %v", name, err)
+		}
+		return projectIDOf(ids.UUID(p.Id))
 	}
-	erp := newProject("ERP rollout")
-	migrate := newProject("Datacentre migration")
+	erp := newProject("ERP rollout", "ERP-27")
+	migration := newProject("Datacentre migration", "DC-4")
 
-	// Three messages with the same counterpart: one about each engagement, and
-	// one ordinary exchange nobody filed. All three are linked to the person,
-	// which is what a person-anchored read walks.
-	mail := func(subject string) ids.UUID {
-		id := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
-			VALUES ($1, 'email', $2, now(), 'manual', 'human:x')`, subject)
-		LinkActivity(t, owner, id, "person", person)
-		return id
+	// Three exchanges with the same contact: one per engagement, and one
+	// ordinary message nobody filed.
+	mail := func(subject string, within *ids.ProjectID) string {
+		logged, _, err := e.Activities.LogActivity(admin, activities.LogActivityInput{
+			Kind: "email", Subject: &subject, Direction: strPtr("inbound"),
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+		})
+		if err != nil {
+			t.Fatalf("log %q: %v", subject, err)
+		}
+		if within != nil {
+			id := ids.From[ids.ActivityKind](ids.UUID(logged.Id))
+			if _, err := e.Activities.RelinkActivity(admin, id, activities.RelinkActivityInput{
+				EntityType: "project", EntityID: within.UUID,
+			}); err != nil {
+				t.Fatalf("file %q under its project: %v", subject, err)
+			}
+		}
+		return ids.UUID(logged.Id).String()
 	}
-	onERP := mail("ERP cutover plan")
-	onOther := mail("Rack decommissioning")
-	unfiled := mail("Invoice question")
 
-	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
-		VALUES ($1, 'project', $2)`, onERP, erp)
-	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
-		VALUES ($1, 'project', $2)`, onOther, migrate)
-
-	return projectScopeFixture{
-		org: org, person: person,
-		erp: projectIDOf(erp), migrate: projectIDOf(migrate),
-		onERP: onERP, onOther: onOther, unfiled: unfiled,
+	return scopeFixture{
+		person: person, erp: erp,
+		onERP:   mail("ERP cutover plan", &erp),
+		onOther: mail("Rack decommissioning", &migration),
+		unfiled: mail("Invoice question", nil),
 	}
 }
 
 func TestTimelineScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
 	e := Setup(t)
-	f := seedTwoProjectAccount(t, e)
-	admin := e.Admin()
+	f := seedTwoEngagementAccount(t, e)
 
 	person := string(datasource.RecordPerson)
-	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{
-		EntityType:      &person,
-		EntityID:        &f.person,
-		WithinProjectID: &f.erp,
+	got, _, err := e.Activities.ListActivities(e.Admin(), activities.ListActivitiesInput{
+		EntityType: &person, EntityID: &f.person, WithinProjectID: &f.erp,
 	})
 	if err != nil {
 		t.Fatalf("list within project: %v", err)
 	}
-
 	seen := map[string]bool{}
 	for _, a := range got {
 		seen[a.Id.String()] = true
 	}
-	// The negative assertion is the one that fails when the predicate does
-	// nothing, which is the failure mode a scope has.
-	if seen[f.onOther.String()] {
+
+	if seen[f.onOther] {
 		t.Error("the other engagement's mail survived a scoped read — the scope filtered nothing")
 	}
-	if !seen[f.onERP.String()] {
+	if !seen[f.onERP] {
 		t.Error("the scoped project's own mail is missing")
 	}
-	// Attribution is optional, so unfiled correspondence is the account's
-	// general history and must survive. Dropping it would leave a brief
-	// reading as though the relationship had no past.
-	if !seen[f.unfiled.String()] {
-		t.Error("correspondence filed under NO project was dropped; the scope excludes other projects, not everything unattributed")
+	// Attribution is optional, so unfiled mail is the account's general
+	// history. Dropping it would leave a brief reading as though the
+	// relationship had no past.
+	if !seen[f.unfiled] {
+		t.Error("mail filed under NO project was dropped; the rule keeps it")
 	}
 }
 
 func TestTimelineWithoutAScopeStillSeesEveryEngagement(t *testing.T) {
 	e := Setup(t)
-	f := seedTwoProjectAccount(t, e)
-	admin := e.Admin()
+	f := seedTwoEngagementAccount(t, e)
 
 	person := string(datasource.RecordPerson)
-	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{
-		EntityType: &person,
-		EntityID:   &f.person,
+	got, _, err := e.Activities.ListActivities(e.Admin(), activities.ListActivitiesInput{
+		EntityType: &person, EntityID: &f.person,
 	})
 	if err != nil {
 		t.Fatalf("list unscoped: %v", err)
 	}
 	if len(got) != 3 {
-		t.Fatalf("unscoped timeline = %d rows, want all 3 — an absent scope must narrow nothing", len(got))
+		t.Fatalf("unscoped timeline = %d rows, want 3 — an absent scope narrows nothing", len(got))
+	}
+}
+
+// The context walk carries its OWN copy of the predicate, in another module a
+// module may not import (ADR-0054). A test of the timeline list alone would
+// pass with this half absent — and this is the half every assembled picture
+// reads, so catch_me_up_on and prep_for_meeting hang off it.
+func TestAssembledContextScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	// AssembleContext embeds nothing — only Search does — so the walk needs no
+	// embedder to answer.
+	retriever := search.NewRetriever(search.NewStore(harnessDB(e.Pool, e.WS)), nil)
+	anchor := datasource.EntityRef{Type: datasource.EntityPerson, ID: f.person}
+
+	idsIn := func(opts retrieval.AssembleOptions) map[string]bool {
+		t.Helper()
+		got, err := retriever.AssembleContext(e.Admin(), anchor, opts)
+		if err != nil {
+			t.Fatalf("assemble: %v", err)
+		}
+		out := map[string]bool{}
+		for _, section := range got.Sections {
+			for _, item := range section.Items {
+				out[item.Ref.ID.String()] = true
+			}
+		}
+		return out
+	}
+
+	scoped := idsIn(retrieval.AssembleOptions{MaxItems: 25, ProjectID: f.erp.String()})
+	if scoped[f.onOther] {
+		t.Error("the context walk carried the other engagement into a scoped picture")
+	}
+	if !scoped[f.onERP] {
+		t.Error("the scoped project's own mail is missing from the walk")
+	}
+	if !scoped[f.unfiled] {
+		t.Error("the walk dropped mail filed under no project; the rule keeps it")
+	}
+
+	// The same anchor unscoped still sees everything, so the narrowing above is
+	// the scope's doing rather than something else in the walk quietly losing a
+	// row — which would make the assertions pass for the wrong reason.
+	wide := idsIn(retrieval.AssembleOptions{MaxItems: 25})
+	if !wide[f.onOther] {
+		t.Error("an unscoped walk lost the other engagement, so the scoped one proves nothing")
 	}
 }

--- a/backend/internal/compose/integration/activity_projectscope_integration_test.go
+++ b/backend/internal/compose/integration/activity_projectscope_integration_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Narrowing a timeline read to ONE body of work.
+//
+// The rule is exclusion rather than selection, and the negative half is the
+// one worth testing: a scope that only proved the wanted rows appear would
+// pass against a filter that does nothing at all. So every case here asserts
+// what is ABSENT as well as what is present.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// projectScopeFixture is one account running two engagements plus ordinary
+// correspondence that belongs to neither — the shape the exclusion exists for.
+type projectScopeFixture struct {
+	org     ids.UUID
+	person  ids.UUID
+	erp     ids.ProjectID
+	migrate ids.ProjectID
+	onERP   ids.UUID
+	onOther ids.UUID
+	unfiled ids.UUID
+}
+
+func seedTwoProjectAccount(t *testing.T, e *Env) projectScopeFixture {
+	t.Helper()
+	owner := OwnerConn(t)
+	org := e.SeedOrg(t, "Acme", &e.Rep1)
+	person := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	newProject := func(name string) ids.UUID {
+		return SeedIDRow(t, owner, `INSERT INTO project (id, owner_id, name, organization_id, source, captured_by)
+			VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, e.Rep1, name, org)
+	}
+	erp := newProject("ERP rollout")
+	migrate := newProject("Datacentre migration")
+
+	// Three messages with the same counterpart: one about each engagement, and
+	// one ordinary exchange nobody filed. All three are linked to the person,
+	// which is what a person-anchored read walks.
+	mail := func(subject string) ids.UUID {
+		id := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1, 'email', $2, now(), 'manual', 'human:x')`, subject)
+		LinkActivity(t, owner, id, "person", person)
+		return id
+	}
+	onERP := mail("ERP cutover plan")
+	onOther := mail("Rack decommissioning")
+	unfiled := mail("Invoice question")
+
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+		VALUES ($1, 'project', $2)`, onERP, erp)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+		VALUES ($1, 'project', $2)`, onOther, migrate)
+
+	return projectScopeFixture{
+		org: org, person: person,
+		erp: projectIDOf(erp), migrate: projectIDOf(migrate),
+		onERP: onERP, onOther: onOther, unfiled: unfiled,
+	}
+}
+
+func TestTimelineScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoProjectAccount(t, e)
+	admin := e.Admin()
+
+	person := string(datasource.RecordPerson)
+	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{
+		EntityType:      &person,
+		EntityID:        &f.person,
+		WithinProjectID: &f.erp,
+	})
+	if err != nil {
+		t.Fatalf("list within project: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, a := range got {
+		seen[a.Id.String()] = true
+	}
+	// The negative assertion is the one that fails when the predicate does
+	// nothing, which is the failure mode a scope has.
+	if seen[f.onOther.String()] {
+		t.Error("the other engagement's mail survived a scoped read — the scope filtered nothing")
+	}
+	if !seen[f.onERP.String()] {
+		t.Error("the scoped project's own mail is missing")
+	}
+	// Attribution is optional, so unfiled correspondence is the account's
+	// general history and must survive. Dropping it would leave a brief
+	// reading as though the relationship had no past.
+	if !seen[f.unfiled.String()] {
+		t.Error("correspondence filed under NO project was dropped; the scope excludes other projects, not everything unattributed")
+	}
+}
+
+func TestTimelineWithoutAScopeStillSeesEveryEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoProjectAccount(t, e)
+	admin := e.Admin()
+
+	person := string(datasource.RecordPerson)
+	got, _, err := e.Activities.ListActivities(admin, activities.ListActivitiesInput{
+		EntityType: &person,
+		EntityID:   &f.person,
+	})
+	if err != nil {
+		t.Fatalf("list unscoped: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("unscoped timeline = %d rows, want all 3 — an absent scope must narrow nothing", len(got))
+	}
+}

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -71,6 +71,17 @@ type ListActivitiesInput struct {
 	// what the partial index behind it is built on. Done-ness is part of
 	// that question rather than a second dial — see openTaskAssigneeClause.
 	AssigneeID *ids.UserID
+	// WithinProjectID narrows to one body of work, EXCLUDING what belongs to
+	// another project and keeping what belongs to none.
+	//
+	// It is not a second spelling of EntityType="project"+EntityID, and the
+	// difference is the whole point. That pair asks "what is filed under this
+	// project"; this asks "what is on this account, minus the other
+	// engagement" — the anchor stays the person or company, and the general
+	// correspondence that carries no project at all stays with it. A reader
+	// preparing for an ERP meeting still wants the relationship's history;
+	// they do not want the datacentre migration.
+	WithinProjectID *ids.ProjectID
 }
 
 // ListActivities is the timeline read: newest first, optionally scoped to

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -126,6 +126,46 @@ func OrgReachSet() string {
 		    WHERE o.org_id IS NOT NULL`, orgArms)
 }
 
+// ActivityWithinProject is the ONE spelling of "this activity belongs to the
+// body of work being asked about", for a query that aliases activity as a.
+//
+// The rule (D7): filed under THIS project, or filed under none. Not "not filed
+// elsewhere" — those two readings differ on an activity linked to this project
+// AND another, which this one keeps and that one drops.
+// `uq_activity_link_project` makes that row unreachable today, but the rule is
+// what the predicate owes its reader, so it is spelled as the rule rather than
+// inferred from an index a later migration could relax without ever touching
+// this file.
+//
+// KEEPING THE UNFILED ROWS IS THE POINT. Attribution is optional, so most
+// correspondence on an account carries no project at all: a plain equality test
+// would drop the general relationship history and describe an account as though
+// nobody had ever spoken to it.
+//
+// It must be a subquery over the activity's links rather than a test on a link
+// row already joined — `activity_link_shape` admits exactly ONE target per row,
+// so a person-link row carries a NULL project_id by construction and a
+// predicate on it would be true everywhere and narrow nothing. Both arms probe
+// `uq_activity_link_project`, which is keyed on activity_id.
+//
+// search.projectScope.clause is the same predicate for the context walk. The
+// two are deliberate copies, not an oversight: a module never imports a sibling
+// (ADR-0054), and this rule is about SUBJECT MATTER rather than authority, so
+// platform/auth — where the activity scope clauses both modules do share
+// already live — is the wrong home for it. Change one, change both.
+//
+// projectPos is the bind position carrying the project id.
+func ActivityWithinProject(projectPos int) string {
+	return sprintf(`(
+			EXISTS (
+			    SELECT 1 FROM activity_link scoped
+			    WHERE scoped.activity_id = a.id AND scoped.project_id = $%[1]d)
+			OR NOT EXISTS (
+			    SELECT 1 FROM activity_link filed
+			    WHERE filed.activity_id = a.id AND filed.project_id IS NOT NULL))`,
+		projectPos)
+}
+
 // openTaskAssigneeClause narrows the timeline to the OPEN tasks one person
 // holds — the queue read the contract declares ("Open tasks for an
 // assignee"), spelled as the predicate the partial index behind it is built
@@ -218,20 +258,7 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 		}
 	}
 	if in.WithinProjectID != nil {
-		// EXCLUSION, not selection: what belongs to ANOTHER project drops out
-		// and what belongs to none stays. Attribution is optional, so most
-		// correspondence carries no project — an equality test would drop the
-		// account's general history and read as though nothing had been said.
-		//
-		// A subquery rather than a predicate on a joined link row, because
-		// `activity_link_shape` admits exactly one target per row: a
-		// person-link row carries a NULL project_id by construction, so a test
-		// on it would be true everywhere and narrow nothing.
-		where = append(where, sprintf(`NOT EXISTS (
-			SELECT 1 FROM activity_link scoped
-			WHERE scoped.activity_id = a.id
-			  AND scoped.project_id IS NOT NULL
-			  AND scoped.project_id <> $%d)`, arg(*in.WithinProjectID)))
+		where = append(where, ActivityWithinProject(arg(*in.WithinProjectID)))
 	}
 	if in.ThreadKey != nil && *in.ThreadKey != "" {
 		where = append(where, sprintf("a.thread_key = $%d", arg(*in.ThreadKey)))

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -217,6 +217,22 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 			where = append(where, sprintf("al.%s = $%d", column, arg(*in.EntityID)))
 		}
 	}
+	if in.WithinProjectID != nil {
+		// EXCLUSION, not selection: what belongs to ANOTHER project drops out
+		// and what belongs to none stays. Attribution is optional, so most
+		// correspondence carries no project — an equality test would drop the
+		// account's general history and read as though nothing had been said.
+		//
+		// A subquery rather than a predicate on a joined link row, because
+		// `activity_link_shape` admits exactly one target per row: a
+		// person-link row carries a NULL project_id by construction, so a test
+		// on it would be true everywhere and narrow nothing.
+		where = append(where, sprintf(`NOT EXISTS (
+			SELECT 1 FROM activity_link scoped
+			WHERE scoped.activity_id = a.id
+			  AND scoped.project_id IS NOT NULL
+			  AND scoped.project_id <> $%d)`, arg(*in.WithinProjectID)))
+	}
 	if in.ThreadKey != nil && *in.ThreadKey != "" {
 		where = append(where, sprintf("a.thread_key = $%d", arg(*in.ThreadKey)))
 	}

--- a/backend/internal/modules/search/graph.go
+++ b/backend/internal/modules/search/graph.go
@@ -74,6 +74,43 @@ var anchorLinkColumn = map[string]string{
 	string(datasource.EntityProject):      "project_id",
 }
 
+// projectScope narrows a walk to one body of work. The zero value scopes
+// nothing, which is the ordinary read.
+//
+// It is a CO-FILTER on an anchor that stays a person, a company or a deal —
+// not an anchor of its own. "Catch me up on Acme" and "catch me up on Acme,
+// but only the ERP rollout" walk the same neighborhood; the second one just
+// refuses to be told about the other engagement.
+type projectScope struct {
+	projectID string
+}
+
+// clause renders the exclusion the scope stands for, or "" when there is no
+// scope. `activityAlias` is the ACTIVITY alias it applies to.
+//
+// It has to be a subquery over the activity's other links, not a test on the
+// link row already joined: `activity_link_shape` admits exactly ONE target per
+// row, so a person-link row carries `project_id IS NULL` by construction. A
+// predicate on that row would be true for every row it saw and would filter
+// nothing at all — a scope that silently does nothing, which reads in a brief
+// exactly like a scope that works.
+//
+// KEEPING THE UNATTRIBUTED ROWS IS THE POINT. Attribution is optional here, so
+// most correspondence on an account carries no project at all: `NOT EXISTS a
+// link to another project` keeps those, and removes only what is filed under a
+// different body of work.
+func (s projectScope) clause(activityAlias string, arg func(any) int) string {
+	if s.projectID == "" {
+		return ""
+	}
+	return fmt.Sprintf(`NOT EXISTS (
+			SELECT 1 FROM activity_link scoped
+			WHERE scoped.activity_id = %s.id
+			  AND scoped.project_id IS NOT NULL
+			  AND scoped.project_id <> $%d)`,
+		activityAlias, arg(s.projectID))
+}
+
 // assembleGraph is the fixed-depth context walk (B-EP05.20a): anchor →
 // linked activities (hop 1) → those activities' other link targets
 // (hop 2). Depth is fixed by construction — two joins, not a traversal
@@ -83,15 +120,15 @@ var anchorLinkColumn = map[string]string{
 // An ACTIVITY anchor takes the other road (graphactivity.go): it names no
 // neighborhood of its own, so it is dereferenced to the records it is about
 // and the walk below runs around one of those.
-func (s *Store) assembleGraph(ctx context.Context, anchorType string, anchorID ids.UUID, maxItems int) ([]graphSection, error) {
+func (s *Store) assembleGraph(ctx context.Context, anchorType string, anchorID ids.UUID, maxItems int, within projectScope) ([]graphSection, error) {
 	var sections []graphSection
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		if anchorType == string(datasource.EntityActivity) {
-			sections, err = s.assembleActivityWithin(ctx, tx, anchorID, maxItems)
+			sections, err = s.assembleActivityWithin(ctx, tx, anchorID, maxItems, within)
 			return err
 		}
-		sections, err = s.assembleRecordWithin(ctx, tx, anchorType, anchorID, maxItems)
+		sections, err = s.assembleRecordWithin(ctx, tx, anchorType, anchorID, maxItems, within)
 		return err
 	})
 	if err != nil {
@@ -103,7 +140,7 @@ func (s *Store) assembleGraph(ctx context.Context, anchorType string, anchorID i
 // assembleRecordWithin is the record half of the walk, on a transaction the
 // caller owns — so an activity anchor can dereference to a record and walk it
 // without opening a second transaction against the same read.
-func (s *Store) assembleRecordWithin(ctx context.Context, tx pgx.Tx, anchorType string, anchorID ids.UUID, maxItems int) ([]graphSection, error) {
+func (s *Store) assembleRecordWithin(ctx context.Context, tx pgx.Tx, anchorType string, anchorID ids.UUID, maxItems int, within projectScope) ([]graphSection, error) {
 	// A record graph anchor is any searchable record type except activity
 	// itself (an activity is a link, not a thing links hang off).
 	var branch *searchBranch
@@ -164,7 +201,7 @@ func (s *Store) assembleRecordWithin(ctx context.Context, tx pgx.Tx, anchorType 
 		return sections, nil
 	}
 
-	touches, openTasks, activityIDs, err := anchorTimeline(ctx, tx, linkCol, anchorID, maxItems, now)
+	touches, openTasks, activityIDs, err := anchorTimeline(ctx, tx, linkCol, anchorID, maxItems, now, within)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +246,7 @@ func anchorProfile(ctx context.Context, tx pgx.Tx, branch *searchBranch, anchorT
 // anchorTimeline is hop 1: the anchor's activity timeline, scope-walked
 // and ranked by recency × trust (§10.7.2 with similarity = 0), split
 // into recent touches and open tasks.
-func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids.UUID, maxItems int, now time.Time) (touches, openTasks []graphItem, activityIDs []ids.ActivityID, err error) {
+func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids.UUID, maxItems int, now time.Time, within projectScope) (touches, openTasks []graphItem, activityIDs []ids.ActivityID, err error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	anchorPos := arg(anchorID)
@@ -223,6 +260,9 @@ func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids
 		WHERE l.%s = $%d AND a.archived_at IS NULL`, linkCol, anchorPos)
 	if scope != "" {
 		activitySQL += " AND " + scope
+	}
+	if narrow := within.clause("a", arg); narrow != "" {
+		activitySQL += " AND " + narrow
 	}
 	activitySQL += fmt.Sprintf(" ORDER BY a.occurred_at DESC LIMIT %d", graphExpansionLimit)
 	rows, err := tx.Query(ctx, activitySQL, args...)

--- a/backend/internal/modules/search/graph.go
+++ b/backend/internal/modules/search/graph.go
@@ -74,43 +74,6 @@ var anchorLinkColumn = map[string]string{
 	string(datasource.EntityProject):      "project_id",
 }
 
-// projectScope narrows a walk to one body of work. The zero value scopes
-// nothing, which is the ordinary read.
-//
-// It is a CO-FILTER on an anchor that stays a person, a company or a deal —
-// not an anchor of its own. "Catch me up on Acme" and "catch me up on Acme,
-// but only the ERP rollout" walk the same neighborhood; the second one just
-// refuses to be told about the other engagement.
-type projectScope struct {
-	projectID string
-}
-
-// clause renders the exclusion the scope stands for, or "" when there is no
-// scope. `activityAlias` is the ACTIVITY alias it applies to.
-//
-// It has to be a subquery over the activity's other links, not a test on the
-// link row already joined: `activity_link_shape` admits exactly ONE target per
-// row, so a person-link row carries `project_id IS NULL` by construction. A
-// predicate on that row would be true for every row it saw and would filter
-// nothing at all — a scope that silently does nothing, which reads in a brief
-// exactly like a scope that works.
-//
-// KEEPING THE UNATTRIBUTED ROWS IS THE POINT. Attribution is optional here, so
-// most correspondence on an account carries no project at all: `NOT EXISTS a
-// link to another project` keeps those, and removes only what is filed under a
-// different body of work.
-func (s projectScope) clause(activityAlias string, arg func(any) int) string {
-	if s.projectID == "" {
-		return ""
-	}
-	return fmt.Sprintf(`NOT EXISTS (
-			SELECT 1 FROM activity_link scoped
-			WHERE scoped.activity_id = %s.id
-			  AND scoped.project_id IS NOT NULL
-			  AND scoped.project_id <> $%d)`,
-		activityAlias, arg(s.projectID))
-}
-
 // assembleGraph is the fixed-depth context walk (B-EP05.20a): anchor →
 // linked activities (hop 1) → those activities' other link targets
 // (hop 2). Depth is fixed by construction — two joins, not a traversal

--- a/backend/internal/modules/search/graphactivity.go
+++ b/backend/internal/modules/search/graphactivity.go
@@ -153,7 +153,7 @@ func participantRoleOrder(alias string) string {
 const linkOnlyRole = -1
 
 // assembleActivityWithin builds the context for an activity anchor.
-func (s *Store) assembleActivityWithin(ctx context.Context, tx pgx.Tx, activityID ids.UUID, maxItems int) ([]graphSection, error) {
+func (s *Store) assembleActivityWithin(ctx context.Context, tx pgx.Tx, activityID ids.UUID, maxItems int, within projectScope) ([]graphSection, error) {
 	profile, err := activityProfile(ctx, tx, activityID)
 	if err != nil {
 		return nil, err
@@ -192,7 +192,7 @@ func (s *Store) assembleActivityWithin(ctx context.Context, tx pgx.Tx, activityI
 		return sections, nil
 	}
 
-	walk, err := s.assembleRecordWithin(ctx, tx, subjects[0].entityType, subjects[0].id, maxItems)
+	walk, err := s.assembleRecordWithin(ctx, tx, subjects[0].entityType, subjects[0].id, maxItems, within)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/search/graphprojectscope.go
+++ b/backend/internal/modules/search/graphprojectscope.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// Narrowing a context walk to ONE body of work.
+
+import "fmt"
+
+// projectScope narrows a walk to one body of work. The zero value scopes
+// nothing, which is the ordinary read.
+//
+// It is a CO-FILTER on an anchor that stays a person, a company or a deal —
+// not an anchor of its own. "Catch me up on Acme" and "catch me up on Acme,
+// but only the ERP rollout" walk the same neighborhood; the second one just
+// refuses to be told about the other engagement.
+type projectScope struct {
+	projectID string
+}
+
+// clause renders the exclusion the scope stands for, or "" when there is no
+// scope. `activityAlias` is the ACTIVITY alias it applies to.
+//
+// It has to be a subquery over the activity's other links, not a test on the
+// link row already joined: `activity_link_shape` admits exactly ONE target per
+// row, so a person-link row carries `project_id IS NULL` by construction. A
+// predicate on that row would be true for every row it saw and would filter
+// nothing at all — a scope that silently does nothing, which reads in a brief
+// exactly like a scope that works.
+//
+// KEEPING THE UNATTRIBUTED ROWS IS THE POINT. Attribution is optional here, so
+// most correspondence on an account carries no project at all, and the rule is
+// "filed HERE, or filed nowhere" — not "not filed elsewhere".
+//
+// Those two readings differ on one row: an activity linked to this project AND
+// to another. `uq_activity_link_project` makes that unreachable today (a unique
+// index on activity_id over the project rows), but the rule is what this
+// predicate owes the reader, so it is spelled as the rule rather than as an
+// inference from an index that could be relaxed by a migration this file would
+// never hear about.
+//
+// activities.ActivityWithinProject is the same predicate for the timeline list.
+// The two are deliberate copies, not an oversight: a module never imports a
+// sibling (ADR-0054), and this rule is about SUBJECT MATTER rather than
+// authority, so platform/auth — where the activity scope clauses both modules
+// do share already live — is the wrong home for it. Change one, change both.
+func (s projectScope) clause(activityAlias string, arg func(any) int) string {
+	if s.projectID == "" {
+		return ""
+	}
+	pos := arg(s.projectID)
+	return fmt.Sprintf(`(
+			EXISTS (
+				SELECT 1 FROM activity_link scoped
+				WHERE scoped.activity_id = %[1]s.id AND scoped.project_id = $%[2]d)
+			OR NOT EXISTS (
+				SELECT 1 FROM activity_link filed
+				WHERE filed.activity_id = %[1]s.id AND filed.project_id IS NOT NULL))`,
+		activityAlias, pos)
+}

--- a/backend/internal/modules/search/retriever.go
+++ b/backend/internal/modules/search/retriever.go
@@ -62,7 +62,8 @@ func (r *Retriever) AssembleContext(ctx context.Context, anchor datasource.Entit
 	if maxItems <= 0 {
 		maxItems = 5
 	}
-	assembled, err := r.store.assembleGraph(ctx, string(anchor.Type), anchor.ID, maxItems)
+	assembled, err := r.store.assembleGraph(ctx, string(anchor.Type), anchor.ID, maxItems,
+		projectScope{projectID: opts.ProjectID})
 	if err != nil {
 		return retrieval.Context{}, fmt.Errorf("search: assemble context: %w", err)
 	}

--- a/backend/internal/shared/ports/retrieval/retrieval.go
+++ b/backend/internal/shared/ports/retrieval/retrieval.go
@@ -69,6 +69,19 @@ type AssembleOptions struct {
 	// MaxItems bounds the assembled context per section (recent touches,
 	// open questions, related people).
 	MaxItems int
+	// ProjectID narrows the picture to ONE body of work, when the caller knows
+	// which. Empty is the ordinary case and filters nothing.
+	//
+	// The rule it applies is exclusion, not selection: material filed under a
+	// DIFFERENT project drops out, while material filed under no project at
+	// all stays. Attribution is optional in this product, so most
+	// correspondence on an account carries no project — a strict "this project
+	// only" read would drop the general relationship history and describe an
+	// account as though it had no past.
+	//
+	// An account running two engagements is where this earns its place: a
+	// brief that blends them is fluent, confident and about the wrong work.
+	ProjectID string
 }
 
 // Context is the assembled, provenance-stamped picture for one anchor.


### PR DESCRIPTION
An account running two engagements produces one blended picture, and nothing in the backend could be told which engagement a question was about. A brief or draft grounded in that is fluent, confident and about the wrong work.

## What it adds

Two reads carry the narrowing, and between them they reach the surfaces that matter:

- **`anchorTimeline`** ([search/graph.go](backend/internal/modules/search/graph.go)) is the single query behind `AssembleContext`, so `catch_me_up_on` and `prep_for_meeting` inherit it.
- **`ListActivitiesInput.WithinProjectID`** feeds the org 360's timeline, and through it the account draft and the account brief.

`retrieval.AssembleOptions` gains `ProjectID` — additive on a struct, so no seam interface changes and no caller breaks.

## The rule is exclusion, not selection

Material filed under **another** project drops out. Material filed under **no** project stays.

That second half is not a softening. Attribution is optional in this product, so most correspondence on an account carries no project at all — an equality test would drop the general relationship history and describe an account as though nobody had ever spoken to it.

## The subtlety that would have shipped as a silent no-op

It has to be a subquery over the activity's *other* links, not a predicate on the link row already joined. `activity_link_shape` admits exactly **one** target per row, so a person-link row carries `project_id IS NULL` by construction — a test on that row is true for every row it sees and narrows nothing.

I wrote the naive version first. The integration test fails on exactly that mistake, with the message "the scope filtered nothing".

## Hop 2 needs no predicate of its own

`hopNeighbors` walks only the activity ids hop 1 returned, so narrowing hop 1 narrows hop 2 structurally rather than by a second clause that could drift.

## Verification

- `make check-backend` green, `make craft-static` clean, `make rls-store-path` and `make no-jurisdiction` green.
- Two integration tests against real Postgres, seeded through the real writers: one account, two engagements, plus unattributed mail.
- **Mutation-checked**: replacing the subquery with the naive same-row predicate fails the negative assertion.

No behaviour changes until a caller passes a project — this merges dark.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes context assembly and activity timelines to a single project to avoid blending multiple engagements. Previously all account activity was blended; now reads keep items filed under the selected project and unfiled items, and exclude items filed only under other projects.

- Adds `retrieval.AssembleOptions.ProjectID` and `activities.ListActivitiesInput.WithinProjectID` (optional; backward compatible).
- Applies the scope in `anchorTimeline` and propagates through the graph via `search.projectScope`, so `catch_me_up_on` and `prep_for_meeting` inherit it; the org 360 timeline uses the `activities` read.
- Uses a single rule shared in two places: `activities.ActivityWithinProject` and `search.projectScope.clause` now enforce "filed HERE or filed nowhere" with an `EXISTS` over the project link OR a `NOT EXISTS` for any project link; this keeps items filed here and elsewhere and avoids the naive same-row predicate that filtered nothing.
- Adds integration tests seeded via real writers and covering both the timeline and `AssembleContext`; unscoped reads are unchanged unless a caller supplies `ProjectID`/`WithinProjectID` (merges dark).

<sup>Written for commit d1f2a7c50cc87f5bbe842a3d564ea8ba5c814561. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-scoped activity timelines and assembled context.
  * Results include activities assigned to the selected project and unassigned activities, while excluding activities from other projects.
  * Unscoped views continue to show activities across all projects.
* **Bug Fixes**
  * Improved project filtering across activity retrieval and contextual results for consistent, relevant information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->