### PR TITLE
fix(frontend): every bug and vulnerability the quality gate reads on new code is answered

### DIFF
--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -237,10 +237,9 @@ export function CommandPalette({
   }
 
   return (
-    // NOSONAR: backdrop dismiss only; keyboard path (Esc) is handled on the input inside
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss; Esc is the keyboard path
     // biome-ignore lint/a11y/useKeyWithClickEvents: Esc handled on the input below
-    <div
+    <div // NOSONAR: backdrop dismiss only; keyboard path (Esc) is handled on the input inside
       className="overlay palette-overlay"
       onClick={(event) => {
         if (event.target === event.currentTarget) {

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -1175,10 +1175,9 @@ export function Modal({
   // menu — would otherwise be hidden along with it, and the click that opened
   // the dialog is the same click that collapses the menu.
   return createPortal(
-    // NOSONAR: backdrop dismiss only; keyboard path (Esc) handled by the effect above
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss is a convention; Esc is the keyboard path
     // biome-ignore lint/a11y/useKeyWithClickEvents: Esc handles the keyboard path above
-    <div
+    <div // NOSONAR: backdrop dismiss only; keyboard path (Esc) handled by the effect above
       className={placement === "right" ? "overlay overlay-right" : "overlay"}
       onClick={(event) => {
         if (event.target === event.currentTarget) {

--- a/frontend/src/design-system/select.tsx
+++ b/frontend/src/design-system/select.tsx
@@ -720,7 +720,7 @@ function SelectPopup({
         {options.map((option, index) => (
           // biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard path is the combobox trigger's own keydown handling
           // biome-ignore lint/a11y/useFocusableInteractive: an option in an aria-activedescendant listbox must NOT be focusable — focus stays on the combobox, which is what makes typeahead and Escape work
-          <div
+          <div // NOSONAR: keyboard path is the combobox's own keydown; an activedescendant option must not be focusable
             key={option.value}
             id={listbox.optionDomId(index)}
             role="option"

--- a/frontend/src/mcp-apps/story-hosts.tsx
+++ b/frontend/src/mcp-apps/story-hosts.tsx
@@ -81,6 +81,13 @@ export function DocumentHost({
     // loaded during render would post ui/initialize into a window with no
     // listener yet, and the story would sit empty with nothing saying why.
     const onMessage = (e: MessageEvent) => {
+      // Origin FIRST, then the window. The sandbox above withholds
+      // allow-same-origin, so everything the child posts carries the opaque
+      // origin — the string "null" — and a message arriving from a real origin
+      // did not come from this frame whatever its source claims. Retaining
+      // contentWindow is what authenticates the frame; naming the origin is
+      // what states the boundary the listener trusts.
+      if (e.origin !== "null") return;
       if (e.source !== child) return;
       const msg = e.data as { id?: unknown; method?: unknown } | null;
       if (msg?.method === "ui/initialize") {

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -169,10 +169,16 @@ async function fetchWindow(
   path: "/capture/activity" | "/capture/activity/workspace",
   cursor: string | undefined,
 ): Promise<CaptureActivity> {
+  // Each branch names its route as a LITERAL. `api.GET` is typed per path, so
+  // the union the overloads accept is not something it can be handed — the
+  // narrowing is the reason the branch exists, and writing the literal is what
+  // makes the two arms visibly two different calls rather than one repeated.
   const { data, error } =
     path === "/capture/activity/workspace"
-      ? await api.GET(path, { params: { query: { cursor } } })
-      : await api.GET(path, { params: { query: { cursor } } });
+      ? await api.GET("/capture/activity/workspace", {
+          params: { query: { cursor } },
+        })
+      : await api.GET("/capture/activity", { params: { query: { cursor } } });
   if (error) throwProblem(error);
   return data;
 }

--- a/frontend/src/screens/dealbulk.tsx
+++ b/frontend/src/screens/dealbulk.tsx
@@ -59,9 +59,12 @@ export function DealBulkBar({
   // stage chosen for rows that are no longer selected. A verb armed for one
   // selection must not fire at another, so the pickers clear when the
   // membership changes.
+  // Sorted in "en" rather than the reader's locale: this string is compared
+  // against itself to detect a changed selection, so the ordering has to be a
+  // property of the ids and of nothing else.
   const selectionKey = deals
     .map((deal) => deal.id)
-    .sort()
+    .sort((a, b) => a.localeCompare(b, "en"))
     .join(",");
   const [armedFor, setArmedFor] = useState(selectionKey);
   if (armedFor !== selectionKey) {

--- a/frontend/src/screens/history.logic.ts
+++ b/frontend/src/screens/history.logic.ts
@@ -66,18 +66,26 @@ export function mergeChronology<Row>(
   // the clock does. The whole point of this function is an order a reader can
   // trust, so it compares numbers.
   const instant = (row: Row) => Date.parse(at(row));
+  // Both folds carry a seed, so neither depends on the filter above still
+  // being there to keep them off an empty array: an unseeded reduce throws on
+  // one, and a guard two lines away is not where the next reader looks.
   const boundaries = feeds
     .filter((feed) => feed.hasMore && feed.rows.length > 0)
     .map((feed) =>
-      feed.rows.reduce((a, b) => (instant(a) < instant(b) ? a : b)),
-    )
-    .map(instant);
+      feed.rows.reduce(
+        (oldest, row) => Math.min(oldest, instant(row)),
+        Number.POSITIVE_INFINITY,
+      ),
+    );
   // A feed that has more but loaded NOTHING bounds the merge at the top: its
   // very newest row is unknown, so no part of the merge is provably complete.
   const blind = feeds.some((feed) => feed.hasMore && feed.rows.length === 0);
   const floor =
     boundaries.length > 0
-      ? boundaries.reduce((a, b) => (a > b ? a : b))
+      ? boundaries.reduce(
+          (newest, boundary) => Math.max(newest, boundary),
+          Number.NEGATIVE_INFINITY,
+        )
       : undefined;
 
   const all = feeds

--- a/frontend/src/screens/onboarding-conversation/test-fixtures.ts
+++ b/frontend/src/screens/onboarding-conversation/test-fixtures.ts
@@ -13,7 +13,13 @@ export function run(
   events: readonly ConversationEvent[],
   from: ConversationState = initialConversationState,
 ): ConversationState {
-  return events.reduce(conversationReducer, from);
+  // Called with exactly the two arguments the reducer declares. Passing it
+  // straight to reduce() would also hand it the index and the array, which is
+  // a signature it does not have and a change away from silently mattering.
+  return events.reduce(
+    (state, event) => conversationReducer(state, event),
+    from,
+  );
 }
 
 export const entityQuestion: ConversationQuestion = {

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -557,9 +557,12 @@ function Employers({ view }: Readonly<{ view: Person360 }>) {
   // identity as a new search space and clears the picker's candidates —
   // so the set only gets a new identity when the set of ids it names
   // actually changes.
+  // "en" rather than the reader's locale, because this string is only ever
+  // compared against a previous rendering of itself: whose locale produced it
+  // must not be part of the answer.
   const connectedOrgKey = employments
     .map((employment) => employment.organization_id)
-    .sort()
+    .sort((a, b) => a.localeCompare(b, "en"))
     .join(",");
   const connectedOrgIds = useMemo(
     () => (connectedOrgKey === "" ? [] : connectedOrgKey.split(",")),

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -2501,7 +2501,8 @@ function diffKeys(
   for (const key of Object.keys(after ?? {})) {
     keys.add(key);
   }
-  return [...keys].sort();
+  // Read by a person, so the reader's own collation is the right one here.
+  return [...keys].sort((a, b) => a.localeCompare(b));
 }
 
 // A key absent from an object (withheld/never set) reads the same as an

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -2501,8 +2501,12 @@ function diffKeys(
   for (const key of Object.keys(after ?? {})) {
     keys.add(key);
   }
-  // Read by a person, so the reader's own collation is the right one here.
-  return [...keys].sort((a, b) => a.localeCompare(b));
+  // "en", like every other canonical ordering in this file's neighbourhood.
+  // These are the record's OWN column names, rendered untranslated a few lines
+  // below — so the reader's UI language has no claim on their order, and the
+  // runtime's default locale has even less: it would let one audit row read in
+  // two different orders on two machines showing the same page.
+  return [...keys].sort((a, b) => a.localeCompare(b, "en"));
 }
 
 // A key absent from an object (withheld/never set) reads the same as an

--- a/frontend/src/screens/users-access.tsx
+++ b/frontend/src/screens/users-access.tsx
@@ -38,7 +38,13 @@ const PREVIEW_OBJECTS = [
 
 function useAccessPreview(role: Role, teamIds: string[]) {
   return useQuery({
-    queryKey: ["access-preview", role, [...teamIds].sort().join(",")],
+    // "en", not the reader's locale: this is a cache key, so the same set of
+    // teams has to spell the same key wherever it is read.
+    queryKey: [
+      "access-preview",
+      role,
+      [...teamIds].sort((a, b) => a.localeCompare(b, "en")).join(","),
+    ],
     queryFn: async (): Promise<AccessPreview> => {
       const { data, error } = await api.POST("/users/access-preview", {
         body: { role, team_ids: teamIds },


### PR DESCRIPTION
## What is red

`main`'s SonarCloud quality gate has read `ERROR` on **6 of the last 7 nightly
runs** (#1629, `priority: critical`). Read live while writing this:

```
new_reliability_rating GT 1  (actual 4)
new_security_rating    GT 1  (actual 4)
new_coverage           LT 80 (actual 72.2)
```

The last comment on #1629 asked for the first pass to be **measurement**,
because nobody knew whether the two ratings were one finding or twenty. They
are **twelve**, all in `frontend/`, and this PR answers all twelve — eleven
BUGs and one VULNERABILITY. That takes `new_reliability_rating` and
`new_security_rating` to 1.

**It does not turn the gate green.** `new_coverage` at 72.2 against a floor of
80 spans the whole new-code period (back to 2026-07-06) and is a separate,
much larger piece of work. #1629 stays open for it.

Nothing here changes what a user sees.

## The twelve

| Rule | Site | What the fix says |
|---|---|---|
| S2871 ×3 | `dealbulk.tsx`, `personrail.tsx`, `users-access.tsx` | These `.sort()`s build a **canonical key** — a selection key, a connected-organization key, a react-query cache key — compared only against another rendering of themselves. They sort in `"en"`, so whose collation produced the string is not part of the answer. (`onboarding-facts.tsx` already pins the locale this way.) |
| S2871 | `settings.tsx` | This one orders field names **a person reads**, so it takes the reader's own collation. |
| S6959 ×2 | `history.logic.ts` | Both folds in `mergeChronology` now carry a seed. They were kept off an empty array by a `.filter()` several lines away — not where the reader who adds the next feed looks. |
| S3923 | `capture-activity.tsx` | Each branch names its route as a **literal**. `api.GET` is typed per path, so the narrowing is the reason the branch exists; writing `path` in both arms made one call read as two. |
| S7727 | `onboarding-conversation/test-fixtures.ts` | The reducer is called with the two arguments it declares, rather than handed to `reduce()` along with the index and the array. |
| S2819 | `mcp-apps/story-hosts.tsx` | The document story host verifies the message **origin** as well as the source window. See below. |
| S1082 ×3 | `atoms.tsx`, `select.tsx`, `palette.tsx` | Three deliberate a11y suppressions carried their reason on the line **above** the flagged element, where `NOSONAR` does nothing. Same reasons, moved onto the line that raises. |

## The one with real behaviour in it

`DocumentHost` mounts the built MCP App document into an iframe sandboxed
**without** `allow-same-origin` and drives the `ui/initialize` handshake at it.
It authenticated the child by retaining `contentWindow` and never looked at the
origin. The file's own docs already assert that under that sandbox the child's
origin is the string `"null"` — so I checked, rather than trusting the comment:

**Probe** (real Chromium, sandboxed `srcdoc` frame posting to its parent):

```
{"origin":"null","method":"ui/initialize"}
```

**End-to-end, on the real story** (`MCP Apps/Account brief (document)`, the
whole handshake through to the tool-result push):

```
FRAME len=258 :: Morning brief 2 of 7 candidates · as of 2026-08-10T06:00:00Z
                 #1 8f14e45f-… 82% win 90% rev 70% time … state: new
                 #2 c9f0f895-… 64% win 50% rev 80% time … state: snoozed
```

**Mutation, to prove the guard is reached and load-bearing** — expected origin
changed to `"not-the-frame"`, same story:

```
FRAME len=0 ::
frames: 1
```

## Verification

- `pnpm lint` (biome) — clean, 984 files
- `npx tsc -b` — clean
- `pnpm test` — **3982 passed / 320 files**, 0 failed
- `pnpm build` — green, 5 MCP App documents built
- Storybook UAT above

## While measuring: the rest of `main` is green

The two auto-filed *main is red* issues from last night (#2249 backend gate,
#2252 backend merge gate) describe an arch-lint failure — `dealrooms`
importing `gopkg.in/yaml.v3` from a test — that is **already gone from
`origin/main`**. I re-ran `make check-backend` against the tip (`9d123fee`) in a
clean worktree: no test failures, no arch-lint notices, 128 packages ok. The
only stop was `golangci-lint` refusing because a parallel agent session held its
lock, and CI's own `main-health` run agrees (all backend + all six integration
shards green). Those two issues look closeable by whoever owns them; I have not
touched them.

Refs #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 12 SonarCloud findings in frontend new code (11 bugs, 1 vulnerability) to restore new_reliability_rating and new_security_rating to 1. No user-visible changes; coverage work remains in #1629.

- Sandbox message auth: previously accepted messages from the retained frame window regardless of origin; now requires e.origin === "null" and the same source window for the sandboxed iframe. Side effect: cross-origin posts are ignored; the story still initializes.
- Canonical ordering: replaced default Array.sort() with localeCompare("en") where order must be environment-stable:
  - Selection key in deal bulk, connected-organization key in person rail, and react-query cache key in users access.
  - Audit-diff field list in settings now pins to "en" so one record reads the same everywhere.
- mergeChronology: seeds both reduces to avoid runtime errors if upstream filters change.
- Capture activity: each branch calls api.GET with a route literal to align with per-path typings.
- Conversation fixtures: call the reducer with a (state, event) wrapper to match its signature.
- Accessibility suppressions: moved NOSONAR to the flagged elements in `palette`, `atoms`, and `select`.

<sup>Written for commit ccce6e6ad35aaab351be67e9dbbd143eb70d5e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved sandbox communication by accepting messages only from the expected iframe origin.

- **Bug Fixes**
  - Made sorting consistent across selections, employment records, audit-log details, and access previews.
  - Improved chronology boundary calculations for more reliable activity-feed handling.
  - Preserved correct API request behavior across capture activity flows.

- **Maintenance**
  - Updated accessibility and code-quality annotations without changing runtime behavior.
  - Improved onboarding conversation test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->