### PR TITLE
docs(records): the rail a rep watches is written down

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@ maps the codebase and links everything below.
 
 - [ai-runtime.md](explanation/ai-runtime.md) — the AI task contract, tiers/ladders, the routing config, the one Router gate, honest tracing, and certification.
 - [agent-surface.md](explanation/agent-surface.md) — the Surface-B reasoning loop and the model runtime.
+- [ai-activity-rail.md](explanation/ai-activity-rail.md) — what the AI is doing for you while it does it: the one `ai_task_run` projection, who reports into it (router vs. carrier vs. step), how an occurrence is attributed to a person, the read's one-statement/two-arm shape and its derived `stalled`, and the separate question of which of the 23 kinds a reader is actually shown — with the written reason for each of the 17 that are not.
 - [search-and-retrieval.md](explanation/search-and-retrieval.md) — the lexical and hybrid lanes, row scope inside the query, embedding identity, and the two kinds of staleness with their two different answers.
 - [relationship-graph.md](explanation/relationship-graph.md) — who on our team knows this contact: participants, the interaction projection, warmth, deal coverage and its risk rules.
 - [company-context.md](explanation/company-context.md) — the cold start, the governed company profile (profile fields, facts, site reads), and how bounded company context reaches AI tasks. This is the *installation's own* company; for the company **record** page see below.

--- a/docs/explanation/ai-activity-rail.md
+++ b/docs/explanation/ai-activity-rail.md
@@ -1,0 +1,280 @@
+# The AI activity rail — what the AI is doing for you, while it does it
+
+A rep who asks the product to write a summary should see that it is being
+written. Before this existed they saw nothing for however long the model took,
+and then the answer appeared — which reads as a product that did nothing and
+then guessed.
+
+This page explains the rail: the one projection behind it, who reports into it,
+who an occurrence belongs to, and — separately, because it is a different
+question with a different owner — which kinds a reader is actually shown.
+
+**The two questions this page keeps apart.** The server's obligation is a
+COMPLETE record: every AI task this build can run reports, because a task that
+reports nothing is AI work the product performed and then denied. What a reader
+is SHOWN is the client's decision, and it is narrower. Conflating them is how
+you get either a silent product or 300 strings nobody reads.
+
+## The shape at a glance
+
+```
+  a writer                     the bus                the projection            the read              the rail
+  ────────                     ───────                ──────────────            ────────              ────────
+  ai.Router          ──┐
+  agent runner       ──┼──▶  ai_task.state_changed ──▶  aiactivity      ──▶  GET /me/ai-activity ──▶  AgentRail
+  attachment extract ──┘         (outbox)                handler              (one statement,          (locale
+                                                          │                    two arms)                decides
+                                                          ▼                                             the words)
+                                                     ai_task_run
+```
+
+Nothing outside `internal/modules/aiactivity` writes `ai_task_run`, and no
+statement in it invents a fact the bus did not carry. That is why the module
+imports no sibling: the facts it needs arrive in the envelope, and a projection
+that reached back into a source's tables would be a second reader of a truth it
+is supposed to hold. (Two exceptions, both retention: `PurgeSettledBefore` ages
+rows out and `CloseAbandonedRouterRuns` settles the ones whose source will never
+settle them. Ageing a read model is not a domain mutation, but it IS a write.)
+
+## Who reports — the router, a carrier, or nobody
+
+`ai.railOwners` (`internal/modules/ai/railowner.go`) answers this for every task
+in `api/ai-tasks.yaml`, and it is TOTAL over that table: a task the generator
+adds and nobody answers fails the build. Three answers:
+
+| Owner | What it means | What it can say |
+|---|---|---|
+| `SourceRouter` (`ai_router`) | The default. The router announces on the task's behalf, so a task is wired before its author has thought about the rail. | It learns of a call only once the call is over — plus a `running` line announced just before the call. Never `queued`. |
+| A **carrier** (`agent_runner`, `attachment_extraction`) | Work that owns a durable row reports for itself. | `queued`, `running`, and — because a carrier declares a lease — a dead attempt that can be derived as `stalled`. |
+| `SourceNoOccurrence` (`none`) | The work is a STEP inside somebody else's occurrence, not an occurrence of its own. | Nothing of its own; it is reported under the unit of work it serves. |
+
+`SourceNoOccurrence` is **not** an exemption from reporting, and every use owes a
+reason in `railNoOccurrenceReasons` — checked, because "reported by nobody" is
+one keystroke from the silence this registry exists to end. One task uses it
+today: `embeddings`, because every embedding call happens in service of a search,
+an enrich or a reindex, and that is the occurrence. A reason that is really an
+editorial preference ("no rep wants to see it") belongs in the CLIENT, which
+decides what to draw.
+
+Where a carrier exists it is the better reporter and **the router stays silent**,
+so the two never write one occurrence between them.
+
+## Who an occurrence belongs to
+
+`ResolveActor` (`aiactivity/actor.go`) derives the owner FROM THE ENVELOPE, never
+from the payload. An emitter chooses its payload; it cannot choose the
+authenticated actor the write shape stamped, so it cannot attribute its work to
+somebody else by filling in a field.
+
+| The event's actor | Scope | `actor_user_id` |
+|---|---|---|
+| human | `personal` | that human |
+| non-human **with** `on_behalf_of` | `personal` | the human behind it |
+| non-human **without** `on_behalf_of` | `workspace` | NULL |
+| human that does not parse | *refused* | — |
+
+The last row is the interesting one: a human actor that does not parse is
+REFUSED rather than quietly made workspace-scoped, because quietly widening it is
+how one person's work becomes a system sweep nobody can find and nobody notices
+is missing.
+
+Stated honestly: on a worker path `OnBehalfOf` is itself derived from the job's
+own args, so this is uniform rather than tamper-proof. Uniform is the benefit
+worth having — one rule, one place, one failure mode.
+
+**The consequence that decides most of the display census below:** a
+workspace-scoped occurrence has a NULL `actor_user_id`, and the read filters
+`actor_user_id = $1`. So background work with nobody behind it reaches nobody's
+rail — not by editorial choice, but structurally.
+
+## The read
+
+`GET /me/ai-activity` (`aiactivity/read.go`), cookie-authenticated, `human-only`,
+read-only — no audit or event row.
+
+**The person is taken from the bound principal and is NOT a parameter, and that
+is the whole of the authorization.** A store method that accepted a user id would
+let any in-process caller ask for somebody else's feed, and the only thing
+standing between that and a leak would be every caller remembering to pass its
+own. Here there is nothing to remember: another person's feed cannot be
+expressed. No RBAC object gates it, because there is no wider set to withhold.
+
+Four properties worth knowing:
+
+- **One statement, not two.** The transaction is READ COMMITTED, so two
+  statements would take two snapshots and an occurrence that settled between them
+  would appear in both — the rail saying "reading your document" and "I've read
+  your document" about one reading at once. One statement is one snapshot, so the
+  window does not exist to be closed.
+- **Two arms, each with its own ordering, bound and partial index.** `live` is
+  `queued`/`running` ordered by `queued_at`; `settled` is bounded by
+  `finished_at`, because "what the AI finished for me today" is a question about
+  when it finished — keyed on its start, a run that began 23:50 and ended 00:10
+  would fall out of `settled` AND have already left `live`, vanishing entirely.
+- **`stalled` is derived at read time and never stored.** A live occurrence past
+  the lease its own source declared is reported stalled, unconditionally, in SQL,
+  against the DATABASE clock. Nothing writes it, so nothing can forget to — which
+  is what stops a worker that died mid-run from being displayed as working
+  forever.
+- **`recent` is bounded** — since local midnight, at most 10. An unbounded
+  per-person history is a per-person activity ledger, which this installation
+  deliberately does not keep. `summary` and `degrade_reason` are capped on the
+  way to the wire (2000 / 500), because a model's whole output — possibly
+  inflated by a prompt injection — otherwise ships to every open tab on every
+  poll.
+
+`degrade_reason` is server-authored prose in the SOURCE's own words, never a
+provider's or a parser's message: those carry vendor text and can echo credential
+material, and this field reaches an ordinary rep. `MarkFailed` takes a typed
+`runner.FailureReason` so a raw error **fails to compile**.
+
+**`kinds` is how a client that draws part of the record asks for its part**, and
+it is applied BEFORE the bounds. Every task reports, so a caller that renders six
+kinds and is served the newest ten of twenty-three can be handed ten it draws
+nothing for — the bound would fall on rows the reader never sees and the rail
+would go blank while its work was reported correctly. An empty list is a 422, and
+so is an unknown name; both would otherwise come back as an empty feed, which is
+the TRUE answer for an AI at rest.
+
+The SPA polls every **3s while something is live, 30s at rest**, and refetches
+explicitly on tab return — focus refetching is disabled app-wide, and the cached
+body is exactly the one that is wrong, because the run it shows as live is the
+run that finished while the tab was away.
+
+## What a reader is actually shown
+
+`frontend/src/app/ai-activity-lines.ts` holds `ACTIVITY_LINE`: for each of the
+contract's 23 kinds, either a `(state → message key)` table or a written reason
+there is none. It is typed `Record`, not `Partial<Record>`, so **a new kind fails
+the build** until somebody either writes its copy in every locale or says, in
+code, why it is not shown. The reason lives in the source rather than in a review
+comment for the same reason: the next author reads the file, not the PR.
+
+Copy is by LITERAL key, never `t(\`agent.activity.${kind}.${state}\`)` — the
+orphan guard in `i18n.test.ts` counts a key as rendered when it starts with a
+template stem, so an interpolated key would vouch for the whole namespace forever
+and a retired kind's copy would sit in three catalogs with nothing to flag it.
+
+**Six kinds are narrated**, in en/de/vi, total over all six states:
+
+| Kind | Reported by | The line a rep sees |
+|---|---|---|
+| `morning_brief` | carrier (`agent_runner`) | the scheduled brief |
+| `overnight_at_risk_sweep` | carrier (`agent_runner`) | the scheduled sweep |
+| `document_extract` | carrier (`attachment_extraction`) | reading a document you attached |
+| `summarize` | router | "I'm writing your summary." |
+| `draft_reply` | router | "I'm drafting your reply." |
+| `offer_draft` | router | "I'm drafting your offer." |
+
+For the three router-owned ones, `queued` copy exists and **is unreachable**: the
+router announces a call it is ABOUT to serve, never one waiting, and no carrier
+owns these tasks. The key exists because the state axis is total and the compiler
+requires it — not because a producer is missing.
+
+**Seventeen are not narrated**, and each reason is a different kind of fact:
+
+| Reason | Kinds | Why |
+|---|---|---|
+| Watched by the asker | `growth_fit`, `cold_start` | `growth_fit` renders on the panel that asked for it, so a line would narrate what the reader is already looking at. `cold_start` runs during onboarding, and the onboarding routes are deliberately RAILLESS — there is no rail on screen for its line to appear on. |
+| System sweep | `brief_ranking`, `capture_classify`, `capture_counterparty_verdict`, `rate_extract`, `signal_extract`, `site_extract`, `site_fact_extract`, `site_triage`, `transcript_propose`, `voice_build` | Background workspace work that belongs to nobody in particular, so it has no personal line to draw. |
+| Reaches nobody | `enrich` | Structural, not editorial. Its one production site is the signature-enrichment pass, which runs under a system principal with no `on_behalf_of` — so every occurrence is workspace-scoped with a NULL `actor_user_id`, and the personal feed selects on `actor_user_id`. Copy for it would be copy no reader can ever be shown. |
+| An operator's measurement | `cert_judge` | The certification lane grading this build's own answers — not a rep's work. |
+| Declared, not built | `deal_health`, `nl_search`, `transcript` | Named in `api/ai-tasks.yaml`; no site runs them, so nothing reports them yet. |
+
+`enrich` is the one worth reading twice, because it looks visible and is not: the
+ticker's own `enrich` key names DIFFERENT work (a provider run on a person, and
+the site-read lanes on a company).
+
+### Two surfaces, one action, no double narration
+
+The taskbar ticker narrates **this tab's own react-query cache**; the rail
+narrates **the server's feed**. Three ticker entries describe work the rail now
+covers, and they do not collide: the bar renders the ticker line OR the rail line
+as one `if/else` on a single span (`agentrail.tsx`), so a reader never sees one
+action twice.
+
+One collision was real and was fixed at the key rather than the table: removing
+the ticker's `email` entry to end a two-vocabulary clash also silenced email
+SENDS, because four mutations shared that key — two drafts and two sends. The key
+is now split (`email-draft` for the rail, `email` for the ticker), so each action
+is narrated exactly once by whichever surface actually knows about it.
+
+## The gates that hold it
+
+All of these live in the ROOT package, because the root is the only place that
+can see the task contract, the wire contract, the read's own bounds and the
+emitters at once.
+
+| Obligation | Held by |
+|---|---|
+| Every task names the source that reports it, and every `SourceNoOccurrence` owes a defensible reason | `TestEveryAITaskNamesTheSourceThatReportsIt` (`backend/aitaskrailcensus_test.go`) |
+| The registry names no task the contract dropped | `TestTheRailRegistryNamesNoTaskTheContractDropped` |
+| A carrier's source literal is one something really emits | `TestEveryCarrierOverrideNamesASourceThatIsReallyEmitted` |
+| Every kind something produces is one the contract enum can express | `TestEveryKindSomethingProducesIsOneTheContractCanExpress` (`backend/aiactivitycatalogparity_test.go`) — its failure prints an `align:` line naming the file, the schema and exactly what to add |
+| Every contract kind has something that produces it | `TestEveryContractKindHasSomethingThatProducesIt` |
+| The read's text caps are the ones the contract publishes | `TestTheReadsTextCapsAreTheOnesTheContractPublishes` |
+| Every spec name can be a message-key segment | `TestEverySpecNameCanBeAMessageKeySegment` |
+| Every contract kind is displayed or carries a written reason | the TypeScript `Record` type — a **compile error**, not a test |
+| Every displayed kind has copy in en/de/vi, for all six states | the `LineSet` type + the i18n catalogs |
+
+The census gate is deliberately derived rather than listed: the router announces
+for every task the registry leaves to it, and that set grows the moment somebody
+declares a task — so a hand-kept list would be one edit behind the contract
+forever. That is the exact shape of the defect that left seventeen shipped tasks
+reporting nothing at all.
+
+## Known limits
+
+- **Five tasks report settled-only** ([#2272]). `transcript_propose`,
+  `site_extract`, `site_fact_extract`, `site_triage` and `voice_build` each
+  already have a durable, attributable row that COULD say `queued`/`running`, but
+  none is registered as a carrier. For long work, settled-only is worse than
+  silence: a rep clicks "read this site", sees nothing for forty seconds, then it
+  appears already finished.
+- **One site read files THREE occurrences** ([#2272]). Its correlation id is the
+  `site_read` row id and it runs three distinct tasks, so the router's
+  `correlation_id + task` key produces three separate lines for one thing a
+  person asked for once. Harmless only while the rail narrates none of them; it
+  becomes visible the moment anybody writes the copy.
+- **A multi-call unit reopens its occurrence once per call** ([#2276]).
+  `CompleteStructured` walks the ladder three times, and the lease is announced
+  once and cannot be renewed.
+- **The projection refuses a write into a live attempt.** `applyStateChangeSQL`
+  guards with strict `>` on `(attempt, rank)`, so an equal-tuple event updates
+  nothing. A lease REFRESH and per-step progress TICKS are both impossible
+  without changing the projection.
+- **The contract has no word for two real states.** Site read's `deferred`
+  ("waiting on budget, retry at `next_attempt_at`" — not `queued`, since nothing
+  will pick it up, and not settled) and `cancelled` (terminal, but `done` and
+  `failed` would both lie). Either the enum grows or somebody rules on the
+  mapping. Two things already fit exactly: `site_read.stopped_reason` is a closed
+  vocabulary that drops straight into `degrade_reason`, and `partial` →
+  `degraded`.
+- **`subject_type` / `subject_id` are carried and stored but never read.** The
+  event envelope has both, `ai_task_run` has both columns, and exactly one
+  emitter populates them (`document_extract` → `attachment`). Nothing selects
+  them, and the wire contract does not expose them.
+
+[#2272]: https://github.com/gradionhq/margince-poc-v1/issues/2272
+[#2276]: https://github.com/gradionhq/margince-poc-v1/issues/2276
+
+## Reference
+
+| Concern | Where |
+|---|---|
+| The projection + the read | `internal/modules/aiactivity` (owns `ai_task_run`, imports no sibling) |
+| Who reports each task | `internal/modules/ai/railowner.go` — `railOwners`, `RailOwner`, `RouterReports` |
+| The router's announce/settle pair | `internal/modules/ai/railstart.go`, `railemit.go` |
+| The carriers | `internal/modules/agents/runner/activity.go`, `internal/modules/activities/extractionactivity.go` |
+| Attribution | `aiactivity/actor.go` — `ResolveActor` |
+| The event | `ai_task.state_changed` (`shared/kernel/events/catalog.go`; payload generated into `internalevents_gen.go`) |
+| The wire | `AiActivity` / `AiActivityKind` / `AiActivityItem` + `GET /me/ai-activity` (`backend/api/crm.yaml`) |
+| What is drawn, and what is not | `frontend/src/app/ai-activity-lines.ts` |
+| The rail component + poll | `frontend/src/app/agentrail.tsx`, `ai-activity.ts` |
+| The census gate | `backend/aiactivitycatalogparity_test.go` |
+
+**Related:** [ai-runtime.md](ai-runtime.md) (the task contract and the Router
+gate) · [write-backbone.md](write-backbone.md) (the outbox the facts ride) ·
+[job-fleet.md](job-fleet.md) (the scheduled work two carriers report) ·
+[frontend-architecture.md](frontend-architecture.md) ·
+[how-to/add-an-ai-task.md](../how-to/add-an-ai-task.md).

--- a/docs/explanation/ai-runtime.md
+++ b/docs/explanation/ai-runtime.md
@@ -367,6 +367,7 @@ writing the case that certifies one:
 | Certification | `internal/compose/aicert` — `make e2e-ai`, `make e2e-ai-report` |
 
 **Related:** [agent-surface.md](agent-surface.md) (what agents do with a call) ·
+[ai-activity-rail.md](ai-activity-rail.md) (how a call reaches the rail a rep watches) ·
 [authorization.md](authorization.md) (the admission gate) ·
 [how-to/connect-a-cloud-model-provider.md](../how-to/connect-a-cloud-model-provider.md) ·
 [how-to/enrich-with-a-local-llm.md](../how-to/enrich-with-a-local-llm.md) ·

--- a/docs/how-to/add-an-ai-task.md
+++ b/docs/how-to/add-an-ai-task.md
@@ -233,6 +233,35 @@ and it caps how much of the site one certification run can cover:
    **`absent`** for your site, which is honest, and the paid lane never gates a
    merge.
 
+   Two gates will stop you here if the task is NEW (a new site on an existing
+   task trips neither), and both are about the activity rail:
+
+   - **`TestEveryKindSomethingProducesIsOneTheContractCanExpress`** — a task the
+     router announces under a name `AiActivityKind` does not carry is a kind the
+     wire cannot express, and the rail renders nothing for AI work that really
+     happened. Its failure prints an `align:` line naming the file and exactly
+     what to add.
+   - **The frontend census** — `ACTIVITY_LINE` in
+     `frontend/src/app/ai-activity-lines.ts` is typed `Record`, not
+     `Partial<Record>`, so a new kind is a **compile error** until you either
+     write its copy in en/de/vi for all six states or state, in code, why it is
+     not shown.
+
+   The second one is a decision, not paperwork, and the default is "not shown":
+   the server's obligation is a complete record, but a reader is shown only work
+   they are waiting on. Ask whether a rep would be sitting there wondering. If
+   the work reaches nobody at all — a system principal with no `on_behalf_of` is
+   workspace-scoped with a NULL `actor_user_id`, and the feed filters on the
+   reader's own id — say THAT, because it is a fact about the work rather than an
+   editorial preference. See
+   [explanation/ai-activity-rail.md](../explanation/ai-activity-rail.md).
+
+   By default the router reports your task, which is why you did not have to
+   think about this earlier. If it owns a durable row with its own lifecycle,
+   consider registering it as a **carrier** in `ai.railOwners` instead — only a
+   carrier can say `queued`/`running` and declare the lease that makes `stalled`
+   derivable.
+
 ## Notes
 
 - **A record is a claim about one (provider, model, env) binding**, not about the


### PR DESCRIPTION
The AI activity rail shipped in two halves (#2275, #2281) and had no page. What existed was a module `doc.go`, a contract description and a TypeScript census — each true, none of them the place a reader looks, and between them they leave the question that actually decides a change unanswered: **why is my new task not on the rail?**

## What this adds

`docs/explanation/ai-activity-rail.md`, plus the step `add-an-ai-task.md` never had.

Three things it records that were only reconstructable by reading four files at once:

**Who reports what.** `ai.railOwners` is total over the task table, and its three answers are not interchangeable — the router is the default and can never say `queued`; a carrier owns a durable row and is the only thing that can declare the lease `stalled` is derived from; `SourceNoOccurrence` is not an exemption from reporting but a claim that the work is a step inside somebody else's occurrence, and it owes a defensible reason.

**Who an occurrence belongs to.** `ResolveActor` reads the envelope, never the payload, and the table of four cases explains most of the display census: a non-human actor with no `on_behalf_of` is workspace-scoped with a NULL `actor_user_id`, and the feed filters on `actor_user_id` — so that work reaches nobody's rail *structurally*, not editorially. That is `enrich`, and it is the single most misread entry in the census.

**The two questions the design keeps apart.** The server owes a COMPLETE record, because a task that reports nothing is AI work the product performed and then denied. What a reader is SHOWN is the client's decision and is narrower — six of twenty-three kinds. Conflating them gets you either a silent product or 300 strings nobody reads, and the page says so where somebody deciding for a new kind will read it.

## The how-to gains the step it never had

`add-an-ai-task.md` walked an author through the contract, the lane, the census and certification and never once mentioned that a new task is a **compile error** in the frontend until somebody writes its copy or its reason. It now names both gates (`TestEveryKindSomethingProducesIsOneTheContractCanExpress` and the `ACTIVITY_LINE` `Record` type), says the default is "not shown", and says which kind of reason is a fact about the work rather than a preference.

## Known limits are recorded, not left to be rediscovered

With their issue numbers: the five settled-only tasks and the three-occurrences-per-site-read grain problem (#2272), the multi-call reopen (#2276), the projection's refusal of an equal-tuple write into a live attempt, the two states the contract has no word for (`deferred`/`cancelled`), and the `subject_type`/`subject_id` pair that is carried on the envelope, stored on the row, and read by nobody.

## Checked, not assumed

Every gate named is named by its real test function. The doc's factual claims were verified against the code rather than against the PR bodies that shipped them — which caught that the `SYSTEM_SWEEP` reason is doing more work than its wording admits, since a human-requested site read carries `OnBehalfOf` and is therefore personal to the requester, not workspace-scoped. That is a code finding, not a docs one, and it is **not** fixed here; the page describes the census as it is.

Docs-only. `go test ./` in the root package (the doc parity, public-reference and craft-doc gates all live there) and `make check-craft-doc` both green; every relative link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the activity rail and the add-a-task path so contributors understand why a new task appears or not. Centralizes reporting ownership, occurrence attribution, read behavior, and the client display rules, with no runtime changes.

- Adds `docs/explanation/ai-activity-rail.md` covering the `ai_task_run` projection, router vs. carrier vs. step reporting, envelope-based attribution, the `GET /me/ai-activity` read (one statement, two arms, derived stalled), and which kinds are shown vs. hidden with reasons.
- Updates `docs/how-to/add-an-ai-task.md` to name the two gates that stop new kinds: `TestEveryKindSomethingProducesIsOneTheContractCanExpress` and the frontend `ACTIVITY_LINE` `Record` type (compile-time). Default is “not shown”; authors must either add copy for all six states in en/de/vi or state a reason in code. Consider registering a durable task as a carrier to enable `queued`/`running` and `stalled`.
- Cross-links from `docs/README.md` and `docs/explanation/ai-runtime.md`; records current limits with issues `#2272` and `#2276`.

<sup>Written for commit bf382ffc7d9b82c073cbe14f335c7c476c3bdfaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for the AI activity rail, including event ownership, attribution, filtering, status handling, polling, localization, and known limitations.
  - Documented requirements for integrating new AI tasks with the activity rail, including lifecycle messaging and visibility rules.
  - Added cross-references to the new activity rail documentation from the documentation map and AI runtime reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->