### PR TITLE
fix(geocode): a shutdown stops counting as an address that cannot be found

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -1169,17 +1169,25 @@ kinds:
     role: worker
     go_type: GeocodeOrganizationArgs
     queue: geocode
-    timeout: 1m
+    timeout: 3m
     opts_owner: caller
     registration: {when: [Geocoder], absent: registers_anyway}
     args:
       Workspace: id
       OrganizationID: id
     reason: >-
-      One address, one lookup, plus the write. A minute is generous for a single
-      HTTP call and deliberately so: the pacer may hold this job for up to the
-      policy interval before the request even starts, and a timeout that fired
-      during the wait would retry into the same queue and make the rate worse.
+      One address, one lookup, plus the write — but the ceiling is set by what
+      the job can WAIT for, not by what it does. The pacer may hold it for the
+      full policy interval (15s) before the request is built, the HTTP client
+      allows 20s, and the write follows: 35s of budget, and three minutes is
+      that with room to spare.
+
+      The margin is load-bearing rather than generous. River applies this
+      timeout by cancelling the job's context, so a job that hit its ceiling is
+      indistinguishable from a worker that was shut down — and the worker
+      treats those differently on purpose, re-queueing a shutdown unrecorded
+      while counting a real failure. A ceiling close to the budget would make
+      that distinction lie.
 
   # The backfill's own kind, not a flag on the per-company one. Geocoding fires
   # on an address WRITE, which never reaches a row written before this

--- a/backend/internal/compose/geocodejobs.go
+++ b/backend/internal/compose/geocodejobs.go
@@ -214,21 +214,27 @@ func (w *geocodeWorker) Work(ctx context.Context, job *river.Job[GeocodeOrganiza
 
 	point, found, err := w.geocoder.Resolve(wsCtx, address.Query)
 	if err != nil {
-		// A CANCELLED job never asked the provider, so it is not a failure of
-		// this address and must not spend one of its three attempts.
+		// A job STOPPED BEFORE IT ASKED never learned anything about this
+		// address, so it must not spend one of its three attempts.
 		//
-		// The pacer holds a job for up to the policy interval before the
+		// The pacer holds a lookup for up to the policy interval before the
 		// request is even built, and it gives up when the context does — so
 		// every lookup waiting its turn when the worker shuts down came back
-		// here with context.Canceled. Recording that as `failed` burned an
-		// attempt, set a day-long backoff, and left a company unlocated for a
-		// reason that had nothing to do with its address. Six of Lars's
-		// companies sat that way, every one of them a valid German address
-		// that resolves in under a second.
+		// here cancelled. Recording that as `failed` burned an attempt, set a
+		// day-long backoff, and left a company unlocated for a reason that had
+		// nothing to do with its address. Six companies sat that way, every one
+		// a valid German address that resolves in under a second.
+		//
+		// The test is the CONTEXT's own state, not the error's. A slow provider
+		// surfaces as context.DeadlineExceeded too — the http.Client's timeout
+		// says exactly that — and that IS a failed lookup worth counting, since
+		// a provider too slow to answer is one this address cannot be resolved
+		// against right now. Asking the context tells the two apart: it is done
+		// when the worker was stopped, and live when only the HTTP call gave up.
 		//
 		// Returned unrecorded: River re-queues the job, and the next worker
 		// asks properly.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if wsCtx.Err() != nil {
 			return jobs.FaultContext(wsCtx,
 				fmt.Errorf("geocoding %q was cut short before the provider was asked: %w",
 					address.Query, err))

--- a/backend/internal/compose/geocodejobs.go
+++ b/backend/internal/compose/geocodejobs.go
@@ -265,7 +265,7 @@ func (w *geocodeWorker) Work(ctx context.Context, job *river.Job[GeocodeOrganiza
 		// publish a fixed sentence rather than a formatted cause. FaultContext
 		// logs the cause for us, so the wrap below is what an operator reads.
 		return jobs.FaultContext(wsCtx, errors.Join(
-			fmt.Errorf("geocoding %q: %w: %w", address.Query, apperrors.ErrProviderUnreachable, err),
+			fmt.Errorf("geocoding %q: %w: %w", address.Query, apperrors.ErrProviderUnusable, err),
 			recErr))
 	}
 	if !found {

--- a/backend/internal/compose/geocodejobs.go
+++ b/backend/internal/compose/geocodejobs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/geocode"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -213,6 +214,25 @@ func (w *geocodeWorker) Work(ctx context.Context, job *river.Job[GeocodeOrganiza
 
 	point, found, err := w.geocoder.Resolve(wsCtx, address.Query)
 	if err != nil {
+		// A CANCELLED job never asked the provider, so it is not a failure of
+		// this address and must not spend one of its three attempts.
+		//
+		// The pacer holds a job for up to the policy interval before the
+		// request is even built, and it gives up when the context does — so
+		// every lookup waiting its turn when the worker shuts down came back
+		// here with context.Canceled. Recording that as `failed` burned an
+		// attempt, set a day-long backoff, and left a company unlocated for a
+		// reason that had nothing to do with its address. Six of Lars's
+		// companies sat that way, every one of them a valid German address
+		// that resolves in under a second.
+		//
+		// Returned unrecorded: River re-queues the job, and the next worker
+		// asks properly.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return jobs.FaultContext(wsCtx,
+				fmt.Errorf("geocoding %q was cut short before the provider was asked: %w",
+					address.Query, err))
+		}
 		// The lookup did not complete. Recorded as failed so the ledger counts
 		// the attempt, and returned so River retries — a rate limit or a network
 		// fault is worth asking again, unlike an address that does not exist.
@@ -229,8 +249,18 @@ func (w *geocodeWorker) Work(ctx context.Context, job *river.Job[GeocodeOrganiza
 		if errors.As(err, &refused) && refused.RetryAfter > 0 {
 			recErr = store.RecordGeocodeBackoff(wsCtx, orgID, address.InputHash, refused.RetryAfter)
 		}
+		// Wrapped so the ROW says what kind of thing went wrong. Unclassified,
+		// it published "the diagnosis is in the process log", which is true and
+		// useless once the process has restarted — exactly when somebody looks.
+		//
+		// The ADDRESS stays out of the published sentence and rides the log
+		// instead: that column is fleet-visible and a provider's prose
+		// routinely quotes what it refused, which is why classified failures
+		// publish a fixed sentence rather than a formatted cause. FaultContext
+		// logs the cause for us, so the wrap below is what an operator reads.
 		return jobs.FaultContext(wsCtx, errors.Join(
-			fmt.Errorf("geocoding %q: %w", address.Query, err), recErr))
+			fmt.Errorf("geocoding %q: %w: %w", address.Query, apperrors.ErrProviderUnreachable, err),
+			recErr))
 	}
 	if !found {
 		// The geocoder answered, and the answer is that this address is not a

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "900593188e6b5117c1fde6e133cdf7d27fcd7e06262cb7613a80ae70d3aca745"
+const jobContractHash = "7d4fb22c1893eebf46f262abe414b0ba286f032bd6434cc8c08f9005e449bfcd"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/compose/jobtimeoutbudget_test.go
+++ b/backend/internal/compose/jobtimeoutbudget_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/geocode"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// The geocode job's ceiling must sit ABOVE everything it can wait for.
+//
+// River applies a job timeout by cancelling the job's context, and the worker
+// reads a cancelled context as "we were stopped" — re-queueing the lookup
+// unrecorded rather than counting it against the address. That is right for a
+// shutdown and wrong for a job that genuinely ran out of time, and the two are
+// indistinguishable once the context is done.
+//
+// So the ceiling is what keeps the distinction honest: while it stays clear of
+// the real budget, a cancelled context means a shutdown and nothing else. The
+// budget is the pacer's full interval plus the HTTP client's own timeout,
+// because the pacer holds a lookup before the request is even built.
+func TestTheGeocodeCeilingStaysClearOfWhatTheJobCanWaitFor(t *testing.T) {
+	spec, declared := jobs.SpecFor("geocode_organization")
+	if !declared {
+		t.Fatal("geocode_organization is not declared, so nothing bounds it")
+	}
+	const httpTimeout = 20 * time.Second // geocode.NewNominatim's default client
+	budget := geocode.RecurringInterval + httpTimeout
+	if spec.Timeout.Fixed <= budget {
+		t.Errorf("the job ceiling is %s against a %s budget (pacer %s + HTTP %s) — a job that "+
+			"hit the ceiling would be read as a shutdown and never counted against the address",
+			spec.Timeout.Fixed, budget, geocode.RecurringInterval, httpTimeout)
+	}
+}

--- a/backend/internal/platform/geocode/pacer_test.go
+++ b/backend/internal/platform/geocode/pacer_test.go
@@ -6,6 +6,8 @@ package geocode
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -39,5 +41,46 @@ func TestAStoppedWaitSaysItWasStopped(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("a stopped wait answered %v, want it to say it was cancelled — a caller "+
 			"that cannot tell records the address as failed and spends one of its attempts", err)
+	}
+}
+
+// A SLOW PROVIDER is not a shutdown, and the difference decides whether a
+// company keeps its attempts.
+//
+// Both surface as a deadline: the http.Client's own timeout reports
+// context.DeadlineExceeded, exactly as a cancelled parent would. So a caller
+// that tests the ERROR cannot tell "we were stopped" from "the provider did
+// not answer in time" — and the second is a real failed lookup that should be
+// counted, while the first learned nothing and must not be.
+//
+// The caller therefore asks the CONTEXT, which is live here and done for a
+// shutdown. This test pins the shape that makes that distinction available.
+func TestASlowProviderLooksLikeADeadlineButTheContextIsLive(t *testing.T) {
+	// Held on a channel rather than a sleep: the handler blocks until the test
+	// releases it, so the client's timeout is what ends the request and the
+	// test never waits on a clock.
+	release := make(chan struct{})
+	slow := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer slow.Close()
+	defer close(release)
+
+	ctx := context.Background()
+	client := NewNominatim(slow.URL, &http.Client{Timeout: 50 * time.Millisecond})
+	_, _, err := client.Resolve(ctx, "Anywhere")
+	if err == nil {
+		t.Fatal("a provider that never answered returned no error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("a slow provider answered %v, want a deadline — the shape a caller must "+
+			"not confuse with a shutdown", err)
+	}
+	if ctx.Err() != nil {
+		t.Error("the context is done after only the HTTP call timed out; the caller would " +
+			"read a slow provider as a shutdown and never count the failed lookup")
 	}
 }

--- a/backend/internal/platform/geocode/pacer_test.go
+++ b/backend/internal/platform/geocode/pacer_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package geocode
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// A shutdown cuts the wait short, and the caller must be able to tell.
+//
+// This is the shape that cost six of an installation's companies their
+// coordinates. The pacer holds a lookup for up to the policy interval before
+// the request is even built; when the worker stops, every lookup queued behind
+// the current one comes back from Wait with the context's error. The caller
+// that treats that as a failure of the ADDRESS burns one of its three attempts
+// and sets a day-long backoff for a request that never reached the provider.
+//
+// Wait must therefore return an error that errors.Is(context.Canceled) rather
+// than something of its own, because the caller's whole decision rests on
+// telling "we were stopped" from "the provider said no".
+func TestAStoppedWaitSaysItWasStopped(t *testing.T) {
+	p := NewPacer(time.Hour)
+	// Take the first slot, so the second caller has to wait out the interval.
+	if err := p.Wait(context.Background()); err != nil {
+		t.Fatalf("the first wait answered %v, want the slot", err)
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+	stop()
+	err := p.Wait(ctx)
+	if err == nil {
+		t.Fatal("a stopped wait answered nil, so the caller proceeds to ask a provider " +
+			"nobody is waiting on")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("a stopped wait answered %v, want it to say it was cancelled — a caller "+
+			"that cannot tell records the address as failed and spends one of its attempts", err)
+	}
+}

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -55,7 +55,7 @@ var mapping = []struct {
 	{apperrors.ErrOverlayFlipBlocked, http.StatusConflict, "overlay_flip_blocked"},
 	{apperrors.ErrIncumbentBudgetExhausted, http.StatusServiceUnavailable, "incumbent_budget_exhausted"},
 	{apperrors.ErrBaseCurrencyLocked, http.StatusConflict, "base_currency_locked"},
-	{apperrors.ErrProviderUnreachable, http.StatusServiceUnavailable, "provider_unreachable"},
+	{apperrors.ErrProviderUnusable, http.StatusBadGateway, "provider_unusable"},
 	{apperrors.ErrRetentionHold, http.StatusLocked, "locked"},
 }
 

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -8,7 +8,6 @@
 package httperr
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -57,6 +55,7 @@ var mapping = []struct {
 	{apperrors.ErrOverlayFlipBlocked, http.StatusConflict, "overlay_flip_blocked"},
 	{apperrors.ErrIncumbentBudgetExhausted, http.StatusServiceUnavailable, "incumbent_budget_exhausted"},
 	{apperrors.ErrBaseCurrencyLocked, http.StatusConflict, "base_currency_locked"},
+	{apperrors.ErrProviderUnreachable, http.StatusServiceUnavailable, "provider_unreachable"},
 	{apperrors.ErrRetentionHold, http.StatusLocked, "locked"},
 }
 
@@ -390,110 +389,3 @@ type DetailedError struct {
 }
 
 func (e *DetailedError) Error() string { return fmt.Sprintf("%s: %s", e.Code, e.Detail) }
-
-// Unauthorized is the shared 401.
-func Unauthorized(w http.ResponseWriter, r *http.Request, detail string) {
-	writeProblem(w, problem{Status: http.StatusUnauthorized, Code: "unauthorized", Detail: detail})
-}
-
-// ServiceUnavailable is the shared 503 for availability states — the
-// installation cannot serve (e.g. not yet bootstrapped), which is an
-// operator condition, never an authentication failure.
-func ServiceUnavailable(w http.ResponseWriter, r *http.Request, detail string) {
-	writeProblem(w, problem{Status: http.StatusServiceUnavailable, Code: "service_unavailable", Detail: detail})
-}
-
-// NotImplemented marks a contract operation that exists on the surface
-// but has no implementation yet — explicit 501, never a silent 404.
-func NotImplemented(w http.ResponseWriter, r *http.Request, op string) {
-	writeProblem(w, problem{
-		Status: http.StatusNotImplemented,
-		Code:   "not_implemented",
-		Detail: fmt.Sprintf("operation %s is specified but not yet implemented", op),
-	})
-}
-
-// Validation is the 422 shape with per-field errors.
-func Validation(field, code, message string) *DetailedError {
-	return &DetailedError{
-		Status: http.StatusUnprocessableEntity,
-		Code:   "validation_error",
-		Detail: message,
-		Fields: []FieldError{{Field: field, Code: code, Message: message}},
-	}
-}
-
-// RequireBodyID refuses a required body id the caller simply omitted, naming the
-// wire field. Nil when the id is present.
-//
-// The defect it closes is the generator's: oapi-codegen renders a REQUIRED body
-// id as a non-pointer UUID, and encoding/json leaves an absent key at the zero
-// value with no error. So "required" in the contract is a claim only this check
-// makes true — and what made it worth a named helper is where the zero value
-// LANDS. It reaches a lookup or a link-target probe, matches no row, and comes
-// back as a bare not-found: the caller is told a record it never mentioned does
-// not exist, on a request whose real fault was an absent key.
-//
-// It lives here rather than per-module because Classify matches *DetailedError
-// before anything else, so one call answers a 422 naming the field on REST AND
-// the same field-named sentence on the MCP tool surface — which never runs a
-// module's HTTP mapper. A module error type per caller would be a second
-// spelling of a rule whose wire output is byte-identical.
-//
-// The id arrives as ids.UUID: this package deliberately does not import the
-// generated contracts, so the openapi_types.UUID conversion happens at the call
-// site, where the contract type legally lives.
-func RequireBodyID(field string, id ids.UUID) error {
-	if id.IsZero() {
-		return Validation(field, "required", field+" is required")
-	}
-	return nil
-}
-
-// fieldDetails renders the per-field breakdown into the contract's
-// `details.errors` body shape. Rendering it here, from Fields, is what keeps
-// the typed list and the wire list the same list.
-const fieldErrorsKey = "errors"
-
-func fieldDetails(fields []FieldError) map[string]any {
-	errs := make([]map[string]string, 0, len(fields))
-	for _, f := range fields {
-		entry := map[string]string{"field": f.Field, "code": f.Code}
-		// A multi-field validator may have no per-entry prose (the code IS the
-		// reason). Omitting the key beats shipping "message": "", which reads
-		// as an explanation that came out blank.
-		if f.Message != "" {
-			entry["message"] = f.Message
-		}
-		errs = append(errs, entry)
-	}
-	return map[string]any{fieldErrorsKey: errs}
-}
-
-// Duplicate is the 409 dedupe shape. existingID is included only when
-// known AND disclosable — a conflict with a row outside the caller's
-// row scope answers 409 without the id.
-func Duplicate(code, existingID string) *DetailedError {
-	e := &DetailedError{
-		Status: http.StatusConflict,
-		Code:   code,
-		Detail: "a live record with this key already exists",
-	}
-	if existingID != "" {
-		e.Details = map[string]any{"existing_id": existingID}
-	}
-	return e
-}
-
-func writeProblem(w http.ResponseWriter, p problem) {
-	if p.Type == "" {
-		p.Type = problemTypeBase + p.Code
-	}
-	if p.Title == "" {
-		p.Title = http.StatusText(p.Status)
-	}
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(p.Status)
-	//craft:ignore swallowed-errors the status line is already on the wire — an encode failure here has no recovery path and no channel back to the client
-	_ = json.NewEncoder(w).Encode(p)
-}

--- a/backend/internal/platform/httperr/responses.go
+++ b/backend/internal/platform/httperr/responses.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// The ready-made refusals: the handful of responses a surface writes directly
+// rather than by classifying an error it was handed.
+//
+// Split from httperr.go at the 500-line cap. The two halves answer different
+// questions — that one asks "what does THIS error mean on the wire", this one
+// is the shorthand for a refusal a handler already knows the shape of — so the
+// seam is a concept rather than a line count.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// Unauthorized is the shared 401.
+func Unauthorized(w http.ResponseWriter, r *http.Request, detail string) {
+	writeProblem(w, problem{Status: http.StatusUnauthorized, Code: "unauthorized", Detail: detail})
+}
+
+// ServiceUnavailable is the shared 503 for availability states — the
+// installation cannot serve (e.g. not yet bootstrapped), which is an
+// operator condition, never an authentication failure.
+func ServiceUnavailable(w http.ResponseWriter, r *http.Request, detail string) {
+	writeProblem(w, problem{Status: http.StatusServiceUnavailable, Code: "service_unavailable", Detail: detail})
+}
+
+// NotImplemented marks a contract operation that exists on the surface
+// but has no implementation yet — explicit 501, never a silent 404.
+func NotImplemented(w http.ResponseWriter, r *http.Request, op string) {
+	writeProblem(w, problem{
+		Status: http.StatusNotImplemented,
+		Code:   "not_implemented",
+		Detail: fmt.Sprintf("operation %s is specified but not yet implemented", op),
+	})
+}
+
+// Validation is the 422 shape with per-field errors.
+func Validation(field, code, message string) *DetailedError {
+	return &DetailedError{
+		Status: http.StatusUnprocessableEntity,
+		Code:   "validation_error",
+		Detail: message,
+		Fields: []FieldError{{Field: field, Code: code, Message: message}},
+	}
+}
+
+// RequireBodyID refuses a required body id the caller simply omitted, naming the
+// wire field. Nil when the id is present.
+//
+// The defect it closes is the generator's: oapi-codegen renders a REQUIRED body
+// id as a non-pointer UUID, and encoding/json leaves an absent key at the zero
+// value with no error. So "required" in the contract is a claim only this check
+// makes true — and what made it worth a named helper is where the zero value
+// LANDS. It reaches a lookup or a link-target probe, matches no row, and comes
+// back as a bare not-found: the caller is told a record it never mentioned does
+// not exist, on a request whose real fault was an absent key.
+//
+// It lives here rather than per-module because Classify matches *DetailedError
+// before anything else, so one call answers a 422 naming the field on REST AND
+// the same field-named sentence on the MCP tool surface — which never runs a
+// module's HTTP mapper. A module error type per caller would be a second
+// spelling of a rule whose wire output is byte-identical.
+//
+// The id arrives as ids.UUID: this package deliberately does not import the
+// generated contracts, so the openapi_types.UUID conversion happens at the call
+// site, where the contract type legally lives.
+func RequireBodyID(field string, id ids.UUID) error {
+	if id.IsZero() {
+		return Validation(field, "required", field+" is required")
+	}
+	return nil
+}
+
+// fieldDetails renders the per-field breakdown into the contract's
+// `details.errors` body shape. Rendering it here, from Fields, is what keeps
+// the typed list and the wire list the same list.
+const fieldErrorsKey = "errors"
+
+func fieldDetails(fields []FieldError) map[string]any {
+	errs := make([]map[string]string, 0, len(fields))
+	for _, f := range fields {
+		entry := map[string]string{"field": f.Field, "code": f.Code}
+		// A multi-field validator may have no per-entry prose (the code IS the
+		// reason). Omitting the key beats shipping "message": "", which reads
+		// as an explanation that came out blank.
+		if f.Message != "" {
+			entry["message"] = f.Message
+		}
+		errs = append(errs, entry)
+	}
+	return map[string]any{fieldErrorsKey: errs}
+}
+
+// Duplicate is the 409 dedupe shape. existingID is included only when
+// known AND disclosable — a conflict with a row outside the caller's
+// row scope answers 409 without the id.
+func Duplicate(code, existingID string) *DetailedError {
+	e := &DetailedError{
+		Status: http.StatusConflict,
+		Code:   code,
+		Detail: "a live record with this key already exists",
+	}
+	if existingID != "" {
+		e.Details = map[string]any{"existing_id": existingID}
+	}
+	return e
+}
+
+func writeProblem(w http.ResponseWriter, p problem) {
+	if p.Type == "" {
+		p.Type = problemTypeBase + p.Code
+	}
+	if p.Title == "" {
+		p.Title = http.StatusText(p.Status)
+	}
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(p.Status)
+	//craft:ignore swallowed-errors the status line is already on the wire — an encode failure here has no recovery path and no channel back to the client
+	_ = json.NewEncoder(w).Encode(p)
+}

--- a/backend/internal/platform/jobs/fault.go
+++ b/backend/internal/platform/jobs/fault.go
@@ -395,6 +395,6 @@ var vocabulary = []struct {
 	{apperrors.ErrIncumbentAlreadyConnected, "incumbent_already_connected", "an incumbent connection already exists for this workspace", "Disconnect the existing incumbent first if this job was meant to replace it."},
 	{apperrors.ErrOverlayFlipBlocked, "overlay_flip_blocked", "the overlay flip preflight is unsatisfied", "Read the flip preflight for what is outstanding, satisfy it, then re-queue."},
 	{apperrors.ErrBaseCurrencyLocked, "base_currency_locked", "the base currency is locked by frozen conversion rates", "Nothing to do in the job: a base currency stops being changeable once rates are frozen against it."},
-	{apperrors.ErrProviderUnreachable, "provider_unreachable", "an outside service could not be reached, so nothing was learned", "Check the provider is reachable and not rate-limiting this installation, then re-queue. A lookup that did not complete says nothing about its subject, so the retry is worth making."},
+	{apperrors.ErrProviderUnusable, "provider_unusable", "an outside service gave no usable answer, so nothing was learned", "Check the provider is reachable, is not rate-limiting this installation, and answers in the expected shape, then re-queue. A request with no answer says nothing about its subject."},
 	{apperrors.ErrRetentionHold, "retention_hold", "the record is held under a statutory retention obligation", "Nothing to do, and nothing to force: the hold outranks this job. The record becomes workable when the obligation lapses."},
 }

--- a/backend/internal/platform/jobs/fault.go
+++ b/backend/internal/platform/jobs/fault.go
@@ -395,5 +395,6 @@ var vocabulary = []struct {
 	{apperrors.ErrIncumbentAlreadyConnected, "incumbent_already_connected", "an incumbent connection already exists for this workspace", "Disconnect the existing incumbent first if this job was meant to replace it."},
 	{apperrors.ErrOverlayFlipBlocked, "overlay_flip_blocked", "the overlay flip preflight is unsatisfied", "Read the flip preflight for what is outstanding, satisfy it, then re-queue."},
 	{apperrors.ErrBaseCurrencyLocked, "base_currency_locked", "the base currency is locked by frozen conversion rates", "Nothing to do in the job: a base currency stops being changeable once rates are frozen against it."},
+	{apperrors.ErrProviderUnreachable, "provider_unreachable", "an outside service could not be reached, so nothing was learned", "Check the provider is reachable and not rate-limiting this installation, then re-queue. A lookup that did not complete says nothing about its subject, so the retry is worth making."},
 	{apperrors.ErrRetentionHold, "retention_hold", "the record is held under a statutory retention obligation", "Nothing to do, and nothing to force: the hold outranks this job. The record becomes workable when the obligation lapses."},
 }

--- a/backend/internal/platform/jobs/fault_test.go
+++ b/backend/internal/platform/jobs/fault_test.go
@@ -4,6 +4,7 @@
 package jobs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -137,5 +138,30 @@ func TestEverySentenceFaultCanWriteIsVetted(t *testing.T) {
 	if !VettedSentence(unclassified) {
 		t.Errorf("Fault wrote %q for an unclassified cause, and the reader would not admit it",
 			unclassified)
+	}
+}
+
+// A provider that could not be reached says so ON THE ROW.
+//
+// Unclassified, this published "the diagnosis is in the process log" — true,
+// and useless once the process has restarted, which is exactly when an
+// operator goes looking. Six companies sat unlocated behind that sentence with
+// nothing anywhere to say why.
+func TestAnUnreachableProviderSaysSoOnTheJobRow(t *testing.T) {
+	cause := fmt.Errorf("geocoding %q: %w: %w", "Alte Wittener Straße 50, Bochum",
+		apperrors.ErrProviderUnreachable, errors.New("connection reset"))
+	got := FaultContext(context.Background(), cause)
+
+	if strings.Contains(got.Error(), "process log") {
+		t.Errorf("an unreachable provider published %q — the sentence that sends a reader "+
+			"to a log the restart already discarded", got.Error())
+	}
+	if _, vetted := VettedFailure("geocode_organization", got.Error()); !vetted {
+		t.Errorf("the published sentence %q is not one a reader can classify", got.Error())
+	}
+	// The cause stays reachable underneath, so anything classifying on the
+	// sentinel downstream still can.
+	if !errors.Is(got, apperrors.ErrProviderUnreachable) {
+		t.Error("the published fault no longer carries the sentinel, so nothing downstream can classify it")
 	}
 }

--- a/backend/internal/platform/jobs/fault_test.go
+++ b/backend/internal/platform/jobs/fault_test.go
@@ -149,7 +149,7 @@ func TestEverySentenceFaultCanWriteIsVetted(t *testing.T) {
 // nothing anywhere to say why.
 func TestAnUnreachableProviderSaysSoOnTheJobRow(t *testing.T) {
 	cause := fmt.Errorf("geocoding %q: %w: %w", "Alte Wittener Straße 50, Bochum",
-		apperrors.ErrProviderUnreachable, errors.New("connection reset"))
+		apperrors.ErrProviderUnusable, errors.New("connection reset"))
 	got := FaultContext(context.Background(), cause)
 
 	if strings.Contains(got.Error(), "process log") {
@@ -161,7 +161,7 @@ func TestAnUnreachableProviderSaysSoOnTheJobRow(t *testing.T) {
 	}
 	// The cause stays reachable underneath, so anything classifying on the
 	// sentinel downstream still can.
-	if !errors.Is(got, apperrors.ErrProviderUnreachable) {
+	if !errors.Is(got, apperrors.ErrProviderUnusable) {
 		t.Error("the published fault no longer carries the sentinel, so nothing downstream can classify it")
 	}
 }

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "900593188e6b5117c1fde6e133cdf7d27fcd7e06262cb7613a80ae70d3aca745"
+const JobContractHash = "7d4fb22c1893eebf46f262abe414b0ba286f032bd6434cc8c08f9005e449bfcd"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -396,7 +396,7 @@ var specs = map[string]Spec{
 		GoType:       "GeocodeOrganizationArgs",
 		Role:         Worker,
 		Queue:        "geocode",
-		Timeout:      TimeoutPolicy{Fixed: 1 * time.Minute},
+		Timeout:      TimeoutPolicy{Fixed: 3 * time.Minute},
 		OptsOwner:    OptsCaller,
 		Registration: Registration{When: []string{"Geocoder"}, AbsentRegistersAnyway: true},
 		Args:         []ArgField{{Name: "OrganizationID"}, {Name: "Workspace"}},

--- a/backend/internal/shared/apperrors/apperrors.go
+++ b/backend/internal/shared/apperrors/apperrors.go
@@ -164,17 +164,21 @@ var ErrBaseCurrencyLocked = errors.New("base currency is locked by frozen conver
 // release, which is its own operation.
 var ErrRetentionHold = errors.New("record is held under a statutory retention obligation")
 
-// ErrProviderUnreachable says an outside service could not be asked — the
-// request did not complete, so nothing was learned about the subject.
+// ErrProviderUnusable says a request to an outside service produced no usable
+// answer: it could not be reached, it refused, or what it sent back could not
+// be read.
 //
-// Distinct from a service that ANSWERED unhelpfully: "this address is not a
-// place" is a fact worth recording and never retrying, while "the lookup did
-// not finish" is no answer at all and is worth asking again. A job that
-// conflates the two either retries forever against a settled question or
-// gives up on a transient one.
+// The three are one condition FOR THE CALLER, which is why they share a
+// sentinel. None of them says anything about the subject — the address, the
+// account, the document — so none may be recorded as a fact about it, and all
+// of them are worth asking again. The distinction that matters is against a
+// service that ANSWERED: "this address is not a place" is a fact, recorded
+// once and never re-asked, and conflating that with a failed request is how a
+// job either retries a settled question forever or gives up on a transient one.
 //
-// It exists so that failure reaches the job row rather than only the process
-// log. An unclassified cause is published as "the diagnosis is in the process
-// log" — true, and useless once the process has restarted, which is exactly
-// when an operator goes looking.
-var ErrProviderUnreachable = errors.New("the provider could not be reached")
+// It is core rather than module-local because the caller's DECISION is core:
+// jobs.FaultContext publishes a classified sentence only for a sentinel this
+// package declares. Left unclassified, the failure reached the job row as
+// "the diagnosis is in the process log" — true, and useless once the process
+// has restarted, which is exactly when an operator goes looking.
+var ErrProviderUnusable = errors.New("the provider returned no usable answer")

--- a/backend/internal/shared/apperrors/apperrors.go
+++ b/backend/internal/shared/apperrors/apperrors.go
@@ -163,3 +163,18 @@ var ErrBaseCurrencyLocked = errors.New("base currency is locked by frozen conver
 // row) — so a caller must never retry it; the one way past it is the audited
 // release, which is its own operation.
 var ErrRetentionHold = errors.New("record is held under a statutory retention obligation")
+
+// ErrProviderUnreachable says an outside service could not be asked — the
+// request did not complete, so nothing was learned about the subject.
+//
+// Distinct from a service that ANSWERED unhelpfully: "this address is not a
+// place" is a fact worth recording and never retrying, while "the lookup did
+// not finish" is no answer at all and is worth asking again. A job that
+// conflates the two either retries forever against a settled question or
+// gives up on a transient one.
+//
+// It exists so that failure reaches the job row rather than only the process
+// log. An unclassified cause is published as "the diagnosis is in the process
+// log" — true, and useless once the process has restarted, which is exactly
+// when an operator goes looking.
+var ErrProviderUnreachable = errors.New("the provider could not be reached")

--- a/backend/tools/seed-demo/dealseed.go
+++ b/backend/tools/seed-demo/dealseed.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// What a seeded deal IS, and what happens to it once it exists.
+//
+// Split from pipeline.go at the 500-line cap, along the seam seedDeals already
+// had: that file decides WHICH deals there are, this one decides what each one
+// looks like when it is born and how it reaches a terminal stage.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// dealBody is the deal as it is BORN — open, at the first stage, with whatever
+// of amount, owner and partner the fixture named.
+//
+// Split from seedDeals at the 80-line cap, and along the seam the function
+// already had: this half decides what a deal IS, the loop around it decides
+// which deals there are and what happens to them next.
+func dealBody(deal demoDeal, refs pipelineRefs, orgID, openAt string) (jsonBody, error) {
+	body := jsonBody{
+		"name":            deal.Name,
+		"pipeline_id":     refs.pipelineID,
+		"stage_id":        openAt,
+		"organization_id": orgID,
+		"source":          seedSource,
+	}
+	if deal.AmountMinor > 0 {
+		body["amount_minor"] = deal.AmountMinor
+		body["currency"] = deal.Currency
+	}
+	if owner, ok := refs.usersByRef[deal.Owner]; ok {
+		body["owner_id"] = owner
+	}
+	// Attributed at BIRTH rather than patched afterwards: the commission
+	// ledger accrues off the deal's won event, and a deal that was already
+	// won before the attribution landed would never produce one.
+	if deal.Partner != "" {
+		partnerID, ok := refs.orgsByDom[strings.ToLower(deal.Partner)]
+		if !ok {
+			return nil, fmt.Errorf("deal %s is attributed to partner %q, which is not seeded",
+				deal.Ref, deal.Partner)
+		}
+		body["partner_org_id"] = partnerID
+		if deal.PartnerAttribution != "" {
+			body["partner_attribution"] = deal.PartnerAttribution
+		}
+	}
+	// A deal is born open, so a close date already past is refused. A closed
+	// deal gets no date here; its close is the event that matters.
+	if deal.CloseInDays > 0 {
+		body["expected_close_date"] = refs.date(deal.CloseInDays)
+	}
+	return body, nil
+}
+
+// closeIfTerminal walks a deal to its won or lost stage, or leaves an open one
+// alone. The CLOSE is a second call on purpose: a deal is born open and
+// advanced, which is the path a rep takes and the one that raises the events
+// the rest of the demo reads.
+func closeIfTerminal(c *client, deal demoDeal, dealID, stageID string) error {
+	terminal := terminalStatus(deal.Stage)
+	if terminal == "" {
+		return nil
+	}
+	advance := jsonBody{"to_stage_id": stageID, "status": terminal}
+	if terminal == "lost" {
+		// The product requires a reason for a loss, and a demo that shrugs at
+		// "why did we lose?" teaches the wrong habit.
+		reason := deal.LostReason
+		if reason == "" {
+			reason = "Kein Grund erfasst"
+		}
+		advance["lost_reason"] = reason
+	}
+	if terminal == "won" {
+		advance["won_without_contract_reason"] = wonWithoutContractReason
+	}
+	if err := c.post("/v1/deals/"+dealID+"/advance", advance, nil); err != nil {
+		return fmt.Errorf("closing deal %s as %s: %w", deal.Ref, terminal, err)
+	}
+	return nil
+}

--- a/backend/tools/seed-demo/pipeline.go
+++ b/backend/tools/seed-demo/pipeline.go
@@ -241,39 +241,9 @@ func seedDeals(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int,
 			continue
 		}
 
-		body := jsonBody{
-			"name":            deal.Name,
-			"pipeline_id":     refs.pipelineID,
-			"stage_id":        openAt,
-			"organization_id": orgID,
-			"source":          seedSource,
-		}
-		if deal.AmountMinor > 0 {
-			body["amount_minor"] = deal.AmountMinor
-			body["currency"] = deal.Currency
-		}
-		if owner, ok := refs.usersByRef[deal.Owner]; ok {
-			body["owner_id"] = owner
-		}
-		// Attributed at BIRTH rather than patched afterwards: the commission
-		// ledger accrues off the deal's won event, and a deal that was already
-		// won before the attribution landed would never produce one.
-		if deal.Partner != "" {
-			partnerID, ok := refs.orgsByDom[strings.ToLower(deal.Partner)]
-			if !ok {
-				return created, fmt.Errorf(
-					"deal %s is attributed to partner %q, which is not seeded",
-					deal.Ref, deal.Partner)
-			}
-			body["partner_org_id"] = partnerID
-			if deal.PartnerAttribution != "" {
-				body["partner_attribution"] = deal.PartnerAttribution
-			}
-		}
-		// A deal is born open, so a close date already past is refused. A
-		// closed deal gets no date here; its close is the event that matters.
-		if deal.CloseInDays > 0 {
-			body["expected_close_date"] = refs.date(deal.CloseInDays)
+		body, err := dealBody(deal, refs, orgID, openAt)
+		if err != nil {
+			return created, err
 		}
 
 		var out struct {
@@ -284,23 +254,8 @@ func seedDeals(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int,
 		}
 		created++
 
-		if terminal := terminalStatus(deal.Stage); terminal != "" {
-			advance := jsonBody{"to_stage_id": stageID, "status": terminal}
-			if terminal == "lost" {
-				// The product requires a reason for a loss, and a demo that
-				// shrugs at "why did we lose?" teaches the wrong habit.
-				reason := deal.LostReason
-				if reason == "" {
-					reason = "Kein Grund erfasst"
-				}
-				advance["lost_reason"] = reason
-			}
-			if terminal == "won" {
-				advance["won_without_contract_reason"] = wonWithoutContractReason
-			}
-			if err := c.post("/v1/deals/"+out.ID+"/advance", advance, nil); err != nil {
-				return created, fmt.Errorf("closing deal %s as %s: %w", deal.Ref, terminal, err)
-			}
+		if err := closeIfTerminal(c, deal, out.ID, stageID); err != nil {
+			return created, err
 		}
 	}
 	return created, nil


### PR DESCRIPTION
## Why six companies failed

Not the addresses. I reproduced all six by hand against Nominatim: **HTTP 200, correct coordinates, under a second** — Bochum, Gütersloh, Berlin, all valid.

The cause was our own shutdown. `geocode.Pacer.Wait` holds a lookup for up to the 15-second policy interval *before the HTTP request is even built*, and gives up when the context does. Every lookup queued behind the current one came back cancelled the moment the worker stopped — and the worker recorded that as a failure **of the address**, spending one of its three attempts and setting a day-long backoff for a request that never reached the provider.

All six fell inside the seven minutes spent restarting stacks while testing.

## What changed

**A cancelled lookup is re-queued, not recorded.** No attempt spent; River asks again.

**A slow provider is still counted.** The first cut tested the error and could not tell them apart — both surface as `DeadlineExceeded`, because the HTTP client's own timeout says exactly that. The context's state distinguishes them: done for a shutdown, live when only the HTTP call gave up.

**The job ceiling stays clear of the wait.** River applies a timeout by cancelling the context, so a job that genuinely ran out of time was indistinguishable from a shutdown. The ceiling was 1 minute against a 35-second budget; it is 3 minutes now, with a test pinning it above the budget rather than at a number someone liked.

**The row says why.** An unclassified failure published *"the diagnosis is in the process log"* — true, and useless once the process restarted, which is exactly what happened here. `ErrProviderUnusable` is now a declared class: its own sentence on the job row, 502 on the wire (matching two existing surfaces), and the address in the log line.

## Also: unblocking everyone

`craft-static` was BLOCKing on main — `seedDeals` at 83 lines against an 80-line cap — so no `make check-backend` on this machine could go green. Four sessions were behind it. Split along the seam the function already had: `dealBody` (what a deal is when born) and `closeIfTerminal` (how it reaches a terminal stage), in `dealseed.go` because `pipeline.go` then crossed the file cap.

## Verified live

Reset the database, ran the backfill, killed the worker mid-flight twice — the exact act that produced the six failures:

- **Zero failed rows**, both times
- **Zero attempts burned** by the shutdown
- **52 companies located** and climbing; three genuine `no_match`

## Gates

All backend tests, `arch-lint`, `go-file-length`, `craft-static` 0/0/0, `drift` clean, `rls-store-path`, `no-jurisdiction`.

`lint-modules` reports findings only in `.tmp/worktrees/batman-demo/` — another session's tree via the machine-wide golangci cache. Linting the changed files directly: 0 issues.