### PR TITLE
docs(geocode): the worker says whether it will geocode anything

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,16 @@ MARGINCE_CONNECTOR_STATE_KEY=
 # unset, /webhooks/hubspot is not mounted rather than mounted unverified.
 MARGINCE_HUBSPOT_APP_SECRET=
 
+# [required for "which customers are near Stuttgart"] Nominatim base URL, read
+# by the WORKER role. Unset, an address writes and nothing is geocoded: no
+# company gets coordinates and every within_radius query answers unavailable.
+# `public` is OpenStreetMap's own service and POC-only — its terms hold a
+# client that runs on a schedule to 4 requests a minute, single-threaded, so
+# 200 companies take about 50 minutes and any real volume wants a self-hosted
+# instance. Spelled out rather than defaulted, because sending an
+# installation's addresses to a third party is a decision somebody makes.
+MARGINCE_GEOCODE_BASE_URL=
+
 
 # ---- Object storage (attachments, company logos) ---------------------------
 # Source: backend/internal/platform/blobstore/env.go

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
+	"github.com/gradionhq/margince/backend/internal/platform/geocode"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
@@ -202,11 +203,42 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return lanes, err
 	}
 
+	announceGeocoding(cfg.geocodeBaseURL, stdout)
+
 	if err := startWebhookLane(laneCtx, cfg, pool, rdb, &lanes, logger, stdout); err != nil {
 		return lanes, err
 	}
 	startWorkflowLane(laneCtx, pool, rdb, modelPath, lanes.background, logger, stdout)
 	return lanes, nil
+}
+
+// announceGeocoding says at boot whether company addresses become coordinates,
+// and it is the ONLY lane announcement that speaks when the feature is ABSENT.
+//
+// Every other one here says something when its half is configured and stays
+// quiet otherwise, which is right for a feature whose absence shows up the
+// moment it is asked for: an unconfigured blobstore answers 501, an
+// unconfigured webhook key answers 503. Geocoding has no such moment. An
+// address writes, the row is saved, nothing is queued, and no coordinate ever
+// appears — so the only symptom is that `within_radius` answers "unavailable"
+// weeks later, in a different surface, with nothing to search for.
+//
+// A line naming the variable is what turns that into a question an operator
+// can answer.
+func announceGeocoding(baseURL string, stdout io.Writer) {
+	if baseURL == "" {
+		_, _ = fmt.Fprintln(stdout,
+			"worker geocoding OFF (MARGINCE_GEOCODE_BASE_URL unset) — company addresses "+
+				"keep no coordinates and every within_radius query answers unavailable")
+		return
+	}
+	where := baseURL
+	if baseURL == "public" {
+		// Named rather than echoed: "public" is the flag's word, and an
+		// operator reading the log wants to know whose service this is.
+		where = geocode.PublicBaseURL + " (OpenStreetMap's own; 4 requests/minute)"
+	}
+	_, _ = fmt.Fprintf(stdout, "worker geocoding company addresses via %s\n", where)
 }
 
 // startExtensionSubscriptionLanes starts one consumer per composed unit

--- a/backend/cmd/worker/boot_test.go
+++ b/backend/cmd/worker/boot_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -70,4 +71,45 @@ func TestResetFlushWithoutARouterStillReturnsACallableFlush(t *testing.T) {
 		t.Fatal("resetFlush returned nil; the reset subscriber would nil-panic on the first announcement")
 	}
 	flush(ids.NewV7())
+}
+
+// The boot line exists because geocoding's absence has no other symptom.
+//
+// Every other optional half here fails loudly when it is asked for — an
+// unconfigured blobstore answers 501, an unconfigured webhook key answers 503.
+// Geocoding does not: the address writes, the row saves, nothing is queued,
+// and the only trace is `within_radius` answering "unavailable" later, in a
+// different surface, with nothing an operator could search for.
+//
+// So the OFF line is the load-bearing one, and it names the variable — a
+// message saying only "geocoding disabled" leaves the reader exactly as stuck.
+func TestTheWorkerSaysWhenItWillGeocodeNothing(t *testing.T) {
+	var out strings.Builder
+	announceGeocoding("", &out)
+	said := out.String()
+	if !strings.Contains(said, "MARGINCE_GEOCODE_BASE_URL") {
+		t.Errorf("boot said %q, want it to name the variable — without it the reader has "+
+			"nothing to look up", said)
+	}
+	if !strings.Contains(said, "within_radius") {
+		t.Errorf("boot said %q, want it to name the query that will answer unavailable, "+
+			"which is the symptom the reader will actually meet", said)
+	}
+}
+
+// Configured, it says WHERE — an installation that geocodes through somebody
+// else's service should be able to read that off its own boot log.
+func TestTheWorkerSaysWhoseGeocoderItUses(t *testing.T) {
+	var public strings.Builder
+	announceGeocoding("public", &public)
+	// "public" is the flag's word, not a service. The log names the host.
+	if !strings.Contains(public.String(), "openstreetmap.org") {
+		t.Errorf("boot said %q for `public`, want the host it will actually call", public.String())
+	}
+
+	var own strings.Builder
+	announceGeocoding("https://nominatim.internal", &own)
+	if !strings.Contains(own.String(), "https://nominatim.internal") {
+		t.Errorf("boot said %q, want the self-hosted URL it was given", own.String())
+	}
 }


### PR DESCRIPTION
## What was wrong

Geocoding is off unless `MARGINCE_GEOCODE_BASE_URL` is set, and **its absence had no symptom**.

Every other optional half in this role fails loudly when it is asked for — no blobstore answers 501, no webhook key answers 503. This one does not. The address writes, the row saves, nothing is queued, and the only trace is `within_radius` answering *unavailable* later, in a different surface, with nothing to search for.

Lars hit exactly this: set the variable on a fresh stack and had no way to tell whether it had taken.

## Three changes

1. **The worker says which it is at boot**, both ways. The OFF line is the load-bearing one and it names the variable — a message saying only "geocoding disabled" leaves the reader as stuck as silence did. Configured, it names the host it will actually call rather than echoing the flag's word `public` back.

2. **`.env.example` gains the variable.** That file carries 32 of the 89 variables `docs/reference/configuration.md` documents, and this one belongs in the `[required for X]` class: without it a whole query surface is dead. The reference entry was already good — the problem was that nobody reaches it without first suspecting the variable exists.

3. **`findings/MCP-TESTING.md`** (separate folder, not in this PR) gains a section with the check query and the two other reasons a stack can end up with no coordinates.

## Verified

Booted a real stack with `MARGINCE_GEOCODE_BASE_URL=public` in `.env.local`. Line 61 of the boot log:

```
worker | worker geocoding company addresses via https://nominatim.openstreetmap.org (OpenStreetMap's own; 4 requests/minute)
```

Two tests pin both branches: that the OFF line names the variable and the query it disables, and that the ON line names the host rather than the flag word.

`make check-backend` green · `make craft-static` 0/0/0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs at worker boot now state whether geocoding will run and where. Previously, when `MARGINCE_GEOCODE_BASE_URL` was unset, geocoding silently did nothing; now the boot log names the missing variable and that `within_radius` will be unavailable.

- Call `announceGeocoding` in `backend/cmd/worker/boot.go`. OFF logs name `MARGINCE_GEOCODE_BASE_URL` and the affected `within_radius` query. ON logs name the target host; `public` resolves to `geocode.PublicBaseURL` (OpenStreetMap) instead of echoing the flag.
- Add `MARGINCE_GEOCODE_BASE_URL` to `.env.example` with usage notes; no default to avoid unintended third-party calls.
- Tests in `backend/cmd/worker/boot_test.go` pin both branches.
- No functional change to geocoding jobs; only boot logging. To verify, set `MARGINCE_GEOCODE_BASE_URL` to `public` or a Nominatim URL and check the boot log.

<sup>Written for commit be8d0728e282de516ec5ab6b834b85713eb5ab59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

