### PR TITLE
docs(principles): the reasoning under the rules is written down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,17 @@ gives them, so write a rule out here rather than citing somewhere they cannot
 reach. A decision number (`ADR-0054`) may appear as a label, but never cite it
 as though a reader could open it — state the rule itself.
 
+**The reasoning under these rules lives in
+[docs/principles/](docs/principles/README.md)** — six pages, one per principle,
+each naming the rulebook section it explains, the method for checking the tree
+still holds it, and what it explicitly does not ask for. The rules below are the
+binding short form and stay here: `cli/craft` feeds the whole nearest
+`AGENTS.md` into its gate prompt, so a rule moved out of that file stops
+reaching the gate. Read a principle when you need to know *why* a rule is shaped
+the way it is, or when you are auditing a subsystem against it —
+[one-source-of-truth.md](docs/principles/one-source-of-truth.md) carries the
+six-probe scan for finding a capability that got built twice.
+
 **Start at [STATUS.md](STATUS.md)** — open work and the session-pickup point.
 Read its *Open work, in one screen* index first and open only the sections that
 bear on your change; the file is not meant to be read end to end. Update it at
@@ -408,8 +419,8 @@ rules, each of them here because this tree has already paid for it.
 grep its nouns across `backend/`, `frontend/src/` and `extensions/`. The
 duplicate is almost never in the package you are editing — that is precisely why
 it gets missed. The agent tool `prep_for_meeting` was written beside a working
-`compose/meetingbrief/` that a one-word grep would have found, and the two now
-answer one question with different grounding rules.
+`compose/meetingbrief/` that a one-word grep would have found, and the two
+answered one question with different grounding rules until a seam was written.
 
 **2. The tool surface and the web surface share ONE engine.** An MCP tool never
 re-derives what an HTTP handler already computes. The binding is a
@@ -440,9 +451,9 @@ an identifier a caller chose is an injection with a placeholder's manners.
 **4. A comment may not claim to be the only implementation unless a test holds
 it.** "the one spelling of X", "the only writer of Y", "the same anonymization
 the eraser performs" — if no test fails when a second one appears, delete the
-claim or write the test. Every such claim audited in this tree was false. A
-false uniqueness claim is worse than silence: the next author greps, finds it,
-and stops looking.
+claim or write the test. Nine of the ten claims counted in this tree were
+false. A false uniqueness claim is worse than silence: the next author greps,
+finds it, and stops looking.
 
 **Two writers of one invariant either share a helper or say why they do not.**
 If you are adding the second, put the reason in the code beside it, not in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,14 +32,18 @@ gives them, so write a rule out here rather than citing somewhere they cannot
 reach. A decision number (`ADR-0054`) may appear as a label, but never cite it
 as though a reader could open it — state the rule itself.
 
-**The reasoning under these rules lives in
-[docs/principles/](docs/principles/README.md)** — six pages, one per principle,
-each naming the rulebook section it explains, the method for checking the tree
-still holds it, and what it explicitly does not ask for. The rules below are the
-binding short form and stay here: `cli/craft` feeds the whole nearest
-`AGENTS.md` into its gate prompt, so a rule moved out of that file stops
-reaching the gate. Read a principle when you need to know *why* a rule is shaped
-the way it is, or when you are auditing a subsystem against it —
+**[docs/principles/](docs/principles/README.md) explains these rules** — six
+pages, one per principle, each naming the rulebook section it explains, the
+method for checking the tree still holds it, and what it explicitly does not ask
+for. That is the PUBLIC explanation and the audit method, which is a different
+thing from the private decision rationale described above: a principle page
+tells you how to check a rule, not why the team chose it.
+
+The binding short form stays in the rulebooks, and specifically in `AGENTS.md`:
+`cli/craft` feeds the whole nearest `AGENTS.md` into its gate prompt, so a rule
+relocated to `docs/` stops reaching the gate. Read a principle when you need to
+know *why* a rule is shaped the way it is, or when you are auditing a subsystem
+against it rather than obeying it on one diff —
 [one-source-of-truth.md](docs/principles/one-source-of-truth.md) carries the
 six-probe scan for finding a capability that got built twice.
 
@@ -503,9 +507,10 @@ function you add will block your push.
   `craftsmanship` job runs the same bar as a required check.
 - `BLOCKER` and `MAJOR` findings both block; `MINOR` is advisory. The size ceilings are
   80 CODE lines / 500 file lines for product code and 160 / 1000 for `*_test.go`.
-  A comment-only line is not length: the ceiling asks how much a reader must hold
-  at once, and an explanation reduces that. The whole-tree file-length check in
-  `scripts/check-go-file-length.sh` counts the same way.
+  A comment-only line is not length for the FUNCTION ceiling: it asks how much a
+  reader must hold at once, and an explanation reduces that. The whole-tree file
+  check in `scripts/check-go-file-length.sh` is a plain `wc -l` and counts every
+  line, with a ratchet file freezing each pre-existing offender.
 - A *genuine* false positive is waived **in-source with a reason**: `//craft:ignore <check> <reason>`
   (a reasonless waiver is itself a finding).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,14 +76,18 @@ A decision number (`ADR-0054`) may appear as a label, but never cite it as
 though a reader could open it — the records are not in this tree. Write the rule
 itself out here, where a public contributor can read it.
 
-**The reasoning under these rules lives in
-[docs/principles/](docs/principles/README.md)** — six pages, one per principle,
-each naming the rulebook section it explains, the method for checking the tree
-still holds it, and what it explicitly does not ask for. The rules below are the
-binding short form and stay here: `cli/craft` feeds the whole nearest
-`AGENTS.md` into its gate prompt, so a rule moved out of that file stops
-reaching the gate. Read a principle when you need to know *why* a rule is shaped
-the way it is, or when you are auditing a subsystem against it —
+**[docs/principles/](docs/principles/README.md) explains these rules** — six
+pages, one per principle, each naming the rulebook section it explains, the
+method for checking the tree still holds it, and what it explicitly does not ask
+for. That is the PUBLIC explanation and the audit method, which is a different
+thing from the private decision rationale described above: a principle page
+tells you how to check a rule, not why the team chose it.
+
+The binding short form stays in the rulebooks, and specifically in `AGENTS.md`:
+`cli/craft` feeds the whole nearest `AGENTS.md` into its gate prompt, so a rule
+relocated to `docs/` stops reaching the gate. Read a principle when you need to
+know *why* a rule is shaped the way it is, or when you are auditing a subsystem
+against it rather than obeying it on one diff —
 [one-source-of-truth.md](docs/principles/one-source-of-truth.md) carries the
 six-probe scan for finding a capability that got built twice.
 
@@ -537,9 +541,10 @@ your push.
   are 80 CODE lines / 500 file lines for product code and 160 / 1000 for `*_test.go`
   — a long scenario test that sets up, acts and asserts once is not the
   god-function smell, but a suite still splits when it stops being navigable.
-  A comment-only line is not length: the ceiling asks how much a reader must hold
-  at once, and an explanation reduces that. The whole-tree file-length check in
-  `scripts/check-go-file-length.sh` counts the same way.
+  A comment-only line is not length for the FUNCTION ceiling: it asks how much a
+  reader must hold at once, and an explanation reduces that. The whole-tree file
+  check in `scripts/check-go-file-length.sh` is a plain `wc -l` and counts every
+  line, with a ratchet file freezing each pre-existing offender.
 - A *genuine* false positive is waived **in-source with a reason**: `//craft:ignore <check> <reason>`
   (a reasonless waiver is itself a finding).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,17 @@ A decision number (`ADR-0054`) may appear as a label, but never cite it as
 though a reader could open it — the records are not in this tree. Write the rule
 itself out here, where a public contributor can read it.
 
+**The reasoning under these rules lives in
+[docs/principles/](docs/principles/README.md)** — six pages, one per principle,
+each naming the rulebook section it explains, the method for checking the tree
+still holds it, and what it explicitly does not ask for. The rules below are the
+binding short form and stay here: `cli/craft` feeds the whole nearest
+`AGENTS.md` into its gate prompt, so a rule moved out of that file stops
+reaching the gate. Read a principle when you need to know *why* a rule is shaped
+the way it is, or when you are auditing a subsystem against it —
+[one-source-of-truth.md](docs/principles/one-source-of-truth.md) carries the
+six-probe scan for finding a capability that got built twice.
+
 **Start at [STATUS.md](STATUS.md)** — open work and the session-pickup point.
 Read its *Open work, in one screen* index first and open only the sections that
 bear on your change; the file is not meant to be read end to end. Update it at
@@ -440,8 +451,8 @@ rules, each of them here because this tree has already paid for it.
 grep its nouns across `backend/`, `frontend/src/` and `extensions/`. The
 duplicate is almost never in the package you are editing — that is precisely why
 it gets missed. The agent tool `prep_for_meeting` was written beside a working
-`compose/meetingbrief/` that a one-word grep would have found, and the two now
-answer one question with different grounding rules.
+`compose/meetingbrief/` that a one-word grep would have found, and the two
+answered one question with different grounding rules until a seam was written.
 
 **2. The tool surface and the web surface share ONE engine.** An MCP tool never
 re-derives what an HTTP handler already computes. The binding is a
@@ -472,9 +483,9 @@ an identifier a caller chose is an injection with a placeholder's manners.
 **4. A comment may not claim to be the only implementation unless a test holds
 it.** "the one spelling of X", "the only writer of Y", "the same anonymization
 the eraser performs" — if no test fails when a second one appears, delete the
-claim or write the test. Every such claim audited in this tree was false. A
-false uniqueness claim is worse than silence: the next author greps, finds it,
-and stops looking.
+claim or write the test. Nine of the ten claims counted in this tree were
+false. A false uniqueness claim is worse than silence: the next author greps,
+finds it, and stops looking.
 
 **Two writers of one invariant either share a helper or say why they do not.**
 If you are adding the second, put the reason in the code beside it, not in the

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,25 @@
 
 Documentation for building and operating **Margince** — a governed, multi-tenant CRM (a Go `/v1` API
 backend; the Vite/React web UI ships separately). The docs follow the [Diátaxis](https://diataxis.fr/) split: **tutorials** to learn,
-**how-to** guides for tasks, **reference** for lookup, **explanation** for the *why*.
+**how-to** guides for tasks, **reference** for lookup, **explanation** for the *why*, plus
+**[principles](principles/README.md)** — the handful of statements about this codebase's shape that
+settle a class of arguments before they start.
 
 **New to the backend? Start with [tutorials/getting-started.md](tutorials/getting-started.md), then
 [explanation/backend-onboarding.md](explanation/backend-onboarding.md)** — the orientation hub that
 maps the codebase and links everything below.
 
 ## Map
+
+### Principles — how this codebase decides things
+
+- [principles/README.md](principles/README.md) — the index. Each page carries the statement, the method for checking the tree still holds it, and what it explicitly does not ask for.
+- [one-source-of-truth.md](principles/one-source-of-truth.md) — one place decides each topic, and module boundaries decide where that place may live. Carries the six-probe duplication scan.
+- [the-record-is-the-code.md](principles/the-record-is-the-code.md) — what outranks what when two sources disagree.
+- [every-mutation-leaves-a-trace.md](principles/every-mutation-leaves-a-trace.md) — domain row, audit row and event commit together.
+- [legibility-is-the-product.md](principles/legibility-is-the-product.md) — why the craft bar is a gate rather than taste.
+- [derive-the-obligation.md](principles/derive-the-obligation.md) — how to write a fitness function that actually holds.
+- [nothing-here-is-private.md](principles/nothing-here-is-private.md) — the public reader, and why a working exploit takes the private path.
 
 ### Tutorials — learn by doing
 - [getting-started.md](tutorials/getting-started.md) — clone → running instance with a bootstrapped workspace.

--- a/docs/explanation/backend-onboarding.md
+++ b/docs/explanation/backend-onboarding.md
@@ -13,6 +13,12 @@ re-explain what they already own.
 5. **This page** — the system in one screen, the find-it map, generated-vs-written, the code you call, the gates, the change-recipes.
 6. **[CONTRIBUTING.md](../../CONTRIBUTING.md)** + **[AGENTS.md](../../AGENTS.md)** — the PR loop and the binding engineering rules.
 
+**[principles/](../principles/README.md)** — the handful of statements about this codebase's shape
+that settle a class of arguments before they start: one source of truth, the record is the code, every
+mutation leaves a trace, legibility is the product, derive the obligation, nothing here is private.
+Read one when you need the *why* behind a rule in [AGENTS.md](../../AGENTS.md), or when auditing a
+subsystem against it.
+
 **Deep dives** — read when you touch that area:
 
 - **[reference/modules.md](../reference/modules.md)** — what each module owns.

--- a/docs/explanation/contract-first.md
+++ b/docs/explanation/contract-first.md
@@ -1,9 +1,10 @@
 # Contract-first
 
-This repository is built **from** a specification that lives in a
-separate sibling repo. Principle P3 is binding: when this
-code and the spec disagree, the spec wins. The same posture applies one
-level down, between the code and its own API contract.
+This repository is not built from a specification that outranks it. What the
+product exposes is defined by `backend/api/crm.yaml` and the Go generated from
+it — see [the record is the code](../principles/the-record-is-the-code.md) for
+the precedence order that replaced the older arrangement. This page is how that
+contract becomes Go, and why drift is merge-blocking.
 
 ## The contract is the source of truth
 

--- a/docs/principles/README.md
+++ b/docs/principles/README.md
@@ -19,7 +19,7 @@ and say which.
 | [The record is the code](the-record-is-the-code.md) | What outranks what when two sources disagree, and where a finding goes once you have it. | *What decides a question here* |
 | [Every mutation leaves a trace](every-mutation-leaves-a-trace.md) | Why the domain row, the audit row and the event commit together, and what each of the two denials means. | *The write shape* |
 | [Legibility is the product](legibility-is-the-product.md) | Why the craft bar is a gate rather than taste, and what each anti-tell is defending against. | *Craftsmanship* |
-| [Derive the obligation](derive-the-obligation.md) | How to write a fitness function that actually holds, and the six ways one reads green over its own defect. | *Rules learned from the review loop* |
+| [Derive the obligation](derive-the-obligation.md) | The six rules from the review loop and what each defends against, plus how to write a fitness function that actually holds rather than one that reads green over its own defect. | *Rules learned from the review loop* |
 | [Nothing here is private](nothing-here-is-private.md) | Who the public reader is, what never appears in the tree, and why a working exploit takes the private path. | *This repository is public* |
 
 The rulebook sections stay where they are. `cli/craft` feeds the **whole**

--- a/docs/principles/README.md
+++ b/docs/principles/README.md
@@ -1,0 +1,42 @@
+# Principles
+
+How this repository decides things, written down once so a reader does not have
+to reconstruct it from the code.
+
+A principle here is broader than a rule and narrower than a philosophy: it is a
+statement about the shape of this codebase that settles a class of arguments
+before they start, plus the method for checking whether the tree still holds it.
+
+These pages explain; they do not enforce. The binding rules live in
+[CLAUDE.md](../../CLAUDE.md) and [AGENTS.md](../../AGENTS.md), and the gates that
+hold them live in tests and in `cli/craft`. When a principle here and a gate
+disagree, the gate is the record of current behaviour — fix one or the other,
+and say which.
+
+| Principle | It settles | Rulebook section it explains |
+|---|---|---|
+| [One source of truth](one-source-of-truth.md) | Where a topic is decided, why a second implementation is a defect rather than untidiness, and which module boundary the owner may live behind. Carries the six-probe scan for auditing a subsystem. | *Reuse before you build*, *Layout* |
+| [The record is the code](the-record-is-the-code.md) | What outranks what when two sources disagree, and where a finding goes once you have it. | *What decides a question here* |
+| [Every mutation leaves a trace](every-mutation-leaves-a-trace.md) | Why the domain row, the audit row and the event commit together, and what each of the two denials means. | *The write shape* |
+| [Legibility is the product](legibility-is-the-product.md) | Why the craft bar is a gate rather than taste, and what each anti-tell is defending against. | *Craftsmanship* |
+| [Derive the obligation](derive-the-obligation.md) | How to write a fitness function that actually holds, and the six ways one reads green over its own defect. | *Rules learned from the review loop* |
+| [Nothing here is private](nothing-here-is-private.md) | Who the public reader is, what never appears in the tree, and why a working exploit takes the private path. | *This repository is public* |
+
+The rulebook sections stay where they are. `cli/craft` feeds the **whole**
+nearest `AGENTS.md` into its gate prompt, so a rule moved out of that file stops
+reaching the gate — these pages carry the reasoning and the method, the rulebook
+carries the binding short form. Four of those sections
+(*The write shape*, *Reuse before you build*, *License headers*,
+*Rules learned from the review loop*) must additionally stay byte-identical in
+both rulebooks; `TestSharedRulebookSectionsAreIdenticalInBothDocs` fails when
+they drift.
+
+## Adding a principle
+
+Write it only when the same argument has been had more than once. A principle
+that no past change would have gone differently under is not a principle, it is
+a preference — put that in the rulebook or leave it out.
+
+Each page carries three things: the statement, the method for checking it, and
+what the principle explicitly does NOT ask for. The third is what stops a
+principle being applied as a cudgel.

--- a/docs/principles/derive-the-obligation.md
+++ b/docs/principles/derive-the-obligation.md
@@ -1,0 +1,77 @@
+# Derive the obligation
+
+**Prefer a fitness function over a point fix, and derive its subject set from
+the tree rather than listing it.** A rule maintained as a list is a rule that
+silently stops covering things.
+
+The binding form is
+[*Rules learned from the review loop*](../../CLAUDE.md#rules-learned-from-the-review-loop-binding).
+This page is the method for writing a gate that actually holds.
+
+## The six rules, and what each one is defending against
+
+1. **Fix the invariant, not the call site.** Grep every mutation and read site
+   of the same column, constraint or record, and fix them as one change. The
+   recurring reviewer catch here is "fixed the case under review, missed the
+   sibling copy".
+2. **Prefer fitness functions over point fixes.** Derive the obligation from the
+   system — every tenant statement carries its workspace predicate; every CHECK
+   violation maps to a 4xx; `backend/arch_test.go` derives its package lists
+   from the tree. Do not maintain it as a list.
+3. **Anything that returns a record is a read**, and carries the row-scope gate
+   — including replay, conflict and error paths.
+4. **No build-process residue in comments.** State the invariant so it stands
+   alone. See [the record is the code](the-record-is-the-code.md).
+5. **Never rationalize a known gap in a comment.** Restructure it away or gate
+   it.
+6. **A test that supplies its own version of production proves nothing about
+   production.** Hand-inserted rows the real writer never writes, or a
+   hand-copied adapter mirroring what compose wires. Seed through the real
+   writer; reach for the real wiring. An unexpectedly uncovered new file usually
+   means a test double stands where the real thing should.
+
+## The method — writing a gate that holds
+
+Every clause here exists because a gate in this tree failed it.
+
+**Derive the subject set from the tree.** A hardcoded coverage map is a list to
+maintain, and it will be short. `draftrulesparity_test.go` asserts four drafting
+surfaces carry the shared rules while more than four exist — the gate is green
+and the rule is not held.
+
+**No waiver map in the test.** The escape hatch belongs at the subject — a
+`doc.go` line, a contract field, a `//craft:ignore <check> <reason>` — where the
+author editing that code sees it. A map inside the test file is invisible to
+exactly the person who needs it. `agenttoolparity_test.go` is the house shape:
+derived from the contract, no waiver map, escape hatch in the contract.
+
+**Ratify the instance, never the category.** A waiver keyed by column, package
+or rule name admits the second offender for free under the first one's reason.
+
+**Write the defect test first.** Mutate the code to reintroduce the bug and
+watch the gate go red. A gate that has never failed proves nothing — several
+fitness functions in this tree passed against the exact bug they described.
+
+**Prove the mutation was reached.** An inverse test can pass for the wrong
+reason: the mutation lands in a function the path never calls, or an earlier
+guard refuses the case before your assertion runs.
+
+**Measure the before, not only the after.** A grep returning 0 after the fix
+proves nothing unless you know what it returned before.
+
+**Watch for the vacuous filter.** A subject filter that looks derived can be
+inert — unbounded is not empty, and a predicate that drops nothing reads exactly
+like a predicate that drops the right things. Measure what your gate *excludes*.
+
+**Write the mirror gate.** A gate can read green over its own defect reversed.
+If you assert A implies B, ask what happens when B appears without A.
+
+## What this does not ask for
+
+- **Not a gate for every rule.** Some obligations are genuinely judgement, and a
+  gate that encodes a judgement badly is worse than the prose. If you cannot
+  state the failure precisely, write the rule and say it is unguarded.
+- **Not blocking on tooling.** A point fix that ships today plus an issue for
+  the gate beats a gate that never lands. Say which you did.
+- **Not deleting a rule because it has no gate.** An unguarded rule is weaker,
+  not void.

--- a/docs/principles/derive-the-obligation.md
+++ b/docs/principles/derive-the-obligation.md
@@ -30,7 +30,7 @@ This page is the method for writing a gate that actually holds.
    writer; reach for the real wiring. An unexpectedly uncovered new file usually
    means a test double stands where the real thing should.
 
-## The method — writing a gate that holds
+## Writing a gate that holds
 
 Every clause here exists because a gate in this tree failed it.
 
@@ -39,11 +39,16 @@ maintain, and it will be short. `draftrulesparity_test.go` asserts four drafting
 surfaces carry the shared rules while more than four exist — the gate is green
 and the rule is not held.
 
-**No waiver map in the test.** The escape hatch belongs at the subject — a
-`doc.go` line, a contract field, a `//craft:ignore <check> <reason>` — where the
-author editing that code sees it. A map inside the test file is invisible to
-exactly the person who needs it. `agenttoolparity_test.go` is the house shape:
-derived from the contract, no waiver map, escape hatch in the contract.
+**Put the escape hatch at the subject.** A `doc.go` line, a contract field, a
+`//craft:ignore <check> <reason>` — where the author editing that code sees it.
+A map inside the test file is invisible to exactly the person who needs it.
+`agenttoolparity_test.go` is the closest thing to the house shape: it derives
+its expectation from the contract rather than restating it, and its escape hatch
+for ordinary tools lives in the contract. It is not a pure example, and the
+impurity is instructive — a hand-maintained `composedIntents` map still sits in
+the test file for the tools that compose several operations, which is precisely
+the kind of list that goes quietly short. If you cannot get the hatch to the
+subject, say in the test why not.
 
 **Ratify the instance, never the category.** A waiver keyed by column, package
 or rule name admits the second offender for free under the first one's reason.

--- a/docs/principles/every-mutation-leaves-a-trace.md
+++ b/docs/principles/every-mutation-leaves-a-trace.md
@@ -16,8 +16,12 @@ Three failures become impossible rather than unlikely:
   circumstances someone later asks about — is exactly the one most likely to be
   missing its record.
 - **An event that describes a row that does not exist**, or a row that changed
-  with no event. At-least-once delivery is survivable; never-delivered is not,
-  and neither is delivered-about-nothing.
+  with no outbox record. Note what the transaction does and does not buy: it
+  guarantees the *staging* is atomic — after the commit there is a durable
+  outbox row or there is no change at all. Getting that row onto the bus is the
+  relay's job, and it is at-least-once with retries, not a delivery guarantee.
+  Atomic staging is what makes the dual-write problem go away; monitoring the
+  relay is a separate obligation.
 - **A caller-supplied actor.** `captured_by` is stamped from the authenticated
   principal, never from the request body. An audit trail whose actor field is an
   input is not a trail.
@@ -50,9 +54,14 @@ including replay, conflict and error paths. That last clause is where this rule
 is usually broken: an error path that echoes the conflicting row has just served
 it.
 
-**A new seam owes the whole shape.** The write-shape gate refuses an optional
-publish, and its standing exceptions rest on reasons a new seam cannot claim.
-If you are adding a write path, audit implies event.
+**A new seam owes the whole shape.** Audit-only mutations do exist and are
+legitimate — installation configuration writes an audit row and no event,
+because the closed event catalog defines no type for it and inventing one
+build-side is forbidden. But they are *enumerated*: `backend/writeshape_test.go`
+carries each one with the argument for why, and the gate refuses an audit-only
+function that is not on the list — as well as a listed one that no longer
+exists. So the rule for a new write path is: audit implies event, unless you can
+write the paragraph that earns a place on that list.
 
 ## What this does not ask for
 

--- a/docs/principles/every-mutation-leaves-a-trace.md
+++ b/docs/principles/every-mutation-leaves-a-trace.md
@@ -1,0 +1,64 @@
+# Every mutation leaves a trace
+
+**A change to a domain row, the audit record of that change, and the event
+announcing it commit together or not at all.** One transaction, three rows.
+
+The binding form is [*The write shape*](../../CLAUDE.md#the-write-shape-non-negotiable)
+in the rulebook, spelled once in `platform/database/storekit` (`Audit` + `Emit`)
+and called by every module store. This page is why it is shaped that way.
+
+## What the single transaction buys
+
+Three failures become impossible rather than unlikely:
+
+- **A change nobody can account for.** If the audit row could fail
+  independently, the interesting case — the write that succeeded under
+  circumstances someone later asks about — is exactly the one most likely to be
+  missing its record.
+- **An event that describes a row that does not exist**, or a row that changed
+  with no event. At-least-once delivery is survivable; never-delivered is not,
+  and neither is delivered-about-nothing.
+- **A caller-supplied actor.** `captured_by` is stamped from the authenticated
+  principal, never from the request body. An audit trail whose actor field is an
+  input is not a trail.
+
+## The method
+
+**Never write a domain row outside a module store's entry point.** The store
+owns the transactional shape. A handler that reaches for SQL has skipped both
+the audit and the gate.
+
+**Publishing is ALWAYS through the outbox.** `platform/events.Relay` ships it;
+no direct XADD from domain code. The bus is at-least-once, so consumers wrap
+handlers in `events.Dedupe` — a consumer that assumes exactly-once is a bug
+waiting for a redelivery.
+
+**Trace the request end to end.** The HTTP layer mints one `correlation_id` per
+request; `Audit()` returns the audit row id; `Emit()` links both. A trace that
+starts at the event has lost the half that says who asked.
+
+**Every store entry point is RBAC-gated**, and the two denials are different
+facts:
+
+| Denial | Sentinel | Wire | Why |
+|---|---|---|---|
+| object denied | `apperrors.ErrPermissionDenied` | 403 | the caller may not perform this verb |
+| row out of scope | `apperrors.ErrNotFound` | 404 | existence-hiding — a 403 here would confirm the row exists |
+
+**Anything that returns a record is a read** and carries the row-scope gate —
+including replay, conflict and error paths. That last clause is where this rule
+is usually broken: an error path that echoes the conflicting row has just served
+it.
+
+**A new seam owes the whole shape.** The write-shape gate refuses an optional
+publish, and its standing exceptions rest on reasons a new seam cannot claim.
+If you are adding a write path, audit implies event.
+
+## What this does not ask for
+
+- **Not an audit row per read.** Reads are gated, not journalled.
+- **Not that evidence tables join the shape.** `raw_capture` is evidence, not a
+  domain row; it neither audits nor emits, and that is correct.
+- **Not a bespoke event per column.** The envelope is the
+  `shared/kernel/events` contract; a new event kind is a catalog change, not a
+  free-form payload.

--- a/docs/principles/legibility-is-the-product.md
+++ b/docs/principles/legibility-is-the-product.md
@@ -1,0 +1,74 @@
+# Legibility is the product
+
+**Code that reads best to a human reads best to the next agent that edits it.**
+Legibility is not polish applied at the end — it is the property that decides
+whether the next change is cheap or dangerous.
+
+The binding form is [*Craftsmanship*](../../CLAUDE.md#craftsmanship) in the
+rulebook: the anti-tell catalog T1–T11 and the deterministic `craft static` gate
+that runs on every push, diff-scoped and strict. This page is the reasoning
+under it.
+
+## Why this repo takes it as a principle rather than taste
+
+Most of this codebase is read by someone — or something — that was not present
+when it was written, holding no context beyond the file. Under that constraint
+the usual trade-off inverts: a clever compression that saves a human author ten
+minutes costs every later reader the reconstruction. The catalog exists because
+each of its entries has already cost this tree a defect.
+
+The sharpest instance: **a comment that reaches a machine reader needs its
+caveat spelled out.** A rule about deriving SQL placeholders was drafted showing
+`fmt.Sprintf("%s = $%d", col, len(args))` without saying what may fill `%s` — a
+human would have inferred "not a request-body string"; the text as written would
+have taught identifier injection to every future agent, because `AGENTS.md` goes
+verbatim into the gate prompt.
+
+## The method
+
+**Comments say why, not what** (T1). The what is on the next line.
+
+**Domain names, not `data`/`tmp`/`helper`** (T4). A name that could belong to any
+function belongs to none.
+
+**Never swallow an error** (T2). No `_ = f()`, no empty catch, no ignored
+return. Errors flow through the sentinels; messages say what went wrong *and*
+what to do, and never leak internals — no stack, no SQL, no table names to a
+client.
+
+**No dead or speculative code** (T3/T8). No abstraction without a second
+concrete caller *today*. No `TODO` without an issue reference — an unreferenced
+TODO is a decision nobody will make.
+
+**Handle the honest hard cases** (T7): the empty page, version skew, a
+cross-tenant id, an unset GUC. The happy path is the part that was never in
+doubt.
+
+**Tests prove behaviour or they are noise** (T11). No assertion-free test — it
+can only fail by panicking. No `time.Sleep`, no real clock, no real network.
+Mock only true boundaries (DB, HTTP, clock, queue) and inject a `Clock`;
+over-mocking that asserts call order tests your mock. Tests read as specs, and
+the integration lane fails loudly without a database, because **a skipped
+security gate looks exactly like a passing one**.
+
+**Size ceilings measure what a reader must hold at once**: 80 code lines / 500
+file lines for product code, 160 / 1000 for tests. A comment-only line is not
+length — an explanation *reduces* what the reader carries. A long scenario test
+that sets up, acts and asserts once is not the god-function smell; a suite still
+splits when it stops being navigable.
+
+**Waive a genuine false positive in-source, with a reason**:
+`//craft:ignore <check> <reason>`. A reasonless waiver is itself a finding.
+
+**The pre-submit self-check**, in the author's own words: would a senior write it
+this way? does it match the surrounding file? do the errors say what went wrong
+*and* what to do? would a stranger find where this change lives without a guide?
+is this the smallest diff that does the job?
+
+## What this does not ask for
+
+- **Not a style debate.** Formatting is `gofumpt`'s job and is not interesting.
+- **Not uniformity across the tree.** The bar is "indistinguishable from a senior
+  human's edit to *the surrounding file*" — match the file you are in.
+- **Not a backlog to work through.** The tree was cleared to zero findings
+  before the gate was armed. The rule is only that touched code is clean.

--- a/docs/principles/legibility-is-the-product.md
+++ b/docs/principles/legibility-is-the-product.md
@@ -5,8 +5,9 @@ Legibility is not polish applied at the end — it is the property that decides
 whether the next change is cheap or dangerous.
 
 The binding form is [*Craftsmanship*](../../CLAUDE.md#craftsmanship) in the
-rulebook: the anti-tell catalog T1–T11 and the deterministic `craft static` gate
-that runs on every push, diff-scoped and strict. This page is the reasoning
+rulebook: the anti-tell catalog T1–T11 and the deterministic `craft static` gate,
+diff-scoped and strict. It judges the **Go files a push changes** — a docs-only
+push exits before it runs at all. This page is the reasoning
 under it.
 
 ## Why this repo takes it as a principle rather than taste
@@ -45,15 +46,22 @@ cross-tenant id, an unset GUC. The happy path is the part that was never in
 doubt.
 
 **Tests prove behaviour or they are noise** (T11). No assertion-free test — it
-can only fail by panicking. No `time.Sleep`, no real clock, no real network.
-Mock only true boundaries (DB, HTTP, clock, queue) and inject a `Clock`;
+can only fail by panicking. In a **unit** test: no `time.Sleep`, no real clock,
+no real network — those are the flakiness sources, not virtues in themselves.
+The integration lane is the opposite case and uses a real Postgres and a real
+Redis on purpose, because a boundary faked on both sides proves nothing about
+the boundary. Mock only true boundaries (DB, HTTP, clock, queue) and inject a `Clock`;
 over-mocking that asserts call order tests your mock. Tests read as specs, and
 the integration lane fails loudly without a database, because **a skipped
 security gate looks exactly like a passing one**.
 
 **Size ceilings measure what a reader must hold at once**: 80 code lines / 500
-file lines for product code, 160 / 1000 for tests. A comment-only line is not
-length — an explanation *reduces* what the reader carries. A long scenario test
+file lines for product code, 160 / 1000 for tests. The two ceilings count
+differently, and it matters: `craft static`'s **function** ceiling discounts a
+comment-only line, because an explanation reduces what a reader carries. The
+whole-tree **file** cap in `scripts/check-go-file-length.sh` is a plain `wc -l`
+and counts every line, with a ratchet file freezing each pre-existing offender.
+A long scenario test
 that sets up, acts and asserts once is not the god-function smell; a suite still
 splits when it stops being navigable.
 

--- a/docs/principles/nothing-here-is-private.md
+++ b/docs/principles/nothing-here-is-private.md
@@ -1,0 +1,58 @@
+# Nothing here is private
+
+**This repository is public. Everything in it is readable by anyone, forever,
+including what you delete tomorrow.**
+
+The binding form is
+[*This repository is public*](../../CLAUDE.md#this-repository-is-public). This
+page is the reasoning and the method.
+
+## Two obligations, one reader
+
+The reader this principle protects is **a public contributor with no access to
+anything but this tree**. Both obligations follow from them existing:
+
+- **Never refer to a private repository, document, path or link** — not in code,
+  comments, tests, docs, issues, commit messages or PR bodies. If a rule
+  matters, write the rule out here. Citing somewhere they cannot reach is the
+  same as not stating the rule, except that it also tells them they are not the
+  intended audience.
+- **Never include local machine paths or secrets.**
+
+A decision number (`ADR-0054`) may appear as a label, but never cite it as
+though a reader could open it — the records are not in this tree. Write the rule
+itself out, here.
+
+## The method
+
+**Assume the automated net is partial, because it is.**
+`TestPublicTreeCitesNothingPrivate` catches a private repository name, a
+`specs/` path or a `foundation#NNNN` reference in tracked source and prose. It
+does **not** read commit messages or PR bodies, and it has no pattern for a
+secret or a machine path. Those stay your judgement, with the secret-scan gate
+as the only other net.
+
+**A vulnerability is not reported here.** An exploitable weakness goes to a
+private GitHub Security Advisory, never a public issue or pull request — a
+public report before a fix ships puts every deployment at risk. The test is the
+one [SECURITY.md](../../SECURITY.md) implies: **if you can write the
+reproduction, it belongs in an advisory.** A cross-tenant read, a row-scope or
+RBAC escape, an agent-governance bypass, a forged or still-binding revoked
+credential, a mutation that skips the audit or outbox row, injection, SSRF.
+
+The `security` label is for hardening and defence-in-depth carrying no live
+exploit. Using it to file a working exploit publishes the exploit.
+
+**Write the reason down when the reason is the rule.** The reasoning behind a
+guardrail is kept by the team and is not in this repository — which is fine only
+because every rule that binds a change is enforced by a gate that names what to
+do instead. If you cannot tell why a rule exists and the answer would change
+your patch, ask in the issue rather than guessing.
+
+## What this does not ask for
+
+- **Not secrecy about the product.** The design, the contract and the reasoning
+  in these docs are meant to be read. This is about not *pointing* at things a
+  reader cannot open, and not leaking material that harms people.
+- **Not avoiding security work in the open.** Hardening lands here in public,
+  with its test. Only live, reproducible weaknesses take the private path.

--- a/docs/principles/nothing-here-is-private.md
+++ b/docs/principles/nothing-here-is-private.md
@@ -27,9 +27,11 @@ itself out, here.
 
 **Assume the automated net is partial, because it is.**
 `TestPublicTreeCitesNothingPrivate` catches a private repository name, a
-`specs/` path or a `foundation#NNNN` reference in tracked source and prose. It
-does **not** read commit messages or PR bodies, and it has no pattern for a
-secret or a machine path. Those stay your judgement, with the secret-scan gate
+`specs/` path or a `foundation#NNNN` reference — but only in the file types it
+scans, which are `.go .md .yml .yaml .json .ts .tsx .sh .sql`. A reference in
+CSS, HTML, or a `.mjs` script walks straight past it. It also does **not** read
+commit messages or PR bodies, and it has no pattern for a secret or a machine
+path. Those stay your judgement, with the secret-scan gate
 as the only other net.
 
 **A vulnerability is not reported here.** An exploitable weakness goes to a
@@ -44,9 +46,12 @@ The `security` label is for hardening and defence-in-depth carrying no live
 exploit. Using it to file a working exploit publishes the exploit.
 
 **Write the reason down when the reason is the rule.** The reasoning behind a
-guardrail is kept by the team and is not in this repository — which is fine only
-because every rule that binds a change is enforced by a gate that names what to
-do instead. If you cannot tell why a rule exists and the answer would change
+guardrail is kept by the team and is not in this repository — which is workable only
+because a rule that binds a change usually reaches you as a gate that names what
+to do instead. *Usually*, not always — some obligations are judgement and stay
+judgement ([derive the obligation](derive-the-obligation.md#what-this-does-not-ask-for)),
+and for those the rule has to be written out here in full or it does not reach
+you at all. If you cannot tell why a rule exists and the answer would change
 your patch, ask in the issue rather than guessing.
 
 ## What this does not ask for

--- a/docs/principles/one-source-of-truth.md
+++ b/docs/principles/one-source-of-truth.md
@@ -42,7 +42,7 @@ writing anything.
 | Topic kind | The choke point | Where |
 |---|---|---|
 | Writing a domain row | the module's store method, and `storekit.Audit`/`Emit` inside one tx | `modules/<name>/`, `platform/database/storekit` |
-| Reading one record's world | an `Assembler` (`org360`/`person360`) | `compose/org360`, `compose/person360` |
+| Reading one record's world | `person360.Service.Assemble` / `org360.Service.Assemble`, reached through the `Assembler` interface each consumer declares | `compose/person360`, `compose/org360` |
 | An MCP tool that answers a question a page already answers | a `compose/*seam*.go` file | `internal/compose/` |
 | A model system prompt for correspondence | `draftrules.Shared` | `compose/draftrules` |
 | Fetching a tenant-supplied URL | `platform/webread` (SSRF-guarded via `platform/netguard`) | `platform/webread` |
@@ -95,7 +95,7 @@ Cheap first, and each probe finds a class the previous one cannot.
 
 ### 1. Grep the topic's nouns tree-wide, never your directory
 
-```
+```shell
 git grep -n "<noun>" origin/main -- backend/internal frontend/src extensions
 ```
 
@@ -115,9 +115,14 @@ spelling: the domain word ("brief", "weighted", "anonymize"), the mechanism
 
 For a topic that ends in a row, the census is exact:
 
+```shell
+git grep -nE "(INSERT INTO|UPDATE|DELETE FROM) <table>" origin/main \
+  -- backend/internal/modules backend/internal/compose | grep -v _test
 ```
-git grep -n "INSERT INTO <table>\|UPDATE <table>" origin/main -- backend/internal/modules backend/internal/compose | grep -v _test
-```
+
+Include `DELETE`. A table whose rows one package writes and another package
+destroys has two owners, not one, and a census of inserts and updates alone
+reports it as clean.
 
 More than one non-test writer is a finding to *rule on*, not automatically a
 defect — each writer may be a distinct verb. The question to answer in the code
@@ -130,7 +135,7 @@ A capability with exactly one non-test importer serves one surface. Sometimes
 that is correct (an internal helper of one package); sometimes it is the finding
 (the other surface built its own).
 
-```
+```shell
 git grep -l "internal/compose/<pkg>\"" origin/main -- 'backend/*.go' | grep -v _test
 ```
 
@@ -141,12 +146,14 @@ git grep -l "internal/compose/<pkg>\"" origin/main -- 'backend/*.go' | grep -v _
 
 Grep the tree for prose that asserts a choke point:
 
-```
+```shell
 git grep -n "the one spelling\|the only writer\|cannot drift\|the same .* the .* performs\|there is no other" origin/main -- backend frontend
 ```
 
-**Nine of the ten claims counted exhaustively in this tree were false**, and
-several of the rest were true but held by nothing. The claim is where the
+**Nine of the ten claims counted exhaustively in this tree were false.** Of the
+claims spot-checked rather than counted, several were true but held by no test,
+which is the next-worst state: correct today, with nothing to notice when it
+stops being. The claim is where the
 duplicate hides, because the next author reads it and stops looking. For each hit, run probe 1 or 2 against the thing it claims. A claim no
 test holds is either deleted or gated — never left standing.
 
@@ -157,7 +164,7 @@ twin; an Art. 17 erasure and a retention anonymize; a website assembler and a
 tool assembler), do not read them for similarity — **enumerate what each one
 touches and diff the lists**. Reference counts are the cheap version:
 
-```
+```shell
 grep -c "field_provenance" erasure.go retentionactions.go
 ```
 
@@ -168,8 +175,11 @@ nothing; counting does.
 
 The last probe is a thought experiment with a mechanical answer: *if a rule about
 this topic changed tomorrow, how many files would the change have to touch?* If
-the answer is more than one, the topic has no choke point yet, whatever the
-comments say. This is the probe that found `person_profile_field`'s five writers
+the answer is more than one, either the topic has no choke point yet — whatever
+the comments say — or it has a **declared divergence**, which is the legitimate
+multi-site case. The difference is whether each site says, in the code, what
+makes it different. An undeclared N is the finding; a declared N is a decision
+somebody already made and wrote down. This is the probe that found `person_profile_field`'s five writers
 and `relationship`'s four.
 
 ## What to do with a finding
@@ -206,8 +216,10 @@ The house shape for a reuse gate, learned from `agenttoolparity_test.go` and
 - **Derive the expectation from the tree, never from a list in the test.** A
   hardcoded coverage set is a list to maintain, and `CLAUDE.md` rule #2 says
   prefer the fitness function. `draftrulesparity_test.go` hardcodes four
-  drafting surfaces while seven exist — that is the failure mode, in the tree,
-  today.
+  drafting surfaces; a sweep found at least one more that carries none of the
+  shared rules and is invisible to it. The exact count is not the point and I am
+  deliberately not quoting one — the failure mode is that a hardcoded census
+  cannot notice the surface added after it was written.
 - **No waiver map in the test.** The escape hatch lives at the subject — a
   `doc.go` line, a contract field, a `//craft:ignore <check> <reason>` — where a
   reviewer editing that code sees it. A map in the test is invisible to the

--- a/docs/principles/one-source-of-truth.md
+++ b/docs/principles/one-source-of-truth.md
@@ -1,0 +1,233 @@
+# One source of truth
+
+**Every topic in this tree has exactly one place that decides it — and module
+boundaries decide where that place may live.** Those are two halves of one rule:
+no second implementation, and no copy smuggled across a tier because importing
+the owner was inconvenient.
+
+"Source of truth" here means the code that DECIDES, not the column that stores.
+The authoritative row is a separate question; this principle is about the one
+function, constant, statement or seam every caller of a topic passes through.
+
+The rulebook states the obligation in
+[*Reuse before you build*](../../CLAUDE.md#reuse-before-you-build-non-negotiable).
+This page is the **method**: how to find out whether a topic already has an
+owner, what to do when it has two, and how to leave a gate behind so the second
+one cannot come back. Read it before adding a capability, and run its scan when
+auditing a subsystem.
+
+## What counts as a topic
+
+A topic is whatever a reader would name in one phrase: "how a person's name is
+normalized for dedupe", "how weighted pipeline value is computed", "what a
+retention anonymize scrubs", "how we build a system prompt for correspondence",
+"how we fetch a URL the tenant supplied". If you cannot name it in a phrase, you
+are probably looking at two topics.
+
+Two implementations of one topic is not untidy. It is two answers to one
+question, and nothing forces the two to be asked together, so they drift until
+they disagree in front of a user. The cost is never paid on the day the second
+one is written — it is paid by the third author, who greps, finds one of them,
+and does not know the other exists.
+
+A choke point is not a layer, not a base class and not an abstraction. It is one
+named function, one SQL literal, one constant, or one seam file that every
+caller of that topic goes through.
+
+## Topic kinds and where their choke point lives
+
+The tree already places these. Use the table to find the existing one before
+writing anything.
+
+| Topic kind | The choke point | Where |
+|---|---|---|
+| Writing a domain row | the module's store method, and `storekit.Audit`/`Emit` inside one tx | `modules/<name>/`, `platform/database/storekit` |
+| Reading one record's world | an `Assembler` (`org360`/`person360`) | `compose/org360`, `compose/person360` |
+| An MCP tool that answers a question a page already answers | a `compose/*seam*.go` file | `internal/compose/` |
+| A model system prompt for correspondence | `draftrules.Shared` | `compose/draftrules` |
+| Fetching a tenant-supplied URL | `platform/webread` (SSRF-guarded via `platform/netguard`) | `platform/webread` |
+| A filter/predicate vocabulary | `storekit.FilterSet` / `predicate.go` | `platform/database/storekit` |
+| Keyset pagination | `storekit.EncodeCursor`/`DecodeCursor`/`Page` | `platform/database/storekit` |
+| An interactive control in the UI | the design system | `frontend/src/design-system/` |
+| A sentinel error a client can see | `shared/apperrors` | `internal/shared/apperrors` |
+| An outbound event | `event_outbox` via `storekit.Emit`, shipped by `platform/events.Relay` | never a direct XADD |
+
+If your topic is not in the table, that does not mean it has no choke point. It
+means you have to run the scan.
+
+## The boundary half
+
+Where the owner is allowed to live is not a style question — it is what makes
+the rule enforceable. The DAG is `shared → platform → modules → compose → cmd`
+(ADR-0054), and it has one consequence that produces most of this tree's
+duplicates:
+
+**A module may not import a sibling module, and may not import `compose`.**
+
+So when capability A in one module needs what capability B in another already
+decides, the honest path is always more work than copying:
+
+| A needs B, where B lives in | The sanctioned move |
+|---|---|
+| `shared/` or `platform/` | **Import it.** No seam needed — that is what those tiers are for. |
+| a sibling module | **A seam.** `compose` injects the edge as one named function. |
+| `compose/` (a subpackage) | **A seam.** Same shape; `compose` binds its own subpackage to the module's injected interface. |
+| the same module | **Call it.** If it is unexported and you need it elsewhere in the package, that is not a boundary problem. |
+
+Copying is never on this list. The reason it keeps happening is that a seam
+looks like ceremony next to a fifteen-line copy — and the seam is still the
+right answer, every time. Say so out loud in review; it is the only thing that
+helps.
+
+Two corollaries worth stating because both have been violated here:
+
+- **A module writes only the tables it owns**, declared in its `doc.go` and held
+  by `backend/tableownership_test.go`. A write into a sibling's table is a
+  boundary crossing wearing a SQL statement's clothes.
+- **A gate keyed by package cannot see an intra-package duplicate.** The
+  ownership test keys its waivers `<package>:<table>`, so every second writer
+  living inside one module is invisible to it. Boundary gates and duplication
+  gates catch different things; you need both.
+
+## The scan — six probes, in this order
+
+Cheap first, and each probe finds a class the previous one cannot.
+
+### 1. Grep the topic's nouns tree-wide, never your directory
+
+```
+git grep -n "<noun>" origin/main -- backend/internal frontend/src extensions
+```
+
+Two rules that decide whether this probe works at all:
+
+- **Grep `origin/main`, not the checkout.** A shared or stale worktree makes an
+  absent file look like a refuted premise.
+- **Grep the whole tree.** The duplicate is almost never in the package you are
+  editing — that is precisely why it was missed.
+
+Grep for the noun in three registers, because the duplicate rarely reuses your
+spelling: the domain word ("brief", "weighted", "anonymize"), the mechanism
+("normalize", "Casefold", "ToLower"), and the artifact ("`_profile_field`",
+"system prompt", "Badge").
+
+### 2. Count the writers of each table
+
+For a topic that ends in a row, the census is exact:
+
+```
+git grep -n "INSERT INTO <table>\|UPDATE <table>" origin/main -- backend/internal/modules backend/internal/compose | grep -v _test
+```
+
+More than one non-test writer is a finding to *rule on*, not automatically a
+defect — each writer may be a distinct verb. The question to answer in the code
+is: **does a new rule about this table have one place to land, or N?** Record
+the answer next to the writers.
+
+### 3. Count the importers of each capability package
+
+A capability with exactly one non-test importer serves one surface. Sometimes
+that is correct (an internal helper of one package); sometimes it is the finding
+(the other surface built its own).
+
+```
+git grep -l "internal/compose/<pkg>\"" origin/main -- 'backend/*.go' | grep -v _test
+```
+
+`compose/meetingbrief` had exactly one importer — the HTTP handler set — while
+`prep_for_meeting` assembled its own brief. One number, one finding.
+
+### 4. Read the uniqueness claims and disbelieve them
+
+Grep the tree for prose that asserts a choke point:
+
+```
+git grep -n "the one spelling\|the only writer\|cannot drift\|the same .* the .* performs\|there is no other" origin/main -- backend frontend
+```
+
+**Nine of the ten claims counted exhaustively in this tree were false**, and
+several of the rest were true but held by nothing. The claim is where the
+duplicate hides, because the next author reads it and stops looking. For each hit, run probe 1 or 2 against the thing it claims. A claim no
+test holds is either deleted or gated — never left standing.
+
+### 5. Diff the two halves you already know about
+
+When a topic legitimately has two implementations (a SQL expression and its Go
+twin; an Art. 17 erasure and a retention anonymize; a website assembler and a
+tool assembler), do not read them for similarity — **enumerate what each one
+touches and diff the lists**. Reference counts are the cheap version:
+
+```
+grep -c "field_provenance" erasure.go retentionactions.go
+```
+
+A zero on one side of a pair is the whole finding. Similarity reading finds
+nothing; counting does.
+
+### 6. Ask what a sweep would have to edit
+
+The last probe is a thought experiment with a mechanical answer: *if a rule about
+this topic changed tomorrow, how many files would the change have to touch?* If
+the answer is more than one, the topic has no choke point yet, whatever the
+comments say. This is the probe that found `person_profile_field`'s five writers
+and `relationship`'s four.
+
+## What to do with a finding
+
+Four outcomes, in order of preference. Pick one explicitly — leaving it unnamed
+is how a duplicate survives a review.
+
+1. **Adopt.** One implementation wins; the others call it and are deleted. Best
+   when both live in the same import tier.
+2. **Seam.** The two live in tiers that cannot import each other (a module may
+   not import a sibling or `compose`, ADR-0054 §3), so `compose` injects the
+   edge — one function crossing, named for the question it answers. **Write the
+   seam; do not write a second assembler.** Rolling your own always looks
+   cheaper, and it is always wrong.
+3. **Declare the divergence.** The two are genuinely different capabilities that
+   read alike. Say so in the code, at both sites, naming what makes them
+   different. A reason in the pull request does not count — the next reader is
+   in the file, not the PR.
+4. **Gate it.** Whatever you chose, leave a fitness function so the answer holds
+   without a human remembering it. See below.
+
+Two writers of one invariant either share a helper or say why they do not. If
+you are adding the second, the reason goes in the code beside it.
+
+## Leaving a gate behind
+
+A rule with no gate has already been tried here and already failed: the frontend
+rulebook has said "open the catalog first — every time, not once" for months,
+and the tree still grew a third spelling of a card.
+
+The house shape for a reuse gate, learned from `agenttoolparity_test.go` and
+`tableownership_test.go`:
+
+- **Derive the expectation from the tree, never from a list in the test.** A
+  hardcoded coverage set is a list to maintain, and `CLAUDE.md` rule #2 says
+  prefer the fitness function. `draftrulesparity_test.go` hardcodes four
+  drafting surfaces while seven exist — that is the failure mode, in the tree,
+  today.
+- **No waiver map in the test.** The escape hatch lives at the subject — a
+  `doc.go` line, a contract field, a `//craft:ignore <check> <reason>` — where a
+  reviewer editing that code sees it. A map in the test is invisible to the
+  author who needs it.
+- **Ratify the instance, never the category.** A waiver keyed by column, by
+  package, or by rule name lets a second offender in for free under the first
+  one's reason.
+- **Write the defect test first.** Mutate the code to reintroduce the duplicate
+  and watch the gate go red. A gate that has never failed proves nothing; four
+  fitness functions in this tree passed against the exact bug they described.
+- **Measure the before, not only the after.** A grep that returns zero after the
+  fix proves nothing unless you know it returned N before.
+
+## What this does not ask for
+
+- **Not deduplication for its own sake.** Two similar-looking things that answer
+  different questions stay two things, with the difference written down. Merging
+  them is how a gate loses the case it existed to catch.
+- **Not abstraction ahead of a second caller.** The choke point exists because
+  two callers need one answer today, not because a third might tomorrow. An
+  abstraction with one caller is a craft finding (`T3 premature-abstraction`).
+- **Not a rewrite.** The cheapest correct outcome is usually a one-function swap
+  or one seam file, and the audit that produced this page found exactly that.

--- a/docs/principles/the-record-is-the-code.md
+++ b/docs/principles/the-record-is-the-code.md
@@ -1,8 +1,11 @@
 # The record is the code
 
 **What this product does is defined by its code, tests, migrations and
-`backend/api/crm.yaml` — not by any document describing them.** A document can
-be stale; a passing test cannot.
+`backend/api/crm.yaml` — not by any document describing them.** A document goes
+stale silently. A test goes stale loudly, *if* it still exercises the obligation
+it was written for — see
+[derive the obligation](derive-the-obligation.md#writing-a-gate-that-holds)
+for the ways a green one can prove nothing.
 
 This replaces the older arrangement where a separate specification outranked the
 tree. It is the principle behind the precedence order in
@@ -43,7 +46,7 @@ readable:
 |---|---|
 | An implementation decision you made | the commit and the PR — git history is the record |
 | A decision that binds future work | raised with the team, where the reasoning is kept |
-| Something found but NOT fixed here | a GitHub issue in this repo, labelled on all three axes |
+| Something found but NOT fixed here | a GitHub issue in this repo, labelled on all three axes — **unless it is an exploitable weakness**, which goes to a private Security Advisory and never a public issue ([nothing here is private](nothing-here-is-private.md)) |
 | Open work / the session pickup point | [STATUS.md](../../STATUS.md), kept to open work only |
 
 **No build-process residue in comments.** No review-ticket numbers, no fix

--- a/docs/principles/the-record-is-the-code.md
+++ b/docs/principles/the-record-is-the-code.md
@@ -1,0 +1,70 @@
+# The record is the code
+
+**What this product does is defined by its code, tests, migrations and
+`backend/api/crm.yaml` — not by any document describing them.** A document can
+be stale; a passing test cannot.
+
+This replaces the older arrangement where a separate specification outranked the
+tree. It is the principle behind the precedence order in
+[CLAUDE.md](../../CLAUDE.md#what-decides-a-question-here), and the reason that
+order puts the running software above every prose artefact except the current
+request and the guardrails.
+
+## Why the order is that order
+
+1. **The explicit current request** — what someone is asking to change.
+2. **Code, tests, migrations, the contract** — what the product does *today*.
+   These are the record, not a description of it.
+3. **Guardrails** — security, privacy, agent authority, auditability, contract
+   compatibility, licensing, durability. Enforced by tests wherever possible,
+   *and the test is the thing to read*: it states the obligation in a form that
+   fails when the obligation stops holding.
+4. **[docs/](../)** — how the product is built and operated.
+5. **Retired material** — history. It never blocks work on its own.
+
+The load-bearing step is 2 above 4. A doc that disagrees with a green test is
+wrong about the product, and the fix is to change the doc — not to argue from
+it.
+
+## The method
+
+**When two sources disagree, run the code.** Not "read both and decide which
+sounds more authoritative" — execute the test, read the migration, open the
+contract. One of them is the record.
+
+**When you change behaviour, the change lands in the record first.** A migration
+and a test, then the doc that describes them. A doc-only change that claims new
+behaviour is a lie with a commit hash.
+
+**Findings route by durability**, and this is the rule that keeps the record
+readable:
+
+| The thing you found | Where it goes |
+|---|---|
+| An implementation decision you made | the commit and the PR — git history is the record |
+| A decision that binds future work | raised with the team, where the reasoning is kept |
+| Something found but NOT fixed here | a GitHub issue in this repo, labelled on all three axes |
+| Open work / the session pickup point | [STATUS.md](../../STATUS.md), kept to open work only |
+
+**No build-process residue in comments.** No review-ticket numbers, no fix
+narration, no "changed in response to". State the invariant so it stands alone.
+The story of how the code got this way is in git; a comment retelling it is a
+second, worse copy that cannot be queried and will not be updated. Same for test
+names.
+
+**Never rationalize a known gap in a comment.** Restructure it away or gate it
+with a test. A comment explaining why something is broken is a defect with
+documentation.
+
+## What this does not ask for
+
+- **Not "documentation does not matter".** `docs/` is step 4, not step none. It
+  explains how the product is built and operated, and that is work the code
+  cannot do.
+- **Not "refuse to evolve because an older document says otherwise".** Name the
+  conflict, say what it costs, and keep building. If the change touches a
+  guardrail, say so in the PR so the decision behind it is updated with the
+  code.
+- **Not "tests are documentation".** A test states one obligation precisely. It
+  does not orient a newcomer, and pretending it does is how a tree becomes
+  unreadable to everyone who did not write it.


### PR DESCRIPTION
## Why

`CLAUDE.md` and `AGENTS.md` say what is binding. They do not say *why*, and the
why is what a reader needs in the two cases the rulebook cannot serve: when a
rule and their patch disagree, and when they are **auditing a subsystem** against
a rule rather than obeying it on one diff.

`docs/principles/` carries six pages, one per principle. Each names the rulebook
section it explains, the method for checking the tree still holds it, and **what
it explicitly does not ask for**. That third part is deliberate — a principle
with no stated limit gets applied as a cudgel.

| Page | Rulebook section it explains |
|---|---|
| `one-source-of-truth.md` | *Reuse before you build*, *Layout* |
| `the-record-is-the-code.md` | *What decides a question here* |
| `every-mutation-leaves-a-trace.md` | *The write shape* |
| `legibility-is-the-product.md` | *Craftsmanship* |
| `derive-the-obligation.md` | *Rules learned from the review loop* |
| `nothing-here-is-private.md` | *This repository is public* |

## What this deliberately does NOT do

**It does not move any rule out of the rulebook.** `cli/craft` feeds the whole
nearest `AGENTS.md` into its gate prompt, so a rule relocated to `docs/` stops
reaching the gate. The pointer paragraph added to both files says so, in both
files, so the next person tempted to tidy the duplication finds the reason
before they act on it. The four parity-checked shared sections keep their text
and `TestSharedRulebookSectionsAreIdenticalInBothDocs` still passes.

## The one page with a method rather than an argument

`one-source-of-truth.md` carries a six-probe scan for finding a topic that got
built twice — grep tree-wide, count a table's writers, count a package's
importers, disbelieve the uniqueness claims, diff the two halves you already
know about, and ask what a sweep would have to edit. Plus the boundary half:
which tier an owner may live in, and why a seam is the right answer every time
even though it always looks like ceremony next to a fifteen-line copy.

I ran that scan over the tree before writing the page, which is where the
corrections below come from.

## Three corrections the scan forced

The tree already said things that turned out not to be true:

1. **Both rulebooks claimed *every* uniqueness claim audited here was false.**
   The honest count is **nine of the ten counted exhaustively**; several of the
   rest are true but held by no test. Overstating a real finding invites the
   reader to discount it, so both files now say nine of ten. (Shared section —
   edited identically in both, as the parity test requires.)

2. **The same rule described `prep_for_meeting` and `compose/meetingbrief` as
   diverging in the present tense.** #2241 closed that with a seam. It now reads
   as history, which is what it is.

3. **`docs/explanation/contract-first.md` still opened by saying this repository
   is built from a specification that outranks it and wins every argument.**
   `CLAUDE.md`'s precedence order replaced that some time ago. The page now says
   what actually decides, and links the principle that explains it.

## Verification

- `TestSharedRulebookSectionsAreIdenticalInBothDocs` — passes.
- `TestPublicTreeCitesNothingPrivate` — passes.
- Every relative link in the twelve changed/added files resolves (scripted check).
- `make check` — passes except `TestPublishedMCPSurfaceMatchesWhatAClientIsServed`,
  which is **main's own red**, not this branch's: it fails identically on a clean
  `origin/main` checkout with these changes stashed. Fixed separately in
  **#2298**; I will rebase onto that before merging, since a red check against a
  fixed base does not re-run on its own.

## Diff shape

Documentation only. No Go, no contract, no migration, no frontend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes down the reasoning under the rulebook and aligns it with what the gates enforce. Adds `docs/principles/` (six principles with audit methods and limits) and links them; rules remain binding in `AGENTS.md`/`CLAUDE.md`.

- Adds `docs/principles/` and links from `AGENTS.md`, `CLAUDE.md`, `docs/README.md`, and backend onboarding; pointer paragraphs explain why rules stay in the rulebooks for `cli/craft`.
- Corrects prior statements: uniqueness claims now “nine of ten,” `prep_for_meeting` vs `compose/meetingbrief` marked as closed by a seam, and contract precedence now points to `backend/api/crm.yaml` and generated Go via the “the record is the code” principle.
- Fixes overclaims found in self-review to match gates: function size ceiling ignores comment-only lines but `scripts/check-go-file-length.sh` counts all lines with a ratchet; `craft static` skips docs-only pushes; some rules are judgement and unguarded; green tests can be stale; exploitable findings route to a private Security Advisory.
- Clarifies methods and seams: integration tests use real Postgres/Redis; `agenttoolparity_test.go` documents its hand-maintained `composedIntents` as a near-miss; the write shape enumerates audit-only exceptions in `writeshape_test.go`; the duplication scan counts DELETEs, respects declared divergence, and removes hardcoded surface counts.

**Rollout**
- Docs-only; no code, contract, or migrations.
- Rebase onto the fix for `TestPublishedMCPSurfaceMatchesWhatAClientIsServed` (tracked in #2298) before merge to restore green checks.

<sup>Written for commit b183c21bd1735a1a05e1d296f8aa3c163404d705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a principles documentation section covering design consistency, traceability, public repository standards, code legibility, and single sources of truth.
  - Expanded documentation navigation and backend onboarding guidance to include the new principles.
  - Clarified that the API contract and generated implementation define the product’s exposed surface.
  - Documented atomic mutation tracing, enforcement gates, repository privacy expectations, and conflict-resolution guidance.
  - Updated contributor guidance on reuse, binding rules, enforcement gates, and accuracy of repository-wide claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->