### PR TITLE
fix(seed-demo): an offer line can state its own price, so a quote need not be in euro

### DIFF
--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -221,6 +221,13 @@ type demoOffer struct {
 type demoOfferLine struct {
 	Product  string `json:"product"`
 	Quantity int    `json:"quantity"`
+	// UnitPriceMinor overrides the product's own price, in the OFFER's
+	// currency. Required when the two differ: a line snapshots its price
+	// from the product, and the API refuses to convert one currency into
+	// another rather than fabricate a rate (ProductCurrencyMismatchError).
+	// Zero means "take the product's price", which is right whenever the
+	// offer and the product agree on currency.
+	UnitPriceMinor int64 `json:"unit_price_minor"`
 }
 
 // demoConsent is a consent state for one person, addressed by their position

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -348,7 +348,14 @@ func seedOffers(c *client, cfg demoConfig, refs pipelineRefs, products map[strin
 			if !ok {
 				return created, fmt.Errorf("offer %s names product %q, which is not seeded", offer.Ref, line.Product)
 			}
-			lines = append(lines, jsonBody{"product_id": productID, "quantity": line.Quantity})
+			item := jsonBody{"product_id": productID, "quantity": line.Quantity}
+			// Only sent when the dataset states one. Otherwise the line takes
+			// the product's own price, which is what every same-currency
+			// offer wants.
+			if line.UnitPriceMinor > 0 {
+				item["unit_price_minor"] = line.UnitPriceMinor
+			}
+			lines = append(lines, item)
 		}
 		body := jsonBody{"currency": offer.Currency, "source": seedSource, "line_items": lines}
 		addIfSet(body, "intro_text", offer.IntroText)


### PR DESCRIPTION
The demo dataset could not express an offer in any currency but euro.

Every product in it is priced in EUR. An offer in another currency is refused
with `422 product_currency_mismatch`: a line snapshots its price from the
product, and the API will not silently convert one currency into another
rather than fabricate a rate.

The API already accepts `unit_price_minor` per line for exactly this case.
`demoOfferLine` had no field for it, so the seeder could never send one.

## What changed

- `demoOfferLine` gains `UnitPriceMinor int64`.
- `seedOffers` sends it when the dataset states one.

Zero means "take the product's price", so every existing euro offer is
unchanged and no dataset edit is required.

## How it came up

Seeding a Vietnamese account (VULETECH) whose deal is in dong. The offer
against it is the first non-EUR offer the dataset has ever carried, and
`tools/seed.sh --fresh` failed on it.

## Verification

`gofmt`, `go vet`, `go build` and `go test ./tools/seed-demo/` all clean.
Verified end to end with a full `tools/seed.sh --fresh` against the demo
dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed demo offers can now set a line’s unit price in the offer’s currency. Previously lines always used the product price (EUR), causing non-EUR offers to fail with 422 product_currency_mismatch; now the seeder forwards a per-line unit_price_minor. When omitted or zero, the product price is used, so existing EUR offers are unchanged.

- Adds UnitPriceMinor to demoOfferLine; seedOffers includes unit_price_minor only when > 0, in the offer currency.
- No dataset edits or migrations required.

<sup>Written for commit b0db4bf5f322c525976e6809def0083485edd0df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

