### PR TITLE
fix(offlinedemo): the dataset says what language an account speaks, not its domain

### DIFF
--- a/backend/internal/modules/capture/offlinedemo/generate.go
+++ b/backend/internal/modules/capture/offlinedemo/generate.go
@@ -205,7 +205,7 @@ type threadSpec struct {
 
 // threadsFor picks the conversations an account's own state calls for.
 func threadsFor(account Account) []threadSpec {
-	locale := localeOf(account.Domain)
+	locale := localeFor(account)
 	words := wordsFor(locale)
 	// One helper so every spec below states only what differs. The subject and
 	// the body come from the same locale, which is what stops a German subject
@@ -293,7 +293,7 @@ func writeThread(mailbox Mailbox, account Account, contact Person, anchor time.T
 	if spec.Meeting {
 		occurred = occurred.AddDate(0, 0, 5)
 		id := fmt.Sprintf("<%s.meet@offline-demo.invalid>", base)
-		words := wordsFor(localeOf(account.Domain))
+		words := wordsFor(localeFor(account))
 		meeting := newMessage(mailbox, account, contact, id, openerID, "",
 			words.Meeting+": "+spec.Subject, words.MeetingBody,
 			occurred, "", "meeting", dealID)
@@ -311,7 +311,7 @@ func newMessage(mailbox Mailbox, account Account, contact Person,
 	if direction == directionInbound {
 		from, fromName, to, toName = contact.Email, contact.Name, mailbox.Email, mailbox.DisplayName
 	}
-	words := wordsFor(localeOf(account.Domain))
+	words := wordsFor(localeFor(account))
 	addressee := firstWord(contact.Name)
 	if direction == directionInbound {
 		addressee = firstWord(mailbox.DisplayName)

--- a/backend/internal/modules/capture/offlinedemo/locale.go
+++ b/backend/internal/modules/capture/offlinedemo/locale.go
@@ -15,12 +15,16 @@ package offlinedemo
 // Hanoi and Seoul, and a Vietnamese manufacturer reading German boilerplate is
 // the one thing it cannot survive being.
 //
-// DERIVED FROM THE DOMAIN, not configured. The seeder has its own localeFor in
-// tools/seed-demo/locale.go, reading datasets/v1/company-locale.json — but that
-// runs in the seeder binary against a dataset directory, and this runs in the
-// WORKER, which has neither. The domain is what both have, and it is already on
-// the Account. So the two answer the same question from the same evidence
-// without one importing the other.
+// THE DATASET'S ANSWER WINS. datasets/v1/company-locale.json is hand-checked
+// precisely because a domain suffix gets this wrong for about a fifth of the
+// Automation World list: vuletech.com is Vietnamese, dacell.com is Korean, and
+// nine of the dataset's 21 Vietnamese companies sit on a .com. Guessing from
+// the suffix would write German to all of them.
+//
+// The seeder reads that file and carries the answer into
+// capture_connection.auth, which this connector already reads for the seat id.
+// The suffix rule below is the FALLBACK, for an installation that was never
+// seeded from a dataset and so has nothing better.
 //
 // The disagreement that matters is deliberate. company-locale.json marks Korean
 // companies `en`, because that is what their WEBSITES publish. That file drives
@@ -33,12 +37,9 @@ package offlinedemo
 // localeKO here and no localeKO there, and the seeder's file is not wrong for
 // lacking it.
 //
-// KNOWN GAP, tracked as issue #2263: a Vietnamese or Korean company on a `.com`
-// still reads as German here, because a suffix cannot see what a hand-checked
-// file knows. Nine of the dataset's 21 Vietnamese companies are affected,
-// fpt-is.com and vuletech.com among them. Closing it means carrying the
-// locale to the worker through the database, which is a wider change than a
-// vocabulary.
+// Issue #2263 is what this closes: nine of the dataset's 21 Vietnamese
+// companies are on a `.com`, fpt-is.com and vuletech.com among them, and every
+// one of them was written to in German.
 
 import "strings"
 
@@ -52,18 +53,28 @@ const (
 	localeEN docLocale = "en"
 )
 
-// localeOf reads the correspondence language off the domain.
+// localeFor answers an account's correspondence language.
 //
-// The suffix is the whole rule here, unlike the seeder's, which consults a
-// hand-checked file. That is a smaller claim and the right one for a fallback:
-// this only decides the language of GENERATED filler, and a company whose
-// domain says nothing gets German, which is the dataset's own majority.
-//
-// A `.com` Korean or Vietnamese company therefore reads as German here and is
-// correct in the seeder. That gap is closed by scripting the account's threads
-// rather than by teaching a suffix table to guess — a guess that is wrong for a
-// fifth of the Automation World list, which is exactly why the seeder stopped
-// guessing and read a file instead.
+// The account's stated Locale first — that is the dataset's hand-checked
+// answer. The suffix only decides for an account that carries none, which
+// means an installation seeded by something other than the demo dataset.
+func localeFor(account Account) docLocale {
+	switch docLocale(strings.ToLower(strings.TrimSpace(account.Locale))) {
+	case localeDE:
+		return localeDE
+	case localeVI:
+		return localeVI
+	case localeKO:
+		return localeKO
+	case localeEN:
+		return localeEN
+	}
+	return localeOf(account.Domain)
+}
+
+// localeOf reads a language off the domain suffix. The fallback, not the rule:
+// it is right for the German majority and wrong for every Vietnamese or Korean
+// company on a generic TLD, which is why localeFor consults the dataset first.
 func localeOf(domain string) docLocale {
 	domain = strings.ToLower(strings.TrimSpace(domain))
 	switch {

--- a/backend/internal/modules/capture/offlinedemo/locale.go
+++ b/backend/internal/modules/capture/offlinedemo/locale.go
@@ -53,12 +53,29 @@ const (
 	localeEN docLocale = "en"
 )
 
-// localeFor answers an account's correspondence language.
+// localeFor answers an account's CORRESPONDENCE language, which is not always
+// the language of its paper.
 //
-// The account's stated Locale first — that is the dataset's hand-checked
-// answer. The suffix only decides for an account that carries none, which
-// means an installation seeded by something other than the demo dataset.
+// The dataset's stated locale wins, with one exception that the dataset itself
+// forces: it marks every Korean company `en`, because that is what their
+// websites and therefore their contracts are in. Taking that literally here
+// would write English to Seoul — and re-break the exact bug this connector was
+// fixed for, since `착수 회의` would go back to `Kickoff`. So a `.kr` domain
+// reads as Korean whatever the dataset says about its paper.
+//
+// The exception is narrow on purpose. It applies only where the domain PROVES
+// the country, never where it merely suggests one: `.kr` is a country-code TLD
+// that a non-Korean company does not hold, whereas a `.com` proves nothing and
+// is left to the dataset, which is the whole reason the dataset is consulted.
+//
+// Everything else takes the dataset's answer, and an account carrying none
+// falls back to the suffix — an installation seeded by something other than
+// this dataset.
 func localeFor(account Account) docLocale {
+	// Korean correspondence is decided by the domain, not by the paper locale.
+	if localeOf(account.Domain) == localeKO {
+		return localeKO
+	}
 	switch docLocale(strings.ToLower(strings.TrimSpace(account.Locale))) {
 	case localeDE:
 		return localeDE

--- a/backend/internal/modules/capture/offlinedemo/locale_test.go
+++ b/backend/internal/modules/capture/offlinedemo/locale_test.go
@@ -135,6 +135,29 @@ func TestAnUnknownStatedLocaleFallsThroughRatherThanDefaulting(t *testing.T) {
 	}
 }
 
+// The dataset marks EVERY Korean company `en`, because that is what their
+// websites and contracts are in. Taking that literally for correspondence
+// writes English to Seoul and turns 착수 회의 back into Kickoff — the exact bug
+// this connector was fixed for.
+//
+// This test carries the dataset's REAL value (`en` for tipa.or.kr, verified in
+// company-locale.json) rather than a convenient one, because the earlier
+// Korean test left Locale empty and so never exercised the seeded path at all.
+func TestAKoreanDomainStaysKoreanEvenThoughItsPaperIsEnglish(t *testing.T) {
+	for _, domain := range []string{"tipa.or.kr", "condt.co.kr", "mv21.kr"} {
+		account := testAccount(domain, "중소기업기술정보진흥원")
+		account.Locale = "en" // what company-locale.json actually says
+		if got := localeFor(account); got != localeKO {
+			t.Errorf("localeFor(%q stated en) = %q, want ko — the dataset's `en` is about PAPER", domain, got)
+		}
+		for _, msg := range generate(testMailbox(), account) {
+			if strings.Contains(msg.Subject, "Kickoff") || strings.Contains(msg.Body, "Best regards") {
+				t.Errorf("%s got English correspondence: %s / %s", domain, msg.Subject, msg.Body)
+			}
+		}
+	}
+}
+
 func TestLocaleOfReadsTheDomainSuffix(t *testing.T) {
 	for domain, want := range map[string]docLocale{
 		"tipa.or.kr":       localeKO,

--- a/backend/internal/modules/capture/offlinedemo/locale_test.go
+++ b/backend/internal/modules/capture/offlinedemo/locale_test.go
@@ -90,6 +90,51 @@ func TestAGermanAccountStillReadsAsGerman(t *testing.T) {
 	}
 }
 
+// The dataset's answer beats the domain, which is the whole point: nine of its
+// 21 Vietnamese companies are on a .com, fpt-is.com and vuletech.com among
+// them, and a suffix rule writes German to every one of them.
+func TestTheDatasetsLocaleBeatsTheDomainSuffix(t *testing.T) {
+	account := testAccount("vuletech.com", "VULETECH")
+	account.Locale = "vi"
+	if got := localeFor(account); got != localeVI {
+		t.Fatalf("localeFor(vuletech.com stated vi) = %q, want vi", got)
+	}
+	for _, msg := range generate(testMailbox(), account) {
+		for _, german := range []string{"Viele Grüße", "Hallo ", "Kickoff", "Rechnung"} {
+			if strings.Contains(msg.Subject, german) || strings.Contains(msg.Body, german) {
+				t.Errorf("a .com Vietnamese company got German %q in\n  subject: %s\n  body: %s",
+					german, msg.Subject, msg.Body)
+			}
+		}
+	}
+}
+
+// An account with no stated locale falls back to the suffix. That is an
+// installation seeded by something other than the demo dataset, and German is
+// the right answer for the majority it will hold.
+func TestAnAccountWithNoStatedLocaleFallsBackToTheSuffix(t *testing.T) {
+	for domain, want := range map[string]docLocale{
+		"vinatechgroup.vn": localeVI,
+		"tipa.or.kr":       localeKO,
+		"valantic.com":     localeDE,
+	} {
+		account := testAccount(domain, "Test")
+		if got := localeFor(account); got != want {
+			t.Errorf("localeFor(%q with no stated locale) = %q, want %q", domain, got, want)
+		}
+	}
+}
+
+// A locale the dataset does not use must not silently become German — it falls
+// through to the suffix, which is a real answer rather than a wrong one.
+func TestAnUnknownStatedLocaleFallsThroughRatherThanDefaulting(t *testing.T) {
+	account := testAccount("vinatechgroup.vn", "Vinatech")
+	account.Locale = "zz"
+	if got := localeFor(account); got != localeVI {
+		t.Errorf("an unrecognised locale on a .vn domain gave %q, want vi from the suffix", got)
+	}
+}
+
 func TestLocaleOfReadsTheDomainSuffix(t *testing.T) {
 	for domain, want := range map[string]docLocale{
 		"tipa.or.kr":       localeKO,
@@ -186,5 +231,32 @@ func TestWordsForAlwaysReturnsAUsableGreeting(t *testing.T) {
 		if strings.TrimSpace(words.SignOff) == "" {
 			t.Errorf("wordsFor(%q) has no sign-off", locale)
 		}
+	}
+}
+
+// The auth bundle must still accept the bare seat id. scripts/seed-dev.sql
+// writes one, and so did every seeder before the locale map — treating that as
+// a parse error would leave a dev database with a mailbox that never syncs.
+func TestReadAuthAcceptsBothTheJSONBundleAndTheBareSeatID(t *testing.T) {
+	const seat = "01a00000-0000-7000-8000-00000000000a"
+
+	bare := readAuth([]byte(seat))
+	if bare.UserID != seat {
+		t.Errorf("a bare seat id parsed to %q, want %q", bare.UserID, seat)
+	}
+	if len(bare.Locales) != 0 {
+		t.Errorf("a bare seat id carried locales: %v", bare.Locales)
+	}
+
+	bundle := readAuth([]byte(`{"user_id":"` + seat + `","locales":{"vuletech.com":"vi"}}`))
+	if bundle.UserID != seat {
+		t.Errorf("the bundle's seat id parsed to %q, want %q", bundle.UserID, seat)
+	}
+	if bundle.Locales["vuletech.com"] != "vi" {
+		t.Errorf("the bundle lost its locales: %v", bundle.Locales)
+	}
+
+	if empty := readAuth(nil); empty.UserID != "" {
+		t.Errorf("an empty credential produced a seat id %q", empty.UserID)
 	}
 }

--- a/backend/internal/modules/capture/offlinedemo/offlinedemo.go
+++ b/backend/internal/modules/capture/offlinedemo/offlinedemo.go
@@ -103,8 +103,13 @@ type Account struct {
 	Name           string
 	Domain         string
 	Lifecycle      string
-	People         []Person
-	Deals          []Deal
+	// Locale is the dataset's own answer for this company — `de`, `vi`, `ko`
+	// or `en` — carried in from company-locale.json through the auth payload.
+	// Empty when the installation was not seeded from a dataset, and the
+	// domain suffix answers instead.
+	Locale string
+	People []Person
+	Deals  []Deal
 	// ContractEndsInDays is negative for a contract already over. Zero when
 	// the account holds none.
 	ContractEndsInDays int
@@ -161,6 +166,42 @@ func (c *Connector) Authenticate(_ context.Context, req connector.AuthRequest) (
 // HealthCheck always succeeds — there is no remote to be unhealthy.
 func (c *Connector) HealthCheck(context.Context, connector.Auth) error { return nil }
 
+// authPayload is what the seeder writes into capture_connection.auth.
+//
+// The seat id alone was enough until the correspondence had to be written in
+// the account's own language. That answer lives in the DATASET
+// (datasets/v1/company-locale.json, hand-checked, because a domain suffix gets
+// it wrong for a fifth of the Automation World list — vuletech.com is
+// Vietnamese and dacell.com is Korean, both on .com). The seeder reads that
+// file; this connector runs in the worker and has no dataset directory, so the
+// answer has to travel, and `auth` is the channel that already exists between
+// exactly these two.
+type authPayload struct {
+	UserID string `json:"user_id"`
+	// Locales maps a lowercased domain to `de`, `vi`, `ko` or `en`. A domain
+	// absent from it falls back to the suffix rule, which is right for the
+	// German majority and is all an installation without a seeded dataset has.
+	Locales map[string]string `json:"locales,omitempty"`
+}
+
+// readAuth parses the credential bundle, tolerating the bare seat id.
+//
+// scripts/seed-dev.sql writes the user id as a plain string, and so did every
+// seeder before the locale map. A payload that is not JSON is therefore not an
+// error: it is the older form, and treating it as one keeps a dev database
+// seeded by either route working.
+func readAuth(auth connector.Auth) authPayload {
+	raw := strings.TrimSpace(string(auth))
+	if raw == "" {
+		return authPayload{}
+	}
+	var payload authPayload
+	if err := json.Unmarshal([]byte(raw), &payload); err == nil && payload.UserID != "" {
+		return payload
+	}
+	return authPayload{UserID: raw}
+}
+
 // cursorState is what a completed sync remembers.
 type cursorState struct {
 	Version int    `json:"v"`
@@ -177,12 +218,14 @@ type cursorState struct {
 func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connector.Cursor, sink connector.Sink) (connector.Cursor, error) {
 	// The seat rides in Auth, the way imap carries its mailbox owner: Auth is
 	// an opaque credential bundle and the connector decides what is in it.
-	// The seeder writes the user id there with no vault ref, so nothing here
-	// needs a keyvault to resolve a secret that does not exist.
-	userID := strings.TrimSpace(string(auth))
-	if userID == "" {
+	// The seeder writes the seat id and the dataset's locale map there with no
+	// vault ref, so nothing here needs a keyvault to resolve a secret that does
+	// not exist.
+	payload := readAuth(auth)
+	if payload.UserID == "" {
 		return cursor, fmt.Errorf("offline demo sync has no seat to generate for")
 	}
+	userID := payload.UserID
 
 	state, since := readCursor(cursor)
 
@@ -193,6 +236,7 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 	newest := since
 	emitted, skipped := 0, 0
 	for _, account := range mailbox.Accounts {
+		account.Locale = payload.Locales[strings.ToLower(account.Domain)]
 		for _, msg := range generate(mailbox, account) {
 			if !since.IsZero() && !msg.OccurredAt.After(since) {
 				skipped++

--- a/backend/tools/seed-demo/comms.go
+++ b/backend/tools/seed-demo/comms.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -43,6 +44,14 @@ import (
 // is no secret: the generator reads the local database and talks to nobody, so
 // a sealed credential would protect an empty room. imap carries its mailbox
 // owner the same way.
+//
+// The DATASET'S LOCALE MAP rides along with it. The connector writes each
+// account's correspondence in that company's own language, and the only
+// trustworthy answer is company-locale.json — hand-checked precisely because a
+// domain suffix is wrong for about a fifth of the Automation World list, where
+// vuletech.com is Vietnamese and dacell.com is Korean. The connector runs in the
+// worker and has no dataset directory, so the seeder carries the answer to it
+// through the one channel these two already share.
 func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error) {
 	if mode == modeDryRun || dsn == "" {
 		return 0, nil
@@ -53,6 +62,14 @@ func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error)
 		return 0, fmt.Errorf("connecting to provision the mailboxes: %w", err)
 	}
 	defer func() { _ = conn.Close(ctx) }() //craft:ignore swallowed-errors closing a seed connection has no failure the caller can act on
+
+	// One map for every seat: the same 272 domains, and the connector picks the
+	// account it is writing to out of it. Small enough to repeat per row and
+	// simpler than a second table nobody else would read.
+	locales := make(map[string]string, len(companyLocales))
+	for domain, locale := range companyLocales {
+		locales[domain] = string(locale)
+	}
 
 	created := 0
 	for _, user := range cfg.Users {
@@ -71,12 +88,24 @@ func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error)
 		// No workspace_id: migration 0282 dropped the tenant column from
 		// capture_connection, because the installation is a singleton and the
 		// row is installation-wide by construction (ADR-0091 §8 phase D).
+		auth, err := json.Marshal(struct {
+			UserID  string            `json:"user_id"`
+			Locales map[string]string `json:"locales,omitempty"`
+		}{UserID: userID, Locales: locales})
+		if err != nil {
+			return created, fmt.Errorf("encoding the mailbox credential for %s: %w", user.Email, err)
+		}
+
+		// DO UPDATE on the auth column, not DO NOTHING. A re-seed after the
+		// dataset's locales change must reach the connector; leaving the old
+		// bundle in place would keep writing German to a company the dataset
+		// has since corrected, and nothing would report it.
 		tag, err := conn.Exec(ctx, `
 			INSERT INTO capture_connection
 			       (provider, user_id, scopes, status, account_label, auth, share_acknowledged_at)
 			VALUES ('offline_demo', $1::uuid, '{read}', 'connected', $2, $3::bytea, now())
-			ON CONFLICT (user_id, provider) DO NOTHING`,
-			userID, user.Email, []byte(userID))
+			ON CONFLICT (user_id, provider) DO UPDATE SET auth = EXCLUDED.auth`,
+			userID, user.Email, auth)
 		if err != nil {
 			return created, fmt.Errorf("provisioning the mailbox for %s: %w", user.Email, err)
 		}

--- a/backend/tools/seed-demo/comms.go
+++ b/backend/tools/seed-demo/comms.go
@@ -96,15 +96,25 @@ func seedCommsConnections(dsn string, cfg demoConfig, mode runMode) (int, error)
 			return created, fmt.Errorf("encoding the mailbox credential for %s: %w", user.Email, err)
 		}
 
-		// DO UPDATE on the auth column, not DO NOTHING. A re-seed after the
-		// dataset's locales change must reach the connector; leaving the old
-		// bundle in place would keep writing German to a company the dataset
-		// has since corrected, and nothing would report it.
+		// DO UPDATE, not DO NOTHING. A re-seed after the dataset's locales
+		// change has to reach the connector; leaving the old bundle in place
+		// would keep writing German to a company the dataset has since
+		// corrected, and nothing would report it.
+		//
+		// credential_ref is CLEARED with it, and that is the load-bearing half.
+		// BackfillCredentials runs on every boot: it seals the auth bytes into
+		// the vault, records a ref and NULLs the column, and Registry's
+		// resolveCredential then prefers the ref unconditionally. So a demo
+		// whose backfill had already run would take a new auth payload into a
+		// column nothing reads — silently, because there is no error in
+		// writing to it. Clearing the ref returns the row to the un-backfilled
+		// state, and the next boot re-seals it from the payload written here.
 		tag, err := conn.Exec(ctx, `
 			INSERT INTO capture_connection
 			       (provider, user_id, scopes, status, account_label, auth, share_acknowledged_at)
 			VALUES ('offline_demo', $1::uuid, '{read}', 'connected', $2, $3::bytea, now())
-			ON CONFLICT (user_id, provider) DO UPDATE SET auth = EXCLUDED.auth`,
+			ON CONFLICT (user_id, provider) DO UPDATE
+			   SET auth = EXCLUDED.auth, credential_ref = NULL`,
 			userID, user.Email, auth)
 		if err != nil {
 			return created, fmt.Errorf("provisioning the mailbox for %s: %w", user.Email, err)


### PR DESCRIPTION
Closes #2263.

Nine of the dataset's 21 Vietnamese companies sit on a `.com` — `fpt-is.com` and
`vuletech.com` among them, two of the deepest accounts in the demo — and every
one was written to in German.

The previous fix derived language from the domain suffix. That is exactly the
guess `company-locale.json` exists to replace: it is hand-checked because the
suffix is wrong for about a fifth of the Automation World list, where
`vuletech.com` is Vietnamese and `dacell.com` is Korean.

## How the answer travels

The seeder reads that file. The connector runs in the worker with no dataset
directory. So the seeder now writes the domain→locale map into
`capture_connection.auth` — the opaque credential bundle these two already
share. No new table, no migration, and the demo-only knowledge stays in the
demo-only row.

`localeFor(account)` takes the dataset's answer, falling back to the suffix for
an installation seeded by something else. An unrecognised locale falls through
rather than defaulting, so a typo produces a real answer instead of a wrong one.

## Two silent failures caught in review

**Korean regressed to English.** The dataset marks every Korean company `en` —
correct for their paper. Taking that as the correspondence language sent
`착수 회의 중소기업기술정보진흥원` straight back to `Kickoff …`. I reproduced it before
fixing it. A `.kr` domain now reads as Korean whatever the dataset says about
its paper; the exception is narrow, applying only where the domain **proves** the
country rather than suggests it.

**The bundle could have been written where nothing reads it.**
`BackfillCredentials` runs on every boot, seals `auth` into the vault, records a
`credential_ref` and NULLs the column — and `resolveCredential` then prefers the
ref unconditionally. On a demo whose backfill had already run, `DO UPDATE SET
auth` wrote into a dead column with no error. The upsert now clears
`credential_ref` alongside, so the next boot re-seals from the new payload.

Measured before fixing: all 7 `offline_demo` connections still carry `auth` and
none carries a ref, so this would have worked locally and broken on the first
machine where the backfill ran first.

## Verification

`make check-backend` EXIT=0, zero findings. `craft-static` PASS 0/0/0.
`rls-store-path`, `no-jurisdiction` clean. Tests cover a `.com` Vietnamese
account, the Korean-paper-vs-correspondence rule using the dataset's real value,
the suffix fallback, an unrecognised locale, and both auth payload shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the dataset’s company locale to generate demo correspondence instead of guessing from the domain suffix. Previously we derived language from TLDs and wrote German to many Vietnamese `.com` accounts; now we read the dataset’s locale, fall back to the suffix when absent, and keep Korean correspondence Korean even when the dataset marks their paper as English.

- Review and rollout
  - Seeder now writes `{"user_id":"…","locales":{"<domain>":"de|vi|ko|en"}}` into `capture_connection.auth` for `offline_demo`; it upserts with DO UPDATE and clears `credential_ref` so backfilled rows re-seal on next boot. Required: rerun the demo seeder to populate the locale map.
  - Connector reads the JSON bundle via `readAuth`, still accepts a bare seat id, and sets `Account.Locale`. `localeFor(account)` prefers the dataset value, special-cases `.kr` as Korean, and otherwise falls back to `localeOf(domain)`. Unknown dataset locales fall through to the suffix rather than defaulting to German.

<sup>Written for commit e7428ccfd1818825e4868c55d31e5c363c9f8964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo content now uses each account’s configured locale when available.
  * Korean domains continue to generate Korean content, regardless of conflicting locale metadata.
  * Authentication supports both legacy user IDs and enhanced credential bundles with locale information.
  * Refreshed mailbox credentials are applied automatically to existing connections.

* **Bug Fixes**
  * Improved locale fallback for missing or unrecognized account settings.
  * Corrected locale propagation when generating messages, meetings, and greetings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->