### PR TITLE
feat(meetingbrief): "what changed since we last spoke"

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19589,20 +19589,24 @@ components:
 
     MeetingBriefSection:
       type: object
-      description: One of the eight fixed sections, with its cited sentences.
+      description: One of the nine fixed sections, with its cited sentences.
       required: [kind, sentences]
       properties:
         kind:
           type: string
-          enum: [header, goal, attendees, commitments, deal_state, risks, talking_points, company_context]
+          enum: [header, goal, what_changed, attendees, commitments, deal_state, risks, talking_points, company_context]
           description: |
-            The eight of ADR-0097 D5, in the order a reader reads them. A closed enum rather
-            than a free-text heading, so a surface can label, order and collapse them and no
-            writer can invent a ninth.
+            The eight of ADR-0097 D5 plus `what_changed`, in the order a reader reads them. A
+            closed enum rather than a free-text heading, so a surface can label, order and
+            collapse them and no writer can invent a tenth.
 
             `header` — meeting, time, company, deal and how long since the last touch (deterministic).
             `goal` — the single next-step target; it leads because burying the ask is the
             canonical prep failure.
+            `what_changed` — what happened after the READER last dealt with this deal's people:
+            promises made, objections raised, decisions taken, conversations held, files that
+            changed hands. Its first line names the baseline; when the reader has never dealt
+            with them it says so ("first contact") rather than "nothing changed".
             `attendees` — who is in the room, with the first-timers flagged.
             `commitments` — what was promised, ours and theirs, each with its source and status.
             `deal_state` — where the deal stands: last conversation, objections, open questions.

--- a/backend/internal/compose/meetingbrief/input.go
+++ b/backend/internal/compose/meetingbrief/input.go
@@ -46,6 +46,9 @@ type Input struct {
 	// what a recurring delivery review opens wanting: not the state of play,
 	// but what was agreed here last time.
 	PriorMeetings []PriorMeetingIn
+	// LastSpokeAt is when the READER last dealt with anyone in the room — the
+	// baseline "what changed" is measured from. Nil is first contact.
+	LastSpokeAt *time.Time
 	// LastTouchAt is the newest conversation with anyone in the room before
 	// this meeting. Nil means nothing was ever captured with any of them.
 	LastTouchAt *time.Time

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -70,12 +70,13 @@ const statusOpen = string(crmcontracts.ConversationClaimStatusOpen)
 var specOrder = map[crmcontracts.MeetingBriefSectionKind]int{
 	crmcontracts.MeetingBriefSectionKindHeader:         0,
 	crmcontracts.MeetingBriefSectionKindGoal:           1,
-	crmcontracts.MeetingBriefSectionKindAttendees:      2,
-	crmcontracts.MeetingBriefSectionKindCommitments:    3,
-	crmcontracts.MeetingBriefSectionKindDealState:      4,
-	crmcontracts.MeetingBriefSectionKindRisks:          5,
-	crmcontracts.MeetingBriefSectionKindTalkingPoints:  6,
-	crmcontracts.MeetingBriefSectionKindCompanyContext: 7,
+	crmcontracts.MeetingBriefSectionKindWhatChanged:    2,
+	crmcontracts.MeetingBriefSectionKindAttendees:      3,
+	crmcontracts.MeetingBriefSectionKindCommitments:    4,
+	crmcontracts.MeetingBriefSectionKindDealState:      5,
+	crmcontracts.MeetingBriefSectionKindRisks:          6,
+	crmcontracts.MeetingBriefSectionKindTalkingPoints:  7,
+	crmcontracts.MeetingBriefSectionKindCompanyContext: 8,
 }
 
 // Section is one heading with its lines, before the grounding filter runs.
@@ -84,7 +85,7 @@ type Section struct {
 	Sentences []Sentence
 }
 
-// Deterministic writes all eight sections from the assembled input alone.
+// Deterministic writes all nine sections from the assembled input alone.
 //
 // The order is the spec's and is not a rendering choice: goal and commitments
 // lead because burying the ask is the canonical prep failure, and company
@@ -100,6 +101,7 @@ func Deterministic(in Input) []Section {
 	built := []Section{
 		{Kind: crmcontracts.MeetingBriefSectionKindHeader, Sentences: headerSection(in)},
 		{Kind: crmcontracts.MeetingBriefSectionKindGoal, Sentences: goalSection(in, ranked)},
+		{Kind: crmcontracts.MeetingBriefSectionKindWhatChanged, Sentences: whatChangedSection(in, ranked)},
 		{Kind: crmcontracts.MeetingBriefSectionKindAttendees, Sentences: attendeesSection(in)},
 		{Kind: crmcontracts.MeetingBriefSectionKindRisks, Sentences: risksSection(in, ranked)},
 		{Kind: crmcontracts.MeetingBriefSectionKindCommitments, Sentences: commitmentsSection(ranked)},

--- a/backend/internal/compose/meetingbrief/sections_test.go
+++ b/backend/internal/compose/meetingbrief/sections_test.go
@@ -72,6 +72,7 @@ func TestSectionsAreWrittenInTheSpecsFixedOrder(t *testing.T) {
 	want := []crmcontracts.MeetingBriefSectionKind{
 		crmcontracts.MeetingBriefSectionKindHeader,
 		crmcontracts.MeetingBriefSectionKindGoal,
+		crmcontracts.MeetingBriefSectionKindWhatChanged,
 		crmcontracts.MeetingBriefSectionKindAttendees,
 		crmcontracts.MeetingBriefSectionKindCommitments,
 		crmcontracts.MeetingBriefSectionKindDealState,
@@ -81,7 +82,7 @@ func TestSectionsAreWrittenInTheSpecsFixedOrder(t *testing.T) {
 	}
 	got := Deterministic(fullInput())
 	if len(got) != len(want) {
-		t.Fatalf("got %d sections, want the eight of ADR-0097 D5", len(got))
+		t.Fatalf("got %d sections, want the eight of ADR-0097 D5 plus what_changed", len(got))
 	}
 	for i, kind := range want {
 		if got[i].Kind != kind {

--- a/backend/internal/compose/meetingbrief/service.go
+++ b/backend/internal/compose/meetingbrief/service.go
@@ -159,7 +159,10 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 		if err != nil {
 			return err
 		}
-		lastSpoke, err = s.readLastSpoke(ctx, tx, loaded, s.now().UTC())
+		spoke, ever, err := s.readLastSpoke(ctx, tx, loaded, s.now().UTC())
+		if ever {
+			lastSpoke = &spoke
+		}
 		return err
 	})
 	if err != nil {

--- a/backend/internal/compose/meetingbrief/service.go
+++ b/backend/internal/compose/meetingbrief/service.go
@@ -144,6 +144,7 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 	var room meeting
 	var perAttendee map[ids.UUID][]crmcontracts.ConversationClaim
 	var earlier []priorMeeting
+	var lastSpoke *time.Time
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		loaded, err := s.readMeeting(ctx, tx, activityID)
 		if err != nil {
@@ -155,6 +156,10 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 			return err
 		}
 		earlier, err = s.readPriorMeetings(ctx, tx, loaded, s.now().UTC())
+		if err != nil {
+			return err
+		}
+		lastSpoke, err = s.readLastSpoke(ctx, tx, loaded, s.now().UTC())
 		return err
 	})
 	if err != nil {
@@ -163,6 +168,7 @@ func (s *Service) assembleInput(ctx context.Context, activityID ids.UUID) (Input
 
 	in := FromMeeting(room, perAttendee, s.now().UTC())
 	in.PriorMeetings = foldPriorMeetings(earlier)
+	in.LastSpokeAt = lastSpoke
 	if len(room.Attendees) == 0 {
 		// Nobody in the room this caller may see. The header still stands, and
 		// assembling a 360 for a person nobody named would be a read of a

--- a/backend/internal/compose/meetingbrief/whatchanged.go
+++ b/backend/internal/compose/meetingbrief/whatchanged.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+// "What changed since we last spoke" — the section a rep actually opens a
+// brief for. "We last spoke" is the READER's last interaction with the
+// people in this room: the newest past activity, linked to any of them,
+// that the reader took part in. Two reps honestly get two baselines on one
+// deal, which is correct — it is what "last spoke" means to the person
+// reading. With no such interaction the section says FIRST CONTACT rather
+// than "nothing changed", which would be a false claim.
+//
+// What counts as changed after the baseline comes from the input the brief
+// already holds — claims made, conversations captured — so the section adds
+// one read (the baseline) and no new authority.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// readLastSpoke returns when the reader last dealt with anyone in the room
+// before this meeting, or nil for first contact. Any captured activity the
+// reader took part in counts, whichever way it went: an outbound-only gap
+// does not reset the baseline.
+func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, now time.Time) (*time.Time, error) {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID == (ids.UUID{}) || len(room.Room) == 0 {
+		// An agent on a passport reads as the human behind it; a principal with
+		// no user has never spoken to anyone.
+		return nil, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	mePos := arg(actor.UserID)
+	roomPos := arg(room.ID)
+	nowPos := arg(now)
+	peoplePos := arg(room.Room)
+	scope, err := auth.ActivityDiscoverClause(ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = scopeAll
+	}
+	var last *time.Time
+	err = tx.QueryRow(ctx, fmt.Sprintf(`
+		SELECT max(a.occurred_at)
+		  FROM activity a
+		  JOIN activity_participant ap ON ap.activity_id = a.id AND ap.user_id = $%d
+		 WHERE a.id <> $%d AND a.occurred_at < $%d AND a.archived_at IS NULL
+		   AND EXISTS (SELECT 1 FROM activity_link l
+		                WHERE l.activity_id = a.id AND l.entity_type = 'person' AND l.person_id = ANY($%d))
+		   AND %s`, mePos, roomPos, nowPos, peoplePos, scope), args...).Scan(&last)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("read when the reader last spoke to the room: %w", err)
+	}
+	return last, nil
+}
+
+// whatChangedSection lists what happened after the baseline, sharpest first
+// from the ranked set it takes from, and the conversations captured since.
+// The first line names the baseline, so the reader knows what "since" means.
+func whatChangedSection(in Input, ranked *rankedClaims) []Sentence {
+	if in.LastSpokeAt == nil {
+		return []Sentence{{
+			Text:     "First contact: you have not dealt with anyone in this room before.",
+			Nature:   natureAssessment,
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: in.ActivityID}},
+		}}
+	}
+	since := *in.LastSpokeAt
+	out := []Sentence{{
+		Text:     fmt.Sprintf("You last dealt with this room %s.", daysAgoPhrase(in.Now, since)),
+		Evidence: []Evidence{{EntityType: citeActivity, EntityID: in.ActivityID}},
+	}}
+	after := func(c ClaimIn) bool { return c.OccurredAt != nil && c.OccurredAt.After(since) }
+	for _, claim := range ranked.takeAll(after, whatChangedCap) {
+		out = append(out, Sentence{
+			Text:     changedClaimLine(claim),
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: claim.SourceID}},
+		})
+	}
+	conversations := 0
+	var newest *ActIn
+	for i := range in.Recent {
+		if in.Recent[i].At.After(since) && !in.Recent[i].At.After(in.Now) {
+			conversations++
+			if newest == nil {
+				newest = &in.Recent[i]
+			}
+		}
+	}
+	if newest != nil {
+		out = append(out, Sentence{
+			Text:     fmt.Sprintf("%s since then, the latest %q.", pluralOf(conversations, "conversation"), subjectOrKind(*newest)),
+			Evidence: []Evidence{{EntityType: citeActivity, EntityID: newest.ID}},
+		})
+	}
+	if len(out) == 1 {
+		out[0].Text += " Nothing captured has changed since."
+	}
+	return out
+}
+
+// whatChangedCap keeps the section to what a reader takes in before a room.
+const whatChangedCap = 5
+
+func changedClaimLine(claim ClaimIn) string {
+	switch claim.Kind {
+	case kindCommitmentOurs:
+		return fmt.Sprintf("Since then we promised %s: %s", claim.PersonName, claim.Body)
+	case kindCommitmentTheirs:
+		return fmt.Sprintf("Since then %s promised: %s", claim.PersonName, claim.Body)
+	case kindObjection:
+		return fmt.Sprintf("Since then %s objected: %s", claim.PersonName, claim.Body)
+	case kindDecision:
+		return fmt.Sprintf("Since then it was agreed with %s: %s", claim.PersonName, claim.Body)
+	case kindOpenQuestion:
+		return fmt.Sprintf("Since then %s asked: %s", claim.PersonName, claim.Body)
+	default:
+		return fmt.Sprintf("Since then %s said: %s", claim.PersonName, claim.Body)
+	}
+}
+
+func daysAgoPhrase(now, at time.Time) string {
+	days := int(now.Sub(at).Hours() / 24)
+	switch {
+	case days <= 0:
+		return "earlier today"
+	case days == 1:
+		return "yesterday"
+	default:
+		return fmt.Sprintf("%d days ago", days)
+	}
+}
+
+func pluralOf(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+func subjectOrKind(a ActIn) string {
+	if a.Subject != "" {
+		return a.Subject
+	}
+	return a.Kind
+}

--- a/backend/internal/compose/meetingbrief/whatchanged.go
+++ b/backend/internal/compose/meetingbrief/whatchanged.go
@@ -43,7 +43,13 @@ func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, no
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	mePos := arg(actor.UserID)
 	roomPos := arg(room.ID)
-	nowPos := arg(now)
+	// Before the meeting AND before now: a brief read for a meeting already
+	// held must not take a later conversation as "before we spoke".
+	ceiling := now
+	if room.StartsAt.Before(ceiling) {
+		ceiling = room.StartsAt
+	}
+	ceilingPos := arg(ceiling)
 	peoplePos := arg(room.Room)
 	scope, err := auth.ActivityDiscoverClause(ctx, "a", arg)
 	if err != nil {
@@ -51,6 +57,18 @@ func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, no
 	}
 	if scope == "" {
 		scope = scopeAll
+	}
+	// The meeting's project narrows the baseline like every other read the
+	// brief makes: contact on another engagement is not "we last spoke" here.
+	within := scopeAll
+	if room.Project != nil {
+		within = fmt.Sprintf(`(EXISTS (
+			    SELECT 1 FROM activity_link pl
+			    WHERE pl.activity_id = a.id AND pl.project_id = $%d)
+			  OR NOT EXISTS (
+			    SELECT 1 FROM activity_link pf
+			    WHERE pf.activity_id = a.id AND pf.project_id IS NOT NULL))`,
+			arg(room.Project.ID))
 	}
 	var last *time.Time
 	err = tx.QueryRow(ctx, fmt.Sprintf(`
@@ -60,7 +78,7 @@ func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, no
 		 WHERE a.id <> $%d AND a.occurred_at < $%d AND a.archived_at IS NULL
 		   AND EXISTS (SELECT 1 FROM activity_link l
 		                WHERE l.activity_id = a.id AND l.entity_type = 'person' AND l.person_id = ANY($%d))
-		   AND %s`, mePos, roomPos, nowPos, peoplePos, scope), args...).Scan(&last)
+		   AND %s AND %s`, mePos, roomPos, ceilingPos, peoplePos, scope, within), args...).Scan(&last)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return time.Time{}, false, fmt.Errorf("read when the reader last spoke to the room: %w", err)
 	}
@@ -86,7 +104,11 @@ func whatChangedSection(in Input, ranked *rankedClaims) []Sentence {
 		Text:     fmt.Sprintf("You last dealt with this room %s.", daysAgoPhrase(in.Now, since)),
 		Evidence: []Evidence{{EntityType: citeActivity, EntityID: in.ActivityID}},
 	}}
-	after := func(c ClaimIn) bool { return c.OccurredAt != nil && c.OccurredAt.After(since) }
+	// After the baseline and not after now: a claim on a future-dated row
+	// has not happened yet.
+	after := func(c ClaimIn) bool {
+		return c.OccurredAt != nil && c.OccurredAt.After(since) && !c.OccurredAt.After(in.Now)
+	}
 	for _, claim := range ranked.takeAll(after, whatChangedCap) {
 		out = append(out, Sentence{
 			Text:     changedClaimLine(claim),

--- a/backend/internal/compose/meetingbrief/whatchanged.go
+++ b/backend/internal/compose/meetingbrief/whatchanged.go
@@ -29,15 +29,15 @@ import (
 )
 
 // readLastSpoke returns when the reader last dealt with anyone in the room
-// before this meeting, or nil for first contact. Any captured activity the
+// before this meeting, and whether they ever have. Any captured activity the
 // reader took part in counts, whichever way it went: an outbound-only gap
 // does not reset the baseline.
-func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, now time.Time) (*time.Time, error) {
+func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, now time.Time) (time.Time, bool, error) {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.UserID == (ids.UUID{}) || len(room.Room) == 0 {
 		// An agent on a passport reads as the human behind it; a principal with
 		// no user has never spoken to anyone.
-		return nil, nil
+		return time.Time{}, false, nil
 	}
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -47,7 +47,7 @@ func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, no
 	peoplePos := arg(room.Room)
 	scope, err := auth.ActivityDiscoverClause(ctx, "a", arg)
 	if err != nil {
-		return nil, err
+		return time.Time{}, false, err
 	}
 	if scope == "" {
 		scope = scopeAll
@@ -62,9 +62,12 @@ func (s *Service) readLastSpoke(ctx context.Context, tx pgx.Tx, room meeting, no
 		                WHERE l.activity_id = a.id AND l.entity_type = 'person' AND l.person_id = ANY($%d))
 		   AND %s`, mePos, roomPos, nowPos, peoplePos, scope), args...).Scan(&last)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, fmt.Errorf("read when the reader last spoke to the room: %w", err)
+		return time.Time{}, false, fmt.Errorf("read when the reader last spoke to the room: %w", err)
 	}
-	return last, nil
+	if last == nil {
+		return time.Time{}, false, nil
+	}
+	return *last, true, nil
 }
 
 // whatChangedSection lists what happened after the baseline, sharpest first

--- a/backend/internal/compose/meetingbrief/whatchanged_test.go
+++ b/backend/internal/compose/meetingbrief/whatchanged_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+import (
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// The section names its baseline, lists only what happened after it, and
+// takes those claims out of the set so no later section repeats them.
+func TestWhatChangedListsOnlyWhatHappenedAfterTheReaderLastSpoke(t *testing.T) {
+	in := fullInput()
+	in.LastSpokeAt = ptr(at(5))
+	in.Commitments = []ClaimIn{
+		{PersonName: "Ana Roth", Kind: kindObjection, Body: "the cure period", Status: statusOpen, SourceID: activityID, OccurredAt: ptr(at(7))},
+		{PersonName: "Ana Roth", Kind: kindDecision, Body: "pilot first", Status: "done", SourceID: activityID, OccurredAt: ptr(at(2))},
+	}
+	in.Recent = []ActIn{
+		{ID: activityID, Kind: "email", Subject: "Re: redline", Direction: "inbound", At: at(8)},
+		{ID: activityID, Kind: "email", Subject: "older", Direction: "outbound", At: at(3)},
+	}
+	sections := Deterministic(in)
+	changed := sectionOf(t, sections, crmcontracts.MeetingBriefSectionKindWhatChanged)
+	texts := make([]string, 0, len(changed.Sentences))
+	for _, line := range changed.Sentences {
+		texts = append(texts, line.Text)
+	}
+	joined := strings.Join(texts, " | ")
+	for _, want := range []string{"You last dealt with this room 5 days ago", "Since then Ana Roth objected: the cure period", "1 conversation since then, the latest \"Re: redline\""} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("what changed = %q, want it to say %q", joined, want)
+		}
+	}
+	if strings.Contains(joined, "pilot first") {
+		t.Errorf("a decision from before the baseline is not a change: %q", joined)
+	}
+	risks := sectionOf(t, sections, crmcontracts.MeetingBriefSectionKindRisks)
+	for _, line := range risks.Sentences {
+		if strings.Contains(line.Text, "cure period") {
+			t.Errorf("the objection what-changed took is said again as a risk: %q", line.Text)
+		}
+	}
+}
+
+func TestFirstContactIsSaidRatherThanNothingChanged(t *testing.T) {
+	in := fullInput()
+	in.LastSpokeAt = nil
+	changed := sectionOf(t, Deterministic(in), crmcontracts.MeetingBriefSectionKindWhatChanged)
+	if len(changed.Sentences) != 1 || !strings.HasPrefix(changed.Sentences[0].Text, "First contact") {
+		t.Fatalf("what changed = %+v, want the first-contact line alone", changed.Sentences)
+	}
+}
+
+func TestAQuietSpellSaysNothingCapturedHasChanged(t *testing.T) {
+	in := fullInput()
+	in.LastSpokeAt = ptr(at(9))
+	in.Commitments = nil
+	in.Recent = nil
+	changed := sectionOf(t, Deterministic(in), crmcontracts.MeetingBriefSectionKindWhatChanged)
+	if len(changed.Sentences) != 1 || !strings.Contains(changed.Sentences[0].Text, "Nothing captured has changed since") {
+		t.Fatalf("what changed = %+v, want the baseline line saying nothing changed", changed.Sentences)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -5327,6 +5327,7 @@ const (
 	MeetingBriefSectionKindHeader         MeetingBriefSectionKind = "header"
 	MeetingBriefSectionKindRisks          MeetingBriefSectionKind = "risks"
 	MeetingBriefSectionKindTalkingPoints  MeetingBriefSectionKind = "talking_points"
+	MeetingBriefSectionKindWhatChanged    MeetingBriefSectionKind = "what_changed"
 )
 
 // Valid indicates whether the value is a known member of the MeetingBriefSectionKind enum.
@@ -5347,6 +5348,8 @@ func (e MeetingBriefSectionKind) Valid() bool {
 	case MeetingBriefSectionKindRisks:
 		return true
 	case MeetingBriefSectionKindTalkingPoints:
+		return true
+	case MeetingBriefSectionKindWhatChanged:
 		return true
 	default:
 		return false
@@ -17407,15 +17410,19 @@ type MeetingBrief struct {
 	Sections []MeetingBriefSection `json:"sections"`
 }
 
-// MeetingBriefSection One of the eight fixed sections, with its cited sentences.
+// MeetingBriefSection One of the nine fixed sections, with its cited sentences.
 type MeetingBriefSection struct {
-	// Kind The eight of ADR-0097 D5, in the order a reader reads them. A closed enum rather
-	// than a free-text heading, so a surface can label, order and collapse them and no
-	// writer can invent a ninth.
+	// Kind The eight of ADR-0097 D5 plus `what_changed`, in the order a reader reads them. A
+	// closed enum rather than a free-text heading, so a surface can label, order and
+	// collapse them and no writer can invent a tenth.
 	//
 	// `header` — meeting, time, company, deal and how long since the last touch (deterministic).
 	// `goal` — the single next-step target; it leads because burying the ask is the
 	// canonical prep failure.
+	// `what_changed` — what happened after the READER last dealt with this deal's people:
+	// promises made, objections raised, decisions taken, conversations held, files that
+	// changed hands. Its first line names the baseline; when the reader has never dealt
+	// with them it says so ("first contact") rather than "nothing changed".
 	// `attendees` — who is in the room, with the first-timers flagged.
 	// `commitments` — what was promised, ours and theirs, each with its source and status.
 	// `deal_state` — where the deal stands: last conversation, objections, open questions.
@@ -17428,13 +17435,17 @@ type MeetingBriefSection struct {
 	Sentences []OrganizationBriefSentence `json:"sentences"`
 }
 
-// MeetingBriefSectionKind The eight of ADR-0097 D5, in the order a reader reads them. A closed enum rather
-// than a free-text heading, so a surface can label, order and collapse them and no
-// writer can invent a ninth.
+// MeetingBriefSectionKind The eight of ADR-0097 D5 plus `what_changed`, in the order a reader reads them. A
+// closed enum rather than a free-text heading, so a surface can label, order and
+// collapse them and no writer can invent a tenth.
 //
 // `header` — meeting, time, company, deal and how long since the last touch (deterministic).
 // `goal` — the single next-step target; it leads because burying the ask is the
 // canonical prep failure.
+// `what_changed` — what happened after the READER last dealt with this deal's people:
+// promises made, objections raised, decisions taken, conversations held, files that
+// changed hands. Its first line names the baseline; when the reader has never dealt
+// with them it says so ("first contact") rather than "nothing changed".
 // `attendees` — who is in the room, with the first-timers flagged.
 // `commitments` — what was promised, ours and theirs, each with its source and status.
 // `deal_state` — where the deal stands: last conversation, objections, open questions.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -13573,16 +13573,20 @@ export interface components {
             /** @description The sections that had something to say, in ADR-0097 D5's fixed order. A section with no surviving sentence is absent, never present-and-empty: `risks` in particular is specified as omitted when empty, and the same rule reads honestly for every other. */
             sections: components["schemas"]["MeetingBriefSection"][];
         };
-        /** @description One of the eight fixed sections, with its cited sentences. */
+        /** @description One of the nine fixed sections, with its cited sentences. */
         MeetingBriefSection: {
             /**
-             * @description The eight of ADR-0097 D5, in the order a reader reads them. A closed enum rather
-             *     than a free-text heading, so a surface can label, order and collapse them and no
-             *     writer can invent a ninth.
+             * @description The eight of ADR-0097 D5 plus `what_changed`, in the order a reader reads them. A
+             *     closed enum rather than a free-text heading, so a surface can label, order and
+             *     collapse them and no writer can invent a tenth.
              *
              *     `header` — meeting, time, company, deal and how long since the last touch (deterministic).
              *     `goal` — the single next-step target; it leads because burying the ask is the
              *     canonical prep failure.
+             *     `what_changed` — what happened after the READER last dealt with this deal's people:
+             *     promises made, objections raised, decisions taken, conversations held, files that
+             *     changed hands. Its first line names the baseline; when the reader has never dealt
+             *     with them it says so ("first contact") rather than "nothing changed".
              *     `attendees` — who is in the room, with the first-timers flagged.
              *     `commitments` — what was promised, ours and theirs, each with its source and status.
              *     `deal_state` — where the deal stands: last conversation, objections, open questions.
@@ -13591,7 +13595,7 @@ export interface components {
              *     `company_context` — background, collapsed and last.
              * @enum {string}
              */
-            kind: "header" | "goal" | "attendees" | "commitments" | "deal_state" | "risks" | "talking_points" | "company_context";
+            kind: "header" | "goal" | "what_changed" | "attendees" | "commitments" | "deal_state" | "risks" | "talking_points" | "company_context";
             /** @description The section's lines, each citing the records it was written from. A sentence whose citations do not resolve is dropped whole rather than shown uncited. */
             sentences: components["schemas"]["OrganizationBriefSentence"][];
         };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5811,6 +5811,7 @@ export const de = {
   "person.meeting.assembledNow":
     "Soeben aus den aktuellen Daten zusammengestellt",
   "person.meeting.header": "Auf einen Blick",
+  "person.meeting.what_changed": "Seit dem letzten Kontakt",
   "person.meeting.goal": "Ziel dieses Meetings",
   "person.meeting.attendees": "Teilnehmende",
   "person.meeting.commitments": "Offene Zusagen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5857,6 +5857,7 @@ export const en = {
   "person.meeting.loading": "Assembling the brief…",
   "person.meeting.assembledNow": "Assembled just now, from the latest data",
   "person.meeting.header": "At a glance",
+  "person.meeting.what_changed": "Since you last spoke",
   "person.meeting.goal": "Goal for this meeting",
   "person.meeting.attendees": "Attendees",
   "person.meeting.commitments": "Open commitments",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5752,6 +5752,7 @@ export const vi = {
   "person.meeting.loading": "Đang tổng hợp bản tóm tắt…",
   "person.meeting.assembledNow": "Vừa được tổng hợp từ dữ liệu mới nhất",
   "person.meeting.header": "Tổng quan",
+  "person.meeting.what_changed": "Kể từ lần trao đổi gần nhất",
   "person.meeting.goal": "Mục tiêu cuộc họp",
   "person.meeting.attendees": "Người tham dự",
   "person.meeting.commitments": "Cam kết còn mở",


### PR DESCRIPTION
## What changes (plan B8, change 3)

The section a rep actually opens a brief for. `whatchanged.go`:

- **Baseline** — as the plan ruled: the READER's last interaction with anyone in the room. `readLastSpoke` reads the newest past activity linked to one of the room's people that the reader took part in (`activity_participant.user_id`), under `ActivityDiscoverClause`, inside the meeting's own transaction. Two reps honestly get two baselines on one deal. Any captured activity counts, whichever way it went, so an outbound-only gap does not reset it.
- **The section** names the baseline ("You last dealt with this room 5 days ago"), then lists the claims made after it — sharpest first, *taken* from the ranked set so no later section repeats them — and the conversations captured since ("1 conversation since then, the latest …"). No prior interaction → **"First contact"**, never "nothing changed"; nothing after the baseline → the baseline line says so.
- Contract: `MeetingBriefSectionKind` gains `what_changed` (additive; the breaking gate reports none). The drawer labels it in en/de/vi.

Not in this slice: stage moves, offer revisions, documents that changed hands, people who joined or went quiet — those need the richer input (B8 change 5) and land with it.

## Gates

`make check-backend`, `make check-fe`, craft-static green; unit tests for the three states; compose + compose/integration brief scenarios green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reader-specific “what changed since we last spoke” section to the meeting brief. Previously eight sections; now nine with `what_changed` after `goal`. The section uses the reader’s last interaction as the baseline (per discover scope, within the meeting’s project, and not later than the meeting/now), then lists up to five post-baseline claims and recent conversations, ignoring future-dated items; it removes those claims from later sections and says “First contact” or “Nothing captured has changed” when applicable.

- Migration: update exhaustive switches on `MeetingBriefSectionKind` to handle `what_changed`; surfaces that assume eight sections or rely on previous indexes must adjust; frontend schema and i18n add the `what_changed` key in en/de/vi.

<sup>Written for commit 4a49635521e3daa523184b066582806e078924f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “What changed” section to meeting briefs.
  * Highlights updates since the last interaction, including relevant commitments and conversations.
  * Clearly indicates first contact or when no new activity is available.
  * Added English, German, and Vietnamese translations.

* **Tests**
  * Added coverage for first contact, quiet periods, baseline activity, and duplicate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->