### PR TITLE
feat(agents): create_task, so a to-do is asked for by name

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3499,6 +3499,36 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
 
   # ---------------------------- /activities ---------------------------------
+  /tasks:
+    post:
+      tags: [Activities]
+      operationId: createTask
+      summary: Create a task — a commitment with an owner, on the records it is about.
+      description: |
+        A task is an activity of kind `task`, and this is the one door that says so:
+        `POST /activities` with `kind: task` stores the same row, but a caller
+        (an agent above all) should not have to know that a to-do is a species of
+        timeline entry. Takes what a task needs and nothing a meeting does.
+      x-mcp-tool: { verb: create_task, record_type: activity, tier: auto_execute, scope: write }
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateTaskRequest' }
+      responses:
+        '201':
+          description: The task, as an activity.
+          headers:
+            Location: { schema: { type: string } }
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Activity' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /activities:
     get:
       tags: [Activities]
@@ -21021,6 +21051,26 @@ components:
                 a transport that sends text-with-files as a caption bounds it far below a
                 text-only message. Zero means no extra bound.
 
+    CreateTaskRequest:
+      type: object
+      description: What a task needs. Stored as an activity of kind `task`.
+      required: [subject, source]
+      properties:
+        subject: { type: string, minLength: 1, description: 'What has to be done, as one line.' }
+        body: { type: [string, 'null'], description: 'Detail, if one line is not enough.' }
+        due_at: { type: [string, 'null'], format: date-time, description: 'When it is due. Optional — a task without a date is still a task.' }
+        assignee_id: { type: [string, 'null'], format: uuid, description: 'Who owes it. Defaults to the caller.' }
+        links:
+          type: array
+          description: The records the task is about. Omit it and the task appears on no timeline.
+          items:
+            type: object
+            required: [entity_type, entity_id]
+            properties:
+              entity_type: { type: string, enum: [person, organization, deal, lead, project] }
+              entity_id: { type: string, format: uuid }
+        source: { type: string }
+      additionalProperties: false
     CreateActivityRequest:
       type: object
       required: [kind, source]

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -211,6 +211,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"scrapeCompany":       scrapeCompanyCommand,
 	"deepReadCompany":     deepReadCompanyCommand,
 	"logActivity":         logActivityCommand,
+	"createTask":          createTaskCommand,
 	"draftEmail":          draftEmailCommand,
 	"relinkActivity":      relinkActivityCommand,
 	"runReport":           runReportCommand,

--- a/backend/internal/compose/agentcommandauto.go
+++ b/backend/internal/compose/agentcommandauto.go
@@ -33,6 +33,19 @@ func logActivityCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body 
 	return agents.NewLogActivityCall(agents.LogActivityCommand{Fields: json.RawMessage(body)}), nil
 }
 
+// createTaskCommand decodes POST /v1/tasks. A task is an activity of kind
+// task, so it binds to the same resolver a logged activity does; the kind is
+// stamped here so the staged command names what the door will write.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func createTaskCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	fields, err := agents.TaskAsActivity(json.RawMessage(body))
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewLogActivityCall(agents.LogActivityCommand{Fields: fields}), nil
+}
+
 // draftEmailCommand decodes POST /v1/activities/{id}/draft-email. The optional
 // `intent` body is not read: nothing the resolver answers depends on it.
 //

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -477,6 +477,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/stages":                                                    {Op: "createStage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/tags":                                                      {Op: "createTag", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/tags/{id}/apply":                                           {Op: "applyTag", Access: "tool", Tool: "apply_tag", RecordType: "tag", Tier: "auto_execute", Scope: "write"},
+	"POST /v1/tasks":                                                     {Op: "createTask", Access: "tool", Tool: "create_task", RecordType: "activity", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/teams":                                                     {Op: "createTeam", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/users":                                                     {Op: "inviteUser", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/users/access-preview":                                      {Op: "previewAccess", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/createtask_integration_test.go
+++ b/backend/internal/compose/integration/createtask_integration_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// POST /tasks is the one door that says a task is an activity of kind task:
+// what it creates must be exactly what GET /activities lists as one.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+func TestATaskCreatedThroughItsOwnDoorIsATaskOnTheTimeline(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	stages := apptest.DiscoverSeededPipeline(t, e)
+	dealID := apptest.CreateOpenDeal(t, e, stages)
+
+	var task apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/tasks", apptest.AnyMap{
+		"subject": "Send the redline",
+		"due_at":  "2026-09-01T09:00:00+02:00",
+		"links":   []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"source":  "ui",
+	}, nil, &task); status != http.StatusCreated {
+		t.Fatalf("create task = %d %v", status, task)
+	}
+	if task["kind"] != "task" || task["subject"] != "Send the redline" || task["due_at"] == nil {
+		t.Fatalf("task = %v", task)
+	}
+
+	var listed apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/activities?kind=task&entity_type=deal&entity_id="+dealID, nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("list = %d %v", status, listed)
+	}
+	rows, _ := listed["data"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("timeline tasks = %v, want the one created", rows)
+	}
+	if status := e.Call(t, "POST", "/v1/tasks", apptest.AnyMap{"subject": "", "source": "ui"}, nil, nil); status != http.StatusUnprocessableEntity {
+		t.Fatalf("empty subject = %d, want 422", status)
+	}
+}

--- a/backend/internal/compose/replayscope.go
+++ b/backend/internal/compose/replayscope.go
@@ -170,6 +170,7 @@ var replayableOperations = map[string]replayTarget{
 	"PATCH /v1/leads/{id}":            {object: tableLead, table: tableLead, idPath: "id"},
 	"POST /v1/leads/{id}/demote":      {object: tableLead, table: tableLead, idPath: "lead.id"},
 	"POST /v1/activities":             {object: tableActivity, table: tableActivity, idPath: "id"},
+	"POST /v1/tasks":                  {object: tableActivity, table: tableActivity, idPath: "id"},
 	"PATCH /v1/activities/{id}":       {object: tableActivity, table: tableActivity, idPath: "id"},
 	"POST /v1/activities/{id}/relink": {object: tableActivity, table: tableActivity, idPath: "id"},
 	// A send answers its outbound ACTIVITY when it went now, and its SCHEDULED

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1711,6 +1711,10 @@ func (stubs) ApplyTag(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontra
 	httperr.NotImplemented(w, r, "ApplyTag")
 }
 
+func (stubs) CreateTask(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.CreateTaskParams) {
+	httperr.NotImplemented(w, r, "CreateTask")
+}
+
 func (stubs) ListTeams(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListTeamsParams) {
 	httperr.NotImplemented(w, r, "ListTeams")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3820,6 +3820,33 @@ func (e CreateStageRequestSemantic) Valid() bool {
 	}
 }
 
+// Defines values for CreateTaskRequestLinksEntityType.
+const (
+	CreateTaskRequestLinksEntityTypeDeal         CreateTaskRequestLinksEntityType = "deal"
+	CreateTaskRequestLinksEntityTypeLead         CreateTaskRequestLinksEntityType = "lead"
+	CreateTaskRequestLinksEntityTypeOrganization CreateTaskRequestLinksEntityType = "organization"
+	CreateTaskRequestLinksEntityTypePerson       CreateTaskRequestLinksEntityType = "person"
+	CreateTaskRequestLinksEntityTypeProject      CreateTaskRequestLinksEntityType = "project"
+)
+
+// Valid indicates whether the value is a known member of the CreateTaskRequestLinksEntityType enum.
+func (e CreateTaskRequestLinksEntityType) Valid() bool {
+	switch e {
+	case CreateTaskRequestLinksEntityTypeDeal:
+		return true
+	case CreateTaskRequestLinksEntityTypeLead:
+		return true
+	case CreateTaskRequestLinksEntityTypeOrganization:
+		return true
+	case CreateTaskRequestLinksEntityTypePerson:
+		return true
+	case CreateTaskRequestLinksEntityTypeProject:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CreateVoiceBuildRequestReason.
 const (
 	CreateVoiceBuildRequestReasonManual     CreateVoiceBuildRequestReason = "manual"
@@ -14982,6 +15009,31 @@ type CreateTagRequest struct {
 	Color *string `json:"color,omitempty"`
 	Name  string  `json:"name"`
 }
+
+// CreateTaskRequest What a task needs. Stored as an activity of kind `task`.
+type CreateTaskRequest struct {
+	// AssigneeId Who owes it. Defaults to the caller.
+	AssigneeId *openapi_types.UUID `json:"assignee_id,omitempty"`
+
+	// Body Detail, if one line is not enough.
+	Body *string `json:"body,omitempty"`
+
+	// DueAt When it is due. Optional — a task without a date is still a task.
+	DueAt *time.Time `json:"due_at,omitempty"`
+
+	// Links The records the task is about. Omit it and the task appears on no timeline.
+	Links *[]struct {
+		EntityId   openapi_types.UUID               `json:"entity_id"`
+		EntityType CreateTaskRequestLinksEntityType `json:"entity_type"`
+	} `json:"links,omitempty"`
+	Source string `json:"source"`
+
+	// Subject What has to be done, as one line.
+	Subject string `json:"subject"`
+}
+
+// CreateTaskRequestLinksEntityType defines model for CreateTaskRequest.Links.EntityType.
+type CreateTaskRequestLinksEntityType string
 
 // CreateTeamRequest defines model for CreateTeamRequest.
 type CreateTeamRequest struct {
@@ -26739,6 +26791,25 @@ type ListTagsParams struct {
 	IncludeArchived *IncludeArchived `form:"include_archived,omitempty" json:"include_archived,omitempty"`
 }
 
+// CreateTaskParams defines parameters for CreateTask.
+type CreateTaskParams struct {
+	// IdempotencyKey Client-supplied key making a mutation safe to retry — an update exactly as much as a
+	// create (API-CC-6). **Scope:** the key is unique within
+	// `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+	// returns the original status + body. Reusing the same key with a *different* request body
+	// returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+	// **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+	// answer lost": without it the blind retry answers `409 version_skew`, because the first
+	// attempt already bumped the version.
+	// **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+	// retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+	// (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+	// what makes an operation replay-safe** — an operation that omits it ignores the header rather
+	// than half-honouring it, so read this contract, not the client, to know which calls are safe
+	// to retry blind.
+	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+}
+
 // ListTeamsParams defines parameters for ListTeams.
 type ListTeamsParams struct {
 	// Cursor Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
@@ -27608,6 +27679,9 @@ type RemoveTagJSONRequestBody = ApplyTagRequest
 
 // ApplyTagJSONRequestBody defines body for ApplyTag for application/json ContentType.
 type ApplyTagJSONRequestBody = ApplyTagRequest
+
+// CreateTaskJSONRequestBody defines body for CreateTask for application/json ContentType.
+type CreateTaskJSONRequestBody = CreateTaskRequest
 
 // CreateTeamJSONRequestBody defines body for CreateTeam for application/json ContentType.
 type CreateTeamJSONRequestBody = CreateTeamRequest
@@ -37188,6 +37262,9 @@ type ServerInterface interface {
 	// Apply a tag to an entity (person/org/deal/lead).
 	// (POST /tags/{id}/apply)
 	ApplyTag(w http.ResponseWriter, r *http.Request, id Id)
+	// Create a task — a commitment with an owner, on the records it is about.
+	// (POST /tasks)
+	CreateTask(w http.ResponseWriter, r *http.Request, params CreateTaskParams)
 	// List workspace teams — cursor-paginated. Read-only.
 	// (GET /teams)
 	ListTeams(w http.ResponseWriter, r *http.Request, params ListTeamsParams)
@@ -39861,6 +39938,12 @@ func (_ Unimplemented) RemoveTag(w http.ResponseWriter, r *http.Request, id Id) 
 // Apply a tag to an entity (person/org/deal/lead).
 // (POST /tags/{id}/apply)
 func (_ Unimplemented) ApplyTag(w http.ResponseWriter, r *http.Request, id Id) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create a task — a commitment with an owner, on the records it is about.
+// (POST /tasks)
+func (_ Unimplemented) CreateTask(w http.ResponseWriter, r *http.Request, params CreateTaskParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -58994,6 +59077,55 @@ func (siw *ServerInterfaceWrapper) ApplyTag(w http.ResponseWriter, r *http.Reque
 	handler.ServeHTTP(w, r)
 }
 
+// CreateTask operation middleware
+func (siw *ServerInterfaceWrapper) CreateTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CreateTaskParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "Idempotency-Key" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("Idempotency-Key")]; found {
+		var IdempotencyKey IdempotencyKey
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "Idempotency-Key", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "Idempotency-Key", valueList[0], &IdempotencyKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "Idempotency-Key", Err: err})
+			return
+		}
+
+		params.IdempotencyKey = &IdempotencyKey
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateTask(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListTeams operation middleware
 func (siw *ServerInterfaceWrapper) ListTeams(w http.ResponseWriter, r *http.Request) {
 
@@ -62520,6 +62652,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/tags/{id}/apply", wrapper.ApplyTag)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/tasks", wrapper.CreateTask)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/teams", wrapper.ListTeams)

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -21,7 +21,10 @@ import (
 
 // fieldKind names the activity kind in the write shape's audit and outbox
 // payloads (the one spelling of the payload key).
-const fieldKind = "kind"
+const (
+	fieldKind    = "kind"
+	fieldSubject = "subject"
+)
 
 // activityCapturedPayload builds the activity.captured event for the
 // direct-log path (this package's only emit site of the event's two) — it
@@ -184,7 +187,7 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 		return crmcontracts.Activity{}, false, err
 	}
 
-	auditID, err := storekit.Audit(ctx, tx, "create", "activity", id.UUID, nil, map[string]any{fieldKind: in.Kind, "subject": in.Subject})
+	auditID, err := storekit.Audit(ctx, tx, "create", "activity", id.UUID, nil, map[string]any{fieldKind: in.Kind, fieldSubject: in.Subject})
 	if err != nil {
 		return crmcontracts.Activity{}, false, err
 	}

--- a/backend/internal/modules/activities/handlers_task.go
+++ b/backend/internal/modules/activities/handlers_task.go
@@ -4,6 +4,8 @@
 package activities
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -23,10 +25,15 @@ func (h Handlers) CreateTask(w http.ResponseWriter, r *http.Request, _ crmcontra
 	// The activity writer admits a blank subject (a captured mail may carry
 	// none); a task is nothing but its subject, so this door refuses one.
 	if strings.TrimSpace(req.Subject) == "" {
-		writeStoreErr(w, r, &RequiredFieldError{Field: "subject"})
+		writeStoreErr(w, r, &RequiredFieldError{Field: fieldSubject})
 		return
 	}
-	in, err := LogActivityInputFrom(activityOfTask(req))
+	activityReq, err := activityOfTask(req)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	in, err := LogActivityInputFrom(activityReq)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -43,7 +50,7 @@ func (h Handlers) CreateTask(w http.ResponseWriter, r *http.Request, _ crmcontra
 // activityOfTask is the fold: the task request as the activity request the
 // writer understands. Kept as a function rather than inlined so a field the
 // task grows is added here once, where its mapping is visible.
-func activityOfTask(req crmcontracts.CreateTaskRequest) crmcontracts.CreateActivityRequest {
+func activityOfTask(req crmcontracts.CreateTaskRequest) (crmcontracts.CreateActivityRequest, error) {
 	subject := req.Subject
 	out := crmcontracts.CreateActivityRequest{
 		Kind:       crmcontracts.CreateActivityRequestKindTask,
@@ -54,17 +61,16 @@ func activityOfTask(req crmcontracts.CreateTaskRequest) crmcontracts.CreateActiv
 		Source:     req.Source,
 	}
 	if req.Links != nil {
-		links := make([]struct {
-			EntityId   crmcontracts.Id                                   `json:"entity_id"`
-			EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
-		}, 0, len(*req.Links))
-		for _, l := range *req.Links {
-			links = append(links, struct {
-				EntityId   crmcontracts.Id                                   `json:"entity_id"`
-				EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
-			}{EntityId: l.EntityId, EntityType: crmcontracts.CreateActivityRequestLinksEntityType(l.EntityType)})
+		// The two link shapes are generated separately and identical on the
+		// wire; a round trip through JSON is the one spelling of the copy that
+		// cannot drift from either generated struct.
+		raw, err := json.Marshal(req.Links)
+		if err != nil {
+			return out, fmt.Errorf("encode task links: %w", err)
 		}
-		out.Links = &links
+		if err := json.Unmarshal(raw, &out.Links); err != nil {
+			return out, fmt.Errorf("decode task links as activity links: %w", err)
+		}
 	}
-	return out
+	return out, nil
 }

--- a/backend/internal/modules/activities/handlers_task.go
+++ b/backend/internal/modules/activities/handlers_task.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"net/http"
+	"strings"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+// CreateTask is the one door that knows a task is an activity of kind `task`.
+// It folds the task's shape into the activity write and goes through exactly
+// the store path LogActivity does, so a task created here and one logged
+// there are the same row with the same gates.
+func (h Handlers) CreateTask(w http.ResponseWriter, r *http.Request, _ crmcontracts.CreateTaskParams) {
+	var req crmcontracts.CreateTaskRequest
+	if !httperr.Decode(w, r, &req) {
+		return
+	}
+	// The activity writer admits a blank subject (a captured mail may carry
+	// none); a task is nothing but its subject, so this door refuses one.
+	if strings.TrimSpace(req.Subject) == "" {
+		writeStoreErr(w, r, &RequiredFieldError{Field: "subject"})
+		return
+	}
+	in, err := LogActivityInputFrom(activityOfTask(req))
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	activity, _, err := h.store.LogActivity(r.Context(), in)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	w.Header().Set("Location", "/v1/activities/"+activity.Id.String())
+	httperr.WriteJSON(w, http.StatusCreated, activity)
+}
+
+// activityOfTask is the fold: the task request as the activity request the
+// writer understands. Kept as a function rather than inlined so a field the
+// task grows is added here once, where its mapping is visible.
+func activityOfTask(req crmcontracts.CreateTaskRequest) crmcontracts.CreateActivityRequest {
+	subject := req.Subject
+	out := crmcontracts.CreateActivityRequest{
+		Kind:       crmcontracts.CreateActivityRequestKindTask,
+		Subject:    &subject,
+		Body:       req.Body,
+		DueAt:      req.DueAt,
+		AssigneeId: req.AssigneeId,
+		Source:     req.Source,
+	}
+	if req.Links != nil {
+		links := make([]struct {
+			EntityId   crmcontracts.Id                                   `json:"entity_id"`
+			EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
+		}, 0, len(*req.Links))
+		for _, l := range *req.Links {
+			links = append(links, struct {
+				EntityId   crmcontracts.Id                                   `json:"entity_id"`
+				EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
+			}{EntityId: l.EntityId, EntityType: crmcontracts.CreateActivityRequestLinksEntityType(l.EntityType)})
+		}
+		out.Links = &links
+	}
+	return out
+}

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -421,7 +421,7 @@ func repointDisplacedParticipants(ctx context.Context, tx pgx.Tx, id ids.Activit
 func updateDelta(in UpdateActivityInput) map[string]any {
 	delta := map[string]any{}
 	if in.Subject != nil {
-		delta["subject"] = *in.Subject
+		delta[fieldSubject] = *in.Subject
 	}
 	if in.Body != nil {
 		delta["body"] = true // presence, not content — bodies can be large

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1326,6 +1326,112 @@
       "warnings"
     ]
   },
+  "create_task": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "trust_tier": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fields",
+          "id",
+          "record_type"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "decide_approval": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/toolcopy_comms.go
+++ b/backend/internal/modules/agents/toolcopy_comms.go
@@ -48,12 +48,11 @@ var sendEmailCopy = toolCopy{
 var sendAccountEmailCopy = toolCopy{
 	Purpose: "Put a mail on the wire to a real recipient, from this workspace, starting a new " +
 		"conversation rather than answering one, and file it on the records it is about.",
-	Limits: "It sends EXACTLY the subject and body it is given and composes nothing. It needs at " +
-		"least one link naming the records the conversation belongs to and is refused without " +
-		"one. Every recipient must have granted the consent purpose the call names, and a person " +
-		"approves the send before it leaves — a message leaving the workspace cannot be recalled.",
-	Instead: "Use send_email when the message answers a conversation already recorded here: that " +
-		"keeps the reply on its own thread, where this starts a separate one beside it.",
+	Limits: "Sends EXACTLY the subject and body given; composes nothing. Needs at least one link " +
+		"naming the records it belongs to. Every recipient must have granted the named consent " +
+		"purpose, and a person approves the send first — a sent mail cannot be recalled.",
+	Instead: "Use send_email to answer a conversation already recorded here; this starts a " +
+		"separate thread beside it.",
 	Retain: "Keep the staged approval id and re-send the identical text and links: the approval " +
 		"is bound to that exact message. The activity_id that comes back is the new conversation.",
 }
@@ -83,11 +82,9 @@ var checkAvailabilityCopy = toolCopy{
 var bookMeetingCopy = toolCopy{
 	Purpose: "Hold a slot in the host's calendar and record the meeting against the records it " +
 		"is about.",
-	Limits: "It requires at least one link saying what the meeting is about and is refused " +
-		"without one. The slot is taken and the meeting becomes a real commitment, so a person " +
-		"approves it before it is booked. It takes no attendee list: who is invited, and whether " +
-		"an invitation is delivered at all, is the deployment's calendar connection rather than " +
-		"this call. Check the slot is free first — this tool does not.",
+	Limits: "Needs at least one link saying what it is about. The slot is taken and the meeting " +
+		"is a real commitment, so a person approves it first. No attendee list: who is invited is " +
+		"the calendar connection's business. Check the slot is free first — this tool does not.",
 	Instead: "Use check_availability to find the time, and log_activity to record a meeting that " +
 		"already happened.",
 	Retain: "Keep the staged approval id and re-send the identical start, end and links: the " +

--- a/backend/internal/modules/agents/toolcopy_intents.go
+++ b/backend/internal/modules/agents/toolcopy_intents.go
@@ -134,13 +134,12 @@ var runReportCopy = toolCopy{
 	Purpose: "Answer a question about totals, counts or breakdowns — pipeline by stage, deals " +
 		"won by owner, activity volume over time — by running one of this workspace's prebuilt " +
 		"reports.",
-	Limits: "Only the named reports exist, and each accepts only its own filter, grouping and " +
-		"measure names; anything outside its lists is refused rather than approximated. It " +
-		"aggregates, so it answers how many and how much, never which record.",
+	Limits: "Only the named reports exist, each with its own filter, grouping and measure names; " +
+		"anything else is refused. It aggregates: how many and how much, never which record.",
 	Instead: "Use search_records or whats_slipping_this_week when the answer wanted is the " +
 		"records themselves rather than a number over them.",
-	Retain: "Call a report with no plan arguments first to see what it answers by default, then " +
-		"narrow using the names its own catalog entry lists.",
+	Retain: "Call a report with no plan first to see its default answer, then narrow with the " +
+		"names its catalog entry lists.",
 }
 
 var readBriefCopy = toolCopy{

--- a/backend/internal/modules/agents/toolcopy_query.go
+++ b/backend/internal/modules/agents/toolcopy_query.go
@@ -10,12 +10,11 @@ var queryWorkspaceCopy = toolCopy{
 	Purpose: "Answer a question that has STRUCTURE — a record type, conditions on its fields, a " +
 		"hop to a related record, or a likeness to describe — by sending a plan and reading back " +
 		"the records that satisfy it, together with what kind of answer it is.",
-	Limits: "Every name in a plan comes from the published vocabulary, and a name outside it is " +
-		"refused by name rather than guessed at. The margince://schema/query resource — not this " +
-		"description — is what says which record types, fields, operators " +
-		"and relationships this workspace can actually be asked about. A plan takes at most one " +
-		"similarity clause and at most one relationship hop. It cannot group, count or total, and " +
-		"there is no cursor: an answer that hit its limit says so instead of offering a next page.",
+	Limits: "Every name in a plan comes from the published vocabulary; one outside it is refused " +
+		"by name. The margince://schema/query resource — not this description — says which " +
+		"record types, fields, operators and relationships can be asked about. At most one " +
+		"similarity clause and one hop. It cannot group, count or total, and has no cursor: an " +
+		"answer that hit its limit says so.",
 	Instead: "Use search_records when you only have a name or a phrase and no conditions to apply, " +
 		"and run_report when the answer wanted is a count, a total or a breakdown rather than the " +
 		"records themselves.",

--- a/backend/internal/modules/agents/toolcopy_records.go
+++ b/backend/internal/modules/agents/toolcopy_records.go
@@ -59,15 +59,12 @@ var createRecordCopy = toolCopy{
 var updateRecordCopy = toolCopy{
 	Purpose: "Change stored field values on a record that already exists — a corrected title, an " +
 		"amount, an expected close date.",
-	Limits: "Only the fields you send change, and only the fields the record type stores: a " +
-		"person's email addresses, for one, are not among them. A field whose current value a " +
-		"HUMAN last set is not overwritten — that part of the call is staged for a person to " +
-		"decide and named in the result, so treat a staged answer as the write not having " +
-		"happened yet. It names the record by id: when a name matches two records, which of them " +
-		"was meant is a question for a person and not a choice to make quietly. There is no " +
-		"sharing verb here, but owner_id is NOT a neutral field — who owns a record is what " +
-		"decides who can see it, so reassigning it moves the record onto someone else's book and " +
-		"can take it off the current owner's.",
+	Limits: "Only the fields you send change, and only the fields the record type stores (a " +
+		"person's email addresses are not among them). A field a HUMAN last set is not " +
+		"overwritten: that part is staged for a person and named in the result, so a staged " +
+		"answer means the write has not happened. It names the record by id; when a name matches " +
+		"two records, a person picks. owner_id is NOT neutral — ownership decides visibility, so " +
+		"reassigning moves the record onto someone else's book and can take it off the owner's.",
 	Instead: "Use advance_deal or progress_deal to move a deal between stages, and relink_activity " +
 		"to change what an activity is about; neither is a field edit.",
 	Retain: "Send if_version with the version you read, and keep the staged approval id from the " +
@@ -77,13 +74,18 @@ var updateRecordCopy = toolCopy{
 var logActivityCopy = toolCopy{
 	Purpose: "Record something that happened — a call, a meeting, a note, a message — on the " +
 		"timeline of the records it was about.",
-	Limits: "It writes history, and changes nothing else: logging a call does not move a deal, " +
-		"update a field or notify anyone. An activity logged without links is stored attached to " +
-		"nothing and appears on no timeline.",
-	Instead: "Use progress_deal when the same event also moves a deal forward, so the move and " +
-		"the note are one act rather than two.",
-	Retain: "The activity id comes back in the result; keep it — draft_email, send_email and " +
-		"send_message all identify a conversation by it.",
+	Limits: "It writes history and changes nothing else: no deal moves, no field updates, nobody " +
+		"is notified. Unlinked, it appears on no timeline.",
+	Instead: "Use progress_deal when the same event also moves a deal, so move and note are one " +
+		"act; create_task for something still owed.",
+	Retain: "Keep the activity id — draft_email, send_email and send_message identify a " +
+		"conversation by it.",
+}
+
+var createTaskCopy = toolCopy{
+	Purpose: "Put a to-do on someone's list: what is owed, by whom, on which records.",
+	Limits:  "Creates the task only — no reminder, no deal move; unlinked, it sits on no timeline.",
+	Instead: "log_activity is for what already happened.",
 }
 
 var relinkActivityCopy = toolCopy{
@@ -125,12 +127,10 @@ var mergeRecordsCopy = toolCopy{
 
 var advanceDealCopy = toolCopy{
 	Purpose: "Move a deal to a different stage of its pipeline.",
-	Limits: "The stage is named by id, not by label, and the id of the stage you are moving TO " +
-		"comes from list_pipelines — call it first, because a deal you have read carries only the " +
-		"stage it is already in. Moving onto or off a stage that closes the deal as won or lost " +
-		"is a decision a person makes: it is staged for approval and needs a lost_reason when the " +
-		"stage is a losing one. Read the target stage's semantic rather than guessing it from its " +
-		"name.",
+	Limits: "The stage is named by id from list_pipelines — call it first; a deal you read " +
+		"carries only its current stage. Moving onto or off a won/lost stage is a person's " +
+		"decision: staged for approval, with a lost_reason for a losing stage. Read the target " +
+		"stage's semantic rather than guessing from its name.",
 	Instead: "Use progress_deal when the move should also leave a note explaining it, which is " +
 		"almost always what a person means by moving a deal on.",
 	Retain: "Send if_version with the version you read of the deal, and keep the staged approval " +

--- a/backend/internal/modules/agents/toolcopy_records.go
+++ b/backend/internal/modules/agents/toolcopy_records.go
@@ -61,8 +61,8 @@ var updateRecordCopy = toolCopy{
 		"amount, an expected close date.",
 	Limits: "Only the fields you send change, and only the fields the record type stores (a " +
 		"person's email addresses are not among them). A field a HUMAN last set is not " +
-		"overwritten: that part is staged for a person and named in the result, so a staged " +
-		"answer means the write has not happened. It names the record by id; when a name matches " +
+		"overwritten: that part is staged for a person and named in the result, and that part " +
+		"of the write has not happened. It names the record by id; when a name matches " +
 		"two records, a person picks. owner_id is NOT neutral — ownership decides visibility, so " +
 		"reassigning moves the record onto someone else's book and can take it off the owner's.",
 	Instead: "Use advance_deal or progress_deal to move a deal between stages, and relink_activity " +

--- a/backend/internal/modules/agents/toolcopy_resolve.go
+++ b/backend/internal/modules/agents/toolcopy_resolve.go
@@ -14,6 +14,6 @@ var resolveEntitiesCopy = toolCopy{
 	Instead: "Use search_records to find a record you know exists, and merge_records once a person " +
 		"has decided that two records are one.",
 	Retain: "Call this BEFORE creating a person or company from anything you did not type. Act on " +
-		"`matched`; on `ambiguous` ask which is meant; on `unresolved` say what you are about to " +
-		"create, because a miss is not proof that nothing exists.",
+		"`matched`; on `ambiguous` ask which is meant; on `unresolved` say what you will create — " +
+		"a miss is not proof nothing exists.",
 }

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -66,6 +66,7 @@ func RegisterCoreTools(r *Registry, p datasource.SystemOfRecordProvider, stages 
 	r.Register(createRecord{p: p})
 	r.Register(updateRecord{p: p, ownership: ownership, staging: r.approvals})
 	r.Register(logActivity{p: p})
+	r.Register(createTask{p: p})
 	r.Register(advanceDeal{p: p, stages: stages})
 	r.Register(progressDeal{p: p, stages: stages})
 	r.Register(qualifyLead{p: p})
@@ -360,7 +361,7 @@ func (t logActivity) Spec() mcp.ToolSpec {
 		// — the refusal that actually binds is the server's.
 		InputSchema: schema(`{"type":"object","required":["kind"],"properties":{
 			"kind":{"type":"string","enum":` + activityKindEnum + `},
-			"channel_provider":{"type":"string","description":"Which messaging transport carried this — required when kind is \"message\", and not allowed otherwise. Name a provider this installation has registered; list_channel_providers reports them."},
+			"channel_provider":{"type":"string","description":"Required when kind is \"message\", else refused; a provider list_channel_providers names."},
 			"subject":{"type":"string"},"body":{"type":"string"},
 			"occurred_at":{"type":"string","format":"date-time"` + timestampNote + `},
 			"direction":{"type":"string","enum":["inbound","outbound"]},
@@ -368,7 +369,7 @@ func (t logActivity) Spec() mcp.ToolSpec {
 			"links":{"type":"array","items":{"type":"object","required":["entity_type","entity_id"],"properties":{
 				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
 				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false},
-				"description":"What the activity is about. Omit it and the activity is stored unattached to any record — it will not appear on a person's, company's or deal's timeline."},
+				"description":"What it is about; unlinked, it appears on no timeline."},
 			"source_system":{"type":"string"},"source_id":{"type":"string"}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[wireRecord](),

--- a/backend/internal/modules/agents/tools_task.go
+++ b/backend/internal/modules/agents/tools_task.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -33,6 +34,10 @@ type taskFields struct {
 	DueAt      *string         `json:"due_at,omitempty"`
 	AssigneeID *string         `json:"assignee_id,omitempty"`
 	Links      json.RawMessage `json:"links,omitempty"`
+	// Source is the REST door's provenance field. The tool stamps its own and
+	// never reads this, but the compose decoder folds a REST body through the
+	// same function, and a required field must not read as an unknown one.
+	Source *string `json:"source,omitempty"`
 }
 
 func (t createTask) Spec() mcp.ToolSpec {
@@ -80,10 +85,11 @@ func TaskAsActivity(in json.RawMessage) (json.RawMessage, error) {
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	if args.Subject == "" {
+	subject := strings.TrimSpace(args.Subject)
+	if subject == "" {
 		return nil, &BadArgsError{Cause: fmt.Errorf("subject is required: a task has to say what is to be done")}
 	}
-	body := map[string]any{"kind": "task", "subject": args.Subject}
+	body := map[string]any{"kind": "task", "subject": subject}
 	if args.Body != nil {
 		body["body"] = *args.Body
 	}
@@ -95,6 +101,9 @@ func TaskAsActivity(in json.RawMessage) (json.RawMessage, error) {
 	}
 	if len(args.Links) > 0 {
 		body["links"] = args.Links
+	}
+	if args.Source != nil {
+		body["source"] = *args.Source
 	}
 	out, err := json.Marshal(body)
 	if err != nil {

--- a/backend/internal/modules/agents/tools_task.go
+++ b/backend/internal/modules/agents/tools_task.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// --- create_task (🟢 write) ---
+//
+// A task IS an activity of kind `task`, and log_activity can store one — but a
+// verb catalog that makes "create a task" a special case of "log something that
+// happened" makes every caller that wants a to-do learn the indirection. The
+// next-best-action surface is the first such caller; this verb exists so its
+// catalog, and an agent's, can say create_task and mean it.
+
+type createTask struct {
+	p datasource.SystemOfRecordProvider
+}
+
+// taskFields is the verb's own shape. Folded into the activity body the
+// provider validates; `kind` is never a caller's to choose here.
+type taskFields struct {
+	Subject    string          `json:"subject"`
+	Body       *string         `json:"body,omitempty"`
+	DueAt      *string         `json:"due_at,omitempty"`
+	AssigneeID *string         `json:"assignee_id,omitempty"`
+	Links      json.RawMessage `json:"links,omitempty"`
+}
+
+func (t createTask) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "create_task", Title: "Create a task", Version: toolVersionV1,
+		Description:   createTaskCopy.render(),
+		RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "createTask",
+		// Terse on purpose: the listing rides every run under a token ceiling,
+		// and log_activity's schema already explains links and timestamps.
+		InputSchema: schema(`{"type":"object","required":["subject"],"properties":{
+			"subject":{"type":"string"},"body":{"type":"string"},
+			"due_at":{"type":"string","format":"date-time"` + timestampNote + `},
+			"assignee_id":{"type":"string","format":"uuid","description":"Defaults to the human you act for."},
+			"links":{"type":"array","items":{"type":"object","required":["entity_type","entity_id"],"properties":{
+				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
+				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false}}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[wireRecord](),
+	}
+}
+
+func (t createTask) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	fields, err := TaskAsActivity(in)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := t.p.Create(ctx, datasource.CreateInput{
+		EntityType: datasource.EntityActivity,
+		Fields:     fields,
+		Source:     ToolSource,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return readBack(ctx, t.p, ref)
+}
+
+// TaskAsActivity is the fold: the verb's arguments as the activity body, with
+// the kind stamped. Decoded strictly first so an unknown field is refused as
+// this verb's rather than surfacing as the provider's complaint about one the
+// caller never typed.
+func TaskAsActivity(in json.RawMessage) (json.RawMessage, error) {
+	var args taskFields
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	if args.Subject == "" {
+		return nil, &BadArgsError{Cause: fmt.Errorf("subject is required: a task has to say what is to be done")}
+	}
+	body := map[string]any{"kind": "task", "subject": args.Subject}
+	if args.Body != nil {
+		body["body"] = *args.Body
+	}
+	if args.DueAt != nil {
+		body["due_at"] = *args.DueAt
+	}
+	if args.AssigneeID != nil {
+		body["assignee_id"] = *args.AssigneeID
+	}
+	if len(args.Links) > 0 {
+		body["links"] = args.Links
+	}
+	out, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("create_task: encoding the activity body: %w", err)
+	}
+	return out, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2287,6 +2287,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a task — a commitment with an owner, on the records it is about.
+         * @description A task is an activity of kind `task`, and this is the one door that says so:
+         *     `POST /activities` with `kind: task` stores the same row, but a caller
+         *     (an agent above all) should not have to know that a to-do is a species of
+         *     timeline entry. Takes what a task needs and nothing a meeting does.
+         */
+        post: operations["createTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/activities": {
         parameters: {
             query?: never;
@@ -14985,6 +15008,31 @@ export interface components {
                 max_body_with_files: number;
             };
         };
+        /** @description What a task needs. Stored as an activity of kind `task`. */
+        CreateTaskRequest: {
+            /** @description What has to be done, as one line. */
+            subject: string;
+            /** @description Detail, if one line is not enough. */
+            body?: string | null;
+            /**
+             * Format: date-time
+             * @description When it is due. Optional — a task without a date is still a task.
+             */
+            due_at?: string | null;
+            /**
+             * Format: uuid
+             * @description Who owes it. Defaults to the caller.
+             */
+            assignee_id?: string | null;
+            /** @description The records the task is about. Omit it and the task appears on no timeline. */
+            links?: {
+                /** @enum {string} */
+                entity_type: "person" | "organization" | "deal" | "lead" | "project";
+                /** Format: uuid */
+                entity_id: string;
+            }[];
+            source: string;
+        };
         CreateActivityRequest: {
             /** @enum {string} */
             kind: "email" | "call" | "meeting" | "note" | "task" | "message";
@@ -24681,6 +24729,53 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+        };
+    };
+    createTask: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a mutation safe to retry — an update exactly as much as a
+                 *     create (API-CC-6). **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+                 *     answer lost": without it the blind retry answers `409 version_skew`, because the first
+                 *     attempt already bumped the version.
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+                 *     what makes an operation replay-safe** — an operation that omits it ignores the header rather
+                 *     than half-honouring it, so read this contract, not the client, to know which calls are safe
+                 *     to retry blind.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTaskRequest"];
+            };
+        };
+        responses: {
+            /** @description The task, as an activity. */
+            201: {
+                headers: {
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Activity"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
         };
     };
     listActivities: {


### PR DESCRIPTION
Plan phase B6a. The plan ruled: build the missing verb rather than route "create a task" through `log_activity` with `kind: task`.

- `POST /tasks` (`createTask`, `x-mcp-tool: create_task`, auto-execute, write): subject (required, non-blank), body, due_at, assignee_id, links. The handler folds it into the activity write — same store path, same gates as `POST /activities`; links are copied by wire shape so the two generated structs cannot drift.
- Agent tool `create_task` (OpenAPIOp `createTask`), stamping `kind: task` itself; the compose decoder binds it to the log-activity resolver. Replayable under Idempotency-Key like its sibling.
- The tool listing has a hard ⅔-window budget and the new verb pushed it over by ~400 tokens. Paid for by trimming prose in log_activity, update_record, advance_deal, send_account_email, book_meeting, resolve_entities, run_report and query_workspace — same meaning, fewer words. Listing now ~16000/16000.
- Goldens regenerated: `testdata/outputshapes.json`, `docs/reference/mcp-info.json` (53 tools).

Verified: `TestATaskCreatedThroughItsOwnDoorIsATaskOnTheTimeline` (integration) — created via `/tasks`, listed by `GET /activities?kind=task` on the deal, blank subject → 422. `make check-backend` + `make craft-static` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POST /tasks` and the `create_task` agent tool so a to-do is created by name instead of via `POST /activities` with `kind: task`. Old behavior: callers logged tasks through `log_activity`. New behavior: an explicit door and verb; same store path and gates; subjects are trimmed and a blank subject is rejected.

- `POST /tasks` (OpenAPI op `createTask`): subject (required, trimmed, non-blank), body, due_at, assignee_id, links, source. Returns the created activity, sets Location, and is replayable via `Idempotency-Key`. Internally folds into the activity writer; links copy by wire shape to keep structs in sync.
- Agent tool `create_task` (auto-execute, write): stamps `kind: task`, binds to the log-activity resolver, trims subject, and its strict decoder now admits `source`. When called via REST, idempotent replays apply like `log_activity`.
- Trims tool copy across `log_activity`, `update_record`, `advance_deal`, `send_account_email`, `book_meeting`, `resolve_entities`, `run_report`, and `query_workspace` to stay within the listing budget and clarify which part of `update_record` was staged.
- Regenerates goldens and schemas (`testdata/outputshapes.json`, `docs/reference/mcp-info.json`, frontend `schema.d.ts`). Adds an integration test asserting tasks created via `/tasks` list under `GET /activities?kind=task` and that a blank subject returns 422.

<sup>Written for commit ee7e16cd174a145586f09814602122512be77761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task creation through the CRM API and assistant tools.
  * Tasks support subjects, descriptions, due dates, assignees, linked records, and source details.
  * Created tasks appear in activity timelines and return standard activity details.
  * Added duplicate-request protection and authorization safeguards.
* **Bug Fixes**
  * Improved validation and error handling, including rejection of missing subjects and invalid fields.
* **Documentation**
  * Clarified guidance for task creation, record updates, reporting, queries, communications, and entity resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->