### PR TITLE
fix(ci): main's analysis reads every coverage report, not one of three

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -16,7 +16,7 @@
 # check is `ci` on the pull request, and this workflow reports on a tree that has
 # already landed.
 #
-# The cadence is the one knob. Every two hours costs ~11 jobs a run against a
+# The cadence is the one knob. Every two hours costs ~15 jobs a run against a
 # 20-concurrent org ceiling that the pull-request lanes also queue in, and narrows
 # the suspect range to roughly a dozen commits. Tighten the cron if a dozen is too
 # many to bisect; it is one line.
@@ -91,7 +91,23 @@ jobs:
         env:
           CONTRACT_BREAKING_REQUIRE_BASE: "1"
           MIGRATION_VERSIONS_REQUIRE_BASE: "1"
+          # The extension units' merged coverage profile, written by the
+          # `test-extensions` leg this gate already runs — instrumenting the run
+          # that decides the verdict rather than repeating it, the same trade
+          # _lane-frontend.yml makes with FE_COVERAGE=1 on its one vitest run.
+          # The sonar job below consumes it: every unit is its own module and so
+          # is unreachable by the integration lane's profile, and a file the
+          # scanner cannot load is not an absent measurement to it — it is a
+          # measurement of zero.
+          EXT_COVER_OUT: ${{ github.workspace }}/backend/coverage-extensions.out
         run: make check-backend
+      - name: Upload extension coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-coverage-extensions
+          path: backend/coverage-extensions.out
+          if-no-files-found: ignore
+          retention-days: 1
 
   # The real-Postgres lane, called rather than copied. Every schema fitness gate
   # that has broken main recently lives here and nowhere else — an unratified
@@ -99,6 +115,21 @@ jobs:
   # without a database would have missed every one of them.
   integration:
     uses: ./.github/workflows/_lane-integration.yml
+
+  # The SPA lane, called rather than copied, for two reasons that arrived
+  # together.
+  #
+  # It closes a hole in what this workflow claims. "Is main red RIGHT NOW" was
+  # answered for the backend and the database and never for the frontend, so a
+  # broken SPA on the tip stayed invisible here until somebody's unrelated pull
+  # request went red for it — which is precisely the delay this workflow exists
+  # to remove, left in place for a third of the product.
+  #
+  # And it is the only producer of the lcov the sonar job needs. Without it that
+  # job scans a tree in which every TypeScript line is uncovered, which is not
+  # what the frontend suite measures.
+  frontend:
+    uses: ./.github/workflows/_lane-frontend.yml
 
   # main's SonarCloud analysis, published from here.
   #
@@ -112,12 +143,33 @@ jobs:
   sonar:
     name: sonarcloud (main)
     timeout-minutes: 30
-    needs: [integration]
-    # Only on a green lane, and only with the coverage in hand. The scanner's Zero
-    # Coverage Sensor scores every executable line it holds no report for as
-    # UNCOVERED, so a scan without the Go profile publishes the tree at 0% rather
-    # than declining to answer — and measuring nothing is not a measurement of zero.
-    if: needs.integration.result == 'success'
+    needs: [gates, integration, frontend]
+    # Only on a green lane, and only with EVERY coverage report in hand. The
+    # scanner's Zero Coverage Sensor scores every executable line it holds no
+    # report for as UNCOVERED, so a scan missing a producer publishes that code
+    # at 0% rather than declining to answer — and measuring nothing is not a
+    # measurement of zero.
+    #
+    # This job did exactly that for as long as it has existed, because it named
+    # one producer and sonar-project.properties names three. Its scan log said
+    # so plainly and nothing read it: "No LCOV files were found using
+    # frontend/coverage/lcov.info" and "report file not found, ignoring this
+    # file backend/coverage-extensions.out". main's published analysis therefore
+    # read frontend/src at 0.0% over 17,781 lines to cover and extensions at
+    # 0.0% over 708 — against a vitest suite that reports real coverage on every
+    # frontend pull request and extension units that measure 86-100% — which is
+    # the whole of the quality gate's new_coverage miss on main (72.1 against a
+    # threshold of 80, while the ci.yml scan that did download all three read
+    # 84.0). Issue #1629.
+    #
+    # So each producer must have SUCCEEDED, not merely not-failed: a red lane
+    # here freezes main's stored analysis for two hours, which is recoverable and
+    # loudly reported below, while a scan published without a report replaces it
+    # with a number describing a tree that does not exist.
+    if: >-
+      needs.gates.result == 'success'
+      && needs.integration.result == 'success'
+      && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -133,12 +185,32 @@ jobs:
           persist-credentials: false
           # Full history so the scanner can attribute blame and compute new code.
           fetch-depth: 0
+      # All three reports sonar-project.properties names, and the paths are its
+      # paths: backend/coverage.out, backend/coverage-extensions.out,
+      # frontend/coverage/lcov.info. None is guarded on its producer, unlike
+      # ci.yml's — there the gates are area-scoped and a skipped area is a real
+      # outcome, whereas here every producer is a `needs` that had to succeed for
+      # this job to run at all. So a missing artifact is not a shape to tolerate:
+      # it means a green producer published nothing, and failing the download
+      # freezes main's analysis rather than replacing it with a partial one.
       - name: Download Go coverage
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: go-coverage
           path: backend
+      - name: Download extension coverage
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: go-coverage-extensions
+          path: backend
+      - name: Download FE coverage
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fe-coverage
+          path: frontend/coverage
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
@@ -153,10 +225,12 @@ jobs:
   report:
     name: report
     timeout-minutes: 10
-    needs: [gates, integration]
+    needs: [gates, integration, frontend]
     if: >-
       !cancelled()
-      && (needs.gates.result == 'failure' || needs.integration.result == 'failure')
+      && (needs.gates.result == 'failure'
+      || needs.integration.result == 'failure'
+      || needs.frontend.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -190,5 +264,6 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MAIN_GATES_RESULT: ${{ needs.gates.result }}
           MAIN_INTEGRATION_RESULT: ${{ needs.integration.result }}
+          MAIN_FRONTEND_RESULT: ${{ needs.frontend.result }}
           MAIN_SUSPECTS: ${{ steps.range.outputs.suspects }}
         run: ./scripts/scheduled-report.sh

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -101,12 +101,20 @@ jobs:
           # measurement of zero.
           EXT_COVER_OUT: ${{ github.workspace }}/backend/coverage-extensions.out
         run: make check-backend
+      # `error`, not ci.yml's `ignore`. There the artifact is optional because a
+      # frontend-only pull request legitimately never runs this job; here the
+      # gate above is unconditional, so no file means `test-extensions` produced
+      # none — and it does exactly that, silently and with exit 0, when
+      # extensions/ holds no Go unit. Tolerating that would leave the gate green,
+      # fail the sonar download two jobs later, and skip the report job (which
+      # reads lane results, all of them successful) — main's analysis frozen with
+      # nobody told, which is the failure this whole change is about.
       - name: Upload extension coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-coverage-extensions
           path: backend/coverage-extensions.out
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 1
 
   # The real-Postgres lane, called rather than copied. Every schema fitness gate
@@ -225,12 +233,20 @@ jobs:
   report:
     name: report
     timeout-minutes: 10
-    needs: [gates, integration, frontend]
+    # `sonar` is here for a reason the three lanes are not. A lane going red is
+    # visible from a dozen other places; the SCAN failing is visible from none —
+    # main's stored analysis does not go missing when a publish fails, it keeps
+    # answering with the last one, so a broken publisher looks exactly like a
+    # working one on every dashboard. Left out of this list, the job that exists
+    # to publish main's verdict was the one job whose failure nobody was told
+    # about.
+    needs: [gates, integration, frontend, sonar]
     if: >-
       !cancelled()
       && (needs.gates.result == 'failure'
       || needs.integration.result == 'failure'
-      || needs.frontend.result == 'failure')
+      || needs.frontend.result == 'failure'
+      || needs.sonar.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -265,5 +281,6 @@ jobs:
           MAIN_GATES_RESULT: ${{ needs.gates.result }}
           MAIN_INTEGRATION_RESULT: ${{ needs.integration.result }}
           MAIN_FRONTEND_RESULT: ${{ needs.frontend.result }}
+          MAIN_SONAR_RESULT: ${{ needs.sonar.result }}
           MAIN_SUSPECTS: ${{ steps.range.outputs.suspects }}
         run: ./scripts/scheduled-report.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /bin/
 *.test
 coverage.out
+# The extension units' merged profile (make test-extensions EXT_COVER_OUT=…).
+# Same debris as coverage.out and it was never listed: only CI wrote it until
+# main-health's backend gate started writing it too, and now anyone reproducing
+# that gate locally has it in `git status`.
+coverage-extensions.out
 .env
 .build/
 .DS_Store

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -527,9 +527,10 @@ beside the gate, deliberately outside it:
   [The shared Go build cache](#the-shared-go-build-cache) for why it is scheduled
   rather than per-push.
 
-- **`main-health.yml`** — every two hours on `main`: the backend gate plus the
-  real-Postgres lane (called, not copied — it `uses:` `_lane-integration.yml`),
-  and `main`'s SonarCloud analysis published from the coverage that lane produces.
+- **`main-health.yml`** — every two hours on `main`: the backend gate, the
+  real-Postgres lane and the SPA lane (the last two called, not copied — it
+  `uses:` `_lane-integration.yml` and `_lane-frontend.yml`), and `main`'s
+  SonarCloud analysis published from the coverage all three produce.
   **It is not a gate and never will be**: it reports on a tree that has already
   landed.
 
@@ -550,7 +551,19 @@ beside the gate, deliberately outside it:
   does not vanish when it stops being refreshed, it FREEZES, while the nightly
   quality-gate job goes on reporting that frozen verdict as current.
 
-  The cadence is the knob: two hours costs ~11 jobs a run and narrows the suspect
+  Being the only publisher is what makes the scan job's inputs load-bearing, and
+  they were wrong. It downloaded `backend/coverage.out` alone while
+  `sonar-project.properties` names three reports, so the scanner's Zero Coverage
+  Sensor published `frontend/src` at 0.0% over 17,781 lines to cover and
+  `extensions/` at 0.0% over 708, while the vitest suite and the extension units
+  were both reporting real coverage on every run that measured them. That was
+  the whole of `main`'s `new_coverage` gate failure (72.1 against a threshold of
+  80; the `ci.yml` scan that downloaded all three read 84.0). The job now `needs` every
+  producer and requires each to have SUCCEEDED: a red lane freezes the analysis
+  for two hours, which the report job files an issue about, while a scan missing
+  a report replaces it with a number describing a tree that does not exist.
+
+  The cadence is the knob: two hours costs ~15 jobs a run and narrows the suspect
   range to roughly a dozen commits at eight merges an hour.
 
 - **`scheduled.yml`** — daily on `main`, the checks whose answer changes when

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -530,7 +530,7 @@ beside the gate, deliberately outside it:
 - **`main-health.yml`** — every two hours on `main`: the backend gate, the
   real-Postgres lane and the SPA lane (the last two called, not copied — it
   `uses:` `_lane-integration.yml` and `_lane-frontend.yml`), and `main`'s
-  SonarCloud analysis published from the coverage all three produce.
+  SonarCloud analysis published from the three coverage reports they produce.
   **It is not a gate and never will be**: it reports on a tree that has already
   landed.
 
@@ -561,7 +561,10 @@ beside the gate, deliberately outside it:
   80; the `ci.yml` scan that downloaded all three read 84.0). The job now `needs` every
   producer and requires each to have SUCCEEDED: a red lane freezes the analysis
   for two hours, which the report job files an issue about, while a scan missing
-  a report replaces it with a number describing a tree that does not exist.
+  a report replaces it with a number describing a tree that does not exist. The
+  report job now watches the scan itself for the same reason — a failed publish
+  leaves the previous analysis answering, which reads identically to a current
+  one, so it was the one failure here nobody was told about.
 
   The cadence is the knob: two hours costs ~15 jobs a run and narrows the suspect
   range to roughly a dozen commits at eight merges an hour.

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -236,6 +236,30 @@ commit and reads as red for a reason its author did not cause."\
     || unreported=1
 fi
 
+if [ "${MAIN_FRONTEND_RESULT:-}" = "failure" ]; then
+  report "main is red: the frontend lane fails on the tip" bug \
+"The SPA lane (biome + vitest + tsc + build) failed against \`main\` on the
+two-hourly health check: $RUN_URL
+
+The frontend was the one area this health check never asked about. It matters
+more here than the count of lanes suggests: the change classifier skips the
+frontend jobs for a commit touching no frontend path, and a skipped required
+check is the same colour as a passing one — so a red SPA on the tip used to wait
+for whoever's pull request happened to touch \`frontend/\` next.
+
+This lane is also what produces main's frontend coverage report, so while it is
+red main's SonarCloud analysis is not refreshed at all. That is deliberate — a
+scan without the lcov publishes every TypeScript line as uncovered, which is a
+worse answer than a stale one — but it means the quality gate's reading for
+\`main\` is frozen until this is fixed.
+
+${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
+
+Reproduce locally with \`make check-fe\` on \`main\`. The run above names which of
+the three legs went red; only one of them has to be reproduced."\
+    || unreported=1
+fi
+
 if [ "$unreported" -ne 0 ]; then
   echo "FAIL: at least one finding could not be filed — the run above names what was broken, but an issue for it does not exist" >&2
   exit 1

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -255,8 +255,37 @@ worse answer than a stale one — but it means the quality gate's reading for
 
 ${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
 
-Reproduce locally with \`make check-fe\` on \`main\`. The run above names which of
-the three legs went red; only one of them has to be reproduced."\
+Reproduce locally with the leg the run above names — \`make fe-quality\`,
+\`make fe-unit FE_COVERAGE=1\` or \`make fe-bundle\`. Not \`make check-fe\`: it
+runs neither the Storybook build nor the coverage report, so it can pass over a
+red \`fe-bundle\` or a broken lcov and send you looking for a failure that is
+not there."\
+    || unreported=1
+fi
+
+if [ "${MAIN_SONAR_RESULT:-}" = "failure" ]; then
+  report "main's SonarCloud analysis was not published" bug \
+"The \`sonarcloud (main)\` job failed on the two-hourly health check, with every
+lane it depends on green: $RUN_URL
+
+This one is filed because it is the failure that hides itself. A stored analysis
+does not go missing when a publish fails — it keeps answering with the last one,
+so \`main\`'s dashboard and the nightly quality-gate job both go on reporting a
+verdict for a tree that has moved on. Nothing else in this repository would say
+so.
+
+The job publishes only with all three coverage reports in hand
+(\`backend/coverage.out\`, \`backend/coverage-extensions.out\`,
+\`frontend/coverage/lcov.info\`), because the scanner's Zero Coverage Sensor
+scores every line it holds no report for as UNCOVERED — a partial scan does not
+decline to answer, it publishes zeros. So the likely cause is an artifact a green
+producer did not upload rather than anything about the scan itself, and the
+failing step names which download it was.
+
+${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
+
+Until it is fixed, treat the quality gate's reading for \`main\` as stale rather
+than as a verdict."\
     || unreported=1
 fi
 

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -126,6 +126,7 @@ expect "a similar title is a different finding" \
 
 readonly INTEGRATION_TITLE="main is red: the integration lane fails on the tip"
 readonly FRONTEND_TITLE="main is red: the frontend lane fails on the tip"
+readonly SONAR_TITLE="main's SonarCloud analysis was not published"
 readonly SUSPECTS="- \`deadbeef\` Some Author — the commit that did it"
 
 # expect_health <name> <lane-result-variable> <expected-title> <suspects>
@@ -162,6 +163,15 @@ expect_health() {
 		failures=$((failures + 1))
 		return
 	fi
+	# The degraded path asserts its own text, not merely that an issue exists.
+	# Without this the no-range cases pass for free: an arm that dropped the
+	# fallback would still file, and "a red lane with no range still files"
+	# would go on reporting ok over a body that says nothing about the window.
+	if [ -z "$suspects" ] && ! printf '%s' "$body" | grep -qF -- "no suspect range was computed"; then
+		echo "FAIL: $name — filed without saying the suspect range is unknown"
+		failures=$((failures + 1))
+		return
+	fi
 	echo "ok: $name"
 }
 
@@ -178,6 +188,21 @@ expect_health "a red lane with no range still files" \
 # the only place a reader learns the quality gate's verdict has stopped moving.
 expect_health "a red frontend lane on main is filed with its suspect range" \
 	MAIN_FRONTEND_RESULT "$FRONTEND_TITLE" "$SUSPECTS"
+
+# Every arm owes the degraded path a case of its own, not only the first one
+# written: the fallback is per-arm text, so a missing one is missing for that arm
+# alone and the other arms' cases go on passing over it.
+expect_health "a red frontend lane with no range still files" \
+	MAIN_FRONTEND_RESULT "$FRONTEND_TITLE" ""
+
+# The publisher, which is the arm that exists because its failure is invisible:
+# a stale analysis reads exactly like a current one, so nothing but this issue
+# would say the verdict stopped moving.
+expect_health "a failed publish of main's analysis is filed with its suspect range" \
+	MAIN_SONAR_RESULT "$SONAR_TITLE" "$SUSPECTS"
+
+expect_health "a failed publish with no range still files" \
+	MAIN_SONAR_RESULT "$SONAR_TITLE" ""
 
 if [ "$failures" -ne 0 ]; then
 	echo "FAIL: $failures case(s)" >&2

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -235,7 +235,22 @@ expect_health "a failed publish with no range still files" \
 # The health arms only. The daily lane's arms (VULN_RESULT, GATE_RESULT, …) carry
 # no suspect range and are covered by the `expect` cases above, so a rule about
 # the fallback text does not apply to them.
-for lane in $(grep -oE 'MAIN_[A-Z_]+_RESULT' "$root/scripts/scheduled-report.sh" | sort -u); do
+#
+# `[A-Z0-9_]`, and the digit is the point: a census that silently drops a subject
+# reports the same "nothing missing" as one that checked it, so a future
+# MAIN_SHARD2_RESULT would be exempt from the rule by spelling alone. The count
+# below is the same argument one level up — a pattern that matches nothing reads
+# as total coverage, which is the loudest way this file could lie.
+# `|| true` so the empty case reaches the message below: grep exits 1 on no match
+# and this script runs under `set -e`, so without it the suite dies at this line
+# having printed thirteen `ok:` lines and no reason — a gate that fails without
+# saying what it found is barely better than one that passes without looking.
+lanes="$(grep -oE 'MAIN_[A-Z0-9_]+_RESULT' "$root/scripts/scheduled-report.sh" | sort -u || true)"
+if [ -z "$lanes" ]; then
+	echo "FAIL: the census found no MAIN_*_RESULT arm in the reporter — the pattern stopped matching, it did not stop mattering"
+	failures=$((failures + 1))
+fi
+for lane in $lanes; do
 	case " $covered_with_range " in
 	*" $lane "*) ;;
 	*)

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -236,16 +236,27 @@ expect_health "a failed publish with no range still files" \
 # no suspect range and are covered by the `expect` cases above, so a rule about
 # the fallback text does not apply to them.
 #
+# What is matched is the ARM — an `if [ "${…:-}" = "failure" ]` line at column
+# zero — rather than a bare identifier anywhere in the file. A bare match reads
+# prose: a single explanatory comment in the reporter naming an arm would invent
+# a lane that does not exist, and the census would both demand cases for it and
+# count it towards the no-arm check below, so a reporter carrying no real arm
+# could satisfy that check on a comment alone. Nothing in the tree does this
+# today; the anchored pattern is what keeps it that way.
+#
 # `[A-Z0-9_]`, and the digit is the point: a census that silently drops a subject
 # reports the same "nothing missing" as one that checked it, so a future
 # MAIN_SHARD2_RESULT would be exempt from the rule by spelling alone. The count
 # below is the same argument one level up — a pattern that matches nothing reads
 # as total coverage, which is the loudest way this file could lie.
+#
 # `|| true` so the empty case reaches the message below: grep exits 1 on no match
 # and this script runs under `set -e`, so without it the suite dies at this line
 # having printed thirteen `ok:` lines and no reason — a gate that fails without
 # saying what it found is barely better than one that passes without looking.
-lanes="$(grep -oE 'MAIN_[A-Z0-9_]+_RESULT' "$root/scripts/scheduled-report.sh" | sort -u || true)"
+lanes="$(grep -oE '^if \[ "\$\{MAIN_[A-Z0-9_]+_RESULT:-\}" = "failure" \]' \
+	"$root/scripts/scheduled-report.sh" |
+	grep -oE 'MAIN_[A-Z0-9_]+_RESULT' | sort -u || true)"
 if [ -z "$lanes" ]; then
 	echo "FAIL: the census found no MAIN_*_RESULT arm in the reporter — the pattern stopped matching, it did not stop mattering"
 	failures=$((failures + 1))

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -124,19 +124,25 @@ expect "a similar title is a different finding" \
 # that filed the issue and dropped MAIN_SUSPECTS would look identical from the
 # outside and be worth nothing.
 
-readonly HEALTH_TITLE="main is red: the integration lane fails on the tip"
+readonly INTEGRATION_TITLE="main is red: the integration lane fails on the tip"
+readonly FRONTEND_TITLE="main is red: the frontend lane fails on the tip"
 readonly SUSPECTS="- \`deadbeef\` Some Author — the commit that did it"
 
-# expect_health <name> <expected-actions> <suspects>
+# expect_health <name> <lane-result-variable> <expected-title> <suspects>
+#
+# The lane is a parameter rather than baked in, so an arm added to the reporter
+# is covered by asking for it here instead of by copying this function. A copy
+# would pass on the day the shared assertion below stopped holding.
 expect_health() {
-	local name="$1" want="$2" suspects="$3" out status got body
+	local name="$1" lane="$2" title="$3" suspects="$4" out status got body
+	local want="create $title"
 	export ACTION_LOG="$stub_dir/actions"
 	export BODY_LOG="$stub_dir/body"
 	: >"$ACTION_LOG"
 	: >"$BODY_LOG"
 	set +e
-	out="$(OPEN_TITLES="" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
-		MAIN_INTEGRATION_RESULT=failure MAIN_SUSPECTS="$suspects" \
+	out="$(env OPEN_TITLES="" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
+		"$lane=failure" MAIN_SUSPECTS="$suspects" \
 		"$root/scripts/scheduled-report.sh" 2>&1)"
 	status=$?
 	set -e
@@ -160,12 +166,18 @@ expect_health() {
 }
 
 expect_health "a red integration lane on main is filed with its suspect range" \
-	"create $HEALTH_TITLE" "$SUSPECTS"
+	MAIN_INTEGRATION_RESULT "$INTEGRATION_TITLE" "$SUSPECTS"
 
 # No range computed is a degraded report, not a silent one: the issue still has to
 # exist, because "main is red" is worth filing even when the window is unknown.
 expect_health "a red lane with no range still files" \
-	"create $HEALTH_TITLE" ""
+	MAIN_INTEGRATION_RESULT "$INTEGRATION_TITLE" ""
+
+# The frontend arm. It carries a second obligation the other two do not: while it
+# is red main's SonarCloud analysis is deliberately not refreshed, so the issue is
+# the only place a reader learns the quality gate's verdict has stopped moving.
+expect_health "a red frontend lane on main is filed with its suspect range" \
+	MAIN_FRONTEND_RESULT "$FRONTEND_TITLE" "$SUSPECTS"
 
 if [ "$failures" -ne 0 ]; then
 	echo "FAIL: $failures case(s)" >&2

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -124,10 +124,19 @@ expect "a similar title is a different finding" \
 # that filed the issue and dropped MAIN_SUSPECTS would look identical from the
 # outside and be worth nothing.
 
+readonly GATES_TITLE="main is red: the backend gate fails on the tip"
 readonly INTEGRATION_TITLE="main is red: the integration lane fails on the tip"
 readonly FRONTEND_TITLE="main is red: the frontend lane fails on the tip"
 readonly SONAR_TITLE="main's SonarCloud analysis was not published"
 readonly SUSPECTS="- \`deadbeef\` Some Author — the commit that did it"
+
+# What the cases below actually exercised, recorded as they run rather than
+# listed by hand. The census at the end of this file reads it: a list kept
+# beside the arms is a list that stops being true the day somebody adds one,
+# which is exactly how MAIN_GATES_RESULT went uncovered while a comment above
+# claimed every arm carried both of its cases.
+covered_with_range=""
+covered_no_range=""
 
 # expect_health <name> <lane-result-variable> <expected-title> <suspects>
 #
@@ -172,15 +181,26 @@ expect_health() {
 		failures=$((failures + 1))
 		return
 	fi
+	if [ -n "$suspects" ]; then
+		covered_with_range="$covered_with_range $lane"
+	else
+		covered_no_range="$covered_no_range $lane"
+	fi
 	echo "ok: $name"
 }
+
+expect_health "a red backend gate on main is filed with its suspect range" \
+	MAIN_GATES_RESULT "$GATES_TITLE" "$SUSPECTS"
+
+expect_health "a red backend gate with no range still files" \
+	MAIN_GATES_RESULT "$GATES_TITLE" ""
 
 expect_health "a red integration lane on main is filed with its suspect range" \
 	MAIN_INTEGRATION_RESULT "$INTEGRATION_TITLE" "$SUSPECTS"
 
 # No range computed is a degraded report, not a silent one: the issue still has to
 # exist, because "main is red" is worth filing even when the window is unknown.
-expect_health "a red lane with no range still files" \
+expect_health "a red integration lane with no range still files" \
 	MAIN_INTEGRATION_RESULT "$INTEGRATION_TITLE" ""
 
 # The frontend arm. It carries a second obligation the other two do not: while it
@@ -191,7 +211,8 @@ expect_health "a red frontend lane on main is filed with its suspect range" \
 
 # Every arm owes the degraded path a case of its own, not only the first one
 # written: the fallback is per-arm text, so a missing one is missing for that arm
-# alone and the other arms' cases go on passing over it.
+# alone and the other arms' cases go on passing over it. The census at the end of
+# this file is what holds that, rather than this comment.
 expect_health "a red frontend lane with no range still files" \
 	MAIN_FRONTEND_RESULT "$FRONTEND_TITLE" ""
 
@@ -203,6 +224,33 @@ expect_health "a failed publish of main's analysis is filed with its suspect ran
 
 expect_health "a failed publish with no range still files" \
 	MAIN_SONAR_RESULT "$SONAR_TITLE" ""
+
+# --- the census -----------------------------------------------------------------
+#
+# Derived from the reporter, not from a list here. Every MAIN_*_RESULT arm it
+# carries owes both cases, and the obligation is checked rather than asserted in a
+# comment — a comment claiming full coverage is what stood over the uncovered
+# MAIN_GATES_RESULT arm until a reviewer read both files side by side.
+#
+# The health arms only. The daily lane's arms (VULN_RESULT, GATE_RESULT, …) carry
+# no suspect range and are covered by the `expect` cases above, so a rule about
+# the fallback text does not apply to them.
+for lane in $(grep -oE 'MAIN_[A-Z_]+_RESULT' "$root/scripts/scheduled-report.sh" | sort -u); do
+	case " $covered_with_range " in
+	*" $lane "*) ;;
+	*)
+		echo "FAIL: the reporter has a $lane arm that no case exercises with a suspect range"
+		failures=$((failures + 1))
+		;;
+	esac
+	case " $covered_no_range " in
+	*" $lane "*) ;;
+	*)
+		echo "FAIL: the reporter has a $lane arm that no case exercises without a suspect range"
+		failures=$((failures + 1))
+		;;
+	esac
+done
 
 if [ "$failures" -ne 0 ]; then
 	echo "FAIL: $failures case(s)" >&2


### PR DESCRIPTION
Closes the live half of #1629.

## What is red

`main`'s SonarCloud quality gate has failed five of the last six nightly runs. The
reliability and security ratings were answered by #2268, so the whole of what is
left is one condition:

```
quality gate on main: ERROR
  failing: new_coverage LT 80 (actual 72.1)
```

The other reds on `main` this week were real and are already fixed: the
`dealrooms` → `gopkg.in/yaml.v3` arch-lint break is gone from the tip, and the
`main-health` run at `2f73f008` is fully green. This is what is left.

## Why it is red, and it is not the tree

`main-health.yml` is the **only** publisher of `main`'s analysis, and its scan job
downloaded `backend/coverage.out` alone while `sonar-project.properties` names
three reports. The scan log has said so on every run:

```
INFO  No LCOV files were found using frontend/coverage/lcov.info
WARN  No coverage information will be saved because all LCOV files cannot be found.
WARN  Coverage report can't be loaded, report file not found, ignoring this file
      backend/coverage-extensions.out.
INFO  Sensor Zero Coverage Sensor
```

The Zero Coverage Sensor scores every executable line it holds no report for as
UNCOVERED. So `main`'s published analysis reads:

| component | published coverage | lines to cover | reality |
|---|---|---|---|
| `backend/internal` | 83.4% | 121,024 | measured |
| `frontend/src` | **0.0%** | 17,781 | vitest: 3,993 tests, **86.6%** lines |
| `extensions` | **0.0%** | 708 | per-unit **86–100%** |

The same tree scanned by `ci.yml` — which downloads all three artifacts — read
**84.0**. The 72.1 is the artifact list, not the code.

## The fix

- **The SPA lane joins `main-health`**, called not copied (`_lane-frontend.yml`).
  It is the producer of the lcov, and it closes a hole this workflow had on its
  own: *"is main red RIGHT NOW"* was answered for the backend and the database
  and never for the frontend.
- **The backend gate emits the extension profile** from the `test-extensions` leg
  it already runs (`EXT_COVER_OUT`), instrumenting the run that decides the
  verdict rather than repeating it — the same trade `_lane-frontend.yml` makes
  with `FE_COVERAGE=1`.
- **The scan downloads all three**, and now `needs` every producer with each
  required to have SUCCEEDED. A red lane freezes `main`'s analysis for two hours,
  which the report job files an issue about; a scan published without a report
  replaces it with a number describing a tree that does not exist.
- **A red SPA lane is reported like the other two**, with the suspect range, and
  it says that the quality gate has stopped moving while it is red.
- `coverage-extensions.out` joins `.gitignore` — it was never listed, and now a
  local reproduction of the backend gate writes it.

## Verified locally on `main`'s tip

| check | result |
|---|---|
| `make check-backend` | green |
| `make fe-quality` / `make fe-unit FE_COVERAGE=1` / `make fe-bundle` | green — 321 files, 3,993 tests; lcov 17,808/20,552 = **86.6%**; `check-lcov-paths` PASS |
| `make test-extensions EXT_COVER_OUT=…` | writes the profile; de 100%, notes 93.2%, relay-probe 86.0%, yogi 100% |
| `EXT_COVER_OUT` through two levels of recursive make | probed — it reaches `test-extensions` from a root `make check-backend` |
| new reporter arm | mutation-verified: deleting the arm fails `make test-scheduled-report`, restoring it passes |

Projecting the measured frontend and extension coverage onto the published line
counts puts the project at **~83.9%**, which is the 84.0 the `ci.yml` scan already
reads — above the 80 threshold.

## Note on #2256

That PR repoints the scan at `margince_margince` after the org migration. The two
do not overlap in files and are independent: whichever project key is in force,
the analysis published for it needs all three reports, or the new project's
baseline restarts already red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `main` SonarCloud analysis by requiring and loading all coverage reports and surfacing publish failures that previously froze the gate. Before: only `backend/coverage.out` was read and missing reports silently published zeros; now: all three producers run, all artifacts are required, and failures are reported.

- Add SPA lane via `./.github/workflows/_lane-frontend.yml` to produce `frontend/coverage/lcov.info`.
- Emit `backend/coverage-extensions.out` from the backend gate; upload with `if-no-files-found: error` and ignore it in `.gitignore`.
- Make the Sonar job `needs` `gates`, `integration`, and `frontend`; download `backend/coverage.out`, `backend/coverage-extensions.out`, and `frontend/coverage/lcov.info` before scanning. A missing or failed producer blocks publish.
- Extend the scheduled report: file when the frontend lane is red (noting the quality gate is frozen) and when the Sonar publish fails; include suspect ranges and correct FE repro commands.
- Strengthen tests: assert degraded-path text; derive arm coverage from the reporter; census now anchors to real `if [...]` arms (not prose), admits digits, fails when no arms are found, and avoids false greens on empty matches.

<sup>Written for commit fa72dacf34ef5a91d858a35849c5109e72e95ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added frontend health checks and coverage reporting to scheduled health scans.
  - Sonar analysis now combines backend, extension, and frontend coverage results.
  - Automated reporting detects frontend, backend, and Sonar analysis failures with troubleshooting details.

- **Documentation**
  - Updated CI pipeline guidance for the additional health lane and coverage requirements.

- **Tests**
  - Expanded scheduled-report validation for all health lanes, failure scenarios, and suspect-range handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->