### PR TITLE
fix(agents-mcp): the published MCP surface names the tool a client is served

### DIFF
--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 52,
+    "tools": 53,
     "resources": 8,
-    "tool_catalog_bytes": 142415,
+    "tool_catalog_bytes": 143504,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 36380,
-    "largest_tool_bytes": 4709,
+    "approx_wire_tokens_total": 36653,
+    "largest_tool_bytes": 4622,
     "largest_tool": "run_report",
     "tool_catalog_composition": {
-      "description_bytes": 35061,
-      "input_schema_bytes": 30800,
-      "output_schema_bytes": 65390,
-      "description_plus_input_schema_bytes": 65861
+      "description_bytes": 34336,
+      "input_schema_bytes": 31442,
+      "output_schema_bytes": 66382,
+      "description_plus_input_schema_bytes": 65778
     }
   },
   "tools": {
@@ -252,7 +252,7 @@
           "readOnlyHint": false,
           "title": "Advance a deal to a stage"
         },
-        "description": "Move a deal to a different stage of its pipeline. The stage is named by id, not by label, and the id of the stage you are moving TO comes from list_pipelines — call it first, because a deal you have read carries only the stage it is already in. Moving onto or off a stage that closes the deal as won or lost is a decision a person makes: it is staged for approval and needs a lost_reason when the stage is a losing one. Read the target stage's semantic rather than guessing it from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope \"write\".)",
+        "description": "Move a deal to a different stage of its pipeline. The stage is named by id from list_pipelines — call it first; a deal you read carries only its current stage. Moving onto or off a won/lost stage is a person's decision: staged for approval, with a lost_reason for a losing stage. Read the target stage's semantic rather than guessing from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1029,7 +1029,7 @@
           "readOnlyHint": false,
           "title": "Book a meeting"
         },
-        "description": "Hold a slot in the host's calendar and record the meeting against the records it is about. It requires at least one link saying what the meeting is about and is refused without one. The slot is taken and the meeting becomes a real commitment, so a person approves it before it is booked. It takes no attendee list: who is invited, and whether an invitation is delivered at all, is the deployment's calendar connection rather than this call. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
+        "description": "Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, so a person approves it first. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1833,6 +1833,179 @@
           "type": "object"
         },
         "title": "Create a record"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": false,
+          "title": "Create a task"
+        },
+        "description": "Put a to-do on someone's list: what is owed, by whom, on which records. Creates the task only — no reminder, no deal move; unlinked, it sits on no timeline. log_activity is for what already happened. (Governance: runs immediately; requires passport scope \"write\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "assignee_id": {
+              "description": "Defaults to the human you act for.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "due_at": {
+              "description": "RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "idempotency_key": {
+              "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "links": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "entity_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "entity_type": {
+                    "enum": [
+                      "person",
+                      "organization",
+                      "deal",
+                      "lead",
+                      "project"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "entity_type",
+                  "entity_id"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "subject": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "subject"
+          ],
+          "type": "object"
+        },
+        "name": "create_task",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "fields": {
+                  "type": "object"
+                },
+                "id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "record_type": {
+                  "type": "string"
+                },
+                "trust_tier": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "fields",
+                "id",
+                "record_type"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Create a task"
       },
       {
         "annotations": {
@@ -3964,7 +4137,7 @@
           "readOnlyHint": false,
           "title": "Log an activity"
         },
-        "description": "Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history, and changes nothing else: logging a call does not move a deal, update a field or notify anyone. An activity logged without links is stored attached to nothing and appears on no timeline. Use progress_deal when the same event also moves a deal forward, so the move and the note are one act rather than two. The activity id comes back in the result; keep it — draft_email, send_email and send_message all identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -3972,7 +4145,7 @@
               "type": "string"
             },
             "channel_provider": {
-              "description": "Which messaging transport carried this — required when kind is \"message\", and not allowed otherwise. Name a provider this installation has registered; list_channel_providers reports them.",
+              "description": "Required when kind is \"message\", else refused; a provider list_channel_providers names.",
               "type": "string"
             },
             "direction": {
@@ -4004,7 +4177,7 @@
               "type": "string"
             },
             "links": {
-              "description": "What the activity is about. Omit it and the activity is stored unattached to any record — it will not appear on a person's, company's or deal's timeline.",
+              "description": "What it is about; unlinked, it appears on no timeline.",
               "items": {
                 "additionalProperties": false,
                 "properties": {
@@ -5587,7 +5760,7 @@
           "readOnlyHint": true,
           "title": "Query the workspace"
         },
-        "description": "Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary, and a name outside it is refused by name rather than guessed at. The margince://schema/query resource — not this description — is what says which record types, fields, operators and relationships this workspace can actually be asked about. A plan takes at most one similarity clause and at most one relationship hop. It cannot group, count or total, and there is no cursor: an answer that hit its limit says so instead of offering a next page. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -7005,7 +7178,7 @@
           "readOnlyHint": true,
           "title": "Resolve people and companies"
         },
-        "description": "Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you are about to create, because a miss is not proof that nothing exists. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you will create — a miss is not proof nothing exists. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -7420,7 +7593,7 @@
           "readOnlyHint": true,
           "title": "Run a report"
         },
-        "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, and each accepts only its own filter, grouping and measure names; anything outside its lists is refused rather than approximated. It aggregates, so it answers how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan arguments first to see what it answers by default, then narrow using the names its own catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -7990,7 +8163,7 @@
           "readOnlyHint": false,
           "title": "Start an email conversation from a record"
         },
-        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. It sends EXACTLY the subject and body it is given and composes nothing. It needs at least one link naming the records the conversation belongs to and is refused without one. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use send_email when the message answers a conversation already recorded here: that keeps the reply on its own thread, where this starts a separate one beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
+        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose, and a person approves the send first — a sent mail cannot be recalled. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -8502,7 +8675,7 @@
           "readOnlyHint": false,
           "title": "Update a record"
         },
-        "description": "Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores: a person's email addresses, for one, are not among them. A field whose current value a HUMAN last set is not overwritten — that part of the call is staged for a person to decide and named in the result, so treat a staged answer as the write not having happened yet. It names the record by id: when a name matches two records, which of them was meant is a question for a person and not a choice to make quietly. There is no sharing verb here, but owner_id is NOT a neutral field — who owns a record is what decides who can see it, so reassigning it moves the record onto someone else's book and can take it off the current owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores (a person's email addresses are not among them). A field a HUMAN last set is not overwritten: that part is staged for a person and named in the result, and that part of the write has not happened. It names the record by id; when a name matches two records, a person picks. owner_id is NOT neutral — ownership decides visibility, so reassigning moves the record onto someone else's book and can take it off the owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -9256,7 +9429,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":52,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activity\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":53,\"execute_directly\":[\"account_coverage\",\"apply_tag\",\"at_risk_relationships\",\"catch_me_up_on\",\"check_availability\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"advance_project_phase\",\"archive_record\",\"book_meeting\",\"commit_import\",\"disqualify_lead\",\"enrich\",\"merge_records\",\"promote_lead\",\"send_account_email\",\"send_email\",\"send_message\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activity\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, key?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, key?: string, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,12 +11,12 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 52 |
+| Tools | 53 |
 | Resources | 8 |
-| Tool catalog | 139.1 KB |
+| Tool catalog | 140.1 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 36380 |
-| Largest tool | `run_report` (4.6 KB) |
+| Approx. wire tokens | 36653 |
+| Largest tool | `run_report` (4.5 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
 Those are the WIRE bytes: they carry each tool's output schema and the governance
@@ -28,11 +28,11 @@ budget in `agenttooldescriptions_test.go`.
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 63.9 KB | 45% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 34.2 KB | 24% | Yes, every step |
-| Input schemas | 30.1 KB | 21% | Yes, every step |
-| _Names, annotations, punctuation_ | 10.9 KB | 7% | Partly |
-| **Description + input schema** | **64.3 KB** | **46%** | **the recurring cost** |
+| Output schemas | 64.8 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 33.5 KB | 23% | Yes, every step |
+| Input schemas | 30.7 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 11.1 KB | 7% | Partly |
+| **Description + input schema** | **64.2 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -55,21 +55,22 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/handoff.html`](#handoff_view) — Delivery handoff
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 
-### Tools (52)
+### Tools (53)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
 | [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 2.7 KB |
-| [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.3 KB |
+| [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.1 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.3 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
 | [`archive_record`](#archive_record) | Archive a record |  |  | 2.3 KB |
 | [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.5 KB |
-| [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.9 KB |
+| [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.8 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.7 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.8 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 2.6 KB |
+| [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 3.0 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 3.0 KB |
 | [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 1.9 KB |
@@ -83,7 +84,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
-| [`log_activity`](#log_activity) | Log an activity |  |  | 3.2 KB |
+| [`log_activity`](#log_activity) | Log an activity |  |  | 2.9 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 3.8 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
@@ -91,7 +92,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.1 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.5 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
-| [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.6 KB |
+| [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 3.5 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
 | [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 2.8 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.5 KB |
@@ -101,13 +102,13 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`remove_tag`](#remove_tag) | Take a tag off a record |  |  | 1.9 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 2.8 KB |
-| [`run_report`](#run_report) | Run a report | yes |  | 4.6 KB |
+| [`run_report`](#run_report) | Run a report | yes |  | 4.5 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.0 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.7 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.5 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.4 KB |
 | [`send_email`](#send_email) | Send an email |  |  | 3.0 KB |
 | [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.4 KB |
-| [`update_record`](#update_record) | Update a record |  |  | 3.9 KB |
+| [`update_record`](#update_record) | Update a record |  |  | 3.7 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
 | [`who_knows`](#who_knows) | Who knows this contact | yes | [`ui://margince/relationship-map.html`](#relationship_map_view) | 2.2 KB |
 | [`whoami`](#whoami) | Who this passport acts for | yes |  | 1.5 KB |
@@ -502,7 +503,7 @@ Answer "is this deal covered?": which roles on the account we have a relationshi
 
 **Advance a deal to a stage**
 
-Move a deal to a different stage of its pipeline. The stage is named by id, not by label, and the id of the stage you are moving TO comes from list_pipelines — call it first, because a deal you have read carries only the stage it is already in. Moving onto or off a stage that closes the deal as won or lost is a decision a person makes: it is staged for approval and needs a lost_reason when the stage is a losing one. Read the target stage's semantic rather than guessing it from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope "write".)
+Move a deal to a different stage of its pipeline. The stage is named by id from list_pipelines — call it first; a deal you read carries only its current stage. Moving onto or off a won/lost stage is a person's decision: staged for approval, with a lost_reason for a losing stage. Read the target stage's semantic rather than guessing from its name. Use progress_deal when the move should also leave a note explaining it, which is almost always what a person means by moving a deal on. Send if_version with the version you read of the deal, and keep the staged approval id when a closing move comes back for approval. (Governance: some calls run immediately and others a person approves first, decided per call from its arguments; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -1329,7 +1330,7 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
 
 **Book a meeting**
 
-Hold a slot in the host's calendar and record the meeting against the records it is about. It requires at least one link saying what the meeting is about and is refused without one. The slot is taken and the meeting becomes a real commitment, so a person approves it before it is booked. It takes no attendee list: who is invited, and whether an invitation is delivered at all, is the deployment's calendar connection rather than this call. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope "send".)
+Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, so a person approves it first. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: a person approves every call before it runs; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -2066,6 +2067,189 @@ Create a person, organization, deal, lead, project, activity or relationship tha
   "required": [
     "record_type",
     "fields"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "fields": {
+          "type": "object"
+        },
+        "id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "record_type": {
+          "type": "string"
+        },
+        "trust_tier": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "fields",
+        "id",
+        "record_type"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### create_task
+
+**Create a task**
+
+Put a to-do on someone's list: what is owed, by whom, on which records. Creates the task only — no reminder, no deal move; unlinked, it sits on no timeline. log_activity is for what already happened. (Governance: runs immediately; requires passport scope "write".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "assignee_id": {
+      "description": "Defaults to the human you act for.",
+      "format": "uuid",
+      "type": "string"
+    },
+    "body": {
+      "type": "string"
+    },
+    "due_at": {
+      "description": "RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional. The same key returns the first result instead of acting twice; different arguments under one key are refused.",
+      "maxLength": 255,
+      "type": "string"
+    },
+    "links": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "entity_type": {
+            "enum": [
+              "person",
+              "organization",
+              "deal",
+              "lead",
+              "project"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_type",
+          "entity_id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "subject": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject"
   ],
   "type": "object"
 }
@@ -4444,7 +4628,7 @@ The workspace's words for grouping records, with the tag_id apply_tag takes. Arc
 
 **Log an activity**
 
-Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history, and changes nothing else: logging a call does not move a deal, update a field or notify anyone. An activity logged without links is stored attached to nothing and appears on no timeline. Use progress_deal when the same event also moves a deal forward, so the move and the note are one act rather than two. The activity id comes back in the result; keep it — draft_email, send_email and send_message all identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
+Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -4456,7 +4640,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "channel_provider": {
-      "description": "Which messaging transport carried this — required when kind is \"message\", and not allowed otherwise. Name a provider this installation has registered; list_channel_providers reports them.",
+      "description": "Required when kind is \"message\", else refused; a provider list_channel_providers names.",
       "type": "string"
     },
     "direction": {
@@ -4488,7 +4672,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "links": {
-      "description": "What the activity is about. Omit it and the activity is stored unattached to any record — it will not appear on a person's, company's or deal's timeline.",
+      "description": "What it is about; unlinked, it appears on no timeline.",
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -6140,7 +6324,7 @@ Fill in what a lead's own data already implies — today the company name, from 
 
 **Query the workspace**
 
-Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary, and a name outside it is refused by name rather than guessed at. The margince://schema/query resource — not this description — is what says which record types, fields, operators and relationships this workspace can actually be asked about. A plan takes at most one similarity clause and at most one relationship hop. It cannot group, count or total, and there is no cursor: an answer that hit its limit says so instead of offering a next page. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope "read".)
+Answer a question that has STRUCTURE — a record type, conditions on its fields, a hop to a related record, or a likeness to describe — by sending a plan and reading back the records that satisfy it, together with what kind of answer it is. Every name in a plan comes from the published vocabulary; one outside it is refused by name. The margince://schema/query resource — not this description — says which record types, fields, operators and relationships can be asked about. At most one similarity clause and one hop. It cannot group, count or total, and has no cursor: an answer that hit its limit says so. Use search_records when you only have a name or a phrase and no conditions to apply, and run_report when the answer wanted is a count, a total or a breakdown rather than the records themselves. Read `coverage` before you use the rows: `complete_exact` means every record matching the plan is here, `ranked_semantic` means these ranked highest and others may match, and `partial_degraded` means something in the plan could not be answered as asked — `notes` says which. Keep each row's record_type and id for any follow-up call, and its `evidence` for the related record that admitted it. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -7631,7 +7815,7 @@ Take one tag off one record — by tag_id or tag_name — leaving the word itsel
 
 **Resolve people and companies**
 
-Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you are about to create, because a miss is not proof that nothing exists. (Governance: runs immediately; requires passport scope "read".)
+Find out whether the people and companies named in something you are holding already exist here, matched on addresses, phone numbers and company domains rather than on text. It reads only. Nothing is created, changed or merged, and it answers person and organization, never leads. A near match comes back `ambiguous` however close it is. Use search_records to find a record you know exists, and merge_records once a person has decided that two records are one. Call this BEFORE creating a person or company from anything you did not type. Act on `matched`; on `ambiguous` ask which is meant; on `unresolved` say what you will create — a miss is not proof nothing exists. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -8059,7 +8243,7 @@ Renders its result in [`ui://margince/commitments.html`](#commitments_view), vis
 
 **Run a report**
 
-Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, and each accepts only its own filter, grouping and measure names; anything outside its lists is refused rather than approximated. It aggregates, so it answers how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan arguments first to see what it answers by default, then narrow using the names its own catalog entry lists. (Governance: runs immediately; requires passport scope "read".)
+Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -8659,7 +8843,7 @@ Find people, organizations, deals, leads and projects when you know roughly what
 
 **Start an email conversation from a record**
 
-Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. It sends EXACTLY the subject and body it is given and composes nothing. It needs at least one link naming the records the conversation belongs to and is refused without one. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use send_email when the message answers a conversation already recorded here: that keeps the reply on its own thread, where this starts a separate one beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope "send".)
+Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose, and a person approves the send first — a sent mail cannot be recalled. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: a person approves every call before it runs; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -9201,7 +9385,7 @@ Reply on a captured chat conversation — the channels this workspace has connec
 
 **Update a record**
 
-Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores: a person's email addresses, for one, are not among them. A field whose current value a HUMAN last set is not overwritten — that part of the call is staged for a person to decide and named in the result, so treat a staged answer as the write not having happened yet. It names the record by id: when a name matches two records, which of them was meant is a question for a person and not a choice to make quietly. There is no sharing verb here, but owner_id is NOT a neutral field — who owns a record is what decides who can see it, so reassigning it moves the record onto someone else's book and can take it off the current owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope "write".)
+Change stored field values on a record that already exists — a corrected title, an amount, an expected close date. Only the fields you send change, and only the fields the record type stores (a person's email addresses are not among them). A field a HUMAN last set is not overwritten: that part is staged for a person and named in the result, and that part of the write has not happened. It names the record by id; when a name matches two records, a person picks. owner_id is NOT neutral — ownership decides visibility, so reassigning moves the record onto someone else's book and can take it off the owner's. Use advance_deal or progress_deal to move a deal between stages, and relink_activity to change what an activity is about; neither is a field edit. Send if_version with the version you read, and keep the staged approval id from the result if you intend to retry the same change once a human has released it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 


### PR DESCRIPTION
## main is red

`TestPublishedMCPSurfaceMatchesWhatAClientIsServed` fails on the tip (`cedb51583`):

```
docs/reference/mcp-info.json is stale — it no longer matches what a client is served.
  committed:     "tools": 52,
  served:        "tools": 53,
```

Reproduced on a clean checkout of `origin/main` with no local changes, so this is
the tip's own red rather than a working-tree artefact.

## What happened

`create_task` (#2290, merged 12:33Z) joined the tool registry without regenerating
the two files that test renders from. The published MCP surface has been
describing a catalog one tool short of the real one ever since.

## The fix

Regenerated, not hand-written:

```
go test ./internal/compose/ -run TestPublishedMCPSurface -update-mcp-info
```

I checked what the regeneration actually moves before trusting it: the only tool
name it adds is `create_task`, and no tool is removed. The remaining ~400 lines
are the byte-count and percentage arithmetic in the Totals tables recomputing
around one more entry.

## Worth a follow-up, not fixed here

This gate is part of `make check`, so it should have blocked #2290 rather than
letting main go red. Either the change classifier skipped the lane for that diff,
or the merge CI built against a base that predated the tool. I have not
diagnosed which, and I would rather not guess in this PR — happy to file it as a
`priority: high` · `area: ci-tests` issue if that reading is right.

## Verification

- `go test ./internal/compose/ -run TestPublishedMCPSurfaceMatchesWhatAClientIsServed` — **fails** on `origin/main`, **passes** with this commit.
- Diff is two generated documentation files. No Go, no contract, no migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the published MCP surface docs to match the served tool catalog, fixing a red build. Docs previously listed 52 tools; now they list 53 and include `create_task`, which restores TestPublishedMCPSurfaceMatchesWhatAClientIsServed.

- Regenerates `docs/reference/mcp-info.json` and `docs/reference/mcp-info.md` from the registry (go test -update-mcp-info). Totals, sizes, and copy reflect current registry content.
- Adds `create_task`; no tool removals. Several descriptions in the docs now match the registry text.
- No Go changes; runtime behavior unchanged. The failing test passes and make check is green.

<sup>Written for commit a22da4377c9e14d4a2aa4d415466b1ebf7bc54c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `create_task` tool for creating tasks with subjects, optional details, due dates, assignees, links, and idempotency support.
  * Updated the available tool catalog to include 53 tools.

* **Documentation**
  * Clarified tool behavior for deal updates, meeting booking, activity logging, reporting, workspace queries, email sending, record updates, and entity resolution.
  * Documented validation, linking, approval, consent, and execution expectations more explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->