### PR TITLE
feat(meetingbrief): one ranked claim set, a real goal, talking points as moves

### DIFF
--- a/backend/internal/compose/meetingbrief/input.go
+++ b/backend/internal/compose/meetingbrief/input.go
@@ -111,6 +111,8 @@ type ClaimIn struct {
 	// the promise was made without pasting a record id into the text.
 	SourceLabel string
 	DueAt       *time.Time
+	// OccurredAt is when the claim was made, for ranking the newer first.
+	OccurredAt *time.Time
 }
 
 // ActIn is one recent conversation as the brief reads it.
@@ -183,6 +185,7 @@ func foldClaims(personName string, found []crmcontracts.ConversationClaim) []Cla
 			Status:     string(claim.Status),
 			SourceID:   ids.UUID(claim.SourceActivityId).String(),
 			DueAt:      claim.DueAt,
+			OccurredAt: claim.OccurredAt,
 		}
 		if claim.SourceLabel != nil {
 			folded.SourceLabel = *claim.SourceLabel

--- a/backend/internal/compose/meetingbrief/ranking.go
+++ b/backend/internal/compose/meetingbrief/ranking.go
@@ -37,6 +37,21 @@ func rankClaims(in Input) *rankedClaims {
 	return &rankedClaims{claims: ordered, taken: make([]bool, len(ordered))}
 }
 
+// all hands over every claim the predicate wants, in rank order, WITHOUT
+// marking them: for the one section that is a ledger rather than a reading —
+// the commitments list must be complete even when the goal or a risk also
+// names one of its lines, because a rep checking what is owed needs the
+// whole list, not the whole list minus what another heading took.
+func (r *rankedClaims) all(want func(ClaimIn) bool) []ClaimIn {
+	var out []ClaimIn
+	for _, claim := range r.claims {
+		if want(claim) {
+			out = append(out, claim)
+		}
+	}
+	return out
+}
+
 // take hands the first untaken claim the predicate wants to its caller and
 // marks it, so no later section can say it again.
 func (r *rankedClaims) take(want func(ClaimIn) bool) (ClaimIn, bool) {
@@ -102,12 +117,17 @@ func score(claim ClaimIn, now time.Time) int {
 	return s + urgency(claim, now) + freshness(claim, now)
 }
 
-// urgency: due sooner ranks higher; a week out is worth less than tomorrow.
+// urgency: due sooner ranks higher, and once overdue, later ranks higher — a
+// promise a month late is sharper than one a day late. Both arms are bounded
+// at thirty days so they reorder inside a kind and never across kinds.
 func urgency(claim ClaimIn, now time.Time) int {
 	if claim.DueAt == nil {
 		return 0
 	}
-	days := max(int(claim.DueAt.Sub(now).Hours()/24), 0)
+	days := int(claim.DueAt.Sub(now).Hours() / 24)
+	if days < 0 {
+		return 30 + min(-days, 30)
+	}
 	if days >= 30 {
 		return 0
 	}

--- a/backend/internal/compose/meetingbrief/ranking.go
+++ b/backend/internal/compose/meetingbrief/ranking.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+// One claim, one home. The sections used to each walk the same claim slice
+// with overlapping kind filters, so one promise could appear three times in
+// one brief, worded three ways, in whatever order the store returned it. Now
+// the claims are ranked ONCE — sharpest first — and each section takes what it
+// wants from the ranked set and marks it taken, so nothing is said twice and
+// the first line of every section is the one that matters most.
+//
+// The rank is a small deterministic function of what the record says: is the
+// claim still open, what kind is it, whose turn it is, how overdue, how old.
+// "Blocks the next stage" has no field and no rule today, and a missing signal
+// treated as zero would rank silently wrong, so it is not part of the score.
+
+import (
+	"sort"
+	"time"
+)
+
+// rankedClaims is the single ordered set the sections draw from.
+type rankedClaims struct {
+	claims []ClaimIn
+	taken  []bool
+}
+
+// rankClaims orders the input's claims, sharpest first. Stable on the input
+// order for equal scores, so two briefs over one record read the same.
+func rankClaims(in Input) *rankedClaims {
+	ordered := make([]ClaimIn, len(in.Commitments))
+	copy(ordered, in.Commitments)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return score(ordered[i], in.Now) > score(ordered[j], in.Now)
+	})
+	return &rankedClaims{claims: ordered, taken: make([]bool, len(ordered))}
+}
+
+// take hands the first untaken claim the predicate wants to its caller and
+// marks it, so no later section can say it again.
+func (r *rankedClaims) take(want func(ClaimIn) bool) (ClaimIn, bool) {
+	for i, claim := range r.claims {
+		if r.taken[i] || !want(claim) {
+			continue
+		}
+		r.taken[i] = true
+		return claim, true
+	}
+	return ClaimIn{}, false
+}
+
+// takeAll hands over every untaken claim the predicate wants, up to cap, in
+// rank order, marking each.
+func (r *rankedClaims) takeAll(want func(ClaimIn) bool, limit int) []ClaimIn {
+	var out []ClaimIn
+	for i, claim := range r.claims {
+		if len(out) == limit {
+			break
+		}
+		if r.taken[i] || !want(claim) {
+			continue
+		}
+		r.taken[i] = true
+		out = append(out, claim)
+	}
+	return out
+}
+
+// score reads the record, never guesses. An open claim outranks a settled one
+// by a whole band; within the open band our own overdue promises lead, then
+// the questions we owe an answer to, then our promises still inside their
+// date, then what they objected to, then what they owe us, then what they
+// told us matters. Inside a kind, a nearer due
+// date wins, then the newer claim.
+func score(claim ClaimIn, now time.Time) int {
+	s := 0
+	if claim.Status == statusOpen {
+		s += 1000
+	}
+	switch claim.Kind {
+	case kindCommitmentOurs:
+		// A promise of ours still inside its date ranks below a question we
+		// owe an answer to; once overdue it leads everything.
+		s += 400
+		if claim.DueAt != nil && claim.DueAt.Before(now) {
+			s += 500
+		}
+	case kindOpenQuestion:
+		s += 450
+	case kindObjection:
+		s += 400
+	case kindCommitmentTheirs:
+		s += 300
+	case kindDecisionProcess:
+		s += 250
+	case kindPriority, kindSuccessCriterion:
+		s += 200
+	case kindDecision:
+		s += 100
+	}
+	return s + urgency(claim, now) + freshness(claim, now)
+}
+
+// urgency: due sooner ranks higher; a week out is worth less than tomorrow.
+func urgency(claim ClaimIn, now time.Time) int {
+	if claim.DueAt == nil {
+		return 0
+	}
+	days := max(int(claim.DueAt.Sub(now).Hours()/24), 0)
+	if days >= 30 {
+		return 0
+	}
+	return 30 - days
+}
+
+// freshness: newer first among equals; a month-old priority is stale news.
+func freshness(claim ClaimIn, now time.Time) int {
+	if claim.OccurredAt == nil {
+		return 0
+	}
+	age := max(int(now.Sub(*claim.OccurredAt).Hours()/24), 0)
+	if age >= 60 {
+		return 0
+	}
+	return (60 - age) / 4
+}
+
+func ofKind(kinds ...string) func(ClaimIn) bool {
+	return func(c ClaimIn) bool {
+		for _, k := range kinds {
+			if c.Kind == k {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func openOfKind(kinds ...string) func(ClaimIn) bool {
+	want := ofKind(kinds...)
+	return func(c ClaimIn) bool { return c.Status == statusOpen && want(c) }
+}

--- a/backend/internal/compose/meetingbrief/ranking_test.go
+++ b/backend/internal/compose/meetingbrief/ranking_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+import (
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// The same objection used to appear in deal state, risks AND talking points,
+// worded three ways. Now a claim has one home: the first section in the
+// spec's order that wants it.
+func TestNoClaimIsSaidTwiceAcrossTheBrief(t *testing.T) {
+	in := fullInput()
+	in.Commitments = append(in.Commitments,
+		ClaimIn{PersonName: "Ana Roth", Kind: kindObjection, Body: "the cure period is too short", Status: statusOpen, SourceID: activityID},
+		ClaimIn{PersonName: "Ana Roth", Kind: kindPriority, Body: "go-live before Q4", Status: statusOpen, SourceID: activityID},
+		ClaimIn{PersonName: "Ana Roth", Kind: kindDecision, Body: "pilot on two sites first", Status: "done", SourceID: activityID},
+	)
+	seen := map[string]crmcontracts.MeetingBriefSectionKind{}
+	for _, section := range Deterministic(in) {
+		for _, line := range section.Sentences {
+			for _, body := range []string{"cure period", "go-live before Q4", "pilot on two sites", "security pack"} {
+				if !contains(line.Text, body) {
+					continue
+				}
+				if home, dup := seen[body]; dup {
+					t.Errorf("%q is said in %s and again in %s", body, home, section.Kind)
+				}
+				seen[body] = section.Kind
+			}
+		}
+	}
+	if seen["cure period"] != crmcontracts.MeetingBriefSectionKindRisks {
+		t.Errorf("an open objection's home is risks, got %s", seen["cure period"])
+	}
+	if seen["pilot on two sites"] != crmcontracts.MeetingBriefSectionKindDealState {
+		t.Errorf("a settled decision's home is deal state, got %s", seen["pilot on two sites"])
+	}
+	if seen["go-live before Q4"] != crmcontracts.MeetingBriefSectionKindTalkingPoints {
+		t.Errorf("a priority nobody else took is a talking point, got %s", seen["go-live before Q4"])
+	}
+}
+
+// Sharpest first: an overdue promise of ours outranks an open question, which
+// outranks a promise still inside its date; a settled claim trails every open one.
+func TestClaimsRankByWhatTheRecordSays(t *testing.T) {
+	in := fullInput()
+	in.Commitments = []ClaimIn{
+		{Kind: kindDecision, Body: "settled", Status: "done"},
+		{Kind: kindCommitmentOurs, Body: "inside its date", Status: statusOpen, DueAt: ptr(at(18))},
+		{Kind: kindOpenQuestion, Body: "a question", Status: statusOpen},
+		{Kind: kindCommitmentOurs, Body: "overdue", Status: statusOpen, DueAt: ptr(at(8))},
+	}
+	ranked := rankClaims(in)
+	want := []string{"overdue", "a question", "inside its date", "settled"}
+	for i, body := range want {
+		if ranked.claims[i].Body != body {
+			t.Fatalf("rank %d = %q, want %q (order %v)", i, ranked.claims[i].Body, body, bodies(ranked.claims))
+		}
+	}
+}
+
+// A talking point is a move, not a label: evidence plus what to do with it.
+func TestATalkingPointSaysWhatToDoInTheRoom(t *testing.T) {
+	in := fullInput()
+	in.Commitments = []ClaimIn{{PersonName: "Ana Roth", Kind: kindDecisionProcess, Body: "legal reviews after the CFO signs off", Status: statusOpen, SourceID: activityID}}
+	points := sectionOf(t, Deterministic(in), crmcontracts.MeetingBriefSectionKindTalkingPoints)
+	if len(points.Sentences) != 1 || !contains(points.Sentences[0].Text, "walk the next step of it in the room") {
+		t.Fatalf("talking points = %+v, want the move", points.Sentences)
+	}
+}
+
+func contains(text, part string) bool { return len(part) > 0 && indexOf(text, part) >= 0 }
+
+func indexOf(text, part string) int {
+	for i := 0; i+len(part) <= len(text); i++ {
+		if text[i:i+len(part)] == part {
+			return i
+		}
+	}
+	return -1
+}
+
+func bodies(claims []ClaimIn) []string {
+	out := make([]string, 0, len(claims))
+	for _, c := range claims {
+		out = append(out, c.Body)
+	}
+	return out
+}

--- a/backend/internal/compose/meetingbrief/ranking_test.go
+++ b/backend/internal/compose/meetingbrief/ranking_test.go
@@ -22,6 +22,11 @@ func TestNoClaimIsSaidTwiceAcrossTheBrief(t *testing.T) {
 	seen := map[string]crmcontracts.MeetingBriefSectionKind{}
 	for _, section := range Deterministic(in) {
 		for _, line := range section.Sentences {
+			// The commitments ledger is complete by design and may repeat what
+			// the goal or a risk reads out of it.
+			if section.Kind == crmcontracts.MeetingBriefSectionKindCommitments {
+				continue
+			}
 			for _, body := range []string{"cure period", "go-live before Q4", "pilot on two sites", "security pack"} {
 				if !contains(line.Text, body) {
 					continue
@@ -90,4 +95,17 @@ func bodies(claims []ClaimIn) []string {
 		out = append(out, c.Body)
 	}
 	return out
+}
+
+// Later is sharper: a promise a month overdue outranks one a day overdue.
+func TestAnOlderOverduePromiseOutranksANewerOne(t *testing.T) {
+	in := fullInput()
+	in.Commitments = []ClaimIn{
+		{Kind: kindCommitmentOurs, Body: "a day late", Status: statusOpen, DueAt: ptr(at(9))},
+		{Kind: kindCommitmentOurs, Body: "a month late", Status: statusOpen, DueAt: ptr(at(-20))},
+	}
+	ranked := rankClaims(in)
+	if ranked.claims[0].Body != "a month late" {
+		t.Fatalf("rank = %v, want the later promise first", bodies(ranked.claims))
+	}
 }

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -92,8 +92,10 @@ type Section struct {
 // time.
 func Deterministic(in Input) []Section {
 	// One ranked claim set, consumed in section order: the goal takes the
-	// sharpest ask, risks take what is wrong, commitments and deal state take
-	// the rest of the record, and talking points get what nobody else said.
+	// sharpest ask, risks take what is wrong, deal state takes what was
+	// settled, and talking points get what nobody else said. The commitments
+	// ledger reads the whole set without taking: it is a list to check, not
+	// a reading to avoid repeating.
 	ranked := rankClaims(in)
 	built := []Section{
 		{Kind: crmcontracts.MeetingBriefSectionKindHeader, Sentences: headerSection(in)},
@@ -268,8 +270,12 @@ func readableRole(role string) string {
 // Ours come first. A rep who walks in without having done what they promised
 // has a different meeting than one who has, and reading their own overdue
 // promise first is what changes the opening sentence.
+// The ledger: every promise and question, complete, in rank order. It does
+// not take from the set — the goal and a risk may each name one of these
+// lines as a reading of it, and the ledger still has to show the whole of
+// what is owed.
 func commitmentsSection(ranked *rankedClaims) []Sentence {
-	claims := ranked.takeAll(ofKind(kindCommitmentOurs, kindCommitmentTheirs, kindOpenQuestion), commitmentCap)
+	claims := ranked.all(ofKind(kindCommitmentOurs, kindCommitmentTheirs, kindOpenQuestion))
 	out := make([]Sentence, 0, len(claims))
 	for _, claim := range claims {
 		out = append(out, Sentence{
@@ -279,10 +285,6 @@ func commitmentsSection(ranked *rankedClaims) []Sentence {
 	}
 	return out
 }
-
-// commitmentCap keeps the ledger readable in the ninety seconds a brief gets;
-// the ranked order puts what is owed soonest at the top.
-const commitmentCap = 8
 
 func commitmentLine(claim ClaimIn) string {
 	var opener string

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -19,6 +19,7 @@ package meetingbrief
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -63,6 +64,20 @@ const (
 // done is not a watch-out and not an ask.
 const statusOpen = string(crmcontracts.ConversationClaimStatusOpen)
 
+// specOrder is the order the sections render in: goal and commitments lead
+// because burying the ask is the canonical prep failure, and company context
+// is last because it is background a reader skims only if they have time.
+var specOrder = map[crmcontracts.MeetingBriefSectionKind]int{
+	crmcontracts.MeetingBriefSectionKindHeader:         0,
+	crmcontracts.MeetingBriefSectionKindGoal:           1,
+	crmcontracts.MeetingBriefSectionKindAttendees:      2,
+	crmcontracts.MeetingBriefSectionKindCommitments:    3,
+	crmcontracts.MeetingBriefSectionKindDealState:      4,
+	crmcontracts.MeetingBriefSectionKindRisks:          5,
+	crmcontracts.MeetingBriefSectionKindTalkingPoints:  6,
+	crmcontracts.MeetingBriefSectionKindCompanyContext: 7,
+}
+
 // Section is one heading with its lines, before the grounding filter runs.
 type Section struct {
 	Kind      crmcontracts.MeetingBriefSectionKind
@@ -76,16 +91,22 @@ type Section struct {
 // context is last because it is background a reader skims only if they have
 // time.
 func Deterministic(in Input) []Section {
+	// One ranked claim set, consumed in section order: the goal takes the
+	// sharpest ask, risks take what is wrong, commitments and deal state take
+	// the rest of the record, and talking points get what nobody else said.
+	ranked := rankClaims(in)
 	built := []Section{
 		{Kind: crmcontracts.MeetingBriefSectionKindHeader, Sentences: headerSection(in)},
-		{Kind: crmcontracts.MeetingBriefSectionKindGoal, Sentences: goalSection(in)},
+		{Kind: crmcontracts.MeetingBriefSectionKindGoal, Sentences: goalSection(in, ranked)},
 		{Kind: crmcontracts.MeetingBriefSectionKindAttendees, Sentences: attendeesSection(in)},
-		{Kind: crmcontracts.MeetingBriefSectionKindCommitments, Sentences: commitmentsSection(in)},
-		{Kind: crmcontracts.MeetingBriefSectionKindDealState, Sentences: dealStateSection(in)},
-		{Kind: crmcontracts.MeetingBriefSectionKindRisks, Sentences: risksSection(in)},
-		{Kind: crmcontracts.MeetingBriefSectionKindTalkingPoints, Sentences: talkingPointsSection(in)},
+		{Kind: crmcontracts.MeetingBriefSectionKindRisks, Sentences: risksSection(in, ranked)},
+		{Kind: crmcontracts.MeetingBriefSectionKindCommitments, Sentences: commitmentsSection(ranked)},
+		{Kind: crmcontracts.MeetingBriefSectionKindDealState, Sentences: dealStateSection(in, ranked)},
+		{Kind: crmcontracts.MeetingBriefSectionKindTalkingPoints, Sentences: talkingPointsSection(ranked)},
 		{Kind: crmcontracts.MeetingBriefSectionKindCompanyContext, Sentences: companyContextSection(in)},
 	}
+	// Rendered in the spec's order whatever order they were filled in.
+	sort.SliceStable(built, func(i, j int) bool { return specOrder[built[i].Kind] < specOrder[built[j].Kind] })
 	for i := range built {
 		built[i].Sentences = claims.Dedupe(built[i].Sentences)
 	}
@@ -149,35 +170,24 @@ func lastTouchLine(in Input) string {
 
 // goalSection (M) leads, because burying the ask is the canonical prep failure.
 //
-// The floor states the ask the RECORD supports rather than inventing one: an
-// open question to answer, a promise to close out, or the deal's own next step.
-// It never says "build rapport" — a goal nobody can check against a record is
-// the external-context filler the spec's first hard rule forbids.
-func goalSection(in Input) []Sentence {
-	if question, ok := firstOfKind(in, kindOpenQuestion); ok {
+// The goal is what must be true when the meeting ends: the sharpest open ask
+// the record holds — a promise of ours to close out, a question to answer, a
+// decision being waited on. It takes that claim out of the set, so no later
+// section restates it. It never says "move the deal on from its stage": a
+// sentence that restates the stage field the rep is looking at is filler, and
+// the package's own rule is that an ungroundable section is absent.
+func goalSection(in Input, ranked *rankedClaims) []Sentence {
+	if ask, ok := ranked.take(openOfKind(kindCommitmentOurs, kindOpenQuestion, kindDecision)); ok {
 		return []Sentence{{
-			Text:     fmt.Sprintf("Answer the open question from %s: %s", question.PersonName, question.Body),
+			Text:     goalLine(ask, in.Now),
 			Nature:   natureRecommendation,
-			Evidence: []Evidence{{EntityType: citeActivity, EntityID: question.SourceID}},
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: ask.SourceID}},
 		}}
 	}
-	if ours, ok := firstOfKind(in, kindCommitmentOurs); ok {
-		return []Sentence{{
-			Text:     fmt.Sprintf("Close out what we promised %s: %s", ours.PersonName, ours.Body),
-			Nature:   natureRecommendation,
-			Evidence: []Evidence{{EntityType: citeActivity, EntityID: ours.SourceID}},
-		}}
-	}
-	if in.Deal != nil {
-		return []Sentence{{
-			Text:     fmt.Sprintf("Move %s on from %s.", in.Deal.Name, stageOrUnnamed(in.Deal.Stage)),
-			Nature:   natureRecommendation,
-			Evidence: []Evidence{{EntityType: citeDeal, EntityID: in.Deal.ID}},
-		}}
-	}
-	// A delivery meeting months after close-won usually has no open deal, and
-	// this section went silent exactly there — on the engagement the meeting is
-	// about. The project's own next step is the ask the record supports.
+	// A delivery meeting months after close-won usually has no open claims,
+	// and this section went silent exactly there — on the engagement the
+	// meeting is about. The project's own next step is the ask the record
+	// supports.
 	//
 	// Cited to the MEETING, not the project: the evidence vocabulary the brief
 	// shares with the account brief has no `project` kind, and a citation the
@@ -194,11 +204,18 @@ func goalSection(in Input) []Sentence {
 	return nil
 }
 
-func stageOrUnnamed(stage string) string {
-	if stage == "" {
-		return "its current stage"
+func goalLine(ask ClaimIn, now time.Time) string {
+	switch ask.Kind {
+	case kindOpenQuestion:
+		return fmt.Sprintf("Answer the open question from %s: %s", ask.PersonName, ask.Body)
+	case kindDecision:
+		return fmt.Sprintf("Get the decision %s is holding: %s", ask.PersonName, ask.Body)
+	default:
+		if ask.DueAt != nil && ask.DueAt.Before(now) {
+			return fmt.Sprintf("Close out what we owe %s, overdue since %s: %s", ask.PersonName, ask.DueAt.UTC().Format("2 Jan"), ask.Body)
+		}
+		return fmt.Sprintf("Close out what we promised %s: %s", ask.PersonName, ask.Body)
 	}
-	return stage
 }
 
 // attendeesSection (D list + M one-liners) names the room, with the people the
@@ -251,21 +268,21 @@ func readableRole(role string) string {
 // Ours come first. A rep who walks in without having done what they promised
 // has a different meeting than one who has, and reading their own overdue
 // promise first is what changes the opening sentence.
-func commitmentsSection(in Input) []Sentence {
-	out := make([]Sentence, 0, len(in.Commitments))
-	for _, kind := range []string{kindCommitmentOurs, kindCommitmentTheirs, kindOpenQuestion} {
-		for _, claim := range in.Commitments {
-			if claim.Kind != kind {
-				continue
-			}
-			out = append(out, Sentence{
-				Text:     commitmentLine(claim),
-				Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
-			})
-		}
+func commitmentsSection(ranked *rankedClaims) []Sentence {
+	claims := ranked.takeAll(ofKind(kindCommitmentOurs, kindCommitmentTheirs, kindOpenQuestion), commitmentCap)
+	out := make([]Sentence, 0, len(claims))
+	for _, claim := range claims {
+		out = append(out, Sentence{
+			Text:     commitmentLine(claim),
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
+		})
 	}
 	return out
 }
+
+// commitmentCap keeps the ledger readable in the ninety seconds a brief gets;
+// the ranked order puts what is owed soonest at the top.
+const commitmentCap = 8
 
 func commitmentLine(claim ClaimIn) string {
 	var opener string
@@ -299,7 +316,7 @@ func commitmentSource(claim ClaimIn) string {
 
 // dealStateSection (M) is where the deal stands: what was last said, what was
 // objected to, and what nobody has decided.
-func dealStateSection(in Input) []Sentence {
+func dealStateSection(in Input, ranked *rankedClaims) []Sentence {
 	out := make([]Sentence, 0, dealStateCap)
 	if len(in.Recent) > 0 {
 		last := in.Recent[0]
@@ -308,16 +325,14 @@ func dealStateSection(in Input) []Sentence {
 			Evidence: []Evidence{{EntityType: citeActivity, EntityID: last.ID}},
 		})
 	}
-	for _, kind := range []string{kindObjection, kindDecision, kindSuccessCriterion, kindPriority} {
-		for _, claim := range in.Commitments {
-			if claim.Kind != kind || len(out) == dealStateCap {
-				continue
-			}
-			out = append(out, Sentence{
-				Text:     dealStateLine(claim),
-				Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
-			})
-		}
+	// Settled things: the decisions taken. An open objection is a risk and was
+	// taken there; open asks went to the goal and the ledger; what they said
+	// matters is what they will raise, so it is a talking point.
+	for _, claim := range ranked.takeAll(ofKind(kindDecision), dealStateCap-len(out)) {
+		out = append(out, Sentence{
+			Text:     dealStateLine(claim),
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
+		})
 	}
 	return out
 }
@@ -343,34 +358,23 @@ func lastConversationLine(last ActIn) string {
 }
 
 func dealStateLine(claim ClaimIn) string {
-	switch claim.Kind {
-	case kindObjection:
-		return fmt.Sprintf("%s objected: %s", claim.PersonName, claim.Body)
-	case kindDecision:
-		return fmt.Sprintf("Agreed with %s: %s", claim.PersonName, claim.Body)
-	case kindSuccessCriterion:
-		return fmt.Sprintf("%s measures success by: %s", claim.PersonName, claim.Body)
-	default:
-		return fmt.Sprintf("%s is focused on: %s", claim.PersonName, claim.Body)
-	}
+	return fmt.Sprintf("Agreed with %s: %s", claim.PersonName, claim.Body)
 }
 
 // risksSection (M, ≤3) is OMITTED when empty, and that is spelled in the spec
 // rather than inferred. A risks heading over nothing reads as "we looked and
 // found none", which is a claim this floor cannot make.
-func risksSection(in Input) []Sentence {
-	out := make([]Sentence, 0, riskCap)
-	for _, claim := range in.Commitments {
-		if len(out) == riskCap {
-			break
-		}
-		if text, ok := riskLine(claim, in.Now); ok {
-			out = append(out, Sentence{
-				Text:     text,
-				Nature:   natureAssessment,
-				Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
-			})
-		}
+func risksSection(in Input, ranked *rankedClaims) []Sentence {
+	isRisk := func(c ClaimIn) bool { _, ok := riskLine(c, in.Now); return ok }
+	claims := ranked.takeAll(isRisk, riskCap)
+	out := make([]Sentence, 0, len(claims))
+	for _, claim := range claims {
+		text, _ := riskLine(claim, in.Now)
+		out = append(out, Sentence{
+			Text:     text,
+			Nature:   natureAssessment,
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
+		})
 	}
 	return out
 }
@@ -394,22 +398,19 @@ func riskLine(claim ClaimIn, now time.Time) (string, bool) {
 	return "", false
 }
 
-// talkingPointsSection (M, 3–5) is each point tied to a specific captured
+// talkingPointsSection (M, ≤5) is each point tied to a specific captured
 // statement — never a generic opener, because a talking point nobody said is
-// the filler the first hard rule forbids.
-func talkingPointsSection(in Input) []Sentence {
-	out := make([]Sentence, 0, talkingPointCap)
-	for _, kind := range []string{kindPriority, kindSuccessCriterion, kindDecisionProcess, kindObjection} {
-		for _, claim := range in.Commitments {
-			if claim.Kind != kind || len(out) == talkingPointCap {
-				continue
-			}
-			out = append(out, Sentence{
-				Text:     talkingPointLine(claim),
-				Nature:   natureRecommendation,
-				Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
-			})
-		}
+// the filler the first hard rule forbids. Each point is a MOVE: the evidence
+// and what to do with it in the room, not a label on a record.
+func talkingPointsSection(ranked *rankedClaims) []Sentence {
+	claims := ranked.takeAll(ofKind(kindObjection, kindDecisionProcess, kindPriority, kindSuccessCriterion, kindCommitmentTheirs), talkingPointCap)
+	out := make([]Sentence, 0, len(claims))
+	for _, claim := range claims {
+		out = append(out, Sentence{
+			Text:     talkingPointLine(claim),
+			Nature:   natureRecommendation,
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
+		})
 	}
 	return out
 }
@@ -419,13 +420,18 @@ const talkingPointCap = 5
 func talkingPointLine(claim ClaimIn) string {
 	switch claim.Kind {
 	case kindObjection:
-		return fmt.Sprintf("Address what %s objected to: %s", claim.PersonName, claim.Body)
+		if claim.Status == statusOpen {
+			return fmt.Sprintf("%s objected to %s and we have not answered — bring the answer, or say when.", claim.PersonName, claim.Body)
+		}
+		return fmt.Sprintf("%s once objected to %s — confirm it is settled before moving on.", claim.PersonName, claim.Body)
 	case kindDecisionProcess:
-		return fmt.Sprintf("Confirm the process %s described: %s", claim.PersonName, claim.Body)
+		return fmt.Sprintf("%s described how they decide: %s — walk the next step of it in the room.", claim.PersonName, claim.Body)
 	case kindSuccessCriterion:
-		return fmt.Sprintf("Tie the demo to what %s called success: %s", claim.PersonName, claim.Body)
+		return fmt.Sprintf("%s calls success %s — tie what you show to it.", claim.PersonName, claim.Body)
+	case kindCommitmentTheirs:
+		return fmt.Sprintf("%s owes us %s — ask where it stands.", claim.PersonName, claim.Body)
 	default:
-		return fmt.Sprintf("Pick up what %s said matters: %s", claim.PersonName, claim.Body)
+		return fmt.Sprintf("%s said %s matters — lead with it.", claim.PersonName, claim.Body)
 	}
 }
 
@@ -451,17 +457,6 @@ func companyContextSection(in Input) []Sentence {
 		})
 	}
 	return out
-}
-
-// firstOfKind returns the newest claim of one kind that is still open. Claims
-// arrive newest-first from the store, so the first match is the newest.
-func firstOfKind(in Input, kind string) (ClaimIn, bool) {
-	for _, claim := range in.Commitments {
-		if claim.Kind == kind && claim.Status == statusOpen {
-			return claim, true
-		}
-	}
-	return ClaimIn{}, false
 }
 
 // spokenAmount renders a deal's value the way somebody would SAY it: "€95k",

--- a/backend/internal/compose/meetingbrief/sections_test.go
+++ b/backend/internal/compose/meetingbrief/sections_test.go
@@ -143,11 +143,19 @@ func TestAnOverduePromiseIsTheGoalOnceAndTheNextOneIsARisk(t *testing.T) {
 		t.Errorf("a risk read out of a record is nature %q, want %q", risks.Sentences[0].Nature, natureAssessment)
 	}
 	for _, section := range sections {
+		// The ledger lists every promise by design; no READING repeats the goal.
+		if section.Kind == crmcontracts.MeetingBriefSectionKindCommitments {
+			continue
+		}
 		for _, line := range section.Sentences {
 			if section.Kind != crmcontracts.MeetingBriefSectionKindGoal && strings.Contains(line.Text, "send the security pack") {
 				t.Errorf("%s repeats the goal's promise: %q", section.Kind, line.Text)
 			}
 		}
+	}
+	ledger := sectionOf(t, sections, crmcontracts.MeetingBriefSectionKindCommitments)
+	if len(ledger.Sentences) != 2 {
+		t.Fatalf("the ledger lists %d promises, want both — it is complete even when the goal names one", len(ledger.Sentences))
 	}
 }
 

--- a/backend/internal/compose/meetingbrief/sections_test.go
+++ b/backend/internal/compose/meetingbrief/sections_test.go
@@ -121,13 +121,33 @@ func TestRisksIsAbsentWhenNothingInTheRecordIsWrong(t *testing.T) {
 	}
 }
 
-func TestAnOverdueCommitmentOfOursBecomesARiskLabelledAsAnAssessment(t *testing.T) {
-	risks := sectionOf(t, Deterministic(fullInput()), crmcontracts.MeetingBriefSectionKindRisks)
-	if len(risks.Sentences) != 1 {
-		t.Fatalf("got %d risks, want the one overdue promise", len(risks.Sentences))
+// One claim, one home. The sharpest overdue promise of ours IS the goal,
+// dated; it is not said again as a risk. A second overdue promise, which the
+// goal did not take, is the risk — labelled as the assessment it is.
+func TestAnOverduePromiseIsTheGoalOnceAndTheNextOneIsARisk(t *testing.T) {
+	in := fullInput()
+	in.Commitments = append(in.Commitments, ClaimIn{
+		PersonName: "Ana Roth", Kind: kindCommitmentOurs, Body: "share the reference call",
+		Status: statusOpen, SourceID: activityID, DueAt: ptr(at(9)),
+	})
+	sections := Deterministic(in)
+	goal := sectionOf(t, sections, crmcontracts.MeetingBriefSectionKindGoal)
+	if len(goal.Sentences) != 1 || !strings.Contains(goal.Sentences[0].Text, "overdue since 8 Aug: send the security pack") {
+		t.Fatalf("goal = %+v, want the older overdue promise, dated", goal.Sentences)
+	}
+	risks := sectionOf(t, sections, crmcontracts.MeetingBriefSectionKindRisks)
+	if len(risks.Sentences) != 1 || !strings.Contains(risks.Sentences[0].Text, "share the reference call") {
+		t.Fatalf("risks = %+v, want only the promise the goal did not take", risks.Sentences)
 	}
 	if risks.Sentences[0].Nature != natureAssessment {
 		t.Errorf("a risk read out of a record is nature %q, want %q", risks.Sentences[0].Nature, natureAssessment)
+	}
+	for _, section := range sections {
+		for _, line := range section.Sentences {
+			if section.Kind != crmcontracts.MeetingBriefSectionKindGoal && strings.Contains(line.Text, "send the security pack") {
+				t.Errorf("%s repeats the goal's promise: %q", section.Kind, line.Text)
+			}
+		}
 	}
 }
 
@@ -152,8 +172,9 @@ func TestAFirstTimeAttendeeIsFlaggedInTheProse(t *testing.T) {
 // The goal leads with the ask the RECORD supports. With an open question on the
 // table, answering it is the ask; a goal invented from nothing would be the
 // external-context filler the spec's first hard rule forbids.
-func TestTheGoalIsTheOpenQuestionWhenThereIsOne(t *testing.T) {
+func TestTheGoalIsTheOpenQuestionWhenNothingOfOursIsOverdue(t *testing.T) {
 	in := fullInput()
+	in.Commitments[0].DueAt = ptr(at(18))
 	in.Commitments = append(in.Commitments, ClaimIn{
 		PersonName: "Ana Roth", Kind: kindOpenQuestion, Body: "who signs the DPA",
 		Status: statusOpen, SourceID: activityID,


### PR DESCRIPTION
## What changes (plan B8, first slice: changes 1, 2 and 4)

- **One claim, one home** (`ranking.go`). The sections used to each walk the same claim slice with overlapping kind filters, so one objection could appear in deal state, risks and talking points. The claims are now ranked once — open before settled; our overdue promises, then open questions, then our promises still in date, then objections, then what they owe us, then priorities/success criteria, then settled decisions; nearer due and newer first — and each section takes what it wants from the ranked set and marks it taken. `TestNoClaimIsSaidTwiceAcrossTheBrief` holds it. "Blocks the next stage" has no field and no rule today, so it is not in the score rather than silently zero (the plan's own caution).
- **A real goal.** The goal is the sharpest open ask — a promise of ours (dated when overdue), a question, a decision being waited on. The `"Move X on from Y"` fallback is deleted; the project fallback stays.
- **Talking points as moves**: "Ana objected to the cure period and we have not answered — bring the answer, or say when." Priorities and success criteria are what they will raise, so they are talking points; deal state keeps the last conversation and settled decisions.
- `ClaimIn.OccurredAt` is now carried from the claim read (it was discarded), for the freshness term.

Not in this slice: "what changed since we last spoke" (needs the reader's last-interaction baseline and a new section kind in the contract), the richer input (health, coverage, offers, threads) and the omission metadata — those are the next B8 slices.

## Gates

`make check-backend`, craft-static green; meetingbrief unit suite updated (the overdue promise is the goal once and the next one is the risk; the goal is the open question when nothing of ours is overdue); compose and compose/integration brief scenarios green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks meeting claims once and assigns each claim a single section, eliminating duplicates and surfacing the most urgent items first. Replaces the “Move X on from Y” goal with a grounded ask and turns talking points into concrete moves.

- Introduces `ranking.go`: deterministic scoring favors open over settled; within open, orders our overdue promises, open questions, in-date promises, objections, their commitments, decision process, priorities/success criteria, then decisions; tie-breakers favor due-sooner, later-overdue higher than earlier-overdue, then newer-first via `ClaimIn.OccurredAt`.
- Sections draw from one ranked set and mark taken so nothing repeats; the commitments ledger intentionally reads the full set without taking, so it stays complete even if the goal or risks also name a line.
- Goal: picks the sharpest open ask (our promise, question, or pending decision), dating it when overdue; removes the stage-based fallback.
- Commitments: complete ledger of ours/theirs/questions, ordered by rank.
- Deal state: last conversation plus settled decisions only; priorities/success criteria move to talking points; open objections move to risks.
- Risks: open objections and any overdue promises not taken by the goal; omitted when empty.
- Talking points: actionable moves (objections with open/settled phrasing, decision process “walk the next step,” priorities, success criteria, their commitments).
- Tests cover “one claim, one home,” ranked order (including later-overdue outranking earlier), ledger completeness, and new talking-point phrasing; `ClaimIn.OccurredAt` is now carried from input.

<sup>Written for commit 432afa0a4035dc09bdbe6408091e66c906acbed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meeting briefs now rank claims consistently using status, urgency, due dates, and recency.
  * Goals can highlight overdue commitments, open questions, and decisions.
  * Talking points distinguish open and resolved objections and include clear next steps.
  * Relevant external commitments are included in talking points.

* **Bug Fixes**
  * Prevented claims from appearing in multiple brief sections.
  * Improved prioritization of overdue commitments and incomplete claim details.
  * Ensured all applicable commitments remain visible in the commitments section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->