### PR TITLE
fix(siteread): a page named in Vietnamese or Korean is still an about page

### DIFF
--- a/backend/internal/compose/sitecrawlrank.go
+++ b/backend/internal/compose/sitecrawlrank.go
@@ -254,41 +254,104 @@ func normalizeCandidate(rawURL string) (string, bool) {
 // /en/about-us, which names nobody. The company then read as publishing no
 // staff at all.
 //
-// Matched with containsAny, which is a substring test, so `gioi-thieu` also
-// catches `gioi-thieu-cong-ty` and `gioi-thieu-ve-tth-automation` — both real
-// paths in the corpus.
+// EXACT-matched, not substring-matched, and that difference is the whole
+// design. The German and English words above stay on containsAny because years
+// of paths have shown what they do. The added ones cannot: a substring test on
+// them is demonstrably wrong, and so is a prefix test.
 //
-// Deliberately NOT here: `company` and `info`. Both appear as ordinary product
-// and section words far more often than as an about page, and a false `about`
-// costs more than a missed one — the profile lane spends its page budget on
-// what this function names, so a wrong classification starves the commercial
-// evidence rather than merely failing to help. That is the same argument
-// legalNoticeSegments makes for keeping contact and about out of the LEGAL
-// gate, applied one level down.
+//	/gioi-thieu-san-pham-moi  "introducing our new PRODUCT" -> about
+//	/acme-introduces-widget   a press release               -> about
+//	/nhan-su/tuyen-dung       a JOBS page                   -> team
+//	/임직원복지                staff BENEFITS                 -> team
+//	/신년인사말                a new-year greeting            -> about
+//	/alienhero                a product name                -> contact
+//
+// Every one of those was produced by earlier versions of this list. A false
+// `about` is worse than a miss: the profile lane spends a limited page budget
+// on what this function names, so a wrong classification starves the
+// commercial evidence rather than merely failing to help.
+//
+// A prefix does not save it. Vietnamese says what it is introducing right
+// after the verb, so `gioi-thieu-cong-ty` ("introducing the company") and
+// `gioi-thieu-san-pham` ("introducing the product") share every leading
+// character that matters. Separating them needs a Vietnamese noun list, which
+// is a bigger claim than this classifier should make on a path alone.
+//
+// So the list holds the forms the corpus actually publishes, matched whole. It
+// reaches every real page in the dataset — a Vietnamese site names the page
+// plainly or appends its own company name — and admits nothing else.
+//
+// Deliberately NOT here at all: `company`, `info`, `introduce`, `nhan-su`,
+// `인사말`. The first two are ordinary section words. `introduce` is an English
+// verb before it is a page name. `nhan-su` ("personnel") and `인사말`
+// ("greeting") name a subject rather than a staff directory. That is the
+// argument legalNoticeSegments already makes for keeping contact and about out
+// of the LEGAL gate, one level down.
 var (
 	// vi: gioi thieu = "introduction", ve chung toi = "about us".
-	// ko: 회사소개 = "company introduction", 인사말 = "greeting" (the
-	// chairman's-letter page Korean corporate sites use for the same purpose).
-	aboutWords = []string{
-		"about", "ueber",
-		"gioi-thieu", "gioithieu", "ve-chung-toi", "introduce",
-		"회사소개", "인사말",
+	// ko: 회사소개 = "company introduction".
+	aboutSegments = map[string]bool{
+		"gioi-thieu": true, "gioithieu": true,
+		"gioi-thieu-cong-ty": true, "ve-chung-toi": true,
+		"회사소개": true,
 	}
-	// vi: doi ngu = "the team", nhan su = "personnel".
-	// ko: 임직원 = "executives and staff", 조직도 = "org chart".
-	teamWords = []string{
-		"team", "leadership",
-		"doi-ngu", "doingu", "nhan-su", "nhansu",
-		"임직원", "조직도",
+	// vi: doi ngu = "the team". ko: 조직도 = "org chart", 임직원 = "executives
+	// and staff" — whole only, so 임직원복지 (staff benefits) is not a directory.
+	teamSegments = map[string]bool{
+		"doi-ngu": true, "doingu": true,
+		"조직도": true, "임직원": true,
 	}
-	// vi: lien he = "contact". ko: 연락처 = "contact details", 오시는길 =
-	// "how to find us", which is where a Korean site prints its address.
-	contactWords = []string{
-		"kontakt", "contact",
-		"lien-he", "lienhe",
-		"연락처", "오시는길",
+	// vi: lien he = "contact". ko: 연락처 = "contact details", 오시는길 = "how to
+	// find us", which is where a Korean site prints its address.
+	contactSegments = map[string]bool{
+		"lien-he": true, "lienhe": true,
+		"연락처": true, "오시는길": true,
 	}
 )
+
+// namedSegment matches a path segment against one of the whole-word sets,
+// tolerating the file extension a static site appends: the corpus publishes
+// both `lien-he` and `lien-he.html`, and both name the same page.
+//
+// It also accepts `<word>-<company name>`, which is the one qualifier a real
+// about page carries — `gioi-thieu-han-my-viet`, `gioi-thieu-ve-tth-automation`
+// — recognised by matching the site's own host label rather than by guessing
+// at Vietnamese grammar.
+func namedSegment(segment, host string, words map[string]bool) bool {
+	segment = strings.TrimSuffix(strings.TrimSuffix(segment, ".html"), ".htm")
+	if words[segment] {
+		return true
+	}
+	label := hostLabel(host)
+	if label == "" {
+		return false
+	}
+	// Compared with the hyphens removed from BOTH sides, because a path spells
+	// a company name in words where the domain runs them together:
+	// hanmyviet.vn publishes /gioi-thieu-han-my-viet.
+	flat := strings.ReplaceAll(segment, "-", "")
+	label = strings.ReplaceAll(label, "-", "")
+	for word := range words {
+		word = strings.ReplaceAll(word, "-", "")
+		if flat == word+label || flat == word+"ve"+label {
+			return true
+		}
+	}
+	return false
+}
+
+// hostLabel is the site's own name as a path would spell it: the registrable
+// label with its dots turned into hyphens, so han-my-viet.vn yields
+// "han-my-viet" and tth-automation.com yields "tth-automation".
+func hostLabel(host string) string {
+	host = strings.ToLower(host)
+	if h, _, ok := strings.Cut(host, ":"); ok {
+		host = h
+	}
+	host = strings.TrimPrefix(host, "www.")
+	label, _, _ := strings.Cut(host, ".")
+	return label
+}
 
 // classifyKind names what a discovered page probably is, from its path alone.
 // Keyword order mirrors the probe list; the first family that matches wins.
@@ -309,11 +372,14 @@ func classifyKind(rawURL string) crmcontracts.SiteReadPageKind {
 	switch {
 	case legalIdentityPath(rawURL):
 		return crmcontracts.SiteReadPageKindImpressum
-	case shallow && containsAny(first, aboutWords...):
+	case shallow && (containsAny(first, "about", "ueber") ||
+		namedSegment(first, parsed.Host, aboutSegments)):
 		return crmcontracts.SiteReadPageKindAbout
-	case shallow && containsAny(first, teamWords...):
+	case shallow && (containsAny(first, "team", "leadership") ||
+		namedSegment(first, parsed.Host, teamSegments)):
 		return crmcontracts.SiteReadPageKindTeam
-	case shallow && containsAny(first, contactWords...):
+	case shallow && (containsAny(first, "kontakt", "contact") ||
+		namedSegment(first, parsed.Host, contactSegments)):
 		return crmcontracts.SiteReadPageKindContact
 	case containsAny(first, "service", "leistung", "solution", "loesung", "lösung"):
 		return crmcontracts.SiteReadPageKindServices

--- a/backend/internal/compose/sitecrawlrank.go
+++ b/backend/internal/compose/sitecrawlrank.go
@@ -244,6 +244,52 @@ func normalizeCandidate(rawURL string) (string, bool) {
 	return parsed.String(), true
 }
 
+// The words a path uses to name its about, team and contact pages.
+//
+// German and English only, until this: a Vietnamese site mounts the same page
+// at /gioi-thieu and a Korean one at /회사소개, and neither matched, so both were
+// classified `other` and the reader never looked for staff on them. It is not
+// a small effect on a dataset with an Asian half — vinatechgroup.vn names its
+// chairman on /gioi-thieu, and the only page that DID classify was the English
+// /en/about-us, which names nobody. The company then read as publishing no
+// staff at all.
+//
+// Matched with containsAny, which is a substring test, so `gioi-thieu` also
+// catches `gioi-thieu-cong-ty` and `gioi-thieu-ve-tth-automation` — both real
+// paths in the corpus.
+//
+// Deliberately NOT here: `company` and `info`. Both appear as ordinary product
+// and section words far more often than as an about page, and a false `about`
+// costs more than a missed one — the profile lane spends its page budget on
+// what this function names, so a wrong classification starves the commercial
+// evidence rather than merely failing to help. That is the same argument
+// legalNoticeSegments makes for keeping contact and about out of the LEGAL
+// gate, applied one level down.
+var (
+	// vi: gioi thieu = "introduction", ve chung toi = "about us".
+	// ko: 회사소개 = "company introduction", 인사말 = "greeting" (the
+	// chairman's-letter page Korean corporate sites use for the same purpose).
+	aboutWords = []string{
+		"about", "ueber",
+		"gioi-thieu", "gioithieu", "ve-chung-toi", "introduce",
+		"회사소개", "인사말",
+	}
+	// vi: doi ngu = "the team", nhan su = "personnel".
+	// ko: 임직원 = "executives and staff", 조직도 = "org chart".
+	teamWords = []string{
+		"team", "leadership",
+		"doi-ngu", "doingu", "nhan-su", "nhansu",
+		"임직원", "조직도",
+	}
+	// vi: lien he = "contact". ko: 연락처 = "contact details", 오시는길 =
+	// "how to find us", which is where a Korean site prints its address.
+	contactWords = []string{
+		"kontakt", "contact",
+		"lien-he", "lienhe",
+		"연락처", "오시는길",
+	}
+)
+
 // classifyKind names what a discovered page probably is, from its path alone.
 // Keyword order mirrors the probe list; the first family that matches wins.
 func classifyKind(rawURL string) crmcontracts.SiteReadPageKind {
@@ -263,11 +309,11 @@ func classifyKind(rawURL string) crmcontracts.SiteReadPageKind {
 	switch {
 	case legalIdentityPath(rawURL):
 		return crmcontracts.SiteReadPageKindImpressum
-	case shallow && containsAny(first, "about", "ueber"):
+	case shallow && containsAny(first, aboutWords...):
 		return crmcontracts.SiteReadPageKindAbout
-	case shallow && containsAny(first, "team", "leadership"):
+	case shallow && containsAny(first, teamWords...):
 		return crmcontracts.SiteReadPageKindTeam
-	case shallow && containsAny(first, "kontakt", "contact"):
+	case shallow && containsAny(first, contactWords...):
 		return crmcontracts.SiteReadPageKindContact
 	case containsAny(first, "service", "leistung", "solution", "loesung", "lösung"):
 		return crmcontracts.SiteReadPageKindServices

--- a/backend/internal/compose/sitecrawlrank_test.go
+++ b/backend/internal/compose/sitecrawlrank_test.go
@@ -52,6 +52,52 @@ func TestClassifyKindDoesNotPromoteGuidesBecauseTheirSlugsMentionTeamsOrProducts
 	}
 }
 
+// Every URL here is a real path from the demo corpus, and every one of them
+// classified `other` before the Vietnamese and Korean words were added — so the
+// reader never looked for staff on any of them. vinatechgroup.vn is the case
+// that shows what it cost: it names its chairman on /gioi-thieu, the only page
+// that DID classify was the English /en/about-us, and that page names nobody,
+// so the company read as publishing no staff at all.
+func TestClassifyKindReadsVietnameseAndKoreanPageNames(t *testing.T) {
+	for rawURL, want := range map[string]crmcontracts.SiteReadPageKind{
+		"https://vinatechgroup.vn/gioi-thieu":                          crmcontracts.SiteReadPageKindAbout,
+		"https://thinksmart.com.vn/gioi-thieu":                         crmcontracts.SiteReadPageKindAbout,
+		"https://tinthanhphat.vn/gioi-thieu/gioi-thieu-cong-ty/":       crmcontracts.SiteReadPageKindAbout,
+		"https://tth-automation.com/gioi-thieu-ve-tth-automation.html": crmcontracts.SiteReadPageKindAbout,
+		"https://vinatechgroup.vn/en/introduce":                        crmcontracts.SiteReadPageKindAbout,
+		"https://itgtechnology.vn/lien-he/":                            crmcontracts.SiteReadPageKindContact,
+		"https://aubot.vn/vi/lien-he/":                                 crmcontracts.SiteReadPageKindContact,
+		"https://tth-automation.com/lien-he.html":                      crmcontracts.SiteReadPageKindContact,
+		// Korean sites percent-encode Hangul in links; url.Parse decodes it
+		// into Path, so both spellings have to land in the same place.
+		"https://example.co.kr/회사소개":                                 crmcontracts.SiteReadPageKindAbout,
+		"https://example.co.kr/%ED%9A%8C%EC%82%AC%EC%86%8C%EA%B0%9C": crmcontracts.SiteReadPageKindAbout,
+		"https://example.co.kr/임직원":                                  crmcontracts.SiteReadPageKindTeam,
+		"https://example.co.kr/연락처":                                  crmcontracts.SiteReadPageKindContact,
+	} {
+		if got := classifyKind(rawURL); got != want {
+			t.Errorf("classifyKind(%q) = %q, want %q", rawURL, got, want)
+		}
+	}
+}
+
+// The widened vocabulary must not start naming ordinary pages. `company` and
+// `info` are kept out for exactly this reason: the profile lane spends its page
+// budget on what classifyKind names, so a false `about` starves the commercial
+// evidence rather than merely failing to help.
+func TestClassifyKindStillRefusesOrdinaryPagesInEveryLanguage(t *testing.T) {
+	for _, rawURL := range []string{
+		"https://example.vn/san-pham/gioi-thieu-san-pham-moi",
+		"https://example.com/company",
+		"https://example.com/info",
+		"https://example.co.kr/news/2026",
+	} {
+		if got := classifyKind(rawURL); got != crmcontracts.SiteReadPageKindOther {
+			t.Errorf("classifyKind(%q) = %q, want other", rawURL, got)
+		}
+	}
+}
+
 func TestProfileEvidenceReadyRequiresCommercialPages(t *testing.T) {
 	pages := make([]crawlPage, profileTriggerNonLegalPages+12)
 	for i := range pages {

--- a/backend/internal/compose/sitecrawlrank_test.go
+++ b/backend/internal/compose/sitecrawlrank_test.go
@@ -60,14 +60,16 @@ func TestClassifyKindDoesNotPromoteGuidesBecauseTheirSlugsMentionTeamsOrProducts
 // so the company read as publishing no staff at all.
 func TestClassifyKindReadsVietnameseAndKoreanPageNames(t *testing.T) {
 	for rawURL, want := range map[string]crmcontracts.SiteReadPageKind{
-		"https://vinatechgroup.vn/gioi-thieu":                          crmcontracts.SiteReadPageKindAbout,
-		"https://thinksmart.com.vn/gioi-thieu":                         crmcontracts.SiteReadPageKindAbout,
-		"https://tinthanhphat.vn/gioi-thieu/gioi-thieu-cong-ty/":       crmcontracts.SiteReadPageKindAbout,
+		"https://vinatechgroup.vn/gioi-thieu":                    crmcontracts.SiteReadPageKindAbout,
+		"https://thinksmart.com.vn/gioi-thieu":                   crmcontracts.SiteReadPageKindAbout,
+		"https://tinthanhphat.vn/gioi-thieu/gioi-thieu-cong-ty/": crmcontracts.SiteReadPageKindAbout,
+		// The one qualifier a real about page carries is the site's OWN name,
+		// matched against the host rather than guessed at as grammar.
 		"https://tth-automation.com/gioi-thieu-ve-tth-automation.html": crmcontracts.SiteReadPageKindAbout,
-		"https://vinatechgroup.vn/en/introduce":                        crmcontracts.SiteReadPageKindAbout,
+		"https://hanmyviet.vn/gioi-thieu-han-my-viet.html":             crmcontracts.SiteReadPageKindAbout,
+		"https://tth-automation.com/lien-he.html":                      crmcontracts.SiteReadPageKindContact,
 		"https://itgtechnology.vn/lien-he/":                            crmcontracts.SiteReadPageKindContact,
 		"https://aubot.vn/vi/lien-he/":                                 crmcontracts.SiteReadPageKindContact,
-		"https://tth-automation.com/lien-he.html":                      crmcontracts.SiteReadPageKindContact,
 		// Korean sites percent-encode Hangul in links; url.Parse decodes it
 		// into Path, so both spellings have to land in the same place.
 		"https://example.co.kr/회사소개":                                 crmcontracts.SiteReadPageKindAbout,
@@ -81,16 +83,34 @@ func TestClassifyKindReadsVietnameseAndKoreanPageNames(t *testing.T) {
 	}
 }
 
-// The widened vocabulary must not start naming ordinary pages. `company` and
-// `info` are kept out for exactly this reason: the profile lane spends its page
-// budget on what classifyKind names, so a false `about` starves the commercial
-// evidence rather than merely failing to help.
+// The widened vocabulary must not start naming ordinary pages, and every URL
+// here is one the FIRST version of it got wrong — matched as a substring
+// anywhere in the leading segment rather than as a prefix of it.
+//
+// They are in the first path segment on purpose: classifyKind only ever looks
+// at that one, so a case built from a two-segment path passes without
+// exercising the match at all. That was the bug in this test before it was the
+// bug in the code.
+//
+// A false `about` costs more than a missed one: the profile lane spends a
+// limited page budget on what classifyKind names, so a wrong classification
+// starves the commercial evidence rather than merely failing to help.
 func TestClassifyKindStillRefusesOrdinaryPagesInEveryLanguage(t *testing.T) {
 	for _, rawURL := range []string{
-		"https://example.vn/san-pham/gioi-thieu-san-pham-moi",
+		// "introducing our new PRODUCT", not an about page.
+		"https://example.vn/gioi-thieu-san-pham-moi",
+		// A press release. `introduce` is an English verb before it is a page.
+		"https://example.com/acme-introduces-widget",
+		// Staff BENEFITS, not a staff directory.
+		"https://example.co.kr/임직원복지",
+		// A new-year greeting, not the chairman's introduction.
+		"https://example.co.kr/신년인사말",
+		// A product name that happens to contain "lienhe".
+		"https://example.com/alienhero",
+		// Ordinary section words, deliberately never in the lists.
 		"https://example.com/company",
 		"https://example.com/info",
-		"https://example.co.kr/news/2026",
+		"https://example.co.kr/news",
 	} {
 		if got := classifyKind(rawURL); got != crmcontracts.SiteReadPageKindOther {
 			t.Errorf("classifyKind(%q) = %q, want other", rawURL, got)


### PR DESCRIPTION
`classifyKind` matched German and English path words only, so a Vietnamese site's
`/gioi-thieu` and a Korean site's `/회사소개` were classified `other` — and the
site reader never looked for staff on them.

On a dataset with an Asian half that is not a small effect. Across the demo
corpus, **23 Vietnamese about and contact pages over 12 companies all classified
`other`**. `vinatechgroup.vn` shows the cost: it names its chairman on
`/gioi-thieu`, the only page that DID classify was the English `/en/about-us`,
and that page names nobody — so the company read as publishing no staff at all,
and the demo dataset invented some for it.

## Matched whole, not as a substring

The added words are matched against the whole segment. A substring test on them
is demonstrably wrong, and a prefix test does not save it: Vietnamese names what
it is introducing directly after the verb, so `gioi-thieu-cong-ty` ("the
company") and `gioi-thieu-san-pham` ("the product") share every leading
character that matters.

Two tolerances the corpus requires: a trailing `.html`, and the site's own name
as a qualifier (`/gioi-thieu-ve-tth-automation`, and `/gioi-thieu-han-my-viet`
on a host spelled `hanmyviet.vn` — hence the hyphen-insensitive comparison).

The German and English words are untouched and stay on `containsAny`.

`introduce`, `nhan-su` and `인사말` are deliberately excluded: the first is an
English verb before it is a page name, the other two name a subject rather than
a staff directory.

## Review

Codex found five false positives in the first version and a sixth in its own
test — the test built its cases from two-segment paths, and `classifyKind` only
reads the first segment, so it passed without exercising a single match. All six
are fixed, and each now has a pinned case.

## Verification

`make check-backend` green. `make craft-static`, `make rls-store-path`,
`make no-jurisdiction` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes classification of Vietnamese and Korean about/team/contact pages by matching known path segments as whole words. Previously these pages were labeled other, so staff detection was skipped and profiles missed real people.

- Adds Vietnamese/Korean segment lists and a whole-segment matcher that tolerates .html/.htm and host-qualified variants (hyphen-insensitive).
- Keeps German/English substring rules unchanged; deliberately excludes ambiguous terms (“company”, “info”, “introduce”, “nhan-su”, “인사말”) to avoid false positives.
- Updates tests with real corpus URLs, including percent-encoded Hangul, and adds negative cases that exercise first-segment-only behavior.

<sup>Written for commit f4f8dab985cee013a0ea26997a3cbd07af4deee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

