### PR TITLE
fix(offlinedemo): the generated mail is written in the account's own language

### DIFF
--- a/backend/internal/modules/capture/offlinedemo/generate.go
+++ b/backend/internal/modules/capture/offlinedemo/generate.go
@@ -205,66 +205,43 @@ type threadSpec struct {
 
 // threadsFor picks the conversations an account's own state calls for.
 func threadsFor(account Account) []threadSpec {
+	locale := localeOf(account.Domain)
+	words := wordsFor(locale)
+	// One helper so every spec below states only what differs. The subject and
+	// the body come from the same locale, which is what stops a German subject
+	// wrapping a Korean company name — the shape this generator shipped with.
+	spec := func(key, subject string, opener string, replies, dayStart int,
+		deal, meeting bool,
+	) threadSpec {
+		return threadSpec{
+			Key: key, Subject: subject, Opener: opener, Replies: replies,
+			DayStart: dayStart, Deal: deal, Meeting: meeting,
+			Body: bodiesFor(locale, key),
+		}
+	}
+
 	stage := strings.ToLower(dealStage(account))
 	switch {
 	case account.Lifecycle == "customer":
 		return []threadSpec{
-			{
-				Key: "kickoff", Subject: "Kickoff " + account.Name, Opener: directionOutbound, Replies: 2,
-				DayStart: 20, Deal: true, Meeting: true, Body: [3]string{
-					"vielen Dank für Ihr Vertrauen. Anbei der Terminvorschlag für den Kickoff.",
-					"passt uns gut, wir bringen die Fachbereiche mit.",
-					"prima, Einladung ist raus. Agenda hängt an.",
-				},
-			},
-			{
-				Key: "invoice", Subject: "Rechnung " + orDash(account.ContractNumber), Opener: directionInbound, Replies: 1,
-				DayStart: 60, Body: [3]string{
-					"kurze Rückfrage zur letzten Rechnung — ist die Position 3 anteilig berechnet?",
-					"ja, anteilig bis zum Periodenende. Ich schicke die Aufstellung mit.", "",
-				},
-			},
+			spec(threadKickoff, words.Kickoff+" "+account.Name, directionOutbound, 2, 20, true, true),
+			spec(threadInvoice, words.Invoice+" "+orDash(account.ContractNumber), directionInbound, 1, 60, false, false),
 		}
 	case account.Lifecycle == "former_customer":
 		return []threadSpec{
-			{
-				Key: "offboarding", Subject: "Kündigung bestätigt", Opener: directionOutbound, Replies: 1,
-				DayStart: 30, Body: [3]string{
-					"wir bestätigen den Eingang Ihrer Kündigung zum Ende der Laufzeit.",
-					"danke für die Bestätigung und die Zusammenarbeit.", "",
-				},
-			},
+			spec(threadOffboarding, words.Offboarding, directionOutbound, 1, 30, false, false),
 		}
 	case stage == "proposal" || stage == "negotiation":
 		return []threadSpec{
-			{
-				Key: "offer", Subject: "Angebot " + account.Name, Opener: directionOutbound, Replies: 2,
-				DayStart: 10, Deal: true, Meeting: true, Body: [3]string{
-					"anbei unser Angebot wie besprochen. Die Staffel greift ab 50 Lizenzen.",
-					"danke — zwei Rückfragen zur Laufzeit und zum Support-Level.",
-					"beides gerne im Termin, Vorschlag hängt an.",
-				},
-			},
+			spec(threadOffer, words.Offer+" "+account.Name, directionOutbound, 2, 10, true, true),
 		}
 	case stage != "":
 		return []threadSpec{
-			{
-				Key: "intro", Subject: "Kurzer Austausch?", Opener: directionOutbound, Replies: 1,
-				DayStart: 5, Deal: true, Body: [3]string{
-					"wir arbeiten mit mehreren Häusern Ihrer Größe — lohnt ein kurzer Austausch?",
-					"gerne, schicken Sie ein paar Slots.", "",
-				},
-			},
+			spec(threadIntro, words.Intro, directionOutbound, 1, 5, true, false),
 		}
 	case account.Lifecycle == "prospect":
 		return []threadSpec{
-			{
-				Key: directionInbound, Subject: "Anfrage über die Website", Opener: directionInbound, Replies: 1,
-				DayStart: 8, Body: [3]string{
-					"wir prüfen gerade Anbieter und würden gerne mehr erfahren.",
-					"sehr gerne — ich melde mich mit zwei Terminvorschlägen.", "",
-				},
-			},
+			spec(threadInbound, words.Enquiry, directionInbound, 1, 8, false, false),
 		}
 	default:
 		// A target nobody has worked. Most get nothing, which is the honest
@@ -273,12 +250,7 @@ func threadsFor(account Account) []threadSpec {
 			return nil
 		}
 		return []threadSpec{
-			{
-				Key: "cold", Subject: "Kurze Frage zu Ihrem Shop", Opener: directionOutbound, Replies: 0,
-				DayStart: 12, Body: [3]string{
-					"eine kurze Frage zu Ihrer Plattform — haben Sie zehn Minuten?", "", "",
-				},
-			},
+			spec(threadCold, words.Cold, directionOutbound, 0, 12, false, false),
 		}
 	}
 }
@@ -321,8 +293,9 @@ func writeThread(mailbox Mailbox, account Account, contact Person, anchor time.T
 	if spec.Meeting {
 		occurred = occurred.AddDate(0, 0, 5)
 		id := fmt.Sprintf("<%s.meet@offline-demo.invalid>", base)
+		words := wordsFor(localeOf(account.Domain))
 		meeting := newMessage(mailbox, account, contact, id, openerID, "",
-			"Termin: "+spec.Subject, "Abstimmung, 45 Minuten, per Video.",
+			words.Meeting+": "+spec.Subject, words.MeetingBody,
 			occurred, "", "meeting", dealID)
 		out = append(out, meeting)
 	}
@@ -338,10 +311,12 @@ func newMessage(mailbox Mailbox, account Account, contact Person,
 	if direction == directionInbound {
 		from, fromName, to, toName = contact.Email, contact.Name, mailbox.Email, mailbox.DisplayName
 	}
-	greeting := "Hallo " + firstWord(contact.Name) + ","
+	words := wordsFor(localeOf(account.Domain))
+	addressee := firstWord(contact.Name)
 	if direction == directionInbound {
-		greeting = "Hallo " + firstWord(mailbox.DisplayName) + ","
+		addressee = firstWord(mailbox.DisplayName)
 	}
+	greeting := words.Greeting(addressee)
 	cc := ""
 	// A CC on some threads, so the participant fan-out has more than two
 	// parties to record.
@@ -350,7 +325,7 @@ func newMessage(mailbox Mailbox, account Account, contact Person,
 	}
 	return message{
 		Mailbox: mailbox, MessageID: id, ThreadKey: threadKey, InReplyTo: inReplyTo,
-		Subject: subject, Body: greeting + "\n\n" + body + "\n\nViele Grüße",
+		Subject: subject, Body: greeting + "\n\n" + body + "\n\n" + words.SignOff,
 		OccurredAt: occurred.UTC(), Direction: direction, Kind: kind,
 		FromAddr: from, FromName: fromName, ToAddr: to, ToName: toName, CCAddr: cc,
 		OrgID: account.OrganizationID, DealID: dealID, PersonEmail: contact.Email,

--- a/backend/internal/modules/capture/offlinedemo/generate.go
+++ b/backend/internal/modules/capture/offlinedemo/generate.go
@@ -316,7 +316,15 @@ func newMessage(mailbox Mailbox, account Account, contact Person,
 	if direction == directionInbound {
 		addressee = firstWord(mailbox.DisplayName)
 	}
-	greeting := words.Greeting(addressee)
+	// A nameless addressee would render " 님께," with a leading space in Korean
+	// and "Hallo ," in German. The compose directory filters out people with no
+	// name, so this is a guard on the Directory CONTRACT rather than on the one
+	// implementation, and it drops the salutation line rather than greeting
+	// nobody.
+	greeting := ""
+	if addressee != "" {
+		greeting = words.Greeting(addressee) + "\n\n"
+	}
 	cc := ""
 	// A CC on some threads, so the participant fan-out has more than two
 	// parties to record.
@@ -325,7 +333,7 @@ func newMessage(mailbox Mailbox, account Account, contact Person,
 	}
 	return message{
 		Mailbox: mailbox, MessageID: id, ThreadKey: threadKey, InReplyTo: inReplyTo,
-		Subject: subject, Body: greeting + "\n\n" + body + "\n\n" + words.SignOff,
+		Subject: subject, Body: greeting + body + "\n\n" + words.SignOff,
 		OccurredAt: occurred.UTC(), Direction: direction, Kind: kind,
 		FromAddr: from, FromName: fromName, ToAddr: to, ToName: toName, CCAddr: cc,
 		OrgID: account.OrganizationID, DealID: dealID, PersonEmail: contact.Email,

--- a/backend/internal/modules/capture/offlinedemo/locale.go
+++ b/backend/internal/modules/capture/offlinedemo/locale.go
@@ -23,10 +23,22 @@ package offlinedemo
 // without one importing the other.
 //
 // The disagreement that matters is deliberate. company-locale.json marks Korean
-// companies `en`, because that is what their WEBSITES publish — and the site
-// reader is what that file serves. Correspondence is a different question: you
-// write to a Korean agency in Korean. Hence localeKO here and no localeKO
-// there, and the seeder's file is not wrong for lacking it.
+// companies `en`, because that is what their WEBSITES publish. That file drives
+// the account's PAPER — contract PDFs, NDAs, price lists — where English is the
+// right answer for a Korean firm that publishes in English.
+//
+// Correspondence is a different question: you write to a Korean agency in
+// Korean. So a `.kr` account can hold English paper and Korean mail, which is
+// what those accounts genuinely look like rather than an inconsistency. Hence
+// localeKO here and no localeKO there, and the seeder's file is not wrong for
+// lacking it.
+//
+// KNOWN GAP, tracked as issue #2263: a Vietnamese or Korean company on a `.com`
+// still reads as German here, because a suffix cannot see what a hand-checked
+// file knows. Nine of the dataset's 21 Vietnamese companies are affected,
+// fpt-is.com and vuletech.com among them. Closing it means carrying the
+// locale to the worker through the database, which is a wider change than a
+// vocabulary.
 
 import "strings"
 
@@ -165,16 +177,18 @@ func wordsFor(locale docLocale) templateWords {
 // body map, and in the message ids — goconst is right that a typo in one of
 // those places would be a silent miss rather than a compile error.
 //
-// threadInbound is deliberately the same string as directionInbound: the
-// prospect thread is keyed by the direction it opens in, which is how it was
-// written before the languages were split out.
+// threadInbound carries its own literal even though it currently equals
+// directionInbound. The key is part of the MESSAGE ID and so is persistent
+// identity: aliasing it to an activity-enum spelling would mean a rename of
+// that enum silently re-keyed every prospect thread, past the natural key and
+// into a duplicate conversation.
 const (
 	threadKickoff     = "kickoff"
 	threadInvoice     = "invoice"
 	threadOffboarding = "offboarding"
 	threadOffer       = "offer"
 	threadIntro       = "intro"
-	threadInbound     = directionInbound
+	threadInbound     = "inbound"
 	threadCold        = "cold"
 )
 
@@ -235,13 +249,42 @@ var threadBodies = map[docLocale]map[string][3]string{
 		},
 		threadIntro: {
 			"chúng tôi đang làm việc với một số doanh nghiệp cùng quy mô — anh/chị có muốn trao đổi ngắn không?",
-			"vâng, anh gửi giúp vài khung giờ.", "",
+			"vâng, nhờ anh/chị gửi giúp vài khung giờ.", "",
 		},
 		threadInbound: {
 			"chúng tôi đang tìm hiểu các nhà cung cấp và muốn biết thêm thông tin.",
 			"rất sẵn lòng — tôi sẽ gửi hai đề xuất lịch họp.", "",
 		},
 		threadCold: {"một câu hỏi ngắn về hệ thống của quý công ty — anh/chị có mười phút không?", "", ""},
+	},
+	localeEN: {
+		threadKickoff: {
+			"thank you for your trust. Attached is a proposed date for the kickoff.",
+			"that works for us, we will bring the technical team.",
+			"good — the invitation is out and the agenda is attached.",
+		},
+		threadInvoice: {
+			"a quick question on the last invoice — is line 3 billed pro rata?",
+			"yes, pro rata to the end of the period. I am attaching the breakdown.", "",
+		},
+		threadOffboarding: {
+			"we confirm receipt of your cancellation at the end of the term.",
+			"thank you for confirming, and for the work together.", "",
+		},
+		threadOffer: {
+			"attached is our offer as discussed. The volume tier starts at 50 licences.",
+			"thank you — two questions, on the term and on the support level.",
+			"both are worth covering in the meeting; a proposal is attached.",
+		},
+		threadIntro: {
+			"we work with several companies of your size — is a short conversation worth it?",
+			"happy to. Send a few slots.", "",
+		},
+		threadInbound: {
+			"we are evaluating suppliers at the moment and would like to know more.",
+			"gladly — I will come back with two proposed times.", "",
+		},
+		threadCold: {"a quick question about your platform — do you have ten minutes?", "", ""},
 	},
 	localeKO: {
 		threadKickoff: {

--- a/backend/internal/modules/capture/offlinedemo/locale.go
+++ b/backend/internal/modules/capture/offlinedemo/locale.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package offlinedemo
+
+// What language the generated correspondence is written in.
+//
+// It was German for everybody, and the subject line was built by concatenating
+// a German word onto the account's own name — so a Korean government agency
+// received "Kickoff 중소기업기술정보진흥원" with a German body and "Viele Grüße"
+// at the bottom. 44 of the 235 generated activities in the demo were German
+// mail sent to Vietnamese and Korean accounts.
+//
+// That is not a translation nicety. The demo dataset exists to be shown in
+// Hanoi and Seoul, and a Vietnamese manufacturer reading German boilerplate is
+// the one thing it cannot survive being.
+//
+// DERIVED FROM THE DOMAIN, not configured. The seeder has its own localeFor in
+// tools/seed-demo/locale.go, reading datasets/v1/company-locale.json — but that
+// runs in the seeder binary against a dataset directory, and this runs in the
+// WORKER, which has neither. The domain is what both have, and it is already on
+// the Account. So the two answer the same question from the same evidence
+// without one importing the other.
+//
+// The disagreement that matters is deliberate. company-locale.json marks Korean
+// companies `en`, because that is what their WEBSITES publish — and the site
+// reader is what that file serves. Correspondence is a different question: you
+// write to a Korean agency in Korean. Hence localeKO here and no localeKO
+// there, and the seeder's file is not wrong for lacking it.
+
+import "strings"
+
+// docLocale is the language one account's correspondence is written in.
+type docLocale string
+
+const (
+	localeDE docLocale = "de"
+	localeVI docLocale = "vi"
+	localeKO docLocale = "ko"
+	localeEN docLocale = "en"
+)
+
+// localeOf reads the correspondence language off the domain.
+//
+// The suffix is the whole rule here, unlike the seeder's, which consults a
+// hand-checked file. That is a smaller claim and the right one for a fallback:
+// this only decides the language of GENERATED filler, and a company whose
+// domain says nothing gets German, which is the dataset's own majority.
+//
+// A `.com` Korean or Vietnamese company therefore reads as German here and is
+// correct in the seeder. That gap is closed by scripting the account's threads
+// rather than by teaching a suffix table to guess — a guess that is wrong for a
+// fifth of the Automation World list, which is exactly why the seeder stopped
+// guessing and read a file instead.
+func localeOf(domain string) docLocale {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	switch {
+	case strings.HasSuffix(domain, ".vn"), strings.HasSuffix(domain, ".com.vn"):
+		return localeVI
+	case strings.HasSuffix(domain, ".kr"), strings.HasSuffix(domain, ".co.kr"),
+		strings.HasSuffix(domain, ".or.kr"):
+		return localeKO
+	default:
+		return localeDE
+	}
+}
+
+// templateWords is every phrase the generator wraps a message body in.
+//
+// A struct rather than a map keyed by string, for the same reason
+// seed-demo/locale.go's contractWords is one: a missing phrase is then a
+// compile error instead of an empty line in a mail nobody proofreads.
+type templateWords struct {
+	// Hello is the salutation, taking the name it addresses. A function
+	// because the name's POSITION differs: German and English lead with the
+	// greeting, Korean appends an honorific to the name itself.
+	Hello func(name string) string
+	// SignOff closes the message.
+	SignOff string
+	// Kickoff, Invoice, Offboarding, Intro, Enquiry and Cold are the subject
+	// lines, and Meeting prefixes a calendar entry.
+	Kickoff     string
+	Invoice     string
+	Offer       string
+	Offboarding string
+	Intro       string
+	Enquiry     string
+	Cold        string
+	Meeting     string
+	// MeetingBody is the one-line body a calendar entry carries.
+	MeetingBody string
+}
+
+// Greeting is the salutation for one addressee.
+func (w templateWords) Greeting(name string) string { return w.Hello(name) }
+
+var vocabulary = map[docLocale]templateWords{
+	localeDE: {
+		Hello:       func(n string) string { return "Hallo " + n + "," },
+		SignOff:     "Viele Grüße",
+		Kickoff:     "Kickoff",
+		Invoice:     "Rechnung",
+		Offer:       "Angebot",
+		Offboarding: "Kündigung bestätigt",
+		Intro:       "Kurzer Austausch?",
+		Enquiry:     "Anfrage über die Website",
+		Cold:        "Kurze Frage zu Ihrem Shop",
+		Meeting:     "Termin",
+		MeetingBody: "Abstimmung, 45 Minuten, per Video.",
+	},
+	localeVI: {
+		Hello:       func(n string) string { return "Kính gửi " + n + "," },
+		SignOff:     "Trân trọng",
+		Kickoff:     "Họp khởi động",
+		Invoice:     "Hóa đơn",
+		Offer:       "Báo giá",
+		Offboarding: "Xác nhận chấm dứt hợp đồng",
+		Intro:       "Xin phép được trao đổi ngắn",
+		Enquiry:     "Liên hệ qua website",
+		Cold:        "Một câu hỏi ngắn về hệ thống của quý công ty",
+		Meeting:     "Lịch họp",
+		MeetingBody: "Trao đổi 45 phút, họp trực tuyến.",
+	},
+	localeKO: {
+		// Korean appends the honorific to the name rather than leading with a
+		// greeting word: "박준서 님께" is how the salutation is actually written.
+		Hello:       func(n string) string { return n + " 님께," },
+		SignOff:     "감사합니다",
+		Kickoff:     "착수 회의",
+		Invoice:     "청구서",
+		Offer:       "제안서",
+		Offboarding: "계약 종료 확인",
+		Intro:       "짧게 논의 가능하실까요",
+		Enquiry:     "홈페이지를 통한 문의",
+		Cold:        "귀사 시스템에 관한 짧은 문의",
+		Meeting:     "일정",
+		MeetingBody: "45분 화상 회의.",
+	},
+	localeEN: {
+		Hello:       func(n string) string { return "Hi " + n + "," },
+		SignOff:     "Best regards",
+		Kickoff:     "Kickoff",
+		Invoice:     "Invoice",
+		Offer:       "Offer",
+		Offboarding: "Cancellation confirmed",
+		Intro:       "A short conversation?",
+		Enquiry:     "Enquiry through the website",
+		Cold:        "A quick question about your platform",
+		Meeting:     "Meeting",
+		MeetingBody: "A 45-minute call, by video.",
+	},
+}
+
+// wordsFor is the vocabulary for a language, falling back to German rather
+// than to a zero struct — a message with a nil Hello would panic, and one with
+// blank phrases would read as a rendering bug rather than a missing language.
+func wordsFor(locale docLocale) templateWords {
+	if words, ok := vocabulary[locale]; ok {
+		return words
+	}
+	return vocabulary[localeDE]
+}
+
+// The thread keys, named once. They appear in threadsFor, in every language's
+// body map, and in the message ids — goconst is right that a typo in one of
+// those places would be a silent miss rather than a compile error.
+//
+// threadInbound is deliberately the same string as directionInbound: the
+// prospect thread is keyed by the direction it opens in, which is how it was
+// written before the languages were split out.
+const (
+	threadKickoff     = "kickoff"
+	threadInvoice     = "invoice"
+	threadOffboarding = "offboarding"
+	threadOffer       = "offer"
+	threadIntro       = "intro"
+	threadInbound     = directionInbound
+	threadCold        = "cold"
+)
+
+// threadBodies is what each thread SAYS, per language.
+//
+// Keyed by the threadSpec's own Key, so a thread added to threadsFor without a
+// translation is caught by bodiesFor's fallback rather than emitting an empty
+// message. The three entries are opener, reply, second reply — the same shape
+// threadSpec.Body has always had.
+var threadBodies = map[docLocale]map[string][3]string{
+	localeDE: {
+		threadKickoff: {
+			"vielen Dank für Ihr Vertrauen. Anbei der Terminvorschlag für den Kickoff.",
+			"passt uns gut, wir bringen die Fachbereiche mit.",
+			"prima, Einladung ist raus. Agenda hängt an.",
+		},
+		threadInvoice: {
+			"kurze Rückfrage zur letzten Rechnung — ist die Position 3 anteilig berechnet?",
+			"ja, anteilig bis zum Periodenende. Ich schicke die Aufstellung mit.", "",
+		},
+		threadOffboarding: {
+			"wir bestätigen den Eingang Ihrer Kündigung zum Ende der Laufzeit.",
+			"danke für die Bestätigung und die Zusammenarbeit.", "",
+		},
+		threadOffer: {
+			"anbei unser Angebot wie besprochen. Die Staffel greift ab 50 Lizenzen.",
+			"danke — zwei Rückfragen zur Laufzeit und zum Support-Level.",
+			"beides gerne im Termin, Vorschlag hängt an.",
+		},
+		threadIntro: {
+			"wir arbeiten mit mehreren Häusern Ihrer Größe — lohnt ein kurzer Austausch?",
+			"gerne, schicken Sie ein paar Slots.", "",
+		},
+		threadInbound: {
+			"wir prüfen gerade Anbieter und würden gerne mehr erfahren.",
+			"sehr gerne — ich melde mich mit zwei Terminvorschlägen.", "",
+		},
+		threadCold: {"eine kurze Frage zu Ihrer Plattform — haben Sie zehn Minuten?", "", ""},
+	},
+	localeVI: {
+		threadKickoff: {
+			"cảm ơn quý công ty đã tin tưởng. Chúng tôi xin gửi đề xuất lịch họp khởi động.",
+			"lịch này phù hợp với chúng tôi, chúng tôi sẽ mời thêm bộ phận chuyên môn.",
+			"vâng, thư mời đã gửi. Chương trình họp đính kèm.",
+		},
+		threadInvoice: {
+			"chúng tôi có một câu hỏi ngắn về hóa đơn vừa rồi — mục 3 được tính theo tỷ lệ phải không?",
+			"vâng, tính theo tỷ lệ đến hết kỳ. Tôi xin gửi kèm bảng chi tiết.", "",
+		},
+		threadOffboarding: {
+			"chúng tôi xác nhận đã nhận được thông báo chấm dứt hợp đồng khi hết hạn.",
+			"cảm ơn xác nhận và cảm ơn thời gian hợp tác vừa qua.", "",
+		},
+		threadOffer: {
+			"xin gửi báo giá như đã trao đổi. Mức chiết khấu áp dụng từ 50 giấy phép.",
+			"cảm ơn — chúng tôi có hai câu hỏi về thời hạn và mức hỗ trợ.",
+			"cả hai xin được trao đổi trong buổi họp, đề xuất đính kèm.",
+		},
+		threadIntro: {
+			"chúng tôi đang làm việc với một số doanh nghiệp cùng quy mô — anh/chị có muốn trao đổi ngắn không?",
+			"vâng, anh gửi giúp vài khung giờ.", "",
+		},
+		threadInbound: {
+			"chúng tôi đang tìm hiểu các nhà cung cấp và muốn biết thêm thông tin.",
+			"rất sẵn lòng — tôi sẽ gửi hai đề xuất lịch họp.", "",
+		},
+		threadCold: {"một câu hỏi ngắn về hệ thống của quý công ty — anh/chị có mười phút không?", "", ""},
+	},
+	localeKO: {
+		threadKickoff: {
+			"믿고 맡겨 주셔서 감사합니다. 착수 회의 일정을 제안드립니다.",
+			"제안하신 일정 좋습니다. 실무 부서도 함께 참석하겠습니다.",
+			"네, 초대장 발송했습니다. 안건은 첨부드립니다.",
+		},
+		threadInvoice: {
+			"지난 청구서 관련해 간단히 여쭙습니다 — 3번 항목은 일할 계산된 것인가요?",
+			"네, 해당 기간 종료일까지 일할 계산했습니다. 내역서 함께 보내드립니다.", "",
+		},
+		threadOffboarding: {
+			"계약 만료 시점의 종료 요청을 접수했음을 확인드립니다.",
+			"확인 감사드리며, 그동안 함께해 주셔서 감사했습니다.", "",
+		},
+		threadOffer: {
+			"논의드린 대로 제안서를 보내드립니다. 50 라이선스부터 할인이 적용됩니다.",
+			"감사합니다 — 계약 기간과 지원 범위에 대해 두 가지 문의가 있습니다.",
+			"두 가지 모두 회의에서 설명드리겠습니다. 제안 사항 첨부합니다.",
+		},
+		threadIntro: {
+			"비슷한 규모의 기업들과 협업하고 있습니다 — 짧게 논의해 보실 수 있을까요?",
+			"네 좋습니다. 가능한 시간대를 몇 개 보내주세요.", "",
+		},
+		threadInbound: {
+			"현재 공급업체를 검토 중이며 좀 더 자세한 내용을 알고 싶습니다.",
+			"네, 회의 일정 두 가지를 제안드리겠습니다.", "",
+		},
+		threadCold: {"귀사 플랫폼에 관해 짧게 여쭙고 싶습니다 — 10분 정도 가능하실까요?", "", ""},
+	},
+}
+
+// bodiesFor is one thread's text in one language.
+//
+// Falls back to German, and then to the German kickoff, so a thread key added
+// to threadsFor without a translation still emits something a reader can
+// recognise as unfinished rather than an empty body.
+func bodiesFor(locale docLocale, key string) [3]string {
+	if byKey, ok := threadBodies[locale]; ok {
+		if body, ok := byKey[key]; ok {
+			return body
+		}
+	}
+	if body, ok := threadBodies[localeDE][key]; ok {
+		return body
+	}
+	return threadBodies[localeDE][threadKickoff]
+}

--- a/backend/internal/modules/capture/offlinedemo/locale_test.go
+++ b/backend/internal/modules/capture/offlinedemo/locale_test.go
@@ -22,12 +22,16 @@ func testMailbox() Mailbox {
 	}
 }
 
-func testAccount(domain, name, lifecycle string) Account {
+// testAccount is a CUSTOMER on purpose: that lifecycle is the one threadsFor
+// gives two threads and a meeting, so it exercises the most vocabulary per
+// call. A thread key no lifecycle reaches is covered by
+// TestEveryLanguageAnswersEveryThreadKey instead, which reads the maps directly.
+func testAccount(domain, name string) Account {
 	return Account{
 		OrganizationID: "01a00000-0000-7000-8000-000000000001",
 		Name:           name,
 		Domain:         domain,
-		Lifecycle:      lifecycle,
+		Lifecycle:      "customer",
 		ContractNumber: "GR-2026-0402",
 		People:         []Person{{Name: "Seo Min-ji", Email: "minji.seo@example.com"}},
 		Now:            time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC),
@@ -39,7 +43,7 @@ func testAccount(domain, name, lifecycle string) Account {
 // Korean ones: the failure mode was German leaking through, and a test that
 // only looked for Korean would pass on a message that carried both.
 func TestAKoreanAccountIsNotWrittenToInGerman(t *testing.T) {
-	msgs := generate(testMailbox(), testAccount("tipa.or.kr", "중소기업기술정보진흥원", "customer"))
+	msgs := generate(testMailbox(), testAccount("tipa.or.kr", "중소기업기술정보진흥원"))
 	if len(msgs) == 0 {
 		t.Fatal("a customer account generated no correspondence at all")
 	}
@@ -54,7 +58,7 @@ func TestAKoreanAccountIsNotWrittenToInGerman(t *testing.T) {
 }
 
 func TestAVietnameseAccountIsNotWrittenToInGerman(t *testing.T) {
-	msgs := generate(testMailbox(), testAccount("vinatechgroup.vn", "Vinatech Group", "customer"))
+	msgs := generate(testMailbox(), testAccount("vinatechgroup.vn", "Vinatech Group"))
 	if len(msgs) == 0 {
 		t.Fatal("a customer account generated no correspondence at all")
 	}
@@ -71,7 +75,7 @@ func TestAVietnameseAccountIsNotWrittenToInGerman(t *testing.T) {
 // A German account must still read as German. The fix would be worthless if it
 // translated the majority of the dataset into something else.
 func TestAGermanAccountStillReadsAsGerman(t *testing.T) {
-	msgs := generate(testMailbox(), testAccount("valantic.com", "valantic", "customer"))
+	msgs := generate(testMailbox(), testAccount("valantic.com", "valantic"))
 	if len(msgs) == 0 {
 		t.Fatal("a customer account generated no correspondence at all")
 	}
@@ -107,8 +111,15 @@ func TestLocaleOfReadsTheDomainSuffix(t *testing.T) {
 // missing entry falls back to German, which is exactly the bug this file is
 // about — so the fallback must never be reached in practice.
 func TestEveryLanguageAnswersEveryThreadKey(t *testing.T) {
-	keys := []string{"kickoff", "invoice", "offboarding", "offer", "intro", "inbound", "cold"}
-	for _, locale := range []docLocale{localeDE, localeVI, localeKO} {
+	keys := []string{
+		threadKickoff, threadInvoice, threadOffboarding,
+		threadOffer, threadIntro, threadInbound, threadCold,
+	}
+	// localeEN is in the list on purpose. It had vocabulary and NO bodies, so
+	// bodiesFor(localeEN, ...) silently returned German — a language that
+	// claimed to exist and did not, which is the same class of bug as the
+	// German-to-Seoul one this file is about.
+	for _, locale := range []docLocale{localeDE, localeVI, localeKO, localeEN} {
 		byKey, ok := threadBodies[locale]
 		if !ok {
 			t.Errorf("no thread bodies at all for %q", locale)
@@ -123,6 +134,40 @@ func TestEveryLanguageAnswersEveryThreadKey(t *testing.T) {
 			if strings.TrimSpace(body[0]) == "" {
 				t.Errorf("%q/%q has an empty opener", locale, key)
 			}
+			// The reply matters as much as the opener: threadsFor asks for one
+			// or two on every thread except `cold`, and an empty one silently
+			// truncates the conversation to a single unanswered message.
+			if key != threadCold && strings.TrimSpace(body[1]) == "" {
+				t.Errorf("%q/%q has no reply — the thread would end unanswered", locale, key)
+			}
+		}
+	}
+}
+
+// Every language must fill every SUBJECT field too. A blank one renders as a
+// bare account name, or as ": " in front of a meeting.
+func TestEveryLanguageNamesEverySubject(t *testing.T) {
+	for _, locale := range []docLocale{localeDE, localeVI, localeKO, localeEN} {
+		w := wordsFor(locale)
+		for name, value := range map[string]string{
+			"Kickoff": w.Kickoff, "Invoice": w.Invoice, "Offer": w.Offer,
+			"Offboarding": w.Offboarding, "Intro": w.Intro, "Enquiry": w.Enquiry,
+			"Cold": w.Cold, "Meeting": w.Meeting, "MeetingBody": w.MeetingBody,
+		} {
+			if strings.TrimSpace(value) == "" {
+				t.Errorf("%q has no %s subject", locale, name)
+			}
+		}
+	}
+}
+
+// An addressee with no name must not produce " 님께," or "Hallo ,".
+func TestANamelessAddresseeGetsNoSalutationRatherThanABrokenOne(t *testing.T) {
+	account := testAccount("tipa.or.kr", "중소기업기술정보진흥원")
+	account.People = []Person{{Name: "", Email: "nobody@example.com"}}
+	for _, msg := range generate(testMailbox(), account) {
+		if strings.HasPrefix(msg.Body, " ") || strings.Contains(msg.Body, "Hallo ,") {
+			t.Errorf("a nameless addressee produced a broken salutation: %q", msg.Body)
 		}
 	}
 }

--- a/backend/internal/modules/capture/offlinedemo/locale_test.go
+++ b/backend/internal/modules/capture/offlinedemo/locale_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package offlinedemo
+
+// The generated correspondence must be in the account's own language.
+//
+// It was German for everybody. The demo's Korean government agency received
+// "Kickoff 중소기업기술정보진흥원" — a German subject word concatenated onto a Korean
+// company name — with a German body and "Viele Grüße" underneath. 44 of the 235
+// generated activities were German mail to Vietnamese and Korean accounts.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func testMailbox() Mailbox {
+	return Mailbox{
+		Email: "lena.fischer@demo.test", DisplayName: "Lena Fischer",
+	}
+}
+
+func testAccount(domain, name, lifecycle string) Account {
+	return Account{
+		OrganizationID: "01a00000-0000-7000-8000-000000000001",
+		Name:           name,
+		Domain:         domain,
+		Lifecycle:      lifecycle,
+		ContractNumber: "GR-2026-0402",
+		People:         []Person{{Name: "Seo Min-ji", Email: "minji.seo@example.com"}},
+		Now:            time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestAKoreanAccountIsNotWrittenToInGerman is the regression this file exists
+// for. It asserts the ABSENCE of the German phrases rather than the presence of
+// Korean ones: the failure mode was German leaking through, and a test that
+// only looked for Korean would pass on a message that carried both.
+func TestAKoreanAccountIsNotWrittenToInGerman(t *testing.T) {
+	msgs := generate(testMailbox(), testAccount("tipa.or.kr", "중소기업기술정보진흥원", "customer"))
+	if len(msgs) == 0 {
+		t.Fatal("a customer account generated no correspondence at all")
+	}
+	for _, msg := range msgs {
+		for _, german := range []string{"Viele Grüße", "Hallo ", "Kickoff", "Rechnung", "Termin:"} {
+			if strings.Contains(msg.Subject, german) || strings.Contains(msg.Body, german) {
+				t.Errorf("a Korean account got German text %q in\n  subject: %s\n  body: %s",
+					german, msg.Subject, msg.Body)
+			}
+		}
+	}
+}
+
+func TestAVietnameseAccountIsNotWrittenToInGerman(t *testing.T) {
+	msgs := generate(testMailbox(), testAccount("vinatechgroup.vn", "Vinatech Group", "customer"))
+	if len(msgs) == 0 {
+		t.Fatal("a customer account generated no correspondence at all")
+	}
+	for _, msg := range msgs {
+		for _, german := range []string{"Viele Grüße", "Hallo ", "Kickoff", "Rechnung", "Termin:"} {
+			if strings.Contains(msg.Subject, german) || strings.Contains(msg.Body, german) {
+				t.Errorf("a Vietnamese account got German text %q in\n  subject: %s\n  body: %s",
+					german, msg.Subject, msg.Body)
+			}
+		}
+	}
+}
+
+// A German account must still read as German. The fix would be worthless if it
+// translated the majority of the dataset into something else.
+func TestAGermanAccountStillReadsAsGerman(t *testing.T) {
+	msgs := generate(testMailbox(), testAccount("valantic.com", "valantic", "customer"))
+	if len(msgs) == 0 {
+		t.Fatal("a customer account generated no correspondence at all")
+	}
+	var sawSignOff bool
+	for _, msg := range msgs {
+		if strings.Contains(msg.Body, "Viele Grüße") {
+			sawSignOff = true
+		}
+	}
+	if !sawSignOff {
+		t.Error("no German sign-off anywhere on a German account")
+	}
+}
+
+func TestLocaleOfReadsTheDomainSuffix(t *testing.T) {
+	for domain, want := range map[string]docLocale{
+		"tipa.or.kr":       localeKO,
+		"mv21.kr":          localeKO,
+		"micube.co.kr":     localeKO,
+		"vinatechgroup.vn": localeVI,
+		"i-soft.com.vn":    localeVI,
+		"valantic.com":     localeDE,
+		"akeneo.com":       localeDE,
+		"":                 localeDE,
+	} {
+		if got := localeOf(domain); got != want {
+			t.Errorf("localeOf(%q) = %q, want %q", domain, got, want)
+		}
+	}
+}
+
+// Every language must answer every thread key the generator can ask for. A
+// missing entry falls back to German, which is exactly the bug this file is
+// about — so the fallback must never be reached in practice.
+func TestEveryLanguageAnswersEveryThreadKey(t *testing.T) {
+	keys := []string{"kickoff", "invoice", "offboarding", "offer", "intro", "inbound", "cold"}
+	for _, locale := range []docLocale{localeDE, localeVI, localeKO} {
+		byKey, ok := threadBodies[locale]
+		if !ok {
+			t.Errorf("no thread bodies at all for %q", locale)
+			continue
+		}
+		for _, key := range keys {
+			body, ok := byKey[key]
+			if !ok {
+				t.Errorf("%q has no body for the %q thread — it would fall back to German", locale, key)
+				continue
+			}
+			if strings.TrimSpace(body[0]) == "" {
+				t.Errorf("%q/%q has an empty opener", locale, key)
+			}
+		}
+	}
+}
+
+// wordsFor must never return a zero struct: Hello is a func, and a nil one
+// panics inside newMessage rather than rendering badly.
+func TestWordsForAlwaysReturnsAUsableGreeting(t *testing.T) {
+	for _, locale := range []docLocale{localeDE, localeVI, localeKO, localeEN, docLocale("xx")} {
+		words := wordsFor(locale)
+		if words.Hello == nil {
+			t.Fatalf("wordsFor(%q) returned a nil Hello", locale)
+		}
+		if got := words.Greeting("Test"); !strings.Contains(got, "Test") {
+			t.Errorf("wordsFor(%q).Greeting does not name the addressee: %q", locale, got)
+		}
+		if strings.TrimSpace(words.SignOff) == "" {
+			t.Errorf("wordsFor(%q) has no sign-off", locale)
+		}
+	}
+}

--- a/backend/internal/modules/capture/offlinedemo/offlinedemo.go
+++ b/backend/internal/modules/capture/offlinedemo/offlinedemo.go
@@ -63,8 +63,17 @@ const Name = "offline_demo"
 // generator starts from the beginning, and the natural key refuses whatever
 // did land.
 // 3: the correspondence is written in the account's own language rather than
-// German for everybody. Without the bump an existing demo keeps the German
-// mail it already captured and never sees a Korean or Vietnamese thread.
+// German for everybody.
+//
+// The bump makes the next sync REPLAY from the start rather than resume, which
+// is what a changed generator needs. It does NOT rewrite what is already
+// captured: the sink's natural key is ON CONFLICT DO NOTHING, so a re-emitted
+// message with the same id is refused and the German row it already wrote
+// stays German. An existing demo therefore keeps its German mail, and only a
+// FRESH seed reads in the account's own language. Relocalising an existing one
+// is a data migration this connector deliberately does not do — capture is
+// append-once, and a connector that edited history would be the wrong thing to
+// build for a demo.
 const generatorVersion = 3
 
 // Directory is what the connector needs to know about the installation to

--- a/backend/internal/modules/capture/offlinedemo/offlinedemo.go
+++ b/backend/internal/modules/capture/offlinedemo/offlinedemo.go
@@ -62,7 +62,10 @@ const Name = "offline_demo"
 // version bump is exactly the tool for that: the cursor no longer matches, the
 // generator starts from the beginning, and the natural key refuses whatever
 // did land.
-const generatorVersion = 2
+// 3: the correspondence is written in the account's own language rather than
+// German for everybody. Without the bump an existing demo keeps the German
+// mail it already captured and never sees a Korean or Vietnamese thread.
+const generatorVersion = 3
 
 // Directory is what the connector needs to know about the installation to
 // write plausible mail for it. Implemented in compose, because reading people


### PR DESCRIPTION
A Korean government agency in the demo received **`Kickoff 중소기업기술정보진흥원`** — a
German subject word concatenated onto a Korean company name — with a German
body and `Viele Grüße` underneath. **44 of the 235 generated activities** were
German mail to Vietnamese and Korean accounts.

The demo dataset exists to be shown in Hanoi and Seoul. A Vietnamese
manufacturer reading German boilerplate is the one thing it cannot survive
being, and it is the same defect the hand-written half of the dataset was
already fixed for.

## What held German

Two places, and fixing one alone would not have worked. `threadsFor` built
every subject and body from German literals, and `newMessage` welded `"Hallo "`
and `"Viele Grüße"` around them — so localised templates would still have
signed off in German to Seoul.

`locale.go` now carries the vocabulary for de/vi/ko/en: salutation, sign-off,
seven subject lines, seven thread bodies. Korean takes a function for the
salutation because the honorific follows the name (`박준서 님께`) rather than
leading it.

## Locale is derived from the domain

This runs in the **worker**, which has neither the seeder's dataset directory
nor its `company-locale.json`. The domain is what both halves have and it is
already on the `Account`.

The divergence from the seeder's file is deliberate and documented: that file
marks Korean companies `en` because their websites publish English, and it
drives the account's **paper**. Who you write to in Korean is a different
question. A `.kr` account holding English contracts and Korean mail is what
those accounts genuinely look like.

## Known gap — #2263

**9 of the dataset's 21 Vietnamese companies sit on a `.com`** and still read as
German, `fpt-is.com` and `vuletech.com` among them. A suffix cannot see what a
hand-checked file knows. Not a regression — German on a `.com` is the
pre-existing behaviour for every account.

## generatorVersion 2 → 3

The bump makes the next sync replay from the start. It does **not** rewrite what
is captured: the sink is `ON CONFLICT DO NOTHING`, so a re-emitted id is
refused. Verified against the seeded database. Only a **fresh** seed reads in the
account's language, and the comment now says so.

## Review

Codex found eight issues; all in-scope ones are fixed in the second commit —
`localeEN` had vocabulary and no bodies (silently German), the version comment
overclaimed, `threadInbound` aliased an activity enum into a persistent message
id, `Greeting("")` rendered `" 님께,"`, and a Vietnamese reply addressed Lena
Fischer as male.

**Still wanted: native-speaker review of the Vietnamese and Korean copy.** Codex
flagged several lines as reading like translations and I cannot judge that.

## Verification

`make check-backend` EXIT=0 with zero findings. `craft-static` PASS 0/0/0.
`rls-store-path`, `no-jurisdiction` clean. Reverting `localeOf` fails the
regression tests with the original symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes generated demo mail to the account’s language, derived from its domain. Previously all threads were in German; now vi/ko/en/de templates consistently set subjects, bodies, greetings, and sign‑offs, removing mixed‑language messages.

- Derives the locale from the domain suffix (.kr/.co.kr/.or.kr → ko; .vn/.com.vn → vi; otherwise de) in the worker, which cannot read the seeder’s company-locale.json.
- Adds localized vocabulary and per‑thread bodies in locale templates; localizes meeting subjects/bodies; uses constants for thread keys; handles nameless addressees by omitting the salutation.
- Bumps generatorVersion to 3; existing captured messages are unchanged. To see localization, run a fresh seed.
- Known gap: Vietnamese/Korean companies on .com still render German (tracked as #2263).

<sup>Written for commit e36020a4872a3011ca155566b4993b1913299b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline demo correspondence now adapts to the account’s language, including subjects, message content, greetings, sign-offs, and meeting terminology.
  * Added support for German, English, Vietnamese, and Korean correspondence.
  * Greetings are omitted when no recipient name is available.

* **Bug Fixes**
  * Prevented unsupported or missing localization data from producing malformed or unusable messages.
  * New demo data now uses localized content while preserving previously captured messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->