### PR TITLE
fix(frontend): the next-meeting card reads the deal's meetings itself and skips a withheld one

### DIFF
--- a/frontend/src/screens/dealmeeting.stories.tsx
+++ b/frontend/src/screens/dealmeeting.stories.tsx
@@ -30,8 +30,13 @@ const BOOKED = {
 } as Activity;
 
 function Served({ children }: Readonly<{ children: ReactNode }>) {
+  const client = new QueryClient();
+  client.setQueryData(["deal-meetings", "deal-1"], {
+    data: [BOOKED],
+    page: {},
+  });
   return (
-    <QueryClientProvider client={new QueryClient()}>
+    <QueryClientProvider client={client}>
       <LocaleProvider initial="en">{children}</LocaleProvider>
     </QueryClientProvider>
   );
@@ -41,7 +46,7 @@ function Served({ children }: Readonly<{ children: ReactNode }>) {
 export const Booked: Story = {
   render: () => (
     <Served>
-      <DealNextMeeting activities={[BOOKED]} />
+      <DealNextMeeting dealId="deal-1" />
     </Served>
   ),
 };

--- a/frontend/src/screens/dealmeeting.test.tsx
+++ b/frontend/src/screens/dealmeeting.test.tsx
@@ -1,9 +1,14 @@
 /** @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { DealNextMeeting, nextBookedMeeting } from "./dealmeeting";
@@ -11,7 +16,10 @@ import { DealNextMeeting, nextBookedMeeting } from "./dealmeeting";
 // The card shows the nearest booked meeting still ahead and nothing else; a
 // held or cancelled one, or one in the past, is not "next".
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 type Activity = components["schemas"]["Activity"];
 
@@ -34,7 +42,11 @@ function meeting(
 
 const render = (ui: ReactNode) =>
   rtlRender(
-    <QueryClientProvider client={new QueryClient()}>
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
       <LocaleProvider initial="en">{ui}</LocaleProvider>
     </QueryClientProvider>,
   );
@@ -53,18 +65,43 @@ it("picks the nearest booked meeting ahead", () => {
   expect(next?.id).toBe("near");
 });
 
-it("renders nothing when no meeting is booked", () => {
-  const { container } = render(
-    <DealNextMeeting activities={[meeting("past", "2020-01-01T09:00:00Z")]} />,
-  );
-  expect(container).toBeEmptyDOMElement();
+it("leaves out a withheld meeting, whose brief would not open", () => {
+  const now = new Date("2026-08-23T09:00:00Z");
+  const withheld = {
+    ...meeting("secret", "2026-08-24T09:00:00Z", "booked"),
+    content_state: "withheld",
+  } as Activity;
+  expect(nextBookedMeeting([withheld], now)).toBeNull();
 });
 
-it("offers the brief for the next meeting", () => {
-  render(
-    <DealNextMeeting activities={[meeting("soon", "2999-01-01T09:00:00Z")]} />,
-  );
-  expect(screen.getByText("Meeting soon")).toBeInTheDocument();
+function stubMeetings(rows: Activity[]) {
+  vi.stubGlobal("fetch", (input: Request) => {
+    const url = new URL(input.url);
+    if (
+      url.pathname.endsWith("/activities") &&
+      url.searchParams.get("kind") === "meeting"
+    ) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: rows, page: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+it("renders nothing when no meeting is booked", async () => {
+  stubMeetings([meeting("past", "2020-01-01T09:00:00Z")]);
+  const { container } = render(<DealNextMeeting dealId="deal-1" />);
+  await waitFor(() => expect(container).toBeEmptyDOMElement());
+});
+
+it("offers the brief for the next meeting", async () => {
+  stubMeetings([meeting("soon", "2999-01-01T09:00:00Z")]);
+  render(<DealNextMeeting dealId="deal-1" />);
+  expect(await screen.findByText("Meeting soon")).toBeInTheDocument();
   expect(
     screen.getByRole("button", { name: "Open the brief" }),
   ).toBeInTheDocument();

--- a/frontend/src/screens/dealmeeting.tsx
+++ b/frontend/src/screens/dealmeeting.tsx
@@ -1,19 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
 import { CalendarClock, Sparkles } from "lucide-react";
 import { useState } from "react";
+import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { formatDateTime } from "../format/format";
 import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
+import { throwProblem } from "./common";
 import { PersonMeetingBrief } from "./persondrawers";
 import "./dealmeeting.css";
 
 // The deal's next booked meeting, with the brief one click away. The brief is
 // the thing a rep opens in the ninety seconds before a room; burying it behind
 // the person page, where it used to live alone, is how it went unopened. The
-// meeting comes from the timeline the page already reads — no second query —
-// and the drawer is the person page's own, so one brief renders everywhere.
+// card reads the deal's meetings itself: the page's timeline is filtered and
+// paged by the reader, and a card that went blank because they searched for
+// an email would read as "no meeting". The drawer is the person page's own,
+// so one brief renders everywhere.
 
 type Activity = components["schemas"]["Activity"];
 
@@ -27,6 +32,11 @@ export function nextBookedMeeting(
     if (a.kind !== "meeting" || new Date(a.occurred_at) <= now) {
       continue;
     }
+    // A meeting the reader may know of but not open has no brief to offer;
+    // the button would 404.
+    if (a.content_state === "withheld") {
+      continue;
+    }
     if (a.meeting_status && a.meeting_status !== "booked") {
       continue;
     }
@@ -37,13 +47,34 @@ export function nextBookedMeeting(
   return best;
 }
 
-export function DealNextMeeting({
-  activities,
-}: Readonly<{ activities: readonly Activity[] }>) {
+// The timeline is ordered newest first, so the window holds the furthest
+// scheduled rows first; this many is beyond any deal's booked horizon.
+const MEETING_WINDOW = 50;
+
+export function DealNextMeeting({ dealId }: Readonly<{ dealId: string }>) {
   const t = useT();
   const { locale } = useLocale();
   const [open, setOpen] = useState(false);
-  const meeting = nextBookedMeeting(activities, new Date());
+  const meetings = useQuery({
+    queryKey: ["deal-meetings", dealId],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/activities", {
+        params: {
+          query: {
+            entity_type: "deal",
+            entity_id: dealId,
+            kind: "meeting",
+            limit: MEETING_WINDOW,
+          },
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+  const meeting = nextBookedMeeting(meetings.data?.data ?? [], new Date());
   if (!meeting) {
     return null;
   }

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -91,16 +91,11 @@ import { DealNextAction } from "./dealnextaction";
 function DealAside({
   dealId,
   dealName,
-  activities,
-}: Readonly<{
-  dealId: string;
-  dealName: string;
-  activities: readonly Activity[];
-}>) {
+}: Readonly<{ dealId: string; dealName: string }>) {
   return (
     <>
       <DealNextAction dealId={dealId} />
-      <DealNextMeeting activities={activities} />
+      <DealNextMeeting dealId={dealId} />
       <DealBriefCard dealId={dealId} />
       <DealHealthCard dealId={dealId} />
       <DealRoomAside dealId={dealId} dealName={dealName} />
@@ -144,7 +139,6 @@ import { groupChronology } from "./timelinegroups";
 // across currencies).
 
 type Deal = components["schemas"]["Deal"];
-type Activity = components["schemas"]["Activity"];
 type Organization = components["schemas"]["Organization"];
 type Stage = components["schemas"]["Stage"];
 type Pipeline = components["schemas"]["Pipeline"];
@@ -3353,11 +3347,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
               )}
               aside={
                 overlay ? undefined : (
-                  <DealAside
-                    dealId={id}
-                    dealName={deal.name}
-                    activities={timelineQuery.activities}
-                  />
+                  <DealAside dealId={id} dealName={deal.name} />
                 )
               }
               asideLabel={t("nba.title")}


### PR DESCRIPTION
Follow-up to #2335 carrying its Codex findings (the fix commit was refused by the pre-commit hook at the time and the PR merged without it): the card queries `GET /activities?entity_type=deal&kind=meeting` itself instead of reading the page's filtered, paged timeline, and a withheld meeting — whose brief would 404 — is never offered. `make check-fe` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Next Meeting card now fetches a deal’s meetings itself and skips withheld meetings. Previously it read the page timeline, which could be filtered/paged and show misleading “no meeting,” and could surface a withheld meeting that 404’d when opening the brief.

- Component API change: DealNextMeeting now requires dealId; replace the activities prop with dealId at call sites.
- Fetches via GET /activities with entity_type=deal, kind=meeting, limit=50; cache key is ["deal-meetings", dealId] in `@tanstack/react-query`.
- Only shows the nearest future meeting with meeting_status=booked and content_state!=withheld; renders nothing otherwise.
- Tests and Storybook updated to stub/fill the new query path and disable retries in tests.

<sup>Written for commit 4738a15bc1893a5f59906e6a5096be6c79f534b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting details now load automatically for each deal.
  * Withheld meetings are excluded from the next-meeting display.
  * Meeting cards support empty results and brief availability states.

* **Bug Fixes**
  * Improved handling of meeting data and API errors when loading deal activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->