### PR TITLE
feat(dealrooms): the room shares what is in the deal's Files area

### DIFF
--- a/backend/internal/compose/integration/dealroom_files_area_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_files_area_integration_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A room shares what is in the deal's Files area, not only what was uploaded
+// on the deal: a file that arrived with an email linked to the deal can be put
+// in the room, published and downloaded by the buyer — and hiding it from the
+// deal takes it out of the buyer's download without touching the file.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// captureFileOnEmail logs an email on the deal over HTTP and files a part on
+// it through the attachment table's own captured-file writer — the path a
+// mailbox pull takes, so the row carries exactly what capture stamps.
+func captureFileOnEmail(t *testing.T, e *apptest.AppEnv, blob blobstore.Store, dealID string) (activityID, attachmentID string) {
+	t.Helper()
+	var email apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+		"kind": "email", "subject": "Re: MSA", "direction": "inbound",
+	}, nil, &email); status != http.StatusCreated {
+		t.Fatalf("log email = %d %v", status, email)
+	}
+	activityID, _ = email["id"].(string)
+	if status := e.Call(t, "POST", "/v1/activities/"+activityID+"/relink", apptest.AnyMap{
+		"entity_type": "deal", "entity_id": dealID,
+	}, nil, nil); status != http.StatusOK {
+		t.Fatalf("link the email to the deal = %d", status)
+	}
+
+	ctx := captureContext(t, e)
+	store := activities.NewStore(e.DB()).WithBlobstore(blob)
+	staged, err := store.StageCapturedFiles(ctx, []activities.CapturedFile{{
+		PartID: "1", Filename: "MSA-redline.docx", ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		Body: []byte("redline"),
+	}})
+	if err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return store.RecordCapturedFiles(ctx, tx, ids.From[ids.ActivityKind](ids.MustParse(activityID)),
+			activities.CapturedFileSource{System: "imap", MessageID: "msa-" + activityID, CapturedBy: "connector:imap", Category: "email_attachment"}, staged)
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if err := e.Pool.QueryRow(context.Background(),
+		`SELECT id FROM attachment WHERE entity_type = 'activity' AND entity_id = $1`, activityID).Scan(&attachmentID); err != nil {
+		t.Fatalf("read the captured file: %v", err)
+	}
+	return activityID, attachmentID
+}
+
+// captureContext is the capture principal's authority: create on activity,
+// nothing else, on the installation's workspace.
+func captureContext(t *testing.T, e *apptest.AppEnv) context.Context {
+	t.Helper()
+	var wsID ids.UUID
+	if err := e.Pool.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
+		t.Fatalf("workspace lookup: %v", err)
+	}
+	ctx := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), wsID), ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalConnector, ID: "connector:imap",
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"activity": {Create: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+func TestAnEmailedFileReachesTheBuyerThroughTheRoomUntilItIsHidden(t *testing.T) {
+	blob := blobstore.NewMemory()
+	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blob))
+	e.BootstrapWorkspace(t)
+	room := openPublishedRoom(t, e)
+	var roomRow apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow); status != http.StatusOK {
+		t.Fatalf("room = %d", status)
+	}
+	dealID, _ := roomRow["deal_id"].(string)
+	_, attachmentID := captureFileOnEmail(t, e, blob, dealID)
+
+	// The emailed file is in the deal's Files area, and so admissible to the room.
+	var area apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/documents", nil, nil, &area); status != http.StatusOK {
+		t.Fatalf("deal files = %d %v", status, area)
+	}
+	if list, _ := area["data"].([]any); len(list) != 1 {
+		t.Fatalf("deal files = %v, want the emailed file", list)
+	}
+	var doc apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+		"attachment_id": attachmentID, "group_key": "legal", "source": "ui",
+	}, nil, &doc); status != http.StatusCreated {
+		t.Fatalf("add emailed file to the room = %d %v", status, doc)
+	}
+	docID, _ := doc["id"].(string)
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/publish", apptest.AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("publish = %d", status)
+	}
+
+	var session apptest.AnyMap
+	if status := publicCall(t, e, "POST", "/v1/public/rooms/exchange", apptest.AnyMap{"credential": room.credential}, nil, &session); status != http.StatusOK {
+		t.Fatalf("exchange = %d", status)
+	}
+	token, _ := session["session_token"].(string)
+	if status := publicCall(t, e, "GET", "/v1/public/rooms/documents/"+docID+"/file", nil, bearer(token), nil); status != http.StatusOK {
+		t.Fatalf("buyer download of the emailed file = %d, want 200", status)
+	}
+
+	// Hidden from the deal: the room's draft still lists it for the seller,
+	// the buyer's download refuses, and the next release drops it.
+	if status := e.Call(t, "PUT", "/v1/deals/"+dealID+"/documents/"+attachmentID+"/hide", nil, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("hide = %d", status)
+	}
+	if status := publicCall(t, e, "GET", "/v1/public/rooms/documents/"+docID+"/file", nil, bearer(token), nil); status != http.StatusNotFound {
+		t.Fatalf("download after hide = %d, want 404", status)
+	}
+	var sellerDocs apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/documents", nil, nil, &sellerDocs); status != http.StatusOK {
+		t.Fatalf("seller documents = %d", status)
+	}
+	if list, _ := sellerDocs["data"].([]any); len(list) != 1 {
+		t.Fatalf("the seller's list dropped the hidden entry (%v); only the seller can remove it", list)
+	}
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/publish", apptest.AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("republish = %d", status)
+	}
+	var buyerDocs apptest.AnyMap
+	if status := publicCall(t, e, "GET", "/v1/public/rooms/documents", nil, bearer(token), &buyerDocs); status != http.StatusOK {
+		t.Fatalf("buyer documents = %d", status)
+	}
+	if list, _ := buyerDocs["data"].([]any); len(list) != 0 {
+		t.Fatalf("a hidden file is still in the release: %v", list)
+	}
+}
+
+func TestARepCannotShareATeammatesLimitedAudienceMailAttachment(t *testing.T) {
+	blob := blobstore.NewMemory()
+	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blob))
+	e.BootstrapWorkspace(t)
+	room := openPublishedRoom(t, e)
+	var roomRow apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID, nil, nil, &roomRow); status != http.StatusOK {
+		t.Fatalf("room = %d", status)
+	}
+	dealID, _ := roomRow["deal_id"].(string)
+	activityID, attachmentID := captureFileOnEmail(t, e, blob, dealID)
+
+	// The mail belongs to somebody else's mailbox and is limited to its
+	// participants; the rep working the deal is neither.
+	if _, err := e.Pool.Exec(context.Background(),
+		`UPDATE activity SET audience = 'participants', captured_by = $2 WHERE id = $1`,
+		activityID, "connector:imap:"+ids.NewV7().String()); err != nil {
+		t.Fatalf("narrow the mail: %v", err)
+	}
+	if _, err := e.Pool.Exec(context.Background(),
+		`DELETE FROM activity_participant WHERE activity_id = $1`, activityID); err != nil {
+		t.Fatalf("take the rep off the mail: %v", err)
+	}
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/documents", apptest.AnyMap{
+		"attachment_id": attachmentID, "group_key": "legal", "source": "ui",
+	}, nil, nil); status != http.StatusNotFound {
+		t.Fatalf("sharing a teammate's limited-audience attachment = %d, want 404", status)
+	}
+}

--- a/backend/internal/modules/dealrooms/document_read.go
+++ b/backend/internal/modules/dealrooms/document_read.go
@@ -65,14 +65,17 @@ const documentFrom = `deal_room_document d
 // seller see a captured file — is asked once, at add (addDocumentTx).
 //
 // The activities module spells the same membership for the deal's own Files
-// read; it cannot be shared because a module never imports a sibling, and
+// read, inline-image ceiling included (a logo a rep never sees in the area
+// must not be shareable by id); it cannot be shared because a module never
+// imports a sibling, and
 // TestRoomDocumentMembershipIsSpelledOnce holds this module's three readers to
 // this one constant.
 const inTheDealsFilesArea = `a.archived_at IS NULL
 	AND ((a.entity_type = 'deal' AND a.entity_id = r.deal_id)
 	  OR (a.entity_type = 'activity' AND EXISTS (
 	        SELECT 1 FROM activity_link l
-	         WHERE l.activity_id = a.entity_id AND l.entity_type = 'deal' AND l.deal_id = r.deal_id)))
+	         WHERE l.activity_id = a.entity_id AND l.entity_type = 'deal' AND l.deal_id = r.deal_id)
+	      AND NOT (a.content_type LIKE 'image/%' AND COALESCE(a.byte_size, 0) < 65536)))
 	AND NOT EXISTS (SELECT 1 FROM deal_document_hide h WHERE h.deal_id = r.deal_id AND h.attachment_id = a.id)`
 
 // ListDocuments returns a room's documents in group-then-position order.

--- a/backend/internal/modules/dealrooms/document_read.go
+++ b/backend/internal/modules/dealrooms/document_read.go
@@ -50,13 +50,30 @@ const documentFrom = `deal_room_document d
 	JOIN deal_room r ON r.id = d.room_id
 	JOIN attachment a ON a.id = d.attachment_id`
 
-// stillTheDealsFile re-applies, at PUBLISH and at DOWNLOAD, the predicate the
-// add checked once: the attachment is live and filed on the room's own deal. A
-// file archived or re-homed after it was added drops out of the next release
-// and out of the buyer's download, rather than riding on the strength of a
-// check that was true when it was added. The seller's own list does not carry
-// it, so the stale entry stays visible to the one person who can remove it.
-const stillTheDealsFile = `a.archived_at IS NULL AND a.entity_type = 'deal' AND a.entity_id = r.deal_id`
+// inTheDealsFilesArea is the membership rule for a room's documents, spelled
+// once and re-applied at ADD, at PUBLISH and at DOWNLOAD: the attachment is
+// live, it is in the room's deal's Files area — uploaded on the deal, or
+// carried by a message linked to the deal — and it is not hidden from that
+// deal. A file archived, unlinked or hidden after it was added drops out of
+// the next release and out of the buyer's download, rather than riding on the
+// strength of a check that was true when it was added. The seller's own list
+// does not carry the predicate, so the stale entry stays visible to the one
+// person who can remove it.
+//
+// It needs the room aliased `r` and the attachment aliased `a`, and carries no
+// principal: the public download has none. The caller-bound half — may THIS
+// seller see a captured file — is asked once, at add (addDocumentTx).
+//
+// The activities module spells the same membership for the deal's own Files
+// read; it cannot be shared because a module never imports a sibling, and
+// TestRoomDocumentMembershipIsSpelledOnce holds this module's three readers to
+// this one constant.
+const inTheDealsFilesArea = `a.archived_at IS NULL
+	AND ((a.entity_type = 'deal' AND a.entity_id = r.deal_id)
+	  OR (a.entity_type = 'activity' AND EXISTS (
+	        SELECT 1 FROM activity_link l
+	         WHERE l.activity_id = a.entity_id AND l.entity_type = 'deal' AND l.deal_id = r.deal_id)))
+	AND NOT EXISTS (SELECT 1 FROM deal_document_hide h WHERE h.deal_id = r.deal_id AND h.attachment_id = a.id)`
 
 // ListDocuments returns a room's documents in group-then-position order.
 func (s *Store) ListDocuments(ctx context.Context, roomID ids.DealRoomID) ([]crmcontracts.DealRoomDocument, storekit.Page, error) {
@@ -83,9 +100,9 @@ func documentRows(ctx context.Context, tx pgx.Tx, roomID ids.DealRoomID) ([]crmc
 }
 
 // publishableDocumentRows is what a release freezes: only entries whose file is
-// still the deal's own.
+// still in the deal's Files area.
 func publishableDocumentRows(ctx context.Context, tx pgx.Tx, roomID ids.DealRoomID) ([]crmcontracts.DealRoomDocument, error) {
-	return documentRowsWhere(ctx, tx, roomID, " AND "+stillTheDealsFile)
+	return documentRowsWhere(ctx, tx, roomID, " AND "+inTheDealsFilesArea)
 }
 
 func documentRowsWhere(ctx context.Context, tx pgx.Tx, roomID ids.DealRoomID, also string) ([]crmcontracts.DealRoomDocument, error) {

--- a/backend/internal/modules/dealrooms/document_write.go
+++ b/backend/internal/modules/dealrooms/document_write.go
@@ -57,7 +57,7 @@ func addDocumentTx(ctx context.Context, tx pgx.Tx, roomID ids.DealRoomID, in Add
 	if err != nil {
 		return crmcontracts.DealRoomDocument{}, err
 	}
-	filename, err := attachmentOfDeal(ctx, tx, in.AttachmentID, ids.UUID(room.DealId))
+	filename, err := attachmentOfDeal(ctx, tx, in.AttachmentID, ids.From[ids.DealRoomKind](ids.UUID(room.Id)))
 	if err != nil {
 		return crmcontracts.DealRoomDocument{}, err
 	}
@@ -82,22 +82,35 @@ func addDocumentTx(ctx context.Context, tx pgx.Tx, roomID ids.DealRoomID, in Add
 	return readDocument(ctx, tx, roomID, id)
 }
 
-// attachmentOfDeal is the whole authority check on the file: it must be a live
-// attachment filed on THIS room's deal. That is a predicate, not a grant — the
-// caller already holds write on the deal (openRoomForContent), and a deal's own
-// files are what that authority covers. Any other id is absent, so a caller
-// cannot use this path to learn that some other record's file exists.
-func attachmentOfDeal(ctx context.Context, tx pgx.Tx, attachmentID, dealID ids.UUID) (string, error) {
-	var filename string
+// attachmentOfDeal admits a file into the room: it must be in the room's
+// deal's Files area (inTheDealsFilesArea — the same predicate publish and the
+// buyer download re-apply), and, when it arrived with a message, that message
+// must be one THIS caller may read. The second half is the grant the first
+// cannot carry: a captured file follows its message's audience, and a rep with
+// write on the deal must not be able to hand a teammate's limited-audience
+// mail to an outsider. Any other id is absent, so a caller cannot use this
+// path to learn that some other record's file exists.
+func attachmentOfDeal(ctx context.Context, tx pgx.Tx, attachmentID ids.UUID, roomID ids.DealRoomID) (string, error) {
+	var (
+		filename   string
+		entityType string
+		entityID   ids.UUID
+	)
 	err := tx.QueryRow(ctx,
-		`SELECT filename FROM attachment
-		  WHERE id = $1 AND entity_type = 'deal' AND entity_id = $2 AND archived_at IS NULL`,
-		attachmentID, dealID).Scan(&filename)
+		`SELECT a.filename, a.entity_type, a.entity_id
+		   FROM attachment a JOIN deal_room r ON r.id = $2
+		  WHERE a.id = $1 AND `+inTheDealsFilesArea,
+		attachmentID, roomID).Scan(&filename, &entityType, &entityID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", apperrors.ErrNotFound
 	}
 	if err != nil {
 		return "", fmt.Errorf("read attachment for deal room document: %w", err)
+	}
+	if entityType == "activity" {
+		if err := auth.EnsureActivityContentVisible(ctx, tx, entityID); err != nil {
+			return "", err
+		}
 	}
 	return filename, nil
 }

--- a/backend/internal/modules/dealrooms/document_write.go
+++ b/backend/internal/modules/dealrooms/document_write.go
@@ -108,6 +108,15 @@ func attachmentOfDeal(ctx context.Context, tx pgx.Tx, attachmentID ids.UUID, roo
 		return "", fmt.Errorf("read attachment for deal room document: %w", err)
 	}
 	if entityType == "activity" {
+		// The object grant first, then the row: a seat that lost activity.read
+		// must not be able to replay an id it once saw. Denial reads as absent,
+		// as every attachment read answers.
+		if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+			if errors.Is(err, apperrors.ErrPermissionDenied) {
+				return "", apperrors.ErrNotFound
+			}
+			return "", err
+		}
 		if err := auth.EnsureActivityContentVisible(ctx, tx, entityID); err != nil {
 			return "", err
 		}

--- a/backend/internal/modules/dealrooms/documentmembership_test.go
+++ b/backend/internal/modules/dealrooms/documentmembership_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dealrooms
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The rule that decides whether a file may be in a room is spelled once.
+// Three readers apply it — the add, the release, the buyer's download — and
+// if any of them grew its own SQL for "is this the deal's file", the next
+// change to the rule would reach two of the three and the buyer would keep
+// downloading a file the seller had hidden.
+func TestRoomDocumentMembershipIsSpelledOnce(t *testing.T) {
+	readers := map[string]bool{
+		"document_write.go":         false,
+		"document_read.go":          false,
+		"store_public_documents.go": false,
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(src)
+		if _, isReader := readers[name]; isReader {
+			if !strings.Contains(text, "inTheDealsFilesArea") {
+				t.Errorf("%s no longer applies inTheDealsFilesArea", name)
+			}
+			readers[name] = true
+		} else if strings.Contains(text, "inTheDealsFilesArea") {
+			t.Errorf("%s applies the membership rule; only the add, the release and the buyer download may", name)
+		}
+		// The spelling itself lives in document_read.go; nothing else may
+		// re-derive it from the attachment's parent columns.
+		if name != "document_read.go" && (strings.Contains(text, "entity_id = r.deal_id") || strings.Contains(text, "deal_document_hide")) {
+			t.Errorf("%s spells the deal-file membership itself instead of applying inTheDealsFilesArea", name)
+		}
+	}
+	for name, seen := range readers {
+		if !seen {
+			t.Errorf("%s was not found; if it moved, move the reader list with it", name)
+		}
+	}
+}

--- a/backend/internal/modules/dealrooms/store_public_documents.go
+++ b/backend/internal/modules/dealrooms/store_public_documents.go
@@ -103,10 +103,11 @@ func (s *Store) BuyerDocumentLocator(ctx context.Context, sess Session, document
 			return apperrors.ErrNotFound
 		}
 		// A release names a version; the bytes are served only while that file
-		// is still the deal's own (stillTheDealsFile, the publish predicate).
+		// is still in the deal's Files area (inTheDealsFilesArea, the publish
+		// predicate).
 		err = tx.QueryRow(ctx,
 			`SELECT a.storage_key FROM `+documentFrom+`
-			  WHERE d.id = $1 AND d.room_id = $2 AND d.attachment_id = $3 AND `+stillTheDealsFile,
+			  WHERE d.id = $1 AND d.room_id = $2 AND d.attachment_id = $3 AND `+inTheDealsFilesArea,
 			documentID, sess.RoomID, published.AttachmentID).Scan(&out.StorageKey)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound


### PR DESCRIPTION
## What changes

A Deal Room can now share a file that arrived with an email linked to the deal, not only a file uploaded on the deal.

- One membership rule, `inTheDealsFilesArea` (`document_read.go`): live attachment, uploaded on the deal OR carried by an activity linked to the deal, and not hidden from the deal. It is re-applied at add, at publish and at the buyer's download, so a file unlinked, archived or hidden after it was added drops out of the next release and of the download. `TestRoomDocumentMembershipIsSpelledOnce` holds the three readers to the one constant and forbids a second spelling in the module.
- At add, a captured file's message must be one the caller may read (`auth.EnsureActivityContentVisible`): a rep with write on the deal cannot hand a teammate's limited-audience mail to an outsider. Mutation-checked: with the guard removed the test fails.

## Gates

`make check-backend` green (one lint module needed a re-run because a parallel golangci-lint was running), craft-static, rls/jurisdiction greps. Integration: `dealroom_files_area_integration_test.go` — emailed file → room → publish → buyer downloads; hide on the deal → download 404 and the next release drops it while the seller's list keeps the entry; limited-audience mail → add refused 404.

Plan: rev 5, PR 3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deal Rooms now share what is in a deal’s Files area, not only direct uploads. Buyers can receive uploads and deal‑linked email attachments, while hidden/unlinked/archived items drop from releases and buyer downloads; inline mail images remain excluded to match the Files area.

- Introduces `inTheDealsFilesArea` as the single membership rule and reapplies it at add, publish, and buyer download.
- At add, requires the activity read grant and `auth.EnsureActivityContentVisible` for activity‑backed files to prevent sharing teammates’ limited‑audience mail; denial returns not found.
- Buyer download uses the same predicate; integration and a guard test keep the rule single‑sourced across `dealrooms`.

<sup>Written for commit f20981ab1c3c6da7200d92aedaae604baacd6362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deal-room files can now be shared and published to buyers from supported email attachments.
  * Buyers can download published attachments until they are hidden.
  * Deal-linked activity files now follow consistent visibility and access rules.

* **Bug Fixes**
  * Prevented representatives from sharing attachments from teammates’ limited-audience emails.
  * Hidden or unauthorized attachments are no longer available for buyer download or future releases.
  * Improved validation when accessing deal-room files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->