### PR TITLE
fix(deals): the data reset keeps its hands off a frozen deal room release

### DIFF
--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -675,3 +675,65 @@ func TestResetKeepsTheDeploymentCredentialsSealedBeforeIt(t *testing.T) {
 		t.Errorf("the sealed license did not survive the reset (Get returned %v) — the ref survived but points at nothing", err)
 	}
 }
+
+// TestSweepClearsADealRoomsFrozenReleases is the behavioural half of
+// deal_room_release's preserve entry: preserved means "not a target", and a
+// preserved table that nothing else clears would leave a buyer's frozen
+// snapshot standing behind a reset that reported success.
+//
+// The offer is not decoration. Its ON DELETE RESTRICT on the deal defers `deal`
+// past the first pass, so the room is reached as a sweep target in its own
+// right rather than being carried off by its deal's cascade — the room's own
+// cascade is then what has to take the releases, which is the claim the
+// preserve entry makes.
+func TestSweepClearsADealRoomsFrozenReleases(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	pipeline, open, _ := integration.DealFixture(t, e)
+	dealID := e.SeedDeal(t, "Voltaq renewal", pipeline, open, &e.Rep1)
+
+	// The offer's ON DELETE RESTRICT defers `deal` past the first pass; without
+	// it the deal's cascade would clear the room and prove nothing about the
+	// room's own.
+	e.WsExec(t, `INSERT INTO offer (deal_id, offer_number, currency, source, captured_by)
+		VALUES ($1, 'OF-1', 'EUR', 'manual', 'human:test')`, dealID)
+
+	roomID, participantID := ids.NewV7(), ids.NewV7()
+	e.WsExec(t, `INSERT INTO deal_room (id, deal_id, title, state, source, captured_by)
+		VALUES ($1, $2, 'Voltaq room', 'live', 'manual', 'human:test')`, roomID, dealID)
+	e.WsExec(t, `INSERT INTO deal_room_participant (id, room_id, full_name, email, source, captured_by)
+		VALUES ($1, $2, 'Bea Buyer', 'bea@voltaq.example', 'manual', 'human:test')`, participantID, roomID)
+	e.WsExec(t, `INSERT INTO deal_room_release (room_id, release_no, snapshot, source, captured_by)
+		VALUES ($1, 1, '{"status": "shown in August"}'::jsonb, 'manual', 'human:test')`, roomID)
+	e.WsExec(t, `INSERT INTO deal_room_task (room_id, side, title, done_at, done_by_participant_id, source, captured_by)
+		VALUES ($1, 'buyer', 'Sign the order form', now(), $2, 'manual', 'human:test')`, roomID, participantID)
+
+	// The premise the preserve entry rests on, asserted rather than assumed: a
+	// release can never be a legitimate sweep target, because the guard refuses
+	// a direct delete for as long as the room stands and the FK forbids a
+	// release whose room does not. If this ever stops raising, the entry is
+	// over-preserving and belongs back among the targets.
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM deal_room_release WHERE room_id = $1`, roomID)
+		return err
+	}); err == nil {
+		t.Fatal("a direct DELETE on deal_room_release succeeded while its room still exists — the frozen release is editable after all")
+	}
+
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		tables, err := resetTargetTables(ctx, tx)
+		if err != nil {
+			return err
+		}
+		return sweepWorkspaceData(ctx, tx, tables)
+	}); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	if got := e.WsCount(t, "SELECT count(*) FROM deal_room"); got != 0 {
+		t.Errorf("deal_room count after sweep = %d, want 0", got)
+	}
+	if got := e.WsCount(t, "SELECT count(*) FROM deal_room_release"); got != 0 {
+		t.Errorf("deal_room_release count after sweep = %d, want 0 — preserved from the sweep's own DELETE, but the room's cascade still has to take it", got)
+	}
+}

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -77,6 +77,29 @@ var preservedResetTables = map[string]bool{
 	// It is still cleared by a reset — `activity` is swept, and the cascade takes
 	// the evidence with it. Preserved here means "not a target", never "kept".
 	"activity_retention_evidence": true,
+	// A buyer's frozen release (migration 1787324555), and here for the same
+	// reason as the line above: a direct DELETE is REFUSED outright. The guard
+	// permits one only once the parent room is already gone — precisely the
+	// room's own CASCADE — and the FK makes an orphaned release impossible, so
+	// every row the sweep's own DELETE could ever meet still has its room and
+	// raises. The raise is a restrict_violation rather than a foreign-key one,
+	// which the pass deferral does not catch, so it aborts the whole reset.
+	//
+	// Preserved rather than classified as a row-conditional guard because the
+	// condition can never be false for a direct delete: this is a protected
+	// store, on the same footing as the append-only ledgers above.
+	//
+	// The sweep does not in fact meet such a row today — `deal_room` sorts
+	// first and no child RESTRICTs it, so its cascade has already taken the
+	// releases by the time the target list reaches them. That is an incidental
+	// consequence of ordering by table name, not a property anyone chose, and
+	// it is not what this entry rests on: one child FK turning to RESTRICT, or
+	// one rename, would defer the room past its own releases.
+	//
+	// It is still cleared by a reset — `deal_room` is swept, and the cascade
+	// takes the releases with it. Preserved here means "not a target", never
+	// "kept".
+	"deal_room_release": true,
 }
 
 // providerCredentialRefs collects the sealed API keys the provider


### PR DESCRIPTION
Closes #2227 — `TestSweepTargetsCarryNoDeleteBlockingTrigger` fails on `origin/main`, so every PR goes red the moment it merges main.

## The answer the issue asked for

The issue offered two branches and asked which one holds. Measured against a real database, neither is quite it, so this takes the third:

**`deal_room_release` is a protected store, not a row-conditional hold.** The guard's condition — "does the parent room still exist?" — can never be false for a direct delete, because `deal_room_release_room_fkey` is `ON DELETE CASCADE` and an orphaned release is therefore impossible. Every row the sweep's own `DELETE` could ever meet still has its room, and raises. So it goes in `preservedResetTables`, exactly as `activity_retention_evidence` already does for the identical shape and for the reason its own comment gives.

A waiver would have been the wrong call: the raise is `restrict_violation`, not a foreign-key violation, so `sweepWorkspaceData`'s per-pass deferral does not catch it — the reset transaction aborts outright.

## On the ordering

`deal_room` does sort before `deal_room_release`, and no child holds a `RESTRICT` on the room, so today the room's cascade has already taken the releases by the time the target list reaches them. I checked this rather than assuming it: with the preserve entry removed, the sweep still passes.

That is an incidental consequence of `ORDER BY c.relname`, not a property anyone chose, and one child FK turning to `RESTRICT` would take it away. It is recorded in the comment as an observation and deliberately not as the thing the entry rests on. Not being a target at all is what makes the reset safe here.

Preserved means *not a target*, never *kept* — `deal_room` is still swept and clears the releases through its cascade.

## Test

`TestSweepClearsADealRoomsFrozenReleases` asserts both halves against a real database:

1. a direct `DELETE FROM deal_room_release` is **refused** while its room stands — the premise the classification rests on, asserted rather than assumed. If this ever stops raising, the entry is over-preserving and belongs back among the targets;
2. a sweep leaves **no releases behind**. The seed's offer is load-bearing: its `ON DELETE RESTRICT` on the deal defers `deal` past the first pass, so the room is swept as a target in its own right and the room's own cascade is what has to clear the releases — rather than the deal's cascade carrying everything off and proving nothing.

## Verification

```
make test-it DIR=backend/internal/compose \
  RUN='TestSweepClearsADealRoomsFrozenReleases|TestSweepTargetsCarryNoDeleteBlockingTrigger|TestPreserveSetIntegrity|TestSweepWorkspaceDataClearsDomainKeepsIdentity'
--- PASS: TestSweepWorkspaceDataClearsDomainKeepsIdentity (0.65s)
--- PASS: TestPreserveSetIntegrity (0.03s)
--- PASS: TestSweepTargetsCarryNoDeleteBlockingTrigger (0.03s)
--- PASS: TestSweepClearsADealRoomsFrozenReleases (0.11s)
```

`make check-backend` green (exit 0).

Unblocks #2200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data reset from aborting on frozen deal room releases by marking `deal_room_release` as preserved. Previously the sweep tried to DELETE rows and hit a restrict_violation; now the sweep never targets the table and relies on `deal_room`’s ON DELETE CASCADE to clear releases.

- Adds `deal_room_release` to `preservedResetTables` because a direct delete is refused while the room exists; the violation is not caught by per-pass FK deferral and would abort the reset.
- Reset behavior is unchanged from a user perspective: releases are still removed when `deal_room` is swept; “preserved” means “not a target,” not “kept.”
- Adds `TestSweepClearsADealRoomsFrozenReleases` to assert both the refused direct delete and that a sweep leaves no releases behind.
- Notes current incidental ordering where `deal_room` sorts before `deal_room_release`; preservation does not rely on this.

<sup>Written for commit e7161e340b4e66480ee0616c2db72b2ac7afd021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace data sweeps now correctly remove preserved deal room release records along with their associated deal rooms.
  * Added coverage to verify cascading cleanup and prevent incomplete data removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->