### PR TITLE
test(authz): the AI writes what its human writes, and a test now says so

### DIFF
--- a/backend/internal/compose/integration/agentwriteparity_integration_test.go
+++ b/backend/internal/compose/integration/agentwriteparity_integration_test.go
@@ -156,30 +156,42 @@ func TestAnAgentWritesExactlyWhatItsHumanWrites(t *testing.T) {
 				t.Fatalf("sharing the %s with rep1 at write: %v", tc.table, err)
 			}
 
+			// The verdicts are asserted ABSOLUTELY, not merely against each
+			// other. A gate that refused everyone would keep the human and their
+			// agent in perfect agreement on every row, so a relative assertion
+			// would report the promise kept by a product that had stopped
+			// answering yes to anybody.
 			for _, row := range []struct {
-				name string
-				id   ids.UUID
+				name                       string
+				id                         ids.UUID
+				rep1, rep1Agent, rep3Agent writeVerdict
 			}{
-				{"owned by rep1", mine},
-				{"owned by rep3", theirs},
-				{"owned by rep3, shared to rep1 at write", sharedWithMe},
+				{"owned by rep1", mine, verdictAdmitted, verdictAdmitted, verdictDenied},
+				{"owned by rep3", theirs, verdictDenied, verdictDenied, verdictAdmitted},
+				{"owned by rep3, shared to rep1 at write", sharedWithMe,
+					verdictAdmitted, verdictAdmitted, verdictAdmitted},
 			} {
 				human := classifyWrite(tc.write(e.As(e.Rep1, rep1Team, tc.perms), e, row.id))
-				agent := classifyWrite(tc.write(e.AgentFor(e.Rep1, rep1Team, tc.perms), e, row.id))
-				stranger := classifyWrite(tc.write(e.AgentFor(e.Rep3, rep3Team, tc.perms), e, row.id))
+				agent := classifyWrite(tc.write(e.AgentFor(t, e.Rep1, rep1Team, tc.perms), e, row.id))
+				stranger := classifyWrite(tc.write(e.AgentFor(t, e.Rep3, rep3Team, tc.perms), e, row.id))
 
 				if human != agent {
 					t.Errorf("%s %s: the human was %s and their own agent was %s — an agent's write "+
 						"authority is its granting human's, and this pair has come apart",
 						tc.table, row.name, human, agent)
 				}
-				// rep3 owns two of the three rows, so the stranger's verdict is
-				// the mirror: where rep1 is admitted rep3 must not be, and the
-				// other way round. Equal verdicts on every row would mean the
-				// gate answers the same thing to everyone.
-				if stranger == human && row.id != sharedWithMe {
-					t.Errorf("%s %s: rep1 and an agent for rep3 both got %s — the gate is not "+
-						"distinguishing the two humans at all", tc.table, row.name, human)
+				for _, got := range []struct {
+					who       string
+					got, want writeVerdict
+				}{
+					{"rep1", human, row.rep1},
+					{"an agent for rep1", agent, row.rep1Agent},
+					{"an agent for rep3", stranger, row.rep3Agent},
+				} {
+					if got.got != got.want {
+						t.Errorf("%s %s: %s was %s, want %s",
+							tc.table, row.name, got.who, got.got, got.want)
+					}
 				}
 			}
 		})
@@ -195,7 +207,7 @@ func TestAnAgentForAStrangerIsRefusedOnEveryRecordType(t *testing.T) {
 	for _, tc := range parityCases(t, e) {
 		t.Run(tc.table, func(t *testing.T) {
 			theirs := tc.seed(t, e, &e.Rep1)
-			got := classifyWrite(tc.write(e.AgentFor(e.Rep3, []ids.UUID{e.Team2}, tc.perms), e, theirs))
+			got := classifyWrite(tc.write(e.AgentFor(t, e.Rep3, []ids.UUID{e.Team2}, tc.perms), e, theirs))
 			if got == verdictAdmitted {
 				t.Errorf("an agent acting for rep3 changed a %s owned by rep1 — the AI is not bounded "+
 					"by the human that granted it", tc.table)

--- a/backend/internal/compose/integration/agentwriteparity_integration_test.go
+++ b/backend/internal/compose/integration/agentwriteparity_integration_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// An agent writes exactly what its granting human writes, never more.
+//
+// Margince states this to customers as "the AI uses your scope", and MCP is
+// governed the same way: a rep's assistant must not be able to change a
+// colleague's records when the rep could not. Today the promise holds by
+// construction — the agent door is middleware into the same REST handlers, and
+// AgentIdentity.Principal() copies the human's permissions and teams — but
+// construction is not a guarantee. A future tool executor that resolved records
+// itself would break the promise without failing anything.
+//
+// So the promise is asserted as an OUTCOME rather than as a shape: for each of
+// the five record types every seat reads, the same mutation is driven by the
+// human, by their agent, and by a different human's agent, and the three
+// verdicts must line up. The shape half — that Principal() copies what it
+// should — is held next to the code it constrains, in
+// modules/identity/passportprincipal_test.go, which needs no database.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// writeVerdict is what a mutation answered, collapsed to the three outcomes the
+// access model distinguishes. It is deliberately three-valued rather than a
+// bool: 403 and 404 mean different things here — the row is visibly not yours
+// to change, versus the row is not yours to know about — and a boolean would
+// let one silently become the other while the parity assertion stayed green.
+type writeVerdict string
+
+const (
+	verdictAdmitted writeVerdict = "admitted"
+	verdictDenied   writeVerdict = "refused 403 (visible, not yours to change)"
+	verdictHidden   writeVerdict = "refused 404 (not yours to see)"
+)
+
+func classifyWrite(err error) writeVerdict {
+	switch {
+	case err == nil:
+		return verdictAdmitted
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return verdictDenied
+	case errors.Is(err, apperrors.ErrNotFound):
+		return verdictHidden
+	default:
+		return writeVerdict("unexpected error: " + err.Error())
+	}
+}
+
+// parityCase is one record type: how to seed a row owned by somebody, and how
+// to attempt the plainest possible change to it.
+type parityCase struct {
+	table string
+	seed  func(t *testing.T, e *Env, owner *ids.UUID) ids.UUID
+	write func(ctx context.Context, e *Env, id ids.UUID) error
+	perms principal.Permissions
+}
+
+func parityCases(t *testing.T, e *Env) []parityCase {
+	t.Helper()
+	pipeline, open, _ := DealFixture(t, e)
+	title := "Changed by the parity suite"
+
+	// AccountRepPerms reads organizations but does not update them, and no
+	// shipped rep fixture does — several suites read those fixtures as a rep who
+	// CANNOT write a company, so widening one there would make them pass while
+	// proving nothing. This case needs the object verb before row scope is even
+	// consulted (auth.Require runs first and refuses everyone without it), so it
+	// carries its own copy rather than reaching for a shared one.
+	orgWriterPerms := AccountRepPerms
+	orgWriterPerms.Objects = map[string]principal.ObjectGrant{}
+	for object, grant := range AccountRepPerms.Objects {
+		orgWriterPerms.Objects[object] = grant
+	}
+	orgWriterPerms.Objects[objOrg] = principal.ObjectGrant{Create: true, Read: true, Update: true}
+
+	return []parityCase{
+		{
+			table: "person",
+			perms: AccountRepPerms,
+			seed:  func(t *testing.T, e *Env, owner *ids.UUID) ids.UUID { return e.SeedPerson(t, "Parity person", owner) },
+			write: func(ctx context.Context, e *Env, id ids.UUID) error {
+				_, err := e.People.UpdatePerson(ctx, ids.From[ids.PersonKind](id),
+					people.UpdatePersonInput{Title: &title})
+				return err
+			},
+		},
+		{
+			table: "organization",
+			perms: orgWriterPerms,
+			seed:  func(t *testing.T, e *Env, owner *ids.UUID) ids.UUID { return e.SeedOrg(t, "Parity company", owner) },
+			write: func(ctx context.Context, e *Env, id ids.UUID) error {
+				_, err := e.People.UpdateOrganization(ctx, ids.From[ids.OrganizationKind](id),
+					people.UpdateOrganizationInput{Description: &title})
+				return err
+			},
+		},
+		{
+			table: "deal",
+			perms: AccountRepPerms,
+			seed: func(t *testing.T, e *Env, owner *ids.UUID) ids.UUID {
+				return e.SeedDeal(t, "Parity deal", pipeline, open, owner)
+			},
+			write: func(ctx context.Context, e *Env, id ids.UUID) error {
+				_, err := e.Deals.UpdateDeal(ctx, ids.From[ids.DealKind](id),
+					deals.UpdateDealInput{Name: &title})
+				return err
+			},
+		},
+	}
+}
+
+// TestAnAgentWritesExactlyWhatItsHumanWrites is the promise itself. For each
+// record type and each ownership arrangement, the human's verdict and their
+// agent's verdict must be the SAME verdict — not merely both refusals, and not
+// merely both successes.
+//
+// The third principal is what makes the pair meaningful. An agent that refused
+// everything would satisfy a human/agent comparison trivially, so every row is
+// also driven by an agent acting for the OTHER human, whose verdict must be the
+// mirror image: admitted where the first pair is refused, refused where it is
+// admitted.
+func TestAnAgentWritesExactlyWhatItsHumanWrites(t *testing.T) {
+	e := Setup(t)
+	svc := identity.NewService(e.Pool)
+
+	for _, tc := range parityCases(t, e) {
+		t.Run(tc.table, func(t *testing.T) {
+			rep1Team := []ids.UUID{e.Team1}
+			rep3Team := []ids.UUID{e.Team2}
+
+			mine := tc.seed(t, e, &e.Rep1)
+			theirs := tc.seed(t, e, &e.Rep3)
+			sharedWithMe := tc.seed(t, e, &e.Rep3)
+
+			// The share goes through the real writer: a hand-inserted grant row
+			// would prove the rule against a state production cannot reach.
+			if _, err := svc.CreateRecordGrant(e.Admin(), identity.CreateGrantInput{
+				RecordType: tc.table, RecordID: sharedWithMe,
+				SubjectType: "user", SubjectID: e.Rep1, Access: "write",
+			}); err != nil {
+				t.Fatalf("sharing the %s with rep1 at write: %v", tc.table, err)
+			}
+
+			for _, row := range []struct {
+				name string
+				id   ids.UUID
+			}{
+				{"owned by rep1", mine},
+				{"owned by rep3", theirs},
+				{"owned by rep3, shared to rep1 at write", sharedWithMe},
+			} {
+				human := classifyWrite(tc.write(e.As(e.Rep1, rep1Team, tc.perms), e, row.id))
+				agent := classifyWrite(tc.write(e.AgentFor(e.Rep1, rep1Team, tc.perms), e, row.id))
+				stranger := classifyWrite(tc.write(e.AgentFor(e.Rep3, rep3Team, tc.perms), e, row.id))
+
+				if human != agent {
+					t.Errorf("%s %s: the human was %s and their own agent was %s — an agent's write "+
+						"authority is its granting human's, and this pair has come apart",
+						tc.table, row.name, human, agent)
+				}
+				// rep3 owns two of the three rows, so the stranger's verdict is
+				// the mirror: where rep1 is admitted rep3 must not be, and the
+				// other way round. Equal verdicts on every row would mean the
+				// gate answers the same thing to everyone.
+				if stranger == human && row.id != sharedWithMe {
+					t.Errorf("%s %s: rep1 and an agent for rep3 both got %s — the gate is not "+
+						"distinguishing the two humans at all", tc.table, row.name, human)
+				}
+			}
+		})
+	}
+}
+
+// TestAnAgentForAStrangerIsRefusedOnEveryRecordType is the guard against the
+// parity test passing vacuously. If EnsureWritable were made to return nil
+// unconditionally, every verdict above would become "admitted" on both sides
+// and the pair would still line up. This asserts the refusal itself.
+func TestAnAgentForAStrangerIsRefusedOnEveryRecordType(t *testing.T) {
+	e := Setup(t)
+	for _, tc := range parityCases(t, e) {
+		t.Run(tc.table, func(t *testing.T) {
+			theirs := tc.seed(t, e, &e.Rep1)
+			got := classifyWrite(tc.write(e.AgentFor(e.Rep3, []ids.UUID{e.Team2}, tc.perms), e, theirs))
+			if got == verdictAdmitted {
+				t.Errorf("an agent acting for rep3 changed a %s owned by rep1 — the AI is not bounded "+
+					"by the human that granted it", tc.table)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -192,28 +193,41 @@ func (e *Env) AgentCtx() context.Context {
 	})
 }
 
-// AgentFor binds the principal AgentIdentity.Principal() mints for a passport
-// granted by `human`: the human's own user id, teams, seat and merged policy,
-// carried under PrincipalAgent.
+// AgentFor binds the principal a passport granted by `human` presents: their own
+// user id, teams, seat and merged policy, carried under PrincipalAgent.
 //
-// It deliberately takes the SAME arguments As() takes, and builds the principal
-// the same way apart from Type and the passport fields. The invariant the agent
-// suites assert is that a human and their agent differ in Type and nothing
-// else — a helper that took its own permission fixture could make the pair
-// agree by construction, which would prove nothing about the product.
+// It calls identity.AgentIdentity.Principal() rather than assembling the struct,
+// because that method IS the thing under test in the agent suites. A
+// hand-written copy would keep agreeing with production only until the two
+// drifted, and the drift would look exactly like a passing test.
+//
+// The permission arguments are the SAME ones As() takes, so a human and their
+// agent differ in what Principal() decides and in nothing the caller chose. A
+// helper with its own permission fixture could make the pair agree by
+// construction, which would prove nothing about the product.
 //
 // AgentCtx and AgentCtxWithPassport are NOT this: they mint a synthetic agent
 // carrying no user, teams or permissions at all, for suites where the staging
-// path rather than the scope is what is under test. One of those would pass any
-// scope assertion vacuously.
-func (e *Env) AgentFor(human ids.UUID, teams []ids.UUID, perms principal.Permissions) context.Context {
+// path rather than the scope is what is under test. Either would pass a scope
+// assertion vacuously.
+func (e *Env) AgentFor(t *testing.T, human ids.UUID, teams []ids.UUID, perms principal.Permissions) context.Context {
+	t.Helper()
+	teamIDs := make([]ids.TeamID, 0, len(teams))
+	for _, team := range teams {
+		teamIDs = append(teamIDs, ids.From[ids.TeamKind](team))
+	}
+	agent := identity.AgentIdentity{
+		PassportID:  ids.New[ids.PassportKind](),
+		WorkspaceID: ids.From[ids.WorkspaceKind](e.WS),
+		OnBehalfOf:  ids.From[ids.UserKind](human),
+		SeatType:    string(principal.SeatFull),
+		Scopes:      principal.ScopeSet{principal.ScopeRead: {}, principal.ScopeWrite: {}},
+		Teams:       teamIDs,
+		Permissions: perms,
+	}
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
-	return principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:" + human.String(),
-		UserID: human, OnBehalfOf: human, TeamIDs: teams,
-		SeatType: principal.SeatFull, Permissions: perms,
-	})
+	return principal.WithActor(ctx, agent.Principal())
 }
 
 // SeedPassport inserts a live passport for Rep1 and returns its id. Rows

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -192,6 +192,30 @@ func (e *Env) AgentCtx() context.Context {
 	})
 }
 
+// AgentFor binds the principal AgentIdentity.Principal() mints for a passport
+// granted by `human`: the human's own user id, teams, seat and merged policy,
+// carried under PrincipalAgent.
+//
+// It deliberately takes the SAME arguments As() takes, and builds the principal
+// the same way apart from Type and the passport fields. The invariant the agent
+// suites assert is that a human and their agent differ in Type and nothing
+// else — a helper that took its own permission fixture could make the pair
+// agree by construction, which would prove nothing about the product.
+//
+// AgentCtx and AgentCtxWithPassport are NOT this: they mint a synthetic agent
+// carrying no user, teams or permissions at all, for suites where the staging
+// path rather than the scope is what is under test. One of those would pass any
+// scope assertion vacuously.
+func (e *Env) AgentFor(human ids.UUID, teams []ids.UUID, perms principal.Permissions) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:" + human.String(),
+		UserID: human, OnBehalfOf: human, TeamIDs: teams,
+		SeatType: principal.SeatFull, Permissions: perms,
+	})
+}
+
 // SeedPassport inserts a live passport for Rep1 and returns its id. Rows
 // that reference a passport carry a real foreign key, so a synthetic id
 // would be rejected by the database rather than by the code under test.

--- a/backend/internal/modules/identity/passportprincipal_test.go
+++ b/backend/internal/modules/identity/passportprincipal_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// The promise this file holds: an agent writes exactly what its granting human
+// writes, never more. Margince states it to customers as "the AI uses your
+// scope", and MCP is governed the same way, so a rep's assistant must not be
+// able to change a colleague's records when the rep could not.
+//
+// The promise rests on one assignment — AgentIdentity.Principal() copying the
+// human's Permissions and Teams onto an agent-typed principal — and on every
+// store entry point enforcing that principal exactly as it enforces a human's.
+// The second half is proved against a real database in
+// compose/integration/agentwriteparity_integration_test.go. This file holds the
+// first half, which needs no database and so fails in a second rather than a
+// minute.
+
+// permissionsFieldCount is the arity Principal() copies wholesale.
+//
+// It is ASSERTED rather than documented because Principal() assigns the struct
+// by value: a field added to Permissions is copied to the agent for free, and
+// every test here would stay green while the question that field deserves — may
+// an agent inherit this? — went unasked. Bumping this constant is where that
+// question gets asked.
+const permissionsFieldCount = 4
+
+func TestAnAgentPrincipalCarriesExactlyItsGrantingHumansAuthority(t *testing.T) {
+	human := ids.New[ids.UserKind]()
+	team := ids.New[ids.TeamKind]()
+	perms := principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"person": {Read: true, Update: true},
+			"deal":   {Read: true},
+		},
+		RowScope: principal.RowScopeTeam,
+		FieldMasks: []principal.FieldMask{
+			{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority},
+		},
+	}
+	agent := AgentIdentity{
+		PassportID:  ids.New[ids.PassportKind](),
+		WorkspaceID: ids.New[ids.WorkspaceKind](),
+		OnBehalfOf:  human,
+		SeatType:    string(principal.SeatFull),
+		Teams:       []ids.TeamID{team},
+		Permissions: perms,
+	}
+
+	got := agent.Principal()
+
+	if got.Type != principal.PrincipalAgent {
+		t.Errorf("principal type = %s, want %s", got.Type, principal.PrincipalAgent)
+	}
+	if got.UserID != human.UUID || got.OnBehalfOf != human.UUID {
+		t.Errorf("principal acts as %s/%s, want the granting human %s on both",
+			got.UserID, got.OnBehalfOf, human.UUID)
+	}
+	if len(got.TeamIDs) != 1 || got.TeamIDs[0] != team.UUID {
+		t.Errorf("agent teams = %v, want exactly the human's %v", got.TeamIDs, team.UUID)
+	}
+	if got.SeatType != principal.SeatFull {
+		t.Errorf("agent seat = %s, want the human's %s", got.SeatType, principal.SeatFull)
+	}
+	// DeepEqual on the WHOLE struct, not field by field: a field-by-field
+	// assertion passes over a field nobody has thought about yet, which is the
+	// case this test exists to catch.
+	if !reflect.DeepEqual(got.Permissions, perms) {
+		t.Errorf("agent permissions = %+v, want its granting human's %+v", got.Permissions, perms)
+	}
+}
+
+func TestPermissionsGainingAFieldIsNotInheritedByAnAgentUnasked(t *testing.T) {
+	if n := reflect.TypeOf(principal.Permissions{}).NumField(); n != permissionsFieldCount {
+		t.Fatalf("principal.Permissions has %d fields, this gate knows %d — a field was added and "+
+			"AgentIdentity.Principal() now copies it to the agent for free. Decide whether an agent may "+
+			"inherit it, then update permissionsFieldCount to record that the question was asked",
+			n, permissionsFieldCount)
+	}
+}
+
+func TestAnAgentPrincipalCannotWidenTheHumansRowScope(t *testing.T) {
+	for _, scope := range []principal.RowScope{
+		principal.RowScopeOwn, principal.RowScopeTeam, principal.RowScopeAll,
+	} {
+		agent := AgentIdentity{
+			PassportID:  ids.New[ids.PassportKind](),
+			OnBehalfOf:  ids.New[ids.UserKind](),
+			Permissions: principal.Permissions{RowScope: scope},
+		}
+		got := agent.Principal()
+		if got.Permissions.RowScope != scope {
+			t.Errorf("agent for a %s-scoped human resolves to %s", scope, got.Permissions.RowScope)
+		}
+		// Unbounded is what every read and write path asks before it renders a
+		// row predicate at all, so a bounded human whose agent answers true here
+		// would have handed the estate over whatever the scope string said.
+		if want := scope == principal.RowScopeAll; auth.Unbounded(got) != want {
+			t.Errorf("auth.Unbounded(agent for a %s-scoped human) = %v, want %v",
+				scope, auth.Unbounded(got), want)
+		}
+	}
+}

--- a/backend/internal/modules/identity/passportprincipal_test.go
+++ b/backend/internal/modules/identity/passportprincipal_test.go
@@ -72,6 +72,16 @@ func TestAnAgentPrincipalCarriesExactlyItsGrantingHumansAuthority(t *testing.T) 
 	if got.SeatType != principal.SeatFull {
 		t.Errorf("agent seat = %s, want the human's %s", got.SeatType, principal.SeatFull)
 	}
+	// A read seat is the case that matters, and asserting only the full one
+	// would pass over a Principal() that minted SeatFull unconditionally:
+	// the licensing ceiling refuses a mutation before RBAC is consulted, so an
+	// agent that inherited the wrong seat would write where its human cannot.
+	readSeat := agent
+	readSeat.SeatType = string(principal.SeatRead)
+	if seat := readSeat.Principal().SeatType; seat != principal.SeatRead {
+		t.Errorf("an agent for a READ-seat human carries seat %s, want %s — the seat ceiling is the "+
+			"licensing half of `agent <= human` and is not inherited", seat, principal.SeatRead)
+	}
 	// DeepEqual on the WHOLE struct, not field by field: a field-by-field
 	// assertion passes over a field nobody has thought about yet, which is the
 	// case this test exists to catch.


### PR DESCRIPTION
Margince tells customers the AI uses their own scope, and MCP is governed the same way. That promise held by construction — the agent door is middleware into the same REST handlers, and `AgentIdentity.Principal()` copies the granting human's permissions and teams — but nothing asserted it. A future tool executor that resolved records itself would have broken the promise without failing a test.

This is tests only. No behaviour changes.

## Two altitudes

**`passportprincipal_test.go`** holds the shape, with no database. An agent principal carries the human's user id, teams, seat and permissions; `DeepEqual` on the whole `Permissions` struct is what makes a later-added field count. A field-count assertion fails when `Permissions` grows, because `Principal()` assigns by value and would otherwise inherit a new field for free with nobody asked whether an agent should.

**`agentwriteparity_integration_test.go`** holds the outcome, against Postgres. For person, organization and deal, the same mutation is driven by the human, by their agent, and by a different human's agent, and the verdicts must line up. Verdicts are three-valued rather than boolean — 403 and 404 mean different things here, and a boolean would let one become the other unnoticed. `TestAnAgentForAStrangerIsRefusedOnEveryRecordType` asserts the refusal itself, so the parity pair cannot pass by both sides being broken.

Both were mutation-checked: admitting agents past `ensureWriteAuthority` fails them, naming the defect.

## Notes for the reader

`Env.AgentFor` is new and deliberately takes the same arguments `As()` takes, so a human and their agent differ in `Type` and nothing else. `AgentCtx` and `AgentCtxWithPassport` mint an agent with no user, teams or permissions at all, for suites testing the staging path — either would have passed every scope assertion vacuously.

The organization case carries its own object grants. No shipped rep fixture grants `organization.update`, and several suites read those fixtures as a rep who cannot write a company, so widening one would have made them pass while proving nothing.

First of four PRs on the access model. The others cover a fitness function for the write gate, a per-record `writable` flag on the wire, and re-seeding `rep`/`manager` to own scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Asserts that an agent can write exactly what its granting human can, and nothing more, to prevent silent scope regressions. No behavior changes; adds tests and updates a harness helper.

- Adds `backend/internal/modules/identity/passportprincipal_test.go` to verify `AgentIdentity.Principal()` mirrors the human: same user, teams, seat (now also asserts read-seat inheritance), and deep-equal permissions; includes a field-count sentinel and row-scope/unbounded checks.
- Adds `backend/internal/compose/integration/agentwriteparity_integration_test.go` to compare three-valued write verdicts (admitted, 403, 404) across person, organization, and deal. Expects absolute outcomes for owned, foreign, and shared rows; includes a guard that a stranger’s agent is refused.
- Updates `backend/internal/compose/integration/harness.go` to implement `Env.AgentFor` by building an `identity.AgentIdentity` and calling `Principal()` (same args as `As()`), preventing helper/production drift and avoiding vacuous passes from `AgentCtx` variants.

<sup>Written for commit a16a476b2eae12560ca48b896b4f4e210a89064f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Access Controls**
  - Delegated agents now consistently follow the granting human’s permissions, team access, seat type, and record scope.
  - Agents cannot expand access or modify records beyond the granting human’s authority.
  - Unauthorized access and changes are blocked across people, organizations, and deals, including shared and unowned records.
- **Reliability**
  - Improved confidence that restricted records remain protected and unauthorized actions are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->