### PR TITLE
fix(ci): the room key's sort is right, and now the gate is told so

### DIFF
--- a/frontend/src/screens/persondealrooms.tsx
+++ b/frontend/src/screens/persondealrooms.tsx
@@ -30,8 +30,10 @@ type DealRoom = components["schemas"]["DealRoom"];
 // requirement for a key. localeCompare is locale-DEPENDENT, so the same
 // addresses would key differently under different locales and a revoke would
 // refresh a cache entry nobody is looking at. Sonar's S2871 asks for
-// localeCompare here; it is right about its real target, sorting NUMBERS with
-// the default comparator, and backwards about strings being joined into a key.
+// localeCompare here: it flags a bare sort on strings because code-unit order
+// is not human alphabetical order — "Ä" after "Z", "a" after "Z". That is a
+// real concern for a list somebody READS and no concern at all for a key
+// nobody reads, where identical-everywhere is the only property that matters.
 export function roomsOfKey(emails: readonly string[]) {
   return ["deal-rooms-of", [...emails].sort().join(",")] as const;
 }

--- a/frontend/src/screens/persondealrooms.tsx
+++ b/frontend/src/screens/persondealrooms.tsx
@@ -23,6 +23,15 @@ type DealRoom = components["schemas"]["DealRoom"];
 
 // The rooms a contact holds a seat in, keyed on the whole address list so a
 // revoke anywhere refreshes it.
+//
+// The bare sort is deliberate and must stay bare: this is a CACHE KEY, not a
+// list a person reads. Default string sort is lexicographic by UTF-16 code
+// unit — deterministic and identical on every machine, which is the whole
+// requirement for a key. localeCompare is locale-DEPENDENT, so the same
+// addresses would key differently under different locales and a revoke would
+// refresh a cache entry nobody is looking at. Sonar's S2871 asks for
+// localeCompare here; it is right about its real target, sorting NUMBERS with
+// the default comparator, and backwards about strings being joined into a key.
 export function roomsOfKey(emails: readonly string[]) {
   return ["deal-rooms-of", [...emails].sort().join(",")] as const;
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -282,10 +282,11 @@ sonar.issue.ignore.multicriteria.e9.resourceKey=frontend/src/mcp-apps/bridge.ts
 # this waiver has to be reconsidered with it.
 sonar.issue.ignore.multicriteria.e10.ruleKey=gosecurity:S5144
 sonar.issue.ignore.multicriteria.e10.resourceKey=backend/internal/modules/identity/oauth_cimd.go
-# typescript:S2871 wants a localeCompare comparator on every bare .sort(). It is
-# right about its real target — sorting NUMBERS with the default comparator —
-# and backwards for persondealrooms.tsx's roomsOfKey, which sorts addresses to
-# build a react-query CACHE KEY. Default string sort is lexicographic by UTF-16
+# typescript:S2871 wants a localeCompare comparator on a bare .sort() of strings,
+# because code-unit order is not human alphabetical order ("Ä" after "Z"). That
+# is a real concern for a list somebody READS, and none at all for
+# persondealrooms.tsx's roomsOfKey, which sorts addresses to build a react-query
+# CACHE KEY nobody reads. Default string sort is lexicographic by UTF-16
 # code unit: deterministic and identical on every machine, which is the whole
 # requirement for a key. localeCompare is locale-DEPENDENT, so the same
 # addresses would key differently under different locales and a revoke would

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -159,7 +159,7 @@ sonar.coverage.exclusions=\
   frontend/src/**/*.stories.tsx
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
@@ -282,3 +282,15 @@ sonar.issue.ignore.multicriteria.e9.resourceKey=frontend/src/mcp-apps/bridge.ts
 # this waiver has to be reconsidered with it.
 sonar.issue.ignore.multicriteria.e10.ruleKey=gosecurity:S5144
 sonar.issue.ignore.multicriteria.e10.resourceKey=backend/internal/modules/identity/oauth_cimd.go
+# typescript:S2871 wants a localeCompare comparator on every bare .sort(). It is
+# right about its real target — sorting NUMBERS with the default comparator —
+# and backwards for persondealrooms.tsx's roomsOfKey, which sorts addresses to
+# build a react-query CACHE KEY. Default string sort is lexicographic by UTF-16
+# code unit: deterministic and identical on every machine, which is the whole
+# requirement for a key. localeCompare is locale-DEPENDENT, so the same
+# addresses would key differently under different locales and a revoke would
+# refresh an entry nobody is looking at. Scoped to the one file that holds the
+# key rather than to the rule or to frontend/**: a bare .sort() on a list a
+# person READS is a genuine finding and stays enforced everywhere else.
+sonar.issue.ignore.multicriteria.e11.ruleKey=typescript:S2871
+sonar.issue.ignore.multicriteria.e11.resourceKey=frontend/src/screens/persondealrooms.tsx


### PR DESCRIPTION
**No runtime behaviour changes.** One comment above `roomsOfKey`, and one scoped Sonar rule waiver so the gate agrees with it.

## Why

`main`'s SonarCloud quality gate reads ERROR, driven by a single CRITICAL raised 2026-08-22 (see #1629):

```
frontend/src/screens/persondealrooms.tsx:27  typescript:S2871
"Provide a compare function that depends on String.localeCompare,
 to reliably sort elements alphabetically."
```

**Taking that advice would introduce a defect.** The sort builds a react-query **cache key**:

```ts
export function roomsOfKey(emails: readonly string[]) {
  return ["deal-rooms-of", [...emails].sort().join(",")] as const;
}
```

Default string sort is lexicographic by UTF-16 code unit — deterministic, locale-independent, identical on every machine, which is exactly and only what a key needs. `localeCompare` is locale-**dependent**, so the same address set would key differently under different locales; a revoke would then refresh a cache entry nobody is looking at, which is the bug this key exists to prevent.

S2871 is right about its real target — sorting **numbers** with the default comparator, where `[10, 9]` genuinely sorts wrong. On strings joined into a key it is backwards.

## Two halves, because prose does not clear a gate

The first version of this PR was the comment alone. A parallel session pointed out the hole before it merged: **Sonar does not read prose**, so a comment-only change leaves `main`'s gate ERROR while looking like it fixed something. Both halves are here now:

1. **The comment** — for the next person reading the line. Necessary because the gate re-raises this on every analysis and the wrong fix **fails silently**: nothing errors, no test breaks, the cache just occasionally misses.
2. **The waiver** — `sonar.issue.ignore.multicriteria.e11`, the mechanism this repository already uses for exactly this (alongside e1–e10), so the ERROR actually clears.

**Why an e-entry rather than `NOSONAR`.** NOSONAR suppresses *every* rule on that line forever, including a future genuine one. An e-entry names the rule, names the path, and is reviewable here rather than in a UI nobody reading the code will open.

**Scope.** `typescript:S2871` on `frontend/src/screens/persondealrooms.tsx` only — not the rule globally, not `frontend/**`. A bare `.sort()` on a list a person *reads* is a real finding and stays enforced everywhere else.

## Verification

`biome check` clean, `tsc -b` exit 0. The runtime diff is empty — comment lines plus a properties entry.

Found by an hourly main-status watch; the finding was spotted by one parallel session, and the prose-does-not-clear-a-gate correction came from another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying that room keys use deterministic lexicographic sorting, ensuring consistent results across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->