### PR TITLE
fix(frontend): the composed workspace's install is not frozen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,10 +218,14 @@ fe-test-ext: composition
 	@# (pnpm-workspace.yaml says why), so without this a unit's screen resolves
 	@# neither its test renderer nor its peers at all.
 	@#
-	@# No --frozen-lockfile: this lockfile is GENERATED, under ignored build
-	@# output, and regenerating it is the point. The root install above keeps
+	@# --no-frozen-lockfile, and EXPLICITLY: this lockfile is GENERATED, under
+	@# ignored build output, and regenerating it is the point. Omitting the flag
+	@# relies on pnpm's default, which flips to frozen when CI=true — so a fresh
+	@# checkout passed while any environment that REUSES build/ failed with
+	@# ERR_PNPM_OUTDATED_LOCKFILE the moment the member set changed. That is a
+	@# persistent runner, or a laptop with CI set. The root install above keeps
 	@# --frozen-lockfile, which is the property this whole change buys.
-	cd build/composition-frontend/workspace && pnpm install
+	cd build/composition-frontend/workspace && pnpm install --no-frozen-lockfile
 	cd frontend && pnpm build && \
 		MARGINCE_COMPOSITION_FRONTEND=../build/composition/frontend pnpm test:ext
 
@@ -453,10 +457,14 @@ fe-typecheck-composed: composition
 	@# (pnpm-workspace.yaml says why), so without this a unit's screen resolves
 	@# neither its test renderer nor its peers at all.
 	@#
-	@# No --frozen-lockfile: this lockfile is GENERATED, under ignored build
-	@# output, and regenerating it is the point. The root install above keeps
+	@# --no-frozen-lockfile, and EXPLICITLY: this lockfile is GENERATED, under
+	@# ignored build output, and regenerating it is the point. Omitting the flag
+	@# relies on pnpm's default, which flips to frozen when CI=true — so a fresh
+	@# checkout passed while any environment that REUSES build/ failed with
+	@# ERR_PNPM_OUTDATED_LOCKFILE the moment the member set changed. That is a
+	@# persistent runner, or a laptop with CI set. The root install above keeps
 	@# --frozen-lockfile, which is the property this whole change buys.
-	cd build/composition-frontend/workspace && pnpm install
+	cd build/composition-frontend/workspace && pnpm install --no-frozen-lockfile
 	@[ -f build/composition/api/crm.yaml ] || { echo "fe-typecheck-composed: build/composition/api/crm.yaml is missing after 'make composition' — the composed lane has no merged contract to type the client against" >&2; exit 1; }
 	cd frontend && pnpm gen:composed-types
 	@[ -f build/composition-frontend/schema.d.ts ] || { echo "fe-typecheck-composed: pnpm gen:composed-types produced no schema.d.ts — the composed lane would silently typecheck against the committed contract" >&2; exit 1; }


### PR DESCRIPTION
## What

The lane that installs `build/composition-frontend/workspace` (added in #2230)
now passes `--no-frozen-lockfile` explicitly, in both `fe-test-ext` and
`fe-typecheck-composed`.

## Why

It relied on pnpm's default, and that default is not constant: it flips to frozen
when `CI` is set. So the install worked on a fresh checkout — which is CI's case,
and why #2230 went in green — and failed the moment anything **reused** the build
directory with a changed member set:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with ../../extensions/<unit>/frontend/package.json
```

That is a persistent runner, or a laptop with `CI` exported, or simply the second
run after a unit's dependencies change.

Nothing about the lockfile was wrong. The lane was asking pnpm to refuse to write
a file whose whole purpose is to be written: it is generated, it lives under
ignored build output, and regenerating it is the point. The **root** install keeps
`--frozen-lockfile`, which is the property the composed workspace exists to
protect.

## How verified

Made the generated lockfile stale the ordinary way — changed a unit's
`devDependencies` range — then ran the lane with `CI=true` both ways:

| | exit |
|---|---|
| without the flag | **2**, `ERR_PNPM_OUTDATED_LOCKFILE` |
| with the flag | **0** |

- [x] `make check` is green
- [x] `make test-integration` is green (unchanged from #2230; this touches no
      tenant data, RLS or write shape — it is one flag in two make recipes)
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by an agent (Claude) under human accountability. The defect was mine, in
#2230: I wrote a comment saying "no --frozen-lockfile" and then expressed it by
omitting the flag rather than passing it, which is only the same thing while `CI`
is unset. Found by running the lane the way a reused build directory does.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly passes `--no-frozen-lockfile` to `pnpm install` for the composed frontend workspace so its generated lockfile can update. Previously the install relied on `pnpm`’s default, which becomes frozen when `CI` is set; reused build directories failed with `ERR_PNPM_OUTDATED_LOCKFILE`. The root workspace keeps `--frozen-lockfile`.

- Applies to `fe-test-ext` and `fe-typecheck-composed` in `build/composition-frontend/workspace` (Makefile-only).
- No migration required; stabilizes installs in CI and on persistent runners.

<sup>Written for commit c651080ea0c1655f39378205115519b92354240e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated composed frontend setup to install dependencies without enforcing frozen lockfiles.
  * Root frontend installations continue using frozen lockfiles for consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->