### PR TITLE
fix(dealrooms): publish answered 500 — the membership rule was spliced into a format string

### DIFF
--- a/backend/internal/modules/dealrooms/document_read.go
+++ b/backend/internal/modules/dealrooms/document_read.go
@@ -111,11 +111,13 @@ func publishableDocumentRows(ctx context.Context, tx pgx.Tx, roomID ids.DealRoom
 func documentRowsWhere(ctx context.Context, tx pgx.Tx, roomID ids.DealRoomID, also string) ([]crmcontracts.DealRoomDocument, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
+	// `also` is a %s operand, never part of the format: the membership rule
+	// carries a LIKE 'image/%' that a format string would read as a verb.
 	rows, err := tx.Query(ctx, storekit.SQLf(
 		`SELECT %s FROM %s
-		  WHERE d.room_id = $%d AND d.archived_at IS NULL`+also+`
+		  WHERE d.room_id = $%d AND d.archived_at IS NULL%s
 		  ORDER BY d.group_key, d.position, d.created_at, d.id`,
-		documentColumns, documentFrom, arg(roomID)), args...)
+		documentColumns, documentFrom, arg(roomID), also), args...)
 	if err != nil {
 		return nil, fmt.Errorf("list deal room documents: %w", err)
 	}


### PR DESCRIPTION
#2312 concatenated `inTheDealsFilesArea` (which carries `LIKE 'image/%'`) into the format string handed to `storekit.SQLf` in `documentRowsWhere`, so every publish failed with a SQL syntax error. The rule is now a `%s` operand. Integration lane for the room scenarios green again. Sorry — the merge of #2312 went out before that lane's re-run had finished.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Deal Room publish failures by passing the membership rule to `storekit.SQLf` as a `%s` operand instead of concatenating it into the format string. Previously `inTheDealsFilesArea` included `LIKE 'image/%'`, which the formatter misread as a verb, producing invalid SQL and 500 responses on publish; now the query binds the rule safely and publish works.

<sup>Written for commit 4e71f8df3837a7559dba8436f45141eeaafd88f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document filtering for predicates containing percent signs, such as MIME type patterns.
  * Improved reliability of document queries using `LIKE` conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->