### PR TITLE
fix(frontend): a list with classic scrollbars no longer measures itself into a crash

### DIFF
--- a/frontend/src/design-system/listtable.css
+++ b/frontend/src/design-system/listtable.css
@@ -404,6 +404,15 @@
   flex: 1;
   min-height: 0;
   overflow: auto;
+  /* The column widths are computed from this box's clientWidth, and with
+   * classic (non-overlay) scrollbars a vertical bar takes part of that width.
+   * Without a reserved gutter the two feed each other: widths → horizontal
+   * bar → less height → vertical bar → less width → new widths → no bar …
+   * until React gives up with "Maximum update depth exceeded" and the list is
+   * an error plate. Reserving the gutter makes the width independent of
+   * whether the bar is showing. Overlay scrollbars reserve nothing, so the
+   * default macOS look is unchanged. */
+  scrollbar-gutter: stable;
 }
 
 /* The table is as wide as its columns need, not as wide as the viewport. Widening

--- a/frontend/src/design-system/listtable.oscillation.test.tsx
+++ b/frontend/src/design-system/listtable.oscillation.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { widthWorthAdopting } from "./listtable";
+
+/**
+ * The scroller's width is not a single number on a platform with classic
+ * scrollbars: showing a vertical bar takes width, and the widths this table
+ * computes are what decide whether the bar shows. These are the readings that
+ * arrive, and which of them the table is allowed to act on.
+ */
+describe("widthWorthAdopting", () => {
+  it("adopts the first real reading", () => {
+    expect(widthWorthAdopting(900, 0, 0)).toBe(true);
+  });
+
+  it("adopts a genuine resize", () => {
+    expect(widthWorthAdopting(1200, 900, 885)).toBe(true);
+  });
+
+  it("refuses a reading the table already holds", () => {
+    expect(widthWorthAdopting(900, 900, 885)).toBe(false);
+  });
+
+  it("refuses a reading that returns to the width of a render ago", () => {
+    // The oscillation: 900 → 885 → 900 → … Left unrefused this is the loop
+    // React aborts with "Maximum update depth exceeded", taking the list with
+    // it.
+    expect(widthWorthAdopting(900, 885, 900)).toBe(false);
+  });
+});

--- a/frontend/src/design-system/listtable.tsx
+++ b/frontend/src/design-system/listtable.tsx
@@ -191,6 +191,32 @@ const COLUMN_SIZES: Readonly<
   verbs: { share: null, min: 320 },
 };
 
+/**
+ * Whether a fresh reading of the scroller's width should be adopted.
+ *
+ * The measurement feeds back into itself, and on a platform with classic
+ * (non-overlay) scrollbars that feedback can oscillate: the column widths
+ * decide whether the body needs a horizontal scrollbar, that bar takes height,
+ * the lost height brings in a vertical bar, and the vertical bar takes the very
+ * width being measured — which produces the first widths again. React stops
+ * such a loop with "Maximum update depth exceeded", and the reader loses the
+ * whole list behind an error plate.
+ *
+ * So a reading that merely returns to the width of a render ago is refused.
+ * Both readings are honest views of a box with two stable states; taking the
+ * first and holding it leaves the table at most one scrollbar's width narrower
+ * than it could be, which is invisible next to losing the list. A genuine
+ * resize still lands, because it reports a width that is neither of the two
+ * being alternated.
+ */
+export function widthWorthAdopting(
+  next: number,
+  current: number,
+  beforeThat: number,
+): boolean {
+  return next !== current && next !== beforeThat;
+}
+
 function sizeOf(column: {
   fixed?: boolean;
   numeric?: boolean;
@@ -463,14 +489,25 @@ export function ListTable<Row>({
   // any other way. Read before paint so the first frame is already right rather
   // than every column starting at its minimum and jumping.
   const [available, setAvailable] = useState(0);
+  const [, setResized] = useState(0);
+  // The width a render ago, which is what makes the re-measure below safe to
+  // run after every render.
+  const previous = useRef(0);
   // Re-read after every render, so a body that arrives late — this surface can
   // render a board instead of its own table, and back again — is measured when
-  // it does rather than leaving every column pinned at its minimum. Setting the
-  // same width twice is a no-op, so this cannot loop.
+  // it does rather than leaving every column pinned at its minimum.
+  //
+  // Which readings are adopted, and why one is refused: widthWorthAdopting.
   useLayoutEffect(() => {
-    if (scroller.current) {
-      setAvailable(scroller.current.clientWidth);
+    if (!scroller.current) {
+      return;
     }
+    const next = scroller.current.clientWidth;
+    if (!widthWorthAdopting(next, available, previous.current)) {
+      return;
+    }
+    previous.current = available;
+    setAvailable(next);
   });
   // Re-attached when the scroller itself comes or goes, since an observer left
   // holding a detached node stops following anything. The dep is a trigger
@@ -485,9 +522,11 @@ export function ListTable<Row>({
     if (!scrolling || typeof ResizeObserver === "undefined") {
       return;
     }
-    const observer = new ResizeObserver(() =>
-      setAvailable(scrolling.clientWidth),
-    );
+    // The observer asks for a fresh look rather than measuring here, so every
+    // width this component adopts passes the oscillation guard above. Bumping a
+    // counter is what schedules that look: the layout effect has no dependency
+    // list and so runs after any render this causes.
+    const observer = new ResizeObserver(() => setResized((n) => n + 1));
     observer.observe(scrolling);
     return () => observer.disconnect();
   }, [drawsOwnTable]);


### PR DESCRIPTION
Reproduced by Lars on the projects list with DevTools closed; not reproducible headlessly (overlay scrollbars). One CSS line on .lt-scroll; rationale in the source comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops ListTable from entering a width-measurement loop and crashing on platforms with classic (non-overlay) scrollbars. Before: column widths oscillated as scrollbars appeared/disappeared. Now: we reserve a vertical gutter and ignore width readings that bounce between two prior states.

- Apply CSS `scrollbar-gutter: stable` on `.lt-scroll` so `clientWidth` stays consistent; overlay scrollbars remain unchanged.
- Add `widthWorthAdopting` to gate re-measurements and change `ResizeObserver` to trigger a re-read instead of setting width directly; includes a unit test.
- Verify on Windows/Linux that lists no longer flicker or crash; content may be slightly narrower. On macOS, layout should be unchanged.

<sup>Written for commit 0120698615d8a041ffef1bf19b07cd6f6881050f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented table columns from repeatedly resizing when the scrollbar appears or disappears.
  * Improved stability when table widths change by ignoring duplicate or oscillating measurements.
  * Preserved the existing overlay-scrollbar behavior while providing more stable table layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->