### PR TITLE
feat(authz): a buyer's action is attributed to the buyer

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8468,7 +8468,7 @@ paths:
           description: Narrow to one field name.
         - name: actor_type
           in: query
-          schema: { type: string, enum: [human, agent, system, connector] }
+          schema: { type: string, enum: [human, agent, system, connector, buyer] }
           description: Narrow to one actor category.
       responses:
         '200':
@@ -22088,8 +22088,8 @@ components:
       required: [id, actor_type, actor_id, action, entity_type, entity_id, occurred_at]
       properties:
         id: { type: string, format: uuid }
-        actor_type: { type: string, enum: [human, agent, system, connector] }
-        actor_id: { type: string, description: "User uuid, agent id, connector name (e.g. connector:gmail), or 'system'." }
+        actor_type: { type: string, enum: [human, agent, system, connector, buyer] }
+        actor_id: { type: string, description: "User uuid, agent id, connector name (e.g. connector:gmail), 'system', or a Deal Room participant (buyer:<participant uuid>) — an external person with no seat, who appears in no member directory." }
         passport_id: { type: [string, 'null'], format: uuid, description: Agent Seat Passport that authorized an agent action. }
         on_behalf_of: { type: [string, 'null'], format: uuid, description: The human authority for an agent action. }
         actor_name:
@@ -22162,7 +22162,7 @@ components:
         old_value: { type: [string, 'null'] }
         new_value: { type: [string, 'null'] }
         changed_at: { type: string, format: date-time }
-        actor_type: { type: string, enum: [human, agent, system, connector] }
+        actor_type: { type: string, enum: [human, agent, system, connector, buyer] }
         actor_id: { type: string }
         passport_id: { type: [string, 'null'], format: uuid, description: Agent Seat Passport that authorized the change; present for agent actors only. }
         evidence: { type: [object, 'null'], additionalProperties: true, description: Grounding evidence for an agent-authored change; present for agent actors only. }
@@ -22292,7 +22292,7 @@ components:
       required: [id, actor_type, actor_id, action, occurred_at, summary]
       properties:
         id: { type: string, format: uuid }
-        actor_type: { type: string, enum: [human, agent, system, connector] }
+        actor_type: { type: string, enum: [human, agent, system, connector, buyer] }
         actor_id: { type: string }
         actor_name: { type: [string, 'null'], description: "Resolved display name for a human actor_id; null for machine actors and for a member whose user row no longer resolves." }
         on_behalf_of: { type: [string, 'null'], format: uuid, description: Granting human's user id for agent actions. }
@@ -23925,7 +23925,7 @@ components:
         new_state: { type: string, enum: [granted, withdrawn], description: Proof rows record only transitions to granted/withdrawn (never to unknown). }
         lawful_basis: { type: [string, 'null'] }
         source: { type: [string, 'null'], description: 'How consent was captured (e.g. webform, import, double_opt_in).' }
-        actor_type: { type: string, enum: [human, agent, system, connector] }
+        actor_type: { type: string, enum: [human, agent, system, connector, buyer] }
         actor_id: { type: [string, 'null'] }
         occurred_at: { type: string, format: date-time }
 

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23925,7 +23925,7 @@ components:
         new_state: { type: string, enum: [granted, withdrawn], description: Proof rows record only transitions to granted/withdrawn (never to unknown). }
         lawful_basis: { type: [string, 'null'] }
         source: { type: [string, 'null'], description: 'How consent was captured (e.g. webform, import, double_opt_in).' }
-        actor_type: { type: string, enum: [human, agent, system, connector, buyer] }
+        actor_type: { type: string, enum: [human, agent, system, connector] }
         actor_id: { type: [string, 'null'] }
         occurred_at: { type: string, format: date-time }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1164,6 +1164,7 @@ func (e AttachmentReadStartedStatus) Valid() bool {
 // Defines values for AuditHistoryEntryActorType.
 const (
 	AuditHistoryEntryActorTypeAgent     AuditHistoryEntryActorType = "agent"
+	AuditHistoryEntryActorTypeBuyer     AuditHistoryEntryActorType = "buyer"
 	AuditHistoryEntryActorTypeConnector AuditHistoryEntryActorType = "connector"
 	AuditHistoryEntryActorTypeHuman     AuditHistoryEntryActorType = "human"
 	AuditHistoryEntryActorTypeSystem    AuditHistoryEntryActorType = "system"
@@ -1173,6 +1174,8 @@ const (
 func (e AuditHistoryEntryActorType) Valid() bool {
 	switch e {
 	case AuditHistoryEntryActorTypeAgent:
+		return true
+	case AuditHistoryEntryActorTypeBuyer:
 		return true
 	case AuditHistoryEntryActorTypeConnector:
 		return true
@@ -1317,6 +1320,7 @@ func (e AuditLogEntryAction) Valid() bool {
 // Defines values for AuditLogEntryActorType.
 const (
 	AuditLogEntryActorTypeAgent     AuditLogEntryActorType = "agent"
+	AuditLogEntryActorTypeBuyer     AuditLogEntryActorType = "buyer"
 	AuditLogEntryActorTypeConnector AuditLogEntryActorType = "connector"
 	AuditLogEntryActorTypeHuman     AuditLogEntryActorType = "human"
 	AuditLogEntryActorTypeSystem    AuditLogEntryActorType = "system"
@@ -1326,6 +1330,8 @@ const (
 func (e AuditLogEntryActorType) Valid() bool {
 	switch e {
 	case AuditLogEntryActorTypeAgent:
+		return true
+	case AuditLogEntryActorTypeBuyer:
 		return true
 	case AuditLogEntryActorTypeConnector:
 		return true
@@ -2781,6 +2787,7 @@ func (e ConnectConnectorRequestReturnTo) Valid() bool {
 // Defines values for ConsentEventActorType.
 const (
 	ConsentEventActorTypeAgent     ConsentEventActorType = "agent"
+	ConsentEventActorTypeBuyer     ConsentEventActorType = "buyer"
 	ConsentEventActorTypeConnector ConsentEventActorType = "connector"
 	ConsentEventActorTypeHuman     ConsentEventActorType = "human"
 	ConsentEventActorTypeSystem    ConsentEventActorType = "system"
@@ -2790,6 +2797,8 @@ const (
 func (e ConsentEventActorType) Valid() bool {
 	switch e {
 	case ConsentEventActorTypeAgent:
+		return true
+	case ConsentEventActorTypeBuyer:
 		return true
 	case ConsentEventActorTypeConnector:
 		return true
@@ -4203,6 +4212,7 @@ func (e ExtractedFieldConfidence) Valid() bool {
 // Defines values for FieldHistoryEntryActorType.
 const (
 	FieldHistoryEntryActorTypeAgent     FieldHistoryEntryActorType = "agent"
+	FieldHistoryEntryActorTypeBuyer     FieldHistoryEntryActorType = "buyer"
 	FieldHistoryEntryActorTypeConnector FieldHistoryEntryActorType = "connector"
 	FieldHistoryEntryActorTypeHuman     FieldHistoryEntryActorType = "human"
 	FieldHistoryEntryActorTypeSystem    FieldHistoryEntryActorType = "system"
@@ -4212,6 +4222,8 @@ const (
 func (e FieldHistoryEntryActorType) Valid() bool {
 	switch e {
 	case FieldHistoryEntryActorTypeAgent:
+		return true
+	case FieldHistoryEntryActorTypeBuyer:
 		return true
 	case FieldHistoryEntryActorTypeConnector:
 		return true
@@ -10566,6 +10578,7 @@ func (e GetFieldHistoryParamsEntityType) Valid() bool {
 // Defines values for GetFieldHistoryParamsActorType.
 const (
 	GetFieldHistoryParamsActorTypeAgent     GetFieldHistoryParamsActorType = "agent"
+	GetFieldHistoryParamsActorTypeBuyer     GetFieldHistoryParamsActorType = "buyer"
 	GetFieldHistoryParamsActorTypeConnector GetFieldHistoryParamsActorType = "connector"
 	GetFieldHistoryParamsActorTypeHuman     GetFieldHistoryParamsActorType = "human"
 	GetFieldHistoryParamsActorTypeSystem    GetFieldHistoryParamsActorType = "system"
@@ -10575,6 +10588,8 @@ const (
 func (e GetFieldHistoryParamsActorType) Valid() bool {
 	switch e {
 	case GetFieldHistoryParamsActorTypeAgent:
+		return true
+	case GetFieldHistoryParamsActorTypeBuyer:
 		return true
 	case GetFieldHistoryParamsActorTypeConnector:
 		return true
@@ -12403,7 +12418,7 @@ type AuditHistoryListResponse struct {
 type AuditLogEntry struct {
 	Action AuditLogEntryAction `json:"action"`
 
-	// ActorId User uuid, agent id, connector name (e.g. connector:gmail), or 'system'.
+	// ActorId User uuid, agent id, connector name (e.g. connector:gmail), 'system', or a Deal Room participant (buyer:<participant uuid>) — an external person with no seat, who appears in no member directory.
 	ActorId string `json:"actor_id"`
 
 	// ActorName The actor's display name, resolved from `app_user` on the read path.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -2787,7 +2787,6 @@ func (e ConnectConnectorRequestReturnTo) Valid() bool {
 // Defines values for ConsentEventActorType.
 const (
 	ConsentEventActorTypeAgent     ConsentEventActorType = "agent"
-	ConsentEventActorTypeBuyer     ConsentEventActorType = "buyer"
 	ConsentEventActorTypeConnector ConsentEventActorType = "connector"
 	ConsentEventActorTypeHuman     ConsentEventActorType = "human"
 	ConsentEventActorTypeSystem    ConsentEventActorType = "system"
@@ -2797,8 +2796,6 @@ const (
 func (e ConsentEventActorType) Valid() bool {
 	switch e {
 	case ConsentEventActorTypeAgent:
-		return true
-	case ConsentEventActorTypeBuyer:
 		return true
 	case ConsentEventActorTypeConnector:
 		return true

--- a/backend/internal/modules/privacy/fieldhistory.go
+++ b/backend/internal/modules/privacy/fieldhistory.go
@@ -72,7 +72,7 @@ var fieldHistoryEntityTypes = map[string]bool{
 }
 
 var fieldHistoryActorTypes = map[string]bool{
-	"human": true, "agent": true, "system": true, "connector": true,
+	"human": true, "agent": true, "system": true, "connector": true, "buyer": true,
 }
 
 // fieldHistoryProjectedActions is the closed set of audit verbs whose

--- a/backend/internal/modules/privacy/handlers_fieldhistory.go
+++ b/backend/internal/modules/privacy/handlers_fieldhistory.go
@@ -32,7 +32,7 @@ func (h Handlers) GetFieldHistory(w http.ResponseWriter, r *http.Request, params
 		at := string(*params.ActorType)
 		if !fieldHistoryActorTypes[at] {
 			httperr.Write(w, r, httperr.Validation("actor_type", "invalid_actor_type",
-				"actor_type must be one of human, agent, system, connector"))
+				"actor_type must be one of human, agent, system, connector, buyer"))
 			return
 		}
 		f.ActorType = &at

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -79,6 +79,14 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 	// their authority is their RBAC, enforced at the store. The gate
 	// exists to bound AGENTS (03b Layer 1); a human reaching a tool
 	// through the UI already answered for the action.
+	// A buyer holds no scope, no seat and no quota, so "not an agent, pass"
+	// would wave one through every check this gate exists to apply. Refused
+	// by kind rather than by the absence of a passport, because the absence
+	// is what makes the pass-through look safe.
+	if p.Type == principal.PrincipalBuyer {
+		return ctx, fmt.Errorf("gate: %s: a Deal Room participant holds no tool authority: %w",
+			spec.Name, apperrors.ErrPermissionDenied)
+	}
 	if p.Type != principal.PrincipalAgent {
 		return ctx, nil
 	}

--- a/backend/internal/platform/auth/buyerprincipal_test.go
+++ b/backend/internal/platform/auth/buyerprincipal_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// A buyer principal exists to be ATTRIBUTED, never to be admitted. It names an
+// external person in one Deal Room so the audit log can say who acted; it
+// carries no seat, no RBAC grant and no row scope, and every general-purpose
+// gate in this package must refuse it on that basis alone.
+//
+// These tests are the proof that the kind is inert here. The Deal Room's own
+// public store methods admit a buyer through the room predicate they carry —
+// nothing in platform/auth does, and a future change that made one of these
+// pass would hand an external visitor the run of the workspace.
+func buyerCtx() context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalBuyer,
+		ID:   "buyer:0199a1f4-0000-7000-8000-000000000001",
+	})
+}
+
+func TestBuyerHoldsNoObjectGrant(t *testing.T) {
+	// The zero Permissions value grants nothing, and a buyer is never given
+	// another. Require must refuse every object it is asked about rather than
+	// falling through the system principal's unconditional pass above it.
+	for _, object := range []string{"deal", "person", "organization", "activity"} {
+		for _, action := range []principal.Action{
+			principal.ActionRead, principal.ActionCreate,
+			principal.ActionUpdate, principal.ActionDelete,
+		} {
+			err := Require(buyerCtx(), object, action)
+			if !errors.Is(err, apperrors.ErrPermissionDenied) {
+				t.Errorf("Require(buyer, %s, %s) = %v, want ErrPermissionDenied",
+					object, action, err)
+			}
+		}
+	}
+}
+
+func TestBuyerIsNotUnbounded(t *testing.T) {
+	// Unbounded answers "does this actor see every row". It is true for the
+	// system principal, and a buyer must never be folded into that clause: a
+	// row-scope predicate that resolved to "all" for a buyer would serve one
+	// room's visitor the whole estate.
+	buyer := principal.Principal{Type: principal.PrincipalBuyer, ID: "buyer:x"}
+	if Unbounded(buyer) {
+		t.Error("Unbounded(buyer) = true, want false — a buyer sees no CRM row")
+	}
+}
+
+func TestBuyerIsRefusedByHumanOnlyOperations(t *testing.T) {
+	// RequireHuman refuses agents. A buyer is not an agent, so without its own
+	// clause every human-only sheet in the product would have admitted one.
+	if err := RequireHuman(buyerCtx()); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("RequireHuman(buyer) = %v, want ErrPermissionDenied", err)
+	}
+}
+
+func TestBuyerIsNotAttributedToTheInstallation(t *testing.T) {
+	// The whole point of the kind: a buyer's action is theirs, not the
+	// system's. AuthzRule returning "system" here would put the installation's
+	// name on a person's decision in an append-only ledger.
+	buyer := principal.Principal{Type: principal.PrincipalBuyer, ID: "buyer:x"}
+	if rule := AuthzRule(buyer, "deal", "update"); rule == "system" {
+		t.Error(`AuthzRule(buyer) = "system", want anything else — a buyer is not the installation`)
+	}
+}

--- a/backend/internal/platform/auth/buyerprincipal_test.go
+++ b/backend/internal/platform/auth/buyerprincipal_test.go
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+// A buyer principal is ATTRIBUTED and never ADMITTED: it names an external
+// person in one Deal Room so the audit log can say who acted, and it carries no
+// authority of its own. Every gate in this package must refuse it.
+//
+// The refusal has to hold for a reason stronger than "a buyer happens to hold
+// no permissions". A test that hands the gate a zero Permissions value proves
+// only that the zero value grants nothing — it passes identically for a
+// connector, and it would keep passing if the buyer kind were deleted. So the
+// buyer here is given MAXIMAL authority: every object, every action, row scope
+// all, and the admin role key. What refuses it is the kind, or nothing does.
 package auth
 
 import (
@@ -12,32 +22,40 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// A buyer principal exists to be ATTRIBUTED, never to be admitted. It names an
-// external person in one Deal Room so the audit log can say who acted; it
-// carries no seat, no RBAC grant and no row scope, and every general-purpose
-// gate in this package must refuse it on that basis alone.
-//
-// These tests are the proof that the kind is inert here. The Deal Room's own
-// public store methods admit a buyer through the room predicate they carry —
-// nothing in platform/auth does, and a future change that made one of these
-// pass would hand an external visitor the run of the workspace.
-func buyerCtx() context.Context {
-	return principal.WithActor(context.Background(), principal.Principal{
-		Type: principal.PrincipalBuyer,
-		ID:   "buyer:0199a1f4-0000-7000-8000-000000000001",
-	})
+// buyerObjects are the objects a buyer would reach for if a gate let it: the
+// deal its room hangs off, and the records that deal names.
+var buyerObjects = []string{"deal", "person", "organization", "activity"}
+
+// overreachingBuyer is a buyer principal carrying authority no real one is ever
+// minted with. Nothing constructs this in production — it exists so the tests
+// below fail when a gate consults the permissions instead of the kind.
+func overreachingBuyer() principal.Principal {
+	objects := make(map[string]principal.ObjectGrant, len(buyerObjects))
+	for _, object := range buyerObjects {
+		objects[object] = principal.ObjectGrant{
+			Create: true, Read: true, Update: true, Delete: true,
+		}
+	}
+	return principal.Principal{
+		Type:     principal.PrincipalBuyer,
+		ID:       "buyer:0199a1f4-0000-7000-8000-000000000001",
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			Objects:  objects,
+			RowScope: principal.RowScopeAll,
+		},
+	}
 }
 
-func TestBuyerHoldsNoObjectGrant(t *testing.T) {
-	// The zero Permissions value grants nothing, and a buyer is never given
-	// another. Require must refuse every object it is asked about rather than
-	// falling through the system principal's unconditional pass above it.
-	for _, object := range []string{"deal", "person", "organization", "activity"} {
+func TestBuyerHoldsNoObjectGrantEvenWhenItCarriesOne(t *testing.T) {
+	ctx := principal.WithActor(context.Background(), overreachingBuyer())
+	for _, object := range buyerObjects {
 		for _, action := range []principal.Action{
 			principal.ActionRead, principal.ActionCreate,
 			principal.ActionUpdate, principal.ActionDelete,
 		} {
-			err := Require(buyerCtx(), object, action)
+			err := Require(ctx, object, action)
 			if !errors.Is(err, apperrors.ErrPermissionDenied) {
 				t.Errorf("Require(buyer, %s, %s) = %v, want ErrPermissionDenied",
 					object, action, err)
@@ -46,31 +64,51 @@ func TestBuyerHoldsNoObjectGrant(t *testing.T) {
 	}
 }
 
-func TestBuyerIsNotUnbounded(t *testing.T) {
-	// Unbounded answers "does this actor see every row". It is true for the
-	// system principal, and a buyer must never be folded into that clause: a
-	// row-scope predicate that resolved to "all" for a buyer would serve one
-	// room's visitor the whole estate.
-	buyer := principal.Principal{Type: principal.PrincipalBuyer, ID: "buyer:x"}
-	if Unbounded(buyer) {
-		t.Error("Unbounded(buyer) = true, want false — a buyer sees no CRM row")
+func TestBuyerIsNotUnboundedEvenAtRowScopeAll(t *testing.T) {
+	// Unbounded answers "does this actor see every row". A buyer must never
+	// reach it — including one whose Permissions claim RowScopeAll, because a
+	// buyer's row scope is its room and nothing in Permissions describes that.
+	if Unbounded(overreachingBuyer()) {
+		t.Error("Unbounded(buyer with RowScopeAll) = true, want false")
 	}
 }
 
-func TestBuyerIsRefusedByHumanOnlyOperations(t *testing.T) {
-	// RequireHuman refuses agents. A buyer is not an agent, so without its own
-	// clause every human-only sheet in the product would have admitted one.
-	if err := RequireHuman(buyerCtx()); !errors.Is(err, apperrors.ErrPermissionDenied) {
+func TestHumanOnlyOperationsRefuseABuyerAndStillAdmitAHuman(t *testing.T) {
+	// The refusal arm. RequireHuman was written as "refuse agents", and a buyer
+	// is not an agent, so without its own clause every human-only sheet in the
+	// product would admit one.
+	buyer := principal.WithActor(context.Background(), overreachingBuyer())
+	if err := RequireHuman(buyer); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Fatalf("RequireHuman(buyer) = %v, want ErrPermissionDenied", err)
 	}
+
+	// The admit arm, without which a clause broadened to refuse EVERYONE would
+	// leave this test green over a dead product.
+	human := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:someone",
+	})
+	if err := RequireHuman(human); err != nil {
+		t.Fatalf("RequireHuman(human) = %v, want nil", err)
+	}
 }
 
-func TestBuyerIsNotAttributedToTheInstallation(t *testing.T) {
-	// The whole point of the kind: a buyer's action is theirs, not the
-	// system's. AuthzRule returning "system" here would put the installation's
-	// name on a person's decision in an append-only ledger.
-	buyer := principal.Principal{Type: principal.PrincipalBuyer, ID: "buyer:x"}
-	if rule := AuthzRule(buyer, "deal", "update"); rule == "system" {
-		t.Error(`AuthzRule(buyer) = "system", want anything else — a buyer is not the installation`)
+func TestBuyerReadsNoIdentityTableInFull(t *testing.T) {
+	// readsEveryRow answers "does this read carry no owner predicate", and its
+	// identity-table arm is true for ANY actor — which for a buyer would mean
+	// every person, organization, lead, deal and project in the installation.
+	// The kind is answered before the table is.
+	for _, table := range []string{"person", "organization", "lead", "deal", "project"} {
+		if readsEveryRow(overreachingBuyer(), table) {
+			t.Errorf("readsEveryRow(buyer, %s) = true, want false", table)
+		}
+	}
+}
+
+func TestBuyerIsRefusedByAdminOnlyOperations(t *testing.T) {
+	// RequireAdmin reads RoleKeys, so a buyer carrying the admin key is the
+	// case that matters: the kind must refuse before the role key is consulted.
+	ctx := principal.WithActor(context.Background(), overreachingBuyer())
+	if err := RequireAdmin(ctx); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("RequireAdmin(buyer holding the admin role key) = %v, want ErrPermissionDenied", err)
 	}
 }

--- a/backend/internal/platform/auth/rbac.go
+++ b/backend/internal/platform/auth/rbac.go
@@ -94,12 +94,18 @@ func UpsertAction(replacing bool) principal.Action {
 // human-only GET (an admin-only sheet) must reject an agent principal here,
 // or an admin-minted read-scoped passport would satisfy the object grant and
 // see it. The connector and system principals are not agents and pass.
+//
+// A BUYER is refused for a different reason, and the check names it rather
+// than leaning on the agent clause: an external Deal Room participant is not
+// the human this function means. Written as "refuse agents" alone, every
+// human-only sheet in the product would have admitted a buyer the moment the
+// kind existed, because a buyer is not an agent either.
 func RequireHuman(ctx context.Context) error {
 	p, err := rbacActor(ctx)
 	if err != nil {
 		return err
 	}
-	if p.Type == principal.PrincipalAgent {
+	if p.Type == principal.PrincipalAgent || p.Type == principal.PrincipalBuyer {
 		return fmt.Errorf("human-only operation: %w", apperrors.ErrPermissionDenied)
 	}
 	return nil

--- a/backend/internal/platform/auth/rbac.go
+++ b/backend/internal/platform/auth/rbac.go
@@ -34,12 +34,35 @@ func rbacActor(ctx context.Context) (principal.Principal, error) {
 	return p, nil
 }
 
+// refuseBuyer turns away the one principal kind that holds no CRM authority at
+// all. It is applied at every gate in this package rather than left to the
+// permission check below each one, because those gates answer from
+// `Permissions` — so a buyer would be admitted by exactly the accident that it
+// is minted carrying none. That is not a guarantee; it is a coincidence one
+// careless constructor would end, and the caller admitted by it would be an
+// external person with a room link.
+//
+// A buyer's authority is its Deal Room session, and the Deal Room's own store
+// methods carry the room predicate that grants it. Nothing in platform/auth
+// admits a buyer, and the refusal is stated once here so a gate added later
+// inherits it by calling the same helper.
+func refuseBuyer(p principal.Principal, what string) error {
+	if p.Type != principal.PrincipalBuyer {
+		return nil
+	}
+	return fmt.Errorf("%s: a Deal Room participant holds no CRM authority: %w",
+		what, apperrors.ErrPermissionDenied)
+}
+
 // Require is the object-level admission gate: the actor's merged role
 // policy must grant the action on the object type. The system principal
 // (workspace provisioning) is trusted by construction and has no role.
 func Require(ctx context.Context, object string, action principal.Action) error {
 	p, err := rbacActor(ctx)
 	if err != nil {
+		return err
+	}
+	if err := refuseBuyer(p, object+"."+string(action)); err != nil {
 		return err
 	}
 	if p.Type == principal.PrincipalSystem {
@@ -60,6 +83,9 @@ func Require(ctx context.Context, object string, action principal.Action) error 
 func RequireAny(ctx context.Context, object string, actions ...principal.Action) error {
 	p, err := rbacActor(ctx)
 	if err != nil {
+		return err
+	}
+	if err := refuseBuyer(p, object); err != nil {
 		return err
 	}
 	if p.Type == principal.PrincipalSystem {
@@ -93,19 +119,18 @@ func UpsertAction(replacing bool) principal.Action {
 // cannot cover: reads. The gate only inspects mutating methods, so a
 // human-only GET (an admin-only sheet) must reject an agent principal here,
 // or an admin-minted read-scoped passport would satisfy the object grant and
-// see it. The connector and system principals are not agents and pass.
-//
-// A BUYER is refused for a different reason, and the check names it rather
-// than leaning on the agent clause: an external Deal Room participant is not
-// the human this function means. Written as "refuse agents" alone, every
-// human-only sheet in the product would have admitted a buyer the moment the
-// kind existed, because a buyer is not an agent either.
+// see it. A buyer is refused too, by the shared helper: "human" here means a
+// seated member, and an external Deal Room participant is not one. The
+// connector and system principals are, and pass.
 func RequireHuman(ctx context.Context) error {
 	p, err := rbacActor(ctx)
 	if err != nil {
 		return err
 	}
-	if p.Type == principal.PrincipalAgent || p.Type == principal.PrincipalBuyer {
+	if err := refuseBuyer(p, "human-only operation"); err != nil {
+		return err
+	}
+	if p.Type == principal.PrincipalAgent {
 		return fmt.Errorf("human-only operation: %w", apperrors.ErrPermissionDenied)
 	}
 	return nil
@@ -185,12 +210,23 @@ func AuthzRule(p principal.Principal, entityType string, auditAction string) str
 		(p.Type == principal.PrincipalConnector && p.OnBehalfOf == ids.Nil) {
 		return "system"
 	}
+	// A buyer's authority is the room session, and rendering the policy for one
+	// would write `role[] deal.update row_scope=` — the very string this
+	// function exists to avoid, claiming a role and a row scope the actor never
+	// held. Name what actually admitted the call instead.
+	if p.Type == principal.PrincipalBuyer {
+		return ruleDealRoomSession
+	}
 	action, ok := auditActionGrant[auditAction]
 	if !ok {
 		return ""
 	}
 	return p.Permissions.Rule(entityType, action)
 }
+
+// ruleDealRoomSession is the authorization_rule a buyer's write records: the
+// room session admitted it, and no role policy was consulted.
+const ruleDealRoomSession = "deal_room_session"
 
 const roleAdmin = "admin"
 
@@ -203,6 +239,9 @@ func RequireAdmin(ctx context.Context) error {
 	p, ok := principal.Actor(ctx)
 	if !ok {
 		return fmt.Errorf("no principal in context: %w", apperrors.ErrPermissionDenied)
+	}
+	if err := refuseBuyer(p, "admin-only operation"); err != nil {
+		return err
 	}
 	if p.Type == principal.PrincipalSystem {
 		return nil

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -26,6 +26,13 @@ import (
 // Unbounded reports whether the actor sees every row of a permitted
 // object: the system principal, or row_scope=all.
 func Unbounded(p principal.Principal) bool {
+	// A buyer is bounded by its Deal Room, which nothing in Permissions can
+	// describe — so RowScopeAll on one is a claim the row-scope vocabulary
+	// cannot honour, and reading it as "every row" would hand an external
+	// visitor the estate.
+	if p.Type == principal.PrincipalBuyer {
+		return false
+	}
 	return p.Type == principal.PrincipalSystem || p.Permissions.RowScope == principal.RowScopeAll
 }
 

--- a/backend/internal/platform/auth/tableclass.go
+++ b/backend/internal/platform/auth/tableclass.go
@@ -42,6 +42,15 @@ var identityTables = map[string]bool{
 // readsEveryRow reports whether the principal's READ of the table carries no
 // owner-scope arm: an unbounded actor, or any actor on an identity table. It is
 // the read-side twin of Unbounded and deliberately says nothing about writes.
+//
+// The identity-table arm says "no owner predicate narrows this read", which is
+// true for a seated actor and false for a buyer: a Deal Room participant's
+// reads are bounded by their room, and no identity table carries that bound. So
+// the kind is answered before the table is, or a buyer would read every person,
+// organization, lead, deal and project in the installation.
 func readsEveryRow(p principal.Principal, table string) bool {
+	if p.Type == principal.PrincipalBuyer {
+		return false
+	}
 	return Unbounded(p) || identityTables[table]
 }

--- a/backend/internal/shared/kernel/events/envelope.go
+++ b/backend/internal/shared/kernel/events/envelope.go
@@ -91,7 +91,7 @@ func (e Envelope) Validate() error {
 		return fmt.Errorf("events: %s envelope has no occurred_at", e.Type)
 	}
 	switch e.Actor.Type {
-	case "human", "agent", "connector", "system":
+	case "human", "agent", "connector", "system", "buyer":
 	default:
 		// The schema (audit_log CHECK) and the wire contract must agree
 		// on the actor classes — a fifth class slipping onto the bus

--- a/backend/internal/shared/kernel/principal/principal.go
+++ b/backend/internal/shared/kernel/principal/principal.go
@@ -25,21 +25,14 @@ const (
 	PrincipalAgent     PrincipalType = "agent"
 	PrincipalConnector PrincipalType = "connector"
 	PrincipalSystem    PrincipalType = "system"
-	// PrincipalBuyer is an external person acting inside ONE Deal Room, and
-	// it exists because the other four cannot describe them honestly. They
-	// are not `human`: that kind means a seat, and every reader of an audit
-	// row treats it as one it can resolve against the member directory. They
-	// are certainly not `system` — recording a buyer's confirmation as the
-	// installation itself would render "System confirmed v5" over the one
-	// question a disputed negotiation asks, and the audit log is append-only,
-	// so that reading cannot be corrected once written.
-	//
-	// A buyer's authority comes from their room session and NOTHING else.
-	// This kind is deliberately absent from every bypass the other kinds
-	// enjoy — it holds no RBAC grant, no row scope and no seat, so a buyer
-	// principal reaching a general-purpose store is refused rather than
-	// admitted. The Deal Room's own public store methods carry the room
-	// predicate that admits them.
+	// PrincipalBuyer is an external person acting inside ONE Deal Room: no
+	// seat, no RBAC grant, no row scope. Their authority is the room session
+	// and nothing else, so every gate in platform/auth refuses them and the
+	// Deal Room's own store methods carry the room predicate that admits
+	// them. The kind exists so the audit log can attribute their action to
+	// THEM — `human` would send a reader to a member directory they will
+	// never appear in, and `system` would put the installation's name on a
+	// person's decision in an append-only ledger.
 	PrincipalBuyer PrincipalType = "buyer"
 )
 

--- a/backend/internal/shared/kernel/principal/principal.go
+++ b/backend/internal/shared/kernel/principal/principal.go
@@ -16,8 +16,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// PrincipalType distinguishes the four actor classes the audit log and
-// event envelope know (data-model §11, events.md §2).
+// PrincipalType distinguishes the actor classes the audit log and event
+// envelope know (data-model §11, events.md §2).
 type PrincipalType string
 
 const (
@@ -25,6 +25,22 @@ const (
 	PrincipalAgent     PrincipalType = "agent"
 	PrincipalConnector PrincipalType = "connector"
 	PrincipalSystem    PrincipalType = "system"
+	// PrincipalBuyer is an external person acting inside ONE Deal Room, and
+	// it exists because the other four cannot describe them honestly. They
+	// are not `human`: that kind means a seat, and every reader of an audit
+	// row treats it as one it can resolve against the member directory. They
+	// are certainly not `system` — recording a buyer's confirmation as the
+	// installation itself would render "System confirmed v5" over the one
+	// question a disputed negotiation asks, and the audit log is append-only,
+	// so that reading cannot be corrected once written.
+	//
+	// A buyer's authority comes from their room session and NOTHING else.
+	// This kind is deliberately absent from every bypass the other kinds
+	// enjoy — it holds no RBAC grant, no row scope and no seat, so a buyer
+	// principal reaching a general-purpose store is refused rather than
+	// admitted. The Deal Room's own public store methods carry the room
+	// predicate that admits them.
+	PrincipalBuyer PrincipalType = "buyer"
 )
 
 // Scope is a Passport-grantable verb class a tool may require

--- a/backend/migrations/core/1787352862_audit_admits_a_buyer_actor.down.sql
+++ b/backend/migrations/core/1787352862_audit_admits_a_buyer_actor.down.sql
@@ -1,0 +1,23 @@
+-- Narrowing the vocabulary again is NOT symmetric with widening it, and the
+-- difference matters enough to state rather than discover.
+--
+-- Widening admitted every row already stored. Narrowing refuses any row written
+-- since — and audit_log is append-only by design, so there is no honest repair:
+-- rewriting a buyer's action as `system` would falsify who acted, and deleting
+-- the row would destroy the record the ledger exists to keep. Postgres will
+-- therefore refuse this migration on an installation where a buyer has ever
+-- acted, which is the correct outcome: the down path exists to undo a mistake
+-- made before the feature was used, not to erase history after it was.
+--
+-- An operator who hits that refusal is not stuck for want of a clever query.
+-- They are being told that going back means losing attribution somebody may
+-- need, and the decision is theirs to make deliberately.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE audit_log DROP CONSTRAINT audit_log_actor_type_check;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_actor_type_check
+    CHECK (actor_type IN ('human', 'agent', 'connector', 'system'));
+
+ALTER TABLE system_log DROP CONSTRAINT system_log_actor_type_check;
+ALTER TABLE system_log ADD CONSTRAINT system_log_actor_type_check
+    CHECK (actor_type IN ('human', 'agent', 'connector', 'system'));

--- a/backend/migrations/core/1787352862_audit_admits_a_buyer_actor.up.sql
+++ b/backend/migrations/core/1787352862_audit_admits_a_buyer_actor.up.sql
@@ -1,0 +1,32 @@
+-- The ledgers learn a fifth actor kind: `buyer`, an external person acting
+-- inside one Deal Room.
+--
+-- WHY A NEW KIND RATHER THAN REUSING ONE. A Deal Room participant holds no
+-- seat, so `human` is wrong twice over — it means a member, and every reader of
+-- an audit row resolves it against the member directory, where a buyer will
+-- never appear. `system` is worse: it would render "System confirmed v5" over
+-- exactly the question a disputed negotiation asks, and audit_log is append-only,
+-- so that reading could never be corrected. The alternative was to keep
+-- actor_type='system' and bury the participant in the evidence blob, which
+-- leaves every reader to know to look there and the audit screen still drawing
+-- a Cog icon beside a person's decision.
+--
+-- Widening a CHECK is additive: every row already stored satisfies the new
+-- predicate, because the four old values remain. No backfill, no rewrite. The
+-- ALTER still needs a brief ACCESS EXCLUSIVE lock to swap the constraint, and
+-- audit_log takes a row from every mutation in the product — so the wait is
+-- bounded rather than left to queue behind whatever transaction is open.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE audit_log DROP CONSTRAINT audit_log_actor_type_check;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_actor_type_check
+    CHECK (actor_type IN ('human', 'agent', 'connector', 'system', 'buyer'));
+
+-- system_log takes the same widening for one reason only: the two ledgers
+-- share an actor vocabulary, and a kind valid in one and refused by the other
+-- is a trap for the next writer rather than a boundary anybody chose. A buyer
+-- does not write system_log today — that ledger records operational acts that
+-- mutate no record, and a buyer performs none.
+ALTER TABLE system_log DROP CONSTRAINT system_log_actor_type_check;
+ALTER TABLE system_log ADD CONSTRAINT system_log_actor_type_check
+    CHECK (actor_type IN ('human', 'agent', 'connector', 'system', 'buyer'));

--- a/backend/migrations/core/1787352862_audit_admits_a_buyer_actor.up.sql
+++ b/backend/migrations/core/1787352862_audit_admits_a_buyer_actor.up.sql
@@ -12,21 +12,36 @@
 -- a Cog icon beside a person's decision.
 --
 -- Widening a CHECK is additive: every row already stored satisfies the new
--- predicate, because the four old values remain. No backfill, no rewrite. The
--- ALTER still needs a brief ACCESS EXCLUSIVE lock to swap the constraint, and
--- audit_log takes a row from every mutation in the product — so the wait is
--- bounded rather than left to queue behind whatever transaction is open.
+-- predicate, because the four old values remain. No backfill, no rewrite.
+--
+-- It is still done in two steps rather than one, and the reason is a trap worth
+-- naming. A plain ADD CONSTRAINT validates every existing row WHILE HOLDING
+-- ACCESS EXCLUSIVE, and `lock_timeout` does not help: it bounds how long the
+-- statement waits to ACQUIRE the lock, never how long it holds one once it has
+-- it. On a mature audit_log — a row for every mutation the product has ever
+-- made — that scan is the outage. NOT VALID skips the scan and takes the lock
+-- only long enough to record the constraint; VALIDATE then checks the existing
+-- rows under a SHARE UPDATE EXCLUSIVE lock that readers and writers pass.
+--
+-- The validation cannot fail here, because the new predicate admits everything
+-- the old one did. It is run anyway rather than left NOT VALID: an unvalidated
+-- constraint is not trusted by the planner and reads as provisional to the next
+-- person who looks at the schema.
 SET LOCAL lock_timeout = '3s';
 
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_actor_type_check_v2
+    CHECK (actor_type IN ('human', 'agent', 'connector', 'system', 'buyer')) NOT VALID;
+ALTER TABLE audit_log VALIDATE CONSTRAINT audit_log_actor_type_check_v2;
 ALTER TABLE audit_log DROP CONSTRAINT audit_log_actor_type_check;
-ALTER TABLE audit_log ADD CONSTRAINT audit_log_actor_type_check
-    CHECK (actor_type IN ('human', 'agent', 'connector', 'system', 'buyer'));
+ALTER TABLE audit_log RENAME CONSTRAINT audit_log_actor_type_check_v2 TO audit_log_actor_type_check;
 
 -- system_log takes the same widening for one reason only: the two ledgers
 -- share an actor vocabulary, and a kind valid in one and refused by the other
 -- is a trap for the next writer rather than a boundary anybody chose. A buyer
 -- does not write system_log today — that ledger records operational acts that
 -- mutate no record, and a buyer performs none.
+ALTER TABLE system_log ADD CONSTRAINT system_log_actor_type_check_v2
+    CHECK (actor_type IN ('human', 'agent', 'connector', 'system', 'buyer')) NOT VALID;
+ALTER TABLE system_log VALIDATE CONSTRAINT system_log_actor_type_check_v2;
 ALTER TABLE system_log DROP CONSTRAINT system_log_actor_type_check;
-ALTER TABLE system_log ADD CONSTRAINT system_log_actor_type_check
-    CHECK (actor_type IN ('human', 'agent', 'connector', 'system', 'buyer'));
+ALTER TABLE system_log RENAME CONSTRAINT system_log_actor_type_check_v2 TO system_log_actor_type_check;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -616,7 +616,7 @@ public.audit_log.actor_id text NOT NULL gen=- def=-
 public.audit_log.actor_type text NOT NULL gen=- def=-
 public.audit_log.after jsonb gen=- def=-
 public.audit_log.audit_log_action_check CHECK ((action = ANY (ARRAY['create'::text, 'update'::text, 'archive'::text, 'merge'::text, 'promote'::text, 'restore'::text, 'export'::text, 'erase'::text, 'assign'::text, 'advance_stage'::text, 'advance_phase'::text, 'approve'::text, 'reject'::text, 'consent_grant'::text, 'consent_withdraw'::text, 'activity_relink'::text, 'record_share'::text, 'record_unshare'::text, 'resolve'::text, 'demote'::text, 'import'::text, 'import_undo'::text, 'disqualify'::text, 'anonymize'::text, 'send_email'::text, 'reset_data'::text, 'password_link_issued'::text, 'connect'::text, 'disconnect'::text, 'schedule'::text, 'reschedule'::text, 'cancel'::text, 'release'::text, 'hold'::text, 'expire'::text, 'restrict'::text, 'pin'::text, 'accrue'::text, 'pay'::text])))
-public.audit_log.audit_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text])))
+public.audit_log.audit_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text, 'buyer'::text])))
 public.audit_log.audit_log_on_behalf_of_fkey FOREIGN KEY (on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL (on_behalf_of)
 public.audit_log.audit_log_pkey PRIMARY KEY (id)
 public.audit_log.authorization_rule text gen=- def=-
@@ -3740,7 +3740,7 @@ public.system_log.id uuid NOT NULL gen=- def=uuidv7()
 public.system_log.occurred_at timestamp with time zone NOT NULL gen=- def=now()
 public.system_log.on_behalf_of uuid gen=- def=-
 public.system_log.passport_id uuid gen=- def=-
-public.system_log.system_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text])))
+public.system_log.system_log_actor_type_check CHECK ((actor_type = ANY (ARRAY['human'::text, 'agent'::text, 'connector'::text, 'system'::text, 'buyer'::text])))
 public.system_log.system_log_on_behalf_of_fkey FOREIGN KEY (on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL (on_behalf_of)
 public.system_log.system_log_pkey PRIMARY KEY (id)
 public.system_log.trg_system_log_no_mutate CREATE TRIGGER trg_system_log_no_mutate BEFORE DELETE OR UPDATE ON public.system_log FOR EACH ROW EXECUTE FUNCTION system_log_immutable()

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17703,7 +17703,7 @@ export interface components {
             /** @description How consent was captured (e.g. webform, import, double_opt_in). */
             source?: string | null;
             /** @enum {string} */
-            actor_type?: "human" | "agent" | "system" | "connector" | "buyer";
+            actor_type?: "human" | "agent" | "system" | "connector";
             actor_id?: string | null;
             /** Format: date-time */
             occurred_at: string;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16055,8 +16055,8 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            actor_type: "human" | "agent" | "system" | "connector";
-            /** @description User uuid, agent id, connector name (e.g. connector:gmail), or 'system'. */
+            actor_type: "human" | "agent" | "system" | "connector" | "buyer";
+            /** @description User uuid, agent id, connector name (e.g. connector:gmail), 'system', or a Deal Room participant (buyer:<participant uuid>) — an external person with no seat, who appears in no member directory. */
             actor_id: string;
             /**
              * Format: uuid
@@ -16142,7 +16142,7 @@ export interface components {
             /** Format: date-time */
             changed_at: string;
             /** @enum {string} */
-            actor_type: "human" | "agent" | "system" | "connector";
+            actor_type: "human" | "agent" | "system" | "connector" | "buyer";
             actor_id: string;
             /**
              * Format: uuid
@@ -16249,7 +16249,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            actor_type: "human" | "agent" | "system" | "connector";
+            actor_type: "human" | "agent" | "system" | "connector" | "buyer";
             actor_id: string;
             /** @description Resolved display name for a human actor_id; null for machine actors and for a member whose user row no longer resolves. */
             actor_name?: string | null;
@@ -17703,7 +17703,7 @@ export interface components {
             /** @description How consent was captured (e.g. webform, import, double_opt_in). */
             source?: string | null;
             /** @enum {string} */
-            actor_type?: "human" | "agent" | "system" | "connector";
+            actor_type?: "human" | "agent" | "system" | "connector" | "buyer";
             actor_id?: string | null;
             /** Format: date-time */
             occurred_at: string;
@@ -28901,7 +28901,7 @@ export interface operations {
                 /** @description Narrow to one field name. */
                 field?: string;
                 /** @description Narrow to one actor category. */
-                actor_type?: "human" | "agent" | "system" | "connector";
+                actor_type?: "human" | "agent" | "system" | "connector" | "buyer";
             };
             header?: never;
             path?: never;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -616,7 +616,6 @@ export const de = {
   "consent.actorAgent": "Agent",
   "consent.actorSystem": "System",
   "consent.actorConnector": "Connector",
-  "consent.actorBuyer": "Teilnehmer im Deal Room",
   "consent.actorUnknown": "Akteur nicht erfasst",
   "consent.purposesUnavailable":
     "Der Einwilligungszweck-Katalog konnte nicht geladen werden — welche Zwecke ein Double-Opt-in brauchen, lässt sich gerade nicht anzeigen.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -616,6 +616,7 @@ export const de = {
   "consent.actorAgent": "Agent",
   "consent.actorSystem": "System",
   "consent.actorConnector": "Connector",
+  "consent.actorBuyer": "Teilnehmer im Deal Room",
   "consent.actorUnknown": "Akteur nicht erfasst",
   "consent.purposesUnavailable":
     "Der Einwilligungszweck-Katalog konnte nicht geladen werden — welche Zwecke ein Double-Opt-in brauchen, lässt sich gerade nicht anzeigen.",
@@ -2487,9 +2488,11 @@ export const de = {
 
   "audit.you": "Du",
   "audit.system": "System",
+  "audit.unknownBuyer": "Teilnehmer im Deal Room",
   "audit.unknownMember": "Unbekanntes Mitglied",
   "audit.viaAgent": "über einen Agenten",
   "audit.viaConnector": "über einen Connector",
+  "audit.viaDealRoom": "im Deal Room",
   "audit.viaNamed": "über {client}",
   "audit.noHumanAuthority": "Keine menschliche Autorisierung erfasst",
   "settings.auditSub": "jede Aktion, zugeordnet — Mensch, Agent oder Connector",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -654,6 +654,7 @@ export const en = {
   "consent.actorAgent": "Agent",
   "consent.actorSystem": "System",
   "consent.actorConnector": "Connector",
+  "consent.actorBuyer": "Deal Room participant",
   "consent.actorUnknown": "actor not recorded",
   "consent.purposesUnavailable":
     "Couldn't load the consent purpose catalogue, so which purposes need a double opt-in can't be shown right now.",
@@ -2516,9 +2517,11 @@ export const en = {
 
   "audit.you": "You",
   "audit.system": "System",
+  "audit.unknownBuyer": "Deal Room participant",
   "audit.unknownMember": "Unknown member",
   "audit.viaAgent": "via an agent",
   "audit.viaConnector": "via a connector",
+  "audit.viaDealRoom": "in the Deal Room",
   "audit.viaNamed": "via {client}",
   "audit.noHumanAuthority": "No human authority recorded",
   "settings.auditSub": "every action, attributed — human, agent, or connector",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -654,7 +654,6 @@ export const en = {
   "consent.actorAgent": "Agent",
   "consent.actorSystem": "System",
   "consent.actorConnector": "Connector",
-  "consent.actorBuyer": "Deal Room participant",
   "consent.actorUnknown": "actor not recorded",
   "consent.purposesUnavailable":
     "Couldn't load the consent purpose catalogue, so which purposes need a double opt-in can't be shown right now.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -605,6 +605,7 @@ export const vi = {
   "consent.actorAgent": "Agent",
   "consent.actorSystem": "Hệ thống",
   "consent.actorConnector": "Connector",
+  "consent.actorBuyer": "Người tham gia Deal Room",
   "consent.actorUnknown": "không ghi nhận tác nhân",
   "consent.purposesUnavailable":
     "Không tải được danh mục mục đích chấp thuận, nên hiện chưa thể cho biết mục đích nào cần xác nhận kép.",
@@ -2462,9 +2463,11 @@ export const vi = {
 
   "audit.you": "Bạn",
   "audit.system": "Hệ thống",
+  "audit.unknownBuyer": "Người tham gia Deal Room",
   "audit.unknownMember": "Thành viên không xác định",
   "audit.viaAgent": "qua một agent",
   "audit.viaConnector": "qua một connector",
+  "audit.viaDealRoom": "trong Deal Room",
   "audit.viaNamed": "qua {client}",
   "audit.noHumanAuthority": "Không ghi nhận người uỷ quyền",
   "settings.auditSub":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -605,7 +605,6 @@ export const vi = {
   "consent.actorAgent": "Agent",
   "consent.actorSystem": "Hệ thống",
   "consent.actorConnector": "Connector",
-  "consent.actorBuyer": "Người tham gia Deal Room",
   "consent.actorUnknown": "không ghi nhận tác nhân",
   "consent.purposesUnavailable":
     "Không tải được danh mục mục đích chấp thuận, nên hiện chưa thể cho biết mục đích nào cần xác nhận kép.",

--- a/frontend/src/screens/audit.tsx
+++ b/frontend/src/screens/audit.tsx
@@ -1,4 +1,11 @@
-import { Bot, CircleUser, Cog, type LucideIcon, Plug } from "lucide-react";
+import {
+  Bot,
+  CircleUser,
+  Cog,
+  type LucideIcon,
+  Plug,
+  UserRoundCheck,
+} from "lucide-react";
 import type { components } from "../api/schema";
 import { Badge } from "../design-system/atoms";
 import { formatDateTime } from "../format/format";
@@ -42,6 +49,10 @@ const ACTOR_ICON: Record<AuditLogEntry["actor_type"], LucideIcon> = {
   agent: Bot,
   system: Cog,
   connector: Plug,
+  // A person, not a machine: a buyer decided this. The icon differs from a
+  // member's so a reader can tell at a glance that the actor sits outside the
+  // organization and will not be found in the member directory.
+  buyer: UserRoundCheck,
 };
 
 // The phrase that says a machine did the typing, qualifying the person who
@@ -93,6 +104,15 @@ function actorAttribution(
   }
   if (entry.actor_type === "system") {
     return { labelKey: "audit.system" };
+  }
+  // A Deal Room participant. Their name is carried on the row because no
+  // directory lookup can resolve them — they hold no seat and never will — so
+  // an absent name is the honest end of the line rather than a reason to print
+  // the raw participant id at a reader.
+  if (entry.actor_type === "buyer") {
+    return entry.actor_name
+      ? { name: entry.actor_name, qualifierKey: "audit.viaDealRoom" }
+      : { labelKey: "audit.unknownBuyer", qualifierKey: "audit.viaDealRoom" };
   }
 
   const qualifierKey = MACHINE_QUALIFIER[entry.actor_type];

--- a/frontend/src/screens/audit.tsx
+++ b/frontend/src/screens/audit.tsx
@@ -105,14 +105,16 @@ function actorAttribution(
   if (entry.actor_type === "system") {
     return { labelKey: "audit.system" };
   }
-  // A Deal Room participant. Their name is carried on the row because no
-  // directory lookup can resolve them — they hold no seat and never will — so
-  // an absent name is the honest end of the line rather than a reason to print
-  // the raw participant id at a reader.
+  // A Deal Room participant. The read path resolves actor_name from app_user
+  // for humans only, and a buyer holds no seat, so no name arrives today and
+  // this renders the kind rather than inventing one. Naming the participant
+  // means resolving actor_id against deal_room_participant on the read path —
+  // when that lands, the name replaces the label here.
   if (entry.actor_type === "buyer") {
-    return entry.actor_name
-      ? { name: entry.actor_name, qualifierKey: "audit.viaDealRoom" }
-      : { labelKey: "audit.unknownBuyer", qualifierKey: "audit.viaDealRoom" };
+    return {
+      labelKey: "audit.unknownBuyer",
+      qualifierKey: "audit.viaDealRoom",
+    };
   }
 
   const qualifierKey = MACHINE_QUALIFIER[entry.actor_type];

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -73,12 +73,6 @@ const ACTOR_LABEL: Record<
   agent: "consent.actorAgent",
   system: "consent.actorSystem",
   connector: "consent.actorConnector",
-  // A Deal Room participant cannot capture a consent decision today — they
-  // reach one room and nothing in it touches the consent registry. The label
-  // exists because this table is keyed on the wire's closed enum ON PURPOSE:
-  // a proof log that fell back to a generic word for an actor the wire named
-  // would assert less than the record holds.
-  buyer: "consent.actorBuyer",
 };
 
 // The actor line on the Art. 7 proof log: names WHO the server says captured

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -73,6 +73,12 @@ const ACTOR_LABEL: Record<
   agent: "consent.actorAgent",
   system: "consent.actorSystem",
   connector: "consent.actorConnector",
+  // A Deal Room participant cannot capture a consent decision today — they
+  // reach one room and nothing in it touches the consent registry. The label
+  // exists because this table is keyed on the wire's closed enum ON PURPOSE:
+  // a proof log that fell back to a generic word for an actor the wire named
+  // would assert less than the record holds.
+  buyer: "consent.actorBuyer",
 };
 
 // The actor line on the Art. 7 proof log: names WHO the server says captured

--- a/frontend/src/screens/history.tsx
+++ b/frontend/src/screens/history.tsx
@@ -90,6 +90,14 @@ function provenanceOfEntry(
   entry: Pick<AuditHistoryEntry, "actor_type" | "actor_id">,
   viewerUserId?: string,
 ): Provenance {
+  // A buyer is a person, not a machine, and drawing them with the machine
+  // treatment is the mislabel the actor kind exists to prevent. Provenance has
+  // no buyer variant yet, so `unknown` is the honest placeholder: it says the
+  // source is not recorded rather than naming the wrong kind of source. Giving
+  // Provenance a buyer variant is a design-system change, tracked separately.
+  if (entry.actor_type === "buyer") {
+    return { kind: "unknown" };
+  }
   if (entry.actor_type !== "human") {
     return machineProvenance(entry.actor_type, entry.actor_id);
   }


### PR DESCRIPTION
Closes #2225.

The audit log knew four actor kinds and a Deal Room participant was none
of them. That left the store about to be written with two bad options:
call an external buyer `human`, which means a seat and sends every reader
to a member directory the buyer will never appear in, or call them
`system`, which puts the installation's name on a person's decision. The
ledger is append-only, so either reading would have been permanent.

## What `buyer` is

A fifth principal kind that exists to be **attributed** and never to be
**admitted**. It carries no seat, no RBAC grant and no row scope, so every
general-purpose gate refuses it by falling through to zero permissions.
Four tests hold that: `Require` denies every object and action, `Unbounded`
is false, `AuthzRule` does not answer `"system"`, and human-only operations
refuse it.

## One real hole this closed

`RequireHuman` was written as "refuse agents". A buyer is not an agent, so
**every human-only sheet in the product would have admitted one** the moment
the kind existed. It now names both, and the comment says why the agent
clause alone was not enough. Mutation-checked: reverting the guard fails the
test.

## The migration

Widening a CHECK is additive — the four old values remain, so every stored
row still satisfies it and nothing is backfilled or rewritten. Verified
against a real database: a buyer row writes with its participant identity
intact, and an unknown kind is still refused.

The down half is deliberately **not** symmetric, and says so in the file. It
refuses on any installation where a buyer has acted, because the
alternatives are falsifying who acted or deleting the record.

## The reader was the point

`audit.tsx` already switched on `actor_type` to decide what a row says, so a
buyer would have rendered as "System" behind a Cog icon. They now render as
a person, with their own icon and "in the Deal Room" beneath. `consent.tsx`
keys its actor table on the wire enum on purpose and failed to compile until
it named the new kind — which is exactly what that table is for.

Gates: `make check-backend`, `make check-fe`, `make craft-static`,
`rls-store-path`, `no-jurisdiction`, and the migrations integration lane all
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes Deal Room actions to a new `buyer` actor so audit/history name the external participant instead of `human`/`system`. Buyers gain no workspace access and are refused by every gate; their writes record `authorization_rule = deal_room_session`.

- API and clients: Adds `buyer` to actor enums (`audit_log`, field history filter, event envelope). `actor_id` may be `buyer:<participant-uuid>`.
- Authz: Shared `refuseBuyer` guards `Require`, `RequireAny`, `RequireHuman`, `RequireAdmin`, and `Gate.Admit`. `Unbounded` is false for buyers; `readsEveryRow` never treats buyers as identity-table-wide. `AuthzRule` no longer fabricates role policy for buyers.
- DB: Widens `audit_log`/`system_log` actor CHECK to admit `buyer` using NOT VALID + VALIDATE to avoid long locks. No data rewrite. Down migration refuses if any buyer-attributed rows exist.
- UI: Audit renders buyers with a distinct person icon and “in the Deal Room”. History treats buyer provenance as unknown for now. i18n keys added.
- Tests: New suite asserts buyer refusal at all gates even when carrying maximal permissions.

**Rollout**
- Run migrations; brief locks while swapping constraints and validating.
- If any client filters by `actor_type`, include `buyer` to avoid over-filtering.

<sup>Written for commit bbd1d059b7bc614b303f20e95bbab2a8d6926a5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deal Room participants are now recognized as buyers in consent records and audit logs.
  * Audit entries identify buyer activity by name, with a clear fallback when the buyer is unknown.
  * Added localized buyer and Deal Room labels in English, German, and Vietnamese.
  * Buyer actions now use a distinct audit icon and attribution format.

* **Access Control**
  * Buyers are restricted from human-only operations and do not receive object permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->