### PR TITLE
style(authz): gofumpt the write-parity table so the next author does not wear it

### DIFF
--- a/backend/internal/compose/integration/agentwriteparity_integration_test.go
+++ b/backend/internal/compose/integration/agentwriteparity_integration_test.go
@@ -168,8 +168,10 @@ func TestAnAgentWritesExactlyWhatItsHumanWrites(t *testing.T) {
 			}{
 				{"owned by rep1", mine, verdictAdmitted, verdictAdmitted, verdictDenied},
 				{"owned by rep3", theirs, verdictDenied, verdictDenied, verdictAdmitted},
-				{"owned by rep3, shared to rep1 at write", sharedWithMe,
-					verdictAdmitted, verdictAdmitted, verdictAdmitted},
+				{
+					"owned by rep3, shared to rep1 at write", sharedWithMe,
+					verdictAdmitted, verdictAdmitted, verdictAdmitted,
+				},
 			} {
 				human := classifyWrite(tc.write(e.As(e.Rep1, rep1Team, tc.perms), e, row.id))
 				agent := classifyWrite(tc.write(e.AgentFor(t, e.Rep1, rep1Team, tc.perms), e, row.id))


### PR DESCRIPTION
## What is wrong

#2351's `deterministic-gates` run reported:

```
internal/compose/integration/agentwriteparity_integration_test.go:171:1:
File is not properly formatted (gofumpt)
make[2]: *** [Makefile:396: lint] Error 1
```

That run **finished at 01:05, eight minutes after the pull request merged at 00:57** — the same merge-outran-the-gate pattern recorded on #1130. The literal it names is still on `main`:

```go
{"owned by rep3, shared to rep1 at write", sharedWithMe,
    verdictAdmitted, verdictAdmitted, verdictAdmitted},
```

## Why nothing has re-reported it, and why that is worse than a plain red

The lint pass that raises this is **diff-scoped against `origin/main`** (`backend/Makefile:399`, the strict second pass). On `main` there is no diff, so it has nothing to judge and `main-health` stays green.

It reappears for **the next person who touches this file**, as a finding on a line they did not write — which is exactly the misattribution class this repo has paid for repeatedly today (a `uat` fossil on #2321, an innocent PR reddened by a timing flake in #1762).

`#2352` merged two minutes later and is green, but that proves nothing here: its `deterministic-gates` run was created at **00:55**, before #2351 merged, so it never saw this commit.

## The change

`gofumpt`'s own output over that one composite literal. **No other file is touched, deliberately** — a tree-wide reformat would defeat the strict pass's diff scoping and fail somebody's unrelated pull request on pre-existing findings.

## Verification, stated honestly

I could **not** reproduce the finding locally, and the reason is the same property that hides it: the strict pass compares against `origin/main`, and in a worktree checked out at `origin/main` there is no diff to scope onto. Both the baseline and strict passes report `0 issues` there with or without the fix.

CI on this branch is the discriminating run — it compares against `origin/main` and *will* see this file. If the finding was not real, this PR is a no-op formatting change; if it was, this is the only thing that clears it.

Found by an hourly main-status watch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats the write-parity test table per `gofumpt` to clear a lingering lint violation. This removes a diff-scoped strict lint trap that would flag future PRs touching this file.

- Changes only `backend/internal/compose/integration/agentwriteparity_integration_test.go`: reformats one composite literal to `gofumpt` output.
- No behavior change; test data and assertions are identical.
- Fixes a strict lint that compares against `origin/main` and was masked on `main` but would reappear on unrelated diffs.

<sup>Written for commit c708d930f667a62209dca57efef06f99b0f14100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved formatting of a shared-record parity test for readability.
  * No changes to test behavior or application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->