### PR TITLE
feat(dealrooms): a contact's page lists the rooms they can still enter, with Revoke

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11116,6 +11116,12 @@ paths:
         - name: state
           in: query
           schema: { $ref: '#/components/schemas/DealRoomState' }
+        - name: participant_email
+          in: query
+          schema: { type: string, format: email }
+          description: >-
+            Only rooms this address may currently enter — a live, non-revoked seat.
+            The admin's path to "which rooms is this departed contact still in".
       responses:
         '200':
           description: A page of Deal Rooms.

--- a/backend/internal/compose/integration/dealroom_by_participant_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_by_participant_integration_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+// "Which rooms is this contact still in" is answered by address: a live seat
+// counts, a revoked one does not, and a stranger's address finds nothing.
+func TestRoomsAreListedByTheAddressThatHoldsASeat(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	room := openPublishedRoom(t, e)
+
+	byEmail := func(email string) int {
+		var page apptest.AnyMap
+		if status := e.Call(t, "GET", "/v1/deal-rooms?participant_email="+url.QueryEscape(email), nil, nil, &page); status != http.StatusOK {
+			t.Fatalf("list by %s = %d %v", email, status, page)
+		}
+		rooms, _ := page["data"].([]any)
+		return len(rooms)
+	}
+	if got := byEmail(room.email); got != 1 {
+		t.Fatalf("rooms for the invited buyer = %d, want 1", got)
+	}
+	if got := byEmail("Laura@Buyer.Example"); got != 1 {
+		t.Fatalf("rooms for the same address in another case = %d, want 1", got)
+	}
+	if got := byEmail("nobody@buyer.example"); got != 0 {
+		t.Fatalf("rooms for a stranger = %d, want 0", got)
+	}
+
+	var roster apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/participants", nil, nil, &roster); status != http.StatusOK {
+		t.Fatalf("roster = %d", status)
+	}
+	seats, _ := roster["data"].([]any)
+	seat, _ := seats[0].(map[string]any)
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+room.roomID+"/participants/"+seat["id"].(string)+"/revoke", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
+		t.Fatalf("revoke = %d", status)
+	}
+	if got := byEmail(room.email); got != 0 {
+		t.Fatalf("rooms after revoke = %d, want 0", got)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24477,6 +24477,9 @@ type ListDealRoomsParams struct {
 	// DealId Only the room belonging to this deal.
 	DealId *openapi_types.UUID `form:"deal_id,omitempty" json:"deal_id,omitempty"`
 	State  *DealRoomState      `form:"state,omitempty" json:"state,omitempty"`
+
+	// ParticipantEmail Only rooms this address may currently enter — a live, non-revoked seat. The admin's path to "which rooms is this departed contact still in".
+	ParticipantEmail *openapi_types.Email `form:"participant_email,omitempty" json:"participant_email,omitempty"`
 }
 
 // CreateDealRoomParams defines parameters for CreateDealRoom.
@@ -45459,6 +45462,19 @@ func (siw *ServerInterfaceWrapper) ListDealRooms(w http.ResponseWriter, r *http.
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "state"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "state", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "participant_email" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "participant_email", r.URL.Query(), &params.ParticipantEmail, runtime.BindQueryParameterOptions{Type: "string", Format: "email"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "participant_email"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "participant_email", Err: err})
 		}
 		return
 	}

--- a/backend/internal/modules/dealrooms/mapping.go
+++ b/backend/internal/modules/dealrooms/mapping.go
@@ -181,6 +181,10 @@ func listInput(params crmcontracts.ListDealRoomsParams) ListRoomsInput {
 		s := string(*params.State)
 		in.State = &s
 	}
+	if params.ParticipantEmail != nil {
+		email := strings.ToLower(strings.TrimSpace(string(*params.ParticipantEmail)))
+		in.ParticipantEmail = &email
+	}
 	return in
 }
 

--- a/backend/internal/modules/dealrooms/room_list.go
+++ b/backend/internal/modules/dealrooms/room_list.go
@@ -20,11 +20,14 @@ import (
 
 // ListRoomsInput narrows a page of rooms.
 type ListRoomsInput struct {
-	DealID          *ids.DealID
-	State           *string
-	IncludeArchived bool
-	Limit           *int
-	Cursor          *string
+	DealID *ids.DealID
+	State  *string
+	// ParticipantEmail narrows to rooms this address holds a live seat in.
+	// Lowercased by the mapping, like every address this module compares.
+	ParticipantEmail *string
+	IncludeArchived  bool
+	Limit            *int
+	Cursor           *string
 }
 
 // ListRooms pages the Deal Rooms whose deals the caller can see.
@@ -61,6 +64,12 @@ func roomPage(ctx context.Context, tx pgx.Tx, in ListRoomsInput) ([]crmcontracts
 	}
 	if in.State != nil {
 		where = append(where, storekit.SQLf("r.state = $%d", arg(*in.State)))
+	}
+	if in.ParticipantEmail != nil {
+		where = append(where, storekit.SQLf(
+			`EXISTS (SELECT 1 FROM deal_room_participant p
+			          WHERE p.room_id = r.id AND p.email = $%d AND p.revoked_at IS NULL AND NOT p.preview)`,
+			arg(*in.ParticipantEmail)))
 	}
 	if in.Cursor != nil && *in.Cursor != "" {
 		decoded, err := storekit.DecodeCursor(*in.Cursor)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -34163,6 +34163,8 @@ export interface operations {
                 /** @description Only the room belonging to this deal. */
                 deal_id?: string;
                 state?: components["schemas"]["DealRoomState"];
+                /** @description Only rooms this address may currently enter — a live, non-revoked seat. The admin's path to "which rooms is this departed contact still in". */
+                participant_email?: string;
             };
             header?: never;
             path?: never;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -905,6 +905,12 @@ export const de = {
   "access.revokeBody":
     "Die Sitzung endet sofort und der Link funktioniert nicht mehr. Kommentare bleiben sichtbar und zugeordnet. Der Zugang lässt sich nicht durch eine Link-Anfrage wiederherstellen.",
   "access.changeCapabilityTitle": "Was darf {name} tun?",
+  "persondealrooms.title": "Deal Rooms",
+  "persondealrooms.sub": "Räume, die dieser Kontakt noch betreten kann.",
+  "persondealrooms.open": "Öffnen",
+  "persondealrooms.seatGone":
+    "Diese Adresse hat in dem Raum keinen Platz mehr.",
+  "persondealrooms.revokeTitle": "Zugang zu {room} entziehen?",
   "room.state.draft": "Entwurf",
   "room.state.building": "Wird erstellt",
   "room.state.ready": "Bereit",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -942,6 +942,12 @@ export const en = {
   "access.revokeBody":
     "Their session ends now and their link stops working. Their comments stay visible and attributed. Access cannot be restored by them asking for a link.",
   "access.changeCapabilityTitle": "What may {name} do?",
+  "persondealrooms.title": "Deal Rooms",
+  "persondealrooms.sub": "Rooms this contact can still enter.",
+  "persondealrooms.open": "Open",
+  "persondealrooms.seatGone":
+    "This address no longer holds a seat in that room.",
+  "persondealrooms.revokeTitle": "Revoke access to {room}?",
   "room.state.draft": "Draft",
   "room.state.building": "Building",
   "room.state.ready": "Ready",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -23,6 +23,7 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // The product name of the buyer surface, and a title that is only the
   // deal's own name in a placeholder.
   "room.card.title",
+  "persondealrooms.title",
   "room.create.defaultTitle",
   // Pure punctuation layouts: every word in them is a placeholder, so there is
   // nothing to translate and a "translation" could only reorder the slots.

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -890,6 +890,11 @@ export const vi = {
   "access.revokeBody":
     "Phiên của họ kết thúc ngay và liên kết ngừng hoạt động. Bình luận của họ vẫn hiển thị và ghi tên. Không thể khôi phục bằng cách xin liên kết.",
   "access.changeCapabilityTitle": "{name} được làm gì?",
+  "persondealrooms.title": "Deal Room",
+  "persondealrooms.sub": "Các phòng liên hệ này vẫn có thể vào.",
+  "persondealrooms.open": "Mở",
+  "persondealrooms.seatGone": "Địa chỉ này không còn chỗ trong phòng đó.",
+  "persondealrooms.revokeTitle": "Thu hồi quyền vào {room}?",
   "room.state.draft": "Bản nháp",
   "room.state.building": "Đang dựng",
   "room.state.ready": "Sẵn sàng",

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -50,6 +50,7 @@ import {
   WhoKnowsThem,
 } from "./person360";
 import { EnrichedFields } from "./personcorrections";
+import { PersonDealRooms } from "./persondealrooms";
 import { PersonGraphPanel } from "./persongraph";
 import {
   createdColumn,
@@ -297,10 +298,14 @@ function PersonAside({
   if (!view) {
     return undefined;
   }
+  const email =
+    view.person.emails?.find((e) => e.is_primary)?.email ??
+    view.person.emails?.[0]?.email;
   return (
     <>
       <RelationshipPulse view={view} />
       <WhoKnowsThem view={view} />
+      {email ? <PersonDealRooms email={email} /> : null}
     </>
   );
 }

--- a/frontend/src/screens/persondealrooms.tsx
+++ b/frontend/src/screens/persondealrooms.tsx
@@ -1,0 +1,152 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { DoorOpen, UserX } from "lucide-react";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
+import { navigate } from "../app/router";
+import { Badge, Button } from "../design-system/atoms";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Panel, PanelRow } from "../design-system/panel";
+import { useT } from "../i18n";
+import { problemMessageOf, QueryStates, throwProblem } from "./common";
+import { STATE_LABELS } from "./dealroom";
+import { participantsKey } from "./dealroomaccess";
+
+// The rooms a contact can still enter, on the contact's own page. An admin
+// removing "Max, who left the buyer" knows the person, not the deals — the
+// room page's Revoke is reachable only from a deal, so this is the path that
+// starts from the name. Each row revokes through the same verb the room page
+// uses, so there is one way to end a seat and it lives in one place.
+
+type DealRoom = components["schemas"]["DealRoom"];
+
+export function PersonDealRooms({ email }: Readonly<{ email: string }>) {
+  const t = useT();
+  const rooms = useQuery({
+    queryKey: ["deal-rooms-of", email],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/deal-rooms", {
+        params: { query: { participant_email: email, limit: 50 } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+  const list = rooms.data?.data ?? [];
+  if (rooms.isSuccess && list.length === 0) {
+    return null;
+  }
+  return (
+    <Panel title={t("persondealrooms.title")} sub={t("persondealrooms.sub")}>
+      <QueryStates query={rooms} pendingLines={2}>
+        {list.map((room) => (
+          <RoomRow key={room.id} room={room} email={email} />
+        ))}
+      </QueryStates>
+    </Panel>
+  );
+}
+
+function RoomRow({ room, email }: Readonly<{ room: DealRoom; email: string }>) {
+  const t = useT();
+  const mayManage = useCanWrite("deal_room", "update");
+  const [confirming, setConfirming] = useState(false);
+  return (
+    <PanelRow className="person-room-row">
+      <div>
+        <p>{room.title}</p>
+        <p className="t-small">{t(STATE_LABELS[room.state])}</p>
+      </div>
+      <div className="card-actions">
+        <Button
+          small
+          variant="ghost"
+          onClick={() =>
+            navigate({ screen: "deals", id: room.deal_id, id2: "room" })
+          }
+        >
+          <DoorOpen aria-hidden />
+          {t("persondealrooms.open")}
+        </Button>
+        {mayManage ? (
+          <Button small variant="ghost" onClick={() => setConfirming(true)}>
+            <UserX aria-hidden />
+            {t("access.revoke")}
+          </Button>
+        ) : null}
+      </div>
+      <RevokeSeat
+        room={room}
+        email={email}
+        open={confirming}
+        onClose={() => setConfirming(false)}
+      />
+    </PanelRow>
+  );
+}
+
+// Revoking from the person's side: find the seat by address in the room's
+// roster, then the same revoke the room page performs.
+function RevokeSeat({
+  room,
+  email,
+  open,
+  onClose,
+}: Readonly<{
+  room: DealRoom;
+  email: string;
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const revoke = useMutation({
+    mutationFn: async (input: { roomId: string; email: string }) => {
+      const roster = await api.GET("/deal-rooms/{id}/participants", {
+        params: { path: { id: input.roomId } },
+      });
+      if (roster.error) {
+        throwProblem(roster.error, t);
+      }
+      const seat = (roster.data?.data ?? []).find(
+        (p) =>
+          p.email.toLowerCase() === input.email.toLowerCase() && !p.revoked_at,
+      );
+      if (!seat) {
+        throw new Error(t("persondealrooms.seatGone"));
+      }
+      const { error } = await api.POST(
+        "/deal-rooms/{id}/participants/{participantId}/revoke",
+        { params: { path: { id: input.roomId, participantId: seat.id } } },
+      );
+      if (error) {
+        throwProblem(error, t);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["deal-rooms-of", email] });
+      queryClient.invalidateQueries({ queryKey: participantsKey(room.id) });
+      onClose();
+    },
+  });
+  return (
+    <ConfirmModal
+      open={open}
+      onClose={onClose}
+      title={t("persondealrooms.revokeTitle", { room: room.title })}
+      confirmLabel={t("access.revoke")}
+      confirmVariant="danger"
+      pending={revoke.isPending}
+      error={revoke.isError ? problemMessageOf(revoke.error, t) : null}
+      onConfirm={() => revoke.mutate({ roomId: room.id, email })}
+    >
+      <p>
+        {email} <Badge>{t(STATE_LABELS[room.state])}</Badge>
+      </p>
+      <p className="t-small">{t("access.revokeBody")}</p>
+    </ConfirmModal>
+  );
+}


### PR DESCRIPTION
## What changes

An admin removing a departed buyer contact knows the person, not the deals. The contact's page now carries a **Deal Rooms** card: every room where this address holds a live seat, each with **Open** (the room page) and **Revoke access** (the room page's own verb, found by address in the roster).

- `GET /deal-rooms?participant_email=` — rooms with a live, non-revoked, non-preview seat for the address (lowercased).
- `frontend/src/screens/persondealrooms.tsx`, rendered in the person aside when the contact has an email; absent when they are in no room.

## Gates

`make check-backend`, `make check-fe`, craft-static green. Integration: `dealroom_by_participant_integration_test.go` (live seat found, case-insensitive, stranger finds nothing, revoked seat drops out).

Plan: rev 5, PR 6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Deal Rooms panel to a contact’s page listing rooms the contact can still enter, with Open and Revoke. Adds a `participant_email` filter to `GET /deal-rooms` to return rooms where that address holds a live, non-revoked, non-preview seat; previously the API could not answer this and revoking was only from a room page.

- Backend: extends OpenAPI with `participant_email`; `ListDealRoomsParams` and mapping lower-case the email; SQL filters via participants table; integration test verifies case-insensitive matching and that revoked seats disappear.
- Frontend: new `PersonDealRooms` panel in the person aside when an email exists; lists rooms with state, Open navigates to the room; Revoke finds the seat by email in the roster and calls the existing revoke endpoint; invalidates `["deal-rooms-of", email]` and `participantsKey(room.id)` queries; adds i18n strings in `en`, `de`, and `vi`.

<sup>Written for commit eb5cd1f92aa7c9431fce0f670d2241b799ab9dbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

