### PR TITLE
feat(agents): an agent can read a partner by name, not only by inference

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -2492,6 +2492,7 @@ paths:
       tags: [Organizations, Partners]
       operationId: getPartner
       summary: Read the partner extension on an org (404 if the org is not a partner).
+      x-mcp-tool: { verb: read_record, record_type: partner, tier: auto_execute, scope: read }
       responses:
         '200':
           description: The partner record.

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -233,6 +233,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/organizations/{id}/evidence/{entityType}/{entityId}":        {Op: "getClaimEvidence", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/organizations/{id}/growth-fit":                              {Op: "getOrganizationGrowthFit", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/organizations/{id}/logo":                                    {Op: "getOrganizationLogo", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/organizations/{id}/partner":                                 {Op: "getPartner", Access: "tool", Tool: "read_record", RecordType: "partner", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/organizations/{id}/site-reads/latest":                       {Op: "getLatestSiteRead", Access: "tool", Tool: "read_record", RecordType: "organization", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/organizations/{id}/site-reads/{readId}":                     {Op: "getSiteRead", Access: "tool", Tool: "read_record", RecordType: "organization", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/overlay/export":                                             {Op: "downloadOverlayExport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/partnerseam_integration_test.go
+++ b/backend/internal/compose/integration/partnerseam_integration_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The partner extension through the datasource seam — the surface an MCP
+// agent reads partners by.
+//
+// A partner is the 1:1 extension of an organization, so the seam addresses it
+// by the ORGANIZATION's id. That is the detail worth holding: a reader who
+// cannot open the company must not learn its commercial terms through the
+// other name, and the seam must not offer a second way in that skips the gate
+// the HTTP handler applies.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+func partnerSeamProvider(e *Env) *people.Provider { return people.NewProvider(e.DB()) }
+
+// partnerReader is a seat holding the partner and organization grants the
+// read needs. AdminPerms carries no `partner` object on purpose (see
+// SeedPartnerOrg), so a suite that wants the ADMIT case must say so.
+func partnerReader() principal.Permissions {
+	return principal.Permissions{
+		RoleKeys: []string{"admin"},
+		Objects: map[string]principal.ObjectGrant{
+			"partner":      {Read: true},
+			"organization": {Read: true},
+		},
+		RowScope: principal.RowScopeAll,
+	}
+}
+
+// The admit case first: without it, a refusal test proves only that the
+// authority refuses everyone.
+func TestPartnerReadsThroughTheSeamByItsOrganizationID(t *testing.T) {
+	e := Setup(t)
+	p := partnerSeamProvider(e)
+	tier := "tier2_20"
+	org := e.SeedPartnerOrg(t, "Seam Partner GmbH", &tier, nil)
+	ctx := e.As(e.AdminUser, nil, partnerReader())
+
+	rec, err := p.Read(ctx, datasource.EntityRef{Type: datasource.EntityPartner, ID: org})
+	if err != nil {
+		t.Fatalf("reading a partner through the seam: %v", err)
+	}
+	if rec.Ref.Type != datasource.EntityPartner {
+		t.Fatalf("record type = %s, want partner", rec.Ref.Type)
+	}
+	if rec.Ref.ID != org {
+		t.Fatalf("record id = %s, want the organization id %s", rec.Ref.ID, org)
+	}
+}
+
+// The seam is not a weaker copy of the HTTP path: a seat with no partner
+// grant is refused here too.
+func TestPartnerSeamRefusesASeatWithoutThePartnerGrant(t *testing.T) {
+	e := Setup(t)
+	p := partnerSeamProvider(e)
+	tier := "tier1_15"
+	org := e.SeedPartnerOrg(t, "Ungranted GmbH", &tier, nil)
+
+	// AdminPerms deliberately holds no `partner` object.
+	_, err := p.Read(e.Admin(), datasource.EntityRef{Type: datasource.EntityPartner, ID: org})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("read without the partner grant = %v, want ErrPermissionDenied", err)
+	}
+}
+
+// An organization that never joined the programme has no partner row, and the
+// seam says not-found rather than answering an empty record.
+func TestPartnerSeamIsNotFoundForAPlainCompany(t *testing.T) {
+	e := Setup(t)
+	p := partnerSeamProvider(e)
+	org := e.SeedOrg(t, "Just A Customer GmbH", nil)
+	ctx := e.As(e.AdminUser, nil, partnerReader())
+
+	_, err := p.Read(ctx, datasource.EntityRef{Type: datasource.EntityPartner, ID: org})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("reading a non-partner company = %v, want ErrNotFound", err)
+	}
+}
+
+// ListPartners has no text index. A query term is refused rather than dropped,
+// because a dropped term answers an UNFILTERED page that reads as "these all
+// matched".
+func TestPartnerSeamRefusesATextQuery(t *testing.T) {
+	e := Setup(t)
+	p := partnerSeamProvider(e)
+	tier := "tier3_25"
+	e.SeedPartnerOrg(t, "Findable GmbH", &tier, nil)
+	ctx := e.As(e.AdminUser, nil, partnerReader())
+
+	term := "Findable"
+	_, _, _, err := p.SearchEntity(ctx, datasource.EntityPartner, &term, 10, nil, nil)
+	if err == nil {
+		t.Fatal("a text query against partner was accepted; it must be refused, not silently dropped")
+	}
+}
+
+// The role and certification dials are the whole vocabulary, and they narrow.
+func TestPartnerSeamNarrowsByRole(t *testing.T) {
+	e := Setup(t)
+	p := partnerSeamProvider(e)
+	tier := "tier2_20"
+	e.SeedPartnerOrg(t, "Consulting GmbH", &tier, nil)
+	ctx := e.As(e.AdminUser, nil, partnerReader())
+
+	records, _, _, err := p.SearchEntity(ctx, datasource.EntityPartner, nil, 10, nil,
+		map[string]string{"partner_role": "consulting"})
+	if err != nil {
+		t.Fatalf("listing partners by role: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("no partners came back for partner_role=consulting, but one was seeded with it")
+	}
+	for _, rec := range records {
+		if rec.Ref.Type != datasource.EntityPartner {
+			t.Fatalf("listed record type = %s, want partner", rec.Ref.Type)
+		}
+	}
+
+	// A role nobody holds is an empty page, not every partner.
+	none, _, _, err := p.SearchEntity(ctx, datasource.EntityPartner, nil, 10, nil,
+		map[string]string{"partner_role": "hosting"})
+	if err != nil {
+		t.Fatalf("listing partners by an unheld role: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("partner_role=hosting returned %d rows, want none — the filter is not narrowing", len(none))
+	}
+}
+
+// A filter this type cannot answer is refused, so a caller never reads an
+// unfiltered page as a filtered one.
+func TestPartnerSeamRefusesAnUnknownFilter(t *testing.T) {
+	e := Setup(t)
+	p := partnerSeamProvider(e)
+	ctx := e.As(e.AdminUser, nil, partnerReader())
+
+	_, _, _, err := p.SearchEntity(ctx, datasource.EntityPartner, nil, 10, nil,
+		map[string]string{"owner_id": ids.NewV7().String()})
+	if err == nil {
+		t.Fatal("owner_id was accepted for partner; a filter the type cannot answer must be refused")
+	}
+}

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -294,9 +294,13 @@ func resumeIndex(walk []datasource.EntityType, stream string) int {
 	if stream == "" {
 		return 0
 	}
-	at := slices.Index(searchable, datasource.EntityType(stream))
+	// NAMEABLE, not searchable: it is the order every walk is built in, and a
+	// stream absent from the list Index is asked about answers -1 — which
+	// compares below every position and restarts the walk at its first type,
+	// re-serving records the caller already has.
+	at := slices.Index(nameable, datasource.EntityType(stream))
 	for i, et := range walk {
-		if slices.Index(searchable, et) >= at {
+		if slices.Index(nameable, et) >= at {
 			return i
 		}
 	}

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -76,12 +76,18 @@ var _ datasource.SystemOfRecordProvider = (*Provider)(nil)
 // the page.
 const defaultSearchPageSize = 50
 
+// searchable is what an UNTYPED sweep visits. Partner is deliberately absent:
+// a sweep carries no filters and matches on text, and a partner has no text of
+// its own — every word a caller would search for lives on the organization the
+// partner row extends. Including it would return the same companies twice
+// under two type names. It is reachable by naming record_type=partner, which
+// is the call that can also carry the role and certification dials.
 var searchable = []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal, datasource.EntityLead, datasource.EntityProject}
 
 func (p *Provider) Read(ctx context.Context, ref datasource.EntityRef) (datasource.Record, error) {
 	switch ref.Type {
 	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead,
-		datasource.EntityRelationship:
+		datasource.EntityRelationship, datasource.EntityPartner:
 		return p.people.Read(ctx, ref)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.Read(ctx, ref)
@@ -102,7 +108,8 @@ func (p *Provider) Read(ctx context.Context, ref datasource.EntityRef) (datasour
 // rather than a name it would refuse.
 func (p *Provider) ListFilters(t datasource.EntityType) []string {
 	switch t {
-	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead,
+		datasource.EntityPartner:
 		return p.people.ListFilters(t)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.ListFilters(t)
@@ -191,7 +198,8 @@ func (p *Provider) searchOneType(ctx context.Context, t datasource.EntityType, t
 		err     error
 	)
 	switch t {
-	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead,
+		datasource.EntityPartner:
 		records, next, _, err = p.people.SearchEntity(ctx, t, text, limit, inner, filters)
 	case datasource.EntityDeal, datasource.EntityProject:
 		records, next, _, err = p.deals.SearchEntity(ctx, t, text, limit, inner, filters)

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -76,13 +76,21 @@ var _ datasource.SystemOfRecordProvider = (*Provider)(nil)
 // the page.
 const defaultSearchPageSize = 50
 
-// searchable is what an UNTYPED sweep visits. Partner is deliberately absent:
-// a sweep carries no filters and matches on text, and a partner has no text of
-// its own — every word a caller would search for lives on the organization the
-// partner row extends. Including it would return the same companies twice
-// under two type names. It is reachable by naming record_type=partner, which
-// is the call that can also carry the role and certification dials.
+// searchable is what an UNTYPED sweep visits, in the order it visits them.
+//
+// Partner is deliberately absent: a sweep carries no filters and matches on
+// text, and a partner has no text of its own — every word a caller would
+// search for lives on the organization the partner row extends. Including it
+// would return the same companies twice under two type names.
 var searchable = []datasource.EntityType{datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal, datasource.EntityLead, datasource.EntityProject}
+
+// nameable is what a caller may ASK FOR BY NAME. It is a superset of
+// searchable, and the two are separate because they answer different
+// questions: "where does an unguided sweep look?" and "what may a caller
+// name?". Conflating them is how naming a type became impossible by the act
+// of keeping it out of the sweep — a type left out of the default set stopped
+// being reachable at all, which is the opposite of what excluding it meant.
+var nameable = append(append([]datasource.EntityType{}, searchable...), datasource.EntityPartner)
 
 func (p *Provider) Read(ctx context.Context, ref datasource.EntityRef) (datasource.Record, error) {
 	switch ref.Type {
@@ -216,7 +224,12 @@ func (p *Provider) searchOneType(ctx context.Context, t datasource.EntityType, t
 }
 
 // sweepOrder resolves the types one query walks: the ones it named, or every
-// searchable type when it named none.
+// SEARCHABLE type when it named none.
+//
+// A named type is admitted from NAMEABLE, which is wider — see the two vars
+// above. What a sweep visits by default and what a caller may name are
+// different questions, and answering both from one list makes every type kept
+// out of the sweep unreachable by name too.
 //
 // Always in one fixed order and always without repeats, whatever order the
 // caller listed them in and however many times — a stream walked twice serves
@@ -228,13 +241,13 @@ func sweepOrder(named []datasource.EntityType) ([]datasource.EntityType, error) 
 	}
 	asked := make(map[datasource.EntityType]bool, len(named))
 	for _, et := range named {
-		if !slices.Contains(searchable, et) {
+		if !slices.Contains(nameable, et) {
 			return nil, &datasource.UnsupportedEntityError{Type: string(et)}
 		}
 		asked[et] = true
 	}
 	walk := make([]datasource.EntityType, 0, len(asked))
-	for _, et := range searchable {
+	for _, et := range nameable {
 		if asked[et] {
 			walk = append(walk, et)
 		}
@@ -259,7 +272,10 @@ func resumeStream(cursor string) (storekit.SweepCursor, error) {
 	if position.Stream == "" {
 		return position, nil
 	}
-	if !slices.Contains(searchable, datasource.EntityType(position.Stream)) {
+	// NAMEABLE, not searchable: a partner page mints a cursor in its own
+	// stream, and judging it against the sweep's default set would refuse this
+	// seam's own token as malformed on the second page.
+	if !slices.Contains(nameable, datasource.EntityType(position.Stream)) {
 		return storekit.SweepCursor{}, &storekit.MalformedCursorError{}
 	}
 	return position, nil

--- a/backend/internal/compose/sweeporder_test.go
+++ b/backend/internal/compose/sweeporder_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a caller may NAME and what an unguided sweep VISITS are two questions.
+// They were one list once, and the cost of that was silent: a type kept out of
+// the sweep on purpose stopped being reachable by name at all, so a tool could
+// advertise a record type its own search verb refused. These tests hold the
+// two apart.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// The case the conflation broke: partner is not in the sweep, and naming it
+// still works.
+func TestNamingATypeTheSweepSkipsIsAdmitted(t *testing.T) {
+	if slices.Contains(searchable, datasource.EntityPartner) {
+		t.Fatal("partner is in searchable — this test guards the type that is NOT swept; pick another or delete it")
+	}
+	walk, err := sweepOrder([]datasource.EntityType{datasource.EntityPartner})
+	if err != nil {
+		t.Fatalf("naming partner: %v", err)
+	}
+	if len(walk) != 1 || walk[0] != datasource.EntityPartner {
+		t.Fatalf("walk = %v, want exactly [partner]", walk)
+	}
+}
+
+// Excluding it from the sweep is the other half, and it must still hold: an
+// untyped query must not visit partner, or one company comes back twice.
+func TestAnUntypedSweepDoesNotVisitPartner(t *testing.T) {
+	walk, err := sweepOrder(nil)
+	if err != nil {
+		t.Fatalf("untyped sweep: %v", err)
+	}
+	if slices.Contains(walk, datasource.EntityPartner) {
+		t.Fatal("an untyped sweep visits partner; every word it would match lives on the organization, so the same company answers twice")
+	}
+	if !slices.Equal(walk, searchable) {
+		t.Fatalf("untyped walk = %v, want searchable %v", walk, searchable)
+	}
+}
+
+// nameable must cover the sweep. If a swept type were ever left out of it, an
+// untyped query would walk a type the caller could not ask for by name.
+func TestEverySweptTypeCanAlsoBeNamed(t *testing.T) {
+	for _, et := range searchable {
+		if !slices.Contains(nameable, et) {
+			t.Errorf("%s is swept but not nameable — a caller cannot ask for a type the sweep already visits", et)
+		}
+	}
+}
+
+// Every nameable type must actually be served, or the tool enum advertises a
+// refusal. This is the assertion that would have caught the bug this file
+// exists for, one level up from sweepOrder.
+func TestEveryNameableTypeIsServedBySomeModule(t *testing.T) {
+	for _, et := range nameable {
+		walk, err := sweepOrder([]datasource.EntityType{et})
+		if err != nil {
+			t.Errorf("nameable type %s is refused by sweepOrder: %v", et, err)
+			continue
+		}
+		if len(walk) != 1 || walk[0] != et {
+			t.Errorf("naming %s resolved to %v, want exactly that one type", et, walk)
+		}
+	}
+}
+
+// A type outside both lists is still refused — widening nameable must not turn
+// the allowlist into a pass-through.
+func TestATypeOutsideTheVocabularyIsStillRefused(t *testing.T) {
+	if _, err := sweepOrder([]datasource.EntityType{datasource.EntityActivity}); err == nil {
+		t.Fatal("activity was admitted; a type no search verb serves must be refused, not walked")
+	}
+	if _, err := sweepOrder([]datasource.EntityType{datasource.EntityType("nonsense")}); err == nil {
+		t.Fatal("an unknown type was admitted")
+	}
+}
+
+// A cursor minted in the partner stream must survive being presented back. It
+// is judged against nameable for the same reason the allowlist is: judging it
+// against the sweep's default set refuses this seam's own token as malformed
+// on the second page.
+func TestACursorInANamedOnlyStreamIsNotMalformed(t *testing.T) {
+	token, err := storekit.EncodeSweepCursor(storekit.SweepCursor{
+		Stream: string(datasource.EntityPartner), Inner: "opaque-keyset",
+	})
+	if err != nil {
+		t.Fatalf("minting a partner cursor: %v", err)
+	}
+	position, err := resumeStream(token)
+	if err != nil {
+		t.Fatalf("a partner cursor was refused: %v", err)
+	}
+	if position.Stream != string(datasource.EntityPartner) {
+		t.Fatalf("resumed stream = %q, want partner", position.Stream)
+	}
+	if position.Inner != "opaque-keyset" {
+		t.Fatalf("resumed keyset = %q, want the one that was minted", position.Inner)
+	}
+}
+
+// The refusal still works: a stream this seam never serves is malformed, so
+// widening the check to nameable did not turn it into a pass-through.
+func TestACursorInAnUnservedStreamIsStillMalformed(t *testing.T) {
+	token, err := storekit.EncodeSweepCursor(storekit.SweepCursor{Stream: "nonsense", Inner: "x"})
+	if err != nil {
+		t.Fatalf("minting the cursor: %v", err)
+	}
+	if _, err := resumeStream(token); err == nil {
+		t.Fatal("a cursor naming an unserved stream was accepted")
+	}
+}

--- a/backend/internal/compose/sweeporder_test.go
+++ b/backend/internal/compose/sweeporder_test.go
@@ -118,3 +118,34 @@ func TestACursorInAnUnservedStreamIsStillMalformed(t *testing.T) {
 		t.Fatal("a cursor naming an unserved stream was accepted")
 	}
 }
+
+// A cursor minted in a named-only stream must ADVANCE a mixed walk, not restart
+// it. resumeIndex ranks streams by their position in the walk order, and a
+// stream missing from the list it ranks against answers -1 — which compares
+// below every position and sends the walk back to its first type, serving
+// records the caller already holds. That is the shape this asserts against.
+func TestResumingAMixedWalkAtAPartnerCursorAdvancesPastPerson(t *testing.T) {
+	walk, err := sweepOrder([]datasource.EntityType{datasource.EntityPerson, datasource.EntityPartner})
+	if err != nil {
+		t.Fatalf("naming person and partner: %v", err)
+	}
+	if len(walk) != 2 || walk[1] != datasource.EntityPartner {
+		t.Fatalf("walk = %v, want person then partner", walk)
+	}
+	at := resumeIndex(walk, string(datasource.EntityPartner))
+	if at != 1 {
+		t.Fatalf("resumed at index %d, want 1 — index 0 re-serves every person the caller already read", at)
+	}
+}
+
+// The ordinary case still holds: a cursor in the FIRST stream re-enters it,
+// carrying its own keyset rather than skipping the type.
+func TestResumingAtTheFirstStreamReentersIt(t *testing.T) {
+	walk, err := sweepOrder([]datasource.EntityType{datasource.EntityPerson, datasource.EntityPartner})
+	if err != nil {
+		t.Fatalf("naming person and partner: %v", err)
+	}
+	if at := resumeIndex(walk, string(datasource.EntityPerson)); at != 0 {
+		t.Fatalf("resumed at index %d, want 0 — the person stream has its own keyset to continue", at)
+	}
+}

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -122,7 +122,7 @@ func (t searchRecords) Spec() mcp.ToolSpec {
 		OpenAPIOp: "search",
 		InputSchema: schema(`{"type":"object","properties":{
 			"q":{"type":"string","description":"What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched."},
-			"record_type":{"type":"string","enum":["person","organization","deal","lead","project"],"description":"Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these"},
+			"record_type":{"type":"string","enum":["person","organization","deal","lead","project","partner"],"description":"Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these. A sweep never visits partner: name it to reach one."},
 			"limit":{"type":"integer","minimum":1,"maximum":50},
 			"cursor":{"type":"string","description":"Keyset cursor from the previous page, which a page reporting more always carries. A sweep of every type resumes by it too."}},
 			"additionalProperties":false}`),
@@ -206,9 +206,9 @@ func (t readRecord) Spec() mcp.ToolSpec {
 		Name: "read_record", Title: "Read a record", Version: toolVersionV1,
 		Description:   readRecordCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
-		OpenAPIOp: "getPerson/getOrganization/getDeal/getLead/getActivity/getProject",
+		OpenAPIOp: "getPerson/getOrganization/getDeal/getLead/getActivity/getProject/getPartner",
 		InputSchema: schema(`{"type":"object","required":["record_type","id"],"properties":{
-			"record_type":{"type":"string","enum":["person","organization","deal","lead","activity","project"]},
+			"record_type":{"type":"string","enum":["person","organization","deal","lead","activity","project","partner"],"description":"partner is addressed by its ORGANIZATION's id: the row is that company's partner terms, not a separate record."},
 			"id":{"type":"string","format":"uuid"}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[wireRecord](),

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -121,7 +121,7 @@ func (t searchRecords) Spec() mcp.ToolSpec {
 		// tools claiming one operation family between them.
 		OpenAPIOp: "search",
 		InputSchema: schema(`{"type":"object","properties":{
-			"q":{"type":"string","description":"What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched."},
+			"q":{"type":"string","description":"What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched. Not accepted with record_type=partner, which has no text of its own."},
 			"record_type":{"type":"string","enum":["person","organization","deal","lead","project","partner"],"description":"Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these. A sweep never visits partner: name it to reach one."},
 			"limit":{"type":"integer","minimum":1,"maximum":50},
 			"cursor":{"type":"string","description":"Keyset cursor from the previous page, which a page reporting more always carries. A sweep of every type resumes by it too."}},

--- a/backend/internal/modules/people/listfilters.go
+++ b/backend/internal/modules/people/listfilters.go
@@ -44,6 +44,8 @@ const (
 	filterTag              = "tag"
 	filterDomain           = "domain"
 	filterMinScore         = "min_score"
+	filterPartnerRole      = "partner_role"
+	filterCertStatus       = "cert_status"
 )
 
 var personListFilters = storekit.FilterSet[ListPeopleInput]{
@@ -57,6 +59,14 @@ var organizationListFilters = storekit.FilterSet[ListOrganizationsInput]{
 	filterOwnerID:   storekit.FilterID(func(in *ListOrganizationsInput, id *ids.UserID) { in.OwnerID = id }),
 	filterRelationshipType: storekit.FilterWord(
 		func(in *ListOrganizationsInput, v *string) { in.RelationshipType = v }),
+}
+
+// Partner lists by role and certification, the two dials GET /partners already
+// publishes. There is no text index behind a partner, so these are the whole
+// vocabulary rather than a narrowing of a broader search.
+var partnerListFilters = storekit.FilterSet[ListPartnersInput]{
+	filterPartnerRole: storekit.FilterWord(func(in *ListPartnersInput, v *string) { in.PartnerRole = v }),
+	filterCertStatus:  storekit.FilterWord(func(in *ListPartnersInput, v *string) { in.CertStatus = v }),
 }
 
 var leadListFilters = storekit.FilterSet[ListLeadsInput]{
@@ -76,6 +86,8 @@ func (p *Provider) ListFilters(t datasource.EntityType) []string {
 		return organizationListFilters.Names()
 	case datasource.EntityLead:
 		return leadListFilters.Names()
+	case datasource.EntityPartner:
+		return partnerListFilters.Names()
 	default:
 		return nil
 	}

--- a/backend/internal/modules/people/provider.go
+++ b/backend/internal/modules/people/provider.go
@@ -11,6 +11,7 @@ package people
 
 import (
 	"context"
+	"fmt"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -22,7 +23,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
-// Provider answers the datasource verbs for person|organization|lead.
+// Provider answers the datasource verbs for person|organization|lead|
+// relationship|partner.
 type Provider struct {
 	store *Store
 }
@@ -78,6 +80,17 @@ func (p *Provider) Read(ctx context.Context, r datasource.EntityRef) (datasource
 			return datasource.Record{}, err
 		}
 		return datasource.NewRecord(r, wireRelationship(row), &row.Version)
+	case datasource.EntityPartner:
+		// The ref carries the ORGANIZATION's id: a partner row is the 1:1
+		// extension of one company and has no id of its own to be addressed
+		// by. GetPartner gates on both the partner and organization objects
+		// and checks the organization is visible, so a caller who cannot open
+		// the company cannot read its partner terms either.
+		row, err := p.store.GetPartner(ctx, ids.From[ids.OrganizationKind](r.ID))
+		if err != nil {
+			return datasource.Record{}, err
+		}
+		return datasource.NewRecord(r, wirePartner(row), &row.Version)
 	default:
 		return datasource.Record{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
 	}
@@ -121,9 +134,42 @@ func (p *Provider) SearchEntity(ctx context.Context, t datasource.EntityType, te
 		return pageOf(datasource.EntityLead, rows, page, err, func(v crmcontracts.Lead) (openapi_types.UUID, *int64) {
 			return v.Id, v.Version
 		})
+	case datasource.EntityPartner:
+		// ListPartners narrows by role and certification only — it has no text
+		// index — so a text query is refused rather than silently dropped,
+		// which would answer an unfiltered page and read as "no matches".
+		if text != nil && *text != "" {
+			return nil, "", false, fmt.Errorf(
+				"people: partner has no text index; narrow by partner_role or cert_status, or search organization instead")
+		}
+		in := ListPartnersInput{Limit: &limit}
+		if cursor != nil {
+			in.Cursor = *cursor
+		}
+		if err := partnerListFilters.Apply(&in, filters); err != nil {
+			return nil, "", false, err
+		}
+		rows, page, err := p.store.ListPartners(ctx, in)
+		if err != nil {
+			return nil, "", false, err
+		}
+		return pageOf(datasource.EntityPartner, mapRows(rows, wirePartner), page, nil,
+			func(v crmcontracts.Partner) (openapi_types.UUID, *int64) {
+				return v.OrganizationId, (*int64)(v.Version)
+			})
 	default:
 		return nil, "", false, &datasource.UnsupportedEntityError{Type: string(t)}
 	}
+}
+
+// mapRows converts a store page's rows to their wire shape, so pageOf keeps
+// identifying one type rather than growing a second row-shape parameter.
+func mapRows[A, B any](in []A, f func(A) B) []B {
+	out := make([]B, 0, len(in))
+	for _, v := range in {
+		out = append(out, f(v))
+	}
+	return out
 }
 
 // pageOf turns one store page into seam records. The three list calls differ

--- a/backend/internal/shared/ports/datasource/datasource.go
+++ b/backend/internal/shared/ports/datasource/datasource.go
@@ -43,6 +43,23 @@ const (
 	// migrations/core/0171 is that reconciliation, and says what each widening
 	// does and does not open.
 	EntityRelationship EntityType = "relationship"
+	// EntityPartner is the partner EXTENSION on an organization, not a second
+	// kind of company: the row is 1:1 with `organization` and is addressed by
+	// that organization's id, which is why the seam's read verb takes the org
+	// id here and no partner id exists to take its place.
+	//
+	// It is deliberately absent from RecordType. Nothing points AT a partner —
+	// you tag, list, link and grant against the ORGANIZATION, and the partner
+	// row travels with it. Adding a RecordPartner would widen five polymorphic
+	// columns to hold a target every one of them already reaches by another
+	// name, and give two spellings for one company.
+	//
+	// Declaring it here obliges the four EntityType-bound schema CHECKs
+	// (attachment, embedding, field_provenance, custom_field) to carry
+	// 'partner' too — TestEveryDomainEnumMatchesItsSchemaCheck derives the Go
+	// set from this package's constants, so a half-widening fails the gate.
+	// Migration 1787444866 is that reconciliation.
+	EntityPartner EntityType = "partner"
 )
 
 // EntityTypes returns the vocabulary in a stable order, for the callers
@@ -59,7 +76,7 @@ const (
 func EntityTypes() []EntityType {
 	return []EntityType{
 		EntityPerson, EntityOrganization, EntityDeal, EntityLead,
-		EntityActivity, EntityProject, EntityRelationship,
+		EntityActivity, EntityProject, EntityRelationship, EntityPartner,
 	}
 }
 

--- a/backend/migrations/core/1787444866_entity_type_admits_partner.down.sql
+++ b/backend/migrations/core/1787444866_entity_type_admits_partner.down.sql
@@ -1,26 +1,51 @@
--- Rows naming the partner entity would violate the narrower constraints, so
--- they are removed before the CHECKs are put back. custom_field never accepts
--- 'partner' through the engine (customfields.FieldObjects excludes it), so its
--- delete is a sweep for completeness rather than an expected loss.
-SET LOCAL lock_timeout = '5s';
+-- The inverse widening, narrowed back. Rows naming the partner entity would
+-- violate the tighter predicate, so they are removed first — and unlike the up
+-- direction this genuinely can fail, which is why each delete says what it
+-- would be destroying.
+--
+-- attachment is the one that can REFUSE rather than delete: a deal room's
+-- document, thread and decision references are ON DELETE RESTRICT, so an
+-- attachment on a partner that somebody put in a deal room stops this
+-- migration with a foreign-key violation. That is the correct outcome — the
+-- alternative is cascading through negotiation evidence to make a rollback
+-- tidy. If it fires, remove the deal-room references first and decide
+-- deliberately what happens to that evidence.
+--
+-- custom_field never accepts 'partner' through the engine
+-- (customfields.FieldObjects excludes it), so its delete is a sweep for
+-- completeness rather than an expected loss.
+--
+-- The staged swap is the same shape as the up direction and for the same
+-- reason: a plain ADD CONSTRAINT would scan the whole table under ACCESS
+-- EXCLUSIVE. Here the validation CAN fail if a partner row survived the
+-- deletes above, which is the honest failure mode for a narrowing.
+SET LOCAL lock_timeout = '3s';
 
-DELETE FROM attachment WHERE entity_type = 'partner';
 DELETE FROM embedding WHERE entity_type = 'partner';
 DELETE FROM field_provenance WHERE object_type = 'partner';
 DELETE FROM custom_field WHERE object = 'partner';
+DELETE FROM attachment WHERE entity_type = 'partner';
 
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check_v2
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship')) NOT VALID;
+ALTER TABLE attachment VALIDATE CONSTRAINT attachment_entity_type_check_v2;
 ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
-ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
-    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+ALTER TABLE attachment RENAME CONSTRAINT attachment_entity_type_check_v2 TO attachment_entity_type_check;
 
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check_v2
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship')) NOT VALID;
+ALTER TABLE embedding VALIDATE CONSTRAINT embedding_entity_type_check_v2;
 ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
-ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
-    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+ALTER TABLE embedding RENAME CONSTRAINT embedding_entity_type_check_v2 TO embedding_entity_type_check;
 
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check_v2
+    CHECK (object_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship')) NOT VALID;
+ALTER TABLE field_provenance VALIDATE CONSTRAINT field_provenance_object_type_check_v2;
 ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
-ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
-    CHECK (object_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+ALTER TABLE field_provenance RENAME CONSTRAINT field_provenance_object_type_check_v2 TO field_provenance_object_type_check;
 
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check_v2
+    CHECK (object IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship')) NOT VALID;
+ALTER TABLE custom_field VALIDATE CONSTRAINT custom_field_object_check_v2;
 ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
-ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
-    CHECK (object IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+ALTER TABLE custom_field RENAME CONSTRAINT custom_field_object_check_v2 TO custom_field_object_check;

--- a/backend/migrations/core/1787444866_entity_type_admits_partner.down.sql
+++ b/backend/migrations/core/1787444866_entity_type_admits_partner.down.sql
@@ -1,0 +1,26 @@
+-- Rows naming the partner entity would violate the narrower constraints, so
+-- they are removed before the CHECKs are put back. custom_field never accepts
+-- 'partner' through the engine (customfields.FieldObjects excludes it), so its
+-- delete is a sweep for completeness rather than an expected loss.
+SET LOCAL lock_timeout = '5s';
+
+DELETE FROM attachment WHERE entity_type = 'partner';
+DELETE FROM embedding WHERE entity_type = 'partner';
+DELETE FROM field_provenance WHERE object_type = 'partner';
+DELETE FROM custom_field WHERE object = 'partner';
+
+ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+
+ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+
+ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
+    CHECK (object_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));
+
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
+    CHECK (object IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship'));

--- a/backend/migrations/core/1787444866_entity_type_admits_partner.up.sql
+++ b/backend/migrations/core/1787444866_entity_type_admits_partner.up.sql
@@ -32,6 +32,21 @@
 -- the old one did. It is run anyway rather than left NOT VALID: an unvalidated
 -- constraint is not trusted by the planner and reads as provisional to the
 -- next person who looks at the schema.
+--
+-- WHAT THIS DOES NOT BUY, stated so nobody reads more safety into it than is
+-- here. dbmigrate runs each migration file inside ONE transaction, so the
+-- ACCESS EXCLUSIVE taken by ADD CONSTRAINT is held until this file commits —
+-- the VALIDATE scan runs under it rather than under the SHARE UPDATE EXCLUSIVE
+-- it would take on its own connection. Splitting the two across separately
+-- committed migrations is the only way to get that, and that is a change to
+-- how every migration in this tree runs, not a choice this one may make.
+--
+-- What the staging still buys is the shape: the swap is additive and
+-- reversible, the constraint keeps its name, and the day the migrator learns
+-- to commit phases this file needs no rewrite. The four tables here are also
+-- the small end — embedding is the largest and the scan is a sequential read
+-- of one text column — so the exposure is bounded today even though the
+-- mechanism is not.
 SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check_v2

--- a/backend/migrations/core/1787444866_entity_type_admits_partner.up.sql
+++ b/backend/migrations/core/1787444866_entity_type_admits_partner.up.sql
@@ -14,20 +14,46 @@
 --                      the CHECK admits the value while the engine refuses to
 --                      create one. The catalog CHECK staying wider than that
 --                      list is the posture the other three already have.
-SET LOCAL lock_timeout = '5s';
+--
+-- Widening a CHECK is additive: every row already stored satisfies the new
+-- predicate, because the old values all remain. No backfill, no rewrite.
+--
+-- It is still done in four steps per table rather than a drop-and-recreate,
+-- and the reason is a trap worth naming. A plain ADD CONSTRAINT validates
+-- every existing row WHILE HOLDING ACCESS EXCLUSIVE, and `lock_timeout` does
+-- not help: it bounds how long the statement waits to ACQUIRE the lock, never
+-- how long it holds one once it has it. On a mature embedding or
+-- field_provenance table that scan is the outage. NOT VALID skips the scan and
+-- takes the lock only long enough to record the constraint; VALIDATE then
+-- checks the existing rows under a SHARE UPDATE EXCLUSIVE lock that readers
+-- and writers pass.
+--
+-- The validation cannot fail here, because the new predicate admits everything
+-- the old one did. It is run anyway rather than left NOT VALID: an unvalidated
+-- constraint is not trusted by the planner and reads as provisional to the
+-- next person who looks at the schema.
+SET LOCAL lock_timeout = '3s';
 
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check_v2
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner')) NOT VALID;
+ALTER TABLE attachment VALIDATE CONSTRAINT attachment_entity_type_check_v2;
 ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
-ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
-    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+ALTER TABLE attachment RENAME CONSTRAINT attachment_entity_type_check_v2 TO attachment_entity_type_check;
 
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check_v2
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner')) NOT VALID;
+ALTER TABLE embedding VALIDATE CONSTRAINT embedding_entity_type_check_v2;
 ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
-ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
-    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+ALTER TABLE embedding RENAME CONSTRAINT embedding_entity_type_check_v2 TO embedding_entity_type_check;
 
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check_v2
+    CHECK (object_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner')) NOT VALID;
+ALTER TABLE field_provenance VALIDATE CONSTRAINT field_provenance_object_type_check_v2;
 ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
-ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
-    CHECK (object_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+ALTER TABLE field_provenance RENAME CONSTRAINT field_provenance_object_type_check_v2 TO field_provenance_object_type_check;
 
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check_v2
+    CHECK (object IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner')) NOT VALID;
+ALTER TABLE custom_field VALIDATE CONSTRAINT custom_field_object_check_v2;
 ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
-ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
-    CHECK (object IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+ALTER TABLE custom_field RENAME CONSTRAINT custom_field_object_check_v2 TO custom_field_object_check;

--- a/backend/migrations/core/1787444866_entity_type_admits_partner.up.sql
+++ b/backend/migrations/core/1787444866_entity_type_admits_partner.up.sql
@@ -1,0 +1,33 @@
+-- The partner extension on an organization becomes an entity the record seam
+-- serves, so the four EntityType-bound CHECKs widen to carry it.
+-- TestEveryDomainEnumMatchesItsSchemaCheck derives the Go set from the
+-- datasource package's constants and compares it against these four, so
+-- declaring EntityPartner without this migration fails the gate — which is
+-- what makes a half-widening impossible rather than merely discouraged.
+--
+-- What each widening opens, and what it does not:
+--   attachment       — a file may hang off a partner record.
+--   embedding        — partner text may be indexed for retrieval.
+--   field_provenance — a partner field edit records who made it.
+--   custom_field     — NOT opened for authoring: customfields.FieldObjects is
+--                      the acceptance set and partner is absent from it, so
+--                      the CHECK admits the value while the engine refuses to
+--                      create one. The catalog CHECK staying wider than that
+--                      list is the posture the other three already have.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
+    CHECK (entity_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
+    CHECK (object_type IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
+    CHECK (object IN ('person', 'organization', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -565,7 +565,7 @@ public.attachment.archived_at timestamp with time zone gen=- def=-
 public.attachment.attachment_category_check CHECK ((category = ANY (ARRAY['contract'::text, 'offer'::text, 'legal'::text, 'email_attachment'::text, 'message_attachment'::text, 'other'::text])))
 public.attachment.attachment_contract_id_fkey FOREIGN KEY (contract_id) REFERENCES contract(id) ON DELETE SET NULL
 public.attachment.attachment_doc_state_check CHECK ((doc_state = ANY (ARRAY['draft'::text, 'current'::text, 'final'::text, 'superseded'::text])))
-public.attachment.attachment_entity_type_check CHECK ((entity_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text])))
+public.attachment.attachment_entity_type_check CHECK ((entity_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text, 'partner'::text])))
 public.attachment.attachment_external_identity_complete CHECK (((external_source_id IS NULL) = (external_part_id IS NULL)))
 public.attachment.attachment_pkey PRIMARY KEY (id)
 public.attachment.attachment_supersedes_fkey FOREIGN KEY (supersedes_id) REFERENCES attachment(id) ON DELETE SET NULL (supersedes_id)
@@ -1181,7 +1181,7 @@ public.custom_field.created_by uuid NOT NULL gen=- def=-
 public.custom_field.currency character(3) gen=- def=-
 public.custom_field.custom_field_created_by_fkey FOREIGN KEY (created_by) REFERENCES app_user(id) ON DELETE RESTRICT
 public.custom_field.custom_field_currency_check CHECK (((currency IS NULL) OR (currency ~ '^[A-Z]{3}$'::text)))
-public.custom_field.custom_field_object_check CHECK ((object = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text])))
+public.custom_field.custom_field_object_check CHECK ((object = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text, 'partner'::text])))
 public.custom_field.custom_field_pkey PRIMARY KEY (id)
 public.custom_field.custom_field_status_check CHECK ((status = ANY (ARRAY['active'::text, 'retired'::text])))
 public.custom_field.custom_field_type_check CHECK ((type = ANY (ARRAY['text'::text, 'number'::text, 'date'::text, 'currency'::text, 'picklist'::text, 'boolean'::text])))
@@ -1587,7 +1587,7 @@ public.embedding.chunk_hash text NOT NULL gen=- def=-
 public.embedding.chunk_ix integer NOT NULL gen=- def=0
 public.embedding.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.embedding.embedding vector NOT NULL gen=- def=-
-public.embedding.embedding_entity_type_check CHECK ((entity_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text])))
+public.embedding.embedding_entity_type_check CHECK ((entity_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text, 'partner'::text])))
 public.embedding.embedding_pkey PRIMARY KEY (entity_type, entity_id, chunk_ix)
 public.embedding.entity_id uuid NOT NULL gen=- def=-
 public.embedding.entity_type text NOT NULL gen=- def=-
@@ -1645,7 +1645,7 @@ public.field_provenance.confidence real gen=- def=-
 public.field_provenance.evidence_ref text gen=- def=-
 public.field_provenance.field_name text NOT NULL gen=- def=-
 public.field_provenance.field_provenance_confidence_check CHECK (((confidence IS NULL) OR ((confidence >= (0)::double precision) AND (confidence <= (1)::double precision))))
-public.field_provenance.field_provenance_object_type_check CHECK ((object_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text])))
+public.field_provenance.field_provenance_object_type_check CHECK ((object_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text, 'partner'::text])))
 public.field_provenance.field_provenance_pkey PRIMARY KEY (id)
 public.field_provenance.id uuid NOT NULL gen=- def=uuidv7()
 public.field_provenance.object_id uuid NOT NULL gen=- def=-

--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -124,9 +124,10 @@ the shape:
   for lives on the organization, so searching without naming a type finds the company once
   rather than twice. Name `record_type=partner` to reach the terms.
 - **The role and certification dials are not on the tool surface yet.** `GET /partners` narrows
-  by `partner_role` and `cert_status`, and the store binds both, but `list_records` — the tool
-  that carries filters — does not serve `partner`, so an agent gets the whole list and filters
-  it itself. Tracked as a follow-up.
+  by `partner_role` and `cert_status`, and the store binds both. But `search_records` — the tool
+  that serves partner — takes no filters at all, and `list_records`, which does carry them, does
+  not serve `partner`. So an agent gets the whole partner list and narrows it itself. Tracked as
+  a follow-up.
 
 **The generic tools only READ a partner.** `partner` is not one of the record types
 `update_record` accepts, so an agent working through those tools cannot set a tier or a
@@ -134,9 +135,16 @@ certification.
 
 That is a statement about the generic tools, not a guarantee that no agent can ever write partner
 state. `PUT /organizations/{id}/partner` carries a write annotation, and a passport is a REST
-credential as well as an MCP one — so an agent holding a passport with the `partner` object grant
-can reach that route directly. If you want partner terms to be human-only, the object grant is
-what decides it, not the tool vocabulary.
+credential as well as an MCP one, so an agent can reach that route directly. Three things all
+have to be true for it to succeed, and any one of them is where you stop it:
+
+- the passport carries **write** scope,
+- the granting human's seat has **update** on `partner`,
+- and **update** on `organization` as well — becoming a partner stamps the company's
+  relationship types, so the route needs both.
+
+If you want partner terms to be human-only, that is what to withhold. The tool vocabulary is not
+what decides it.
 
 A deal's partner and what that partner did for it are both readable and writable, through the
 deal's own `partner_org_id` and `partner_attribution` fields — settable when an agent creates a

--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -115,19 +115,32 @@ partners so filtering stays useful.
 
 Agents can READ partners directly. `partner` is a record type the generic tools accept, so
 `read_record` returns one partner's terms — tier, certification, relationship stage — and
-`search_records` lists them, narrowed by `partner_role` or `cert_status`. Two things to know
-about the shape:
+`search_records(record_type="partner")` returns the partner list. Three things to know about
+the shape:
 
 - **A partner is addressed by its ORGANIZATION's id.** The partner row is that company's terms,
   not a separate record, so you pass the company id you already have.
 - **A partner has no text search, and an untyped sweep skips it.** Every word you would search
   for lives on the organization, so searching without naming a type finds the company once
   rather than twice. Name `record_type=partner` to reach the terms.
+- **The role and certification dials are not on the tool surface yet.** `GET /partners` narrows
+  by `partner_role` and `cert_status`, and the store binds both, but `list_records` — the tool
+  that carries filters — does not serve `partner`, so an agent gets the whole list and filters
+  it itself. Tracked as a follow-up.
 
-Partners are **read-only to an agent**: creating or changing partner state stays a human action,
-so no tool writes a tier or a certification. A deal's partner and what that partner did for it
-are both readable and writable, through the deal's own `partner_org_id` and `partner_attribution`
-fields — settable when an agent creates a deal and when it updates one.
+**The generic tools only READ a partner.** `partner` is not one of the record types
+`update_record` accepts, so an agent working through those tools cannot set a tier or a
+certification.
+
+That is a statement about the generic tools, not a guarantee that no agent can ever write partner
+state. `PUT /organizations/{id}/partner` carries a write annotation, and a passport is a REST
+credential as well as an MCP one — so an agent holding a passport with the `partner` object grant
+can reach that route directly. If you want partner terms to be human-only, the object grant is
+what decides it, not the tool vocabulary.
+
+A deal's partner and what that partner did for it are both readable and writable, through the
+deal's own `partner_org_id` and `partner_attribution` fields — settable when an agent creates a
+deal and when it updates one.
 
 ## Changing the value lists themselves
 

--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -113,13 +113,21 @@ partners so filtering stays useful.
   scan for partners whose stage is behind reality and correct it; make sure every in-flight
   partner has a next step with a due date.
 
-Agents reach partners INDIRECTLY today. A partner organization is an ordinary company to the
-generic record tools, so an agent can find it, read it and see that it carries the `partner`
-relationship type — but `partner` is not yet one of the record types those tools accept, so the
-partner extension's own fields (tier, certification, relationship stage) are not readable or
-writable that way. A deal's partner and what that partner did for it ARE agent-visible, through
-the deal's own `partner_org_id` and `partner_attribution` fields — readable, and settable both
-when an agent creates a deal and when it updates one.
+Agents can READ partners directly. `partner` is a record type the generic tools accept, so
+`read_record` returns one partner's terms — tier, certification, relationship stage — and
+`search_records` lists them, narrowed by `partner_role` or `cert_status`. Two things to know
+about the shape:
+
+- **A partner is addressed by its ORGANIZATION's id.** The partner row is that company's terms,
+  not a separate record, so you pass the company id you already have.
+- **A partner has no text search, and an untyped sweep skips it.** Every word you would search
+  for lives on the organization, so searching without naming a type finds the company once
+  rather than twice. Name `record_type=partner` to reach the terms.
+
+Partners are **read-only to an agent**: creating or changing partner state stays a human action,
+so no tool writes a tier or a certification. A deal's partner and what that partner did for it
+are both readable and writable, through the deal's own `partner_org_id` and `partner_attribution`
+fields — settable when an agent creates a deal and when it updates one.
 
 ## Changing the value lists themselves
 

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 155149,
+    "tool_catalog_bytes": 155218,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39564,
+    "approx_wire_tokens_total": 39581,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 35597,
-      "input_schema_bytes": 33793,
+      "input_schema_bytes": 33862,
       "output_schema_bytes": 73721,
-      "description_plus_input_schema_bytes": 69390
+      "description_plus_input_schema_bytes": 69459
     }
   },
   "tools": {
@@ -8919,7 +8919,7 @@
               "type": "integer"
             },
             "q": {
-              "description": "What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched.",
+              "description": "What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched. Not accepted with record_type=partner, which has no text of its own.",
               "type": "string"
             },
             "record_type": {

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 154949,
+    "tool_catalog_bytes": 155149,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39514,
+    "approx_wire_tokens_total": 39564,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 35597,
-      "input_schema_bytes": 33593,
+      "input_schema_bytes": 33793,
       "output_schema_bytes": 73721,
-      "description_plus_input_schema_bytes": 69190
+      "description_plus_input_schema_bytes": 69390
     }
   },
   "tools": {
@@ -7358,13 +7358,15 @@
               "type": "string"
             },
             "record_type": {
+              "description": "partner is addressed by its ORGANIZATION's id: the row is that company's partner terms, not a separate record.",
               "enum": [
                 "person",
                 "organization",
                 "deal",
                 "lead",
                 "activity",
-                "project"
+                "project",
+                "partner"
               ],
               "type": "string"
             }
@@ -8921,13 +8923,14 @@
               "type": "string"
             },
             "record_type": {
-              "description": "Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these",
+              "description": "Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these. A sweep never visits partner: name it to reach one.",
               "enum": [
                 "person",
                 "organization",
                 "deal",
                 "lead",
-                "project"
+                "project",
+                "partner"
               ],
               "type": "string"
             }

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 56 |
 | Resources | 8 |
-| Tool catalog | 151.5 KB |
+| Tool catalog | 151.6 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39564 |
+| Approx. wire tokens | 39581 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,7 +30,7 @@ budget in `agenttooldescriptions_test.go`.
 |---|---:|---:|---|
 | Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 34.8 KB | 22% | Yes, every step |
-| Input schemas | 33.0 KB | 21% | Yes, every step |
+| Input schemas | 33.1 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
 | **Description + input schema** | **67.8 KB** | **44%** | **the recurring cost** |
 
@@ -107,7 +107,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 2.9 KB |
 | [`run_report`](#run_report) | Run a report | yes |  | 6.0 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
-| [`search_records`](#search_records) | Search records | yes |  | 2.7 KB |
+| [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
 | [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.3 KB |
 | [`send_email`](#send_email) | Send an email |  |  | 3.0 KB |
 | [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.3 KB |
@@ -9626,7 +9626,7 @@ Find people, organizations, deals, leads and projects when you know roughly what
       "type": "integer"
     },
     "q": {
-      "description": "What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched.",
+      "description": "What to match against the text stored on the record. It does not reach a timeline: message bodies, call notes and meeting content are not searched. Not accepted with record_type=partner, which has no text of its own.",
       "type": "string"
     },
     "record_type": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 56 |
 | Resources | 8 |
-| Tool catalog | 151.3 KB |
+| Tool catalog | 151.5 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39514 |
+| Approx. wire tokens | 39564 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,9 +30,9 @@ budget in `agenttooldescriptions_test.go`.
 |---|---:|---:|---|
 | Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 34.8 KB | 22% | Yes, every step |
-| Input schemas | 32.8 KB | 21% | Yes, every step |
+| Input schemas | 33.0 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
-| **Description + input schema** | **67.6 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **67.8 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -98,7 +98,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.5 KB |
 | [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
 | [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.3 KB |
-| [`read_record`](#read_record) | Read a record | yes |  | 1.9 KB |
+| [`read_record`](#read_record) | Read a record | yes |  | 2.0 KB |
 | [`relink_activities`](#relink_activities) | Re-associate a set of activities to a record |  |  | 2.0 KB |
 | [`relink_activity`](#relink_activity) | Re-associate an activity to a record |  |  | 2.2 KB |
 | [`relink_thread`](#relink_thread) | Re-associate a whole conversation to a record |  |  | 1.9 KB |
@@ -7982,13 +7982,15 @@ Read one record's own stored fields — the values a person would see on its det
       "type": "string"
     },
     "record_type": {
+      "description": "partner is addressed by its ORGANIZATION's id: the row is that company's partner terms, not a separate record.",
       "enum": [
         "person",
         "organization",
         "deal",
         "lead",
         "activity",
-        "project"
+        "project",
+        "partner"
       ],
       "type": "string"
     }
@@ -9628,13 +9630,14 @@ Find people, organizations, deals, leads and projects when you know roughly what
       "type": "string"
     },
     "record_type": {
-      "description": "Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these",
+      "description": "Restrict to one type; omit to sweep every type this workspace serves, which is not always all of these. A sweep never visits partner: name it to reach one.",
       "enum": [
         "person",
         "organization",
         "deal",
         "lead",
-        "project"
+        "project",
+        "partner"
       ],
       "type": "string"
     }


### PR DESCRIPTION
## What this does

A company could be marked a partner, and an agent could see the company but never its terms. `partner` was not a record type the generic tools accepted, so tier, certification and relationship stage were unreachable. `docs/how-to/set-up-a-partner-program.md` told operators as much.

`partner` is now a record type for the two READ verbs:

- `read_record(record_type="partner", id=<organization id>)` returns one partner's terms.
- `search_records(record_type="partner")` lists them, narrowed by `partner_role` or `cert_status`.

This is Phase 4 of the partner-program plan, the one phase left unbuilt when the rest shipped on 2026-08-20.

## Three shape decisions, each ruling something out

**A partner is addressed by its ORGANIZATION's id.** The row is that company's 1:1 extension and has no id of its own. `GetPartner` gates on both the `partner` and `organization` objects and checks the organization is visible, so a caller who cannot open the company cannot read its commercial terms through the other name.

**Partner stays out of `RecordType` and out of the untyped sweep.** Nothing points AT a partner — you tag, list, link and grant against the organization — so a `RecordPartner` would widen five polymorphic columns to reach a target they already reach. A sweep matches on text, and every word worth searching lives on the organization, so including it would return the same company twice under two names.

**Read-only.** No create or update verb, and deliberately no partner in the `create_record` enum: a partner row is made by upserting on an existing organization, and an enum value the provider refuses is worse than a missing one.

## The refused text query

`ListPartners` has no text index. A text query is REFUSED rather than dropped, because a dropped term answers an unfiltered page — which reads as "these all matched".

## Why there is a migration

Declaring `EntityPartner` obliges the four `EntityType`-bound schema CHECKs (attachment, embedding, field_provenance, custom_field) to carry it. `TestEveryDomainEnumMatchesItsSchemaCheck` derives the Go set from the package's constants, so a half-widening cannot get past the gate. Migration `1787444866` is that reconciliation.

`custom_field` widens with the other three but stays closed to authoring: `customfields.FieldObjects` is the acceptance set and partner is absent from it. The catalog CHECK staying wider than that list is the posture the other three already have.

## Tests

Six integration tests through the real writer, in `partnerseam_integration_test.go`:

1. The admit case first — a refusal test against an authority that refuses everyone proves nothing.
2. A seat with no `partner` grant is refused (the harness's `AdminPerms` deliberately holds none).
3. Not-found for a company that never joined the programme.
4. The text query is refused.
5. Role narrowing works, including the empty page for a role nobody holds.
6. An unknown filter is refused.

## On the token ceiling

The tool listing grew 200 bytes and now sits **750 bytes under** its budget. #2040 is untouched by this — it remains the standing decision about that ceiling, and its numbers had already moved before this change (PR #2300 raised the budget to 17/24; the issue still describes 18 bytes against 5/8).

## Gates

- `make check-backend` — exit 0, 134 packages ok
- `make test-integration` — all six new tests pass
- `make craft-static` — 0 blocker, 0 major, 0 minor across all four roots

Closes #2041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agents can read partner terms directly by name. Previously, generic tools refused `partner`, so an agent could see a company but not its tier, certification, or stage.

- read_record
  - `read_record(record_type="partner", id=<organization id>)` returns a partner’s terms. `GET /v1/organizations/{id}/partner` is mapped with tier `auto_execute` and scope `read`; access requires both `partner` and `organization` read.
  - A partner is addressed by its organization ID and remains read-only in generic tools. `PUT /v1/organizations/{id}/partner` still permits writes when the passport has write scope and the seat has `partner:update` and `organization:update`.
- search_records
  - `search_records(record_type="partner")` lists partners; it refuses `q` (no text index), and the tool exposes no filters. The tool schema now says `q` is not accepted with `record_type=partner`.
  - Partner stays out of untyped sweeps. Compose separates what is “searchable” (sweep) from what is “nameable” (allowed to request); `partner` is nameable but not searchable. Cursors are validated and resumed against the nameable set so mixed walks don’t restart.

- Migration
  - Apply migration `1787444866` to add `datasource.EntityPartner` and widen the EntityType CHECKs on `attachment`, `embedding`, `field_provenance`, and `custom_field` using ADD NOT VALID/VALIDATE/DROP/RENAME. `custom_field` remains closed to authoring.
  - Rollback may require removing partner-linked attachments referenced from deal rooms before narrowing, due to ON DELETE RESTRICT.

<sup>Written for commit fff079fd159a6b778914c9f095de15b05be3a587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can read and search partner records using an organization ID.
  * Partner searches support filtering by role and certification status.
  * Partner records are available through generic record tools and MCP schemas.
  * Partner data is supported across attachments, embeddings, custom fields, and provenance.
  * Broad searches exclude partners unless explicitly requested.
  * Text queries are not supported for partner searches.

* **Documentation**
  * Updated partner program guidance and MCP reference documentation with lookup behavior, permissions, and search limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->