### PR TITLE
feat(frontend): the deal page says the next move, and one click performs it

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4149,6 +4149,12 @@ export const de = {
   "room.decisions.empty": "Noch keine Entscheidungen.",
   "room.decisions.confirm_version": "hat die Version bestätigt",
   "room.decisions.request_changes": "hat Änderungen angefordert",
+  "nba.title": "Nächster Schritt",
+  "nba.sub": "Eine Sache, die auf diesem Deal zu tun ist — und warum.",
+  "nba.createTask": "Aufgabe anlegen",
+  "nba.draftReply": "Antwort entwerfen",
+  "nba.openBrief": "Meeting-Briefing öffnen",
+  "nba.nothingToDo": "Gerade nichts hinzuzufügen.",
   "prefs.rateLimited":
     "Gerade zu viele Versuche von hier aus. Warte eine Minute und lade neu.",
   "prefs.subscribed": "Abonniert",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4209,6 +4209,12 @@ export const en = {
   "room.decisions.empty": "No decisions yet.",
   "room.decisions.confirm_version": "confirmed the version",
   "room.decisions.request_changes": "asked for changes",
+  "nba.title": "Next move",
+  "nba.sub": "One thing to do on this deal, and why.",
+  "nba.createTask": "Add this task",
+  "nba.draftReply": "Draft the reply",
+  "nba.openBrief": "Open the meeting brief",
+  "nba.nothingToDo": "Nothing to add right now.",
   "prefs.rateLimited":
     "Too many attempts from here just now. Wait a minute and reload.",
   "prefs.subscribed": "Subscribed",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4114,6 +4114,12 @@ export const vi = {
   "room.decisions.empty": "Chưa có quyết định.",
   "room.decisions.confirm_version": "đã xác nhận phiên bản",
   "room.decisions.request_changes": "đã yêu cầu thay đổi",
+  "nba.title": "Bước tiếp theo",
+  "nba.sub": "Một việc cần làm trên giao dịch này, và lý do.",
+  "nba.createTask": "Thêm việc này",
+  "nba.draftReply": "Soạn thư trả lời",
+  "nba.openBrief": "Mở bản tóm tắt cuộc họp",
+  "nba.nothingToDo": "Hiện không có gì cần thêm.",
   "prefs.rateLimited":
     "Vừa có quá nhiều lần thử từ đây. Hãy đợi một phút rồi tải lại.",
   "prefs.subscribed": "Đã đăng ký",

--- a/frontend/src/screens/dealnextaction.css
+++ b/frontend/src/screens/dealnextaction.css
@@ -1,0 +1,26 @@
+/* The deal's next-move card. Tokens only. */
+
+.nba {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.nba-reason {
+  margin: 0;
+}
+
+.nba-evidence {
+  margin: 0;
+  padding-left: var(--space-4);
+  color: var(--textMeta);
+}
+
+.nba-none {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--textMeta);
+}

--- a/frontend/src/screens/dealnextaction.test.tsx
+++ b/frontend/src/screens/dealnextaction.test.tsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { DealNextAction } from "./dealnextaction";
+
+// The card performs the server's recommendation through the verb it names,
+// with the arguments the server prepared — never a body it derived itself.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+type Sent = { key: string; body: unknown };
+
+function stub(nba: unknown, sent: Sent[] = []) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      sent.push({ key, body });
+      if (key === "GET /deals/deal-1/next-best-action") {
+        return jsonResponse(nba);
+      }
+      if (key === "POST /tasks") {
+        return jsonResponse({ id: "act-9", kind: "task" }, 201);
+      }
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DealNextAction", () => {
+  it("creates the task the server prepared, with its body as it came", async () => {
+    const args = {
+      subject: "Agree the next step on Acme rollout",
+      links: [{ entity_type: "deal", entity_id: "deal-1" }],
+      source: "ui",
+    };
+    const sent = stub({
+      deal_id: "deal-1",
+      action: "create_task",
+      reason: "Nothing has happened on this deal yet — decide the first step.",
+      arguments: args,
+      evidence: [],
+      computed_at: "2026-08-22T12:00:00Z",
+    });
+    const user = userEvent.setup();
+    render(<DealNextAction dealId="deal-1" />);
+
+    await screen.findByText(/decide the first step/);
+    await user.click(screen.getByRole("button", { name: "Add this task" }));
+    await waitFor(() =>
+      expect(sent.find((s) => s.key === "POST /tasks")).toBeTruthy(),
+    );
+    expect(sent.find((s) => s.key === "POST /tasks")?.body).toEqual(args);
+  });
+
+  it("says why there is nothing to do, and offers no button", async () => {
+    stub({
+      deal_id: "deal-1",
+      action: "none",
+      reason: 'An open task already says what is next: "Send the redline".',
+      evidence: [{ text: "Open task: Send the redline" }],
+      computed_at: "2026-08-22T12:00:00Z",
+    });
+    render(<DealNextAction dealId="deal-1" />);
+
+    await screen.findByText("Open task: Send the redline");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText("Nothing to add right now.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/dealnextaction.tsx
+++ b/frontend/src/screens/dealnextaction.tsx
@@ -1,0 +1,168 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowRight, ListChecks, Mail, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Button } from "../design-system/atoms";
+import { Panel, PanelBody } from "../design-system/panel";
+import { useT } from "../i18n";
+import { problemMessageOf, QueryStates, throwProblem } from "./common";
+import { ComposeModal } from "./compose";
+import { PersonMeetingBrief } from "./persondrawers";
+import "./dealnextaction.css";
+
+// The deal's one next move. The READ computes it (a pure GET, retried and
+// re-run like every other read on this page, so it must never write); the
+// CLICK performs it through the verb the answer names — the task door, the
+// compose modal, the meeting-brief drawer — so nothing here re-implements a
+// write or skips its gates.
+
+type NextBestAction = components["schemas"]["DealNextBestAction"];
+
+export function DealNextAction({ dealId }: Readonly<{ dealId: string }>) {
+  const t = useT();
+  const nba = useQuery({
+    queryKey: ["deal-next-action", dealId],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/deals/{id}/next-best-action", {
+        params: { path: { id: dealId } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+  return (
+    <Panel title={t("nba.title")} sub={t("nba.sub")} tone="accent">
+      <QueryStates query={nba} pendingLines={2}>
+        {nba.data ? <Recommendation dealId={dealId} nba={nba.data} /> : null}
+      </QueryStates>
+    </Panel>
+  );
+}
+
+function Recommendation({
+  dealId,
+  nba,
+}: Readonly<{ dealId: string; nba: NextBestAction }>) {
+  return (
+    <PanelBody>
+      <div className="nba">
+        <p className="nba-reason">{nba.reason}</p>
+        <ActionButton dealId={dealId} nba={nba} />
+        {(nba.evidence ?? []).length > 0 ? (
+          <ul className="nba-evidence t-small">
+            {(nba.evidence ?? []).map((row) => (
+              <li key={`${row.activity_id ?? ""}-${row.text}`}>{row.text}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </PanelBody>
+  );
+}
+
+// activityIdOf reads the one operand the navigation and reply verbs take. The
+// arguments object is typed open on the wire; a missing id renders no button
+// rather than a button that would 404.
+function activityIdOf(nba: NextBestAction): string | null {
+  const raw = nba.arguments?.activity_id;
+  return typeof raw === "string" && raw !== "" ? raw : null;
+}
+
+function ActionButton({
+  dealId,
+  nba,
+}: Readonly<{ dealId: string; nba: NextBestAction }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [composing, setComposing] = useState(false);
+  const [briefOpen, setBriefOpen] = useState(false);
+  const activityId = activityIdOf(nba);
+  const createTask = useMutation({
+    mutationKey: ["deal-next-action-create-task"],
+    // The arguments ARE the task body the server prepared; the click sends
+    // them as they came rather than re-deriving them from render state.
+    mutationFn: async (body: Record<string, unknown>) => {
+      const { data, error } = await api.POST("/tasks", {
+        body: body as components["schemas"]["CreateTaskRequest"],
+      });
+      if (error) {
+        throwProblem(error, t);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["deal-next-action", dealId] });
+      queryClient.invalidateQueries({ queryKey: ["activities"] });
+    },
+  });
+
+  switch (nba.action) {
+    case "create_task":
+      return (
+        <>
+          <Button
+            variant="primary"
+            pending={createTask.isPending}
+            onClick={() => createTask.mutate(nba.arguments ?? {})}
+          >
+            <ListChecks aria-hidden />
+            {t("nba.createTask")}
+          </Button>
+          {createTask.isError ? (
+            <p className="t-small t-danger">
+              {problemMessageOf(createTask.error, t)}
+            </p>
+          ) : null}
+        </>
+      );
+    case "draft_email":
+      if (!activityId) {
+        return null;
+      }
+      return (
+        <>
+          <Button variant="primary" onClick={() => setComposing(true)}>
+            <Mail aria-hidden />
+            {t("nba.draftReply")}
+          </Button>
+          {composing ? (
+            <ComposeModal
+              activityId={activityId}
+              entityType="deal"
+              entityId={dealId}
+              kind="email"
+              open={composing}
+              onClose={() => setComposing(false)}
+            />
+          ) : null}
+        </>
+      );
+    case "open_meeting_brief":
+      if (!activityId) {
+        return null;
+      }
+      return (
+        <>
+          <Button variant="primary" onClick={() => setBriefOpen(true)}>
+            <Sparkles aria-hidden />
+            {t("nba.openBrief")}
+          </Button>
+          <PersonMeetingBrief
+            activityId={activityId}
+            open={briefOpen}
+            onClose={() => setBriefOpen(false)}
+          />
+        </>
+      );
+    default:
+      return (
+        <p className="t-small nba-none">
+          <ArrowRight aria-hidden />
+          {t("nba.nothingToDo")}
+        </p>
+      );
+  }
+}

--- a/frontend/src/screens/dealnextaction.tsx
+++ b/frontend/src/screens/dealnextaction.tsx
@@ -96,17 +96,23 @@ function ActionButton({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["deal-next-action", dealId] });
       queryClient.invalidateQueries({ queryKey: ["activities"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 
+  const taskBody = nba.arguments;
   switch (nba.action) {
     case "create_task":
+      // No body, no button: a click that sent {} would only be refused.
+      if (!taskBody) {
+        return null;
+      }
       return (
         <>
           <Button
             variant="primary"
             pending={createTask.isPending}
-            onClick={() => createTask.mutate(nba.arguments ?? {})}
+            onClick={() => createTask.mutate(taskBody)}
           >
             <ListChecks aria-hidden />
             {t("nba.createTask")}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -77,6 +77,7 @@ import { CreateAction } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { DealBulkBar } from "./dealbulk";
+import { DealNextAction } from "./dealnextaction";
 import { DealRoomAside, useDealRoomPresence } from "./dealroom";
 import { EditAction } from "./edit";
 import { EntityRef, useEntityName } from "./entityref";
@@ -3245,8 +3246,15 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                 { overlay, pending: timelineQuery.isPending },
                 t,
               )}
-              aside={hasDealRoom ? <DealRoomAside dealId={id} /> : undefined}
-              asideLabel={t("room.tasks.title")}
+              aside={
+                overlay ? undefined : (
+                  <>
+                    <DealNextAction dealId={id} />
+                    {hasDealRoom ? <DealRoomAside dealId={id} /> : null}
+                  </>
+                )
+              }
+              asideLabel={t("nba.title")}
             >
               <div style={{ marginBottom: 16 }}>
                 <SegmentedControl

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -78,6 +78,21 @@ import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { DealBulkBar } from "./dealbulk";
 import { DealNextAction } from "./dealnextaction";
+
+// The deal page's aside: the next move first, then the Deal Room when the deal
+// has one. Its own component so the screen's render stays readable.
+function DealAside({
+  dealId,
+  hasDealRoom,
+}: Readonly<{ dealId: string; hasDealRoom: boolean }>) {
+  return (
+    <>
+      <DealNextAction dealId={dealId} />
+      {hasDealRoom ? <DealRoomAside dealId={dealId} /> : null}
+    </>
+  );
+}
+
 import { DealRoomAside, useDealRoomPresence } from "./dealroom";
 import { EditAction } from "./edit";
 import { EntityRef, useEntityName } from "./entityref";
@@ -3248,10 +3263,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
               )}
               aside={
                 overlay ? undefined : (
-                  <>
-                    <DealNextAction dealId={id} />
-                    {hasDealRoom ? <DealRoomAside dealId={id} /> : null}
-                  </>
+                  <DealAside dealId={id} hasDealRoom={hasDealRoom} />
                 )
               }
               asideLabel={t("nba.title")}


### PR DESCRIPTION
Plan slice S8 over #2293.

A **Next move** card at the top of the deal's aside (`dealnextaction.tsx`): the server's reason sentence, the evidence it rests on, and one button that performs the answer through the verb it names — `POST /tasks` with the prepared body, the existing `ComposeModal` for a reply on the named activity, or the existing `PersonMeetingBrief` drawer for a booked meeting. `none` says so and offers nothing. Nothing executes on load; the read is a plain query.

The deal aside (next move + Deal Room panels) is its own `DealAside` component to keep the screen under the complexity ceiling. i18n en/de/vi; two vitest cases (the click sends the server's body verbatim; `none` renders no button).

Clicked through `make dev`: empty deal → "decide the first step" → **Add this task** → the card flips to "An open task already says what is next". `make check-fe` green (4009 + 36).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a Next move card at the top of the deal aside that explains the server’s recommended next action and performs it in one click via existing flows. Previously the aside only hosted Deal Room panels; now it begins with the Next move card, and “none” recommendations show an explanation with no button.

- Adds `DealAside` and inserts `DealNextAction` before Deal Room; uses `t("nba.title")` for the aside label and hides the aside when an overlay is open.
- Reads `GET /deals/{id}/next-best-action` and displays reason and evidence; no writes happen on load.
- For `create_task`, performs `POST /tasks` with the server-provided body verbatim; renders no button when the body is missing.
- For `draft_email` and `open_meeting_brief`, opens existing `ComposeModal` and `PersonMeetingBrief` respectively (requires `activity_id`).
- After task creation, invalidates `["deal-next-action", id]`, `["activities"]`, and `["tasks"]`.
- Adds i18n strings (`en`, `de`, `vi`), light CSS, and two vitest cases for verbatim task body and the `none` state.

**Integration requirements**
- Backend must provide `GET /deals/{id}/next-best-action`:
  - For `create_task`, include the full task request body in `arguments`.
  - For `draft_email` and `open_meeting_brief`, include `arguments.activity_id`; without it, no action button renders.

<sup>Written for commit b8aee17ba34690d740a2b5885a022fb512c28a36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Next move” panel to deal records with recommended actions, reasons, and supporting evidence.
  * Added options to create a task, draft an email reply, or open a meeting brief.
  * Added a clear no-action state when no follow-up is recommended.
  * Added English, German, and Vietnamese translations.
* **Bug Fixes**
  * Prevented navigation-based actions when required activity details are unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->