### PR TITLE
fix(platform): the declared-timeout test measures from work start, not enqueue

### DIFF
--- a/backend/internal/compose/jobtimeout_integration_test.go
+++ b/backend/internal/compose/jobtimeout_integration_test.go
@@ -93,6 +93,20 @@ type timeoutProbeWorker struct {
 func (w *timeoutProbeWorker) Work(ctx context.Context, _ *river.Job[timeoutProbeArgs]) error {
 	if d, ok := ctx.Deadline(); ok {
 		// Read the clock HERE, beside the deadline it is compared against.
+		//
+		// This is a real clock rather than an injected one, and it cannot be
+		// otherwise: River builds the worker deadline with context.WithTimeout
+		// against its own clock, jobs.Config exposes no seam onto it, and a
+		// deadline is a time.Time -- comparing it to anything requires reading
+		// a clock somewhere. What the pairing buys is the SIZE of the window
+		// that reading is exposed to. Measured from enqueue it spanned a
+		// LISTEN/NOTIFY round trip and a queue, which is why 200ms was not
+		// enough three times; measured from here it spans the goroutine
+		// scheduling slots between River computing the deadline and this
+		// statement running. For that to exceed deadlineReadMargin the runtime
+		// would have to stall this goroutine for 25ms between two adjacent
+		// statements, at which point the machine has a problem the test is
+		// right to report.
 		w.deadline <- deadlineRead{deadline: d, readAt: time.Now()}
 	} else {
 		close(w.deadline)

--- a/backend/internal/compose/jobtimeout_integration_test.go
+++ b/backend/internal/compose/jobtimeout_integration_test.go
@@ -37,26 +37,44 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 )
 
-// deadlinePickupMargin is the ONLY slack TestTheDeclaredTimeoutIsTheDeadlineRiverApplies
+// deadlineReadMargin is the ONLY slack TestTheDeclaredTimeoutIsTheDeadlineRiverApplies
 // grants, and it is absolute rather than a fraction of the declared value:
 // a multiplicative window (e.g. declared/2..declared*10) pins the order of
 // magnitude, not the value, and would admit a deadline that drifted from
 // what was declared by a fixed offset or a small scaling error just as
-// happily as it admits the right one. This margin instead covers only
-// River's own pickup latency between Enqueue returning and Work reading
-// ctx.Deadline() -- LISTEN/NOTIFY dispatch, the insert round trip, goroutine
-// scheduling -- which the GREEN runs recorded during development placed at
-// well under 100ms even with database setup folded in. 200ms is generous
-// slack for a loaded CI runner while still rejecting anything that is
-// wrong rather than merely late.
-const deadlinePickupMargin = 200 * time.Millisecond
+// happily as it admits the right one.
+//
+// It covers the gap between River computing the deadline as Work is invoked
+// and Work's first statement reading ctx.Deadline() -- a few goroutine
+// scheduling slots, microseconds in practice. It deliberately does NOT cover
+// pickup: the measurement starts INSIDE Work rather than at Enqueue, so
+// LISTEN/NOTIFY dispatch, the insert round trip and a busy runner are outside
+// the window entirely instead of being budgeted for.
+//
+// That distinction is why this constant is 25ms rather than the 200ms it
+// replaces. Measuring from enqueue made the assertion "the declared timeout is
+// right AND the runner picked the job up quickly", and the second half is a
+// property of the machine, not of the code under test: a loaded runner put the
+// total at 311ms, 329ms and 333ms against a 300ms ceiling on three separate
+// occasions, reddening main once and two innocent pull requests. A wall-clock
+// ceiling over pickup is a bet that CI never has a bad minute, and widening it
+// only moves the bet.
+const deadlineReadMargin = 25 * time.Millisecond
 
 type timeoutProbeArgs struct{}
 
 func (timeoutProbeArgs) Kind() string { return "timeout_probe" }
 
+// deadlineRead is what the probe saw and when it looked. The pair is the
+// whole point: `deadline` alone can only be compared against a clock reading
+// taken outside Work, which folds pickup latency into the comparison.
+type deadlineRead struct {
+	deadline time.Time
+	readAt   time.Time
+}
+
 type timeoutProbeWorker struct {
-	deadline chan time.Time
+	deadline chan deadlineRead
 	// release lets a job whose context is NEVER cancelled by design (the
 	// {none: true} case) return once the test has read what it needs, rather
 	// than blocking forever. Left nil for the fixed-timeout case, where
@@ -74,7 +92,8 @@ type timeoutProbeWorker struct {
 // not after a fixed delay.
 func (w *timeoutProbeWorker) Work(ctx context.Context, _ *river.Job[timeoutProbeArgs]) error {
 	if d, ok := ctx.Deadline(); ok {
-		w.deadline <- d
+		// Read the clock HERE, beside the deadline it is compared against.
+		w.deadline <- deadlineRead{deadline: d, readAt: time.Now()}
 	} else {
 		close(w.deadline)
 	}
@@ -120,7 +139,7 @@ func newProbeRunner(t *testing.T, workers *river.Workers) (*jobs.Runner, func())
 func TestTheDeclaredTimeoutIsTheDeadlineRiverApplies(t *testing.T) {
 	const declared = 100 * time.Millisecond
 
-	probe := &timeoutProbeWorker{deadline: make(chan time.Time, 1)}
+	probe := &timeoutProbeWorker{deadline: make(chan deadlineRead, 1)}
 	workers := river.NewWorkers()
 	river.AddWorker(workers, jobs.Govern[timeoutProbeArgs](
 		probe,
@@ -131,24 +150,26 @@ func TestTheDeclaredTimeoutIsTheDeadlineRiverApplies(t *testing.T) {
 	runner, cleanup := newProbeRunner(t, workers)
 	defer cleanup()
 
-	started := time.Now()
 	if err := runner.Enqueue(context.Background(), timeoutProbeArgs{}, nil); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 
 	select {
-	case deadline, ok := <-probe.deadline:
+	case read, ok := <-probe.deadline:
 		if !ok {
 			t.Fatal("Work ran with NO deadline — the declared timeout did not reach River")
 		}
-		got := deadline.Sub(started)
+		// From the moment Work looked, never from the moment the job was
+		// enqueued: how long River took to pick the job up says nothing about
+		// whether the declared timeout is the one it applied.
+		got := read.deadline.Sub(read.readAt)
 		off := got - declared
 		if off < 0 {
 			off = -off
 		}
-		if off > deadlinePickupMargin {
-			t.Errorf("deadline arrived %v after enqueue, want %v ± %v (declared %v) — Govern's value is not what River applied",
-				got, declared, deadlinePickupMargin, declared)
+		if off > deadlineReadMargin {
+			t.Errorf("deadline sits %v after Work began, want %v ± %v (declared %v) — Govern's value is not what River applied",
+				got, declared, deadlineReadMargin, declared)
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("Work never started; the probe job was not picked up")
@@ -169,7 +190,7 @@ func TestADeclaredAbsenceLeavesTheJobWithNoDeadline(t *testing.T) {
 	// it. Without release, Work would still be waiting on a deadline that
 	// will never arrive when cleanup calls Stop, and Stop would hang out its
 	// full budget every run.
-	probe := &timeoutProbeWorker{deadline: make(chan time.Time, 1), release: make(chan struct{})}
+	probe := &timeoutProbeWorker{deadline: make(chan deadlineRead, 1), release: make(chan struct{})}
 	workers := river.NewWorkers()
 	river.AddWorker(workers, jobs.Govern[timeoutProbeArgs](
 		probe,


### PR DESCRIPTION
Closes #1762.

## What broke

`main-health` went red on `b5db9a918` (run 32597341306):

```
integration shard 4/6 — --- FAIL: TestTheDeclaredTimeoutIsTheDeadlineRiverApplies
jobtimeout_integration_test.go:150: deadline arrived 329.180501ms after enqueue,
want 100ms ± 200ms (declared 100ms) — Govern's value is not what River applied
```

The run's second red job (`integration (RLS + erasure + HTTP e2e)`) is the rollup reporting `SHARDS_RESULT: failure`, not an independent break. One flaky test, two red jobs, a red verdict on `main`.

## Why it is flaky by construction

The assertion measured `deadline − timeBeforeEnqueue`, so it asserted two things at once: that Govern's declared timeout is the one River applied, **and** that the runner picked the job up quickly. Only the first is about the code under test. The second is a property of the machine, and it is the half that fails.

| When | Measured | Where it landed |
|---|---|---|
| 2026-08-19 | 333.18ms | `main` after #1714's squash — read as the last merger's fault |
| 2026-08-22 | 311.11ms | #2308, a PR about SQLSTATE and ISO-4217 |
| 2026-08-22 | 329.18ms | **main-health on `b5db9a918`** |

All three sit between 311ms and 334ms against a 300ms ceiling: a distribution whose right tail crosses the bound, not a constant that is a little too small. Widening the margin moves the bet without settling it.

The third occurrence is the one that made this worth fixing rather than recording. The first two misattributed a failure to an innocent author; this one corrupted the only post-merge signal `main` has, and a health check that cries wolf is discounted by the time it is right.

## The fix

The probe now reports **when** it read the deadline alongside what it read, and the assertion is `deadline − workStart`. Pickup is outside the window by construction rather than budgeted for, so no constant has to encode a guess about how slow CI can get.

That lets the margin state what it actually covers: **25ms** for the goroutine scheduling slots between River computing the deadline and `Work`'s first statement reading it, in place of **200ms** for a LISTEN/NOTIFY round trip and a queue.

## Verification

Against real Postgres (`make test-it DIR=backend/internal/compose`):

**The pickup latency the old form was budgeting for, measured on the same run** (temporary instrumentation, not committed):

```
PROBE old-form (deadline-enqueue)=202.375917ms
      new-form (deadline-workStart)=99.987458ms
      pickup=102.388459ms
```

On an *idle* laptop the old assertion already spent 202ms of its 300ms budget, 102ms of it pure pickup. The new form reads 99.99ms against a declared 100ms — 12.5µs of error.

**The tightened assertion is stricter, not just quieter.** Mutating `Govern` to apply `declared + 40ms`:

```
deadline sits 139.990125ms after Work began, want 100ms ± 25ms (declared 100ms)
--- FAIL: TestTheDeclaredTimeoutIsTheDeadlineRiverApplies
```

That drift passed the old ±200ms window. Restored, both deadline tests pass (`TestTheDeclaredTimeoutIsTheDeadlineRiverApplies`, `TestADeclaredAbsenceLeavesTheJobWithNoDeadline`).

Found by an hourly main-status watch; the second occurrence was reported by a parallel session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measures the declared timeout from `Work` start instead of enqueue to remove pickup latency from the assertion and deflake the test. Old behavior compared deadline − enqueue; new behavior compares deadline − in-`Work` read time, making the check stricter and stable.

- Compares `deadline − readAt` inside `Work`; introduces a `deadlineRead` payload (deadline + readAt) and updates failure messaging.
- Tightens margin from 200ms to 25ms (`deadlineReadMargin`) since pickup is now outside the window.
- Adds inline docs explaining why the probe uses a real clock and how `readAt` pairing narrows the timing window.
- Tests only; no production changes (`backend/internal/compose/jobtimeout_integration_test.go`).

<sup>Written for commit 829305b1cac806ebde6eb6e932ea4b6c7da809b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved timeout integration coverage by measuring deadlines at the point they are read.
  * Tightened timing validation to detect smaller discrepancies.
  * Updated fixed-timeout and no-deadline scenarios to use the revised timing checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->