### PR TITLE
chore(sonar): repoint the scan at margince_margince

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Read main's quality gate
         id: gate
         env:
-          PROJECT_KEY: gradionhq_margince-poc-v1
+          PROJECT_KEY: margince_margince
         run: |
           set -euo pipefail
           if [ -z "${SONAR_TOKEN:-}" ]; then

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-# SonarCloud analysis scope (project gradionhq_margince-poc-v1).
+# SonarCloud analysis scope (project margince_margince).
 # Read by the CI-based scan (the `sonarcloud` job in .github/workflows/ci.yml),
 # NOT by Automatic Analysis — disable Automatic Analysis in the dashboard
 # (project → Administration → Analysis Method) so the two do not compete. The
@@ -7,8 +7,8 @@
 # app cannot produce (Automatic Analysis runs no tests → a false 0%). This
 # narrows the quality signal to hand-written product code — not generated
 # files, append-only DDL, dev tooling, or test scaffolding.
-sonar.projectKey=gradionhq_margince-poc-v1
-sonar.organization=gradion
+sonar.projectKey=margince_margince
+sonar.organization=margince
 
 # --- Which files are TypeScript at all. Stated here, not left to the server.
 # This is the instance default; it is spelled out because the SonarCloud PROJECT


### PR DESCRIPTION
Follows the org migration. The SonarCloud project key is derived from the GitHub org, so the move orphaned `gradionhq_margince-poc-v1`.

| | from | to |
|---|---|---|
| `sonar.projectKey` | `gradionhq_margince-poc-v1` | `margince_margince` |
| `sonar.organization` | `gradion` | `margince` |
| `scheduled.yml` `PROJECT_KEY` | `gradionhq_margince-poc-v1` | `margince_margince` |

**Prerequisites before merging:**
- [ ] `SONAR_TOKEN` updated to a token valid for the new org
- [ ] **Automatic Analysis DISABLED** on the new project (Administration → Analysis Method)

Historical trend data stays with the old project by decision — the quality-gate baseline restarts here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repoints SonarCloud analysis from `gradionhq_margince-poc-v1` in `gradion` to `margince_margince` in `margince` after the GitHub org migration. CI scans now target the new project; historical trends remain on the old project and the quality-gate baseline restarts.

**Rollout**
- Update `SONAR_TOKEN` to a token valid for the `margince` org.
- Disable Automatic Analysis for `margince_margince` (Administration → Analysis Method) so only the CI scan runs.

<sup>Written for commit 48beea0f92c15921521c951e8265d1c8d5f9dbf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated SonarCloud project configuration to use the current project and organization settings.
  * Updated scheduled quality-gate checks to reference the correct SonarCloud project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->