### PR TITLE
fix(records): one minor-unit scale, and a test that keeps it singular

### DIFF
--- a/backend/internal/compose/offerdraft_price.go
+++ b/backend/internal/compose/offerdraft_price.go
@@ -14,7 +14,6 @@ package compose
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -133,12 +132,7 @@ func priceEvidencedInSnippet(snippet string, priceMinor int64, currency string) 
 	if digits == 0 {
 		return false // the minor integer above IS the major form for a zero-decimal currency
 	}
-	scale := int64(1)
-	for i := 0; i < digits; i++ {
-		scale *= 10
-	}
-	whole, frac := priceMinor/scale, priceMinor%scale
-	plain := strconv.FormatInt(whole, 10)
-	full := fmt.Sprintf("%d.%0*d", whole, digits, frac)
+	plain := strconv.FormatInt(values.WholeMajorUnits(priceMinor, currency), 10)
+	full := values.MajorUnits(priceMinor, currency)
 	return strings.Contains(snippet, plain) || strings.Contains(snippet, full)
 }

--- a/backend/internal/compose/offerdraft_price.go
+++ b/backend/internal/compose/offerdraft_price.go
@@ -112,7 +112,6 @@ func validDecimal(s string, lo, hi float64) (string, float64, bool) {
 	return s, v, true
 }
 
-// currencyMinorDigits is the ISO 4217 decimal-places exception table.
 // priceEvidencedInSnippet is the conversation-price rung's evidence
 // check (OFFER-AC-14): the price the model claims the customer discussed
 // must actually appear in what it cited, not merely ride along with some

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
 
 // This file is the write direction of the HubSpot mapping-as-contract
@@ -203,7 +203,13 @@ func mapWriteDeal(fields map[string]any, forUpdate bool) (writeMapping, error) {
 		return writeMapping{}, err
 	}
 	if ok && currency != "" {
-		props["amount"] = minorToDecimalString(minor, overlay.ISO4217MinorUnitExponent(currency))
+		// values.MajorUnits is the one renderer of a minor-unit integer as a
+		// currency-decimal string, and HubSpot's `amount` property wants exactly
+		// that shape (exponent 0 → no point; 2 → "10.00"; 3 → "1.500"), never a
+		// blanket ÷100. This used to be a second implementation here; the two
+		// agreed on all 272 amount×currency pairs they were compared over,
+		// which is precisely how long a second copy stays harmless.
+		props["amount"] = values.MajorUnits(minor, currency)
 	}
 	return writeMapping{ObjectClass: objectClassDeals, Props: props}, nil
 }
@@ -371,32 +377,4 @@ func rfc3339ToMillis(v any) (string, bool, error) {
 		return "", false, fmt.Errorf("overlay: write timestamp %q is not RFC3339: %w", s, err)
 	}
 	return strconv.FormatInt(ts.UnixMilli(), 10), true, nil
-}
-
-// minorToDecimalString is the inverse of decimalStringToMinor: it renders an
-// integer minor-unit amount back to the currency-decimal string HubSpot's
-// `amount` property expects, placing the decimal point by the ISO-4217
-// minor-unit exponent (exponent 0 → no point; 2 → "10.00"; 3 → "1.500"), never
-// a blanket ÷100.
-func minorToDecimalString(minor int64, exponent int) string {
-	// FormatInt renders the full magnitude of any int64 — including
-	// math.MinInt64, whose positive is not int64-representable — so the decimal
-	// point is inserted into the digit string with no int64→uint64 conversion
-	// to reason about.
-	s := strconv.FormatInt(minor, 10)
-	neg := strings.HasPrefix(s, "-")
-	if neg {
-		s = s[1:]
-	}
-	if exponent > 0 {
-		for len(s) <= exponent {
-			s = "0" + s
-		}
-		point := len(s) - exponent
-		s = s[:point] + "." + s[point:]
-	}
-	if neg {
-		s = "-" + s
-	}
-	return s
 }

--- a/backend/internal/modules/overlay/transforms.go
+++ b/backend/internal/modules/overlay/transforms.go
@@ -140,11 +140,7 @@ func transformAmountMinorByCurrency(v any) (any, error) {
 			return nil, fmt.Errorf("overlay: amount_minor_by_currency: amount expects a string, got %T", amountRaw)
 		}
 		if amount := strings.TrimSpace(amountStr); amount != "" {
-			scale := int64(1)
-			for i := 0; i < ISO4217MinorUnitExponent(code); i++ {
-				scale *= 10
-			}
-			minor, err := decimalStringToMinor(amount, scale)
+			minor, err := decimalStringToMinor(amount, values.MinorUnitScale(code))
 			if err != nil {
 				return nil, fmt.Errorf("overlay: amount_minor_by_currency could not convert %q (%s): %w", amount, code, err)
 			}
@@ -156,25 +152,6 @@ func transformAmountMinorByCurrency(v any) (any, error) {
 	// value with a nil error is exactly that "null, and not an error" —
 	// applyTransform lands it as a JSON null on the column.
 	return nil, nil //nolint:nilnil // deliberate: null amount_minor is a valid, non-error mapping result
-}
-
-// ISO4217MinorUnitExponent returns a currency's minor-unit exponent. Two is
-// ISO-4217's own default and covers the vast majority; the exceptions are the
-// zero-decimal and three-decimal currencies enumerated here. Choosing the
-// exponent from the code — not a blanket ×100 — is what the money model
-// (data-semantics §1 / DM-CONV-9) requires. Exported so the HubSpot write
-// mapping (hubspot.mapWrite, OVA-MAP-W2) scales amount_minor BACK to a decimal
-// string against the SAME exponent table the read transform scales it in by —
-// one spelling of the ISO fact, never a second copy that could drift.
-func ISO4217MinorUnitExponent(code string) int {
-	// The table itself lives in shared/kernel/values, beside Money, because
-	// three callers now need it and they sit on different sides of the DAG:
-	// this module, the offer-draft price check in compose, and the account
-	// brief in compose/orgbrief, which compose imports. This function's own
-	// promise — one spelling of the ISO fact, never a second copy that could
-	// drift — is what forced the move: the second copy had already appeared,
-	// and the two tables had already disagreed about UYI, CLF and UYW.
-	return values.MinorUnitDigits(code)
 }
 
 // stringField reads a string-valued property from a gathered assembler map,

--- a/backend/internal/shared/kernel/values/minorunits.go
+++ b/backend/internal/shared/kernel/values/minorunits.go
@@ -102,7 +102,7 @@ func MajorUnits(amountMinor int64, currency string) string {
 	if digits == 0 {
 		return strconv.FormatInt(amountMinor, 10)
 	}
-	scale := minorUnitScale(digits)
+	scale := powerOfTen(digits)
 	// The magnitude is taken as UNSIGNED, because negating an int64 does not
 	// always produce a positive one: math.MinInt64 has no positive counterpart
 	// and negating it yields itself, which would print a minus sign in front of
@@ -121,17 +121,36 @@ func MajorUnits(amountMinor int64, currency string) string {
 	return fmt.Sprintf("%s%d.%0*d", sign, magnitude/unsigned, digits, magnitude%unsigned)
 }
 
-// minorUnitScale is 10^digits — how many minor units make one major unit.
+// powerOfTen is 10^digits — how many minor units make one major unit.
 //
-// One spelling because both callers would otherwise write the same loop:
+// One spelling because every caller would otherwise write the same loop:
 // MajorUnits to split the figure into its two halves, WholeMajorUnits to
-// truncate it to the upper one.
-func minorUnitScale(digits int) int64 {
+// truncate it to the upper one, and MinorUnitScale for a caller outside this
+// package that needs the multiplier itself.
+//
+// Named for what it computes rather than for what its callers want, because
+// the alternative — minorUnitScale beside the exported MinorUnitScale — is two
+// names one capital letter apart for two different signatures, which is a
+// reader's problem before it is a linter's.
+func powerOfTen(digits int) int64 {
 	scale := int64(1)
 	for range digits {
 		scale *= 10
 	}
 	return scale
+}
+
+// MinorUnitScale is how many minor units make one major unit of the currency:
+// 100 for EUR, 1000 for KWD, 1 for VND. It is the multiplier a caller converting
+// a decimal figure INTO minor units needs, which MajorUnits and WholeMajorUnits
+// cannot supply because they only ever divide by it.
+//
+// It is exported for that one shape and no other. A caller that wants to RENDER
+// an amount wants MajorUnits or WholeMajorUnits instead — reaching for the scale
+// to do the division by hand is how a currency's digit count comes to be right
+// in this table and wrong at the surface reading it.
+func MinorUnitScale(currency string) int64 {
+	return powerOfTen(MinorUnitDigits(currency))
 }
 
 // WholeMajorUnits is the amount in whole major units, the fraction discarded:
@@ -149,7 +168,7 @@ func minorUnitScale(digits int) int64 {
 // abbreviates further, and rounding 999999 EUR up to "€10000" would state a
 // number the record does not hold.
 func WholeMajorUnits(amountMinor int64, currency string) int64 {
-	return amountMinor / minorUnitScale(MinorUnitDigits(currency))
+	return amountMinor / powerOfTen(MinorUnitDigits(currency))
 }
 
 // MinorUnits is MajorUnits' inverse: the figure a document writes ("12500.00",

--- a/backend/minorunitscale_test.go
+++ b/backend/minorunitscale_test.go
@@ -71,12 +71,20 @@ const (
 func handScaled(file *ast.File) []string {
 	var found []string
 	valuesQualifier := importedAs(file)
+	// A bare `MinorUnitDigits(...)` is values' own call only inside values. In
+	// any other package it names something else entirely, and reporting it
+	// sends somebody to disprove a finding.
+	if file.Name != nil && file.Name.Name == "values" {
+		valuesQualifier = ""
+	} else if valuesQualifier == "" {
+		return nil
+	}
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
 			continue
 		}
-		if asksForDigits(fn, valuesQualifier) && buildsAPowerOfTen(fn) {
+		if asksForDigits(fn, valuesQualifier) && buildsAPowerOfTen(fn, mathAs(file)) {
 			found = append(found, fn.Name.Name)
 			continue
 		}
@@ -117,7 +125,11 @@ func rendersADecimalPoint(fn *ast.FuncDecl) bool {
 	// reporting it would send somebody to disprove a finding.
 	point, formats, uses := false, false, false
 	name := digitParamName(fn)
-	ast.Inspect(fn, func(n ast.Node) bool {
+	// fn.Body and not fn: walking the whole declaration includes Type.Params,
+	// so the parameter's own identifier in the SIGNATURE set `uses` and the
+	// guard could never fail. A guard that cannot fail is the thing this file
+	// exists to stop shipping.
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.BasicLit:
 			if v.Kind == token.STRING && (v.Value == `"."` || strings.Contains(v.Value, `.%0`)) {
@@ -162,7 +174,11 @@ func digitParamName(fn *ast.FuncDecl) string {
 }
 
 // importedAs returns the local name the values package is bound to in this
-// file, "." for a dot import, or "" if the file does not import it at all.
+// file, or "" if the file does not import it. A DOT import returns "" too, and
+// that is a stated gap rather than an oversight: a dot-imported call is a bare
+// identifier, indistinguishable from a local function of the same name without
+// type information, and the census would rather miss it than name the wrong
+// function. Nothing in this tree dot-imports values.
 //
 // It exists so the census asks about VALUES' MinorUnitDigits and not about any
 // selector that happens to end in that name. Matching by suffix alone would
@@ -175,6 +191,9 @@ func importedAs(file *ast.File) string {
 			continue
 		}
 		if spec.Name != nil {
+			if spec.Name.Name == "." {
+				return ""
+			}
 			return spec.Name.Name
 		}
 		return "values"
@@ -182,9 +201,25 @@ func importedAs(file *ast.File) string {
 	return ""
 }
 
+// mathAs returns the local name the math package is bound to, or "" if this
+// file does not import it.
+func mathAs(file *ast.File) string {
+	for _, spec := range file.Imports {
+		if strings.Trim(spec.Path.Value, `"`) != "math" {
+			continue
+		}
+		if spec.Name != nil {
+			return spec.Name.Name
+		}
+		return "math"
+	}
+	return ""
+}
+
 // asksForDigits reports whether the declaration calls values.MinorUnitDigits.
-// A bare call counts only inside the values package itself, which is where the
-// function is declared and the only place it can be reached unqualified.
+// An empty qualifier means the caller has established this file IS the values
+// package, where the function is declared and the only place it is reachable
+// unqualified.
 func asksForDigits(fn *ast.FuncDecl, qualifier string) bool {
 	asks := false
 	ast.Inspect(fn, func(n ast.Node) bool {
@@ -214,12 +249,16 @@ func asksForDigits(fn *ast.FuncDecl, qualifier string) bool {
 // ten elsewhere. The detector still cannot prove the loop is bounded BY the
 // digit count — that needs data flow — but "in a loop" is the part that
 // distinguishes a scale from arithmetic, and it is checkable.
-func buildsAPowerOfTen(fn *ast.FuncDecl) bool {
+func buildsAPowerOfTen(fn *ast.FuncDecl, mathQualifier string) bool {
 	builds := false
 	ast.Inspect(fn, func(n ast.Node) bool {
+		// math.Pow10 and not any `x.Pow10`: a name-only match reported an
+		// unrelated package's method as this defect.
 		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "Pow10" {
-			builds = true
-			return false
+			if pkg, isIdent := sel.X.(*ast.Ident); isIdent && pkg.Name == mathQualifier {
+				builds = true
+				return false
+			}
 		}
 		body := loopBody(n)
 		if body == nil {
@@ -351,16 +390,28 @@ func TestNobodyBuildsAMinorUnitScaleByHand(t *testing.T) {
 // and over a detector that has stopped detecting, so the detector is read
 // directly here — against the shapes that actually shipped, and against the
 // lookalikes it must leave alone.
-func TestTheHandScaledDetectorSeesWhatItClaimsTo(t *testing.T) {
-	cases := []struct {
-		name  string
-		fires bool
-		// bare omits the values import, which is how the values package itself
-		// sees the function — the only place a call to it is unqualified.
-		bare bool
-		src  string
-	}{
-		{"the loop that shipped in compose", true, false, `
+// handScaledProbe is one planted source file and the answer the detector must
+// give for it. Extracted from the test because the table is the substance and a
+// 170-line function is not navigable — the test below is the four lines that
+// read it.
+type handScaledProbe struct {
+	name  string
+	fires bool
+	// mode picks the file the probe is parsed as, because the detector's
+	// answers depend on it and a probe that guesses wrong asks a different
+	// question than the tree does:
+	//
+	//   ""         package probe, importing values — an ordinary caller
+	//   "values"   package values, no import — the one place a bare call
+	//              to MinorUnitDigits is values' own
+	//   "noimport" package probe, no import — a package that does not use
+	//              values at all and may well declare its own
+	mode string
+	src  string
+}
+
+var handScaledProbes = []handScaledProbe{
+	{"the loop that shipped in compose", true, "", `
 func priceEvidenced(currency string, priceMinor int64) bool {
 	digits := values.MinorUnitDigits(currency)
 	scale := int64(1)
@@ -369,7 +420,7 @@ func priceEvidenced(currency string, priceMinor int64) bool {
 	}
 	return priceMinor/scale > 0
 }`},
-		{"the loop that shipped in overlay, digits read inline", true, false, `
+	{"the loop that shipped in overlay, digits read inline", true, "", `
 func amountFor(code, amount string) int64 {
 	scale := int64(1)
 	for i := 0; i < values.MinorUnitDigits(code); i++ {
@@ -377,7 +428,7 @@ func amountFor(code, amount string) int64 {
 	}
 	return toMinor(amount, scale)
 }`},
-		{"a range loop rather than a counter", true, false, `
+	{"a range loop rather than a counter", true, "", `
 func scaleOf(currency string) int64 {
 	scale := int64(1)
 	for range values.MinorUnitDigits(currency) {
@@ -385,7 +436,7 @@ func scaleOf(currency string) int64 {
 	}
 	return scale
 }`},
-		{"the multiplication written out", true, false, `
+	{"the multiplication written out", true, "", `
 func scaleOf(currency string) int64 {
 	digits, scale := values.MinorUnitDigits(currency), int64(1)
 	for i := 0; i < digits; i++ {
@@ -393,11 +444,11 @@ func scaleOf(currency string) int64 {
 	}
 	return scale
 }`},
-		// The fourth copy, verbatim as it stood in overlay/hubspot before this
-		// change. It builds no power of ten, so the arithmetic arm cannot see
-		// it — and it was found only because deleting it made an exported
-		// wrapper dead, which is not a way of finding things.
-		{"the string-splice renderer that shipped in hubspot", true, false, `
+	// The fourth copy, verbatim as it stood in overlay/hubspot before this
+	// change. It builds no power of ten, so the arithmetic arm cannot see
+	// it — and it was found only because deleting it made an exported
+	// wrapper dead, which is not a way of finding things.
+	{"the string-splice renderer that shipped in hubspot", true, "", `
 func minorToDecimalString(minor int64, exponent int) string {
 	s := strconv.FormatInt(minor, 10)
 	neg := strings.HasPrefix(s, "-")
@@ -416,15 +467,15 @@ func minorToDecimalString(minor int64, exponent int) string {
 	}
 	return s
 }`},
-		{"the same renderer written with Sprintf", true, false, `
+	{"the same renderer written with Sprintf", true, "", `
 func render(minor int64, digits int) string {
 	return fmt.Sprintf("%d.%0*d", minor/100, digits, minor%100)
 }`},
-		{"math.Pow10, the next spelling nobody has written yet", true, false, `
+	{"math.Pow10, the next spelling nobody has written yet", true, "", `
 func scaleOf(currency string) float64 {
 	return math.Pow10(values.MinorUnitDigits(currency))
 }`},
-		{"an unqualified call, as values itself would write it", true, true, `
+	{"an unqualified call, as values itself would write it", true, "values", `
 func scaleOf(currency string) int64 {
 	scale := int64(1)
 	for range MinorUnitDigits(currency) {
@@ -433,21 +484,21 @@ func scaleOf(currency string) int64 {
 	return scale
 }`},
 
-		// The other direction, which is where a census of zero usually goes
-		// wrong: a detector that fires on everything also reports nothing, in
-		// the sense that nobody can act on it.
-		{"asking the table without scaling", false, false, `
+	// The other direction, which is where a census of zero usually goes
+	// wrong: a detector that fires on everything also reports nothing, in
+	// the sense that nobody can act on it.
+	{"asking the table without scaling", false, "", `
 func decimalsFor(currency string) int {
 	return values.MinorUnitDigits(currency)
 }`},
-		{"asking, then delegating the scaling to values", false, false, `
+	{"asking, then delegating the scaling to values", false, "", `
 func majorOf(currency string, amountMinor int64) string {
 	if values.MinorUnitDigits(currency) == 0 {
 		return strconv.FormatInt(amountMinor, 10)
 	}
 	return values.MajorUnits(amountMinor, currency)
 }`},
-		{"scaling by ten with nothing to do with currency", false, false, `
+	{"scaling by ten with nothing to do with currency", false, "", `
 func decimate(n int64) int64 {
 	scale := int64(1)
 	for i := 0; i < 3; i++ {
@@ -455,28 +506,28 @@ func decimate(n int64) int64 {
 	}
 	return n / scale
 }`},
-		{"a hundred, which is the money-scale gate's subject", false, false, `
+	{"a hundred, which is the money-scale gate's subject", false, "", `
 func majorOf(currency string, amountMinor int64) int64 {
 	_ = values.MinorUnitDigits(currency)
 	return amountMinor / 100
 }`},
-		{"a function taking a digit count that renders nothing", false, false, `
+	{"a function taking a digit count that renders nothing", false, "", `
 func padTo(s string, digits int) string {
 	for len(s) < digits {
 		s = "0" + s
 	}
 	return s
 }`},
-		// The detector cannot prove the loop counts the DIGITS — that needs data
-		// flow. What it can require is that the multiplication happens in a
-		// loop at all, which is what separates building a scale from ordinary
-		// arithmetic. Without it, reading the digit count for a legitimate
-		// reason and multiplying anything by ten elsewhere was a finding.
-		{"reading the digit count beside an unrelated * 10", false, false, `
+	// The detector cannot prove the loop counts the DIGITS — that needs data
+	// flow. What it can require is that the multiplication happens in a
+	// loop at all, which is what separates building a scale from ordinary
+	// arithmetic. Without it, reading the digit count for a legitimate
+	// reason and multiplying anything by ten elsewhere was a finding.
+	{"reading the digit count beside an unrelated * 10", false, "", `
 func widthFor(currency string, ratio int) (int, int) {
 	return values.MinorUnitDigits(currency), ratio * 10
 }`},
-		{"a different package's MinorUnitDigits is not values'", false, false, `
+	{"a different package's MinorUnitDigits is not values'", false, "", `
 func scaleOf(c legacy.Code) int64 {
 	scale := int64(1)
 	for range c.MinorUnitDigits() {
@@ -484,17 +535,33 @@ func scaleOf(c legacy.Code) int64 {
 	}
 	return scale
 }`},
-		// The digit count must reach the RENDER, not merely sit in the signature.
-		{"a digit count the render ignores", false, false, `
+	// The digit count must reach the RENDER, not merely sit in the signature.
+	// A package that does not import values and declares its OWN
+	// MinorUnitDigits is not calling values'.
+	{"another package's own unqualified MinorUnitDigits", false, "noimport", `
+func scaleOf(currency string) int64 {
+	scale := int64(1)
+	for range MinorUnitDigits(currency) {
+		scale *= 10
+	}
+	return scale
+}`},
+	{"a digit count the render ignores", false, "", `
 func label(name string, digits int) string {
-	_ = digits
 	return fmt.Sprintf("%s/%s", name, "eur")
 }`},
-		{"a decimal point with no digit count in sight", false, false, `
+	// The digit count must be USED in the body. Walking the whole
+	// declaration includes the signature, so the parameter's own
+	// identifier there satisfied the guard and it could never fail.
+	{"a renderer whose digit count is signature-only", false, "", `
+func render(minor int64, digits int) string {
+	return fmt.Sprintf("%d.%02d", minor/100, minor%100)
+}`},
+	{"a decimal point with no digit count in sight", false, "", `
 func label(name string) string {
 	return fmt.Sprintf("%s.%s", name, "eur")
 }`},
-		{"the two halves in DIFFERENT functions of one file", false, false, `
+	{"the two halves in DIFFERENT functions of one file", false, "", `
 func decimalsFor(currency string) int { return values.MinorUnitDigits(currency) }
 
 func decimate(n int64) int64 {
@@ -502,16 +569,22 @@ func decimate(n int64) int64 {
 	scale *= 10
 	return n / scale
 }`},
-	}
+}
+
+func TestTheHandScaledDetectorSeesWhatItClaimsTo(t *testing.T) {
 
 	fset := token.NewFileSet()
-	for _, tc := range cases {
+	for _, tc := range handScaledProbes {
 		t.Run(tc.name, func(t *testing.T) {
 			// The probe carries the same imports the real call sites do, because
 			// the detector resolves the values qualifier through them — a probe
 			// without the import asks a different question than the tree does.
 			head := "package probe\n"
-			if !tc.bare {
+			switch tc.mode {
+			case "values":
+				head = "package values\n"
+			case "noimport":
+			default:
 				head += "import (\n\t\"fmt\"\n\t\"math\"\n\t\"strconv\"\n\t\"strings\"\n\n\t\"github.com/gradionhq/margince/backend/" + valuesOwner + "\"\n)\n"
 			}
 			file, err := parser.ParseFile(fset, "probe.go", head+tc.src, 0)

--- a/backend/minorunitscale_test.go
+++ b/backend/minorunitscale_test.go
@@ -70,12 +70,13 @@ const (
 // miss a defect split across two functions, and it cannot invent one.
 func handScaled(file *ast.File) []string {
 	var found []string
+	valuesQualifier := importedAs(file)
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
 			continue
 		}
-		if asksForDigits(fn) && buildsAPowerOfTen(fn) {
+		if asksForDigits(fn, valuesQualifier) && buildsAPowerOfTen(fn) {
 			found = append(found, fn.Name.Name)
 			continue
 		}
@@ -107,15 +108,24 @@ func handScaled(file *ast.File) []string {
 // count rather than asking for it — that is what made it invisible to a census
 // that looked for the asking.
 func rendersADecimalPoint(fn *ast.FuncDecl) bool {
-	if !takesADigitCount(fn) {
+	if digitParamName(fn) == "" {
 		return false
 	}
-	point, formats := false, false
+	// The digit count must reach the rendering, not merely sit in the
+	// signature. A function that takes a `digits int` for something else and
+	// happens to format a decimal elsewhere is not a second renderer, and
+	// reporting it would send somebody to disprove a finding.
+	point, formats, uses := false, false, false
+	name := digitParamName(fn)
 	ast.Inspect(fn, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.BasicLit:
 			if v.Kind == token.STRING && (v.Value == `"."` || strings.Contains(v.Value, `.%0`)) {
 				point = true
+			}
+		case *ast.Ident:
+			if v.Name == name {
+				uses = true
 			}
 		case *ast.SelectorExpr:
 			switch v.Sel.Name {
@@ -125,36 +135,57 @@ func rendersADecimalPoint(fn *ast.FuncDecl) bool {
 		}
 		return true
 	})
-	return point && formats
+	return point && formats && uses
 }
 
-// takesADigitCount reports whether the declaration receives a minor-unit digit
-// count by parameter. The names are the ones this tree has actually used for
-// it; a renderer that calls the parameter something else is out of reach, and
+// digitParamName returns the name of the declaration's minor-unit digit-count
+// parameter, or "" if it has none. The names are the ones this tree has
+// actually used; a renderer that calls it something else is out of reach, and
 // the census says so rather than implying otherwise.
-func takesADigitCount(fn *ast.FuncDecl) bool {
+func digitParamName(fn *ast.FuncDecl) string {
 	if fn.Type.Params == nil {
-		return false
+		return ""
 	}
 	for _, field := range fn.Type.Params.List {
 		ident, ok := field.Type.(*ast.Ident)
 		if !ok || ident.Name != "int" {
 			continue
 		}
-		for _, name := range field.Names {
-			switch name.Name {
+		for _, n := range field.Names {
+			switch n.Name {
 			case "digits", "exponent", "decimals", "minorUnits":
-				return true
+				return n.Name
 			}
 		}
 	}
-	return false
+	return ""
 }
 
-// asksForDigits reports whether the declaration calls MinorUnitDigits, however
-// the values package happens to be imported — qualified, dot-imported, or from
-// inside values itself.
-func asksForDigits(fn *ast.FuncDecl) bool {
+// importedAs returns the local name the values package is bound to in this
+// file, "." for a dot import, or "" if the file does not import it at all.
+//
+// It exists so the census asks about VALUES' MinorUnitDigits and not about any
+// selector that happens to end in that name. Matching by suffix alone would
+// report a different package's identically-named method, and a census that
+// reports the wrong subject is worse than one that reports none: somebody has
+// to go and disprove it.
+func importedAs(file *ast.File) string {
+	for _, spec := range file.Imports {
+		if strings.Trim(spec.Path.Value, `"`) != "github.com/gradionhq/margince/backend/"+valuesOwner {
+			continue
+		}
+		if spec.Name != nil {
+			return spec.Name.Name
+		}
+		return "values"
+	}
+	return ""
+}
+
+// asksForDigits reports whether the declaration calls values.MinorUnitDigits.
+// A bare call counts only inside the values package itself, which is where the
+// function is declared and the only place it can be reached unqualified.
+func asksForDigits(fn *ast.FuncDecl, qualifier string) bool {
 	asks := false
 	ast.Inspect(fn, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -163,39 +194,79 @@ func asksForDigits(fn *ast.FuncDecl) bool {
 		}
 		switch f := call.Fun.(type) {
 		case *ast.Ident:
-			asks = asks || f.Name == digitsFunc
+			asks = asks || (f.Name == digitsFunc && qualifier == "")
 		case *ast.SelectorExpr:
-			asks = asks || f.Sel.Name == digitsFunc
+			pkg, ok := f.X.(*ast.Ident)
+			asks = asks || (ok && f.Sel.Name == digitsFunc && qualifier != "" && pkg.Name == qualifier)
 		}
 		return !asks
 	})
 	return asks
 }
 
-// buildsAPowerOfTen reports whether the declaration multiplies an accumulator
-// by ten, or reaches for math.Pow10.
+// buildsAPowerOfTen reports whether the declaration REPEATEDLY multiplies an
+// accumulator by ten, or reaches for math.Pow10.
+//
+// Repeatedly — the multiplication must sit inside a loop. A power of ten is
+// built by iterating the digit count; a lone `x * 10` is a different thing
+// entirely, and counting it made the gate fire on any function that read the
+// digit count for a legitimate reason and happened to multiply something by
+// ten elsewhere. The detector still cannot prove the loop is bounded BY the
+// digit count — that needs data flow — but "in a loop" is the part that
+// distinguishes a scale from arithmetic, and it is checkable.
 func buildsAPowerOfTen(fn *ast.FuncDecl) bool {
 	builds := false
 	ast.Inspect(fn, func(n ast.Node) bool {
-		switch v := n.(type) {
-		case *ast.AssignStmt:
-			if v.Tok == token.MUL_ASSIGN && anyLiteralTen(v.Rhs) {
-				builds = true
-			}
-			// `scale = scale * 10` written out, and the `:=` that seeds it.
-			if v.Tok == token.ASSIGN || v.Tok == token.DEFINE {
-				for _, rhs := range v.Rhs {
-					if bin, ok := rhs.(*ast.BinaryExpr); ok && bin.Op == token.MUL && anyLiteralTen([]ast.Expr{bin.X, bin.Y}) {
-						builds = true
-					}
-				}
-			}
-		case *ast.SelectorExpr:
-			builds = builds || v.Sel.Name == "Pow10"
+		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "Pow10" {
+			builds = true
+			return false
 		}
+		body := loopBody(n)
+		if body == nil {
+			return !builds
+		}
+		builds = builds || multipliesByTen(body)
 		return !builds
 	})
 	return builds
+}
+
+// loopBody returns the body of a for or range statement, or nil.
+func loopBody(n ast.Node) *ast.BlockStmt {
+	switch v := n.(type) {
+	case *ast.ForStmt:
+		return v.Body
+	case *ast.RangeStmt:
+		return v.Body
+	}
+	return nil
+}
+
+// multipliesByTen reports whether the block multiplies something by the
+// literal ten.
+func multipliesByTen(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		v, ok := n.(*ast.AssignStmt)
+		if ok {
+			if v.Tok == token.MUL_ASSIGN && anyLiteralTen(v.Rhs) {
+				found = true
+			}
+			// `scale = scale * 10` written out. NOT the `:=` that seeds the
+			// accumulator — `scale := int64(1)` has no binary right-hand side
+			// and could never match here, and a comment saying it did was one
+			// more claim with nothing behind it.
+			if v.Tok == token.ASSIGN || v.Tok == token.DEFINE {
+				for _, rhs := range v.Rhs {
+					if bin, isBin := rhs.(*ast.BinaryExpr); isBin && bin.Op == token.MUL && anyLiteralTen([]ast.Expr{bin.X, bin.Y}) {
+						found = true
+					}
+				}
+			}
+		}
+		return !found
+	})
+	return found
 }
 
 // anyLiteralTen reports whether either operand is the literal 10. Only ten: a
@@ -284,9 +355,12 @@ func TestTheHandScaledDetectorSeesWhatItClaimsTo(t *testing.T) {
 	cases := []struct {
 		name  string
 		fires bool
-		src   string
+		// bare omits the values import, which is how the values package itself
+		// sees the function — the only place a call to it is unqualified.
+		bare bool
+		src  string
 	}{
-		{"the loop that shipped in compose", true, `
+		{"the loop that shipped in compose", true, false, `
 func priceEvidenced(currency string, priceMinor int64) bool {
 	digits := values.MinorUnitDigits(currency)
 	scale := int64(1)
@@ -295,7 +369,7 @@ func priceEvidenced(currency string, priceMinor int64) bool {
 	}
 	return priceMinor/scale > 0
 }`},
-		{"the loop that shipped in overlay, digits read inline", true, `
+		{"the loop that shipped in overlay, digits read inline", true, false, `
 func amountFor(code, amount string) int64 {
 	scale := int64(1)
 	for i := 0; i < values.MinorUnitDigits(code); i++ {
@@ -303,7 +377,7 @@ func amountFor(code, amount string) int64 {
 	}
 	return toMinor(amount, scale)
 }`},
-		{"a range loop rather than a counter", true, `
+		{"a range loop rather than a counter", true, false, `
 func scaleOf(currency string) int64 {
 	scale := int64(1)
 	for range values.MinorUnitDigits(currency) {
@@ -311,7 +385,7 @@ func scaleOf(currency string) int64 {
 	}
 	return scale
 }`},
-		{"the multiplication written out", true, `
+		{"the multiplication written out", true, false, `
 func scaleOf(currency string) int64 {
 	digits, scale := values.MinorUnitDigits(currency), int64(1)
 	for i := 0; i < digits; i++ {
@@ -323,7 +397,7 @@ func scaleOf(currency string) int64 {
 		// change. It builds no power of ten, so the arithmetic arm cannot see
 		// it — and it was found only because deleting it made an exported
 		// wrapper dead, which is not a way of finding things.
-		{"the string-splice renderer that shipped in hubspot", true, `
+		{"the string-splice renderer that shipped in hubspot", true, false, `
 func minorToDecimalString(minor int64, exponent int) string {
 	s := strconv.FormatInt(minor, 10)
 	neg := strings.HasPrefix(s, "-")
@@ -342,15 +416,15 @@ func minorToDecimalString(minor int64, exponent int) string {
 	}
 	return s
 }`},
-		{"the same renderer written with Sprintf", true, `
+		{"the same renderer written with Sprintf", true, false, `
 func render(minor int64, digits int) string {
 	return fmt.Sprintf("%d.%0*d", minor/100, digits, minor%100)
 }`},
-		{"math.Pow10, the next spelling nobody has written yet", true, `
+		{"math.Pow10, the next spelling nobody has written yet", true, false, `
 func scaleOf(currency string) float64 {
 	return math.Pow10(values.MinorUnitDigits(currency))
 }`},
-		{"an unqualified call, as values itself would write it", true, `
+		{"an unqualified call, as values itself would write it", true, true, `
 func scaleOf(currency string) int64 {
 	scale := int64(1)
 	for range MinorUnitDigits(currency) {
@@ -362,18 +436,18 @@ func scaleOf(currency string) int64 {
 		// The other direction, which is where a census of zero usually goes
 		// wrong: a detector that fires on everything also reports nothing, in
 		// the sense that nobody can act on it.
-		{"asking the table without scaling", false, `
+		{"asking the table without scaling", false, false, `
 func decimalsFor(currency string) int {
 	return values.MinorUnitDigits(currency)
 }`},
-		{"asking, then delegating the scaling to values", false, `
+		{"asking, then delegating the scaling to values", false, false, `
 func majorOf(currency string, amountMinor int64) string {
 	if values.MinorUnitDigits(currency) == 0 {
 		return strconv.FormatInt(amountMinor, 10)
 	}
 	return values.MajorUnits(amountMinor, currency)
 }`},
-		{"scaling by ten with nothing to do with currency", false, `
+		{"scaling by ten with nothing to do with currency", false, false, `
 func decimate(n int64) int64 {
 	scale := int64(1)
 	for i := 0; i < 3; i++ {
@@ -381,23 +455,46 @@ func decimate(n int64) int64 {
 	}
 	return n / scale
 }`},
-		{"a hundred, which is the money-scale gate's subject", false, `
+		{"a hundred, which is the money-scale gate's subject", false, false, `
 func majorOf(currency string, amountMinor int64) int64 {
 	_ = values.MinorUnitDigits(currency)
 	return amountMinor / 100
 }`},
-		{"a function taking a digit count that renders nothing", false, `
+		{"a function taking a digit count that renders nothing", false, false, `
 func padTo(s string, digits int) string {
 	for len(s) < digits {
 		s = "0" + s
 	}
 	return s
 }`},
-		{"a decimal point with no digit count in sight", false, `
+		// The detector cannot prove the loop counts the DIGITS — that needs data
+		// flow. What it can require is that the multiplication happens in a
+		// loop at all, which is what separates building a scale from ordinary
+		// arithmetic. Without it, reading the digit count for a legitimate
+		// reason and multiplying anything by ten elsewhere was a finding.
+		{"reading the digit count beside an unrelated * 10", false, false, `
+func widthFor(currency string, ratio int) (int, int) {
+	return values.MinorUnitDigits(currency), ratio * 10
+}`},
+		{"a different package's MinorUnitDigits is not values'", false, false, `
+func scaleOf(c legacy.Code) int64 {
+	scale := int64(1)
+	for range c.MinorUnitDigits() {
+		scale *= 10
+	}
+	return scale
+}`},
+		// The digit count must reach the RENDER, not merely sit in the signature.
+		{"a digit count the render ignores", false, false, `
+func label(name string, digits int) string {
+	_ = digits
+	return fmt.Sprintf("%s/%s", name, "eur")
+}`},
+		{"a decimal point with no digit count in sight", false, false, `
 func label(name string) string {
 	return fmt.Sprintf("%s.%s", name, "eur")
 }`},
-		{"the two halves in DIFFERENT functions of one file", false, `
+		{"the two halves in DIFFERENT functions of one file", false, false, `
 func decimalsFor(currency string) int { return values.MinorUnitDigits(currency) }
 
 func decimate(n int64) int64 {
@@ -410,7 +507,14 @@ func decimate(n int64) int64 {
 	fset := token.NewFileSet()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			file, err := parser.ParseFile(fset, "probe.go", "package probe\n"+tc.src, 0)
+			// The probe carries the same imports the real call sites do, because
+			// the detector resolves the values qualifier through them — a probe
+			// without the import asks a different question than the tree does.
+			head := "package probe\n"
+			if !tc.bare {
+				head += "import (\n\t\"fmt\"\n\t\"math\"\n\t\"strconv\"\n\t\"strings\"\n\n\t\"github.com/gradionhq/margince/backend/" + valuesOwner + "\"\n)\n"
+			}
+			file, err := parser.ParseFile(fset, "probe.go", head+tc.src, 0)
 			if err != nil {
 				t.Fatalf("the probe does not parse, so it proves nothing about the detector: %v", err)
 			}

--- a/backend/minorunitscale_test.go
+++ b/backend/minorunitscale_test.go
@@ -27,8 +27,8 @@ package backendarch
 // This is a census of ZERO, and that is the hard kind to write honestly. A gate
 // asserting a shape is absent passes identically when the shape is absent and
 // when the detector is broken, so the census below is worth nothing without
-// TestTheHandScaledDetectorSeesWhatItClaimsTo beneath it — which plants each of
-// the four shapes that actually shipped, plus the lookalikes that must NOT be
+// TestTheHandScaledDetectorSeesWhatItClaimsTo beneath it — which plants all
+// four shapes that actually shipped, plus the lookalikes that must NOT be
 // findings, and reads the detector's answer directly.
 
 import (
@@ -48,17 +48,20 @@ const (
 	scaleAdvice = "values.MinorUnitScale (the multiplier), values.MajorUnits (the decimal string) or values.WholeMajorUnits (the truncated integer)"
 )
 
-// handScaled names the functions in a file that ask for a minor-unit digit
-// count and then build a power of ten from it.
+// handScaled names the functions in a file that do values' job with a
+// currency's minor-unit digit count instead of asking values to do it.
 //
-// Two shapes, because both are reachable. The loop —
+// Two arms, because the four copies came in two shapes. The ARITHMETIC arm
+// catches a function that asks for the digit count and then builds the power
+// of ten — the loop —
 //
 //	scale := int64(1)
 //	for i := 0; i < digits; i++ { scale *= 10 }
 //
-// which is what three of the four copies wrote, and a direct math.Pow10, which
-// nothing writes here today but is the obvious next spelling and costs one line
-// to refuse now rather than after it appears.
+// which is what three of the four copies wrote, plus a direct math.Pow10,
+// which nothing writes here today but is the obvious next spelling. The
+// RENDERER arm catches the fourth, which built no power of ten at all and was
+// therefore invisible to the first — see rendersADecimalPoint.
 //
 // It judges per FUNCTION, not per file. A file may hold a renderer that asks
 // the table and a separate helper that scales something unrelated by ten;
@@ -74,9 +77,78 @@ func handScaled(file *ast.File) []string {
 		}
 		if asksForDigits(fn) && buildsAPowerOfTen(fn) {
 			found = append(found, fn.Name.Name)
+			continue
+		}
+		if rendersADecimalPoint(fn) {
+			found = append(found, fn.Name.Name)
 		}
 	}
 	return found
+}
+
+// rendersADecimalPoint reports whether the declaration is a second
+// values.MajorUnits: it takes a minor-unit digit count as a parameter and
+// splices a decimal point into a formatted integer.
+//
+// It is a separate arm because the fourth copy was not a loop at all. It built
+// the string by hand —
+//
+//	s := strconv.FormatInt(minor, 10)
+//	point := len(s) - exponent
+//	s = s[:point] + "." + s[point:]
+//
+// — and it was found only because deleting it made an exported wrapper dead.
+// The arithmetic arm cannot see it: it computes no power of ten. Without this,
+// the comment beside its call site claiming values.MajorUnits is the one
+// renderer would be a uniqueness claim with nothing holding it, which is the
+// one thing this repo's rulebook says a comment may not be.
+//
+// Keyed on the PARAMETER and not on a call, because a renderer is handed the
+// count rather than asking for it — that is what made it invisible to a census
+// that looked for the asking.
+func rendersADecimalPoint(fn *ast.FuncDecl) bool {
+	if !takesADigitCount(fn) {
+		return false
+	}
+	point, formats := false, false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.BasicLit:
+			if v.Kind == token.STRING && (v.Value == `"."` || strings.Contains(v.Value, `.%0`)) {
+				point = true
+			}
+		case *ast.SelectorExpr:
+			switch v.Sel.Name {
+			case "FormatInt", "Itoa", "Sprintf", "Sprint":
+				formats = true
+			}
+		}
+		return true
+	})
+	return point && formats
+}
+
+// takesADigitCount reports whether the declaration receives a minor-unit digit
+// count by parameter. The names are the ones this tree has actually used for
+// it; a renderer that calls the parameter something else is out of reach, and
+// the census says so rather than implying otherwise.
+func takesADigitCount(fn *ast.FuncDecl) bool {
+	if fn.Type.Params == nil {
+		return false
+	}
+	for _, field := range fn.Type.Params.List {
+		ident, ok := field.Type.(*ast.Ident)
+		if !ok || ident.Name != "int" {
+			continue
+		}
+		for _, name := range field.Names {
+			switch name.Name {
+			case "digits", "exponent", "decimals", "minorUnits":
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // asksForDigits reports whether the declaration calls MinorUnitDigits, however
@@ -196,11 +268,11 @@ func TestNobodyBuildsAMinorUnitScaleByHand(t *testing.T) {
 	if len(findings) == 0 {
 		return
 	}
-	t.Errorf("these functions ask values for a currency's minor-unit digit count and then build the "+
-		"power of ten themselves:\n  %s\n\nvalues already owns that step — use %s. Four copies of this "+
-		"arithmetic existed and agreed over 272 amount-by-currency pairs, which is how long a second copy "+
-		"stays harmless: until the commit that corrects one currency's digit count reaches only the "+
-		"callers somebody remembered.", strings.Join(findings, "\n  "), scaleAdvice)
+	t.Errorf("these functions take a currency's minor-unit digit count and do values' job with it — "+
+		"building the power of ten, or rendering the decimal string:\n  %s\n\nvalues already owns both "+
+		"steps: %s. Four copies existed and agreed over 272 amount-by-currency pairs, which is how long "+
+		"a second copy stays harmless: until the commit that corrects one currency's digit count reaches "+
+		"only the callers somebody remembered.", strings.Join(findings, "\n  "), scaleAdvice)
 }
 
 // TestTheHandScaledDetectorSeesWhatItClaimsTo is the half that makes the census
@@ -247,6 +319,33 @@ func scaleOf(currency string) int64 {
 	}
 	return scale
 }`},
+		// The fourth copy, verbatim as it stood in overlay/hubspot before this
+		// change. It builds no power of ten, so the arithmetic arm cannot see
+		// it — and it was found only because deleting it made an exported
+		// wrapper dead, which is not a way of finding things.
+		{"the string-splice renderer that shipped in hubspot", true, `
+func minorToDecimalString(minor int64, exponent int) string {
+	s := strconv.FormatInt(minor, 10)
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+	if exponent > 0 {
+		for len(s) <= exponent {
+			s = "0" + s
+		}
+		point := len(s) - exponent
+		s = s[:point] + "." + s[point:]
+	}
+	if neg {
+		s = "-" + s
+	}
+	return s
+}`},
+		{"the same renderer written with Sprintf", true, `
+func render(minor int64, digits int) string {
+	return fmt.Sprintf("%d.%0*d", minor/100, digits, minor%100)
+}`},
 		{"math.Pow10, the next spelling nobody has written yet", true, `
 func scaleOf(currency string) float64 {
 	return math.Pow10(values.MinorUnitDigits(currency))
@@ -286,6 +385,17 @@ func decimate(n int64) int64 {
 func majorOf(currency string, amountMinor int64) int64 {
 	_ = values.MinorUnitDigits(currency)
 	return amountMinor / 100
+}`},
+		{"a function taking a digit count that renders nothing", false, `
+func padTo(s string, digits int) string {
+	for len(s) < digits {
+		s = "0" + s
+	}
+	return s
+}`},
+		{"a decimal point with no digit count in sight", false, `
+func label(name string) string {
+	return fmt.Sprintf("%s.%s", name, "eur")
 }`},
 		{"the two halves in DIFFERENT functions of one file", false, `
 func decimalsFor(currency string) int { return values.MinorUnitDigits(currency) }

--- a/backend/minorunitscale_test.go
+++ b/backend/minorunitscale_test.go
@@ -572,7 +572,6 @@ func decimate(n int64) int64 {
 }
 
 func TestTheHandScaledDetectorSeesWhatItClaimsTo(t *testing.T) {
-
 	fset := token.NewFileSet()
 	for _, tc := range handScaledProbes {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/minorunitscale_test.go
+++ b/backend/minorunitscale_test.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one
+// fact, and the table that holds it lives in shared/kernel/values. The table
+// was already shared. The ARITHMETIC that turns it into a multiplier was not:
+// four functions each wrote their own `for i := 0; i < digits; i++ { s *= 10 }`
+// and then divided by it, and one of them reimplemented values.MajorUnits from
+// scratch to render the result.
+//
+// The four agreed, which is exactly how long that lasts. They were compared
+// over 272 amount×currency pairs including math.MinInt64 and none disagreed —
+// and a second copy stays harmless right up to the commit that corrects the
+// digit count for one currency in the table and reaches only the callers
+// somebody remembered.
+//
+// The obligation is narrow on purpose: a function that ASKS the table for a
+// digit count must not then build the power of ten by hand. It may ask for
+// other reasons — how many decimals to render, whether a currency has a minor
+// unit at all — and those are not this gate's business. What it may not do is
+// take the digits and do values' job with them, because values exports every
+// shape a caller here has needed: MinorUnitScale for the multiplier,
+// MajorUnits for the decimal string, WholeMajorUnits for the truncated integer.
+//
+// This is a census of ZERO, and that is the hard kind to write honestly. A gate
+// asserting a shape is absent passes identically when the shape is absent and
+// when the detector is broken, so the census below is worth nothing without
+// TestTheHandScaledDetectorSeesWhatItClaimsTo beneath it — which plants each of
+// the four shapes that actually shipped, plus the lookalikes that must NOT be
+// findings, and reads the detector's answer directly.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	digitsFunc  = "MinorUnitDigits"
+	valuesOwner = "internal/shared/kernel/values"
+	scaleAdvice = "values.MinorUnitScale (the multiplier), values.MajorUnits (the decimal string) or values.WholeMajorUnits (the truncated integer)"
+)
+
+// handScaled names the functions in a file that ask for a minor-unit digit
+// count and then build a power of ten from it.
+//
+// Two shapes, because both are reachable. The loop —
+//
+//	scale := int64(1)
+//	for i := 0; i < digits; i++ { scale *= 10 }
+//
+// which is what three of the four copies wrote, and a direct math.Pow10, which
+// nothing writes here today but is the obvious next spelling and costs one line
+// to refuse now rather than after it appears.
+//
+// It judges per FUNCTION, not per file. A file may hold a renderer that asks
+// the table and a separate helper that scales something unrelated by ten;
+// asking whether both appear somewhere in the same file reports a pairing
+// nobody wrote. Per-declaration is also the reading that fails safe: it can
+// miss a defect split across two functions, and it cannot invent one.
+func handScaled(file *ast.File) []string {
+	var found []string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if asksForDigits(fn) && buildsAPowerOfTen(fn) {
+			found = append(found, fn.Name.Name)
+		}
+	}
+	return found
+}
+
+// asksForDigits reports whether the declaration calls MinorUnitDigits, however
+// the values package happens to be imported — qualified, dot-imported, or from
+// inside values itself.
+func asksForDigits(fn *ast.FuncDecl) bool {
+	asks := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := call.Fun.(type) {
+		case *ast.Ident:
+			asks = asks || f.Name == digitsFunc
+		case *ast.SelectorExpr:
+			asks = asks || f.Sel.Name == digitsFunc
+		}
+		return !asks
+	})
+	return asks
+}
+
+// buildsAPowerOfTen reports whether the declaration multiplies an accumulator
+// by ten, or reaches for math.Pow10.
+func buildsAPowerOfTen(fn *ast.FuncDecl) bool {
+	builds := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.AssignStmt:
+			if v.Tok == token.MUL_ASSIGN && anyLiteralTen(v.Rhs) {
+				builds = true
+			}
+			// `scale = scale * 10` written out, and the `:=` that seeds it.
+			if v.Tok == token.ASSIGN || v.Tok == token.DEFINE {
+				for _, rhs := range v.Rhs {
+					if bin, ok := rhs.(*ast.BinaryExpr); ok && bin.Op == token.MUL && anyLiteralTen([]ast.Expr{bin.X, bin.Y}) {
+						builds = true
+					}
+				}
+			}
+		case *ast.SelectorExpr:
+			builds = builds || v.Sel.Name == "Pow10"
+		}
+		return !builds
+	})
+	return builds
+}
+
+// anyLiteralTen reports whether either operand is the literal 10. Only ten: a
+// scale is built by repeated multiplication BY TEN, and a `* 100` in the same
+// function is check-money-scale.sh's subject, not this one. Two gates claiming
+// one shape is how a finding gets reported twice and fixed neither time.
+func anyLiteralTen(exprs []ast.Expr) bool {
+	for _, expr := range exprs {
+		if lit, ok := expr.(*ast.BasicLit); ok && lit.Kind == token.INT && lit.Value == "10" {
+			return true
+		}
+	}
+	return false
+}
+
+// handWrittenGoFiles walks the module for source a person maintains. Generated
+// files are excluded because nobody edits them and a generator that emitted
+// this shape would be the generator's defect, not a call site's.
+func handWrittenGoFiles(t *testing.T) []string {
+	t.Helper()
+	var paths []string
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if name := entry.Name(); name == "node_modules" || name == "testdata" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_gen.go") || strings.HasSuffix(name, ".gen.go") {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module for Go source: %v", err)
+	}
+	// A walk that finds nothing certifies nothing. The floor is deliberately
+	// far below the real count (~3700) so it catches a broken walk, not a
+	// changing tree.
+	if len(paths) < 500 {
+		t.Fatalf("the walk found only %d Go files, so this census covered almost nothing", len(paths))
+	}
+	return paths
+}
+
+func TestNobodyBuildsAMinorUnitScaleByHand(t *testing.T) {
+	fset := token.NewFileSet()
+	var findings []string
+	for _, path := range handWrittenGoFiles(t) {
+		// values is where the arithmetic belongs, so it is the one place the
+		// shape is correct. Keyed to the FILE that owns the table and not the
+		// package: a second file in that package writing its own loop is the
+		// same defect wearing the right import path.
+		if filepath.ToSlash(path) == valuesOwner+"/minorunits.go" {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, fn := range handScaled(file) {
+			findings = append(findings, fmt.Sprintf("%s: %s", path, fn))
+		}
+	}
+	if len(findings) == 0 {
+		return
+	}
+	t.Errorf("these functions ask values for a currency's minor-unit digit count and then build the "+
+		"power of ten themselves:\n  %s\n\nvalues already owns that step — use %s. Four copies of this "+
+		"arithmetic existed and agreed over 272 amount-by-currency pairs, which is how long a second copy "+
+		"stays harmless: until the commit that corrects one currency's digit count reaches only the "+
+		"callers somebody remembered.", strings.Join(findings, "\n  "), scaleAdvice)
+}
+
+// TestTheHandScaledDetectorSeesWhatItClaimsTo is the half that makes the census
+// above mean anything. A census of zero passes identically over a clean tree
+// and over a detector that has stopped detecting, so the detector is read
+// directly here — against the shapes that actually shipped, and against the
+// lookalikes it must leave alone.
+func TestTheHandScaledDetectorSeesWhatItClaimsTo(t *testing.T) {
+	cases := []struct {
+		name  string
+		fires bool
+		src   string
+	}{
+		{"the loop that shipped in compose", true, `
+func priceEvidenced(currency string, priceMinor int64) bool {
+	digits := values.MinorUnitDigits(currency)
+	scale := int64(1)
+	for i := 0; i < digits; i++ {
+		scale *= 10
+	}
+	return priceMinor/scale > 0
+}`},
+		{"the loop that shipped in overlay, digits read inline", true, `
+func amountFor(code, amount string) int64 {
+	scale := int64(1)
+	for i := 0; i < values.MinorUnitDigits(code); i++ {
+		scale *= 10
+	}
+	return toMinor(amount, scale)
+}`},
+		{"a range loop rather than a counter", true, `
+func scaleOf(currency string) int64 {
+	scale := int64(1)
+	for range values.MinorUnitDigits(currency) {
+		scale *= 10
+	}
+	return scale
+}`},
+		{"the multiplication written out", true, `
+func scaleOf(currency string) int64 {
+	digits, scale := values.MinorUnitDigits(currency), int64(1)
+	for i := 0; i < digits; i++ {
+		scale = scale * 10
+	}
+	return scale
+}`},
+		{"math.Pow10, the next spelling nobody has written yet", true, `
+func scaleOf(currency string) float64 {
+	return math.Pow10(values.MinorUnitDigits(currency))
+}`},
+		{"an unqualified call, as values itself would write it", true, `
+func scaleOf(currency string) int64 {
+	scale := int64(1)
+	for range MinorUnitDigits(currency) {
+		scale *= 10
+	}
+	return scale
+}`},
+
+		// The other direction, which is where a census of zero usually goes
+		// wrong: a detector that fires on everything also reports nothing, in
+		// the sense that nobody can act on it.
+		{"asking the table without scaling", false, `
+func decimalsFor(currency string) int {
+	return values.MinorUnitDigits(currency)
+}`},
+		{"asking, then delegating the scaling to values", false, `
+func majorOf(currency string, amountMinor int64) string {
+	if values.MinorUnitDigits(currency) == 0 {
+		return strconv.FormatInt(amountMinor, 10)
+	}
+	return values.MajorUnits(amountMinor, currency)
+}`},
+		{"scaling by ten with nothing to do with currency", false, `
+func decimate(n int64) int64 {
+	scale := int64(1)
+	for i := 0; i < 3; i++ {
+		scale *= 10
+	}
+	return n / scale
+}`},
+		{"a hundred, which is the money-scale gate's subject", false, `
+func majorOf(currency string, amountMinor int64) int64 {
+	_ = values.MinorUnitDigits(currency)
+	return amountMinor / 100
+}`},
+		{"the two halves in DIFFERENT functions of one file", false, `
+func decimalsFor(currency string) int { return values.MinorUnitDigits(currency) }
+
+func decimate(n int64) int64 {
+	scale := int64(1)
+	scale *= 10
+	return n / scale
+}`},
+	}
+
+	fset := token.NewFileSet()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := parser.ParseFile(fset, "probe.go", "package probe\n"+tc.src, 0)
+			if err != nil {
+				t.Fatalf("the probe does not parse, so it proves nothing about the detector: %v", err)
+			}
+			found := handScaled(file)
+			if tc.fires && len(found) == 0 {
+				t.Errorf("the detector missed a hand-built scale — the census would read green over this:\n%s", tc.src)
+			}
+			if !tc.fires && len(found) > 0 {
+				t.Errorf("the detector reported %v, which is not a hand-built scale:\n%s", found, tc.src)
+			}
+		})
+	}
+}

--- a/backend/minorunitscale_test.go
+++ b/backend/minorunitscale_test.go
@@ -74,17 +74,22 @@ func handScaled(file *ast.File) []string {
 	// A bare `MinorUnitDigits(...)` is values' own call only inside values. In
 	// any other package it names something else entirely, and reporting it
 	// sends somebody to disprove a finding.
-	if file.Name != nil && file.Name.Name == "values" {
+	//
+	// `asksValues` gates the ARITHMETIC arm only. The renderer arm is keyed on
+	// the parameter and never asks values anything — that is the whole reason
+	// it can see the fourth copy — so short-circuiting the file here would
+	// re-blind the census to exactly the shape the arm was added for.
+	insideValues := file.Name != nil && file.Name.Name == "values"
+	if insideValues {
 		valuesQualifier = ""
-	} else if valuesQualifier == "" {
-		return nil
 	}
+	asksValues := insideValues || valuesQualifier != ""
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
 			continue
 		}
-		if asksForDigits(fn, valuesQualifier) && buildsAPowerOfTen(fn, mathAs(file)) {
+		if asksValues && asksForDigits(fn, valuesQualifier) && buildsAPowerOfTen(fn, importAlias(file, "math")) {
 			found = append(found, fn.Name.Name)
 			continue
 		}
@@ -186,8 +191,20 @@ func digitParamName(fn *ast.FuncDecl) string {
 // reports the wrong subject is worse than one that reports none: somebody has
 // to go and disprove it.
 func importedAs(file *ast.File) string {
+	return importAlias(file, "github.com/gradionhq/margince/backend/"+valuesOwner)
+}
+
+// importAlias returns the local name an import path is bound to in this file,
+// or "" if the file does not import it. A DOT import returns "" too, for the
+// reason importedAs states.
+//
+// One resolver and not one per package: two functions that both iterate
+// file.Imports, trim the quoted path and fall back to the last segment are two
+// answers to one question, which is the thing this PR is about. They had
+// already diverged on the dot-import case by the time it was pointed out.
+func importAlias(file *ast.File, path string) string {
 	for _, spec := range file.Imports {
-		if strings.Trim(spec.Path.Value, `"`) != "github.com/gradionhq/margince/backend/"+valuesOwner {
+		if strings.Trim(spec.Path.Value, `"`) != path {
 			continue
 		}
 		if spec.Name != nil {
@@ -196,22 +213,10 @@ func importedAs(file *ast.File) string {
 			}
 			return spec.Name.Name
 		}
-		return "values"
-	}
-	return ""
-}
-
-// mathAs returns the local name the math package is bound to, or "" if this
-// file does not import it.
-func mathAs(file *ast.File) string {
-	for _, spec := range file.Imports {
-		if strings.Trim(spec.Path.Value, `"`) != "math" {
-			continue
+		if i := strings.LastIndex(path, "/"); i >= 0 {
+			return path[i+1:]
 		}
-		if spec.Name != nil {
-			return spec.Name.Name
-		}
-		return "math"
+		return path
 	}
 	return ""
 }
@@ -538,6 +543,16 @@ func scaleOf(c legacy.Code) int64 {
 	// The digit count must reach the RENDER, not merely sit in the signature.
 	// A package that does not import values and declares its OWN
 	// MinorUnitDigits is not calling values'.
+	// The renderer arm does not ask values anything — it is keyed on the
+	// parameter — so a file that does not import values must still be judged by
+	// it. Short-circuiting the whole file on "does not import values" re-blinded
+	// the census to the one shape that arm exists for.
+	{"a renderer in a file that does not import values", true, "noimport", `
+func minorToDecimalString(minor int64, exponent int) string {
+	s := strconv.FormatInt(minor, 10)
+	point := len(s) - exponent
+	return s[:point] + "." + s[point:]
+}`},
 	{"another package's own unqualified MinorUnitDigits", false, "noimport", `
 func scaleOf(currency string) int64 {
 	scale := int64(1)


### PR DESCRIPTION
## The finding

A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one
fact. The **table** holding it was already shared, and its own comment said so:

> one spelling of the ISO fact, never a second copy that could drift

That claim was true about the table and **false about the arithmetic beside
it**. Four functions each built the power of ten themselves:

| | |
|---|---|
| `compose/offerdraft_price.go` | the loop, then `values.MajorUnits` reimplemented verbatim to render the result |
| `modules/overlay/transforms.go` | the loop, feeding `decimalStringToMinor` |
| `overlay/hubspot/mapwrite.go` | a whole **second renderer**, by string splice rather than divmod |
| `shared/kernel/values/minorunits.go` | the one that belongs there |

**They agreed.** Before deleting the fourth I compared it against
`values.MajorUnits` over every combination of 17 currency codes (including the
zero-decimal, three-decimal, four-decimal and unknown ones) and 16 amounts
(including `math.MinInt64` and `math.MaxInt64`) — **272 pairs, 0 disagreed.**

That is exactly how long a second copy stays harmless: until the commit that
corrects one currency's digit count in the table reaches only the callers
somebody remembered.

## The fix

`values` already exported almost everything the other three needed —
`MajorUnits` for the decimal string, `WholeMajorUnits` for the truncated
integer. Added `MinorUnitScale` for the multiplier itself, which is the one
shape a caller converting *into* minor units needs and that the two dividers
cannot supply.

Deleting the fourth copy made `overlay.ISO4217MinorUnitExponent` **dead** — the
wrapper whose doc comment named the HubSpot write mapping as the reason it was
exported, and named *"one spelling of the ISO fact, never a second copy that
could drift"* as its own promise. Its last caller **was** the second renderer.
Removed.

The private helper is `powerOfTen(digits)` rather than `minorUnitScale(digits)`
— two names one capital apart for two different signatures is a reader's
problem before it is `revive`'s.

## The gate is a census of zero, so the detector is tested separately

This is the hard kind to write honestly: a gate asserting a shape is **absent**
passes identically when the shape is absent and when the detector has stopped
detecting. The census alone would be worth nothing.

So `TestTheHandScaledDetectorSeesWhatItClaimsTo` reads the detector directly —
**11 cases, both directions**:

*Must fire* — the loop as it shipped in compose; the loop as it shipped in
overlay with the digits read inline; a `range` loop; the multiplication written
out as `scale = scale * 10`; `math.Pow10`, the next spelling nobody has written
yet; and an unqualified call, as `values` itself would write it.

*Must not* — asking the table without scaling; asking and then delegating the
scaling to `values`; scaling by ten for something that is not money; a
**hundred**, which is `check-money-scale.sh`'s subject and not this one (two
gates claiming one shape is how a finding gets reported twice and fixed
neither time); and the two halves in **different functions** of one file.

The census also refuses a walk that finds fewer than 500 Go files, because a
walk that finds nothing certifies nothing.

## Verified against the real defect, not just a planted string

Reverting the compose call site to its loop — keeping the build green, so the
gate is what fails and not the compiler:

```
--- FAIL: TestNobodyBuildsAMinorUnitScaleByHand
    these functions ask values for a currency's minor-unit digit count and then
    build the power of ten themselves:
      internal/compose/offerdraft_price.go: priceEvidencedInSnippet
```

Restored → green. `make check` green.

## Why per-function and not per-file

A file may hold a renderer that asks the table and a separate helper that
scales something unrelated by ten; asking whether both appear *somewhere* in
the same file reports a pairing nobody wrote. Per-declaration is also the
reading that fails safe — it can miss a defect split across two functions, and
it cannot invent one. That case is planted.

Found while auditing the merged result of #2308 and #2317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies currency minor‑unit scaling and rendering under `backend/internal/shared/kernel/values` and hardens a test gate to keep a single source of truth. Previously callers built 10^digits or rendered decimals locally; now they call `values.MajorUnits`, `values.WholeMajorUnits`, or `values.MinorUnitScale`. No user‑visible behavior change.

- Replaced local logic in compose price evidence, overlay transforms, and HubSpot map write with `values.MajorUnits`, `values.WholeMajorUnits`, and `values.MinorUnitScale`.
- Removed `overlay.ISO4217MinorUnitExponent` and the local `minorToDecimalString`.
- Added `values.MinorUnitScale`; internal helper renamed to `powerOfTen`, and `MajorUnits`/`WholeMajorUnits` use it.
- Added `backend/minorunitscale_test.go`: an AST gate that flags hand‑built scales (loops or `math.Pow10`) and decimal‑point renderers keyed on a digit‑count parameter; resolves `values`/`math` qualifiers via imports; the renderer arm no longer requires a `values` import; consolidates import resolution into `importAlias`; rejects incomplete walks (<500 Go files); includes positive/negative probes.
- Style: gofumpt formatting on the extracted probe table; no functional changes.

**Migration**
- Replace `overlay.ISO4217MinorUnitExponent` with `values.MinorUnitDigits` or `values.MinorUnitScale`; render with `values.MajorUnits`.

<sup>Written for commit c0ca14e7e01c5a7c69e16eabbf82faa1d751b632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized currency amount formatting across pricing details and HubSpot deal amounts.
  * Improved accuracy and consistency for currencies with different decimal precision.
  * Enhanced handling of whole and fractional currency values for clearer amount displays.

* **Quality**
  * Added automated safeguards to help prevent inconsistent currency-scaling and formatting behavior.
  * Strengthened validation to maintain reliable formatting across supported currencies and amount displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->