### PR TITLE
fix(agents-mcp): the native-mode guard derives which tools may answer not-found

### DIFF
--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -424,38 +425,42 @@ func TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard(t *testing.T) {
 	registry := compose.NewRegistryFor(e.DB(), compose.SendPath{})
 	ctx := e.As(e.Rep1, nil, nativeToolReaderPerms())
 
-	// The tools whose NOT-FOUND is itself a served answer — the answer only a
-	// workspace that actually ran the lookup can give. Everything else must
-	// SUCCEED, so a native path that broke outright cannot hide behind "well, it
-	// didn't say unsupported_by_sor".
-	notFoundIsAnAnswer := map[string]bool{
-		// Anchored intents and writes, against an anchor id that is minted
-		// rather than seeded.
-		"catch_me_up_on": true, "prep_for_meeting": true, "intro_path_to": true,
-		"disqualify_lead": true, "promote_lead": true, "merge_records": true, "advance_deal": true,
-		// The delivery briefing is anchored on a project id, and the anchor
-		// above is minted rather than seeded. Not-found is the served answer
-		// here, and the RIGHT one: the project read runs first and its refusal
-		// is returned unchanged, so a native workspace saying "no such project"
-		// is the mode guard having stood aside exactly as it should.
-		"prepare_handoff": true,
-		// A rep with no assembled brief: read_brief re-reads a persisted run and
-		// never ranks, so "none has been generated" is what it owes rather than
-		// an empty queue that reads as a quiet morning.
-		"read_brief": true,
-	}
+	// A tool whose fixture carries the MINTED anchor is asking about a record
+	// that was never seeded, so not-found is itself a served answer — the answer
+	// only a workspace that actually ran the lookup can give. Everything else
+	// must SUCCEED, so a native path that broke outright cannot hide behind
+	// "well, it didn't say unsupported_by_sor".
+	//
+	// Derived from the fixture rather than listed, because a hand-kept list is
+	// the wrong shape for this: it has to be extended by whoever adds an
+	// anchored tool, and the failure when they forget accuses the new tool of
+	// breaking the native path when nothing is wrong with it. read_project_360
+	// was added with its fixture and without its list entry, and that is exactly
+	// how it read.
+	//
+	// One tool answers not-found without an anchor, and it is named because
+	// nothing about its arguments could tell you: read_brief re-reads a
+	// persisted run and never ranks, so "none has been generated" is what it
+	// owes a rep with no assembled brief, rather than an empty queue that reads
+	// as a quiet morning.
+	const unanchoredNotFound = "read_brief"
 
 	anchor := ids.NewV7()
-	for name, args := range mergedFixtures(nativeOnlyAgentTools(anchor), providerRefusedRecordWrites(anchor)) {
+	fixtures := mergedFixtures(nativeOnlyAgentTools(anchor), providerRefusedRecordWrites(anchor))
+	if _, ok := fixtures[unanchoredNotFound]; !ok {
+		t.Fatalf("%s is no longer in the fixture set — the exception outlived the tool it names", unanchoredNotFound)
+	}
+	for name, args := range fixtures {
 		t.Run(name, func(t *testing.T) {
+			notFoundIsAnAnswer := name == unanchoredNotFound || strings.Contains(args, anchor.String())
 			_, err := registry.Invoke(ctx, name, json.RawMessage(args))
 			if errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 				t.Fatalf("%s refused a NATIVE workspace with unsupported_by_sor — the mode guard is inverted", name)
 			}
 			switch {
-			case notFoundIsAnAnswer[name] && err != nil && !errors.Is(err, apperrors.ErrNotFound):
+			case notFoundIsAnAnswer && err != nil && !errors.Is(err, apperrors.ErrNotFound):
 				t.Fatalf("%s err = %v, want nil or ErrNotFound", name, err)
-			case !notFoundIsAnAnswer[name] && err != nil:
+			case !notFoundIsAnAnswer && err != nil:
 				t.Fatalf("%s err = %v, want nil — a native workspace must actually be served", name, err)
 			}
 		})


### PR DESCRIPTION
## main is red, and this unbreaks it

The integration lane fails on `origin/main` today:

```
--- FAIL: TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard/read_project_360
    overlay_toolsurface_integration_test.go:459: read_project_360 err = not found,
      want nil — a native workspace must actually be served
```

Nothing is wrong with `read_project_360`. The test mints its anchor id rather
than seeding it, so a tool asked about that id answers not-found — and for an
anchored tool that IS the served answer, the one only a workspace that actually
ran the lookup can give. Eight such tools were listed in a hand-kept
`notFoundIsAnAnswer` map. #2300 added a ninth, with its fixture and without its
map entry.

`main-health` has not run since 13:00Z, so nothing had announced it; two further
merges landed on the red base while it sat there.

## The map is the defect, not the missing line in it

A list that must be extended by whoever adds an anchored tool fails, when they
forget, by **accusing the new tool of breaking the native path**. That is how
this one read, and it is why telling "main is red" from "my branch is red" took
a clean-worktree reproduction rather than a glance.

It is derived from the fixture instead: a tool whose arguments carry the minted
anchor may answer not-found. Same nine names today; it cannot fall behind
tomorrow.

`read_brief` stays named, because nothing about its arguments could tell you —
it takes none, and re-reads a persisted run, so "none has been generated" is
what it owes a rep with no assembled brief rather than an empty queue that reads
as a quiet morning. The exception is itself checked against the fixture set, so
it cannot outlive the tool it names.

## Why CI missed it

CI builds `refs/pull/N/merge`. #2300 was green against the main of its time; the
map it left short only met `read_project_360` once both were on main.

## Verification

The whole integration lane, twice, on a real Postgres:

| tree | result |
|---|---|
| clean worktree at `origin/main` | `FAIL` — this one test, nothing else |
| same worktree with this change | `OK: integration passed with 0 skips (42 packages, parallel)` |

Census of the two sets at `origin/main`, so the claim is that the gap is closed
rather than patched:

- anchored on the minted id: `advance_deal`, `catch_me_up_on`, `disqualify_lead`,
  `intro_path_to`, `merge_records`, `prep_for_meeting`, `prepare_handoff`,
  `promote_lead`, `read_project_360`
- in `notFoundIsAnAnswer`: those eight, plus `read_brief`
- **anchored but not allowed: `read_project_360` — the only one**
- allowed but not anchored: `read_brief` — deliberate, and now the one named
  exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives which native-mode tools may return not-found from their fixtures instead of a hand-kept list. This fixes the integration failure on `read_project_360` and prevents future drift when adding anchored tools.

- Old: a map listed tools allowed to return `apperrors.ErrNotFound`. New: the test infers allowance when fixture args include the minted anchor; tools without the anchor must succeed. `read_brief` remains the only unanchored exception and the test asserts it exists in the fixture set.
- Guards remain: any `apperrors.ErrUnsupportedBySoR` still fails the test. Change is test-only; integration lane turns green.

<sup>Written for commit 8f1ced39157e463754c039dfc7f5229242708d5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration coverage for native workspace error handling.
  - Tests now verify that “not found” responses match the relevant fixture data, helping detect inconsistencies earlier.
  - Added validation to ensure required exception scenarios remain covered, improving confidence in workspace tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->