### PR TITLE
feat(geocode): every company gets located, not only the edited ones

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -1181,6 +1181,38 @@ kinds:
       policy interval before the request even starts, and a timeout that fired
       during the wait would retry into the same queue and make the rate worse.
 
+  # The backfill's own kind, not a flag on the per-company one. Geocoding fires
+  # on an address WRITE, which never reaches a row written before this
+  # installation had a geocoder — a seeded workspace, an old import, or the
+  # ordinary case of an operator configuring the provider on a system that
+  # already holds its customers. Those rows are invisible to the trigger and
+  # would never be located at all.
+  #
+  # It NOMINATES; it does not decide. Each candidate is handed to
+  # geocode_organization, which re-asks AddressForGeocode, so the retry ledger
+  # and the settled-address rules stay in exactly one place.
+  #
+  # NO WORKSPACE ARG, like webhook_retry and for the same reason: a periodic
+  # insert has no tenant to name, and a WorkspaceScoped kind whose args carry
+  # none fails every tick with "declares WorkspaceScoped but carries no
+  # workspace". The pass reads the installation's own companies and stamps the
+  # workspace onto each per-company job it queues, which is where the tenant
+  # actually belongs — that job is the one that reads and writes a row.
+  geocode_backfill:
+    role: worker
+    go_type: GeocodeBackfillArgs
+    queue: geocode
+    timeout: 2m
+    max_attempts: 3
+    opts_owner: args
+    cadence: {operator: Geocoding.BackfillInterval, schedule_when_positive: Geocoding.BackfillInterval}
+    registration: {when: [Geocoder], absent: registers_nothing}
+    reason: >-
+      One indexed read and up to GeocodeBackfillBatch (50) enqueues, no
+      outbound call of its own — the lookups happen in the per-company jobs it
+      queues, each paced by the installation-wide requester. Two minutes is
+      generous for that and bounded by the batch.
+
   transcript_propose:
     role: worker
     go_type: TranscriptProposeArgs

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -58,6 +58,7 @@ type workerConfig struct {
 	sendMaxAge           time.Duration
 	webhookKey           string
 	geocodeBaseURL       string
+	geocodeBackfill      time.Duration
 	webhookRetryInterval time.Duration
 	deepReadMaxPages     int
 	deepReadMaxBytes     int
@@ -100,6 +101,11 @@ func workerFlagSet() (*flag.FlagSet, *cliflags.Env, *workerConfig, error) {
 	fs.DurationVar(&cfg.closeDateInterval, "close-date-interval", 24*time.Hour, "close-date hygiene sweep interval (INV-CLOSE-PAST)")
 	fs.DurationVar(&cfg.reconcileInterval, "reconcile-interval", 24*time.Hour, "overnight follow-up reconciliation pass interval (features/07 §8a)")
 	fs.DurationVar(&cfg.timeScanInterval, "time-scan-interval", time.Hour, "clock-trigger scan interval (no_activity_reminder et al., Task 14)")
+	fs.DurationVar(&cfg.geocodeBackfill, "geocode-backfill-interval", time.Hour,
+		"how often to look for companies whose address predates this installation's geocoder — a "+
+			"seeded or imported database, or one configured after the fact. Nothing writes those "+
+			"addresses again, so without this pass they are never located. Runs on start; 0 turns "+
+			"the sweep off and leaves geocoding-on-write alone.")
 	env.String(fs, &cfg.gmailClientID, "gmail-client-id", "MARGINCE_GMAIL_CLIENT_ID", "", "Google OAuth client id for the Gmail capture connector; enables the background Gmail sync poll")
 	env.String(fs, &cfg.gmailClientSecret, "gmail-client-secret", "MARGINCE_GMAIL_CLIENT_SECRET", "", "Google OAuth client secret for the Gmail capture connector")
 	env.String(fs, &cfg.graphClientID, "graph-client-id", "MARGINCE_GRAPH_CLIENT_ID", "", "Microsoft (Entra) application id for the Outlook/M365 capture connector; enables its background sync poll")

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -152,7 +152,8 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		// worker records that it cannot resolve, and radius queries stay
 		// unavailable — which is honest for an installation that geocodes
 		// nothing, and better than answering from an empty table.
-		Geocoder: geocoderFor(cfg.geocodeBaseURL),
+		Geocoder:  geocoderFor(cfg.geocodeBaseURL),
+		Geocoding: compose.GeocodingConfig{BackfillInterval: cfg.geocodeBackfill},
 		// The registry that resolves a staged delivery's mailbox: the SAME
 		// sweep registry the capture polls use, so the connector set that
 		// syncs a mailbox is the one that transmits from it.

--- a/backend/internal/compose/geocodejobs.go
+++ b/backend/internal/compose/geocodejobs.go
@@ -26,7 +26,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/rivertype"
 
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -94,16 +93,20 @@ type geocodeEnqueuer interface {
 func geocodeInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
 		Queue: geocodeQueue,
-		// The states matter as much as ByArgs. River's default duplicate set
-		// includes running and completed, which is wrong here: a company edited
-		// while its lookup is in flight would have its successor job silently
-		// dropped, and the row would sit stale forever with nothing to resolve
-		// it. Only a job still WAITING is a duplicate — one already running
-		// resolved a different address, and one that completed is history.
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:  true,
-			ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStateScheduled},
-		},
+		// ByArgs across every ACTIVE state. River requires the unique set to
+		// include pending and running and refuses a narrower one outright —
+		// "UniqueOpts.ByState must contain all required states" — which the
+		// first cut of this never learned, because nothing had ever queued a
+		// lookup to find out.
+		//
+		// The narrower set was trying to say something real: a company edited
+		// while its lookup is in flight should queue a successor rather than
+		// have it dropped, because the running job resolved the OLD address.
+		// The row is not lost. It is marked stale by the trigger and carries no
+		// coordinates, so the backfill sweep — which takes stale rows — picks
+		// it up on its next pass. Correctness now rests on the sweep rather
+		// than on a state set River will not accept.
+		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 		// The provider is asked at most this many times for one address. River's
 		// own default would keep retrying past the point the attempt ledger
 		// stops caring, spending the installation's shared rate on a lookup
@@ -279,6 +282,13 @@ const geocodeProvider = "nominatim"
 // enforceable at one worker.
 func WithGeocoding(inserter *jobs.Runner) Option {
 	return func(s *Server, _ *pgxpool.Pool) {
-		s.peopleStore = s.peopleStore.WithGeocodeEnqueue(GeocodeEnqueueFor(inserter))
+		enqueue := GeocodeEnqueueFor(inserter)
+		// BOTH, because they are two stores. The services read s.peopleStore
+		// and the HTTP transport carries its own, built by newPeopleHandlers —
+		// so wiring one left every address a rep writes marked stale with
+		// nothing coming to resolve it.
+		s.peopleStore = s.peopleStore.WithGeocodeEnqueue(enqueue)
+		//nolint:staticcheck // QF1008: the embedded name is load-bearing — s.Handlers resolves to briefs.Handlers, a different embedded type
+		s.peopleHandlers = s.peopleHandlers.WithGeocodeEnqueue(enqueue)
 	}
 }

--- a/backend/internal/compose/geocodejobs.go
+++ b/backend/internal/compose/geocodejobs.go
@@ -164,6 +164,15 @@ func (w *geocodeWorker) Work(ctx context.Context, job *river.Job[GeocodeOrganiza
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
+	// The lookup reads and writes under an actor of its own, and it needs one:
+	// AddressForGeocode takes organization:read and RecordGeocode takes
+	// organization:update, both of which refuse a context with no principal.
+	//
+	// Nobody noticed until the backfill queued the first job. Every enqueue
+	// before it rode an address WRITE, and no address had been written on an
+	// installation whose companies were seeded before the geocoder was
+	// configured — so the worker had never actually run.
+	wsCtx = geocodeJobActor(wsCtx)
 	store := people.NewStore(database.Bind(w.pool, func(context.Context) (ids.WorkspaceID, error) {
 		return ids.From[ids.WorkspaceKind](args.Workspace), nil
 	}))
@@ -241,6 +250,16 @@ func (w *geocodeWorker) Work(ctx context.Context, job *river.Job[GeocodeOrganiza
 	return jobs.FaultContext(wsCtx, errors.Join(
 		store.RecordGeocode(wsCtx, orgID, people.GeocodeOK, &point.Lat, &point.Lon, geocodeProvider, address.InputHash),
 		cacheErr))
+}
+
+// geocodeJobActor binds the principal a geocode lookup runs as: the
+// installation asking where its own company is, named so an audit row does not
+// have to invent a person who was not involved.
+func geocodeJobActor(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:geocode",
+	})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
 }
 
 // geocodeProvider names what answered, recorded on the row so a later change

--- a/backend/internal/compose/jobcensusconfig.go
+++ b/backend/internal/compose/jobcensusconfig.go
@@ -99,6 +99,7 @@ func censusJobConfig() JobRunnerConfig {
 		WebhookRetry:           WebhookRetryConfig{Interval: censusInterval, Deliverer: func(*database.DB) *webhooks.Deliverer { return &webhooks.Deliverer{} }},
 		ProviderRuns:           ProviderRunsConfig{Registry: censusProviderRegistry(), Vault: keyvault.NewMemory()},
 		PrivacyRetention:       PrivacyRetentionConfig{Interval: censusInterval},
+		Geocoding:              GeocodingConfig{BackfillInterval: censusInterval},
 		CloseDateInterval:      censusInterval,
 		ReconcileInterval:      censusInterval,
 		TimeScanInterval:       censusInterval,

--- a/backend/internal/compose/jobdeclared_test.go
+++ b/backend/internal/compose/jobdeclared_test.go
@@ -512,6 +512,7 @@ func TestArgsOwnedAttemptCapsMatchTheirDeclaration(t *testing.T) {
 // rather than against the type the runtime registers.
 var argsForKind = map[string]river.JobArgs{
 	WebhookRetryArgs{}.Kind():        WebhookRetryArgs{},
+	GeocodeBackfillArgs{}.Kind():     GeocodeBackfillArgs{},
 	AgentSchedulerArgs{}.Kind():      AgentSchedulerArgs{},
 	AgentTaskRetentionArgs{}.Kind():  AgentTaskRetentionArgs{},
 	AIActivityReconcileArgs{}.Kind(): AIActivityReconcileArgs{},

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "6bd58ed095eb57d676047459c40725b2d97b902b8e0451f054eb71aaf81b133b"
+const jobContractHash = "900593188e6b5117c1fde6e133cdf7d27fcd7e06262cb7613a80ae70d3aca745"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -59,6 +59,7 @@ type declaredJobArgs interface {
 		FollowUpReconcileArgs |
 		FollowUpWorkspaceArgs |
 		FxRateRefreshArgs |
+		GeocodeBackfillArgs |
 		GeocodeOrganizationArgs |
 		GmailSyncArgs |
 		GmailWatchArgs |

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -178,6 +178,10 @@ type JobRunnerConfig struct {
 	// that geocodes nothing — an offline demo, or one that has not been given
 	// a provider — and the worker records that rather than retrying forever.
 	Geocoder geocode.Client
+	// Geocoding carries the backfill's cadence — the sweep that reaches
+	// companies whose address was written before this installation had a
+	// geocoder, and which no write will ever touch again.
+	Geocoding GeocodingConfig
 	// DocumentExtractBrain is the lane a queued document reading runs on. Nil =
 	// no AI configured, and the kind registers anyway so the reading FAILS with
 	// a message the rep can see rather than sitting queued behind a worker that
@@ -335,6 +339,7 @@ func wireJobs(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobRe
 		addScheduledSendRecoveryJob(reg, pool, cfg, log),
 		addPrivacyRetentionJobs(reg, pool, cfg, log),
 		addWebhookRetryJobs(reg, pool, cfg),
+		addGeocodeBackfillJobs(reg, pool, cfg),
 		addProviderRunJobs(reg, pool, cfg),
 		addAgentSchedulerJobs(reg, pool, cfg),
 		addSignalJobs(reg, pool, cfg, log),

--- a/backend/internal/compose/jobs_geocodebackfill.go
+++ b/backend/internal/compose/jobs_geocodebackfill.go
@@ -106,24 +106,26 @@ func (w *geocodeBackfillWorker) Work(ctx context.Context, _ *river.Job[GeocodeBa
 	return nil
 }
 
-// backfillInsertOpts is geocodeInsertOpts for a NON-transactional insert.
+// geocodeBackfillPriority is one rung below River's default, which is what an
+// address write takes by saying nothing.
+const geocodeBackfillPriority = river.PriorityDefault + 1
+
+// geocodeBackfillOpts is geocodeInsertOpts with the sweep's own PRIORITY.
 //
-// Same intent — one pending lookup per company — but River requires a
-// client-side unique set to include every active state, so the address-write
-// opts are refused here with "must contain all required states". Widening
-// those instead would change what an ADDRESS WRITE means: they deliberately
-// exclude running, so a company edited while its lookup is in flight still
-// queues a successor rather than having it silently dropped.
+// Everything else is shared, so a nomination and an address write dedupe
+// against each other rather than queueing the same company twice.
 //
-// The sweep needs no such precision. It nominates rows nothing has asked about
-// at all, so a company with any live job is one it should skip — which is
-// exactly what the wider set gives.
-func backfillInsertOpts() *river.InsertOpts {
-	return &river.InsertOpts{
-		Queue:       geocodeQueue,
-		MaxAttempts: geocodeMaxAttempts,
-		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
-	}
+// The priority is what makes the sweep safe to run at all. One worker drains
+// this queue at four lookups a minute, so a batch of fifty is twelve minutes
+// of it — and without this a rep who corrects an address waits behind every
+// one of them for a lookup they are watching for. River fetches every
+// priority-1 job before any priority-2 job, so an address write always jumps
+// the backlog. The reverse cannot starve: the sweep nominates rows nobody is
+// touching, and rows nobody is touching produce no priority-1 work.
+func geocodeBackfillOpts() *river.InsertOpts {
+	opts := geocodeInsertOpts()
+	opts.Priority = geocodeBackfillPriority
+	return opts
 }
 
 // sweepOneWorkspace nominates one tenant's never-asked companies.
@@ -155,7 +157,7 @@ func (w *geocodeBackfillWorker) sweepOneWorkspace(ctx context.Context, ws ids.UU
 		if _, err := client.Insert(wsCtx, GeocodeOrganizationArgs{
 			Workspace:      ws,
 			OrganizationID: orgID.UUID,
-		}, backfillInsertOpts()); err != nil {
+		}, geocodeBackfillOpts()); err != nil {
 			return 0, err
 		}
 	}

--- a/backend/internal/compose/jobs_geocodebackfill.go
+++ b/backend/internal/compose/jobs_geocodebackfill.go
@@ -140,7 +140,7 @@ func (w *geocodeBackfillWorker) sweepOneWorkspace(ctx context.Context, ws ids.UU
 	store := people.NewStore(database.Bind(w.pool, func(context.Context) (ids.WorkspaceID, error) {
 		return ids.From[ids.WorkspaceKind](ws), nil
 	}))
-	due, err := store.ListNeverGeocoded(wsCtx, people.GeocodeBackfillBatch)
+	due, err := store.ListGeocodeOrphans(wsCtx, people.GeocodeBackfillBatch)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/compose/jobs_geocodebackfill.go
+++ b/backend/internal/compose/jobs_geocodebackfill.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The geocoding backfill: the pass that reaches companies an address write
+// never will.
+//
+// Geocoding fires when an address is WRITTEN, which is the right trigger and a
+// complete answer only for a company written after this installation had a
+// geocoder. A seeded workspace, an import that ran last month, or an operator
+// setting MARGINCE_GEOCODE_BASE_URL on a system that already holds its
+// customers all leave rows nothing will ever write again — invisible to the
+// trigger, and so never located. `within_radius` then answers from an empty
+// set while looking exactly like a query that works.
+//
+// It NOMINATES, it does not decide. Each candidate goes to the same
+// geocode_organization job an address write queues, and that worker re-asks
+// AddressForGeocode — so the retry ledger, the settled-address rule and the
+// attempt cap stay in one place rather than being restated here.
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// GeocodeBackfillArgs is one pass over the companies never asked about.
+//
+// It carries NO workspace, like WebhookRetryArgs and for the same reason: a
+// periodic insert has no tenant to name, and a WorkspaceScoped kind whose args
+// carry none fails every tick with "declares WorkspaceScoped but carries no
+// workspace". The tenant belongs on the per-company job this pass queues —
+// that is the one that reads and writes a row.
+type GeocodeBackfillArgs struct{}
+
+// Kind is the stable job identifier River persists in river_job.
+func (GeocodeBackfillArgs) Kind() string { return "geocode_backfill" }
+
+// InsertOpts carries the attempt cap the declaration publishes, because the
+// periodic insert supplies uniqueness and no attempt policy of its own — the
+// same reason webhook_retry states one.
+func (GeocodeBackfillArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue:       geocodeQueue,
+		MaxAttempts: 3,
+		UniqueOpts:  river.UniqueOpts{ByState: activeSweepStates},
+	}
+}
+
+// addGeocodeBackfillJobs registers the sweep and returns its schedule.
+//
+// A deployment with no geocoder registers NOTHING: there is nothing for the
+// nominated jobs to be worked by, and queueing rows nobody can answer is worse
+// than leaving the addresses unlocated, which is the honest state.
+func addGeocodeBackfillJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig) []*river.PeriodicJob {
+	if cfg.Geocoder == nil {
+		return nil
+	}
+	addDeclaredWorker[GeocodeBackfillArgs](reg, &geocodeBackfillWorker{pool: pool})
+	return periodicFor(cfg, GeocodeBackfillArgs{})
+}
+
+// geocodeBackfillWorker enqueues one batch of never-asked companies.
+type geocodeBackfillWorker struct{ pool *pgxpool.Pool }
+
+// Work nominates up to GeocodeBackfillBatch companies.
+//
+// One transaction for the whole batch, so a pass either queues its nominations
+// or queues none: a partial batch would be re-read identically on the next
+// tick anyway, and the deduplication on geocode_organization makes a repeat
+// nomination harmless — but a half-committed pass that logged success would
+// misreport what it did.
+func (w *geocodeBackfillWorker) Work(ctx context.Context, _ *river.Job[GeocodeBackfillArgs]) error {
+	workspaces, err := enumerateWorkspaces(ctx, w.pool)
+	if err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	queued := 0
+	for _, ws := range workspaces {
+		n, err := w.sweepOneWorkspace(ctx, ws)
+		if err != nil {
+			return jobs.FaultContext(ctx, err)
+		}
+		queued += n
+	}
+	if queued == 0 {
+		return nil
+	}
+	// Said out loud because the pace is the surprising part: the provider's
+	// terms hold this installation to four lookups a minute, so a batch of
+	// fifty is twelve minutes of work, and an operator watching for
+	// coordinates should know that is normal rather than stuck.
+	slog.InfoContext(ctx, "geocoding backfill queued a batch",
+		"companies", queued, "batch", people.GeocodeBackfillBatch)
+	return nil
+}
+
+// backfillInsertOpts is geocodeInsertOpts for a NON-transactional insert.
+//
+// Same intent — one pending lookup per company — but River requires a
+// client-side unique set to include every active state, so the address-write
+// opts are refused here with "must contain all required states". Widening
+// those instead would change what an ADDRESS WRITE means: they deliberately
+// exclude running, so a company edited while its lookup is in flight still
+// queues a successor rather than having it silently dropped.
+//
+// The sweep needs no such precision. It nominates rows nothing has asked about
+// at all, so a company with any live job is one it should skip — which is
+// exactly what the wider set gives.
+func backfillInsertOpts() *river.InsertOpts {
+	return &river.InsertOpts{
+		Queue:       geocodeQueue,
+		MaxAttempts: geocodeMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}
+}
+
+// sweepOneWorkspace nominates one tenant's never-asked companies.
+//
+// The workspace is bound here rather than by the args, so each per-company job
+// is stamped with the tenant whose row it will read — the binding the pass
+// itself does not need and the lookup cannot do without.
+func (w *geocodeBackfillWorker) sweepOneWorkspace(ctx context.Context, ws ids.UUID) (int, error) {
+	// Reads under an actor of its own. Nothing queued this on a person's
+	// behalf — it is the installation asking which of its own companies it
+	// never located — so it names itself rather than borrowing a principal,
+	// and organization:read is gated like any other read.
+	wsCtx := geocodeBackfillActor(principal.WithWorkspaceID(ctx, ws))
+	store := people.NewStore(database.Bind(w.pool, func(context.Context) (ids.WorkspaceID, error) {
+		return ids.From[ids.WorkspaceKind](ws), nil
+	}))
+	due, err := store.ListNeverGeocoded(wsCtx, people.GeocodeBackfillBatch)
+	if err != nil {
+		return 0, err
+	}
+	if len(due) == 0 {
+		return 0, nil
+	}
+	client, err := river.ClientFromContextSafely[pgx.Tx](wsCtx)
+	if err != nil {
+		return 0, err
+	}
+	for _, orgID := range due {
+		if _, err := client.Insert(wsCtx, GeocodeOrganizationArgs{
+			Workspace:      ws,
+			OrganizationID: orgID.UUID,
+		}, backfillInsertOpts()); err != nil {
+			return 0, err
+		}
+	}
+	return len(due), nil
+}
+
+// geocodeBackfillActor binds the principal the sweep reads as, the same shape
+// providerJobActor gives a provider run: a system principal that names what it
+// is, so an audit row says the installation went looking rather than leaving a
+// gated read with no one behind it.
+func geocodeBackfillActor(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:geocode-backfill",
+	})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}
+
+// GeocodingConfig is the backfill's cadence.
+//
+// Separate from the Geocoder itself because they answer to different roles: the
+// provider is what this installation may call, and the interval is how often it
+// goes looking for work. A zero interval registers the worker and no schedule —
+// the posture the declaration states — so an operator can turn the sweep off
+// without giving up geocoding on write.
+type GeocodingConfig struct {
+	// BackfillInterval is how often the sweep looks for companies never asked
+	// about. It runs on start too, so configuring a geocoder on a database that
+	// already holds its customers begins locating them at boot rather than at
+	// the first tick.
+	BackfillInterval time.Duration
+}

--- a/backend/internal/compose/jobschedule.go
+++ b/backend/internal/compose/jobschedule.go
@@ -149,13 +149,14 @@ func configDependencies(cfg JobRunnerConfig) map[string]bool {
 // field paths, and answered the same way and for the same reasons.
 func operatorIntervals(cfg JobRunnerConfig) map[string]time.Duration {
 	return map[string]time.Duration{
-		"AgentScheduler.Interval":   cfg.AgentScheduler.Interval,
-		"CloseDateInterval":         cfg.CloseDateInterval,
-		"GmailWatch.Interval":       cfg.GmailWatch.Interval,
-		"OverlayInterval":           cfg.OverlayInterval,
-		"PrivacyRetention.Interval": cfg.PrivacyRetention.Interval,
-		"ReconcileInterval":         cfg.ReconcileInterval,
-		"TimeScanInterval":          cfg.TimeScanInterval,
-		"WebhookRetry.Interval":     cfg.WebhookRetry.Interval,
+		"AgentScheduler.Interval":    cfg.AgentScheduler.Interval,
+		"CloseDateInterval":          cfg.CloseDateInterval,
+		"Geocoding.BackfillInterval": cfg.Geocoding.BackfillInterval,
+		"GmailWatch.Interval":        cfg.GmailWatch.Interval,
+		"OverlayInterval":            cfg.OverlayInterval,
+		"PrivacyRetention.Interval":  cfg.PrivacyRetention.Interval,
+		"ReconcileInterval":          cfg.ReconcileInterval,
+		"TimeScanInterval":           cfg.TimeScanInterval,
+		"WebhookRetry.Interval":      cfg.WebhookRetry.Interval,
 	}
 }

--- a/backend/internal/modules/people/geocode.go
+++ b/backend/internal/modules/people/geocode.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -365,6 +366,19 @@ func movedAddress(after map[string]any) bool {
 // the rule cannot be forgotten: six writers in this package touch an address,
 // several through table-driven SQL with no seam to carry, and the seventh will
 // be written by somebody who never read this file.
+// namesAPlace says whether a create carried an address worth looking up.
+//
+// The same question locatable answers for a stored row, asked of the input
+// instead: a country alone is not a place a radius can measure from, and
+// spending one of the installation's four-per-minute lookups on "Germany" is
+// spending it on nothing.
+func namesAPlace(address *crmcontracts.Address) bool {
+	if address == nil {
+		return false
+	}
+	return locatable(address.Line1, address.City, address.PostalCode)
+}
+
 func (s *Store) enqueueGeocode(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) error {
 	if s.geocodeEnqueue == nil {
 		return nil

--- a/backend/internal/modules/people/geocode_integration_test.go
+++ b/backend/internal/modules/people/geocode_integration_test.go
@@ -21,6 +21,7 @@ package people
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -94,4 +95,78 @@ func readGeocode(t *testing.T, e *dedupeEnv, orgID ids.OrganizationID) (status s
 		t.Fatalf("reading the recorded geocode: %v", err)
 	}
 	return status, lat, lon
+}
+
+// The sweep finds the rows an address write never will, and only those.
+//
+// This is the backfill's whole reason: a company written before the
+// installation had a geocoder is invisible to the trigger, because nothing
+// will ever write its address again. A seeded workspace is exactly that case,
+// and without this pass within_radius answers from an empty set while looking
+// like a query that works.
+func TestTheSweepFindsCompaniesNoWriteWillEverReach(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	located, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Findable GmbH", Source: "manual",
+		Address: &crmcontracts.Address{City: strPtr("Stuttgart"), Country: strPtr("DE")},
+	})
+	if err != nil {
+		t.Fatalf("seeding a company with an address: %v", err)
+	}
+	// A country alone is not a place; the sweep must not spend a lookup on it.
+	if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Nowhere GmbH", Source: "manual",
+		Address: &crmcontracts.Address{Country: strPtr("DE")},
+	}); err != nil {
+		t.Fatalf("seeding a company with no usable address: %v", err)
+	}
+	if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Addressless GmbH", Source: "manual",
+	}); err != nil {
+		t.Fatalf("seeding a company with no address: %v", err)
+	}
+
+	due, err := e.store.ListNeverGeocoded(ctx, GeocodeBackfillBatch)
+	if err != nil {
+		t.Fatalf("ListNeverGeocoded: %v", err)
+	}
+	wantID := ids.From[ids.OrganizationKind](ids.UUID(located.Id))
+	if !slices.Contains(due, wantID) {
+		t.Errorf("the sweep listed %v, want the company with a city among them — "+
+			"a seeded database is the case this exists for", due)
+	}
+	for _, id := range due {
+		if id == wantID {
+			continue
+		}
+		t.Errorf("the sweep also nominated %v; a company without a usable address "+
+			"costs a lookup to learn nothing", id)
+	}
+
+	// Answered rows are not re-swept. A company that has been through the
+	// worker carries its own retry ledger — `failed` waits for its backoff,
+	// `no_match` waits for its address to change — and re-nominating those
+	// would spend the installation's rate re-asking settled questions and
+	// defeat the backoff by asking again every pass.
+	// Through the real read, because RecordGeocode only writes when the input
+	// hash still matches the row's address — a guard against a worker landing
+	// an answer for an address that was edited while it was away. A made-up
+	// hash writes nothing and the assertion below would pass on an empty
+	// update, proving only that the test was wrong.
+	answered, ok, err := e.store.AddressForGeocode(ctx, wantID)
+	if err != nil || !ok {
+		t.Fatalf("AddressForGeocode before recording: %v (ok=%v)", err, ok)
+	}
+	if err := e.store.RecordGeocode(ctx, wantID, GeocodeNoMatch, nil, nil, "test", answered.InputHash); err != nil {
+		t.Fatalf("recording an answer: %v", err)
+	}
+	after, err := e.store.ListNeverGeocoded(ctx, GeocodeBackfillBatch)
+	if err != nil {
+		t.Fatalf("ListNeverGeocoded after an answer: %v", err)
+	}
+	if slices.Contains(after, wantID) {
+		t.Error("an answered company is still swept, so every pass re-asks a settled question")
+	}
 }

--- a/backend/internal/modules/people/geocode_integration_test.go
+++ b/backend/internal/modules/people/geocode_integration_test.go
@@ -24,6 +24,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -225,5 +227,68 @@ func TestAStaleCompanyWithNoJobComingIsSwept(t *testing.T) {
 	if !slices.Contains(swept, orgID) {
 		t.Error("a company marked stale by the trigger is not swept, so its coordinates " +
 			"are gone and nothing will ever replace them")
+	}
+}
+
+// A lookup that never completed is re-asked once its backoff expires.
+//
+// `failed` is not an answer — it says the lookup did not finish — and a
+// deployment that recorded it because it had NO PROVIDER AT ALL is the same
+// shape: configure one later and these are exactly the rows that need asking.
+// Sweeping only never-asked rows left them orphaned, because a failure whose
+// backoff has expired has no River job left to carry it either.
+func TestAFailedLookupIsAskedAgainOnceItsBackoffExpires(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Unreachable GmbH", Source: "manual",
+		Address: &crmcontracts.Address{City: strPtr("Leipzig"), Country: strPtr("DE")},
+	})
+	if err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+	address, ok, err := e.store.AddressForGeocode(ctx, orgID)
+	if err != nil || !ok {
+		t.Fatalf("AddressForGeocode: %v (ok=%v)", err, ok)
+	}
+
+	// A failure records a wait — the provider's own, or a day when it gave
+	// none. Inside that wait the row is left alone: the ledger asked for it,
+	// and re-nominating every pass is how a rate limit becomes a block.
+	if err := e.store.RecordGeocode(ctx, orgID, GeocodeFailed, nil, nil, "", address.InputHash); err != nil {
+		t.Fatalf("recording the refusal: %v", err)
+	}
+	waiting, err := e.store.ListGeocodeOrphans(ctx, GeocodeBackfillBatch)
+	if err != nil {
+		t.Fatalf("ListGeocodeOrphans during the backoff: %v", err)
+	}
+	if slices.Contains(waiting, orgID) {
+		t.Error("a company still inside its backoff is swept, so the pass asks again " +
+			"exactly when the ledger said not to")
+	}
+
+	// Once the wait is spent there is no River job left to carry the retry —
+	// the worker returned successfully after recording the backoff — so the
+	// sweep is the only thing that will ever ask again. Sweeping NULL rows
+	// alone orphaned these permanently, which is the case a deployment that
+	// records `failed` for having no provider at all lands in: configure one
+	// later and these are exactly the rows that need asking.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`UPDATE organization_geocode_state SET next_attempt_at = now() - interval '1 minute'
+			  WHERE organization_id = $1`, orgID)
+		return err
+	}); err != nil {
+		t.Fatalf("spending the backoff: %v", err)
+	}
+	swept, err := e.store.ListGeocodeOrphans(ctx, GeocodeBackfillBatch)
+	if err != nil {
+		t.Fatalf("ListGeocodeOrphans after the backoff: %v", err)
+	}
+	if !slices.Contains(swept, orgID) {
+		t.Error("a company whose lookup never completed and whose wait is spent is not " +
+			"swept — nothing else will ever ask, so it stays unlocated forever")
 	}
 }

--- a/backend/internal/modules/people/geocode_integration_test.go
+++ b/backend/internal/modules/people/geocode_integration_test.go
@@ -128,9 +128,9 @@ func TestTheSweepFindsCompaniesNoWriteWillEverReach(t *testing.T) {
 		t.Fatalf("seeding a company with no address: %v", err)
 	}
 
-	due, err := e.store.ListNeverGeocoded(ctx, GeocodeBackfillBatch)
+	due, err := e.store.ListGeocodeOrphans(ctx, GeocodeBackfillBatch)
 	if err != nil {
-		t.Fatalf("ListNeverGeocoded: %v", err)
+		t.Fatalf("ListGeocodeOrphans: %v", err)
 	}
 	wantID := ids.From[ids.OrganizationKind](ids.UUID(located.Id))
 	if !slices.Contains(due, wantID) {
@@ -162,11 +162,68 @@ func TestTheSweepFindsCompaniesNoWriteWillEverReach(t *testing.T) {
 	if err := e.store.RecordGeocode(ctx, wantID, GeocodeNoMatch, nil, nil, "test", answered.InputHash); err != nil {
 		t.Fatalf("recording an answer: %v", err)
 	}
-	after, err := e.store.ListNeverGeocoded(ctx, GeocodeBackfillBatch)
+	after, err := e.store.ListGeocodeOrphans(ctx, GeocodeBackfillBatch)
 	if err != nil {
-		t.Fatalf("ListNeverGeocoded after an answer: %v", err)
+		t.Fatalf("ListGeocodeOrphans after an answer: %v", err)
 	}
 	if slices.Contains(after, wantID) {
 		t.Error("an answered company is still swept, so every pass re-asks a settled question")
+	}
+}
+
+// A company whose coordinates went stale with no job coming is swept.
+//
+// The trigger marks a row stale on any address column that changes, but only
+// the update path pairs that with an enqueue. The site-read profile apply
+// writes address_line1 through table-driven SQL with no seam to carry a
+// callback, so a company whose address arrives from its own website is marked
+// stale, loses its old point, and has nothing coming to resolve it. Without the
+// sweep it sits that way forever, invisible to within_radius and to anyone
+// looking for a reason.
+func TestAStaleCompanyWithNoJobComingIsSwept(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Moved GmbH", Source: "manual",
+		Address: &crmcontracts.Address{City: strPtr("Hamburg"), Country: strPtr("DE")},
+	})
+	if err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	// Give it a point, the way the worker would.
+	located, ok, err := e.store.AddressForGeocode(ctx, orgID)
+	if err != nil || !ok {
+		t.Fatalf("AddressForGeocode: %v (ok=%v)", err, ok)
+	}
+	lat, lon := 53.5511, 9.9937
+	if err := e.store.RecordGeocode(ctx, orgID, GeocodeOK, &lat, &lon, "test", located.InputHash); err != nil {
+		t.Fatalf("recording a point: %v", err)
+	}
+	if swept, err := e.store.ListGeocodeOrphans(ctx, GeocodeBackfillBatch); err != nil {
+		t.Fatalf("ListGeocodeOrphans: %v", err)
+	} else if slices.Contains(swept, orgID) {
+		t.Fatal("a located company is swept, so the pass re-asks what it already knows")
+	}
+
+	// Move it. The store's update path enqueues as well as marking stale, and
+	// this environment wires no enqueue — which is exactly the orphan shape the
+	// site-read apply produces in production, where the column is written
+	// through table-driven SQL with no seam to carry a callback. Either way the
+	// row ends up stale with nothing coming, and the sweep is what finds it.
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{
+		Address: &crmcontracts.Address{City: strPtr("München"), Country: strPtr("DE")},
+	}); err != nil {
+		t.Fatalf("moving the company: %v", err)
+	}
+	swept, err := e.store.ListGeocodeOrphans(ctx, GeocodeBackfillBatch)
+	if err != nil {
+		t.Fatalf("ListGeocodeOrphans after the move: %v", err)
+	}
+	if !slices.Contains(swept, orgID) {
+		t.Error("a company marked stale by the trigger is not swept, so its coordinates " +
+			"are gone and nothing will ever replace them")
 	}
 }

--- a/backend/internal/modules/people/geocode_test.go
+++ b/backend/internal/modules/people/geocode_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 )
 
 // A transient failure must NOT settle the address.
@@ -120,5 +122,37 @@ func TestOnlyAMovedAddressQueuesALookup(t *testing.T) {
 	}
 	if movedAddress(map[string]any{}) {
 		t.Error("a patch that changed nothing queued a lookup")
+	}
+}
+
+// A create with an address earns a lookup, and a create without one does not.
+//
+// This is the gap the feature shipped with: geocoding was wired to the UPDATE
+// path only, so a company arriving with its address already filled in — every
+// seeded row, every imported row, every MCP create — was written and never
+// located. Nothing else would ever write that address again, so nothing would
+// ever ask where it was.
+func TestACreateWithAnAddressAsksWhereItIs(t *testing.T) {
+	line1, city := "Königstraße 1", "Stuttgart"
+	country := "DE"
+	for _, tc := range []struct {
+		name    string
+		address *crmcontracts.Address
+		want    bool
+	}{
+		{"a street and a city", &crmcontracts.Address{Line1: &line1, City: &city}, true},
+		{"a city alone", &crmcontracts.Address{City: &city}, true},
+		// A country is not somewhere a distance can be measured from, and
+		// asking about one spends fifteen seconds of a rate the whole
+		// installation shares to learn nothing.
+		{"a country alone", &crmcontracts.Address{Country: &country}, false},
+		{"no address at all", nil, false},
+		{"an address carrying nothing", &crmcontracts.Address{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := namesAPlace(tc.address); got != tc.want {
+				t.Errorf("namesAPlace(%+v) = %v, want %v", tc.address, got, tc.want)
+			}
+		})
 	}
 }

--- a/backend/internal/modules/people/geocodebackfill.go
+++ b/backend/internal/modules/people/geocodebackfill.go
@@ -72,8 +72,26 @@ func (s *Store) ListGeocodeOrphans(ctx context.Context, limit int) ([]ids.Organi
 		rows, err := tx.Query(ctx, `
 			SELECT o.id
 			  FROM organization o
+			  LEFT JOIN organization_geocode_state g ON g.organization_id = o.id
 			 WHERE o.archived_at IS NULL
-			   AND (o.geocode_status IS NULL OR o.geocode_status = 'stale')
+			   -- NULL: never asked. 'stale': the trigger cleared the point and
+			   -- some writers cannot queue (see above). 'failed': the lookup did
+			   -- not complete, which is not an answer — and a failure whose
+			   -- backoff has expired has no River job left to carry it, so
+			   -- nothing but this would ever ask again. A deployment that
+			   -- records 'failed' because it had no provider AT ALL is the same
+			   -- shape: configure one later and these are the rows it needs.
+			   --
+			   -- 'ok' and 'no_match' are answers and are never swept.
+			   AND (o.geocode_status IS NULL
+			     OR o.geocode_status IN ('stale', 'failed'))
+			   -- A failure still inside its backoff is left alone: the ledger
+			   -- asked for that wait, and re-nominating every pass is how a
+			   -- rate limit becomes a block. AddressForGeocode re-checks this
+			   -- too; asking here keeps the sweep from queueing work it knows
+			   -- will decline.
+			   AND (g.next_attempt_at IS NULL OR g.next_attempt_at <= now())
+			   AND coalesce(g.attempts, 0) < $2
 			   -- The same bar locatable() holds a written address to: a country
 			   -- on its own is not a place a distance can be measured from, and
 			   -- nominating one spends a lookup to learn nothing.
@@ -81,7 +99,7 @@ func (s *Store) ListGeocodeOrphans(ctx context.Context, limit int) ([]ids.Organi
 			     OR coalesce(o.address_city, '') <> ''
 			     OR coalesce(o.address_postal_code, '') <> '')
 			 ORDER BY o.created_at
-			 LIMIT $1`, limit)
+			 LIMIT $1`, limit, geocodeMaxAttempts)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/people/geocodebackfill.go
+++ b/backend/internal/modules/people/geocodebackfill.go
@@ -40,7 +40,8 @@ import (
 // would sit behind an address a person edited and is waiting on.
 const GeocodeBackfillBatch = 50
 
-// ListNeverGeocoded answers which companies have an address and no answer.
+// ListGeocodeOrphans answers which companies have an address and no coordinates
+// coming.
 //
 // NEVER-ASKED only, deliberately. A row with any geocode_status has been
 // through the worker and carries its own retry ledger — `failed` waits for its
@@ -48,10 +49,18 @@ const GeocodeBackfillBatch = 50
 // re-nominated those would spend the installation's rate on questions already
 // answered, and would defeat the backoff by asking again every pass.
 //
-// `stale` is not swept either: the trigger sets it in the same transaction as
-// the address write that also queues the lookup, so a stale row already has a
-// job coming.
-func (s *Store) ListNeverGeocoded(ctx context.Context, limit int) ([]ids.OrganizationID, error) {
+// `stale` IS swept, and that is not symmetry — it closes an orphan. The
+// trigger marks a row stale on any address column that changes, but only the
+// update path pairs that with an enqueue. The site-read profile apply writes
+// address_line1 through table-driven SQL with no seam to carry a callback
+// (company.go), so a company whose address arrives from its own website is
+// marked stale with nothing coming to resolve it, and its old coordinates are
+// gone. Without this it would sit that way forever.
+//
+// Re-nominating a stale row costs nothing when a job IS already coming: the
+// insert deduplicates by args across every active state, so the sweep's
+// nomination collapses into the one the write queued.
+func (s *Store) ListGeocodeOrphans(ctx context.Context, limit int) ([]ids.OrganizationID, error) {
 	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
 		return nil, err
 	}
@@ -64,7 +73,7 @@ func (s *Store) ListNeverGeocoded(ctx context.Context, limit int) ([]ids.Organiz
 			SELECT o.id
 			  FROM organization o
 			 WHERE o.archived_at IS NULL
-			   AND o.geocode_status IS NULL
+			   AND (o.geocode_status IS NULL OR o.geocode_status = 'stale')
 			   -- The same bar locatable() holds a written address to: a country
 			   -- on its own is not a place a distance can be measured from, and
 			   -- nominating one spends a lookup to learn nothing.

--- a/backend/internal/modules/people/geocodebackfill.go
+++ b/backend/internal/modules/people/geocodebackfill.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The backfill: companies whose address was written before this installation
+// had a geocoder, or before geocoding existed at all.
+//
+// Geocoding fires on an address WRITE, which is the right trigger and a
+// complete answer only for a company written after the feature was configured.
+// Everything already in the database is invisible to it — a seeded workspace,
+// an import that ran last month, or the ordinary case of an operator setting
+// MARGINCE_GEOCODE_BASE_URL on a system that already holds its customers. None
+// of those rows will ever be written again, so none of them will ever be
+// located, and `within_radius` answers from an empty set while looking exactly
+// like a working query.
+//
+// This does not decide anything. It finds rows that have never been asked
+// about and hands each to the same per-company job an address write queues;
+// AddressForGeocode still makes the real judgement one row at a time, so a
+// company the sweep nominates but that turns out settled costs a read and no
+// lookup.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// GeocodeBackfillBatch is how many companies one sweep pass nominates.
+//
+// Small on purpose. The provider's terms hold this installation to four
+// lookups a minute, so a pass of 50 is already twelve minutes of work — and
+// the pass runs again. A larger batch would not geocode anything sooner; it
+// would only pile rows into a queue that drains at a fixed rate, where they
+// would sit behind an address a person edited and is waiting on.
+const GeocodeBackfillBatch = 50
+
+// ListNeverGeocoded answers which companies have an address and no answer.
+//
+// NEVER-ASKED only, deliberately. A row with any geocode_status has been
+// through the worker and carries its own retry ledger — `failed` waits for its
+// backoff, `no_match` waits for its address to change — and a sweep that
+// re-nominated those would spend the installation's rate on questions already
+// answered, and would defeat the backoff by asking again every pass.
+//
+// `stale` is not swept either: the trigger sets it in the same transaction as
+// the address write that also queues the lookup, so a stale row already has a
+// job coming.
+func (s *Store) ListNeverGeocoded(ctx context.Context, limit int) ([]ids.OrganizationID, error) {
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = GeocodeBackfillBatch
+	}
+	var out []ids.OrganizationID
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT o.id
+			  FROM organization o
+			 WHERE o.archived_at IS NULL
+			   AND o.geocode_status IS NULL
+			   -- The same bar locatable() holds a written address to: a country
+			   -- on its own is not a place a distance can be measured from, and
+			   -- nominating one spends a lookup to learn nothing.
+			   AND (coalesce(o.address_line1, '') <> ''
+			     OR coalesce(o.address_city, '') <> ''
+			     OR coalesce(o.address_postal_code, '') <> '')
+			 ORDER BY o.created_at
+			 LIMIT $1`, limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.OrganizationID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			out = append(out, id)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/modules/people/handlers.go
+++ b/backend/internal/modules/people/handlers.go
@@ -56,6 +56,20 @@ func (h Handlers) WithMatchStager(stage func(context.Context) error) Handlers {
 	return h
 }
 
+// WithGeocodeEnqueue wires the coordinate lookup an address write queues, into
+// the TRANSPORT's own store.
+//
+// It has to be said here as well as on the store, because the two are not the
+// same object: compose builds the handlers from newPeopleHandlers and keeps a
+// separate s.peopleStore for the services. Wiring only the latter left every
+// address written over HTTP marked stale by the trigger with no job coming —
+// the enqueue existed, was correct, and was reachable from nothing a rep
+// touches.
+func (h Handlers) WithGeocodeEnqueue(enqueue GeocodeEnqueue) Handlers {
+	h.store = h.store.WithGeocodeEnqueue(enqueue)
+	return h
+}
+
 // WithBlobstore wires the object store the organization-logo stream reads.
 func (h Handlers) WithBlobstore(blob blobstore.Store) Handlers {
 	h.blob = blob

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -59,7 +59,10 @@ func (s *Store) CreateOrganization(ctx context.Context, in CreateOrganizationInp
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = createOrganizationInTx(ctx, tx, in, by, active)
-		return err
+		if err != nil {
+			return err
+		}
+		return s.geocodeANewCompany(ctx, tx, out, in.Address)
 	})
 	return out, err
 }
@@ -83,7 +86,33 @@ func (s *Store) CreateOrganizationTx(ctx context.Context, tx pgx.Tx, in CreateOr
 		return crmcontracts.Organization{}, err
 	}
 	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
-	return createOrganizationInTx(ctx, tx, in, by, nil)
+	out, err := createOrganizationInTx(ctx, tx, in, by, nil)
+	if err != nil {
+		return out, err
+	}
+	return out, s.geocodeANewCompany(ctx, tx, out, in.Address)
+}
+
+// geocodeANewCompany queues the lookup a create earned.
+//
+// It sits on the two store entry points rather than inside
+// createOrganizationInTx because that one is a free function with no store —
+// which is exactly why the enqueue was missed when the update path got it.
+// Both doors call this, so neither can create a company that never asks where
+// it is.
+//
+// A create with no usable address queues nothing: the row is simply not a
+// place yet, and the update path will queue when it becomes one.
+func (s *Store) geocodeANewCompany(ctx context.Context, tx pgx.Tx,
+	out crmcontracts.Organization, address *crmcontracts.Address,
+) error {
+	if !namesAPlace(address) {
+		return nil
+	}
+	if err := s.enqueueGeocode(ctx, tx, ids.From[ids.OrganizationKind](ids.UUID(out.Id))); err != nil {
+		return fmt.Errorf("locating a new company: %w", err)
+	}
+	return nil
 }
 
 // readyOrganizationCreate runs what a create settles BEFORE any transaction

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "6bd58ed095eb57d676047459c40725b2d97b902b8e0451f054eb71aaf81b133b"
+const JobContractHash = "900593188e6b5117c1fde6e133cdf7d27fcd7e06262cb7613a80ae70d3aca745"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -379,6 +379,17 @@ var specs = map[string]Spec{
 		Timeout:   TimeoutPolicy{Fixed: 10 * time.Minute},
 		OptsOwner: OptsCaller,
 		Args:      []ArgField{{Name: "RequestedBy"}, {Name: "Workspace"}},
+	},
+	"geocode_backfill": {
+		Kind:         "geocode_backfill",
+		GoType:       "GeocodeBackfillArgs",
+		Role:         Worker,
+		Queue:        "geocode",
+		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
+		MaxAttempts:  3,
+		OptsOwner:    OptsArgs,
+		Cadence:      Cadence{OperatorField: "Geocoding.BackfillInterval", ScheduleWhenPositive: "Geocoding.BackfillInterval"},
+		Registration: Registration{When: []string{"Geocoder"}},
 	},
 	"geocode_organization": {
 		Kind:         "geocode_organization",


### PR DESCRIPTION
## What was wrong

Geocoding fired on an address **UPDATE** and nowhere else, so it reached almost nothing.

A seeded workspace, an import, an MCP create — all arrive with the address already filled in, and no writer ever touches it again. Lars set `MARGINCE_GEOCODE_BASE_URL` on a database of 196 companies, 65 of them with a city, and got **zero coordinates and zero queued jobs**. Nothing in that database would ever be written again, so nothing would ever ask where it was.

## Three gaps, one cause

**1. Create now enqueues.** `createOrganizationInTx` is a free function with no store receiver, which is exactly why the enqueue landed on the update path alone. Both store doors now call `geocodeANewCompany`, so neither can create a company that never asks where it is. A create with no usable address queues nothing — a country on its own is not somewhere a distance can be measured from.

**2. A backfill reaches the rest.** `geocode_backfill` nominates companies never asked about and hands each to the same per-company job an address write queues. It nominates; it does not decide — `AddressForGeocode` still makes the real judgement, so the retry ledger and the settled-address rules stay in one place. Never-asked only: a row with any status carries its own backoff, and re-nominating it would defeat that every pass.

**3. The geocode worker never bound an actor.** `AddressForGeocode` takes `organization:read` and `RecordGeocode` takes `organization:update`; both refuse a context with no principal, so the worker failed on its first line. Nothing had noticed because nothing had ever queued it — a bug that could only surface once something did.

## Verified live

Against a running stack with 196 seeded companies, coordinates arrived at the paced rate:

```
2txt        | Berlin          | 52.5474 | 13.4129
adesso      | Dortmund        | 51.5043 |  7.5268
Admetrics   | Frankfurt/Main  | 50.1138 |  8.6737
Adsmasters  | Düsseldorf      | 51.2337 |  6.7494
```

Real points for the right cities, plus `no_match` rows for addresses that are not places — which is the honest answer, not a failure.

The pace is Nominatim's own: 4 requests a minute for a recurring client, so 65 companies take about 16 minutes. That is the service's rule, not a tunable.

## Gates

`make check-backend` green (all backend tests, arch-lint, go-file-length, drift, craft-static) · `make test-it DIR=backend/internal/modules/people` green, including a new integration test that proves the sweep finds seeded rows and stops nominating a company once it has an answer.

`lint-modules` reports findings only in `.tmp/worktrees/batman-dealroom/`, another session's tree — a stale golangci cache, not this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Geocoding now runs on create and via a periodic backfill, so existing, failed-without-retry, and stale companies get coordinates. Previously we only geocoded on address updates, leaving seeded/imported and site-updated rows unlocated, and some failures never retried.

- Create enqueues a lookup when `namesAPlace(address)` is true; the HTTP path now enqueues too by wiring the same `GeocodeEnqueue` into both the services store and transport handlers.
- Adds `geocode_backfill` (batch 50). It nominates companies with no `geocode_status` or with status `stale` or `failed` whose backoff has expired, requires a locatable address, hands each to the existing per-company job, registers only when a Geocoder is configured, runs on start, and uses `Geocoding.BackfillInterval`. Inserts dedupe by args across active states; backfill runs one priority below writes so user edits jump the queue.
- The geocode worker binds `system:geocode`; the backfill uses `system:geocode-backfill`.
- Tests cover create-path enqueue, sweep selection (including stale rows and failed-with-due-backoff), dedup behavior, and that answered rows are not re-swept.

- Rollout
  - Ensure `MARGINCE_GEOCODE_BASE_URL` is set; without a Geocoder, `geocode_backfill` does not register.
  - Optional: tune `--geocode-backfill-interval` (default 1h). Set to 0 to disable the sweep while keeping geocoding-on-write.
  - Expect provider pacing (~4 lookups/min); batches of 50 drain in ~12 minutes. No schema changes.

<sup>Written for commit 18d0414f518bf563756ca9a0a4a936e0598dbb24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

