### PR TITLE
fix(ci-tests): the tool conformance sweep accounts for list_tags

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -237,7 +237,10 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 	"apply_tag": "needs a seat holding tag.read, which this lane's seat does not carry — " +
 		"granting it here would widen the authority every other tool in the sweep runs under, " +
 		"and the answer shape it would prove is the one remove_tag already shares",
-	"remove_tag":           "same missing tag.read as apply_tag above",
+	"remove_tag": "same missing tag.read as apply_tag above",
+	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
+		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
+		"than proven elsewhere",
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
 	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",


### PR DESCRIPTION
**main is red on the integration lane**, and has been since `list_tags` merged. Anyone running `make test-integration` sees a failure that is not theirs.

`TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas` asserts every registered tool is either invoked in the sweep or named as unreachable. `list_tags` arrived registered and unnamed, which is the check doing its job.

## The fix

It is unreachable in this lane for the same reason `apply_tag` and `remove_tag` already are: the sweep runs under a seat holding no `tag.read`, and the existing waiver explains why granting one is the wrong trade — it would widen the authority every other tool in the sweep runs under.

## The waiver says what it costs

`remove_tag` is waived safely because `apply_tag` proves the answer shape they share. `list_tags` shares its shape with nothing else here, so this waiver leaves that shape unproven rather than proven elsewhere. That is written into the waiver text rather than left for the next reader to work out.

## Verification

`TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas` passes; confirmed failing on `origin/main` without this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks `list_tags` unreachable in the tool conformance sweep to restore green integration tests. The lane lacks `tag.read`; the waiver avoids widening the seat’s authority and notes that `list_tags`’s answer shape remains unproven here.

- Adds `list_tags` to `unreachableInThisLane` with rationale, alongside `apply_tag`/`remove_tag`.
- No permission changes; we do not grant `tag.read`.
- `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas` now passes; it fails on `main` without this change.

<sup>Written for commit 6b38da489e54f5db99d4e95729f07641ba035917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

