### PR TITLE
feat(records): the brief recalls when this room last met

### DIFF
--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/meetingbrief"
 	"github.com/gradionhq/margince/backend/internal/compose/person360"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -440,10 +441,67 @@ func TestMeetingBriefRecallsNoMeetingFromAnotherEngagement(t *testing.T) {
 			recalled += sentence.Text + "\n"
 		}
 	}
+	// Three assertions, because the rule has three arms and an OR over two of
+	// them would let a mutation that drops either one still pass.
 	if strings.Contains(recalled, "Rack walkthrough") {
 		t.Errorf("recalled = %q, but that meeting belongs to the other engagement", recalled)
 	}
-	if !strings.Contains(recalled, "ERP kickoff") && !strings.Contains(recalled, "Quarterly catch-up") {
-		t.Errorf("recalled = %q, want this engagement's history or the unfiled kind", recalled)
+	if !strings.Contains(recalled, "ERP kickoff") {
+		t.Errorf("recalled = %q, want this engagement's own earlier meeting", recalled)
+	}
+	if !strings.Contains(recalled, "Quarterly catch-up") {
+		t.Errorf("recalled = %q, want the unfiled meeting too — attribution is optional, so most history carries no project", recalled)
+	}
+}
+
+// Naming an earlier meeting means printing its SUBJECT, which is content
+// rather than a marker. A reader who may DISCOVER that a conversation
+// happened is not thereby entitled to read what it was called, so this
+// section takes the content clause — the weaker discover clause is documented
+// as covering the safe markers alone (a last-touch date, an open-task count).
+func TestMeetingBriefRecallsNoSubjectItMayNotRead(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	ours := e.SeedPerson(t, "Ana Roth", &e.Rep1)
+
+	// An earlier meeting our attendee sat in, whose author then limited it to
+	// its participants. Rep1 is not one, so the row stays DISCOVERABLE to them
+	// and its content does not — which is the exact gap between the two
+	// clauses, and the only fixture that can tell them apart.
+	when := roomAgo(6 * 24 * time.Hour)
+	hidden, _, err := e.Activities.LogActivity(
+		e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms),
+		activities.LogActivityInput{
+			Kind: "meeting", Subject: strPtr("Board compensation review"),
+			OccurredAt: &when, Source: "manual",
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: ours}},
+		})
+	if err != nil {
+		t.Fatalf("log the earlier meeting: %v", err)
+	}
+	hiddenID := ids.From[ids.ActivityKind](ids.UUID(hidden.Id))
+	seatInRoom(t, owner, e.WS, ids.UUID(hidden.Id), ours)
+	if _, err := e.Activities.SetAudience(
+		e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms),
+		hiddenID, activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("limit the earlier meeting: %v", err)
+	}
+
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Cutover review', $2, 'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", ours)
+	seatInRoom(t, owner, e.WS, meeting, ours)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPermsWithProject())
+	brief, err := meetingBriefService(e).Get(rep, meeting)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for _, section := range brief.Sections {
+		for _, sentence := range section.Sentences {
+			if strings.Contains(sentence.Text, "compensation") {
+				t.Errorf("the brief disclosed a subject this caller may not read: %q", sentence.Text)
+			}
+		}
 	}
 }

--- a/backend/internal/compose/integration/meetingbrief_integration_test.go
+++ b/backend/internal/compose/integration/meetingbrief_integration_test.go
@@ -342,3 +342,108 @@ func TestMeetingBriefWithholdsTheEngagementFromACallerWithNoProjectGrant(t *test
 		t.Errorf("the brief disclosed the engagement to a caller with no project grant: %q", prose)
 	}
 }
+
+// "This room" is the PEOPLE, not the calendar entry. A recurring series that
+// changed its title is still the same conversation; two unrelated meetings on
+// one account are not. Only a real query proves the overlap rule.
+func TestMeetingBriefRecallsWhenThisRoomLastMet(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	ours := e.SeedPerson(t, "Ana Roth", &e.Rep1)
+	stranger := e.SeedPerson(t, "Someone Else", &e.Rep1)
+
+	newMeeting := func(subject string, when time.Duration, who ids.UUID) {
+		id := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1, 'meeting', $2, $3, 'manual', 'human:x')`, subject, roomAgo(when))
+		LinkActivity(t, owner, id, "person", who)
+		seatInRoom(t, owner, e.WS, id, who)
+	}
+	newMeeting("Kickoff", 30*24*time.Hour, ours)
+	// A meeting on the same account with nobody from this room in it. It must
+	// not be recalled: it is a different conversation.
+	newMeeting("Unrelated review", 5*24*time.Hour, stranger)
+
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'Cutover review', $2, 'manual', 'human:x')`, roomTomorrow)
+	LinkActivity(t, owner, meeting, "person", ours)
+	seatInRoom(t, owner, e.WS, meeting, ours)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPermsWithProject())
+	brief, err := meetingBriefService(e).Get(rep, meeting)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	var recalled string
+	for _, section := range brief.Sections {
+		if section.Kind != "company_context" {
+			continue
+		}
+		for _, sentence := range section.Sentences {
+			recalled += sentence.Text + "\n"
+		}
+	}
+	if !strings.Contains(recalled, "Kickoff") {
+		t.Errorf("recalled = %q, want the earlier meeting with this same room", recalled)
+	}
+	if strings.Contains(recalled, "Unrelated") {
+		t.Errorf("recalled = %q, but nobody from this room was in that meeting", recalled)
+	}
+}
+
+// A brief scoped to one engagement must not reach into the other for its
+// history — the same rule the rest of the page runs.
+func TestMeetingBriefRecallsNoMeetingFromAnotherEngagement(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	org := e.SeedOrg(t, "Northwind", &e.Rep1)
+	ours := e.SeedPerson(t, "Ana Roth", &e.Rep1)
+
+	newProject := func(name, key string) ids.UUID {
+		return SeedIDRow(t, owner, `INSERT INTO project (id, owner_id, name, key, organization_id, source, captured_by)
+			VALUES ($1, $2, $3, $4, $5, 'manual', 'human:x')`, e.Rep1, name, key, org)
+	}
+	erp := newProject("ERP rollout", "ERP-27")
+	migration := newProject("Datacentre migration", "DC-4")
+
+	fileUnder := func(activity, project ids.UUID) {
+		e.WsExec(t, `INSERT INTO activity_link (activity_id, entity_type, project_id)
+			VALUES ($1, 'project', $2)`, activity, project)
+	}
+	newMeeting := func(subject string, when time.Duration) ids.UUID {
+		id := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1, 'meeting', $2, $3, 'manual', 'human:x')`, subject, roomAgo(when))
+		LinkActivity(t, owner, id, "person", ours)
+		seatInRoom(t, owner, e.WS, id, ours)
+		return id
+	}
+
+	fileUnder(newMeeting("ERP kickoff", 30*24*time.Hour), erp)
+	fileUnder(newMeeting("Rack walkthrough", 5*24*time.Hour), migration)
+	// Unfiled history stays: attribution is optional, so most of the record
+	// carries no project and dropping it would erase the relationship.
+	newMeeting("Quarterly catch-up", 10*24*time.Hour)
+
+	meeting := newMeeting("Cutover review", -24*time.Hour)
+	fileUnder(meeting, erp)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPermsWithProject())
+	brief, err := meetingBriefService(e).Get(rep, meeting)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	var recalled string
+	for _, section := range brief.Sections {
+		if section.Kind != "company_context" {
+			continue
+		}
+		for _, sentence := range section.Sentences {
+			recalled += sentence.Text + "\n"
+		}
+	}
+	if strings.Contains(recalled, "Rack walkthrough") {
+		t.Errorf("recalled = %q, but that meeting belongs to the other engagement", recalled)
+	}
+	if !strings.Contains(recalled, "ERP kickoff") && !strings.Contains(recalled, "Quarterly catch-up") {
+		t.Errorf("recalled = %q, want this engagement's history or the unfiled kind", recalled)
+	}
+}

--- a/backend/internal/compose/meetingbrief/input.go
+++ b/backend/internal/compose/meetingbrief/input.go
@@ -42,6 +42,10 @@ type Input struct {
 	Commitments []ClaimIn
 	// Recent is the newest captured conversation with the lead attendee first.
 	Recent []ActIn
+	// PriorMeetings are the last times this same room met, newest first. It is
+	// what a recurring delivery review opens wanting: not the state of play,
+	// but what was agreed here last time.
+	PriorMeetings []PriorMeetingIn
 	// LastTouchAt is the newest conversation with anyone in the room before
 	// this meeting. Nil means nothing was ever captured with any of them.
 	LastTouchAt *time.Time
@@ -55,6 +59,24 @@ type DealIn struct {
 	AmountMinor int64
 	Currency    string
 	CloseDate   *time.Time
+}
+
+// PriorMeetingIn is one earlier meeting with somebody from this room.
+type PriorMeetingIn struct {
+	ID       string
+	Subject  string
+	StartsAt time.Time
+}
+
+// foldPriorMeetings maps the read rows into the brief's own shape.
+func foldPriorMeetings(rows []priorMeeting) []PriorMeetingIn {
+	out := make([]PriorMeetingIn, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, PriorMeetingIn{
+			ID: row.ID.String(), Subject: row.Subject, StartsAt: row.StartsAt,
+		})
+	}
+	return out
 }
 
 // ProjectIn is the engagement this meeting is part of.

--- a/backend/internal/compose/meetingbrief/meeting.go
+++ b/backend/internal/compose/meetingbrief/meeting.go
@@ -42,6 +42,12 @@ type meeting struct {
 	Deal      *dealRow
 	Project   *projectRow
 	Attendees []attendeeRow
+	// Room is every attendee this caller may see, uncapped. Attendees above is
+	// the DISPLAY list and stops at attendeeCap, so a reader is not scanning
+	// names — but "who was in this room" is a different question from "who do
+	// we name", and history shared only with the ninth person is still this
+	// room's history.
+	Room []ids.UUID
 }
 
 // dealRow is the deal this meeting is linked to, if the caller may read it.
@@ -172,9 +178,16 @@ func (s *Service) readMeeting(ctx context.Context, tx pgx.Tx, activityID ids.UUI
 		deal.Currency = deref(currency)
 		out.Deal = &deal
 	}
-	out.Attendees, err = decodeAttendees(attendees)
+	full, err := decodeAttendees(attendees)
 	if err != nil {
 		return meeting{}, err
+	}
+	for _, attendee := range full {
+		out.Room = append(out.Room, attendee.PersonID)
+	}
+	out.Attendees = full
+	if len(out.Attendees) > attendeeCap {
+		out.Attendees = out.Attendees[:attendeeCap]
 	}
 	return out, nil
 }
@@ -309,17 +322,17 @@ func scopeFor(ctx context.Context, object, alias string, arg func(any) int) (str
 	return clause, nil
 }
 
-// decodeAttendees reads the sub-select's JSON into the room.
+// decodeAttendees reads the sub-select's JSON into the room, UNCAPPED.
 //
-// The cap lands here, beside the type it bounds; the sub-select already carries
-// the row-scope predicate that decides which names may appear at all.
+// The display cap is applied by the caller, which also keeps the full set: a
+// list bounded here would make "who was in this room" unanswerable, and the
+// prior-meeting history is matched on the room rather than on the names the
+// brief prints. The sub-select already carries the row-scope predicate that
+// decides which names may appear at all.
 func decodeAttendees(raw []byte) ([]attendeeRow, error) {
 	var decoded []attendeeRow
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		return nil, fmt.Errorf("decode the meeting attendees: %w", err)
-	}
-	if len(decoded) > attendeeCap {
-		decoded = decoded[:attendeeCap]
 	}
 	return decoded, nil
 }

--- a/backend/internal/compose/meetingbrief/priormeetings.go
+++ b/backend/internal/compose/meetingbrief/priormeetings.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+// "When we last met" — the prior meetings with this same room.
+//
+// It is the one fact a delivery review asks for first and the brief could not
+// answer. Everything else on the page describes the state of play; this
+// answers "what did we agree in this room last time", which is what a reader
+// actually opens a recurring meeting wanting to know.
+//
+// It replaces the company-context line rather than adding a ninth section: the
+// section list is a CLOSED enum by contract, and the brief is budgeted as a
+// two-to-three-minute read. What it displaces was one sentence saying the
+// company is where the lead attendee works — a fact the header already
+// implies.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// priorMeetingCap bounds how far back the section looks. Two is the reader's
+// question ("last time, and the time before"); a longer list is the timeline,
+// which is a different surface with paging of its own.
+const priorMeetingCap = 2
+
+// priorMeeting is one earlier meeting with somebody from this room.
+type priorMeeting struct {
+	ID       ids.UUID
+	Subject  string
+	StartsAt time.Time
+}
+
+// readPriorMeetings finds the most recent meetings before this one that shared
+// at least one attendee with it.
+//
+// Scoped three ways, and each is load-bearing:
+//   - the activity row scope, so a meeting the caller may not discover is not
+//     named to them;
+//   - the same project rule the rest of the brief runs, so a scoped brief does
+//     not reach into the other engagement for its history;
+//   - overlapping attendees, because "this room" is the people, not the
+//     recurring calendar entry — a series that changed its title is still the
+//     same conversation, and two different meetings on one account are not.
+func (s *Service) readPriorMeetings(ctx context.Context, tx pgx.Tx, room meeting) ([]priorMeeting, error) {
+	if len(room.Attendees) == 0 {
+		return nil, nil
+	}
+	attendees := make([]ids.UUID, 0, len(room.Attendees))
+	for _, attendee := range room.Attendees {
+		attendees = append(attendees, attendee.PersonID)
+	}
+
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	roomPos := arg(room.ID)
+	startsPos := arg(room.StartsAt)
+	attendeePos := arg(attendees)
+	scope, err := auth.ActivityDiscoverClause(ctx, "m", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = scopeAll
+	}
+	// A project this brief is scoped to narrows the history to the same body of
+	// work. Without one the rule is absent rather than permissive: an
+	// unattributed meeting reads its whole shared history, which is what it had
+	// before this section existed.
+	within := scopeAll
+	if room.Project != nil {
+		within = fmt.Sprintf(`(EXISTS (
+			    SELECT 1 FROM activity_link ml
+			    WHERE ml.activity_id = m.id AND ml.project_id = $%d)
+			  OR NOT EXISTS (
+			    SELECT 1 FROM activity_link mf
+			    WHERE mf.activity_id = m.id AND mf.project_id IS NOT NULL))`,
+			arg(room.Project.ID))
+	}
+
+	rows, err := tx.Query(ctx, fmt.Sprintf(priorMeetingsQuery, scope, within, roomPos, startsPos, attendeePos, priorMeetingCap), args...)
+	if err != nil {
+		return nil, fmt.Errorf("read the earlier meetings: %w", err)
+	}
+	defer rows.Close()
+
+	var out []priorMeeting
+	for rows.Next() {
+		var prior priorMeeting
+		var subject *string
+		if err := rows.Scan(&prior.ID, &subject, &prior.StartsAt); err != nil {
+			return nil, fmt.Errorf("read an earlier meeting: %w", err)
+		}
+		prior.Subject = deref(subject)
+		out = append(out, prior)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read the earlier meetings: %w", err)
+	}
+	return out, nil
+}
+
+// priorMeetingsQuery reads the newest meetings before this one sharing a person
+// with it. DISTINCT because a meeting with three of the same attendees is one
+// meeting, not three.
+const priorMeetingsQuery = `
+	SELECT DISTINCT m.id, m.subject, m.occurred_at
+	FROM activity m
+	JOIN activity_participant mp ON mp.activity_id = m.id
+	WHERE m.kind = 'meeting' AND m.archived_at IS NULL
+	  AND m.id <> $%[3]d AND m.occurred_at < $%[4]d
+	  AND mp.person_id = ANY($%[5]d)
+	  AND %[1]s
+	  AND %[2]s
+	ORDER BY m.occurred_at DESC
+	LIMIT %[6]d`

--- a/backend/internal/compose/meetingbrief/priormeetings.go
+++ b/backend/internal/compose/meetingbrief/priormeetings.go
@@ -50,21 +50,35 @@ type priorMeeting struct {
 //   - overlapping attendees, because "this room" is the people, not the
 //     recurring calendar entry — a series that changed its title is still the
 //     same conversation, and two different meetings on one account are not.
-func (s *Service) readPriorMeetings(ctx context.Context, tx pgx.Tx, room meeting) ([]priorMeeting, error) {
-	if len(room.Attendees) == 0 {
+//
+// And it recalls only meetings that actually HAPPENED: earlier than this one,
+// already past, and not cancelled or no-showed. "You met 4 days ago" about a
+// meeting nobody attended is worse than saying nothing.
+func (s *Service) readPriorMeetings(ctx context.Context, tx pgx.Tx, room meeting, now time.Time) ([]priorMeeting, error) {
+	// room.Room, not room.Attendees: the latter is the DISPLAY list and stops
+	// at eight, so matching on it would lose history shared only with the ninth
+	// person in a large room.
+	if len(room.Room) == 0 {
 		return nil, nil
 	}
-	attendees := make([]ids.UUID, 0, len(room.Attendees))
-	for _, attendee := range room.Attendees {
-		attendees = append(attendees, attendee.PersonID)
-	}
+	attendees := room.Room
 
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	roomPos := arg(room.ID)
+	// Earlier than this meeting AND already past. Constraining on the current
+	// meeting alone would let a brief for a meeting three weeks out say "you
+	// met" about one happening next Tuesday — a room that has not met yet.
 	startsPos := arg(room.StartsAt)
+	nowPos := arg(now)
 	attendeePos := arg(attendees)
-	scope, err := auth.ActivityDiscoverClause(ctx, "m", arg)
+	// CONTENT, not discover. This section prints an earlier meeting's SUBJECT,
+	// and ActivityDiscoverClause is documented as covering the safe markers
+	// alone — a last-touch date, an open-task count. A reader who may know
+	// that a conversation happened is not thereby entitled to read what it was
+	// called, and picking the weaker clause for content is precisely the
+	// defect restrictedreaders_test.go exists to catch.
+	scope, err := auth.ActivityContentClause(ctx, "m", arg)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +100,7 @@ func (s *Service) readPriorMeetings(ctx context.Context, tx pgx.Tx, room meeting
 			arg(room.Project.ID))
 	}
 
-	rows, err := tx.Query(ctx, fmt.Sprintf(priorMeetingsQuery, scope, within, roomPos, startsPos, attendeePos, priorMeetingCap), args...)
+	rows, err := tx.Query(ctx, fmt.Sprintf(priorMeetingsQuery, scope, within, roomPos, startsPos, nowPos, attendeePos, priorMeetingCap), args...)
 	if err != nil {
 		return nil, fmt.Errorf("read the earlier meetings: %w", err)
 	}
@@ -116,9 +130,10 @@ const priorMeetingsQuery = `
 	FROM activity m
 	JOIN activity_participant mp ON mp.activity_id = m.id
 	WHERE m.kind = 'meeting' AND m.archived_at IS NULL
-	  AND m.id <> $%[3]d AND m.occurred_at < $%[4]d
-	  AND mp.person_id = ANY($%[5]d)
+	  AND m.id <> $%[3]d AND m.occurred_at < $%[4]d AND m.occurred_at <= $%[5]d
+	  AND (m.meeting_status IS NULL OR m.meeting_status = 'held')
+	  AND mp.person_id = ANY($%[6]d)
 	  AND %[1]s
 	  AND %[2]s
 	ORDER BY m.occurred_at DESC
-	LIMIT %[6]d`
+	LIMIT %[7]d`

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -429,18 +429,28 @@ func talkingPointLine(claim ClaimIn) string {
 	}
 }
 
-// companyContextSection (D) is background, collapsed and last. Provider
-// research is not wired to this surface, so it says what THIS installation
-// recorded and nothing more: an empty section is honest, and a filled one made
-// of inference would be exactly the filler the spec's first rule forbids.
+// companyContextSection (D) is background, collapsed and last.
+//
+// It answers "when did this room last meet, and about what" — the question a
+// recurring delivery review opens with, and the one thing on the page that is
+// about the CONVERSATION rather than the state of play.
+//
+// It used to say the company is where the lead attendee works, which the
+// header already implies. The section kind is a closed enum by contract, so
+// this replaces that line rather than adding a ninth heading, and the brief
+// keeps its two-to-three-minute budget.
+//
+// Empty is honest and stays empty: a first meeting with a room has no history,
+// and inventing background for one is the filler the spec's first rule forbids.
 func companyContextSection(in Input) []Sentence {
-	if in.Company == "" || len(in.Attendees) == 0 {
-		return nil
+	out := make([]Sentence, 0, len(in.PriorMeetings))
+	for _, prior := range in.PriorMeetings {
+		out = append(out, Sentence{
+			Text:     priorMeetingLine(prior, in.Now),
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: prior.ID}},
+		})
 	}
-	return []Sentence{{
-		Text:     fmt.Sprintf("%s is where %s works.", in.Company, in.Attendees[0].FullName),
-		Evidence: []Evidence{{EntityType: citePerson, EntityID: in.Attendees[0].PersonID}},
-	}}
+	return out
 }
 
 // firstOfKind returns the newest claim of one kind that is still open. Claims

--- a/backend/internal/compose/meetingbrief/sections_test.go
+++ b/backend/internal/compose/meetingbrief/sections_test.go
@@ -297,3 +297,46 @@ func TestAMeetingWithNoProjectSaysNothingAboutOne(t *testing.T) {
 		}
 	}
 }
+
+func TestTheLastSectionSaysWhenThisRoomLastMet(t *testing.T) {
+	in := fullInput()
+	in.PriorMeetings = []PriorMeetingIn{
+		{ID: activityID, Subject: "Kickoff", StartsAt: at(3)},
+	}
+	section := sectionOf(t, Deterministic(in), crmcontracts.MeetingBriefSectionKindCompanyContext)
+	if len(section.Sentences) != 1 {
+		t.Fatalf("prior meetings = %d sentences, want 1", len(section.Sentences))
+	}
+	// Days, not a date: the reader is placing it against today.
+	if !strings.Contains(section.Sentences[0].Text, "7 days ago") {
+		t.Errorf("line = %q, want the gap in days", section.Sentences[0].Text)
+	}
+	if !strings.Contains(section.Sentences[0].Text, "Kickoff") {
+		t.Errorf("line = %q, want the meeting named — a gap alone says which conversation?", section.Sentences[0].Text)
+	}
+}
+
+func TestAFirstMeetingWithARoomInventsNoHistory(t *testing.T) {
+	// A section with nothing to say is ABSENT, and background invented for a
+	// room nobody has met is the filler the brief's first rule forbids.
+	in := fullInput()
+	in.PriorMeetings = nil
+	for _, section := range Deterministic(in) {
+		if section.Kind == crmcontracts.MeetingBriefSectionKindCompanyContext &&
+			len(section.Sentences) > 0 {
+			t.Errorf("a first meeting got history: %q", section.Sentences[0].Text)
+		}
+	}
+}
+
+func TestEveryPriorMeetingCitesTheMeetingItNames(t *testing.T) {
+	// The reader's next move is to open the earlier meeting, so the line must
+	// carry the record rather than only describing it.
+	in := fullInput()
+	in.PriorMeetings = []PriorMeetingIn{{ID: activityID, Subject: "Kickoff", StartsAt: at(3)}}
+	section := sectionOf(t, Deterministic(in), crmcontracts.MeetingBriefSectionKindCompanyContext)
+	cited := section.Sentences[0].Evidence
+	if len(cited) != 1 || cited[0].EntityID != activityID || cited[0].EntityType != citeActivity {
+		t.Errorf("evidence = %+v, want the earlier meeting's own activity", cited)
+	}
+}

--- a/backend/internal/compose/meetingbrief/sectionsproject.go
+++ b/backend/internal/compose/meetingbrief/sectionsproject.go
@@ -12,6 +12,7 @@ package meetingbrief
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // projectHeaderLine names the engagement and where it stands. The key rides
@@ -60,4 +61,26 @@ func phaseOrUnnamed(phase string) string {
 		return "its current phase"
 	}
 	return phase
+}
+
+// priorMeetingLine says when this room last met and what it was called.
+//
+// Days ago, not a date, for the same reason the last-touch line is: the reader
+// is placing it against today, and a date makes them do the arithmetic. The
+// subject rides along because "three weeks ago" alone does not tell them which
+// conversation they are being reminded of.
+func priorMeetingLine(prior PriorMeetingIn, now time.Time) string {
+	subject := prior.Subject
+	if subject == "" {
+		subject = "A meeting"
+	}
+	days := int(now.Sub(prior.StartsAt).Hours() / 24)
+	switch {
+	case days <= 0:
+		return fmt.Sprintf("You met earlier today: %s.", subject)
+	case days == 1:
+		return fmt.Sprintf("You met yesterday: %s.", subject)
+	default:
+		return fmt.Sprintf("You met %d days ago: %s.", days, subject)
+	}
 }

--- a/backend/internal/compose/meetingbrief/service.go
+++ b/backend/internal/compose/meetingbrief/service.go
@@ -116,6 +116,7 @@ func (s *Service) Get(ctx context.Context, activityID ids.UUID) (crmcontracts.Me
 func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input, error) {
 	var room meeting
 	var perAttendee map[ids.UUID][]crmcontracts.ConversationClaim
+	var earlier []priorMeeting
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		loaded, err := s.readMeeting(ctx, tx, activityID)
 		if err != nil {
@@ -123,6 +124,10 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 		}
 		room = loaded
 		perAttendee, err = s.claimsPerAttendee(ctx, tx, loaded)
+		if err != nil {
+			return err
+		}
+		earlier, err = s.readPriorMeetings(ctx, tx, loaded)
 		return err
 	})
 	if err != nil {
@@ -130,6 +135,7 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 	}
 
 	in := FromMeeting(room, perAttendee, s.now().UTC())
+	in.PriorMeetings = foldPriorMeetings(earlier)
 	if len(room.Attendees) == 0 {
 		// Nobody in the room this caller may see. The header still stands, and
 		// assembling a 360 for a person nobody named would be a read of a

--- a/backend/internal/compose/meetingbrief/service.go
+++ b/backend/internal/compose/meetingbrief/service.go
@@ -127,7 +127,7 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 		if err != nil {
 			return err
 		}
-		earlier, err = s.readPriorMeetings(ctx, tx, loaded)
+		earlier, err = s.readPriorMeetings(ctx, tx, loaded, s.now().UTC())
 		return err
 	})
 	if err != nil {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5474,7 +5474,7 @@ export const de = {
   "person.meeting.deal_state": "Stand des Deals",
   "person.meeting.risks": "Risiken und Warnsignale",
   "person.meeting.talking_points": "Vorgeschlagene Gesprächspunkte",
-  "person.meeting.company_context": "Unternehmenskontext",
+  "person.meeting.company_context": "Letztes Treffen",
 
   "co.strip.healthSummary": "Zustand",
   "co.strip.healthSummary.failingOf": "{failing} von {rated} gefährdet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5526,7 +5526,7 @@ export const en = {
   "person.meeting.deal_state": "Where the deal stands",
   "person.meeting.risks": "Risks and watch-outs",
   "person.meeting.talking_points": "Suggested talking points",
-  "person.meeting.company_context": "Company context",
+  "person.meeting.company_context": "When you last met",
 
   "co.strip.healthSummary": "Health",
   "co.strip.healthSummary.failingOf": "{failing} of {rated} at risk",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5424,7 +5424,7 @@ export const vi = {
   "person.meeting.deal_state": "Tình trạng thương vụ",
   "person.meeting.risks": "Rủi ro và điểm cần lưu ý",
   "person.meeting.talking_points": "Gợi ý nội dung trao đổi",
-  "person.meeting.company_context": "Bối cảnh công ty",
+  "person.meeting.company_context": "Lần gặp gần nhất",
 
   "co.strip.healthSummary": "Tình hình",
   "co.strip.healthSummary.failingOf": "{failing}/{rated} đang gặp rủi ro",


### PR DESCRIPTION
The one question a recurring delivery review opens with — *what did we agree here last time* — was the one thing on the page the brief could not answer. Everything else describes the state of play.

## Where it goes

It replaces the `company_context` line rather than adding a ninth section. The contract says the section list is closed ("no writer can invent a ninth"), the brief is budgeted as a two-to-three-minute read, and what it displaces was one sentence saying the company is where the lead attendee works — a fact the header already implies.

## "This room" is the people, not the calendar entry

A series that changed its title is still the same conversation; two unrelated meetings on one account are not. The read matches on **overlapping attendees**, capped at the last two — the reader's question is "last time, and the time before", and a longer list is the timeline, which is a different surface with paging of its own.

It carries both other scopes the page runs:

- the **activity row scope**, so a meeting the caller may not discover is never named to them;
- the **project rule**, so a brief scoped to one engagement does not reach into the other for its history — filed here, or filed nowhere.

A first meeting with a room recalls nothing. Background invented for people nobody has met is the filler the brief's first rule forbids.

## Verification

- `make check-backend` green, `make craft-static` clean.
- Three unit tests, two integration tests against real Postgres.
- **Mutation-checked**: disabling the project narrowing recalls the other engagement's meeting and fails `TestMeetingBriefRecallsNoMeetingFromAnotherEngagement`.
- The attendee-overlap rule is proved by a negative: a meeting on the same account with nobody from this room in it must not be recalled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The meeting brief now recalls when this room last met and about what. Previously the last section said the company is where the lead attendee works; now it lists the last one or two prior meetings for this room and shows nothing for first meetings.

- Matches by overlapping attendees using the full authorized room (not the capped display list), capped at two; each line reads “You met N days ago: subject.” and cites the prior meeting activity.
- Only recalls meetings that actually happened and are in the past; excludes future, cancelled, and no‑showed meetings.
- Uses the content access clause to avoid leaking subjects; also respects activity access scope and project narrowing. Unfiled history is eligible; history does not cross into other engagements.
- Reuses the existing `company_context` section kind; UI labels updated to “When you last met” in all locales. No schema or migration changes.
- New unit and integration tests cover content-scope behavior, attendee overlap, project scoping, and held-only filtering.

<sup>Written for commit eb3c16030d16bb83b0495c7e04e03c4db2325c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

