### PR TITLE
fix(frontend): the rail's acceptance spec counts the Projects door

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -150,13 +150,18 @@ function accountTrigger(page: Page) {
   });
 }
 
-// The canonical ten, in order: Home alone, then records / work / intelligence.
-// Ten rows, but not upstream's ten: Duplicates is a destination here (the queue
+// The canonical twelve, in order: Home alone, then records / work /
+// intelligence. Not upstream's set: Duplicates is a destination here (the queue
 // had no address outside a home digest card) while Automations is not (it is
 // set-and-forget configuration on Settings → AI). Two labels differ from their
 // route ids on purpose — `deals` presents as Pipeline and `inbox` as Approvals
 // — so this asserts what a person reads, not what the router matches.
-test("AC-shell-1: the rail renders the canonical 11 items in order", async ({
+//
+// The count and the list are both spelled out on purpose. NAV_GROUPS in
+// src/app/nav.ts is the source of the rail; deriving this from it would assert
+// only that the rail renders itself, so a destination added there is meant to
+// fail here until somebody says what a person now reads and where.
+test("AC-shell-1: the rail renders the canonical 12 items in order", async ({
   page,
 }) => {
   await page.goto("/#/home");
@@ -165,7 +170,7 @@ test("AC-shell-1: the rail renders the canonical 11 items in order", async ({
   // Scoped to the level the panel is showing: the DESTINATIONS are its rows,
   // while the foot's Settings door rides the same `.navitem` geometry without
   // being one of them.
-  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(11);
+  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(12);
   const labels = await page
     .locator("nav.rail .navlevel a.navitem")
     .evaluateAll((links) =>
@@ -179,6 +184,7 @@ test("AC-shell-1: the rail renders the canonical 11 items in order", async ({
     "Duplikate",
     "Filter & Ansichten",
     "Pipeline",
+    "Projekte",
     "Aufgaben",
     "Freigaben",
     "Berichte",
@@ -268,7 +274,7 @@ test("AC-shell-7: the top bar's search opens the palette", async ({ page }) => {
   ).toBeVisible();
   // And it is not a destination of its own — the links AC-shell-1 counts are
   // unchanged by search leaving the sidebar.
-  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(11);
+  await expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(12);
 });
 
 // The account menu carries what belongs to the PERSON rather than to the page:


### PR DESCRIPTION
## What broke

`main`'s **`uat (AC screens + axe WCAG 2.2 AA + 390px, mocked)`** lane is red. Two failures, one cause:

```
e2e/ac.spec.ts:168  AC-shell-1: the rail renders the canonical 11 items in order
e2e/ac.spec.ts:271  AC-shell-7: the top bar's search opens the palette
    expect(page.locator("nav.rail .navlevel a.navitem")).toHaveCount(11)
    Received: 12
```

#2310 (`8caa2c98e`, "projects have a list, a page and a place in the product") added a twelfth destination to `frontend/src/app/nav.ts`:

```ts
{ screen: "projects", labelKey: "nav.projects", icon: Briefcase },
```

and updated `rail.test.tsx` but not `frontend/e2e/ac.spec.ts`. The rail is twelve; its acceptance spec expects eleven.

Same reason CI did not catch it as #2300's: the PR was green against the `main` of its time, and `refs/pull/N/merge` only met the other half later. This lane is also **not a required check**, so three PRs merged straight past a red one.

## The fix, and two things it deliberately does not do

**Not a bare 11 → 12.** AC-shell-1 also asserts the ordered `aria-label`s a person reads, so incrementing the count alone would have moved the failure to the label array. `"Projekte"` takes its place between `"Pipeline"` and `"Aufgaben"` — where `NAV_GROUPS` puts it in the work group.

**Not derived from `nav.ts`.** The tempting fitness-function move is wrong here, and the file now says so. `nav.ts` *is* the rail's source: a spec derived from it would assert only that the rail renders itself, and would have accepted #2310 silently rather than failing. The literal list is the point — an acceptance criterion about what a person reads, not a second copy of the data. (Contrast #2307, where deriving was right precisely because the map restated what the fixture already knew.)

**The prose was further behind than the code.** The comment above the test said "The canonical ten" over an assertion of eleven, and the title said eleven. All three now say twelve.

## Verification

Measured before and after, locally, against a real build:

| | Result |
|---|---|
| `origin/main`'s spec, `-g "canonical\|palette"` | **2 failed** — both `Received: 12`, at 168 and 271 |
| With this change, full `e2e/ac.spec.ts` | **86 passed** (19.1s) |

Also `biome check` clean and `tsc -b` exit 0 on the changed file.

One note for whoever reads the local lane: `make fe-uat` is the change-scoped **Storybook** render lane and reports `fe-uat OK — diff touches no component/story (empty scope)` for a diff like this one. It is not the AC-screens lane and its green says nothing about this failure — `pnpm exec playwright test e2e/ac.spec.ts` is what actually runs these.

Found by an hourly main-status watch; reported independently by two parallel sessions, neither of whose branches touched navigation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the UAT failures by updating the rail acceptance spec to expect 12 destinations and include Projects. Previously the spec expected 11; now it asserts “Projekte” between “Pipeline” and “Aufgaben” to match the current rail.

- Updates AC-shell-1 and AC-shell-7 to count 12 items and verifies the explicit ordered labels, including “Projekte”.
- Keeps the spec literal (not derived from `src/app/nav.ts`) to assert what a person reads; updates comments and test title to “canonical twelve”.
- No runtime changes; only the e2e spec is updated.

<sup>Written for commit 01fe45570b022558ff4d1f734297d2fc256634d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated acceptance tests to reflect the rail’s 12 canonical destinations.
  * Added “Projekte” to the expected destination list.
  * Updated search palette validation for the revised rail count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->