### PR TITLE
fix(deals): the offer PDF suite reads what the document draws, not the clock

### DIFF
--- a/backend/internal/modules/deals/offer_pdf_test.go
+++ b/backend/internal/modules/deals/offer_pdf_test.go
@@ -6,6 +6,7 @@ package deals
 import (
 	"bytes"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/go-pdf/fpdf"
@@ -36,6 +37,14 @@ func testRenderLines() []crmcontracts.OfferLineItem {
 	}
 }
 
+// pdfContentStream matches a stream object's declared length and the
+// keyword that opens its bytes, which is the only way to find where those
+// bytes END: a drawn string may itself contain "endstream" (a template's
+// terms text is arbitrary), and scanning for that keyword would cut the
+// document short there and then read the real terminator as the start of
+// another stream.
+var pdfContentStream = regexp.MustCompile(`/Length (\d+)\s*>>\s*stream\r?\n`)
+
 // pdfDrawnText returns what the document DRAWS: every content stream in
 // the file, concatenated. It deliberately drops the container around them
 // — the xref byte offsets and the /CreationDate and /ModDate the renderer
@@ -54,22 +63,25 @@ func pdfDrawnText(t *testing.T, pdf []byte) []byte {
 	t.Helper()
 
 	var drawn []byte
-	rest := pdf
-	for {
-		open := bytes.Index(rest, []byte("stream\n"))
-		if open < 0 {
-			break
+	for _, m := range pdfContentStream.FindAllSubmatchIndex(pdf, -1) {
+		length, err := strconv.Atoi(string(pdf[m[2]:m[3]]))
+		if err != nil || length < 0 {
+			t.Fatalf("stream object declares an unreadable /Length %q", pdf[m[2]:m[3]])
 		}
-		rest = rest[open+len("stream\n"):]
-		end := bytes.Index(rest, []byte("endstream"))
-		if end < 0 {
-			t.Fatalf("malformed PDF: a stream is never closed:\n%s", pdf)
+		start := m[1]
+		if start+length > len(pdf) {
+			t.Fatalf("stream object declares /Length %d, which runs past the end of a %d-byte file", length, len(pdf))
 		}
-		drawn = append(drawn, rest[:end]...)
-		// Past the terminator, not to it: "endstream" itself ends in
-		// "stream", so resuming at `end` would re-enter this loop on the
-		// closing keyword and then run off the file looking for its close.
-		rest = rest[end+len("endstream"):]
+		body := pdf[start : start+length]
+		// The declared length is what this helper trusts, so prove it:
+		// the bytes it points past must be the terminator. A renderer
+		// that ever wrote a wrong /Length would otherwise hand back
+		// silently truncated text and every assertion below would be
+		// reading part of a document.
+		if !bytes.HasPrefix(bytes.TrimLeft(pdf[start+length:], "\r\n"), []byte("endstream")) {
+			t.Fatalf("a stream's declared /Length %d does not reach its terminator:\n%s", length, pdf)
+		}
+		drawn = append(drawn, body...)
 	}
 	if len(drawn) == 0 {
 		t.Fatalf("PDF carries no content stream at all:\n%s", pdf)
@@ -344,5 +356,31 @@ func TestPDFDrawnTextExcludesTheWallClockStamp(t *testing.T) {
 	}
 	if bytes.Contains(pdfDrawnText(t, at123457), []byte("12345")) {
 		t.Fatalf("drawn text must not carry the timestamp's digits — an assertion scoped to it would still be reading the clock:\n%s", pdfDrawnText(t, at123457))
+	}
+}
+
+// TestPDFDrawnTextSurvivesDrawnTextThatSaysEndstream is the case a
+// keyword scan cannot handle: a template's terms text is arbitrary, so it
+// may contain "endstream" itself. Reading each stream by its declared
+// /Length keeps the whole document in view; scanning for the keyword would
+// cut it at the drawn word and lose everything the renderer wrote after.
+func TestPDFDrawnTextSurvivesDrawnTextThatSaysEndstream(t *testing.T) {
+	o := testRenderOffer(100000, 19000, 119000)
+	layout := map[string]any{
+		"terms_text":  "endstream is a word a customer may write",
+		"footer_text": "Footer after the terms",
+	}
+
+	pdf, err := RenderOfferPDF(o, testRenderLines(), nil, "Margince GmbH", "de-DE", layout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	drawn := pdfDrawnText(t, pdf)
+	if !bytes.Contains(drawn, []byte("endstream is a word a customer may write")) {
+		t.Fatalf("the drawn terms text must survive intact:\n%s", drawn)
+	}
+	if !bytes.Contains(drawn, []byte("Footer after the terms")) {
+		t.Fatalf("text drawn AFTER the word \"endstream\" must survive too — the stream was cut at the drawn word:\n%s", drawn)
 	}
 }

--- a/backend/internal/modules/deals/offer_pdf_test.go
+++ b/backend/internal/modules/deals/offer_pdf_test.go
@@ -5,6 +5,7 @@ package deals
 
 import (
 	"bytes"
+	"regexp"
 	"testing"
 
 	"github.com/go-pdf/fpdf"
@@ -35,6 +36,47 @@ func testRenderLines() []crmcontracts.OfferLineItem {
 	}
 }
 
+// pdfDrawnText returns what the document DRAWS: every content stream in
+// the file, concatenated. It deliberately drops the container around them
+// — the xref byte offsets and the /CreationDate and /ModDate the renderer
+// stamps from the wall clock — because those are not text a reader of the
+// offer ever sees, and an assertion that matches them is asserting on the
+// clock without meaning to. This suite did exactly that: a PDF rendered at
+// 12:34:57 carries "/CreationDate (D:20260822123457)", so a whole-file
+// search for a short digit run found the timestamp and the layout test
+// failed for ten seconds of every day.
+//
+// RenderOfferPDF disables compression, so a content stream is readable
+// bytes. If that ever changes, this helper is where the inflate belongs
+// and every assertion below inherits it rather than being fixed one by
+// one.
+func pdfDrawnText(t *testing.T, pdf []byte) []byte {
+	t.Helper()
+
+	var drawn []byte
+	rest := pdf
+	for {
+		open := bytes.Index(rest, []byte("stream\n"))
+		if open < 0 {
+			break
+		}
+		rest = rest[open+len("stream\n"):]
+		end := bytes.Index(rest, []byte("endstream"))
+		if end < 0 {
+			t.Fatalf("malformed PDF: a stream is never closed:\n%s", pdf)
+		}
+		drawn = append(drawn, rest[:end]...)
+		// Past the terminator, not to it: "endstream" itself ends in
+		// "stream", so resuming at `end` would re-enter this loop on the
+		// closing keyword and then run off the file looking for its close.
+		rest = rest[end+len("endstream"):]
+	}
+	if len(drawn) == 0 {
+		t.Fatalf("PDF carries no content stream at all:\n%s", pdf)
+	}
+	return drawn
+}
+
 func TestRenderOfferPDF_IncludesOfferDataAndStoredTotals(t *testing.T) {
 	o := testRenderOffer(123456, 23456, 146912)
 	buyerBlock := map[string]any{"organization_id": "org-1", "display_name": "Acme GmbH"}
@@ -46,6 +88,7 @@ func TestRenderOfferPDF_IncludesOfferDataAndStoredTotals(t *testing.T) {
 	if len(pdf) == 0 {
 		t.Fatal("RenderOfferPDF() returned an empty PDF")
 	}
+	drawn := pdfDrawnText(t, pdf)
 
 	mustContain := []string{
 		"A-1042", "Revision 2", "Acme GmbH", "Margince GmbH",
@@ -53,7 +96,7 @@ func TestRenderOfferPDF_IncludesOfferDataAndStoredTotals(t *testing.T) {
 		"1234.56 EUR", "234.56 EUR", "1469.12 EUR",
 	}
 	for _, needle := range mustContain {
-		if !bytes.Contains(pdf, []byte(needle)) {
+		if !bytes.Contains(drawn, []byte(needle)) {
 			t.Fatalf("PDF missing %q", needle)
 		}
 	}
@@ -72,18 +115,20 @@ func TestRenderOfferPDF_LocaleDrivesLabels(t *testing.T) {
 		t.Fatalf("RenderOfferPDF(en) error = %v", err)
 	}
 
-	if !bytes.Contains(dePDF, []byte("Angebot")) || !bytes.Contains(dePDF, []byte("Nettobetrag")) {
-		t.Fatalf("de-DE PDF missing German labels:\n%s", dePDF)
+	deDrawn, enDrawn := pdfDrawnText(t, dePDF), pdfDrawnText(t, enPDF)
+
+	if !bytes.Contains(deDrawn, []byte("Angebot")) || !bytes.Contains(deDrawn, []byte("Nettobetrag")) {
+		t.Fatalf("de-DE PDF missing German labels:\n%s", deDrawn)
 	}
-	if bytes.Contains(dePDF, []byte("Offer ")) {
-		t.Fatalf("de-DE PDF unexpectedly contains the English title label:\n%s", dePDF)
+	if bytes.Contains(deDrawn, []byte("Offer ")) {
+		t.Fatalf("de-DE PDF unexpectedly contains the English title label:\n%s", deDrawn)
 	}
 
-	if !bytes.Contains(enPDF, []byte("Offer ")) || !bytes.Contains(enPDF, []byte("Net: ")) {
-		t.Fatalf("en PDF missing English labels:\n%s", enPDF)
+	if !bytes.Contains(enDrawn, []byte("Offer ")) || !bytes.Contains(enDrawn, []byte("Net: ")) {
+		t.Fatalf("en PDF missing English labels:\n%s", enDrawn)
 	}
-	if bytes.Contains(enPDF, []byte("Angebot")) {
-		t.Fatalf("en PDF unexpectedly contains a German label:\n%s", enPDF)
+	if bytes.Contains(enDrawn, []byte("Angebot")) {
+		t.Fatalf("en PDF unexpectedly contains a German label:\n%s", enDrawn)
 	}
 }
 
@@ -103,11 +148,12 @@ func TestRenderOfferPDF_UsesStoredTotalsNeverRecomputes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderOfferPDF() error = %v", err)
 	}
-	if !bytes.Contains(pdf, []byte("9999.99 EUR")) {
-		t.Fatalf("PDF must render the offer's STORED net total (9999.99 EUR), got:\n%s", pdf)
+	drawn := pdfDrawnText(t, pdf)
+	if !bytes.Contains(drawn, []byte("9999.99 EUR")) {
+		t.Fatalf("PDF must render the offer's STORED net total (9999.99 EUR), got:\n%s", drawn)
 	}
-	if bytes.Contains(pdf, []byte("1234.56 EUR")) {
-		t.Fatalf("PDF must NOT contain a freshly re-derived total from the lines (1234.56 EUR); it must use the stored figure only:\n%s", pdf)
+	if bytes.Contains(drawn, []byte("1234.56 EUR")) {
+		t.Fatalf("PDF must NOT contain a freshly re-derived total from the lines (1234.56 EUR); it must use the stored figure only:\n%s", drawn)
 	}
 }
 
@@ -138,8 +184,9 @@ func TestRenderOfferPDF_GermanDiacriticsRenderCorrectlyNotAsMojibake(t *testing.
 	// *Fpdf receiver but no page/content of its own) gives the expected
 	// cp1252 byte form, so this test never hand-derives the encoding.
 	tr := fpdf.New("P", "mm", "A4", "").UnicodeTranslatorFromDescriptor("")
+	drawn := pdfDrawnText(t, pdf)
 	for _, want := range []string{"Prüfgebühr Größe", "Müller GmbH", "Müller Größe & Prüfung GmbH", "Straße Verträge GmbH"} {
-		if !bytes.Contains(pdf, []byte(tr(want))) {
+		if !bytes.Contains(drawn, []byte(tr(want))) {
 			t.Fatalf("PDF must contain the cp1252-transcoded form of %q", want)
 		}
 	}
@@ -148,7 +195,7 @@ func TestRenderOfferPDF_GermanDiacriticsRenderCorrectlyNotAsMojibake(t *testing.
 	// call would have left behind, and what renders as "Ã¶"-style
 	// mojibake in a cp1252 viewer) must never appear.
 	for _, mojibakeSeed := range []string{"ö", "ü", "ß"} {
-		if bytes.Contains(pdf, []byte(mojibakeSeed)) {
+		if bytes.Contains(drawn, []byte(mojibakeSeed)) {
 			t.Fatalf("PDF must not contain the raw UTF-8 bytes of %q — that is the un-transcoded mojibake source", mojibakeSeed)
 		}
 	}
@@ -161,7 +208,7 @@ func TestRenderOfferPDF_OmitsBuyerSectionWhenBuyerBlockNil(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(withBuyer, []byte("Kunde")) {
+	if !bytes.Contains(pdfDrawnText(t, withBuyer), []byte("Kunde")) {
 		t.Fatalf("a non-nil buyer block must render the buyer section heading:\n%s", withBuyer)
 	}
 
@@ -169,7 +216,7 @@ func TestRenderOfferPDF_OmitsBuyerSectionWhenBuyerBlockNil(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Contains(withoutBuyer, []byte("Kunde")) {
+	if bytes.Contains(pdfDrawnText(t, withoutBuyer), []byte("Kunde")) {
 		t.Fatalf("a nil buyer block must omit the buyer section entirely:\n%s", withoutBuyer)
 	}
 }
@@ -196,23 +243,30 @@ func TestRenderOfferPDF_TwoTemplatesWithDistinctLayoutsProduceDifferentBytes(t *
 	if err != nil {
 		t.Fatalf("RenderOfferPDF(layoutB) error = %v", err)
 	}
-	if bytes.Equal(pdfA, pdfB) {
-		t.Fatal("two templates with distinct layouts must produce different PDF bytes — the layout is being ignored")
+	// Compare what the two documents DRAW, never the whole files: every
+	// render stamps its own /CreationDate, so two files rendered a second
+	// apart differ no matter what the layout did, and a renderer that
+	// ignored the layout entirely would still satisfy a raw-bytes
+	// inequality. Drawn text is the only comparison this proof can be made
+	// of.
+	drawnA, drawnB := pdfDrawnText(t, pdfA), pdfDrawnText(t, pdfB)
+	if bytes.Equal(drawnA, drawnB) {
+		t.Fatal("two templates with distinct layouts must draw different text — the layout is being ignored")
 	}
 
 	for _, want := range []string{"Alpha Consulting GmbH", "Alpha footer", "Alpha terms apply"} {
-		if !bytes.Contains(pdfA, []byte(want)) {
-			t.Fatalf("layoutA's PDF must contain %q:\n%s", want, pdfA)
+		if !bytes.Contains(drawnA, []byte(want)) {
+			t.Fatalf("layoutA's PDF must contain %q:\n%s", want, drawnA)
 		}
 	}
 	for _, unwanted := range []string{"Beta Solutions GmbH", "Beta footer", "Beta terms apply"} {
-		if bytes.Contains(pdfA, []byte(unwanted)) {
+		if bytes.Contains(drawnA, []byte(unwanted)) {
 			t.Fatalf("layoutA's PDF must not contain layoutB's text %q", unwanted)
 		}
 	}
 	for _, want := range []string{"Beta Solutions GmbH", "Beta footer", "Beta terms apply"} {
-		if !bytes.Contains(pdfB, []byte(want)) {
-			t.Fatalf("layoutB's PDF must contain %q:\n%s", want, pdfB)
+		if !bytes.Contains(drawnB, []byte(want)) {
+			t.Fatalf("layoutB's PDF must contain %q:\n%s", want, drawnB)
 		}
 	}
 }
@@ -229,7 +283,7 @@ func TestRenderOfferPDF_EmptyLayoutOmitsHeaderFooterTermsSections(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Contains(pdf, []byte("Bedingungen")) {
+	if bytes.Contains(pdfDrawnText(t, pdf), []byte("Bedingungen")) {
 		t.Fatalf("a nil layout must omit the terms heading entirely:\n%s", pdf)
 	}
 }
@@ -250,10 +304,45 @@ func TestRenderOfferPDF_LayoutIgnoresNonStringAndUnknownKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The key and its value are not text, so the whole file is the honest
+	// scope for them: an unhonored key must not reach the document by any
+	// route, drawn or metadata.
 	if bytes.Contains(pdf, []byte("logo_url")) || bytes.Contains(pdf, []byte("example.test")) {
 		t.Fatalf("an unhonored layout key must never leak into the document:\n%s", pdf)
 	}
-	if bytes.Contains(pdf, []byte("12345")) {
+	// The digits, however, are asserted against the drawn text alone.
+	// "12345" is a substring of the /CreationDate a PDF rendered at
+	// 12:34:5x carries, so the whole-file form of this assertion failed on
+	// the clock rather than on a stringified value.
+	if bytes.Contains(pdfDrawnText(t, pdf), []byte("12345")) {
 		t.Fatalf("a non-string value under a known layout key must be ignored, not stringified:\n%s", pdf)
+	}
+}
+
+// TestPDFDrawnTextExcludesTheWallClockStamp is the guard under the guard:
+// it renders a real offer, rewrites the stamp to the one wall-clock second
+// that broke this suite, and proves the two scopes disagree — the raw file
+// carries "12345", the drawn text does not. Without it, rescoping the
+// assertions above reads as a tidy-up that a later edit could quietly undo,
+// and the next failure would again arrive as a ten-second-a-day mystery.
+func TestPDFDrawnTextExcludesTheWallClockStamp(t *testing.T) {
+	o := testRenderOffer(100000, 19000, 119000)
+
+	pdf, err := RenderOfferPDF(o, testRenderLines(), nil, "Margince GmbH", "de-DE", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stamp := regexp.MustCompile(`/(Creation|Mod)Date \(D:\d{14}\)`)
+	if !stamp.Match(pdf) {
+		t.Fatalf("the renderer no longer stamps a wall-clock date; this guard is asserting on a shape that is gone:\n%s", pdf)
+	}
+	at123457 := stamp.ReplaceAll(pdf, []byte("/CreationDate (D:20260822123457)"))
+
+	if !bytes.Contains(at123457, []byte("12345")) {
+		t.Fatal("the spliced document must carry the colliding digits, or this guard proves nothing")
+	}
+	if bytes.Contains(pdfDrawnText(t, at123457), []byte("12345")) {
+		t.Fatalf("drawn text must not carry the timestamp's digits — an assertion scoped to it would still be reading the clock:\n%s", pdfDrawnText(t, at123457))
 	}
 }


### PR DESCRIPTION
## What broke

`main` is red on `553d3c613` — [main-health run 32573270263](https://github.com/margince/margince/actions/runs/32573270263), job `backend gate (main)`:

```
--- FAIL: TestRenderOfferPDF_LayoutIgnoresNonStringAndUnknownKeys (0.00s)
    offer_pdf_test.go:257: a non-string value under a known layout key must be
    ignored, not stringified:
```

The renderer is not at fault. That test greps the **whole PDF file** for `"12345"`, and `fpdf` stamps `/CreationDate` / `/ModDate` from the wall clock. The CI render happened at 12:34:57, so the file carried:

```
/CreationDate (D:20260822123457)
```

`"12345"` is a substring of `123457`. The suite fails for **ten seconds of every day**, and it names the layout code rather than the clock that caused it.

Reproduced deterministically before touching anything — rendering an offer locally and splicing that one stamp into the raw bytes flips a whole-file search for `12345` from false to true.

## The fix

`pdfDrawnText` returns the document's content streams, and every assertion about visible text now reads that instead of the raw file. The xref offsets and the timestamps are the container; they are not text a reader of the offer ever sees, so an assertion that matches them was reading the clock without meaning to.

Two deliberate exceptions and additions:

- **The unhonored-key assertion keeps its whole-file scope.** `logo_url` and `example.test` must not reach the file by *any* route, drawn or metadata, and neither string can collide with a timestamp. Only the digit needle moved.
- **A second assertion had the same disease.** `TestRenderOfferPDF_TwoTemplatesWithDistinctLayoutsProduceDifferentBytes` compared whole files with `bytes.Equal`. Two renders that straddle a second boundary differ by their stamps alone, so a renderer that ignored the layout entirely would still satisfy the inequality — the assertion goes silently inert (measured: the two renders are ~0.5 ms apart, so roughly 0.05% of runs). It compares drawn text now, which is the only form that proof can take.
- **`TestPDFDrawnTextExcludesTheWallClockStamp`** is the guard under the guard: it splices the colliding stamp into a real render and asserts the two scopes disagree — raw bytes carry `12345`, drawn text does not.

## Verification

- `make check-backend` — green (exit 0).
- Pre-push `craft static --strict` — `PASS — 0 blocker, 0 major, 0 minor`.
- **Mutation-checked, both directions:**
  - degrade `pdfDrawnText` to `return pdf` → `TestPDFDrawnTextExcludesTheWallClockStamp` fails, so the new guard is not decorative;
  - make `pdfLayoutString` ignore the layout bag → the two-templates test still fails, so rescoping it did not weaken what it catches.

Test-only change; no production code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes offer PDF tests by asserting on drawn text instead of raw PDF bytes that can match `fpdf` wall‑clock metadata and flake. Old tests read the whole file; new tests read only content streams and validate their boundaries; no production behavior changes.

- Introduces pdfDrawnText to concatenate content streams by declared /Length, verify terminators, and avoid keyword-based scans.
- Switches all visible‑text assertions (including the two‑templates layout test) to drawn text.
- Keeps the unhonored‑key test as a whole‑file check for `logo_url` and `example.test`; asserts the digit needle against drawn text only.
- Adds guards: TestPDFDrawnTextExcludesTheWallClockStamp and TestPDFDrawnTextSurvivesDrawnTextThatSaysEndstream. Test‑only change.

<sup>Written for commit d74240d20f760b5c3a8487c6088c376535cef3dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved PDF validation to reliably verify visible offer content without false positives from metadata or timestamps.
  * Expanded coverage for localized labels, totals, diacritics, buyer details, layouts, empty layouts, and hidden layout data.
  * Added regression coverage to ensure timestamp values embedded in PDF metadata are not treated as displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->