### PR TITLE
fix(records): a research claim lands in the columns it names, and reuse becomes a rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,12 @@ binding every column to the wrong value. That is not hypothetical: it shipped in
 `people/researchclaim.go`, and the accept path was dead for two days because no
 test executed the statement.
 
+The `%s` in that pattern is the COLUMN, and it carries its own rule: a compile-
+time literal, or a catalog name quoted with `pgx.Identifier.Sanitize` — the one
+spelling this repo uses (`storekit/customcolumns.go`). Never a string off a
+request body. Values are always `$N`; only identifiers are ever formatted, and
+an identifier a caller chose is an injection with a placeholder's manners.
+
 **4. A comment may not claim to be the only implementation unless a test holds
 it.** "the one spelling of X", "the only writer of Y", "the same anonymization
 the eraser performs" — if no test fails when a second one appears, delete the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,7 +412,7 @@ answer one question with different grounding rules.
 
 **2. The tool surface and the web surface share ONE engine.** An MCP tool never
 re-derives what an HTTP handler already computes. The binding is a
-`compose/*seam*.go` file, and the ten that exist each state the rule in their
+`compose/*seam*.go` file, and the seams that exist each state the rule in their
 own words — `briefseam.go`: "one queue rather than two readings of it";
 `importseam.go`: "it delegates rather than reimplementing, and that is the whole
 design". **If no seam exists for the capability you need, write the seam** — do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,55 @@ scope clauses in `platform/auth`): object denial →
 `apperrors.ErrPermissionDenied` (403), row-scope miss →
 `apperrors.ErrNotFound` (404, existence-hiding).
 
+## Reuse before you build (non-negotiable)
+
+A second implementation of one capability is not untidy — it is two answers to
+one question, and the two drift until they disagree in front of a user. Four
+rules, each of them here because this tree has already paid for it.
+
+**1. Search the whole tree, not your directory.** Before adding a capability,
+grep its nouns across `backend/`, `frontend/src/` and `extensions/`. The
+duplicate is almost never in the package you are editing — that is precisely why
+it gets missed. The agent tool `prep_for_meeting` was written beside a working
+`compose/meetingbrief/` that a one-word grep would have found, and the two now
+answer one question with different grounding rules.
+
+**2. The tool surface and the web surface share ONE engine.** An MCP tool never
+re-derives what an HTTP handler already computes. The binding is a
+`compose/*seam*.go` file, and the ten that exist each state the rule in their
+own words — `briefseam.go`: "one queue rather than two readings of it";
+`importseam.go`: "it delegates rather than reimplementing, and that is the whole
+design". **If no seam exists for the capability you need, write the seam** — do
+not write a second assembler. A module may not import a sibling or `compose`
+(ADR-0054 §3), so rolling your own will always look like the cheaper path; it is
+the wrong one, and this is the case where saying so out loud is the only thing
+that helps.
+
+**3. Never hand-type a SQL placeholder.** Derive `$N` from the argument slice —
+`args = append(args, v)` then `fmt.Sprintf("%s = $%d", col, len(args))`, as
+`deals/offer_lines.go` does — or use `storekit.InsertFragments`. Nothing in this
+repo checks that a statement's column count, placeholder count and argument
+count agree, so a hand-numbered statement is one careless sweep away from
+binding every column to the wrong value. That is not hypothetical: it shipped in
+`people/researchclaim.go`, and the accept path was dead for two days because no
+test executed the statement.
+
+**4. A comment may not claim to be the only implementation unless a test holds
+it.** "the one spelling of X", "the only writer of Y", "the same anonymization
+the eraser performs" — if no test fails when a second one appears, delete the
+claim or write the test. Every such claim audited in this tree was false. A
+false uniqueness claim is worse than silence: the next author greps, finds it,
+and stops looking.
+
+**Two writers of one invariant either share a helper or say why they do not.**
+If you are adding the second, put the reason in the code beside it, not in the
+pull request where the next reader will not see it.
+
+Catalogs to read before building anything they might already list:
+[docs/reference/modules.md](docs/reference/modules.md) for backend capabilities,
+[frontend/src/design-system/README.md](frontend/src/design-system/README.md) for
+every control that already exists.
+
 ## Craftsmanship
 
 The anti-tell catalog T1–T11, in full below — this list is the rule, not a summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,7 +444,7 @@ answer one question with different grounding rules.
 
 **2. The tool surface and the web surface share ONE engine.** An MCP tool never
 re-derives what an HTTP handler already computes. The binding is a
-`compose/*seam*.go` file, and the ten that exist each state the rule in their
+`compose/*seam*.go` file, and the seams that exist each state the rule in their
 own words — `briefseam.go`: "one queue rather than two readings of it";
 `importseam.go`: "it delegates rather than reimplementing, and that is the whole
 design". **If no seam exists for the capability you need, write the seam** — do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,12 @@ binding every column to the wrong value. That is not hypothetical: it shipped in
 `people/researchclaim.go`, and the accept path was dead for two days because no
 test executed the statement.
 
+The `%s` in that pattern is the COLUMN, and it carries its own rule: a compile-
+time literal, or a catalog name quoted with `pgx.Identifier.Sanitize` — the one
+spelling this repo uses (`storekit/customcolumns.go`). Never a string off a
+request body. Values are always `$N`; only identifiers are ever formatted, and
+an identifier a caller chose is an injection with a placeholder's manners.
+
 **4. A comment may not claim to be the only implementation unless a test holds
 it.** "the one spelling of X", "the only writer of Y", "the same anonymization
 the eraser performs" — if no test fails when a second one appears, delete the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working in this
 repository. It is the long form: the full operating detail lives here.
 [AGENTS.md](AGENTS.md) is a deliberately shorter digest for other agent
 harnesses that links back here. Most sections differ on purpose, so do not sync
-them line by line. **Three sections are the exception** — *The write shape*,
-*License headers*, and *Rules learned from the review loop* — which both files
-carry in full because both are read in isolation. They must stay byte-identical,
-and `TestSharedRulebookSectionsAreIdenticalInBothDocs` in
-`backend/agentsdocparity_test.go` fails when they drift: edit one, edit both.
+them line by line. **Four sections are the exception** — *The write shape*,
+*Reuse before you build*, *License headers*, and *Rules learned from the review
+loop* — which both files carry in full because both are read in isolation. They
+must stay byte-identical, and `TestSharedRulebookSectionsAreIdenticalInBothDocs`
+in `backend/agentsdocparity_test.go` fails when they drift: edit one, edit both.
 
 AGENTS.md is machine-read, so keep it accurate: `cli/craft` feeds the **whole**
 nearest AGENTS.md into the gate prompt (`gate.Assembler.nearestAgents` walks up
@@ -428,6 +428,55 @@ point is RBAC-gated (`auth.Require` + `auth.EnsureVisible` + the list
 scope clauses in `platform/auth`): object denial →
 `apperrors.ErrPermissionDenied` (403), row-scope miss →
 `apperrors.ErrNotFound` (404, existence-hiding).
+
+## Reuse before you build (non-negotiable)
+
+A second implementation of one capability is not untidy — it is two answers to
+one question, and the two drift until they disagree in front of a user. Four
+rules, each of them here because this tree has already paid for it.
+
+**1. Search the whole tree, not your directory.** Before adding a capability,
+grep its nouns across `backend/`, `frontend/src/` and `extensions/`. The
+duplicate is almost never in the package you are editing — that is precisely why
+it gets missed. The agent tool `prep_for_meeting` was written beside a working
+`compose/meetingbrief/` that a one-word grep would have found, and the two now
+answer one question with different grounding rules.
+
+**2. The tool surface and the web surface share ONE engine.** An MCP tool never
+re-derives what an HTTP handler already computes. The binding is a
+`compose/*seam*.go` file, and the ten that exist each state the rule in their
+own words — `briefseam.go`: "one queue rather than two readings of it";
+`importseam.go`: "it delegates rather than reimplementing, and that is the whole
+design". **If no seam exists for the capability you need, write the seam** — do
+not write a second assembler. A module may not import a sibling or `compose`
+(ADR-0054 §3), so rolling your own will always look like the cheaper path; it is
+the wrong one, and this is the case where saying so out loud is the only thing
+that helps.
+
+**3. Never hand-type a SQL placeholder.** Derive `$N` from the argument slice —
+`args = append(args, v)` then `fmt.Sprintf("%s = $%d", col, len(args))`, as
+`deals/offer_lines.go` does — or use `storekit.InsertFragments`. Nothing in this
+repo checks that a statement's column count, placeholder count and argument
+count agree, so a hand-numbered statement is one careless sweep away from
+binding every column to the wrong value. That is not hypothetical: it shipped in
+`people/researchclaim.go`, and the accept path was dead for two days because no
+test executed the statement.
+
+**4. A comment may not claim to be the only implementation unless a test holds
+it.** "the one spelling of X", "the only writer of Y", "the same anonymization
+the eraser performs" — if no test fails when a second one appears, delete the
+claim or write the test. Every such claim audited in this tree was false. A
+false uniqueness claim is worse than silence: the next author greps, finds it,
+and stops looking.
+
+**Two writers of one invariant either share a helper or say why they do not.**
+If you are adding the second, put the reason in the code beside it, not in the
+pull request where the next reader will not see it.
+
+Catalogs to read before building anything they might already list:
+[docs/reference/modules.md](docs/reference/modules.md) for backend capabilities,
+[frontend/src/design-system/README.md](frontend/src/design-system/README.md) for
+every control that already exists.
 
 ## Craftsmanship
 

--- a/backend/agentsdocparity_test.go
+++ b/backend/agentsdocparity_test.go
@@ -9,14 +9,14 @@ package backendarch
 // the long form, AGENTS.md the digest other agent harnesses read. Most sections
 // differ on purpose and must not be synced.
 //
-// Three sections are the exception. They state binding invariants — the write
-// shape, the license header, and the rules the review loop produced — and both
-// files carry them in full because both are read in isolation: CLAUDE.md by
-// Claude Code, AGENTS.md by `cli/craft`, which feeds the whole nearest
-// AGENTS.md into the gate prompt. A pointer in one of them would leave whoever
-// reads the other without the rule.
+// Four sections are the exception. They state binding invariants — the write
+// shape, the reuse rule, the license header, and the rules the review loop
+// produced — and both files carry them in full because both are read in
+// isolation: CLAUDE.md by Claude Code, AGENTS.md by `cli/craft`, which feeds
+// the whole nearest AGENTS.md into the gate prompt. A pointer in one of them
+// would leave whoever reads the other without the rule.
 //
-// Full copies in two files drift. This asserts they have not: the three
+// Full copies in two files drift. This asserts they have not: the four
 // sections must be byte-identical, so changing an invariant in one file fails
 // here until it is changed in both.
 
@@ -30,6 +30,7 @@ import (
 // Each entry is matched as a prefix, so a heading may carry a parenthetical.
 var sharedSections = []string{
 	"## The write shape",
+	"## Reuse before you build",
 	"## License headers",
 	"## Rules learned from the review loop",
 }

--- a/backend/internal/modules/people/researchclaim.go
+++ b/backend/internal/modules/people/researchclaim.go
@@ -114,23 +114,19 @@ func (s *Store) SaveResearchClaims(ctx context.Context, personID ids.PersonID, c
 			// ON CONFLICT because the table holds one row per (person, field):
 			// accepting a newer claim about the same field REPLACES what was
 			// there, which is what a reader who just chose it expects.
+			// updated_at and version are the trigger's
+			// (trg_person_profile_field_updated), so the branch names neither.
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
-				VALUES ($1, $1, $2, $3, $4, $6, $5)
+				VALUES ($1, $2, $3, $4, $5, $6, $7)
 				ON CONFLICT (person_id, field) DO UPDATE
 				SET value = EXCLUDED.value,
 				    evidence_snippet = EXCLUDED.evidence_snippet,
 				    source_ref = EXCLUDED.source_ref,
 				    source = EXCLUDED.source,
-				    captured_by = EXCLUDED.captured_by
-				-- The conflict target is workspace-blind (migration 0097's
-				-- uq_person_profile_field), so the branch names the workspace
-				-- itself. Person ids are unique across the fleet, but an
-				-- executor that bypasses row-level security would otherwise be
-				-- one id collision away from updating another tenant's row.
-				`,
-				storekit.MustWorkspace(ctx), personID, claim.Field, claim.Value,
-				claim.Quote, claim.SourceURL, by, researchSource); err != nil {
+				    captured_by = EXCLUDED.captured_by`,
+				personID, claim.Field, claim.Value, claim.Quote,
+				claim.SourceURL, researchSource, by); err != nil {
 				return fmt.Errorf("save the research claim %q: %w", claim.Field, err)
 			}
 			saved++

--- a/backend/internal/modules/people/researchclaim_integration_test.go
+++ b/backend/internal/modules/people/researchclaim_integration_test.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Saving an accepted research claim, over a real Postgres.
+//
+// The statement is exercised rather than read, because reading it is what
+// failed: it shipped with its columns bound to the wrong placeholders and its
+// argument count disagreeing with its highest placeholder, so every call
+// errored — and the two tests this package already had over the accept path
+// both filter input and never reach the database. A writer nothing executes is
+// a writer nothing checks.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// asArchiver is the accepting rep's context plus the delete grant archiving
+// needs. Separate from as() so the accept path is always exercised under a
+// seat that may update and nothing more.
+func (e *dedupeEnv) asArchiver() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Read: true, Update: true, Delete: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// storedClaim is one person_profile_field row as the reader sees it.
+type storedClaim struct {
+	value      string
+	snippet    string
+	sourceRef  string
+	source     string
+	capturedBy string
+	version    int64
+}
+
+func readStoredClaim(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.PersonID, field string) storedClaim {
+	t.Helper()
+	var got storedClaim
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT value, evidence_snippet, source_ref, source, captured_by, version
+			FROM person_profile_field WHERE person_id = $1 AND field = $2`,
+			personID, field).Scan(&got.value, &got.snippet, &got.sourceRef,
+			&got.source, &got.capturedBy, &got.version)
+	}); err != nil {
+		t.Fatalf("read back the %s claim: %v", field, err)
+	}
+	return got
+}
+
+// Every column holds what the caller supplied for it. Asserted column by
+// column rather than "a row exists": the defect this covers wrote a row on
+// every field, and each value was the neighbouring argument.
+func TestSavingAResearchClaimWritesEachColumnTheValueItWasGiven(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Nadia Farrow", "nadia@research.test", "Farrow Systems", "research.test")
+
+	saved, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
+		Field:     "title",
+		Value:     "Head of Procurement",
+		Quote:     "Nadia Farrow leads procurement across the group.",
+		SourceURL: "https://research.test/team",
+	}})
+	if err != nil {
+		t.Fatalf("SaveResearchClaims: %v", err)
+	}
+	if saved != 1 {
+		t.Fatalf("saved = %d, want 1", saved)
+	}
+
+	got := readStoredClaim(ctx, t, e, personID, "title")
+	want := storedClaim{
+		value:      "Head of Procurement",
+		snippet:    "Nadia Farrow leads procurement across the group.",
+		sourceRef:  "https://research.test/team",
+		source:     researchSource,
+		capturedBy: "human:" + e.rep.String(),
+		version:    1,
+	}
+	if got != want {
+		t.Errorf("stored claim = %+v, want %+v", got, want)
+	}
+}
+
+// The person id is the person's, and the field is the field's. Its own case
+// because the shipped defect put the WORKSPACE id in both, which a
+// value-only assertion cannot see: the row was unreachable by the id a reader
+// looks it up under, so "no row" and "wrong row" had to be told apart.
+func TestASavedResearchClaimIsFoundUnderThePersonAndFieldItNames(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Tomas Reit", "tomas@lookup.test", "Reit GmbH", "lookup.test")
+
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
+		Field:     "role",
+		Value:     "Board member",
+		Quote:     "Tomas Reit sits on the supervisory board.",
+		SourceURL: "https://lookup.test/board",
+	}}); err != nil {
+		t.Fatalf("SaveResearchClaims: %v", err)
+	}
+
+	var rows int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM person_profile_field
+			WHERE person_id = $1 AND field = 'role'`, personID).Scan(&rows)
+	}); err != nil {
+		t.Fatalf("count the role claim: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("rows under (person, 'role') = %d, want 1 — the claim is stored under something else", rows)
+	}
+}
+
+// A later claim about the same field replaces the earlier one, and the
+// trigger moves the version with it. This is the DO UPDATE arm, which the
+// accept drawer reaches whenever a reader revisits a field they already chose.
+func TestAcceptingASecondClaimAboutOneFieldReplacesTheFirst(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Iris Lund", "iris@replace.test", "Lund AS", "replace.test")
+
+	first := ResearchClaimInput{
+		Field:     "title",
+		Value:     "Engineer",
+		Quote:     "Iris Lund, engineer, joined in 2019.",
+		SourceURL: "https://replace.test/old",
+	}
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{first}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	second := ResearchClaimInput{
+		Field:     "title",
+		Value:     "Chief Engineer",
+		Quote:     "Iris Lund was promoted to chief engineer.",
+		SourceURL: "https://replace.test/new",
+	}
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{second}); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	got := readStoredClaim(ctx, t, e, personID, "title")
+	if got.value != second.Value || got.snippet != second.Quote || got.sourceRef != second.SourceURL {
+		t.Errorf("stored claim = %+v, want the second claim's value/quote/source", got)
+	}
+	// The trigger owns this, so a fill that stopped bumping it would mean the
+	// UPDATE arm stopped firing and the row was being inserted afresh.
+	if got.version != 2 {
+		t.Errorf("version = %d, want 2 after the replacement", got.version)
+	}
+}
+
+// Several claims in one call all land. The loop commits inside one
+// transaction, so a statement that failed on the second claim would leave the
+// reader's first choice saved and their second silently gone.
+func TestEveryClaimInOneAcceptanceLands(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Ana Sol", "ana@many.test", "Sol SA", "many.test")
+
+	saved, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{
+		{Field: "title", Value: "CFO", Quote: "Ana Sol, CFO.", SourceURL: "https://many.test/a"},
+		{Field: "role", Value: "Signatory", Quote: "Ana Sol may sign alone.", SourceURL: "https://many.test/b"},
+		{
+			Field: "linkedin", Value: "https://linkedin.test/in/anasol",
+			Quote: "Ana Sol's profile is linked from the team page.", SourceURL: "https://many.test/c",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveResearchClaims: %v", err)
+	}
+	if saved != 3 {
+		t.Fatalf("saved = %d, want 3", saved)
+	}
+	for field, value := range map[string]string{
+		"title":    "CFO",
+		"role":     "Signatory",
+		"linkedin": "https://linkedin.test/in/anasol",
+	} {
+		if got := readStoredClaim(ctx, t, e, personID, field); got.value != value {
+			t.Errorf("%s = %q, want %q", field, got.value, value)
+		}
+	}
+}
+
+// A claim missing any of its three evidence parts is refused, and nothing is
+// written. The validation runs before authority is asked about, so this also
+// pins that a malformed request never reaches the person row.
+func TestAResearchClaimMissingItsEvidenceIsRefusedAndStoresNothing(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Petra Vogel", "petra@refuse.test", "Vogel KG", "refuse.test")
+
+	for name, claim := range map[string]ResearchClaimInput{
+		"no value":  {Field: "title", Quote: "Petra Vogel, director.", SourceURL: "https://refuse.test/a"},
+		"no quote":  {Field: "title", Value: "Director", SourceURL: "https://refuse.test/a"},
+		"no source": {Field: "title", Value: "Director", Quote: "Petra Vogel, director."},
+	} {
+		if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{claim}); err == nil {
+			t.Errorf("%s: SaveResearchClaims = nil error, want a refusal", name)
+		}
+	}
+
+	var rows int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM person_profile_field WHERE person_id = $1`, personID).Scan(&rows)
+	}); err != nil {
+		t.Fatalf("count the claims: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("rows = %d, want 0 — a refused claim was stored anyway", rows)
+	}
+}
+
+// A source that is not a document a reader can open is refused at the WRITE,
+// not only where the run produced it. A client is not obliged to send back
+// what the run returned, so a read path that refuses a script URL and a write
+// path that accepts it is how untrusted input reaches the record.
+func TestAResearchClaimWhoseSourceIsNotAWebURLIsRefusedAtTheWrite(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Ravi Menon", "ravi@scheme.test", "Menon Ltd", "scheme.test")
+
+	for _, source := range []string{
+		"javascript:alert(1)",
+		"data:text/html,<script>alert(1)</script>",
+		"file:///etc/passwd",
+		"https://",
+	} {
+		_, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
+			Field: "title", Value: "CTO",
+			Quote: "Ravi Menon is the CTO.", SourceURL: source,
+		}})
+		if err == nil {
+			t.Errorf("source %q was accepted, want a refusal", source)
+		}
+	}
+}
+
+// An archived person takes no new claims. The accept drawer can be open when
+// somebody else archives the record, so the guard is the write's, not the
+// screen's.
+func TestAnArchivedPersonTakesNoResearchClaim(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Elke Braun", "elke@archived.test", "Braun GmbH", "archived.test")
+	// Archived by a seat that may delete, which the accepting rep is not: the
+	// point is that a live grant to UPDATE does not survive the record being
+	// retired by somebody else.
+	if _, err := e.store.ArchivePerson(e.asArchiver(), personID, nil); err != nil {
+		t.Fatalf("archive the person: %v", err)
+	}
+
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
+		Field: "title", Value: "Owner",
+		Quote: "Elke Braun owns the company.", SourceURL: "https://archived.test/about",
+	}}); err == nil {
+		t.Fatal("SaveResearchClaims = nil error on an archived person, want a refusal")
+	}
+}

--- a/backend/internal/modules/people/researchclaim_integration_test.go
+++ b/backend/internal/modules/people/researchclaim_integration_test.go
@@ -209,9 +209,8 @@ func TestEveryClaimInOneAcceptanceLands(t *testing.T) {
 	}
 }
 
-// A claim missing any of its three evidence parts is refused, and nothing is
-// written. The validation runs before authority is asked about, so this also
-// pins that a malformed request never reaches the person row.
+// A claim missing any of its three evidence parts is refused, and the table is
+// left empty — a partial claim is not stored in a weaker form.
 func TestAResearchClaimMissingItsEvidenceIsRefusedAndStoresNothing(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()

--- a/backend/internal/modules/people/researchclaim_integration_test.go
+++ b/backend/internal/modules/people/researchclaim_integration_test.go
@@ -5,35 +5,42 @@
 
 package people
 
-// Saving an accepted research claim, over a real Postgres.
+// Saving the research claims a human accepted, over a real Postgres.
 //
-// The statement is exercised rather than read, because reading it is what
-// failed: it shipped with its columns bound to the wrong placeholders and its
-// argument count disagreeing with its highest placeholder, so every call
-// errored — and the two tests this package already had over the accept path
-// both filter input and never reach the database. A writer nothing executes is
-// a writer nothing checks.
+// The statement is EXECUTED here rather than read, because a claim's columns
+// are only checkable against a database: the accept path's other tests filter
+// input and return before the transaction opens, so they can say nothing about
+// what a row ends up holding.
+//
+// Every column is asserted individually rather than "a row exists". A row
+// exists for any argument order, so the weaker assertion admits a statement
+// whose values are each their neighbour's — and the stored value is what a
+// reader is later shown as a fact about a person.
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// asArchiver is the accepting rep's context plus the delete grant archiving
-// needs. Separate from as() so the accept path is always exercised under a
-// seat that may update and nothing more.
+// asArchiver is a COLLEAGUE who may retire a record, which the accepting rep
+// may not: `as()` carries no delete grant. Two seats, so an acceptance refused
+// on an archived person is refused because the record is retired and not
+// because the caller lacks authority over it.
 func (e *dedupeEnv) asArchiver() context.Context {
+	other := e.otherRep
 	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Type: principal.PrincipalHuman, ID: "human:" + other.String(), UserID: other,
 		Permissions: principal.Permissions{
-			RoleKeys: []string{"admin"},
+			RoleKeys: []string{"rep"},
 			Objects: map[string]principal.ObjectGrant{
 				"person": {Read: true, Update: true, Delete: true},
 			},
@@ -67,9 +74,22 @@ func readStoredClaim(ctx context.Context, t *testing.T, e *dedupeEnv, personID i
 	return got
 }
 
-// Every column holds what the caller supplied for it. Asserted column by
-// column rather than "a row exists": the defect this covers wrote a row on
-// every field, and each value was the neighbouring argument.
+func claimRowsFor(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.PersonID) int {
+	t.Helper()
+	var rows int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM person_profile_field WHERE person_id = $1`, personID).Scan(&rows)
+	}); err != nil {
+		t.Fatalf("count the stored claims: %v", err)
+	}
+	return rows
+}
+
+// Every column holds what the caller supplied for it, and the row is found
+// under the person and field a reader looks it up by — the two halves are
+// separate assertions because a row stored under the wrong key is invisible to
+// the lookup while still being a row.
 func TestSavingAResearchClaimWritesEachColumnTheValueItWasGiven(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
@@ -101,43 +121,14 @@ func TestSavingAResearchClaimWritesEachColumnTheValueItWasGiven(t *testing.T) {
 	if got != want {
 		t.Errorf("stored claim = %+v, want %+v", got, want)
 	}
-}
-
-// The person id is the person's, and the field is the field's. Its own case
-// because the shipped defect put the WORKSPACE id in both, which a
-// value-only assertion cannot see: the row was unreachable by the id a reader
-// looks it up under, so "no row" and "wrong row" had to be told apart.
-func TestASavedResearchClaimIsFoundUnderThePersonAndFieldItNames(t *testing.T) {
-	e := setupDedupe(t)
-	ctx := e.as()
-	personID, _ := e.seedEmployedPerson(ctx, t,
-		"Tomas Reit", "tomas@lookup.test", "Reit GmbH", "lookup.test")
-
-	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
-		Field:     "role",
-		Value:     "Board member",
-		Quote:     "Tomas Reit sits on the supervisory board.",
-		SourceURL: "https://lookup.test/board",
-	}}); err != nil {
-		t.Fatalf("SaveResearchClaims: %v", err)
-	}
-
-	var rows int
-	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
-			SELECT count(*) FROM person_profile_field
-			WHERE person_id = $1 AND field = 'role'`, personID).Scan(&rows)
-	}); err != nil {
-		t.Fatalf("count the role claim: %v", err)
-	}
-	if rows != 1 {
-		t.Errorf("rows under (person, 'role') = %d, want 1 — the claim is stored under something else", rows)
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 1 {
+		t.Errorf("rows under this person = %d, want 1 — the claim is stored under another key too", rows)
 	}
 }
 
-// A later claim about the same field replaces the earlier one, and the
-// trigger moves the version with it. This is the DO UPDATE arm, which the
-// accept drawer reaches whenever a reader revisits a field they already chose.
+// A later claim about the same field replaces the earlier one. This is the
+// DO UPDATE arm, which the accept drawer reaches whenever a reader revisits a
+// field they have already chosen.
 func TestAcceptingASecondClaimAboutOneFieldReplacesTheFirst(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
@@ -168,22 +159,33 @@ func TestAcceptingASecondClaimAboutOneFieldReplacesTheFirst(t *testing.T) {
 	if got.value != second.Value || got.snippet != second.Quote || got.sourceRef != second.SourceURL {
 		t.Errorf("stored claim = %+v, want the second claim's value/quote/source", got)
 	}
-	// The trigger owns this, so a fill that stopped bumping it would mean the
-	// UPDATE arm stopped firing and the row was being inserted afresh.
+	// The trigger owns the bump, so a version still at 1 means the row was
+	// inserted afresh rather than updated — the replacement never happened and
+	// a reader would be looking at a second row under a key they cannot see.
 	if got.version != 2 {
 		t.Errorf("version = %d, want 2 after the replacement", got.version)
 	}
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 1 {
+		t.Errorf("rows for the replaced field = %d, want 1", rows)
+	}
 }
 
-// Several claims in one call all land. The loop commits inside one
-// transaction, so a statement that failed on the second claim would leave the
-// reader's first choice saved and their second silently gone.
-func TestEveryClaimInOneAcceptanceLands(t *testing.T) {
+// One acceptance of several claims writes them all, and carries the write
+// shape: the domain rows, one audit_log row and one event_outbox row in ONE
+// transaction. Without the ledger half a reader's decision changes a person's
+// record with nothing recording who decided it, on a table whose whole purpose
+// is to make a fact traceable.
+func TestOneAcceptanceWritesEveryClaimAndTheWriteShape(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
 	personID, _ := e.seedEmployedPerson(ctx, t,
 		"Ana Sol", "ana@many.test", "Sol SA", "many.test")
 
+	accepted := map[string]string{
+		"title":    "CFO",
+		"role":     "Signatory",
+		"linkedin": "https://linkedin.test/in/anasol",
+	}
 	saved, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{
 		{Field: "title", Value: "CFO", Quote: "Ana Sol, CFO.", SourceURL: "https://many.test/a"},
 		{Field: "role", Value: "Signatory", Quote: "Ana Sol may sign alone.", SourceURL: "https://many.test/b"},
@@ -195,18 +197,57 @@ func TestEveryClaimInOneAcceptanceLands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveResearchClaims: %v", err)
 	}
-	if saved != 3 {
-		t.Fatalf("saved = %d, want 3", saved)
+	if saved != len(accepted) {
+		t.Fatalf("saved = %d, want %d", saved, len(accepted))
 	}
-	for field, value := range map[string]string{
-		"title":    "CFO",
-		"role":     "Signatory",
-		"linkedin": "https://linkedin.test/in/anasol",
-	} {
+	for field, value := range accepted {
 		if got := readStoredClaim(ctx, t, e, personID, field); got.value != value {
 			t.Errorf("%s = %q, want %q", field, got.value, value)
 		}
 	}
+
+	audits, events, counted := acceptanceLedger(ctx, t, e, personID)
+	if audits != 1 {
+		t.Errorf("%d audit_log rows for the acceptance, want 1 — nothing records who accepted these claims", audits)
+	}
+	if events != 1 {
+		t.Errorf("%d event_outbox rows for the acceptance, want 1 — no consumer is told the person changed", events)
+	}
+	// The audited count is read off the row rather than trusted from the
+	// return value: the same number reaches the caller and the ledger, and a
+	// ledger claiming more than landed is a false history of a person's record.
+	if counted != len(accepted) {
+		t.Errorf("audited research_claims_saved = %d, want %d", counted, len(accepted))
+	}
+}
+
+// acceptanceLedger returns the person's audit_log and event_outbox rows for an
+// acceptance, and the count the audit row recorded.
+//
+// Both sides key on the acceptance's own marker — the audit's
+// research_claims_saved and the envelope's profile_fields — because the seed
+// that creates the person, their employer and the edge between them emits
+// events carrying this person's id too. Matching the id alone counts those and
+// reads as "the acceptance emitted three".
+func acceptanceLedger(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.PersonID) (audits, events, counted int) {
+	t.Helper()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT (SELECT count(*) FROM audit_log
+			         WHERE entity_type = 'person' AND entity_id = $1
+			           AND after -> 'research_claims_saved' IS NOT NULL),
+			       (SELECT count(*) FROM event_outbox
+			         WHERE envelope::text LIKE '%' || $1::text || '%'
+			           AND envelope::text LIKE '%profile_fields%'),
+			       coalesce((SELECT (after ->> 'research_claims_saved')::int FROM audit_log
+			                  WHERE entity_type = 'person' AND entity_id = $1
+			                    AND after -> 'research_claims_saved' IS NOT NULL
+			                  LIMIT 1), 0)`,
+			personID).Scan(&audits, &events, &counted)
+	}); err != nil {
+		t.Fatalf("counting the acceptance's ledger rows: %v", err)
+	}
+	return audits, events, counted
 }
 
 // A claim missing any of its three evidence parts is refused, and the table is
@@ -226,56 +267,42 @@ func TestAResearchClaimMissingItsEvidenceIsRefusedAndStoresNothing(t *testing.T)
 			t.Errorf("%s: SaveResearchClaims = nil error, want a refusal", name)
 		}
 	}
-
-	var rows int
-	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
-			`SELECT count(*) FROM person_profile_field WHERE person_id = $1`, personID).Scan(&rows)
-	}); err != nil {
-		t.Fatalf("count the claims: %v", err)
-	}
-	if rows != 0 {
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 0 {
 		t.Errorf("rows = %d, want 0 — a refused claim was stored anyway", rows)
 	}
 }
 
-// A source that is not a document a reader can open is refused at the WRITE,
-// not only where the run produced it. A client is not obliged to send back
-// what the run returned, so a read path that refuses a script URL and a write
-// path that accepts it is how untrusted input reaches the record.
-func TestAResearchClaimWhoseSourceIsNotAWebURLIsRefusedAtTheWrite(t *testing.T) {
+// A field outside the closed set takes the WHOLE acceptance down with it. The
+// set is the database's (person_profile_field's field check), so this claim is
+// refused mid-transaction rather than by the loop above it — which is what
+// makes it the case that proves the acceptance is all-or-nothing. A reader
+// whose second choice was rejected must not find their first one saved, since
+// they would have no way to tell which half of their decision took effect.
+func TestAnUnknownFieldTakesTheWholeAcceptanceDown(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
 	personID, _ := e.seedEmployedPerson(ctx, t,
-		"Ravi Menon", "ravi@scheme.test", "Menon Ltd", "scheme.test")
+		"Milan Prit", "milan@atomic.test", "Prit doo", "atomic.test")
 
-	for _, source := range []string{
-		"javascript:alert(1)",
-		"data:text/html,<script>alert(1)</script>",
-		"file:///etc/passwd",
-		"https://",
-	} {
-		_, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
-			Field: "title", Value: "CTO",
-			Quote: "Ravi Menon is the CTO.", SourceURL: source,
-		}})
-		if err == nil {
-			t.Errorf("source %q was accepted, want a refusal", source)
-		}
+	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{
+		{Field: "title", Value: "COO", Quote: "Milan Prit, COO.", SourceURL: "https://atomic.test/a"},
+		{Field: "email", Value: "milan@atomic.test", Quote: "Contact Milan at this address.", SourceURL: "https://atomic.test/b"},
+	}); err == nil {
+		t.Fatal("SaveResearchClaims = nil error for a field outside the closed set, want a refusal")
+	}
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 0 {
+		t.Errorf("rows = %d, want 0 — the first claim survived a refused acceptance", rows)
 	}
 }
 
 // An archived person takes no new claims. The accept drawer can be open when
-// somebody else archives the record, so the guard is the write's, not the
+// somebody else archives the record, so the guard is the write's and not the
 // screen's.
 func TestAnArchivedPersonTakesNoResearchClaim(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
 	personID, _ := e.seedEmployedPerson(ctx, t,
 		"Elke Braun", "elke@archived.test", "Braun GmbH", "archived.test")
-	// Archived by a seat that may delete, which the accepting rep is not: the
-	// point is that a live grant to UPDATE does not survive the record being
-	// retired by somebody else.
 	if _, err := e.store.ArchivePerson(e.asArchiver(), personID, nil); err != nil {
 		t.Fatalf("archive the person: %v", err)
 	}
@@ -283,7 +310,34 @@ func TestAnArchivedPersonTakesNoResearchClaim(t *testing.T) {
 	if _, err := e.store.SaveResearchClaims(ctx, personID, []ResearchClaimInput{{
 		Field: "title", Value: "Owner",
 		Quote: "Elke Braun owns the company.", SourceURL: "https://archived.test/about",
-	}}); err == nil {
-		t.Fatal("SaveResearchClaims = nil error on an archived person, want a refusal")
+	}}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("SaveResearchClaims on an archived person = %v, want ErrNotFound", err)
+	}
+}
+
+// A rep bounded to their own rows cannot accept claims about a person they may
+// only READ. The seat matters more here than anywhere else in this file: every
+// other case runs unbounded, where the write-authority arm short-circuits, so
+// without this one the narrower half of the gate is never exercised.
+//
+// ErrPermissionDenied and not ErrNotFound, which is the write gate's own rule
+// (auth/writescope.go): the visibility probe runs first and keeps its 404, and
+// this caller PASSES it — they can open the record — so the write arm refuses
+// in the open rather than hiding a row already shown to them.
+func TestARepWhoMayOnlyReadAPersonCannotAcceptClaimsOnThem(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Sofia Reyes", "sofia@bounded.test", "Reyes SL", "bounded.test")
+
+	reader := e.asRowScope(principal.RowScopeOwn)
+	if _, err := e.store.SaveResearchClaims(reader, personID, []ResearchClaimInput{{
+		Field: "title", Value: "Head of Legal",
+		Quote: "Sofia Reyes heads the legal team.", SourceURL: "https://bounded.test/team",
+	}}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("SaveResearchClaims without write authority = %v, want ErrPermissionDenied", err)
+	}
+	if rows := claimRowsFor(ctx, t, e, personID); rows != 0 {
+		t.Errorf("rows = %d, want 0 — a refused acceptance wrote anyway", rows)
 	}
 }

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -36,7 +36,8 @@ func TestSchema_amountMinorBaseIsDatabaseGenerated(t *testing.T) {
 	ctx := context.Background()
 
 	var isGenerated, generationExpr string
-	if err := owner.QueryRow(ctx, `
+	if err := owner.QueryRow(
+		ctx, `
 		SELECT is_generated, generation_expression
 		FROM information_schema.columns
 		WHERE table_schema = 'public' AND table_name = 'deal' AND column_name = 'amount_minor_base'`,
@@ -56,7 +57,8 @@ func TestSchema_amountMinorBaseIsDatabaseGenerated(t *testing.T) {
 	// Postgres's STORED-generated marker (the only kind it currently
 	// supports), cross-checking the information_schema view above.
 	var attgenerated string
-	if err := owner.QueryRow(ctx, `
+	if err := owner.QueryRow(
+		ctx, `
 		SELECT attgenerated FROM pg_attribute
 		WHERE attrelid = 'deal'::regclass AND attname = 'amount_minor_base' AND NOT attisdropped`,
 	).Scan(&attgenerated); err != nil {
@@ -80,7 +82,8 @@ func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
 	ctx := context.Background()
 
 	var reloptions []string
-	if err := owner.QueryRow(ctx, `
+	if err := owner.QueryRow(
+		ctx, `
 		SELECT COALESCE(reloptions, '{}') FROM pg_class
 		WHERE relname = 'organization_open_pipeline_rollup' AND relnamespace = 'public'::regnamespace`,
 	).Scan(&reloptions); err != nil {
@@ -276,13 +279,18 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// GetDedupeCandidate). All six entries rest on that read, held by
 	// TestDedupeQueueHidesPairsOutsideTheCallersRowScope and, per entity type and
 	// per side, TestDedupeQueueHidesAPairTheCallerCanOnlyHalfSee.
-	"dedupe_candidate.left_person_id":           "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
-	"dedupe_candidate.right_person_id":          "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
-	"dedupe_candidate.left_org_id":              "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
-	"dedupe_candidate.right_org_id":             "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
-	"dedupe_candidate.left_lead_id":             "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
-	"dedupe_candidate.right_lead_id":            "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
-	"person_profile_field.person_id":            "server-derived: the enrich pass resolves the person from its own connector-activity query (PO-DDL-12), never from a request body — it runs as the system principal, so what holds this is the absence of a caller, not a scope clause",
+	"dedupe_candidate.left_person_id":  "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.right_person_id": "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.left_org_id":     "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.right_org_id":    "server-derived: stamped by recordDedupeCandidate from the writing path's own match query",
+	"dedupe_candidate.left_lead_id":    "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
+	"dedupe_candidate.right_lead_id":   "server-derived: stamped by recordDedupeCandidate from fuzzyLead's own match query",
+	// Two writers, two different things holding them, so both are named: the
+	// enrich pass has no caller to scope against, and the research accept has
+	// one. This census is keyed by COLUMN, so it cannot notice a second writer
+	// of an already-waived column — the text is the only control, and a waiver
+	// naming one writer would read as covering both.
+	"person_profile_field.person_id":            "server-derived for the enrich pass — it resolves the person from its own connector-activity query (PO-DDL-12) as the system principal, so what holds it is the absence of a caller; gated for SaveResearchClaims, whose person id IS the request path's — auth.EnsureWritableLive inside the write's own transaction",
 	"capture_auto_enrich_state.organization_id": "server-derived: the auto-enrich sweep keys the cursor on an org id its own ListDueOrgs read produced (CAP-PARAM-7), never from a request body — a background pass with no caller to scope against",
 	// The signature pass's read cursor (PO-F-2a): both ids come from the
 	// pass's own SignatureCandidates query — the person it just read for and


### PR DESCRIPTION
## What this changes

Two commits, and the second exists because of the first.

1. **`people/researchclaim.go` bound every column of its insert to the wrong placeholder.** `SaveResearchClaims` errored on every call, so the person-research accept path has been dead on `main`.
2. **The rule against building a capability twice is now in both rulebooks** instead of only in ten source comments.

Found while auditing #2145's "same duplication with Meeting Brief in MCP and Website" comment.

## 1. The broken writer

```
INSERT INTO person_profile_field (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
VALUES ($1, $1, $2, $3, $4, $6, $5)
```

Arguments passed: `MustWorkspace(ctx)`, `personID`, `claim.Field`, `claim.Value`, `claim.Quote`, `claim.SourceURL`, `by`, `researchSource`.

| Column | Was bound to | Should be |
|---|---|---|
| `person_id` | `$1` = workspace id | `personID` |
| `field` | `$1` = workspace id | `claim.Field` |
| `value` | `$2` = personID | `claim.Value` |
| `evidence_snippet` | `$3` = claim.Field | `claim.Quote` |
| `source_ref` | `$4` = claim.Value | `claim.SourceURL` |
| `source` | `$6` = claim.SourceURL | `researchSource` |
| `captured_by` | `$5` = claim.Quote | `by` |

The statement also declared `$1..$6` while eight arguments were passed — `by` and `researchSource` were never referenced.

Postgres refused it before any of that reached a row, because `$1` served a uuid and a text column in one statement:

```
ERROR: inconsistent types deduced for parameter $1 (SQLSTATE 42P08)
```

**Introduced** in #1764 ("close the gaps the phase-D column removals left in SQL literals"), 2026-08-19. The sweep removed the workspace column from this statement and renumbered wrongly.

`MustWorkspace` goes with the fix: `person_profile_field` has no workspace column — phase D removed it — and `uq_person_profile_field` is `UNIQUE (person_id, field)`. The comment claiming the branch had to name the workspace described a column that no longer exists.

## Why no gate caught it

Nothing in the tree executed the statement:

- `compose/personresearch/service_test.go` has two tests; both filter input and never reach the database.
- `rbacgate_test.go` is a static census.
- Only one test file in the whole tree mentions `person_profile_field` at all.

That is CLAUDE.md rule #6 — *"a test that supplies its own version of production proves nothing about production."*

## The tests

Seven integration tests, asserting the stored row **column by column** rather than that a row exists — the defect wrote a row every time, and each value was its neighbour's.

Verified they fail without the fix:

```
$ git stash push -- backend/internal/modules/people/researchclaim.go
$ make test-it DIR=backend/internal/modules/people RUN=TestSavingAResearchClaimWritesEachColumn
    researchclaim_integration_test.go:67: SaveResearchClaims: save the research claim "title":
      ERROR: inconsistent types deduced for parameter $1 (SQLSTATE 42P08)
--- FAIL: TestSavingAResearchClaimWritesEachColumnTheValueItWasGiven (0.30s)
```

Coverage of the changed code:

| Function | Coverage |
|---|---|
| `SaveResearchClaims` | **84.6%** |
| `webSourceURL` | **83.3%** |

Uncovered remainder is the unreachable error returns (`CapturedBy`, `Audit`, `EmitEvent` failures).

## 2. The rulebook change

The rule was already written ten times, in `compose/*seam*.go` comments — `briefseam.go`: *"one queue rather than two readings of it"*; `importseam.go`: *"it delegates rather than reimplementing, and that is the whole design"*. A comment inside the right file only helps someone who already found the right file.

No gate could catch it either:

- `gate.Inputs` (`cli/craft/gate/prompt.go:14-22`) carries the diff, touched files and their **siblings**. Reviewing a new assembler in `modules/agents/`, craft never sees `compose/meetingbrief/`.
- Reuse appears once in the rubric, as `P5 restraint`, in the section `prompt.go:88` labels *"never blocks"*.

So `prep_for_meeting` was written beside a working meeting brief, and the two now answer one question with different grounding: the web surface drops a sentence whose citations do not resolve, the tool keeps everything.

The new section states four rules — search the whole tree; the tool and web surfaces share one engine and you write the seam if none exists; never hand-type a SQL placeholder; a comment may not claim to be the only implementation unless a test holds it. It goes in **both** files and into `sharedSections`, so the parity test holds the copies together, and because `AGENTS.md` is fed whole into the gate prompt the rule reaches the reviewer as well as the author.

## Verification

```
make check                 exit 0  (backend + frontend)
craft static --strict      PASS — 0 blocker, 0 major, 0 minor
make test-it (people)      7/7 pass
```

Rebased on `origin/main` at `ed6e76a1a`.

## Deliberately not in this PR

Found in the same audit, each wants its own change:

- `compose/sitepeople.go:80` uses `strings.ToLower`, which does not fold ß→ss, while `namesim.go:46` says full casefold exists because *"the DACH market meets that pair daily"*. A German site rendering a name two ways mints two leads.
- `privacy/retentionactions.go:211` claims *"the same in-place anonymization the eraser performs"*; it never nulls custom columns and never deletes `field_provenance` or `ai_feedback` for person or lead. Extends #2205, which covers the `activity` arm only.
- `compose/report.go:51` calls itself *"the one spelling of weighted value"* that *"cannot drift apart"*; `orgrollup.go:107` computes it again in Go with no test comparing them.
- Unlike its three siblings, `SaveResearchClaims` never calls `storekit.StampFields`, so a research-accepted field gets no `field_provenance` row.
- `relationship` has four independent INSERT writers bypassing `CreateRelationship`.

Refs #2145.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes research claim saves and makes “reuse before you build” an enforced rule. Old: `SaveResearchClaims` reused `$1`, misnumbered placeholders, and failed with 42P08. New: the insert binds `$1..$7` in order, removes workspace, and upserts by `(person_id, field)`, preventing duplicate implementations noted in Linear #2145.

- Backend
  - Old: reused `$1`, declared `$1..$6` but passed 8 args; wrote wrong columns or failed. New: `INSERT ... VALUES ($1..$7)` with `ON CONFLICT (person_id, field)` updating value, evidence, source, and captured_by; trigger sets timestamps/version; drops obsolete workspace reference.
  - Adds Postgres integration tests that assert each stored column and the write shape: 1 `audit_log`, 1 `event_outbox`, audited count matches; acceptance is atomic on unknown fields; denies row-scope-only writers (`ErrPermissionDenied`); rejects archived persons (`ErrNotFound`).
  - Updates schema fitness waiver for `person_profile_field.person_id` to document both writers (enrich vs `SaveResearchClaims`) and gating.

- Rulebook and parity
  - Adds “Reuse before you build” to `AGENTS.md` and `CLAUDE.md`; `backend/agentsdocparity_test.go` now enforces four shared sections and byte-identical copies.
  - Tightens SQL placeholder guidance: derive `$N`; use only column literals or sanitized identifiers via `pgx.Identifier.Sanitize`; never hand-type placeholders; removes brittle counts.

<sup>Written for commit 10ada25f31c1630f562f95b9be394f44b1d77c0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

