### PR TITLE
feat(records): a 360 and the activities list can be narrowed to one project

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -930,6 +930,13 @@ paths:
 
         Native system-of-record only: a workspace reading from an incumbent mirror gets
         `422 unsupported_in_overlay_mode`.
+      parameters:
+        - name: project_id
+          in: query
+          schema: { type: string, format: uuid }
+          description: >-
+            Narrow the timeline sections to one body of work: what is filed under this project
+            or under no project; correspondence filed under another project is left out.
       responses:
         '200':
           description: The person's 360 view.
@@ -1877,6 +1884,13 @@ paths:
         Native system-of-record only: a workspace reading from an incumbent mirror gets
         `422 unsupported_in_overlay_mode`, the same refusal entity-scoped activity reads
         give, because the mirror holds none of these relationships.
+      parameters:
+        - name: project_id
+          in: query
+          schema: { type: string, format: uuid }
+          description: >-
+            Narrow the timeline sections to one body of work: what is filed under this project
+            or under no project; correspondence filed under another project is left out.
       responses:
         '200':
           description: The organization's 360 view.
@@ -3534,6 +3548,12 @@ paths:
         - name: q
           in: query
           schema: { type: string }
+        - name: project_id
+          in: query
+          schema: { type: string, format: uuid }
+          description: >-
+            Narrow the timeline sections to one body of work: what is filed under this project
+            or under no project; correspondence filed under another project is left out.
         - name: thread_key
           in: query
           schema: { type: string }

--- a/backend/internal/compose/integration/activity_projectscope_integration_test.go
+++ b/backend/internal/compose/integration/activity_projectscope_integration_test.go
@@ -14,7 +14,9 @@ package integration
 // mode a predicate like this actually has.
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
@@ -27,11 +29,21 @@ import (
 // scopeFixture is one account running two engagements, plus ordinary
 // correspondence belonging to neither — the shape the rule exists for.
 type scopeFixture struct {
-	person  ids.UUID
-	erp     ids.ProjectID
-	onERP   string
-	onOther string
-	unfiled string
+	person ids.UUID
+	org    ids.UUID
+	erp    ids.ProjectID
+	// bystander is a second contact who appears ONLY in the other
+	// engagement's mail — the hop-2 case: a scoped walk reaches people
+	// through the activities it kept, so a person reachable only through a
+	// dropped activity must not appear either.
+	bystander ids.UUID
+	onERP     string
+	onOther   string
+	unfiled   string
+	// otherAt is when the other engagement's mail arrived — the NEWEST
+	// exchange on the account, so an unscoped last-touch date is this one and
+	// a scoped read that still reports it has leaked.
+	otherAt time.Time
 }
 
 // Everything here is written by the REAL writers — CreateProject, LogActivity
@@ -55,13 +67,22 @@ func seedTwoEngagementAccount(t *testing.T, e *Env) scopeFixture {
 	}
 	erp := newProject("ERP rollout", "ERP-27")
 	migration := newProject("Datacentre migration", "DC-4")
+	bystander := e.SeedPerson(t, "Rack Vendor", &e.Rep1)
 
-	// Three exchanges with the same contact: one per engagement, and one
-	// ordinary message nobody filed.
-	mail := func(subject string, within *ids.ProjectID) string {
+	// Three exchanges with the same contact on the same account: one per
+	// engagement, and one ordinary message nobody filed. Each is linked to
+	// the person AND the organization so both record pages read them.
+	mail := func(subject string, within *ids.ProjectID, occurredAt time.Time, others ...ids.UUID) string {
+		links := []activities.ActivityLinkInput{
+			{EntityType: "person", EntityID: person},
+			{EntityType: "organization", EntityID: org},
+		}
+		for _, other := range others {
+			links = append(links, activities.ActivityLinkInput{EntityType: "person", EntityID: other})
+		}
 		logged, _, err := e.Activities.LogActivity(admin, activities.LogActivityInput{
 			Kind: "email", Subject: &subject, Direction: strPtr("inbound"),
-			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+			OccurredAt: &occurredAt, Links: links,
 		})
 		if err != nil {
 			t.Fatalf("log %q: %v", subject, err)
@@ -77,11 +98,12 @@ func seedTwoEngagementAccount(t *testing.T, e *Env) scopeFixture {
 		return ids.UUID(logged.Id).String()
 	}
 
+	otherAt := roomFixedNow.AddDate(0, 0, -1)
 	return scopeFixture{
-		person: person, erp: erp,
-		onERP:   mail("ERP cutover plan", &erp),
-		onOther: mail("Rack decommissioning", &migration),
-		unfiled: mail("Invoice question", nil),
+		person: person, org: org, erp: erp, bystander: bystander, otherAt: otherAt,
+		onERP:   mail("ERP cutover plan", &erp, roomFixedNow.AddDate(0, 0, -3)),
+		onOther: mail("Rack decommissioning", &migration, otherAt, bystander),
+		unfiled: mail("Invoice question", nil, roomFixedNow.AddDate(0, 0, -2)),
 	}
 }
 
@@ -145,17 +167,7 @@ func TestAssembledContextScopedToOneProjectDropsTheOtherEngagement(t *testing.T)
 
 	idsIn := func(opts retrieval.AssembleOptions) map[string]bool {
 		t.Helper()
-		got, err := retriever.AssembleContext(e.Admin(), anchor, opts)
-		if err != nil {
-			t.Fatalf("assemble: %v", err)
-		}
-		out := map[string]bool{}
-		for _, section := range got.Sections {
-			for _, item := range section.Items {
-				out[item.Ref.ID.String()] = true
-			}
-		}
-		return out
+		return walkIDs(e.Admin(), t, retriever, anchor, opts)
 	}
 
 	scoped := idsIn(retrieval.AssembleOptions{MaxItems: 25, ProjectID: f.erp.String()})
@@ -175,5 +187,48 @@ func TestAssembledContextScopedToOneProjectDropsTheOtherEngagement(t *testing.T)
 	wide := idsIn(retrieval.AssembleOptions{MaxItems: 25})
 	if !wide[f.onOther] {
 		t.Error("an unscoped walk lost the other engagement, so the scoped one proves nothing")
+	}
+}
+
+// walkIDs flattens one context walk to the ids it carried, across every
+// section.
+func walkIDs(ctx context.Context, t *testing.T, retriever *search.Retriever, anchor datasource.EntityRef, opts retrieval.AssembleOptions) map[string]bool {
+	t.Helper()
+	got, err := retriever.AssembleContext(ctx, anchor, opts)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	out := map[string]bool{}
+	for _, section := range got.Sections {
+		for _, item := range section.Items {
+			out[item.Ref.ID.String()] = true
+		}
+	}
+	return out
+}
+
+// Hop 2 follows the activities hop 1 KEPT. A person reachable only through
+// the dropped mail is outside the scope too; had hop 2 walked the unscoped
+// timeline, the other engagement's contact would still be in the picture
+// under a heading the scope claims to have narrowed.
+//
+// Anchored on the ACCOUNT: a person anchor never walks person neighbours (the
+// anchor is not its own neighbour), so related_people only exists from here.
+func TestAssembledContextScopedToOneProjectDropsPeopleReachedOnlyThroughTheOtherEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	retriever := search.NewRetriever(search.NewStore(harnessDB(e.Pool, e.WS)), nil)
+	anchor := datasource.EntityRef{Type: datasource.EntityOrganization, ID: f.org}
+
+	scoped := walkIDs(e.Admin(), t, retriever, anchor, retrieval.AssembleOptions{MaxItems: 25, ProjectID: f.erp.String()})
+	if scoped[f.bystander.String()] {
+		t.Error("a person linked only through the other engagement's mail reached the scoped walk's related_people")
+	}
+	if !scoped[f.person.String()] {
+		t.Error("the contact on the scoped engagement's own mail is missing from related_people")
+	}
+	wide := walkIDs(e.Admin(), t, retriever, anchor, retrieval.AssembleOptions{MaxItems: 25})
+	if !wide[f.bystander.String()] {
+		t.Error("an unscoped walk lost the other engagement's contact, so the scoped absence proves nothing")
 	}
 }

--- a/backend/internal/compose/integration/activity_projectscope_integration_test.go
+++ b/backend/internal/compose/integration/activity_projectscope_integration_test.go
@@ -40,6 +40,13 @@ type scopeFixture struct {
 	onERP     string
 	onOther   string
 	unfiled   string
+	// One open task and one future meeting per engagement, so the next-steps,
+	// next-meeting and since-last-visit sections each have a row the scope
+	// must drop and a row it must keep.
+	erpTask      string
+	otherTask    string
+	erpMeeting   string
+	otherMeeting string
 	// otherAt is when the other engagement's mail arrived — the NEWEST
 	// exchange on the account, so an unscoped last-touch date is this one and
 	// a scoped read that still reports it has leaked.
@@ -72,18 +79,16 @@ func seedTwoEngagementAccount(t *testing.T, e *Env) scopeFixture {
 	// Three exchanges with the same contact on the same account: one per
 	// engagement, and one ordinary message nobody filed. Each is linked to
 	// the person AND the organization so both record pages read them.
-	mail := func(subject string, within *ids.ProjectID, occurredAt time.Time, others ...ids.UUID) string {
-		links := []activities.ActivityLinkInput{
+	log := func(in activities.LogActivityInput, subject string, within *ids.ProjectID, occurredAt time.Time, others ...ids.UUID) string {
+		in.Subject, in.OccurredAt = &subject, &occurredAt
+		in.Links = []activities.ActivityLinkInput{
 			{EntityType: "person", EntityID: person},
 			{EntityType: "organization", EntityID: org},
 		}
 		for _, other := range others {
-			links = append(links, activities.ActivityLinkInput{EntityType: "person", EntityID: other})
+			in.Links = append(in.Links, activities.ActivityLinkInput{EntityType: "person", EntityID: other})
 		}
-		logged, _, err := e.Activities.LogActivity(admin, activities.LogActivityInput{
-			Kind: "email", Subject: &subject, Direction: strPtr("inbound"),
-			OccurredAt: &occurredAt, Links: links,
-		})
+		logged, _, err := e.Activities.LogActivity(admin, in)
 		if err != nil {
 			t.Fatalf("log %q: %v", subject, err)
 		}
@@ -98,12 +103,28 @@ func seedTwoEngagementAccount(t *testing.T, e *Env) scopeFixture {
 		return ids.UUID(logged.Id).String()
 	}
 
+	mail := func(subject string, within *ids.ProjectID, occurredAt time.Time, others ...ids.UUID) string {
+		return log(activities.LogActivityInput{Kind: "email", Direction: strPtr("inbound")}, subject, within, occurredAt, others...)
+	}
+	task := func(subject string, within *ids.ProjectID) string {
+		return log(activities.LogActivityInput{Kind: "task"}, subject, within, roomFixedNow.AddDate(0, 0, -1))
+	}
+	meeting := func(subject string, within *ids.ProjectID, startsAt time.Time) string {
+		return log(activities.LogActivityInput{Kind: "meeting", MeetingStatus: strPtr("booked")}, subject, within, startsAt)
+	}
 	otherAt := roomFixedNow.AddDate(0, 0, -1)
 	return scopeFixture{
 		person: person, org: org, erp: erp, bystander: bystander, otherAt: otherAt,
-		onERP:   mail("ERP cutover plan", &erp, roomFixedNow.AddDate(0, 0, -3)),
-		onOther: mail("Rack decommissioning", &migration, otherAt, bystander),
-		unfiled: mail("Invoice question", nil, roomFixedNow.AddDate(0, 0, -2)),
+		onERP:     mail("ERP cutover plan", &erp, roomFixedNow.AddDate(0, 0, -3)),
+		onOther:   mail("Rack decommissioning", &migration, otherAt, bystander),
+		unfiled:   mail("Invoice question", nil, roomFixedNow.AddDate(0, 0, -2)),
+		erpTask:   task("Send ERP cutover checklist", &erp),
+		otherTask: task("Book the rack haulier", &migration),
+		// The other engagement's meeting is the SOONER one, so an unscoped
+		// next-meeting read names it and a scoped read that still does has
+		// leaked the other project.
+		erpMeeting:   meeting("ERP go-live rehearsal", &erp, roomFixedNow.AddDate(0, 0, 5)),
+		otherMeeting: meeting("Rack move walkthrough", &migration, roomFixedNow.AddDate(0, 0, 2)),
 	}
 }
 
@@ -148,8 +169,8 @@ func TestTimelineWithoutAScopeStillSeesEveryEngagement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list unscoped: %v", err)
 	}
-	if len(got) != 3 {
-		t.Fatalf("unscoped timeline = %d rows, want 3 — an absent scope narrows nothing", len(got))
+	if len(got) != 7 {
+		t.Fatalf("unscoped timeline = %d rows, want all 7 — an absent scope narrows nothing", len(got))
 	}
 }
 

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -222,3 +222,50 @@ func TestTheOwnerDialsRefuseEachOtherOnTheWire(t *testing.T) {
 		t.Fatalf("GET %s = %d, want 422 — two owner dials name two different sets", path, status)
 	}
 }
+
+// The project scope on the timeline list, over the wire. Three activities on
+// one person — filed under the asked-for project, filed under another, filed
+// under none — and the scoped page must be exactly the first and the third: a
+// handler that drops `project_id` answers all three with the right shape.
+func TestTheActivityListNarrowsByProjectOnTheWire(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	org := createdRecord(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Acme"})
+	person := createdRecord(t, e, "/v1/people", apptest.AnyMap{"full_name": "Dana Buyer"})
+	project := func(name string) string {
+		return createdRecord(t, e, "/v1/projects", apptest.AnyMap{
+			"name": name, "organization_id": org, "source": "manual",
+		})
+	}
+	erp, migration := project("ERP rollout"), project("Datacentre migration")
+
+	mail := func(subject string, within string) string {
+		links := []apptest.AnyMap{{"entity_type": "person", "entity_id": person}}
+		if within != "" {
+			links = append(links, apptest.AnyMap{"entity_type": "project", "entity_id": within})
+		}
+		return createdRecord(t, e, "/v1/activities", apptest.AnyMap{
+			"kind": "email", "subject": subject, "direction": "inbound", "links": links,
+		})
+	}
+	onERP := mail("ERP cutover plan", erp)
+	onOther := mail("Rack decommissioning", migration)
+	unfiled := mail("Invoice question", "")
+
+	var page listedIDs
+	path := "/v1/activities?entity_type=person&entity_id=" + person + "&project_id=" + erp
+	if status := e.Call(t, "GET", path, nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200", path, status)
+	}
+	seen := map[string]bool{}
+	for _, row := range page.Data {
+		seen[row.ID] = true
+	}
+	if seen[onOther] {
+		t.Errorf("GET %s returned the other engagement's mail — the handler dropped project_id", path)
+	}
+	if !seen[onERP] || !seen[unfiled] {
+		t.Errorf("GET %s lost the scoped project's own mail or the unfiled one: got %v", path, seen)
+	}
+}

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -277,7 +277,7 @@ func TestOrganization360TransportServesANativeWorkspace(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/"+org.String()+"/360", nil)
-	handlers.GetOrganization360(rec, req.WithContext(rep), crmcontracts.Id(org.UUID))
+	handlers.GetOrganization360(rec, req.WithContext(rep), crmcontracts.Id(org.UUID), crmcontracts.GetOrganization360Params{})
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body %s", rec.Code, rec.Body.String())

--- a/backend/internal/compose/integration/person360_http_integration_test.go
+++ b/backend/internal/compose/integration/person360_http_integration_test.go
@@ -62,7 +62,9 @@ func TestPerson360SurfacesAllRefuseAForeignContactWith404(t *testing.T) {
 	id := crmcontracts.Id(theirs)
 
 	for name, run := range map[string]func(http.ResponseWriter, *http.Request){
-		"the composite read": func(w http.ResponseWriter, r *http.Request) { h.GetPerson360(w, r, id) },
+		"the composite read": func(w http.ResponseWriter, r *http.Request) {
+			h.GetPerson360(w, r, id, crmcontracts.GetPerson360Params{})
+		},
 		"the profile-field sidecar": func(w http.ResponseWriter, r *http.Request) {
 			h.GetPersonProfileFields(w, r, id)
 		},
@@ -86,7 +88,9 @@ func TestGetPerson360AnswersOneParseableComposite(t *testing.T) {
 	h := personHandlers(e)
 
 	code, body := call(rep, http.MethodGet, "/v1/people/"+mine.String()+"/360",
-		func(w http.ResponseWriter, r *http.Request) { h.GetPerson360(w, r, crmcontracts.Id(mine)) })
+		func(w http.ResponseWriter, r *http.Request) {
+			h.GetPerson360(w, r, crmcontracts.Id(mine), crmcontracts.GetPerson360Params{})
+		})
 	if code != http.StatusOK {
 		t.Fatalf("360 → %d, want 200", code)
 	}
@@ -125,7 +129,9 @@ func TestTheViewBaselineMovesOnlyOnTheAcknowledgement(t *testing.T) {
 	}
 
 	if code, _ := call(rep, http.MethodGet, "/v1/people/"+mine.String()+"/360",
-		func(w http.ResponseWriter, r *http.Request) { h.GetPerson360(w, r, crmcontracts.Id(mine)) }); code != http.StatusOK {
+		func(w http.ResponseWriter, r *http.Request) {
+			h.GetPerson360(w, r, crmcontracts.Id(mine), crmcontracts.GetPerson360Params{})
+		}); code != http.StatusOK {
 		t.Fatalf("360 → %d", code)
 	}
 	if baseline() != 0 {
@@ -199,7 +205,9 @@ func TestAMomentDoesNotClaimAbsenceForASectionTheReaderCouldNotSee(t *testing.T)
 	read := func(ctx context.Context) crmcontracts.Person360 {
 		t.Helper()
 		code, body := call(ctx, http.MethodGet, "/v1/people/"+mine.String()+"/360",
-			func(w http.ResponseWriter, r *http.Request) { h.GetPerson360(w, r, crmcontracts.Id(mine)) })
+			func(w http.ResponseWriter, r *http.Request) {
+				h.GetPerson360(w, r, crmcontracts.Id(mine), crmcontracts.GetPerson360Params{})
+			})
 		if code != http.StatusOK {
 			t.Fatalf("360 → %d, want 200", code)
 		}

--- a/backend/internal/compose/integration/projectscope_360_integration_test.go
+++ b/backend/internal/compose/integration/projectscope_360_integration_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The project scope on the two record pages. Each page reads its timeline
+// and its last-touch dates through its own SQL, so the timeline list being
+// scoped proves nothing about either; and the last-touch date is the number a
+// reader trusts most, so it is asserted on its own rather than inferred from
+// the rows beneath it.
+//
+// The fixture makes the OTHER engagement's mail the newest exchange on the
+// account. An unscoped read therefore reports that date as the last inbound
+// touch, and a scoped read that still does has leaked the other project
+// through the one section the rows do not show.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/org360"
+	"github.com/gradionhq/margince/backend/internal/compose/person360"
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+)
+
+// timelineIDs collects which activities a page's timeline section shows.
+func timelineIDs(rows []crmcontracts.Activity) map[string]bool {
+	out := map[string]bool{}
+	for _, a := range rows {
+		out[a.Id.String()] = true
+	}
+	return out
+}
+
+// assertScopedTimeline is the one reading both pages must give: the scoped
+// project's mail and the unfiled mail stay, the other engagement's goes, and
+// the last inbound touch is no longer the other engagement's date.
+func assertScopedTimeline(t *testing.T, f scopeFixture, seen map[string]bool, lastInbound *time.Time) {
+	t.Helper()
+	if seen[f.onOther] {
+		t.Error("the other engagement's mail survived a scoped page — the scope filtered nothing")
+	}
+	if !seen[f.onERP] {
+		t.Error("the scoped project's own mail is missing from the page")
+	}
+	if !seen[f.unfiled] {
+		t.Error("mail filed under NO project was dropped; the rule keeps it")
+	}
+	if lastInbound == nil {
+		t.Fatal("the scoped page reports no inbound touch at all, though two in-scope mails are inbound")
+	}
+	if lastInbound.Equal(f.otherAt) {
+		t.Errorf("last_inbound_at = %s, the other engagement's mail — the last-touch read ignores the scope", f.otherAt)
+	}
+}
+
+func TestPerson360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	svc := personRoomService(e)
+	personID := PersonIDOf(f.person)
+
+	scoped, err := svc.AssembleScoped(e.Admin(), personID, person360.AssembleOptions{ProjectID: &f.erp})
+	if err != nil {
+		t.Fatalf("assemble scoped: %v", err)
+	}
+	if scoped.Activities == nil {
+		t.Fatal("the activities section was withheld, so the scope cannot be judged")
+	}
+	assertScopedTimeline(t, f, timelineIDs(scoped.Activities.Data), scoped.LastInboundAt)
+
+	// Unscoped, the same page still shows the other engagement and dates its
+	// last touch from it — so the narrowing above is the scope's doing.
+	wide, err := svc.Assemble(e.Admin(), personID)
+	if err != nil {
+		t.Fatalf("assemble unscoped: %v", err)
+	}
+	if !timelineIDs(wide.Activities.Data)[f.onOther] {
+		t.Error("an unscoped page lost the other engagement, so the scoped one proves nothing")
+	}
+	if wide.LastInboundAt == nil || !wide.LastInboundAt.Equal(f.otherAt) {
+		t.Errorf("unscoped last_inbound_at = %v, want the other engagement's %s", wide.LastInboundAt, f.otherAt)
+	}
+}
+
+func TestOrganization360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	svc := org360.NewService(e.Pool, e.People, approvals.NewService(e.DB()),
+		func() time.Time { return roomFixedNow })
+	orgID := orgIDOf(f.org)
+
+	scoped, err := svc.AssembleScoped(e.Admin(), orgID, org360.AssembleOptions{ProjectID: &f.erp})
+	if err != nil {
+		t.Fatalf("assemble scoped: %v", err)
+	}
+	if scoped.Activities == nil {
+		t.Fatal("the activities section was withheld, so the scope cannot be judged")
+	}
+	assertScopedTimeline(t, f, timelineIDs(scoped.Activities.Data), scoped.LastInboundAt)
+
+	wide, err := svc.Assemble(e.Admin(), orgID)
+	if err != nil {
+		t.Fatalf("assemble unscoped: %v", err)
+	}
+	if !timelineIDs(wide.Activities.Data)[f.onOther] {
+		t.Error("an unscoped page lost the other engagement, so the scoped one proves nothing")
+	}
+	if wide.LastInboundAt == nil || !wide.LastInboundAt.Equal(f.otherAt) {
+		t.Errorf("unscoped last_inbound_at = %v, want the other engagement's %s", wide.LastInboundAt, f.otherAt)
+	}
+}

--- a/backend/internal/compose/integration/projectscope_360_integration_test.go
+++ b/backend/internal/compose/integration/projectscope_360_integration_test.go
@@ -17,13 +17,22 @@ package integration
 // through the one section the rows do not show.
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"testing"
 	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	"github.com/gradionhq/margince/backend/internal/compose/person360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // timelineIDs collects which activities a page's timeline section shows.
@@ -57,6 +66,38 @@ func assertScopedTimeline(t *testing.T, f scopeFixture, seen map[string]bool, la
 	}
 }
 
+// assertScopedNeighbours covers the sections beside the timeline that read
+// activities through their own SQL: the open tasks, the next meeting and the
+// since-last-visit count. Each assertion is the one that fails when that
+// section's copy of the scope is missing.
+//
+// inScope is how many of the fixture's rows the scope keeps: the ERP mail, the
+// unfiled mail, the ERP task and the ERP meeting. The caller has no visit
+// baseline, so the count runs over the whole history.
+func assertScopedNeighbours(t *testing.T, f scopeFixture, tasks map[string]bool, nextMeeting *string, newActivities int) {
+	t.Helper()
+	if tasks[f.otherTask] {
+		t.Error("the other engagement's open task survived a scoped page — next_steps ignores the scope")
+	}
+	if !tasks[f.erpTask] {
+		t.Error("the scoped project's own open task is missing from next_steps")
+	}
+	switch {
+	case nextMeeting == nil:
+		t.Error("the scoped page names no next meeting, though the scoped project has one booked")
+	case *nextMeeting == f.otherMeeting:
+		t.Error("the scoped page's next meeting is the other engagement's — next_meeting ignores the scope")
+	case *nextMeeting != f.erpMeeting:
+		t.Errorf("next_meeting = %s, want the scoped project's %s", *nextMeeting, f.erpMeeting)
+	}
+	const inScope = 4
+	if newActivities != inScope {
+		t.Errorf("since_last_visit.new_activities = %d, want %d — the count reads rows the scope drops", newActivities, inScope)
+	}
+}
+
+func activityIDOf(id openapi_types.UUID) *string { s := id.String(); return &s }
+
 func TestPerson360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
 	e := Setup(t)
 	f := seedTwoEngagementAccount(t, e)
@@ -71,6 +112,14 @@ func TestPerson360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
 		t.Fatal("the activities section was withheld, so the scope cannot be judged")
 	}
 	assertScopedTimeline(t, f, timelineIDs(scoped.Activities.Data), scoped.LastInboundAt)
+	if scoped.NextSteps == nil || scoped.SinceLastVisit == nil {
+		t.Fatal("next_steps or since_last_visit was withheld, so the scope cannot be judged")
+	}
+	var nextMeeting *string
+	if scoped.NextMeeting != nil {
+		nextMeeting = activityIDOf(scoped.NextMeeting.ActivityId)
+	}
+	assertScopedNeighbours(t, f, timelineIDs(scoped.NextSteps.Data), nextMeeting, scoped.SinceLastVisit.NewActivities)
 
 	// Unscoped, the same page still shows the other engagement and dates its
 	// last touch from it — so the narrowing above is the scope's doing.
@@ -80,6 +129,9 @@ func TestPerson360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) {
 	}
 	if !timelineIDs(wide.Activities.Data)[f.onOther] {
 		t.Error("an unscoped page lost the other engagement, so the scoped one proves nothing")
+	}
+	if wide.NextMeeting == nil || wide.NextMeeting.ActivityId.String() != f.otherMeeting {
+		t.Error("an unscoped page does not name the other engagement's sooner meeting, so the scoped one proves nothing")
 	}
 	if wide.LastInboundAt == nil || !wide.LastInboundAt.Equal(f.otherAt) {
 		t.Errorf("unscoped last_inbound_at = %v, want the other engagement's %s", wide.LastInboundAt, f.otherAt)
@@ -101,6 +153,18 @@ func TestOrganization360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) 
 		t.Fatal("the activities section was withheld, so the scope cannot be judged")
 	}
 	assertScopedTimeline(t, f, timelineIDs(scoped.Activities.Data), scoped.LastInboundAt)
+	if scoped.NextSteps == nil || scoped.SinceLastVisit == nil {
+		t.Fatal("next_steps or since_last_visit was withheld, so the scope cannot be judged")
+	}
+	tasks := map[string]bool{}
+	for _, step := range scoped.NextSteps.Data {
+		tasks[step.ActivityId.String()] = true
+	}
+	var nextMeeting *string
+	if scoped.NextMeeting != nil {
+		nextMeeting = activityIDOf(scoped.NextMeeting.ActivityId)
+	}
+	assertScopedNeighbours(t, f, tasks, nextMeeting, scoped.SinceLastVisit.NewActivities)
 
 	wide, err := svc.Assemble(e.Admin(), orgID)
 	if err != nil {
@@ -109,7 +173,77 @@ func TestOrganization360ScopedToOneProjectDropsTheOtherEngagement(t *testing.T) 
 	if !timelineIDs(wide.Activities.Data)[f.onOther] {
 		t.Error("an unscoped page lost the other engagement, so the scoped one proves nothing")
 	}
+	if wide.NextMeeting == nil || wide.NextMeeting.ActivityId.String() != f.otherMeeting {
+		t.Error("an unscoped page does not name the other engagement's sooner meeting, so the scoped one proves nothing")
+	}
 	if wide.LastInboundAt == nil || !wide.LastInboundAt.Equal(f.otherAt) {
 		t.Errorf("unscoped last_inbound_at = %v, want the other engagement's %s", wide.LastInboundAt, f.otherAt)
+	}
+}
+
+// The scope is a read of the project. A caller with no project grant may not
+// use it as an oracle for which activities are filed under one (403), and a
+// project the caller cannot see — or that does not exist — answers the same
+// existence-hiding 404 a direct read gives.
+func TestAProjectScopeIsGatedLikeAReadOfTheProject(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	noProjectGrant := roomPerms
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, noProjectGrant)
+	nobodyID := ids.From[ids.ProjectKind](ids.NewV7())
+	person := string(datasource.RecordPerson)
+
+	if _, _, err := e.Activities.ListActivities(rep, activities.ListActivitiesInput{
+		EntityType: &person, EntityID: &f.person, WithinProjectID: &f.erp,
+	}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("list scoped to a project without a project grant: err = %v, want permission denied", err)
+	}
+	if _, _, err := e.Activities.ListActivities(e.Admin(), activities.ListActivitiesInput{
+		EntityType: &person, EntityID: &f.person, WithinProjectID: &nobodyID,
+	}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("list scoped to a project that does not exist: err = %v, want not found", err)
+	}
+
+	personSvc := personRoomService(e)
+	if _, err := personSvc.AssembleScoped(rep, PersonIDOf(f.person), person360.AssembleOptions{ProjectID: &f.erp}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("person page scoped without a project grant: err = %v, want permission denied", err)
+	}
+	if _, err := personSvc.AssembleScoped(e.Admin(), PersonIDOf(f.person), person360.AssembleOptions{ProjectID: &nobodyID}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("person page scoped to a project that does not exist: err = %v, want not found", err)
+	}
+
+	orgSvc := org360.NewService(e.Pool, e.People, approvals.NewService(e.DB()), func() time.Time { return roomFixedNow })
+	if _, err := orgSvc.AssembleScoped(rep, orgIDOf(f.org), org360.AssembleOptions{ProjectID: &f.erp}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("company page scoped without a project grant: err = %v, want permission denied", err)
+	}
+	if _, err := orgSvc.AssembleScoped(e.Admin(), orgIDOf(f.org), org360.AssembleOptions{ProjectID: &nobodyID}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("company page scoped to a project that does not exist: err = %v, want not found", err)
+	}
+}
+
+// The same gate on the wire: the handler maps the refusal to the status a
+// client acts on rather than answering an unfiltered page.
+func TestAProjectScopeOnTheActivityListAnswers403And404OnTheWire(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	h := activities.NewHandlers(e.DB())
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
+	list := func(ctx context.Context, projectID ids.UUID) int {
+		t.Helper()
+		wire := openapi_types.UUID(projectID)
+		status, _ := call(ctx, http.MethodGet, "/v1/activities?project_id="+projectID.String(),
+			func(w http.ResponseWriter, r *http.Request) {
+				h.ListActivities(w, r, crmcontracts.ListActivitiesParams{ProjectId: &wire})
+			})
+		return status
+	}
+	if got := list(rep, f.erp.UUID); got != http.StatusForbidden {
+		t.Errorf("GET /activities?project_id= without a project grant = %d, want 403", got)
+	}
+	if got := list(e.Admin(), ids.NewV7()); got != http.StatusNotFound {
+		t.Errorf("GET /activities?project_id=<nobody> = %d, want 404", got)
+	}
+	if got := list(e.Admin(), f.erp.UUID); got != http.StatusOK {
+		t.Errorf("GET /activities?project_id= with the grant = %d, want 200 — the gate refuses everyone", got)
 	}
 }

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -178,6 +178,8 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		{"disqualify_lead", `{"lead_id":"` + lead.String() + `"}`},
 		{"log_activity", `{"kind":"note","body":"conformance","links":[{"entity_type":"deal","entity_id":"` +
 			deal.String() + `"}]}`},
+		{"create_task", `{"subject":"conformance","links":[{"entity_type":"deal","entity_id":"` +
+			deal.String() + `"}]}`},
 		{"update_record", `{"record_type":"person","id":"` + person.String() +
 			`","fields":{"title":"Head of Conformance"}}`},
 		{"progress_deal", `{"deal_id":"` + deal.String() + `","to_stage_id":"` + open.String() +

--- a/backend/internal/compose/org360/accountstate.go
+++ b/backend/internal/compose/org360/accountstate.go
@@ -51,6 +51,12 @@ func (a *assembly) readLastTouch() error {
 	if scope != "" {
 		where += " AND " + scope
 	}
+	// The same narrowing the timeline section applied: a last-touch date
+	// taken from the other engagement's mail would contradict the rows shown
+	// beneath it.
+	if a.opts.ProjectID != nil {
+		where += " AND " + activities.ActivityWithinProject(arg(*a.opts.ProjectID))
+	}
 	// Two ordered LIMIT-1 arms in ONE round trip, rather than two FILTERed
 	// max() aggregates. An aggregate has to see every qualifying row before it
 	// can answer; each arm here stops at the first, so the cost is bounded by

--- a/backend/internal/compose/org360/accountstate.go
+++ b/backend/internal/compose/org360/accountstate.go
@@ -51,12 +51,7 @@ func (a *assembly) readLastTouch() error {
 	if scope != "" {
 		where += " AND " + scope
 	}
-	// The same narrowing the timeline section applied: a last-touch date
-	// taken from the other engagement's mail would contradict the rows shown
-	// beneath it.
-	if a.opts.ProjectID != nil {
-		where += " AND " + activities.ActivityWithinProject(arg(*a.opts.ProjectID))
-	}
+	where += a.opts.projectScope(arg)
 	// Two ordered LIMIT-1 arms in ONE round trip, rather than two FILTERed
 	// max() aggregates. An aggregate has to see every qualifying row before it
 	// can answer; each arm here stops at the first, so the cost is bounded by

--- a/backend/internal/compose/org360/assemble.go
+++ b/backend/internal/compose/org360/assemble.go
@@ -80,6 +80,18 @@ type AssembleOptions struct {
 	ProjectID *ids.ProjectID
 }
 
+// projectScope renders the body-of-work narrowing as one more WHERE term on
+// the activity alias `a`, or nothing when the page is unscoped. Every
+// activity-reading section goes through it — timeline, last touch, next
+// steps, next meeting, the since-last-visit count — so the page cannot show
+// one project's rows beside another project's date or task.
+func (o AssembleOptions) projectScope(arg func(any) int) string {
+	if o.ProjectID == nil {
+		return ""
+	}
+	return " AND " + activities.ActivityWithinProject(arg(*o.ProjectID))
+}
+
 // AssembleScoped is Assemble narrowed by opts.
 func (s *Service) AssembleScoped(ctx context.Context, orgID ids.OrganizationID, opts AssembleOptions) (crmcontracts.Organization360, error) {
 	now := s.now().UTC()
@@ -97,6 +109,15 @@ func (s *Service) AssembleScoped(ctx context.Context, orgID ids.OrganizationID, 
 			return err
 		}
 		out.Organization = org
+		// The scope is a read of the project, gated before any section
+		// filters on it — and as the whole read's refusal, not a section's:
+		// a page narrowed to a project the caller may not see has no honest
+		// sections at all.
+		if opts.ProjectID != nil {
+			if err := activities.RequireProjectScope(ctx, tx, *opts.ProjectID); err != nil {
+				return err
+			}
+		}
 		return s.sections(ctx, tx, orgID, now, opts, &out)
 	})
 	if err != nil {
@@ -339,7 +360,7 @@ func (a *assembly) readNextSteps() error {
 	if err := auth.Require(a.ctx, "activity", principal.ActionRead); err != nil {
 		return err
 	}
-	data, page, err := nextStepsSection(a.ctx, a.tx, a.orgID, a.now)
+	data, page, err := nextStepsSection(a.ctx, a.tx, a.orgID, a.now, a.opts)
 	if err != nil {
 		return err
 	}
@@ -357,7 +378,7 @@ func (a *assembly) readNextMeeting() error {
 	if err := auth.Require(a.ctx, "activity", principal.ActionRead); err != nil {
 		return err
 	}
-	meeting, err := nextMeetingSection(a.ctx, a.tx, a.orgID, a.now)
+	meeting, err := nextMeetingSection(a.ctx, a.tx, a.orgID, a.now, a.opts)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/compose/org360/assemble.go
+++ b/backend/internal/compose/org360/assemble.go
@@ -66,6 +66,22 @@ func NewService(pool *pgxpool.Pool, peopleStore *people.Store, approvalsSvc *app
 // refusal; every other section is attempted, and a section refused for
 // lack of a grant is omitted and named rather than returned empty.
 func (s *Service) Assemble(ctx context.Context, orgID ids.OrganizationID) (crmcontracts.Organization360, error) {
+	return s.AssembleScoped(ctx, orgID, AssembleOptions{})
+}
+
+// AssembleOptions narrows what the page reads. The zero value is the whole
+// record.
+type AssembleOptions struct {
+	// ProjectID scopes the timeline and the last-touch dates to one body of
+	// work: rows filed under this project or under none, never rows filed
+	// under another project. The rule is activities.ActivityWithinProject;
+	// contacts, deals and tags describe the account, not a project, and stay
+	// whole.
+	ProjectID *ids.ProjectID
+}
+
+// AssembleScoped is Assemble narrowed by opts.
+func (s *Service) AssembleScoped(ctx context.Context, orgID ids.OrganizationID, opts AssembleOptions) (crmcontracts.Organization360, error) {
 	now := s.now().UTC()
 	out := crmcontracts.Organization360{AsOf: now, SectionsOmitted: []crmcontracts.Organization360SectionsOmitted{}}
 	// The custom-field catalog is read above the transaction, not inside it:
@@ -81,7 +97,7 @@ func (s *Service) Assemble(ctx context.Context, orgID ids.OrganizationID) (crmco
 			return err
 		}
 		out.Organization = org
-		return s.sections(ctx, tx, orgID, now, &out)
+		return s.sections(ctx, tx, orgID, now, opts, &out)
 	})
 	if err != nil {
 		return crmcontracts.Organization360{}, err
@@ -95,8 +111,8 @@ func (s *Service) Assemble(ctx context.Context, orgID ids.OrganizationID) (crmco
 // apperrors.ErrPermissionDenied is omitted and named; any other error
 // fails the whole read, because a section that broke for a real reason
 // must never be reported as one the caller may not see.
-func (s *Service) sections(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time, out *crmcontracts.Organization360) error {
-	a := &assembly{svc: s, ctx: ctx, tx: tx, orgID: orgID, now: now, out: out}
+func (s *Service) sections(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time, opts AssembleOptions, out *crmcontracts.Organization360) error {
+	a := &assembly{svc: s, ctx: ctx, tx: tx, orgID: orgID, now: now, opts: opts, out: out}
 	each := []struct {
 		name crmcontracts.Organization360SectionsOmitted
 		read func() error
@@ -145,6 +161,7 @@ type assembly struct {
 	tx    pgx.Tx
 	orgID ids.OrganizationID
 	now   time.Time
+	opts  AssembleOptions
 	out   *crmcontracts.Organization360
 
 	// baseCurrency is the installation's reporting currency, resolved at most
@@ -262,9 +279,10 @@ func (a *assembly) readTimeline() error {
 	entityType := "organization"
 	limit := sectionLimit
 	data, page, err := activities.ListActivitiesTx(a.ctx, a.tx, activities.ListActivitiesInput{
-		EntityType: &entityType,
-		EntityID:   &orgUUID,
-		Limit:      &limit,
+		EntityType:      &entityType,
+		EntityID:        &orgUUID,
+		Limit:           &limit,
+		WithinProjectID: a.opts.ProjectID,
 	})
 	if err != nil {
 		return err

--- a/backend/internal/compose/org360/handlers.go
+++ b/backend/internal/compose/org360/handlers.go
@@ -36,11 +36,16 @@ func NewHandlers(svc *Service, overlay OverlayMode) Handlers {
 }
 
 // GetOrganization360 implements GET /organizations/{id}/360.
-func (h Handlers) GetOrganization360(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+func (h Handlers) GetOrganization360(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, params crmcontracts.GetOrganization360Params) {
 	if !h.nativeOnly(w, r) {
 		return
 	}
-	view, err := h.svc.Assemble(r.Context(), ids.From[ids.OrganizationKind](ids.UUID(id)))
+	var opts AssembleOptions
+	if params.ProjectId != nil {
+		projectID := ids.From[ids.ProjectKind](ids.UUID(*params.ProjectId))
+		opts.ProjectID = &projectID
+	}
+	view, err := h.svc.AssembleScoped(r.Context(), ids.From[ids.OrganizationKind](ids.UUID(id)), opts)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/org360/handlers_test.go
+++ b/backend/internal/compose/org360/handlers_test.go
@@ -35,7 +35,7 @@ func TestGetOrganization360RefusesAnOverlayWorkspace(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/x/360", nil)
 
-	h.GetOrganization360(rec, req, crmcontracts.Id(ids.NewV7()))
+	h.GetOrganization360(rec, req, crmcontracts.Id(ids.NewV7()), crmcontracts.GetOrganization360Params{})
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422", rec.Code)
@@ -95,7 +95,7 @@ func TestGetOrganization360RefusesWhenTheModeCannotBeResolved(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/x/360", nil)
 
-	h.GetOrganization360(rec, req, crmcontracts.Id(ids.NewV7()))
+	h.GetOrganization360(rec, req, crmcontracts.Id(ids.NewV7()), crmcontracts.GetOrganization360Params{})
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d after a failed mode lookup, want 500 — the mode is unknown, so neither native data nor a tidy refusal is an honest answer",

--- a/backend/internal/compose/org360/nextmeeting.go
+++ b/backend/internal/compose/org360/nextmeeting.go
@@ -56,7 +56,7 @@ const meetingParticipantLimit = 8
 // per account than per page. The attendees come back as JSON from a lateral
 // sub-select, carrying their own row-scope predicate.
 func nextMeetingSection(
-	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time,
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time, opts AssembleOptions,
 ) (*crmcontracts.Organization360NextMeeting, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -117,11 +117,11 @@ func nextMeetingSection(
 		  -- booking nobody has tracked a status on, which is a real meeting.
 		  AND (a.meeting_status IS NULL OR a.meeting_status = 'booked')
 		  AND a.occurred_at > $%[4]d
-		  AND %[1]s AND %[2]s
+		  AND %[1]s AND %[2]s%[7]s
 		ORDER BY a.occurred_at, a.id
 		LIMIT 1`,
 		activityScope, activities.OrgLinkedActivityExists(orgPos), dealVisible, nowPos,
-		personVisible, meetingParticipantLimit),
+		personVisible, meetingParticipantLimit, opts.projectScope(arg)),
 		args...,
 	).Scan(&id, &occurred, &meeting.Subject, &dealID, &meeting.Participants)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/compose/org360/sections.go
+++ b/backend/internal/compose/org360/sections.go
@@ -106,7 +106,7 @@ func linkScope(ctx context.Context, alias string, arg func(any) int) (string, er
 // is an any-link rule, so a task reachable through a visible contact would
 // otherwise hand back the id of a deal the caller may not read — the task
 // is theirs to see, the colleague's deal is not.
-func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time) ([]crmcontracts.Organization360NextStep, crmcontracts.PageInfo, error) {
+func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time, opts AssembleOptions) ([]crmcontracts.Organization360NextStep, crmcontracts.PageInfo, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	orgPos := arg(orgID)
@@ -138,10 +138,11 @@ func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 		         ORDER BY pl.id LIMIT 1)
 		FROM activity a
 		WHERE a.kind = 'task' AND NOT a.is_done AND a.archived_at IS NULL AND %[1]s
-		  AND %[2]s
+		  AND %[2]s%[6]s
 		ORDER BY (a.due_at IS NULL), a.due_at, a.id
 		LIMIT %[5]d`,
-		activityScope, activities.OrgLinkedActivityExists(orgPos), linkVisible, personVisible, sectionLimit+1), args...)
+		activityScope, activities.OrgLinkedActivityExists(orgPos), linkVisible, personVisible, sectionLimit+1,
+		opts.projectScope(arg)), args...)
 	if err != nil {
 		return nil, crmcontracts.PageInfo{}, err
 	}

--- a/backend/internal/compose/org360/viewbaseline.go
+++ b/backend/internal/compose/org360/viewbaseline.go
@@ -120,8 +120,8 @@ func (s *Service) sinceLastVisit(ctx context.Context, tx pgx.Tx, orgID ids.Organ
 	if err := tx.QueryRow(ctx, fmt.Sprintf(`
 		SELECT count(*)
 		FROM activity a
-		WHERE a.archived_at IS NULL AND a.created_at > $%d AND %s AND (%s)`,
-		sincePos, activities.OrgLinkedActivityExists(orgPos), activityScope),
+		WHERE a.archived_at IS NULL AND a.created_at > $%d AND %s AND (%s)%s`,
+		sincePos, activities.OrgLinkedActivityExists(orgPos), activityScope, a.opts.projectScope(arg)),
 		args...).Scan(&out.NewActivities); err != nil {
 		return out, fmt.Errorf("count new activities: %w", err)
 	}

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -364,6 +364,9 @@ func (s Server) ListActivities(w http.ResponseWriter, r *http.Request, params cr
 			// telegram" had been applied, which reads as a much larger
 			// conversation than the one that exists.
 			{"channel_provider", params.ChannelProvider != nil},
+			// The mirror carries no project attribution either, so "minus the
+			// other engagement" cannot be answered from it.
+			{"project_id", params.ProjectId != nil},
 		},
 		params.Q, params.Cursor, params.Limit, overlayWireActivity,
 		func(data []crmcontracts.Activity, page crmcontracts.PageInfo) any {

--- a/backend/internal/compose/person360/assemble.go
+++ b/backend/internal/compose/person360/assemble.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -123,6 +124,15 @@ func (s *Service) AssembleScoped(ctx context.Context, personID ids.PersonID, opt
 			return err
 		}
 		out.Person = person
+		// The scope is a read of the project, gated before any section
+		// filters on it — and as the whole read's refusal, not a section's:
+		// a page narrowed to a project the caller may not see has no honest
+		// sections at all.
+		if opts.ProjectID != nil {
+			if err := activities.RequireProjectScope(ctx, tx, *opts.ProjectID); err != nil {
+				return err
+			}
+		}
 
 		for _, section := range s.sections(personID, now, opts) {
 			if err := section.read(ctx, tx, &out); err != nil {
@@ -202,7 +212,7 @@ func (s *Service) sections(personID ids.PersonID, now time.Time, opts AssembleOp
 			return s.providerProfileSection(ctx, tx, personID, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedNextMeeting, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.nextMeetingSection(ctx, tx, personID, now, out)
+			return s.nextMeetingSection(ctx, tx, personID, now, opts, out)
 		}},
 		// LAST, and it has to be: the moments are derived from what the
 		// sections above gathered, so a moment can never cite evidence this

--- a/backend/internal/compose/person360/assemble.go
+++ b/backend/internal/compose/person360/assemble.go
@@ -87,8 +87,24 @@ type providerDescriptors interface {
 	Descriptor(name string) (provider.Descriptor, error)
 }
 
+// AssembleOptions narrows what the page reads. The zero value is the whole
+// record.
+type AssembleOptions struct {
+	// ProjectID scopes the timeline sections — recent activity, next steps,
+	// last touch, since-last-visit — to one body of work: rows filed under
+	// this project or under none, never rows filed under another project.
+	// The rule is activities.ActivityWithinProject; the identity, employment
+	// and network sections describe the person, not a project, and stay whole.
+	ProjectID *ids.ProjectID
+}
+
 // Assemble reads the whole person page inside ONE workspace transaction.
 func (s *Service) Assemble(ctx context.Context, personID ids.PersonID) (crmcontracts.Person360, error) {
+	return s.AssembleScoped(ctx, personID, AssembleOptions{})
+}
+
+// AssembleScoped is Assemble narrowed by opts.
+func (s *Service) AssembleScoped(ctx context.Context, personID ids.PersonID, opts AssembleOptions) (crmcontracts.Person360, error) {
 	now := s.now().UTC()
 	out := crmcontracts.Person360{
 		AsOf:            now,
@@ -108,7 +124,7 @@ func (s *Service) Assemble(ctx context.Context, personID ids.PersonID) (crmcontr
 		}
 		out.Person = person
 
-		for _, section := range s.sections(personID, now) {
+		for _, section := range s.sections(personID, now, opts) {
 			if err := section.read(ctx, tx, &out); err != nil {
 				// A section the caller may not read is named, not returned
 				// empty. Any other failure is the whole read's failure —
@@ -135,7 +151,7 @@ type section struct {
 	read func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error
 }
 
-func (s *Service) sections(personID ids.PersonID, now time.Time) []section {
+func (s *Service) sections(personID ids.PersonID, now time.Time, opts AssembleOptions) []section {
 	return []section{
 		{name: crmcontracts.Person360SectionsOmittedStrength, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
 			return s.strengthSection(ctx, tx, personID, now, out)
@@ -150,13 +166,13 @@ func (s *Service) sections(personID ids.PersonID, now time.Time) []section {
 			return s.dealRolesSection(ctx, tx, personID, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedActivities, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.activitiesSection(ctx, tx, personID, out)
+			return s.activitiesSection(ctx, tx, personID, opts, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedNextSteps, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.nextStepsSection(ctx, tx, personID, out)
+			return s.nextStepsSection(ctx, tx, personID, opts, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedLastTouch, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.lastTouchSection(ctx, tx, personID, out)
+			return s.lastTouchSection(ctx, tx, personID, opts, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedNetwork, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
 			return s.networkSection(ctx, tx, personID, now, out)
@@ -168,7 +184,7 @@ func (s *Service) sections(personID ids.PersonID, now time.Time) []section {
 			return s.profileFieldsSection(ctx, tx, personID, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedSinceLastVisit, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.sinceLastVisitSection(ctx, tx, personID, out)
+			return s.sinceLastVisitSection(ctx, tx, personID, opts, out)
 		}},
 		// Both of these run BEFORE the moments below, because the ladder's
 		// rules read them: the meeting-prep rung asks what is booked, and the

--- a/backend/internal/compose/person360/handlers.go
+++ b/backend/internal/compose/person360/handlers.go
@@ -46,11 +46,15 @@ func NewHandlers(svc *Service, overlay OverlayMode) Handlers {
 }
 
 // GetPerson360 implements GET /people/{id}/360.
-func (h Handlers) GetPerson360(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+func (h Handlers) GetPerson360(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, params crmcontracts.GetPerson360Params) {
 	if !h.nativeOnly(w, r) {
 		return
 	}
-	view, err := h.svc.Assemble(r.Context(), ids.From[ids.PersonKind](ids.UUID(id)))
+	var opts AssembleOptions
+	if params.ProjectId != nil {
+		opts.ProjectID = ptr(ids.From[ids.ProjectKind](ids.UUID(*params.ProjectId)))
+	}
+	view, err := h.svc.AssembleScoped(r.Context(), ids.From[ids.PersonKind](ids.UUID(id)), opts)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -23,8 +23,8 @@ func at(daysAgo int) time.Time { return now.AddDate(0, 0, -daysAgo) }
 
 func ahead(hours int) time.Time { return now.Add(time.Duration(hours) * time.Hour) }
 
-// activities builds the timeline section the rules read.
-func activities(rows ...crmcontracts.Activity) *struct {
+// timelineOf builds the timeline section the rules read.
+func timelineOf(rows ...crmcontracts.Activity) *struct {
 	Data []crmcontracts.Activity `json:"data"`
 	Page crmcontracts.PageInfo   `json:"page"`
 } {
@@ -89,7 +89,7 @@ func TestAnAnsweredConversationIsNotGoneQuiet(t *testing.T) {
 	page := &crmcontracts.Person360{
 		LastOutboundAt: ptr(at(30)),
 		LastInboundAt:  ptr(at(2)),
-		Activities:     activities(),
+		Activities:     timelineOf(),
 		Network: &struct {
 			Colleagues []crmcontracts.PersonNetworkColleague `json:"colleagues"`
 		}{},
@@ -140,7 +140,7 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 		"meeting prep": {NextMeeting: &crmcontracts.Person360NextMeeting{StartsAt: ahead(24)}},
 		"gone quiet":   {LastOutboundAt: ptr(at(9)), LastInboundAt: ptr(at(16))},
 		"thin relationship": {
-			Activities: activities(),
+			Activities: timelineOf(),
 			Network: &struct {
 				Colleagues []crmcontracts.PersonNetworkColleague `json:"colleagues"`
 			}{},
@@ -277,7 +277,7 @@ func assertActionsAreHonest(t *testing.T, moment crmcontracts.PersonMoment) {
 // for, and an empty card fails to give it.
 func TestAQuietRecordStillGetsAnAnswer(t *testing.T) {
 	page := &crmcontracts.Person360{
-		Activities: activities(crmcontracts.Activity{Id: openapi_types.UUID{}, Kind: "email", OccurredAt: at(3)}),
+		Activities: timelineOf(crmcontracts.Activity{Id: openapi_types.UUID{}, Kind: "email", OccurredAt: at(3)}),
 		Network: &struct {
 			Colleagues []crmcontracts.PersonNetworkColleague `json:"colleagues"`
 		}{Colleagues: []crmcontracts.PersonNetworkColleague{{}}},

--- a/backend/internal/compose/person360/nextmeeting.go
+++ b/backend/internal/compose/person360/nextmeeting.go
@@ -40,7 +40,7 @@ const meetingParticipantCap = 8
 // ONE query, not two. Participants come back as JSON from a lateral sub-select
 // carrying its own row-scope predicate: a section that read the row and then
 // its children is how a composite read starts costing per record.
-func (s *Service) nextMeetingSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *crmcontracts.Person360) error {
+func (s *Service) nextMeetingSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, opts AssembleOptions, out *crmcontracts.Person360) error {
 	if err := requireRead(ctx, "activity"); err != nil {
 		return err
 	}
@@ -85,9 +85,9 @@ func (s *Service) nextMeetingSection(ctx context.Context, tx pgx.Tx, personID id
 		  AND (a.meeting_status IS NULL OR a.meeting_status = 'booked')
 		  AND a.occurred_at > $%d
 		  AND `+personLinkedActivity+`
-		  AND (%s)
+		  AND (%s)%s
 		ORDER BY a.occurred_at, a.id
-		LIMIT 1`, participantScope, nowPos, linkPos, scope), args...).
+		LIMIT 1`, participantScope, nowPos, linkPos, scope, projectScope(opts, arg)), args...).
 		Scan(&activityID, &meeting.StartsAt, &subject, &dealID, &participants)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Nothing booked. That IS the answer, and the strip renders "None".

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/network"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -60,13 +61,24 @@ func activityScopeUnder(ctx context.Context, arg func(any) int,
 	return clause, nil
 }
 
+// projectScope renders the body-of-work narrowing as one more WHERE term, or
+// nothing when the page is unscoped. Every timeline section of this page goes
+// through it, so the recent rows, the open tasks, the last-touch dates and the
+// since-last-visit count cannot disagree about which project they describe.
+func projectScope(opts AssembleOptions, arg func(any) int) string {
+	if opts.ProjectID == nil {
+		return ""
+	}
+	return " AND " + activities.ActivityWithinProject(arg(*opts.ProjectID))
+}
+
 // activitiesSection is the recent timeline — a summary, not a paging
 // surface: page two comes from GET /activities with its own cursor.
-func (s *Service) activitiesSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, out *crmcontracts.Person360) error {
+func (s *Service) activitiesSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, out *crmcontracts.Person360) error {
 	if err := requireRead(ctx, "activity"); err != nil {
 		return err
 	}
-	rows, hasMore, err := s.readActivities(ctx, tx, personID, "")
+	rows, hasMore, err := s.readActivities(ctx, tx, personID, opts, "")
 	if err != nil {
 		return err
 	}
@@ -79,11 +91,11 @@ func (s *Service) activitiesSection(ctx context.Context, tx pgx.Tx, personID ids
 
 // nextStepsSection is the open work filed against this person: tasks not
 // yet done. A task with no due date still counts — it is owed either way.
-func (s *Service) nextStepsSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, out *crmcontracts.Person360) error {
+func (s *Service) nextStepsSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, out *crmcontracts.Person360) error {
 	if err := requireRead(ctx, "activity"); err != nil {
 		return err
 	}
-	rows, hasMore, err := s.readActivities(ctx, tx, personID,
+	rows, hasMore, err := s.readActivities(ctx, tx, personID, opts,
 		`AND a.kind = 'task' AND coalesce(a.is_done, false) = false`)
 	if err != nil {
 		return err
@@ -105,7 +117,7 @@ func (s *Service) nextStepsSection(ctx context.Context, tx pgx.Tx, personID ids.
 // column for a whole slice — the narrowing added it there and nothing pointed
 // at the copy. TestThePerson360TimelineNamesTheTransportThatCarriedAMessage is
 // the guard that says so out loud.
-func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, extra string) ([]crmcontracts.Activity, bool, error) {
+func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, extra string) ([]crmcontracts.Activity, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	personPos := arg(personID)
@@ -126,10 +138,10 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		       a.occurred_at, a.due_at, a.is_done, a.source, a.captured_by, a.created_at,
 		       a.audience, (%s) AS content_available
 		FROM activity a
-		WHERE a.archived_at IS NULL AND %s AND (%s) %s
+		WHERE a.archived_at IS NULL AND %s AND (%s)%s %s
 		ORDER BY a.occurred_at DESC, a.id DESC
 		LIMIT %d`,
-		contentArm, fmt.Sprintf(personLinkedActivity, personPos), scope, extra, sectionCap+1), args...)
+		contentArm, fmt.Sprintf(personLinkedActivity, personPos), scope, projectScope(opts, arg), extra, sectionCap+1), args...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -177,7 +189,7 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 // one "last touch" hides the only distinction a reader acts on: a contact
 // we mailed a fortnight ago with no reply and one who wrote to us this
 // morning have the same last-touch date and opposite meanings.
-func (s *Service) lastTouchSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, out *crmcontracts.Person360) error {
+func (s *Service) lastTouchSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, out *crmcontracts.Person360) error {
 	if err := requireRead(ctx, "activity"); err != nil {
 		return err
 	}
@@ -192,8 +204,8 @@ func (s *Service) lastTouchSection(ctx context.Context, tx pgx.Tx, personID ids.
 		SELECT max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound')
 		FROM activity a
-		WHERE a.archived_at IS NULL AND %s AND (%s)`,
-		fmt.Sprintf(personLinkedActivity, personPos), scope), args...).
+		WHERE a.archived_at IS NULL AND %s AND (%s)%s`,
+		fmt.Sprintf(personLinkedActivity, personPos), scope, projectScope(opts, arg)), args...).
 		Scan(&out.LastInboundAt, &out.LastOutboundAt)
 }
 
@@ -350,7 +362,7 @@ func (s *Service) applyFieldVerdicts(
 // baseline. READ-ONLY: nothing here advances the mark — only view-ack does,
 // because a GET that moved it would destroy the answer the caller opened
 // the page to read.
-func (s *Service) sinceLastVisitSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, out *crmcontracts.Person360) error {
+func (s *Service) sinceLastVisitSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, out *crmcontracts.Person360) error {
 	if err := requireRead(ctx, "activity"); err != nil {
 		return err
 	}
@@ -372,8 +384,8 @@ func (s *Service) sinceLastVisitSection(ctx context.Context, tx pgx.Tx, personID
 	if err := tx.QueryRow(ctx, fmt.Sprintf(`
 		SELECT count(*)
 		FROM activity a
-		WHERE a.archived_at IS NULL AND a.created_at > $%d AND %s AND (%s)`,
-		sincePos, fmt.Sprintf(personLinkedActivity, personPos), scope), args...).
+		WHERE a.archived_at IS NULL AND a.created_at > $%d AND %s AND (%s)%s`,
+		sincePos, fmt.Sprintf(personLinkedActivity, personPos), scope, projectScope(opts, arg)), args...).
 		Scan(&view.NewActivities); err != nil {
 		return fmt.Errorf("count new activities: %w", err)
 	}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1043,7 +1043,7 @@ func (stubs) UpdateOrganization(w nethttp.ResponseWriter, r *nethttp.Request, id
 	httperr.NotImplemented(w, r, "UpdateOrganization")
 }
 
-func (stubs) GetOrganization360(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+func (stubs) GetOrganization360(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.GetOrganization360Params) {
 	httperr.NotImplemented(w, r, "GetOrganization360")
 }
 
@@ -1259,7 +1259,7 @@ func (stubs) UpdatePerson(w nethttp.ResponseWriter, r *nethttp.Request, id crmco
 	httperr.NotImplemented(w, r, "UpdatePerson")
 }
 
-func (stubs) GetPerson360(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+func (stubs) GetPerson360(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.GetPerson360Params) {
 	httperr.NotImplemented(w, r, "GetPerson360")
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -23202,6 +23202,9 @@ type ListActivitiesParams struct {
 	AssigneeId *openapi_types.UUID `form:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	Q          *string             `form:"q,omitempty" json:"q,omitempty"`
 
+	// ProjectId Narrow the timeline sections to one body of work: what is filed under this project or under no project; correspondence filed under another project is left out.
+	ProjectId *openapi_types.UUID `form:"project_id,omitempty" json:"project_id,omitempty"`
+
 	// ThreadKey One provider conversation. The company view's timeline groups by thread client-side over the page it holds, so a group cut off by that page completes itself through this rather than by widening the page for every account that has no long thread.
 	ThreadKey *string `form:"thread_key,omitempty" json:"thread_key,omitempty"`
 }
@@ -25261,6 +25264,12 @@ type UpdateOrganizationParams struct {
 	IfMatch *IfMatch `json:"If-Match,omitempty"`
 }
 
+// GetOrganization360Params defines parameters for GetOrganization360.
+type GetOrganization360Params struct {
+	// ProjectId Narrow the timeline sections to one body of work: what is filed under this project or under no project; correspondence filed under another project is left out.
+	ProjectId *openapi_types.UUID `form:"project_id,omitempty" json:"project_id,omitempty"`
+}
+
 // AskAboutOrganizationJSONBody defines parameters for AskAboutOrganization.
 type AskAboutOrganizationJSONBody struct {
 	// Question The prepared questions. Fixed, because each one names the records its answer is
@@ -25757,6 +25766,12 @@ type UpdatePersonParams struct {
 	// re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
 	// Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
 	IfMatch *IfMatch `json:"If-Match,omitempty"`
+}
+
+// GetPerson360Params defines parameters for GetPerson360.
+type GetPerson360Params struct {
+	// ProjectId Narrow the timeline sections to one body of work: what is filed under this project or under no project; correspondence filed under another project is left out.
+	ProjectId *openapi_types.UUID `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // RecordConsentParams defines parameters for RecordConsent.
@@ -36689,7 +36704,7 @@ type ServerInterface interface {
 	UpdateOrganization(w http.ResponseWriter, r *http.Request, id Id, params UpdateOrganizationParams)
 	// The whole company record page in one round trip — profile, contacts, deals, timeline, tags, approvals, next steps.
 	// (GET /organizations/{id}/360)
-	GetOrganization360(w http.ResponseWriter, r *http.Request, id Id)
+	GetOrganization360(w http.ResponseWriter, r *http.Request, id Id, params GetOrganization360Params)
 	// Ask one of the prepared questions about this account.
 	// (POST /organizations/{id}/ask)
 	AskAboutOrganization(w http.ResponseWriter, r *http.Request, id Id)
@@ -36851,7 +36866,7 @@ type ServerInterface interface {
 	UpdatePerson(w http.ResponseWriter, r *http.Request, id Id, params UpdatePersonParams)
 	// The whole person record page in one round trip — identity, employments, buying roles, strength, who-knows-them, timeline, consent, provenance.
 	// (GET /people/{id}/360)
-	GetPerson360(w http.ResponseWriter, r *http.Request, id Id)
+	GetPerson360(w http.ResponseWriter, r *http.Request, id Id, params GetPerson360Params)
 	// The standing relationship brief — who this person is commercially, what they care about, what changed.
 	// (GET /people/{id}/brief)
 	GetPersonBrief(w http.ResponseWriter, r *http.Request, id Id)
@@ -38864,7 +38879,7 @@ func (_ Unimplemented) UpdateOrganization(w http.ResponseWriter, r *http.Request
 
 // The whole company record page in one round trip — profile, contacts, deals, timeline, tags, approvals, next steps.
 // (GET /organizations/{id}/360)
-func (_ Unimplemented) GetOrganization360(w http.ResponseWriter, r *http.Request, id Id) {
+func (_ Unimplemented) GetOrganization360(w http.ResponseWriter, r *http.Request, id Id, params GetOrganization360Params) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -39188,7 +39203,7 @@ func (_ Unimplemented) UpdatePerson(w http.ResponseWriter, r *http.Request, id I
 
 // The whole person record page in one round trip — identity, employments, buying roles, strength, who-knows-them, timeline, consent, provenance.
 // (GET /people/{id}/360)
-func (_ Unimplemented) GetPerson360(w http.ResponseWriter, r *http.Request, id Id) {
+func (_ Unimplemented) GetPerson360(w http.ResponseWriter, r *http.Request, id Id, params GetPerson360Params) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -40292,6 +40307,19 @@ func (siw *ServerInterfaceWrapper) ListActivities(w http.ResponseWriter, r *http
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "project_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "project_id", r.URL.Query(), &params.ProjectId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "project_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "project_id", Err: err})
 		}
 		return
 	}
@@ -51313,8 +51341,24 @@ func (siw *ServerInterfaceWrapper) GetOrganization360(w http.ResponseWriter, r *
 
 	r = r.WithContext(ctx)
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetOrganization360Params
+
+	// ------------- Optional query parameter "project_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "project_id", r.URL.Query(), &params.ProjectId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "project_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "project_id", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetOrganization360(w, r, id)
+		siw.Handler.GetOrganization360(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -53817,8 +53861,24 @@ func (siw *ServerInterfaceWrapper) GetPerson360(w http.ResponseWriter, r *http.R
 
 	r = r.WithContext(ctx)
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetPerson360Params
+
+	// ------------- Optional query parameter "project_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "project_id", r.URL.Query(), &params.ProjectId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "project_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "project_id", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetPerson360(w, r, id)
+		siw.Handler.GetPerson360(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -112,6 +112,11 @@ func ListActivitiesTx(ctx context.Context, tx pgx.Tx, in ListActivitiesInput) ([
 	if err := ensureNarrowingTargetVisible(ctx, tx, in.EntityType, in.EntityID); err != nil {
 		return nil, storekit.Page{}, err
 	}
+	if in.WithinProjectID != nil {
+		if err := RequireProjectScope(ctx, tx, *in.WithinProjectID); err != nil {
+			return nil, storekit.Page{}, err
+		}
+	}
 	limit := storekit.ClampLimit(in.Limit)
 	join, where, content, args, err := listActivitiesFilter(ctx, in)
 	if err != nil {

--- a/backend/internal/modules/activities/handlers_activity.go
+++ b/backend/internal/modules/activities/handlers_activity.go
@@ -20,6 +20,7 @@ func (h Handlers) ListActivities(w http.ResponseWriter, r *http.Request, params 
 		ThreadKey:       params.ThreadKey,
 		IncludeArchived: params.IncludeArchived != nil && *params.IncludeArchived,
 		AssigneeID:      idArg[ids.UserKind](params.AssigneeId),
+		WithinProjectID: idArg[ids.ProjectKind](params.ProjectId),
 	}
 	if params.Kind != nil {
 		k := string(*params.Kind)

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -9,9 +9,12 @@ package activities
 import (
 	"context"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -164,6 +167,25 @@ func ActivityWithinProject(projectPos int) string {
 			    SELECT 1 FROM activity_link filed
 			    WHERE filed.activity_id = a.id AND filed.project_id IS NOT NULL))`,
 		projectPos)
+}
+
+// RequireProjectScope is the authority check every read narrowed BY a project
+// owes before it filters on one. Filtering by a record is a read of it: the
+// scoped page answers "these activities are filed under this project", which
+// a caller with no project grant may not learn, and a caller outside its row
+// scope may not learn it exists. Object denial is a 403; an invisible,
+// archived or missing project is the same existence-hiding 404 a direct read
+// gives.
+//
+// The LIVE probe, not the plain one: EnsureVisible lets an unbounded caller
+// through without touching the table, so a scope naming a project nobody ever
+// created would answer a full page as though the filter had matched, and an
+// archived project is no longer a body of work a page can be narrowed to.
+func RequireProjectScope(ctx context.Context, tx pgx.Tx, projectID ids.ProjectID) error {
+	if err := auth.Require(ctx, string(datasource.RecordProject), principal.ActionRead); err != nil {
+		return err
+	}
+	return auth.EnsureVisibleLive(ctx, tx, string(datasource.RecordProject), projectID.UUID)
 }
 
 // openTaskAssigneeClause narrows the timeline to the OPEN tasks one person

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 52,
+    "tools": 53,
     "resources": 8,
-    "tool_catalog_bytes": 142415,
+    "tool_catalog_bytes": 143504,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 36380,
-    "largest_tool_bytes": 4709,
+    "approx_wire_tokens_total": 36653,
+    "largest_tool_bytes": 4622,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 35061,
-      "input_schema_bytes": 30800,
-      "output_schema_bytes": 65390,
-      "description_plus_input_schema_bytes": 65861
+      "description_bytes": 34336,
+      "input_schema_bytes": 31442,
+      "output_schema_bytes": 66382,
+      "description_plus_input_schema_bytes": 65778
     }
   },
   "tools": {
@@ -252,7 +252,7 @@
           "readOnlyHint": false,
           "title": "Advance a deal to a stage"
         },
-        "description": "Move a deal to a different stage of its pipeline. The stage is named by id, not by label, and the id of the stage you are moving TO comes from list_pipelines — call it first, because a deal you have read carries only the stage it is already in. Moving onto or off a stage that closes the deal as won or lost is a decision a person makes: it is staged for approval and needs a lost_reason when the stage is a losing one. Read the target stage's semantic rather than guessing it from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope \"write\".)",
+        "description": "Move a deal to a different stage of its pipeline. The stage is named by id from list_pipelines — call it first; a deal you read carries only its current stage. Moving onto or off a won/lost stage is a person's decision: staged for approval, with a lost_reason for a losing stage. Read the target stage's semantic rather than guessing from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1029,7 +1029,7 @@
           "readOnlyHint": false,
           "title": "Book a meeting"
         },
-        "description": "Hold a slot in the host's calendar and record the meeting against the records it is about. It requires at least one link saying what the meeting is about and is refused without one. The slot is taken and the meeting becomes a real commitment, so a person approves it before it is booked. It takes no attendee list: who is invited, and whether an invitation is delivered at all, is the deployment's calendar connection rather than this call. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
+        "description": "Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, so a person approves it first. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1833,6 +1833,179 @@
           "type": "object"
         },
         "title": "Create a record"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": false,
+          "title": "Create a task"
+        },
+        "description": "Put a to-do on someone's list: what is owed, by whom, on which records. Creates the task only — no reminder, no deal move; unlinked, it sits on no timeline. log_activity is for what already happened. (Governance: runs immediately; requires passport scope \"write\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "assignee_id": {
+              "description": "Defaults to the human you act for.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "due_at": {
+              "description": "RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "idempotency_key": {
+              "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "links": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "entity_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "entity_type": {
+                    "enum": [
+                      "person",
+                      "organization",
+                      "deal",
+                      "lead",
+                      "project"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "entity_type",
+                  "entity_id"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "subject": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "subject"
+          ],
+          "type": "object"
+        },
+        "name": "create_task",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "fields": {
+                  "type": "object"
+                },
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "record_type": {
+                  "type": "string"
+                },
+                "trust_tier": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "fields",
+                "id",
+                "record_type"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Create a task"
       },
       {
         "annotations": {
@@ -3964,7 +4137,7 @@
           "readOnlyHint": false,
           "title": "Log an activity"
         },
-        "description": "Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history, and changes nothing else: logging a call does not move a deal, update a field or notify anyone. An activity logged without links is stored attached to nothing and appears on no timeline. Use progress_deal when the same event also moves a deal forward, so the move and the note are one act rather than two. The activity id comes back in the result; keep it — draft_email, send_email and send_message all identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -3972,7 +4145,7 @@
               "type": "string"
             },
             "channel_provider": {
-              "description": "Which messaging transport carried this — required when kind is \"message\", and not allowed otherwise. Name a provider this installation has registered; list_channel_providers reports them.",
+              "description": "Required when kind is \"message\", else refused; a provider list_channel_providers names.",
               "type": "string"
             },
             "direction": {
@@ -4004,7 +4177,7 @@
               "type": "string"
             },
             "links": {
-              "description": "What the activity is about. Omit it and the activity is stored unattached to any record — it will not appear on a person's, company's or deal's timeline.",
+              "description": "What it is about; unlinked, it appears on no timeline.",
               "items": {
                 "additionalProperties": false,
                 "properties": {
@@ -5587,7 +5760,7 @@
           "readOnlyHint": true,
           "title": "Query the workspace"
         },
-        "description": "Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary, and a name outside it is refused by name rather than guessed at. The margince://schema/query resource — not this description — is what says which record types, fields, operators and relationships this workspace can actually be asked about. A plan takes at most one similarity clause and at most one relationship hop. It cannot group, count or total, and there is no cursor: an answer that hit its limit says so instead of offering a next page. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -7005,7 +7178,7 @@
           "readOnlyHint": true,
           "title": "Resolve people and companies"
         },
-        "description": "Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you are about to create, because a miss is not proof that nothing exists. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you will create — a miss is not proof nothing exists. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -7420,7 +7593,7 @@
           "readOnlyHint": true,
           "title": "Run a report"
         },
-        "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, and each accepts only its own filter, grouping and measure names; anything outside its lists is refused rather than approximated. It aggregates, so it answers how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan arguments first to see what it answers by default, then narrow using the names its own catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -7990,7 +8163,7 @@
           "readOnlyHint": false,
           "title": "Start an email conversation from a record"
         },
-        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. It sends EXACTLY the subject and body it is given and composes nothing. It needs at least one link naming the records the conversation belongs to and is refused without one. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use send_email when the message answers a conversation already recorded here: that keeps the reply on its own thread, where this starts a separate one beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
+        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose, and a person approves the send first — a sent mail cannot be recalled. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -8502,7 +8675,7 @@
           "readOnlyHint": false,
           "title": "Update a record"
         },
-        "description": "Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores: a person's email addresses, for one, are not among them. A field whose current value a HUMAN last set is not overwritten — that part of the call is staged for a person to decide and named in the result, so treat a staged answer as the write not having happened yet. It names the record by id: when a name matches two records, which of them was meant is a question for a person and not a choice to make quietly. There is no sharing verb here, but owner_id is NOT a neutral field — who owns a record is what decides who can see it, so reassigning it moves the record onto someone else's book and can take it off the current owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores (a person's email addresses are not among them). A field a HUMAN last set is not overwritten: that part is staged for a person and named in the result, and that part of the write has not happened. It names the record by id; when a name matches two records, a person picks. owner_id is NOT neutral — ownership decides visibility, so reassigning moves the record onto someone else's book and can take it off the owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -9256,7 +9429,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":52,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activity\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":53,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activity\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, key?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, key?: string, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,12 +11,12 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 52 |
+| Tools | 53 |
 | Resources | 8 |
-| Tool catalog | 139.1 KB |
+| Tool catalog | 140.1 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 36380 |
-| Largest tool | `run_report` (4.6 KB) |
+| Approx. wire tokens | 36653 |
+| Largest tool | `run_report` (4.5 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
 Those are the WIRE bytes: they carry each tool's output schema and the governance
@@ -28,11 +28,11 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 63.9 KB | 45% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 34.2 KB | 24% | Yes, every step |
-| Input schemas | 30.1 KB | 21% | Yes, every step |
-| _Names, annotations, punctuation_ | 10.9 KB | 7% | Partly |
-| **Description + input schema** | **64.3 KB** | **46%** | **the recurring cost** |
+| Output schemas | 64.8 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 33.5 KB | 23% | Yes, every step |
+| Input schemas | 30.7 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 11.1 KB | 7% | Partly |
+| **Description + input schema** | **64.2 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -55,21 +55,22 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/handoff.html`](#handoff_view) — Delivery handoff
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 
-### Tools (52)
+### Tools (53)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
 | [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.7 KB |
-| [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.3 KB |
+| [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.1 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.3 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
 | [`archive_record`](#archive_record) | Archive a record |  |  | 2.3 KB |
 | [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.5 KB |
-| [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.9 KB |
+| [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.8 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.7 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.8 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 2.6 KB |
+| [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 3.0 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 3.0 KB |
 | [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 1.9 KB |
@@ -83,7 +84,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
-| [`log_activity`](#log_activity) | Log an activity |  |  | 3.2 KB |
+| [`log_activity`](#log_activity) | Log an activity |  |  | 2.9 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 3.8 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
@@ -91,7 +92,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.1 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.5 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
-| [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.6 KB |
+| [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.5 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
 | [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 2.8 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.5 KB |
@@ -101,13 +102,13 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`remove_tag`](#remove_tag) | Take a tag off a record |  |  | 1.9 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 2.8 KB |
-| [`run_report`](#run_report) | Run a report | yes |  | 4.6 KB |
+| [`run_report`](#run_report) | Run a report | yes |  | 4.5 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.0 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.7 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.5 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.4 KB |
 | [`send_email`](#send_email) | Send an email |  |  | 3.0 KB |
 | [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.4 KB |
-| [`update_record`](#update_record) | Update a record |  |  | 3.9 KB |
+| [`update_record`](#update_record) | Update a record |  |  | 3.7 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
 | [`who_knows`](#who_knows) | Who knows this contact | yes | [`ui://margince/relationship-map.html`](#relationship_map_view) | 2.2 KB |
 | [`whoami`](#whoami) | Who this passport acts for | yes |  | 1.5 KB |
@@ -502,7 +503,7 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
 
 **Advance a deal to a stage**
 
-Move a deal to a different stage of its pipeline. The stage is named by id, not by label, and the id of the stage you are moving TO comes from list_pipelines — call it first, because a deal you have read carries only the stage it is already in. Moving onto or off a stage that closes the deal as won or lost is a decision a person makes: it is staged for approval and needs a lost_reason when the stage is a losing one. Read the target stage's semantic rather than guessing it from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope "write".)
+Move a deal to a different stage of its pipeline. The stage is named by id from list_pipelines — call it first; a deal you read carries only its current stage. Moving onto or off a won/lost stage is a person's decision: staged for approval, with a lost_reason for a losing stage. Read the target stage's semantic rather than guessing from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -1329,7 +1330,7 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
 
 **Book a meeting**
 
-Hold a slot in the host's calendar and record the meeting against the records it is about. It requires at least one link saying what the meeting is about and is refused without one. The slot is taken and the meeting becomes a real commitment, so a person approves it before it is booked. It takes no attendee list: who is invited, and whether an invitation is delivered at all, is the deployment's calendar connection rather than this call. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope "send".)
+Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, so a person approves it first. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -2066,6 +2067,189 @@ Create a person, organization, deal, lead, project, activity or relationship tha
   "required": [
     "record_type",
     "fields"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "fields": {
+          "type": "object"
+        },
+        "id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "record_type": {
+          "type": "string"
+        },
+        "trust_tier": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "fields",
+        "id",
+        "record_type"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### create_task
+
+**Create a task**
+
+Put a to-do on someone's list: what is owed, by whom, on which records. Creates the task only — no reminder, no deal move; unlinked, it sits on no timeline. log_activity is for what already happened. (Governance: runs immediately; requires passport scope "write".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "assignee_id": {
+      "description": "Defaults to the human you act for.",
+      "format": "uuid",
+      "type": "string"
+    },
+    "body": {
+      "type": "string"
+    },
+    "due_at": {
+      "description": "RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+      "maxLength": 255,
+      "type": "string"
+    },
+    "links": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "entity_type": {
+            "enum": [
+              "person",
+              "organization",
+              "deal",
+              "lead",
+              "project"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_type",
+          "entity_id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "subject": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject"
   ],
   "type": "object"
 }
@@ -4444,7 +4628,7 @@ The workspace's words for grouping records, with the tag_id apply_tag takes. Arc
 
 **Log an activity**
 
-Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history, and changes nothing else: logging a call does not move a deal, update a field or notify anyone. An activity logged without links is stored attached to nothing and appears on no timeline. Use progress_deal when the same event also moves a deal forward, so the move and the note are one act rather than two. The activity id comes back in the result; keep it — draft_email, send_email and send_message all identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
+Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -4456,7 +4640,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "channel_provider": {
-      "description": "Which messaging transport carried this — required when kind is \"message\", and not allowed otherwise. Name a provider this installation has registered; list_channel_providers reports them.",
+      "description": "Required when kind is \"message\", else refused; a provider list_channel_providers names.",
       "type": "string"
     },
     "direction": {
@@ -4488,7 +4672,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "links": {
-      "description": "What the activity is about. Omit it and the activity is stored unattached to any record — it will not appear on a person's, company's or deal's timeline.",
+      "description": "What it is about; unlinked, it appears on no timeline.",
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -6140,7 +6324,7 @@ Fill in what a lead's own data already implies — today the company name, from 
 
 **Query the workspace**
 
-Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary, and a name outside it is refused by name rather than guessed at. The margince://schema/query resource — not this description — is what says which record types, fields, operators and relationships this workspace can actually be asked about. A plan takes at most one similarity clause and at most one relationship hop. It cannot group, count or total, and there is no cursor: an answer that hit its limit says so instead of offering a next page. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope "read".)
+Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -7631,7 +7815,7 @@ Take one tag off one record — by tag_id or tag_name — leaving the word itsel
 
 **Resolve people and companies**
 
-Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you are about to create, because a miss is not proof that nothing exists. (Governance: runs immediately; requires passport scope "read".)
+Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you will create — a miss is not proof nothing exists. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -8059,7 +8243,7 @@ Renders its result in [`ui://margince/commitments.html`](#commitments_view), vis
 
 **Run a report**
 
-Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, and each accepts only its own filter, grouping and measure names; anything outside its lists is refused rather than approximated. It aggregates, so it answers how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan arguments first to see what it answers by default, then narrow using the names its own catalog entry lists. (Governance: runs immediately; requires passport scope "read".)
+Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -8659,7 +8843,7 @@ Find people, organizations, deals, leads and projects when you know roughly what
 
 **Start an email conversation from a record**
 
-Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. It sends EXACTLY the subject and body it is given and composes nothing. It needs at least one link naming the records the conversation belongs to and is refused without one. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use send_email when the message answers a conversation already recorded here: that keeps the reply on its own thread, where this starts a separate one beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope "send".)
+Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose, and a person approves the send first — a sent mail cannot be recalled. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -9201,7 +9385,7 @@ Reply on a captured chat conversation — the channels this workspace has connec
 
 **Update a record**
 
-Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores: a person's email addresses, for one, are not among them. A field whose current value a HUMAN last set is not overwritten — that part of the call is staged for a person to decide and named in the result, so treat a staged answer as the write not having happened yet. It names the record by id: when a name matches two records, which of them was meant is a question for a person and not a choice to make quietly. There is no sharing verb here, but owner_id is NOT a neutral field — who owns a record is what decides who can see it, so reassigning it moves the record onto someone else's book and can take it off the current owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope "write".)
+Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores (a person's email addresses are not among them). A field a HUMAN last set is not overwritten: that part is staged for a person and named in the result, and that part of the write has not happened. It names the record by id; when a name matches two records, a person picks. owner_id is NOT neutral — ownership decides visibility, so reassigning moves the record onto someone else's book and can take it off the owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21602,7 +21602,10 @@ export interface operations {
     };
     getPerson360: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Narrow the timeline sections to one body of work: what is filed under this project or under no project; correspondence filed under another project is left out. */
+                project_id?: string;
+            };
             header?: never;
             path: {
                 /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
@@ -22695,7 +22698,10 @@ export interface operations {
     };
     getOrganization360: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Narrow the timeline sections to one body of work: what is filed under this project or under no project; correspondence filed under another project is left out. */
+                project_id?: string;
+            };
             header?: never;
             path: {
                 /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
@@ -24725,6 +24731,8 @@ export interface operations {
                 /** @description Open tasks for an assignee. */
                 assignee_id?: string;
                 q?: string;
+                /** @description Narrow the timeline sections to one body of work: what is filed under this project or under no project; correspondence filed under another project is left out. */
+                project_id?: string;
                 /** @description One provider conversation. The company view's timeline groups by thread client-side over the page it holds, so a group cut off by that page completes itself through this rather than by widening the page for every account that has no long thread. */
                 thread_key?: string;
             };


### PR DESCRIPTION
GET /activities, GET /people/{id}/360 and GET /organizations/{id}/360 take
project_id. The rule is the one the context walk already runs: keep what is
filed under this project, keep what is filed under none, drop what is filed
under another. Person360's last-touch and since-last-visit reads and the
org360 last touch take the same predicate, so the number a reader trusts most
does not count the other engagement.

The hop-2 guard test anchors on an organization: a person reached only
through the other engagement's mail is absent from the scoped related_people
section.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## Verification
- `make check-backend`, `make craft-static`, `make check-fe` green locally.
- Integration: `TestPerson360ScopedToOneProjectDropsTheOtherEngagement`, `TestOrganization360ScopedToOneProjectDropsTheOtherEngagement`, `TestTheActivityListNarrowsByProjectOnTheWire`, and the hop-2 guard `TestAssembledContextScopedToOneProjectDropsPeopleReachedOnlyThroughTheOtherEngagement`. Each mutation-checked by removing its predicate.

Part of the projects plan (Phase 1.5a leftovers). Batman-mode merge: local gates + Codex review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Person 360, Org 360, and the activities list to one project via query project_id. Previously all projects were included; now we keep items filed under the given project or none and drop items filed under other projects, and all headline metrics use the same scope.

- GET /activities, GET /people/{id}/360, and GET /organizations/{id}/360 accept project_id; overlay workspaces return 422 when project_id is set.
- Authorization: project scoping requires the same grants as reading the project. Returns 403 without the grant and 404 when the project is invisible or missing.
- Person360: timeline, next steps, last touch, since-last-visit, and next meeting respect the scope. Related people (hop-2) include only contacts reachable via kept activities.
- Org360: timeline, next steps, last touch, since-last-visit, and next meeting respect the scope.
- Activities list: supports project_id (forwarded as WithinProjectID); enforces the same gating and overlay refusal.
- Contracts/handlers: `ServerInterface` methods for `GetPerson360` and `GetOrganization360` now accept params with optional project_id; stubs and handlers updated. `frontend/src/api/schema.d.ts` exposes project_id for these routes. `docs/reference/mcp-info.md` and `docs/reference/mcp-info.json` regenerated to include the filter.

<sup>Written for commit e4f39b16f5c9fedb713f7fe1d38c2cf394ff4dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task creation through the Activities API and MCP, including due dates, assignees, links, and idempotency support.
  * Added optional project filtering to Person 360 and Organization 360 views.
  * Timelines and activity lists now include selected-project and unassigned activity while excluding other projects.

* **Bug Fixes**
  * Corrected project-scoped timeline metrics, next meetings, and next steps.
  * Added authorization and validation for project-scoped activity and 360-view requests.
  * Overlay activity views now reject unsupported project filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Also carries the one-line fix for main's red lane**: #2290 registered `create_task` without adding it to the tool conformance sweep (`TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas`). Added it here because it blocked this branch's integration lane.

Codex review: D7 (project_id as an existence oracle) fixed with `RequireProjectScope`; D1–D3 (org next steps, since-last-visit, next meeting) fixed; D4–D6 (health/strength/suggestion aggregates) filed as #2291.