### PR TITLE
chore(migration): repoint org references to margince/margince

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
       value: >-
         **Not for security findings.** A tenant-isolation, RBAC, agent-governance
         or authentication defect goes through
-        [private reporting](https://github.com/gradionhq/margince-poc-v1/security/advisories/new),
+        [private reporting](https://github.com/margince/margince/security/advisories/new),
         never a public issue — a public report before a fix ships puts every
         deployment at risk.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,17 +1,17 @@
 blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability (private)
-    url: https://github.com/gradionhq/margince-poc-v1/security/advisories/new
+    url: https://github.com/margince/margince/security/advisories/new
     about: >-
       Never file a vulnerability as a public issue. Report it privately through
       GitHub Security Advisories; see SECURITY.md for scope and what to include.
   - name: Read the documentation first
-    url: https://github.com/gradionhq/margince-poc-v1/blob/main/docs/README.md
+    url: https://github.com/margince/margince/blob/main/docs/README.md
     about: >-
       Tutorials, how-to guides, reference (make targets, configuration, the
       module map) and explanation. Most "how do I" questions are answered here.
   - name: How contributions are reviewed
-    url: https://github.com/gradionhq/margince-poc-v1/blob/main/CONTRIBUTING.md
+    url: https://github.com/margince/margince/blob/main/CONTRIBUTING.md
     about: >-
       The gates every change passes, DCO sign-off, AI disclosure, and the human
       accountability rule. Read this before opening a pull request.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ name: Release
 # parent commit only, however many commits landed since the last release. That
 # is a known gap, not a property worth relying on: the base belongs at the last
 # PUBLISHED release, which is
-# https://github.com/gradionhq/margince-poc-v1/issues/1798. Until that lands, a
+# https://github.com/margince/margince/issues/1798. Until that lands, a
 # dispatched release's patch describes one commit, and a consumer applying
 # patches in order cannot use this stream to move forward. Nothing consumes it
 # today, which is why this is recorded rather than blocking. The step below keeps
@@ -79,8 +79,11 @@ permissions:
 
 env:
   # The release-management CLI image, published :latest from constellation's
-  # main (gradionhq/margince-constellation). The pull authenticates with the
-  # job's default GITHUB_TOKEN (packages: read).
+  # main (gradionhq/margince-constellation). NOTE: since this repo moved to the
+  # margince org, the job's default GITHUB_TOKEN can NO LONGER read that package
+  # — it is private and owned by another organisation. A release dispatched
+  # before a cross-org PAT (read:packages on gradionhq) is wired into the three
+  # `docker login ghcr.io` steps below WILL FAIL at login.
   RELEASE_MANAGEMENT_IMAGE: ghcr.io/gradionhq/margince-constellation/release-management:latest
   # The dist service of the constellation deployment the release is drafted
   # into. The CLI reads this variable directly and refuses a non-https URL.
@@ -521,7 +524,7 @@ jobs:
           `data/admin-password` inside the folder.
 
           Configuration, updating in place, and troubleshooting:
-          [docs/how-to/build-the-desktop-app.md](https://github.com/gradionhq/margince-poc-v1/blob/main/docs/how-to/build-the-desktop-app.md)
+          [docs/how-to/build-the-desktop-app.md](https://github.com/margince/margince/blob/main/docs/how-to/build-the-desktop-app.md)
           NOTES
           sed -i "s/@VERSION@/$VERSION/g" notes.md
           printf '\nRevision: %s\n' "$REVISION" >> notes.md

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 
 # Default owner: without this, a PR touching anything not named below
 # requests no reviewer at all.
-*                                   @gradionhq/margince
+*                                   @margince/margince
 
 # The extension tier (ADR-0069) and every seam that defines it.
 /extensions/                        @lstrojny


### PR DESCRIPTION
First PR in the new home — doubles as the post-transfer smoke test.

- `CODEOWNERS` → `@margince/margince` (the team now exists and holds write)
- security-advisory / docs / contributing URLs repointed
- `release.yml` comment corrected: the default `GITHUB_TOKEN` can no longer pull the constellation image cross-org

**Not changed:** `sonar-project.properties` — the SonarCloud project has not been recreated, so repointing the key would break the scan.

**Do not dispatch a release** until a cross-org PAT with `read:packages` is wired into the three `docker login ghcr.io` steps.