### PR TITLE
feat(records): the meeting brief knows which engagement it is about

### DIFF
--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -179,3 +179,166 @@ func seatInRoom(t *testing.T, owner *pgx.Conn, ws, activity, person ids.UUID) {
 		t.Fatalf("seating a participant: %v", err)
 	}
 }
+
+// roomPermsWithProject is the bounded rep plus the project grant. A brief that
+// names an engagement is TWO reads, and the project half needs its own object
+// grant — roomPerms deliberately carries none, which is what
+// TestMeetingBriefWithholdsTheEngagementFromACallerWithNoProjectGrant proves.
+func roomPermsWithProject() principal.Permissions {
+	perms := roomPerms
+	perms.Objects = map[string]principal.ObjectGrant{"project": {Read: true}}
+	for object, grant := range roomPerms.Objects {
+		perms.Objects[object] = grant
+	}
+	return perms
+}
+
+// The brief's project lines are rendered from a lateral join and a correlated
+// sub-select, and both reference an alias declared elsewhere in the same FROM
+// clause. Unit tests over the section writers cannot see any of that: they are
+// handed an Input that already holds a project. Only a real query proves the
+// SQL puts one there.
+func TestMeetingBriefNamesTheEngagementItIsFiledUnder(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	org := e.SeedOrg(t, "Northwind", &e.Rep1)
+	attendee := e.SeedPerson(t, "Ana Roth", &e.Rep1)
+
+	project := SeedIDRow(t, owner, `INSERT INTO project (id, owner_id, name, key, phase, organization_id, source, captured_by)
+		VALUES ($1, $2, 'ERP rollout', 'ERP-27', 'delivering', $3, 'manual', 'human:x')`, e.Rep1, org)
+
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Cutover review', $2, 'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", attendee)
+	seatInRoom(t, owner, e.WS, meeting, attendee)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+		VALUES ($1, 'project', $2)`, meeting, project)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPermsWithProject())
+	brief, err := meetingBriefService(e).Get(rep, meeting)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	var header, goal string
+	for _, section := range brief.Sections {
+		for _, sentence := range section.Sentences {
+			switch section.Kind {
+			case "header":
+				header += sentence.Text + "\n"
+			case "goal":
+				goal += sentence.Text + "\n"
+			}
+		}
+	}
+	if !strings.Contains(header, "ERP rollout") || !strings.Contains(header, "ERP-27") {
+		t.Errorf("header = %q, want the engagement and its key", header)
+	}
+	// The room has no deal and no open promise, so before the project arm the
+	// goal section was absent entirely — which is the failure this fixes.
+	if !strings.Contains(goal, "ERP rollout") {
+		t.Errorf("goal = %q, want the engagement's own next step", goal)
+	}
+}
+
+// A meeting filed under one engagement must not report a last touch measured
+// against another. This is the number a reader trusts most, and scoping the
+// deal while leaving the attendee sub-select alone is the predicted mistake.
+func TestMeetingBriefCountsNoLastTouchFromAnotherEngagement(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	org := e.SeedOrg(t, "Northwind", &e.Rep1)
+	attendee := e.SeedPerson(t, "Ana Roth", &e.Rep1)
+
+	newProject := func(name, key string) ids.UUID {
+		return SeedIDRow(t, owner, `INSERT INTO project (id, owner_id, name, key, organization_id, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5, 'manual', 'human:x')`, e.Rep1, name, key, org)
+	}
+	erp := newProject("ERP rollout", "ERP-27")
+	migration := newProject("Datacentre migration", "DC-4")
+
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Cutover review', $2, 'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", attendee)
+	seatInRoom(t, owner, e.WS, meeting, attendee)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+		VALUES ($1, 'project', $2)`, meeting, erp)
+
+	// The ONLY prior conversation with this attendee belongs to the other
+	// engagement, so within this room's scope they have never been spoken to.
+	other := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Rack decommissioning', $2, 'manual', 'human:x')`, roomAgo(3*24*time.Hour))
+	LinkActivity(t, owner, other, "person", attendee)
+	seatInRoom(t, owner, e.WS, other, attendee)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+		VALUES ($1, 'project', $2)`, other, migration)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPermsWithProject())
+	brief, err := meetingBriefService(e).Get(rep, meeting)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	var attendees string
+	for _, section := range brief.Sections {
+		if section.Kind != "attendees" {
+			continue
+		}
+		for _, sentence := range section.Sentences {
+			attendees += sentence.Text + "\n"
+		}
+	}
+	if attendees == "" {
+		t.Fatal("the brief rendered no attendees section, so this proves nothing")
+	}
+	if !strings.Contains(attendees, "first") {
+		t.Errorf("attendees = %q; want Ana Roth flagged first-time — her only prior conversation belongs to the other engagement", attendees)
+	}
+}
+
+// The project is a SECOND gate, and the two are different questions: row scope
+// decides which projects a caller may see, the object grant decides whether
+// they may see projects at all. Since projects became workspace-readable the
+// row clause admits everyone, so without the grant check a caller who may open
+// the meeting reads the engagement's name, key, phase and target date off it.
+func TestMeetingBriefWithholdsTheEngagementFromACallerWithNoProjectGrant(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	org := e.SeedOrg(t, "Northwind", &e.Rep1)
+	attendee := e.SeedPerson(t, "Ana Roth", &e.Rep1)
+	project := SeedIDRow(t, owner, `INSERT INTO project (id, owner_id, name, key, phase, organization_id, source, captured_by)
+		VALUES ($1, $2, 'ERP rollout', 'ERP-27', 'delivering', $3, 'manual', 'human:x')`, e.Rep1, org)
+
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Cutover review', $2, 'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", attendee)
+	seatInRoom(t, owner, e.WS, meeting, attendee)
+	e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+		VALUES ($1, 'project', $2)`, meeting, project)
+
+	read := func(perms principal.Permissions) string {
+		t.Helper()
+		brief, err := meetingBriefService(e).Get(e.As(e.Rep1, []ids.UUID{e.Team1}, perms), meeting)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		var prose string
+		for _, section := range brief.Sections {
+			for _, sentence := range section.Sentences {
+				prose += sentence.Text + "\n"
+			}
+		}
+		return prose
+	}
+
+	// The admit case first. Three security tests in this repo once passed
+	// against an authority that refused everyone, so a refusal test proves
+	// nothing until the same fixture is shown to admit.
+	if !strings.Contains(read(roomPermsWithProject()), "ERP rollout") {
+		t.Fatal("a caller WITH the project grant cannot see the engagement, so the refusal below proves nothing")
+	}
+
+	// roomPerms itself carries no project grant.
+	if prose := read(roomPerms); strings.Contains(prose, "ERP") {
+		t.Errorf("the brief disclosed the engagement to a caller with no project grant: %q", prose)
+	}
+}

--- a/backend/internal/compose/meetingbrief/input.go
+++ b/backend/internal/compose/meetingbrief/input.go
@@ -28,8 +28,13 @@ type Input struct {
 	// several places that could straddle a midnight.
 	Now time.Time
 
-	Company   string
-	Deal      *DealIn
+	Company string
+	Deal    *DealIn
+	// Project is the body of work the meeting belongs to, when it is filed
+	// under one. It is what gives a DELIVERY meeting a goal: months after
+	// close-won there is often no open deal, and the section that leads the
+	// brief fell silent exactly when the engagement was the whole point.
+	Project   *ProjectIn
 	Attendees []AttendeeIn
 	// Commitments are the room's open promises and questions, ours and theirs,
 	// flattened across attendees because the reader asks "what is outstanding
@@ -50,6 +55,15 @@ type DealIn struct {
 	AmountMinor int64
 	Currency    string
 	CloseDate   *time.Time
+}
+
+// ProjectIn is the engagement this meeting is part of.
+type ProjectIn struct {
+	ID            string
+	Name          string
+	Key           string
+	Phase         string
+	TargetEndDate *time.Time
 }
 
 // AttendeeIn is one person in the room.
@@ -102,6 +116,15 @@ func FromMeeting(room meeting, perAttendee map[ids.UUID][]crmcontracts.Conversat
 			Currency:    room.Deal.Currency,
 			CloseDate:   room.Deal.CloseDate,
 			AmountMinor: derefInt(room.Deal.AmountMinor),
+		}
+	}
+	if room.Project != nil {
+		in.Project = &ProjectIn{
+			ID:            room.Project.ID.String(),
+			Name:          room.Project.Name,
+			Key:           room.Project.Key,
+			Phase:         room.Project.Phase,
+			TargetEndDate: room.Project.TargetEndDate,
 		}
 	}
 	for _, attendee := range room.Attendees {

--- a/backend/internal/compose/meetingbrief/meeting.go
+++ b/backend/internal/compose/meetingbrief/meeting.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // attendeeCap bounds who is named. This is "who is in the room" for prep, not
@@ -107,10 +108,7 @@ func (s *Service) readMeeting(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 	if err != nil {
 		return meeting{}, err
 	}
-	// The project the meeting is filed under decides which deal the header
-	// names and narrows the attendees' last touch, so it is read under the
-	// caller's own project scope like every other record on this page.
-	projectScope, err := scopeFor(ctx, "project", "prj", arg)
+	projectScope, err := projectJoinPredicate(ctx, "prj", arg)
 	if err != nil {
 		return meeting{}, err
 	}
@@ -276,6 +274,30 @@ func seatJoinPredicate(ctx context.Context, alias string, arg func(any) int) (st
 // scopeFor renders one object's row-scope clause, substituting the
 // narrows-nothing predicate for the helper's empty string. An empty clause
 // means the caller is unbounded for that object, never that the gate is skipped.
+// projectJoinPredicate admits the meeting's engagement, or matches it away.
+//
+// TWO GATES, not one, and conflating them is what this function exists to
+// prevent. Row scope (scopeFor below) decides WHICH projects a caller may see;
+// the OBJECT grant decides whether they may see projects at all. Since projects
+// became workspace-readable, row scope returns an unrestricted clause to
+// everyone — so a caller holding no project grant would have read the
+// engagement's name, key, phase and target date straight off a meeting they
+// could otherwise open.
+//
+// A refusal becomes a never-match rather than an error, the way the seat edge
+// beside it does: the project decorates a brief it does not select, so a caller
+// without the grant gets the brief with no project line — the same shape as a
+// meeting filed under nothing — rather than losing a brief they may read.
+func projectJoinPredicate(ctx context.Context, alias string, arg func(any) int) (string, error) {
+	if err := auth.Require(ctx, "project", principal.ActionRead); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return "FALSE", nil
+		}
+		return "", err
+	}
+	return scopeFor(ctx, "project", alias, arg)
+}
+
 func scopeFor(ctx context.Context, object, alias string, arg func(any) int) (string, error) {
 	clause, err := auth.ScopeClauseFor(ctx, object, alias, arg)
 	if err != nil {

--- a/backend/internal/compose/meetingbrief/meeting.go
+++ b/backend/internal/compose/meetingbrief/meeting.go
@@ -39,6 +39,7 @@ type meeting struct {
 	Subject   string
 	StartsAt  time.Time
 	Deal      *dealRow
+	Project   *projectRow
 	Attendees []attendeeRow
 }
 
@@ -53,6 +54,17 @@ type dealRow struct {
 	AmountMinor *int64
 	Currency    string
 	CloseDate   *time.Time
+}
+
+// projectRow is the body of work this meeting belongs to, if the meeting is
+// filed under one and the caller may read it. Absent is the ordinary case:
+// most meetings carry no project, and the brief simply says nothing about one.
+type projectRow struct {
+	ID            ids.UUID
+	Name          string
+	Key           string
+	Phase         string
+	TargetEndDate *time.Time
 }
 
 // attendeeRow is one person in the room, with what a reader needs to open a
@@ -95,6 +107,13 @@ func (s *Service) readMeeting(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 	if err != nil {
 		return meeting{}, err
 	}
+	// The project the meeting is filed under decides which deal the header
+	// names and narrows the attendees' last touch, so it is read under the
+	// caller's own project scope like every other record on this page.
+	projectScope, err := scopeFor(ctx, "project", "prj", arg)
+	if err != nil {
+		return meeting{}, err
+	}
 	// The last-touch sub-select reads ACTIVITIES, so it takes the activity row
 	// scope like every other activity read on this page. Without it the brief
 	// reports when an attendee last spoke to us using a conversation this
@@ -125,9 +144,12 @@ func (s *Service) readMeeting(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 	var dealID *ids.UUID
 	var stage, currency *string
 	var attendees []byte
-	err = tx.QueryRow(ctx, fmt.Sprintf(meetingQuery, dealScope, personScope, idPos, touchScope, edgeJoin), args...).
+	var project projectRow
+	var projectID *ids.UUID
+	err = tx.QueryRow(ctx, fmt.Sprintf(meetingQuery, dealScope, personScope, idPos, touchScope, edgeJoin, projectScope), args...).
 		Scan(&out.ID, &out.StartsAt, &subject,
 			&dealID, &deal.Name, &stage, &deal.AmountMinor, &currency, &deal.CloseDate,
+			&projectID, &project.Name, &project.Key, &project.Phase, &project.TargetEndDate,
 			&attendees)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// The visibility probe passed, so the row exists and the caller may
@@ -141,6 +163,10 @@ func (s *Service) readMeeting(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 
 	if subject != nil {
 		out.Subject = *subject
+	}
+	if projectID != nil {
+		project.ID = *projectID
+		out.Project = &project
 	}
 	if dealID != nil {
 		deal.ID = *dealID
@@ -166,6 +192,7 @@ func (s *Service) readMeeting(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 const meetingQuery = `
 	SELECT a.id, a.occurred_at, a.subject,
 	       d.id, COALESCE(d.name, ''), d.stage_name, d.amount_minor, d.currency, d.expected_close_date,
+	       pr.id, COALESCE(pr.name, ''), COALESCE(pr.key, ''), COALESCE(pr.phase, ''), pr.target_end_date,
 	       COALESCE((
 	         SELECT json_agg(json_build_object(
 	                  'person_id', p.id,
@@ -178,6 +205,17 @@ const meetingQuery = `
 	                    WHERE pp.person_id = p.id AND pa.archived_at IS NULL
 	                      AND pa.id <> a.id AND pa.occurred_at <= a.occurred_at
 	                      AND %[4]s
+	                      -- Scoped with the rest of the brief. This is the number
+	                      -- a reader trusts most, and it is the one that leaks:
+	                      -- narrow the deal and leave this alone and the brief
+	                      -- says "last spoke 3 days ago" counting a conversation
+	                      -- about the other engagement entirely.
+	                      AND (pr.id IS NULL OR EXISTS (
+	                            SELECT 1 FROM activity_link tl
+	                            WHERE tl.activity_id = pa.id AND tl.project_id = pr.id)
+	                          OR NOT EXISTS (
+	                            SELECT 1 FROM activity_link tf
+	                            WHERE tf.activity_id = pa.id AND tf.project_id IS NOT NULL))
 	                  ))
 	                ORDER BY p.full_name, p.id)
 	         FROM (SELECT DISTINCT ap.person_id FROM activity_participant ap
@@ -190,12 +228,25 @@ const meetingQuery = `
 	       ), '[]'::json)
 	FROM activity a
 	LEFT JOIN LATERAL (
+	  SELECT prj.id, prj.name, prj.key, prj.phase, prj.target_end_date
+	  FROM activity_link pl
+	  JOIN project prj ON prj.id = pl.project_id AND prj.archived_at IS NULL
+	  WHERE pl.activity_id = a.id AND pl.project_id IS NOT NULL AND %[6]s
+	  LIMIT 1
+	) pr ON TRUE
+	LEFT JOIN LATERAL (
 	  SELECT dd.id, dd.name, s.name AS stage_name, dd.amount_minor, dd.currency, dd.expected_close_date
 	  FROM activity_link dl
 	  JOIN deal dd ON dd.id = dl.deal_id AND dd.archived_at IS NULL
 	  LEFT JOIN stage s ON s.id = dd.stage_id
 	  WHERE dl.activity_id = a.id AND dl.deal_id IS NOT NULL AND %[1]s
-	  ORDER BY dd.expected_close_date NULLS LAST, dd.id
+	  -- The meeting's own project decides WHICH deal this brief is about. An
+	  -- account running two engagements carries two open deals, and picking by
+	  -- close date alone named whichever happened to land first — a header
+	  -- confidently about the other body of work. Nulls sort last, so an
+	  -- unattributed meeting keeps the old ordering exactly.
+	  ORDER BY (pr.id IS NOT NULL AND dd.project_id = pr.id) DESC,
+	           dd.expected_close_date NULLS LAST, dd.id
 	  LIMIT 1
 	) d ON TRUE
 	WHERE a.id = $%[3]d AND a.kind = 'meeting' AND a.archived_at IS NULL`

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -97,6 +97,12 @@ func Deterministic(in Input) []Section {
 func headerSection(in Input) []Sentence {
 	self := []Evidence{{EntityType: citeActivity, EntityID: in.ActivityID}}
 	out := []Sentence{{Text: meetingLine(in), Evidence: self}}
+	// Which engagement, before which deal: on an account running two bodies of
+	// work the project is what tells the reader they are in the right room, and
+	// a deal line alone leaves that to be inferred from the deal's name.
+	if in.Project != nil {
+		out = append(out, Sentence{Text: projectHeaderLine(*in.Project), Evidence: self})
+	}
 	if in.Deal != nil {
 		out = append(out, Sentence{
 			Text:     dealHeaderLine(*in.Deal),
@@ -105,18 +111,6 @@ func headerSection(in Input) []Sentence {
 	}
 	out = append(out, Sentence{Text: lastTouchLine(in), Evidence: self})
 	return out
-}
-
-func meetingLine(in Input) string {
-	subject := in.Subject
-	if subject == "" {
-		subject = "Meeting"
-	}
-	when := in.StartsAt.Format("Mon 2 Jan 15:04 MST")
-	if in.Company == "" {
-		return fmt.Sprintf("%s, %s.", subject, when)
-	}
-	return fmt.Sprintf("%s with %s, %s.", subject, in.Company, when)
 }
 
 // dealHeaderLine states the commercial stake in one line: what is on the table,
@@ -174,14 +168,30 @@ func goalSection(in Input) []Sentence {
 			Evidence: []Evidence{{EntityType: citeActivity, EntityID: ours.SourceID}},
 		}}
 	}
-	if in.Deal == nil {
-		return nil
+	if in.Deal != nil {
+		return []Sentence{{
+			Text:     fmt.Sprintf("Move %s on from %s.", in.Deal.Name, stageOrUnnamed(in.Deal.Stage)),
+			Nature:   natureRecommendation,
+			Evidence: []Evidence{{EntityType: citeDeal, EntityID: in.Deal.ID}},
+		}}
 	}
-	return []Sentence{{
-		Text:     fmt.Sprintf("Move %s on from %s.", in.Deal.Name, stageOrUnnamed(in.Deal.Stage)),
-		Nature:   natureRecommendation,
-		Evidence: []Evidence{{EntityType: citeDeal, EntityID: in.Deal.ID}},
-	}}
+	// A delivery meeting months after close-won usually has no open deal, and
+	// this section went silent exactly there — on the engagement the meeting is
+	// about. The project's own next step is the ask the record supports.
+	//
+	// Cited to the MEETING, not the project: the evidence vocabulary the brief
+	// shares with the account brief has no `project` kind, and a citation the
+	// reader cannot resolve is dropped whole rather than shown. The meeting is
+	// the record that carries the project link, so it is the honest source for
+	// a claim about which engagement this room is here to move.
+	if in.Project != nil {
+		return []Sentence{{
+			Text:     projectGoalLine(*in.Project),
+			Nature:   natureRecommendation,
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: in.ActivityID}},
+		}}
+	}
+	return nil
 }
 
 func stageOrUnnamed(stage string) string {

--- a/backend/internal/compose/meetingbrief/sections_test.go
+++ b/backend/internal/compose/meetingbrief/sections_test.go
@@ -278,8 +278,20 @@ func TestAProjectWithNoTargetDateClaimsNoDeadline(t *testing.T) {
 func TestAMeetingWithNoProjectSaysNothingAboutOne(t *testing.T) {
 	// Most meetings belong to no project, and a brief that mentioned one
 	// anyway would be describing a body of work nobody filed it under.
-	header := sectionOf(t, Deterministic(fullInput()), crmcontracts.MeetingBriefSectionKindHeader)
-	for _, sentence := range header.Sentences {
+	// Counted, not string-matched. An assertion that only rejects the fixture's
+	// own project name would pass against an unconditional zero-value line —
+	// a bare "." in the header — or a project fabricated under another name.
+	unprojected := sectionOf(t, Deterministic(fullInput()), crmcontracts.MeetingBriefSectionKindHeader)
+	projected := sectionOf(t, Deterministic(deliveryInput()), crmcontracts.MeetingBriefSectionKindHeader)
+	// The delivery fixture drops the deal and adds a project, so the two
+	// headers carry the same number of lines: meeting, one record line, last
+	// touch. Any EXTRA line on the unprojected one is a project line it should
+	// not have.
+	if len(unprojected.Sentences) != len(projected.Sentences) {
+		t.Fatalf("header lines: unprojected %d, projected %d — want the same shape",
+			len(unprojected.Sentences), len(projected.Sentences))
+	}
+	for _, sentence := range unprojected.Sentences {
 		if strings.Contains(sentence.Text, "ERP") {
 			t.Errorf("unprojected meeting header mentions a project: %q", sentence.Text)
 		}

--- a/backend/internal/compose/meetingbrief/sections_test.go
+++ b/backend/internal/compose/meetingbrief/sections_test.go
@@ -4,6 +4,7 @@
 package meetingbrief
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ const (
 	dealID     = "0198f000-0000-7000-8000-000000000002"
 	personID   = "0198f000-0000-7000-8000-000000000003"
 	activityID = "0198f000-0000-7000-8000-000000000004"
+	projectID  = "0198f000-0000-7000-8000-000000000005"
 )
 
 func at(day int) time.Time {
@@ -212,5 +214,74 @@ func TestAColdRoomStillGetsAHeader(t *testing.T) {
 	}
 	if header.Sentences[1].Text != "Nothing has been captured with anyone in this room before." {
 		t.Errorf("quiet line is %q", header.Sentences[1].Text)
+	}
+}
+
+// A delivery meeting is the case the project lines exist for: the engagement
+// runs for months after close-won, and the deal that started it is long shut.
+func deliveryInput() Input {
+	in := fullInput()
+	// No open deal, and no promise or question either, so the goal has nothing
+	// left to say unless the project speaks.
+	in.Deal = nil
+	in.Commitments = nil
+	in.Project = &ProjectIn{
+		ID: projectID, Name: "ERP rollout", Key: "ERP-27",
+		Phase: "delivering", TargetEndDate: ptr(at(28)),
+	}
+	return in
+}
+
+func TestADeliveryMeetingWithNoOpenDealStillLeadsWithAGoal(t *testing.T) {
+	// The section the package calls the antidote to "the canonical prep
+	// failure" used to fall silent exactly here, because its last fallback was
+	// the deal's next stage and a delivery meeting has no deal.
+	goal := sectionOf(t, Deterministic(deliveryInput()), crmcontracts.MeetingBriefSectionKindGoal)
+	if len(goal.Sentences) == 0 {
+		t.Fatal("a delivery meeting got no goal; the section exists to prevent exactly that")
+	}
+	if !strings.Contains(goal.Sentences[0].Text, "ERP rollout") {
+		t.Errorf("goal = %q, want it to name the engagement", goal.Sentences[0].Text)
+	}
+	if goal.Sentences[0].Nature != natureRecommendation {
+		t.Error("the goal is an ask, so it must be labelled a recommendation")
+	}
+}
+
+func TestTheHeaderNamesTheEngagementAndItsKey(t *testing.T) {
+	header := sectionOf(t, Deterministic(deliveryInput()), crmcontracts.MeetingBriefSectionKindHeader)
+	var found string
+	for _, sentence := range header.Sentences {
+		if strings.Contains(sentence.Text, "ERP rollout") {
+			found = sentence.Text
+		}
+	}
+	if found == "" {
+		t.Fatal("the header never names the project; on a two-engagement account that is what says you are in the right room")
+	}
+	// The key is what a reader sees in subject lines all day, so it rides along.
+	if !strings.Contains(found, "ERP-27") {
+		t.Errorf("header project line = %q, want the key beside the name", found)
+	}
+}
+
+func TestAProjectWithNoTargetDateClaimsNoDeadline(t *testing.T) {
+	// A deadline nobody set is the invented context the grounding rule forbids.
+	in := deliveryInput()
+	in.Project.TargetEndDate = nil
+	goal := sectionOf(t, Deterministic(in), crmcontracts.MeetingBriefSectionKindGoal)
+	if strings.Contains(goal.Sentences[0].Text, "target") {
+		t.Errorf("goal = %q, want no target named when the record carries none", goal.Sentences[0].Text)
+	}
+}
+
+func TestAMeetingWithNoProjectSaysNothingAboutOne(t *testing.T) {
+	// Most meetings belong to no project, and a brief that mentioned one
+	// anyway would be describing a body of work nobody filed it under.
+	header := sectionOf(t, Deterministic(fullInput()), crmcontracts.MeetingBriefSectionKindHeader)
+	for _, sentence := range header.Sentences {
+		if strings.Contains(sentence.Text, "ERP") {
+			t.Errorf("unprojected meeting header mentions a project: %q", sentence.Text)
+		}
 	}
 }

--- a/backend/internal/compose/meetingbrief/sectionsproject.go
+++ b/backend/internal/compose/meetingbrief/sectionsproject.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+// How the brief speaks about the body of work a meeting belongs to.
+//
+// A delivery meeting is the case these lines exist for: months after
+// close-won there is often no open deal at all, and the sections that lead the
+// brief fell silent exactly when the engagement was the whole point.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// projectHeaderLine names the engagement and where it stands. The key rides
+// along when the project has one, because that is the string a reader sees in
+// subject lines all day and recognises faster than the name.
+func projectHeaderLine(project ProjectIn) string {
+	parts := []string{project.Name}
+	if project.Key != "" {
+		parts[0] = fmt.Sprintf("%s (%s)", project.Name, project.Key)
+	}
+	if project.Phase != "" {
+		parts = append(parts, project.Phase)
+	}
+	if project.TargetEndDate != nil {
+		parts = append(parts, "target "+project.TargetEndDate.Format("2 Jan 2006"))
+	}
+	return strings.Join(parts, " · ") + "."
+}
+
+func meetingLine(in Input) string {
+	subject := in.Subject
+	if subject == "" {
+		subject = "Meeting"
+	}
+	when := in.StartsAt.Format("Mon 2 Jan 15:04 MST")
+	if in.Company == "" {
+		return fmt.Sprintf("%s, %s.", subject, when)
+	}
+	return fmt.Sprintf("%s with %s, %s.", subject, in.Company, when)
+}
+
+// projectGoalLine states where the engagement stands and what it is running
+// at. The target date is named only when the record carries one — a deadline
+// nobody set is the invented context the grounding rule forbids.
+func projectGoalLine(project ProjectIn) string {
+	if project.TargetEndDate == nil {
+		return fmt.Sprintf("Move %s on from %s.", project.Name, phaseOrUnnamed(project.Phase))
+	}
+	return fmt.Sprintf("Move %s on from %s, against a target of %s.",
+		project.Name, phaseOrUnnamed(project.Phase),
+		project.TargetEndDate.Format("2 Jan 2006"))
+}
+
+func phaseOrUnnamed(phase string) string {
+	if phase == "" {
+		return "its current phase"
+	}
+	return phase
+}


### PR DESCRIPTION
An account running two bodies of work got one blended brief.

## Two leaks, and the second is the one that gets missed

**The deal was picked by close date.** `LEFT JOIN LATERAL … ORDER BY expected_close_date LIMIT 1` — on a two-engagement account that names whichever deal happened to land first. The meeting's own project link now wins the ordering, falling back to close date, so an unattributed meeting orders exactly as before.

**The per-attendee last touch was unscoped.** Fix the deal alone and the brief narrows the header, then prints "last touch 3 days ago" counting a conversation about the other engagement. That is the number a reader trusts most. It takes the same narrowing now.

The rule both use: filed under **this** project, or filed under **none**. Attribution is optional, so most correspondence carries no project — dropping it would leave a brief reading as though the room had never spoken.

## A defect projects exposed

`goalSection` fell through open-question → our-commitment → **the deal's next stage**, and returned nothing without a deal. A delivery review months after close-won has no open deal, so the section the package itself calls the antidote to "the canonical prep failure" went silent exactly when the engagement was the point. It now falls through to the project's next step.

The goal cites the **meeting**, not the project: the evidence vocabulary this brief shares with the account brief has no `project` kind, and a citation that does not resolve is dropped whole. The meeting is the record carrying the link.

## Verification

- `make check-backend` green, `make craft-static` clean, integration lane green — including the existing `TestMeetingBriefDoesNotReportALastTouchTheCallerCannotRead`, which proves the new subquery did not disturb the last-touch row scope.
- Four new unit tests.
- **Mutation-checked**: removing the project arm from `goalSection` fails the delivery-meeting test.

`sections.go` crossed the 500-line ceiling, so the project lines moved to their own file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the meeting brief to the meeting’s project and enforces the project grant so headers, per-attendee last touch, and goals refer to the correct engagement without disclosing projects to callers lacking access. Previously the brief picked a deal by close date, last touch ignored project, the goal disappeared without a deal, and project details could leak under row scope alone.

- Header: adds a project line (name/key/phase/target date). The deal lateral prefers a deal on that project, then falls back to close date. If the caller lacks the project read grant, the project join is matched away and no project line is shown.
- Last touch: narrows per-attendee last touch to conversations linked to the same project or to none, preventing cross-engagement leakage.
- Goal: when no deal, falls through to the project’s next step; cites the meeting because `project` is not an evidence kind.
- Security/Query: `projectJoinPredicate` checks the object grant before row scope; on refusal it returns a never-match predicate so the brief shape is preserved without leaking project data.
- Structure/Tests: `backend/internal/compose/meetingbrief` adds `Project` to `Input` and moves project rendering to `sectionsproject.go`. Integration tests assert engagement visibility with and without the project grant, and unit tests count header lines to prevent zero-value leakage; existing last-touch scope test remains green.

<sup>Written for commit 6e2f5c65344a9ce5e764a8c9eb854f0ee9c3a31f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

