### PR TITLE
fix(frontend): the contact's rooms are looked up on every address

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -923,6 +923,8 @@ export const de = {
   "persondealrooms.open": "Öffnen",
   "persondealrooms.seatGone":
     "Diese Adresse hat in dem Raum keinen Platz mehr.",
+  "persondealrooms.cut":
+    "Nur die ersten Räume werden gezeigt; dieser Kontakt sitzt in weiteren.",
   "persondealrooms.revokeTitle": "Zugang zu {room} entziehen?",
   "room.state.draft": "Entwurf",
   "room.state.building": "Wird erstellt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -960,6 +960,8 @@ export const en = {
   "persondealrooms.open": "Open",
   "persondealrooms.seatGone":
     "This address no longer holds a seat in that room.",
+  "persondealrooms.cut":
+    "Only the first rooms are shown; this contact sits in more.",
   "persondealrooms.revokeTitle": "Revoke access to {room}?",
   "room.state.draft": "Draft",
   "room.state.building": "Building",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -907,6 +907,8 @@ export const vi = {
   "persondealrooms.sub": "Các phòng liên hệ này vẫn có thể vào.",
   "persondealrooms.open": "Mở",
   "persondealrooms.seatGone": "Địa chỉ này không còn chỗ trong phòng đó.",
+  "persondealrooms.cut":
+    "Chỉ hiện các phòng đầu tiên; liên hệ này còn ở trong các phòng khác.",
   "persondealrooms.revokeTitle": "Thu hồi quyền vào {room}?",
   "room.state.draft": "Bản nháp",
   "room.state.building": "Đang dựng",

--- a/frontend/src/screens/dealroomaccess.tsx
+++ b/frontend/src/screens/dealroomaccess.tsx
@@ -54,6 +54,18 @@ export function participantsKey(roomId: string) {
   return ["deal-room-participants", roomId] as const;
 }
 
+// Every read of "who sits where" — the room's roster and the person page's
+// room list — goes stale together when a seat changes.
+export function refreshSeats(
+  queryClient: ReturnType<typeof useQueryClient>,
+  roomId: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: participantsKey(roomId) }),
+    queryClient.invalidateQueries({ queryKey: ["deal-rooms-of"] }),
+  ]);
+}
+
 export function useParticipants(roomId: string) {
   return useQuery({
     queryKey: participantsKey(roomId),
@@ -305,7 +317,7 @@ function InviteDialog({
       return data;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: participantsKey(room.id) });
+      refreshSeats(queryClient, room.id);
       if (data) {
         setIssued(data);
       }
@@ -409,7 +421,7 @@ function ReissueDialog({
       return data;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: participantsKey(room.id) });
+      refreshSeats(queryClient, room.id);
       if (data) {
         setIssued(data);
       }
@@ -466,7 +478,7 @@ function RevokeDialog({
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: participantsKey(room.id) });
+      refreshSeats(queryClient, room.id);
       onClose();
     },
   });
@@ -522,7 +534,7 @@ function CapabilityDialog({
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: participantsKey(room.id) });
+      refreshSeats(queryClient, room.id);
       onClose();
     },
   });

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -303,14 +303,15 @@ function PersonAside({
   if (!view) {
     return undefined;
   }
-  const email =
-    view.person.emails?.find((e) => e.is_primary)?.email ??
-    view.person.emails?.[0]?.email;
+  // Every address the contact has: a seat may have been invited on a
+  // secondary one, and a card that checked only the primary would tell an
+  // admin the contact is out of every room when they are not.
+  const emails = (view.person.emails ?? []).map((e) => e.email);
   return (
     <>
       <RelationshipPulse view={view} />
       <WhoKnowsThem view={view} />
-      {email ? <PersonDealRooms email={email} /> : null}
+      {emails.length > 0 ? <PersonDealRooms emails={emails} /> : null}
     </>
   );
 }

--- a/frontend/src/screens/persondealrooms.tsx
+++ b/frontend/src/screens/persondealrooms.tsx
@@ -21,36 +21,74 @@ import { participantsKey } from "./dealroomaccess";
 
 type DealRoom = components["schemas"]["DealRoom"];
 
-export function PersonDealRooms({ email }: Readonly<{ email: string }>) {
+// The rooms a contact holds a seat in, keyed on the whole address list so a
+// revoke anywhere refreshes it.
+export function roomsOfKey(emails: readonly string[]) {
+  return ["deal-rooms-of", [...emails].sort().join(",")] as const;
+}
+
+// More rooms than any one contact sits in; past this the card says the list
+// is cut rather than pretending it is whole.
+const ROOMS_LIMIT = 50;
+
+export function PersonDealRooms({
+  emails,
+}: Readonly<{ emails: readonly string[] }>) {
   const t = useT();
   const rooms = useQuery({
-    queryKey: ["deal-rooms-of", email],
+    queryKey: roomsOfKey(emails),
     queryFn: async () => {
-      const { data, error } = await api.GET("/deal-rooms", {
-        params: { query: { participant_email: email, limit: 50 } },
-      });
-      if (error) {
-        throwProblem(error);
+      const pages = await Promise.all(
+        emails.map(async (email) => {
+          const { data, error } = await api.GET("/deal-rooms", {
+            params: { query: { participant_email: email, limit: ROOMS_LIMIT } },
+          });
+          if (error) {
+            throwProblem(error);
+          }
+          return {
+            email,
+            rooms: data?.data ?? [],
+            cut: data?.page.has_more ?? false,
+          };
+        }),
+      );
+      // One row per room, even when two of the contact's addresses sit in
+      // it; the first address found is the one the revoke uses.
+      const seen = new Map<string, { room: DealRoom; email: string }>();
+      for (const page of pages) {
+        for (const room of page.rooms) {
+          if (!seen.has(room.id)) {
+            seen.set(room.id, { room, email: page.email });
+          }
+        }
       }
-      return data;
+      return { seats: [...seen.values()], cut: pages.some((p) => p.cut) };
     },
   });
-  const list = rooms.data?.data ?? [];
-  if (rooms.isSuccess && list.length === 0) {
+  const seats = rooms.data?.seats ?? [];
+  if (rooms.isSuccess && seats.length === 0) {
     return null;
   }
   return (
     <Panel title={t("persondealrooms.title")} sub={t("persondealrooms.sub")}>
       <QueryStates query={rooms} pendingLines={2}>
-        {list.map((room) => (
-          <RoomRow key={room.id} room={room} email={email} />
+        {seats.map(({ room, email }) => (
+          <RoomRow key={room.id} room={room} email={email} emails={emails} />
         ))}
+        {rooms.data?.cut ? (
+          <p className="t-small">{t("persondealrooms.cut")}</p>
+        ) : null}
       </QueryStates>
     </Panel>
   );
 }
 
-function RoomRow({ room, email }: Readonly<{ room: DealRoom; email: string }>) {
+function RoomRow({
+  room,
+  email,
+  emails,
+}: Readonly<{ room: DealRoom; email: string; emails: readonly string[] }>) {
   const t = useT();
   const mayManage = useCanWrite("deal_room", "update");
   const [confirming, setConfirming] = useState(false);
@@ -81,6 +119,7 @@ function RoomRow({ room, email }: Readonly<{ room: DealRoom; email: string }>) {
       <RevokeSeat
         room={room}
         email={email}
+        emails={emails}
         open={confirming}
         onClose={() => setConfirming(false)}
       />
@@ -93,11 +132,13 @@ function RoomRow({ room, email }: Readonly<{ room: DealRoom; email: string }>) {
 function RevokeSeat({
   room,
   email,
+  emails,
   open,
   onClose,
 }: Readonly<{
   room: DealRoom;
   email: string;
+  emails: readonly string[];
   open: boolean;
   onClose: () => void;
 }>) {
@@ -127,7 +168,7 @@ function RevokeSeat({
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["deal-rooms-of", email] });
+      queryClient.invalidateQueries({ queryKey: roomsOfKey(emails) });
       queryClient.invalidateQueries({ queryKey: participantsKey(room.id) });
       onClose();
     },


### PR DESCRIPTION
Follow-up to #2327 with the review findings on it: the person page's Deal Rooms card queries every address the contact has (a seat invited on a secondary address was invisible), says when the list is cut at 50, and the room page's invite/revoke/capability writes refresh it. Reviewed as part of #2327's Codex pass; `make check-fe` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows all rooms a contact sits in across every email address and keeps the person page in sync with room changes. Previously the Deal Rooms card checked only the primary address; now it aggregates across all addresses and updates after invite/reissue/revoke/capability changes.

- Person page: `PersonDealRooms` receives all emails, queries rooms for each with limit 50, de-duplicates by room ID, uses the first matching email for revoke, and shows a “list is cut” notice when any page has more. Adds i18n key `persondealrooms.cut` in `en`, `de`, and `vi`.
- Sync behavior: Adds a `refreshSeats` helper that invalidates both the room participants and the “deal-rooms-of” queries; mutations on the room page now call it so the person card refreshes immediately.

<sup>Written for commit 5a3f9a0d5a802af7c7b2bb0db82677e7d3b11873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deal Room listings now include rooms associated with all of a contact’s email addresses.
  - Duplicate rooms are removed, and notices indicate when additional rooms exist beyond those displayed.
  - Added German, English, and Vietnamese translations for the new Deal Room notices.

- **Bug Fixes**
  - Deal Room lists now refresh correctly after inviting, reissuing, revoking access, or updating capabilities.
  - Revoking access refreshes related contact and room information consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->