### PR TITLE
fix(finance): the mirror sweep may read the currency it converts into

### DIFF
--- a/backend/internal/compose/jobs_finance.go
+++ b/backend/internal/compose/jobs_finance.go
@@ -71,25 +71,60 @@ type financeSyncWorker struct {
 	log  *slog.Logger
 }
 
+// financeSweepPrincipal is who the scheduled mirror pass acts as.
+//
+// The connector is the acting principal: every mirrored row carries
+// `connector:` provenance, so a reader can tell an imported invoice from
+// anything a person typed.
+//
+// PrincipalConnector and not PrincipalSystem, and the two have to agree: the
+// audit row stamps actor_type from the TYPE and actor_id from the ID, so a
+// system type beside a `connector:` id writes a row that contradicts itself,
+// and audit_log is append-only — the contradiction cannot be corrected
+// afterwards. No OnBehalfOf: finance has no connect flow and so no granting
+// human, and storekit.OwnerOrActor already reads a bare connector as the row
+// nobody owns.
+//
+// It carries PERMISSIONS because that Type costs it the system exemption.
+// auth.Require passes a PrincipalSystem unconditionally; everything else falls
+// through to Permissions.Allows, which a zero Permissions denies. Without a
+// grant the sweep read its way into "this job's principal is not permitted the
+// action it attempted", and every pass WITH WORK TO DO was discarded after
+// three attempts — an installation whose invoices simply never arrived, with
+// nothing on any screen to say why.
+//
+// The grant is the fixed minimum this worker exercises, the way
+// telegramChannelPrincipal states its own: the mirror converts the source
+// ledger into the installation's base currency as it writes, and reads that one
+// setting through identity.BaseCurrencyOf. Nothing else on the sweep's path
+// takes a gate. RowScopeAll because a mirrored ledger belongs to the workspace
+// rather than to any seat.
+//
+// A function rather than a literal inline so the tests can assert the real
+// thing: the integration suite injects a stub base currency and a principal
+// carrying admin grants, and so cannot see this class of failure at all.
+func financeSweepPrincipal() principal.Principal {
+	return principal.Principal{
+		Type: principal.PrincipalConnector,
+		ID:   "connector:finance",
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"connector"},
+			Objects: map[string]principal.ObjectGrant{
+				// Asked of the entry rather than spelled here, so renaming the
+				// object cannot leave this grant naming one that is gone.
+				identity.BaseCurrency.Object(): {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	}
+}
+
 func (w *financeSyncWorker) Work(ctx context.Context, job *river.Job[FinanceSyncArgs]) error {
 	wsCtx, err := workspaceJobCtx(ctx, job.Args)
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
-	// The connector is the acting principal: every mirrored row carries
-	// connector: provenance, so a reader can tell an imported invoice from
-	// anything a person typed.
-	//
-	// PrincipalConnector and not PrincipalSystem, and the two have to agree:
-	// the audit row stamps actor_type from the TYPE and actor_id from the ID,
-	// so a system type beside a `connector:` id writes a row that contradicts
-	// itself, and audit_log is append-only — the contradiction cannot be
-	// corrected afterwards. No OnBehalfOf: finance has no connect flow and so
-	// no granting human, and storekit.OwnerOrActor already reads a bare
-	// connector as the row nobody owns.
-	wsCtx = principal.WithActor(wsCtx, principal.Principal{
-		Type: principal.PrincipalConnector, ID: "connector:finance",
-	})
+	wsCtx = principal.WithActor(wsCtx, financeSweepPrincipal())
 	wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
 
 	provider, configured, err := w.providerFor(wsCtx, job.Args.Workspace)

--- a/backend/internal/compose/jobs_finance_principal_test.go
+++ b/backend/internal/compose/jobs_finance_principal_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The finance sweep's principal must pass the gates the sweep actually takes.
+//
+// This exists because it did not, and nothing caught it. PR #1936 changed the
+// sweep's principal from PrincipalSystem to PrincipalConnector so the audit row
+// would stamp actor_type=connector — correct on its own terms, and it silently
+// cost the sweep auth.Require's unconditional pass for a system principal. The
+// zero Permissions that came with it then denied the base-currency read, so
+// every finance_sync pass WITH WORK TO DO was discarded after three attempts
+// and no invoice was ever mirrored.
+//
+// The integration suite stayed green throughout, because its fixture stubs both
+// halves of the failure: it injects a literal base currency instead of
+// identity.BaseCurrencyOf, and it binds a principal carrying admin grants that
+// production has never had. A test at that level cannot see this class of bug.
+//
+// So this test asserts the one thing those cannot: that the principal the
+// WORKER builds satisfies the gate the REAL read takes.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestTheFinanceSweepsPrincipalMayReadTheBaseCurrency(t *testing.T) {
+	ctx := principal.WithActor(context.Background(), financeSweepPrincipal())
+
+	if err := auth.Require(ctx, identity.BaseCurrency.Object(),
+		principal.ActionRead); err != nil {
+		t.Fatalf("the finance sweep may not read %s: %v\n"+
+			"the mirror converts every ledger into the base currency as it writes, "+
+			"so a sweep refused here is a sweep that mirrors nothing — and it fails "+
+			"as three discarded jobs and an empty invoice list, not as anything a "+
+			"reader would connect to a permission",
+			identity.BaseCurrency.Object(), err)
+	}
+}
+
+// The sweep stays a CONNECTOR, because the audit row it writes says so.
+//
+// finance's own TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold pins
+// actor_type=connector on every finance audit row, and audit_log is
+// append-only. Answering the permission failure by going back to
+// PrincipalSystem would trade one silent wrong for another: rows that read
+// `system` beside a `connector:` actor_id, which cannot be corrected later.
+func TestTheFinanceSweepStaysAConnector(t *testing.T) {
+	p := financeSweepPrincipal()
+	if p.Type != principal.PrincipalConnector {
+		t.Errorf("the finance sweep binds %s, want connector — "+
+			"its audit rows stamp actor_type from this and are append-only", p.Type)
+	}
+	if p.OnBehalfOf != (principal.Principal{}).OnBehalfOf {
+		t.Errorf("the finance sweep names a granting human (%v); finance has no "+
+			"connect flow, and a bare connector is what leaves the mirrored row "+
+			"ownerless as storekit.OwnerOrActor expects", p.OnBehalfOf)
+	}
+}
+
+// The grant stays MINIMAL. A connector on a schedule holds no role a human
+// granted, so every object on it is one somebody has to justify. The sweep
+// reads one setting; it writes finance rows through paths that take no gate.
+func TestTheFinanceSweepGrantsOnlyWhatItReads(t *testing.T) {
+	objects := financeSweepPrincipal().Permissions.Objects
+	if len(objects) != 1 {
+		t.Fatalf("the finance sweep holds %d object grants, want exactly 1: %v",
+			len(objects), objects)
+	}
+	grant, ok := objects[identity.BaseCurrency.Object()]
+	if !ok {
+		t.Fatalf("the finance sweep's one grant is not on %s: %v",
+			identity.BaseCurrency.Object(), objects)
+	}
+	if grant.Create || grant.Update || grant.Delete {
+		t.Errorf("the finance sweep holds a WRITE grant (%+v) on a settings "+
+			"object it only reads", grant)
+	}
+}


### PR DESCRIPTION
No installation has mirrored an invoice since 2026-08-20.

Every `finance_sync` pass with work to do is discarded after three attempts with
`this job's principal is not permitted the action it attempted`, and
`finance_invoice` / `finance_payment` stay empty. Nothing on any screen says why —
the revenue cards are simply blank, which looks like an installation nobody has
connected.

## Cause

#1936 changed the sweep's principal from `PrincipalSystem` to
`PrincipalConnector` so the audit row would stamp `actor_type=connector`. That is
right: a `system` type beside a `connector:` actor_id writes a row that
contradicts itself, and `audit_log` is append-only.

What it also did, invisibly, was cost the sweep `auth.Require`'s unconditional
pass for a system principal. The connector it minted carries no `Permissions`, so
the base-currency read the mirror takes through `identity.BaseCurrencyOf` →
`settings.RequireTx` was denied and the whole pass failed closed.

## Fix

The sweep stays a connector and gains the one grant it exercises: read on the
installation-settings object. The mirror converts a source ledger into the
installation's base currency as it writes and reads that single setting; nothing
else on its path takes a gate. The grant is stated the way
`telegramChannelPrincipal` states its own, and asks the entry for the object name
rather than spelling it.

## Why the tests did not catch it

The finance integration fixture stubs **both** halves: it injects a literal base
currency instead of `identity.BaseCurrencyOf`, and binds a principal carrying
admin grants production has never had. It stayed green through the whole
regression.

Three new tests pin what it cannot see — that the sweep's principal passes the
gate the real read takes, that it is still a connector with no granting human,
and that its grant stays minimal and read-only. Reverting the `Permissions` block
fails the first with the symptom spelled out.

## Verification

- `make check-backend` green (full gate).
- Finance integration lane green, including
  `TestTheMirrorsAuditRowsNameNoGrantTheSweepDoesNotHold`, the test that pins
  #1936's intent.
- `make craft-static`, `make rls-store-path`, `make no-jurisdiction` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores finance mirror sweeps by granting the scheduled connector principal read access to the installation’s base-currency setting. Previously, after moving from `PrincipalSystem` to `PrincipalConnector`, `auth.Require` denied the `identity.BaseCurrency` read and `finance_sync` jobs with work were discarded, leaving invoices and payments empty.

- Introduces `financeSweepPrincipal()` that returns a `PrincipalConnector` with `RowScopeAll` and a single read grant on `identity.BaseCurrency.Object()`, then uses it in `jobs_finance.go`.
- Adds tests (`jobs_finance_principal_test.go`) to assert the read passes via `auth.Require`, the principal stays a connector with no `OnBehalfOf`, and the grant remains minimal and read-only.

<sup>Written for commit 7f65612555c5694d99ed872ce95f8e78679a2b2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Finance synchronization jobs can now read workspace base-currency settings across all workspace records.
  * Improved finance sync reliability by applying the appropriate read-only connector access during synchronization.

* **Tests**
  * Added coverage verifying base-currency access and confirming permissions remain limited to the required read-only setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->