### PR TITLE
fix(frontend): AC-deal-6 says how the win was won, as the product requires

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -438,6 +438,20 @@ test("AC-deal-6: a terminal-stage drop is a 🟡 confirm — nothing runs before
   const won = page.locator('[data-stage="s4"]');
   await card.dragTo(won);
   await expect(page.getByText("Nach Won verschieben?")).toBeVisible();
+
+  // The first Confirm is REFUSED, and that is the criterion rather than a
+  // detour: this deal carries no signed contract, and a win without paper has
+  // to say how it was won (deals/deal_advance.go's ensureWinEvidence). The
+  // reason panel is deliberately not shown before the refusal — a win the
+  // paperwork already explains stays one click, because a field every rep must
+  // fill is a field every rep fills with the same lie.
+  await page.getByRole("button", { name: "Bestätigen" }).click();
+  await expect(page.getByText("Wie wurde er gewonnen?")).toBeVisible();
+  // Still nothing has run: the drop is not applied while the dialog is open.
+  await expect(page.getByText("Nach Won verschoben")).toHaveCount(0);
+
+  await page.getByRole("combobox", { name: "Wie wurde er gewonnen?" }).click();
+  await page.getByRole("option", { name: "Per Bestellung" }).click();
   await page.getByRole("button", { name: "Bestätigen" }).click();
   await expect(page.getByText("Nach Won verschoben")).toBeVisible();
 });


### PR DESCRIPTION
## What broke

`main`'s **`uat`** lane is red, and the last three merged PRs (#2337, #2338, #2339) all carry a red `uat` they did not cause.

```
e2e/ac.spec.ts:430  AC-deal-6: a terminal-stage drop is a 🟡 confirm — nothing runs before Confirm
    Error: expect(locator).toBeVisible() failed
    Locator: getByText('Nach Won verschoben')
```

Reproduced on a clean detached worktree at `origin/main` (`04426386d`), then instrumented to find what the click actually did:

```
REQ POST /v1/deals/d-fleet/advance {"to_stage_id":"s4","status":"won"}
RES 422 {"code":"validation_error","details":{"errors":[{
  "field":"won_without_contract_reason","code":"win_evidence_required",
  "message":"a won deal needs a signed contract with its paper attached, or a reason why there is none"}]}}
```

So the confirm dialog opened and `Bestätigen` was clicked — the failing locator is the **success toast**, not the dialog. The advance was refused.

## Cause

#2332 (`e10c79623`, "docs(projects): … walked against the product") taught `e2e/seed.ts` the rule the server has enforced since #1402, and its comment says so plainly:

```ts
// A win needs evidence, exactly as deals/deal_advance.go's ensureWinEvidence
// demands it: a signed contract (none is seeded) or a reason.
if (advance.status === "won" && !advance.won_without_contract_reason) { … 422 … }
```

It did not update AC-deal-6, which drags to Won and confirms with neither.

**The mock became more faithful, not less.** Until #2332 it accepted a win the real server would have refused — so this criterion was passing against behaviour the product does not have. That makes this a spec fix, not a workaround: I have not touched the mock, the rule, or the product.

## The fix

AC-deal-6 now walks the flow a rep walks: confirm → refused → say how the deal was won → confirm again.

The refusal is part of the criterion rather than a detour. The reason panel appears only *after* the server asks for it, and `deals.tsx` says why: a win the paperwork already explains stays one click, because "making every rep justify a win the paperwork already explains is how a required field becomes a field everyone fills with the same lie."

The test's own claim — *nothing runs before Confirm* — is asserted harder than before: `Nach Won verschoben` is now checked to have count 0 between the refusal and the reason, which is exactly where a premature write would show.

## Verification

| | Result |
|---|---|
| `origin/main`'s spec, `-g "AC-deal-6"` | **1 failed** — `element(s) not found`, the success toast |
| With this change, `-g "AC-deal-6"` | **1 passed** |
| With this change, full `e2e/ac.spec.ts` | **86 passed** (18.5s) |

`biome check` clean on the changed file.

## Note for whoever picks up #2325

This is the second time in three hours that a `uat` break survived merges because nothing watches that lane: `main` carries no `uat` check-runs at all, so the only way to learn its state is to inspect merged PRs' checks one at a time. #2310 cost three merges; this one cost three more.

Found by an hourly main-status watch; independently reported by two parallel sessions whose branches touch no frontend code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns AC-deal-6 with the product rule that a win needs evidence. Previously the test confirmed a win without a contract or reason and waited for a success toast; now it captures the refusal, supplies a reason, and confirms again to fix the UAT failure.

- Adds the initial refusal path: click Confirm, expect “Wie wurde er gewonnen?”.
- Selects a reason (“Per Bestellung”) and confirms again to get “Nach Won verschoben”.
- Asserts the success toast has count 0 between refusal and reason to prove nothing runs before Confirm.

<sup>Written for commit f40bffd19b4d8541648fa0b2537cf58d3f85ba64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for terminal-stage deal changes.
  - Confirmations are now verified to require win evidence before the stage change is applied.
  - Added coverage for selecting “Per Bestellung” and completing the confirmation successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->