### PR TITLE
feat(authz): a record is the owner's to change, and its amount is everyone's to see

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17489,6 +17489,19 @@ components:
         full_name: { type: string, description: Always present (display name). }
         title: { type: [string, 'null'], description: Denormalized current title; authoritative title is on the employment relationship. }
         owner_id: { type: [string, 'null'], format: uuid }
+        writable:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether THIS caller may change THIS row: the same question the server's write
+            gate answers on a mutation — the owner, the owner's team where the role is
+            team-scoped, a live `write` record grant, or an unbounded seat. Server-computed
+            per row, per caller.
+            It is a UX signal, never the enforcement. A client uses it to draw or withhold
+            edit affordances so a reader is not offered a control the save would refuse; the
+            server refuses an unauthorized write with 403 whatever this said. Absent means
+            NOT writable, so a client reading a response from a server too old to send it
+            fails closed.
         social:
           type: object
           additionalProperties: true
@@ -17696,6 +17709,19 @@ components:
           enum: [null, '1-10', '11-50', '51-200', '201-500', '501-1000', '1001-5000', '5000+']
         address: { $ref: '#/components/schemas/Address' }
         owner_id: { type: [string, 'null'], format: uuid }
+        writable:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether THIS caller may change THIS row: the same question the server's write
+            gate answers on a mutation — the owner, the owner's team where the role is
+            team-scoped, a live `write` record grant, or an unbounded seat. Server-computed
+            per row, per caller.
+            It is a UX signal, never the enforcement. A client uses it to draw or withhold
+            edit affordances so a reader is not offered a control the save would refuse; the
+            server refuses an unauthorized write with 403 whatever this said. Absent means
+            NOT writable, so a client reading a response from a server too old to send it
+            fails closed.
         parent_org_id: { type: [string, 'null'], format: uuid, description: Single-level hierarchy FK; no cycles. }
         merged_into_id: { type: [string, 'null'], format: uuid }
         computed_fields:
@@ -20741,6 +20767,19 @@ components:
             defaults it to `sourced`. Commission accrues on `sourced` only.
         project_id: { type: [string, 'null'], format: uuid, description: 'The body of work this deal belongs to. A deal has at most one project; a project carries several deals over time. The deal and the project must name the same company — a cross-company pointer is refused 422. Null when the caller may not read that project, in which case `masked_fields` names it.' }
         owner_id: { type: [string, 'null'], format: uuid }
+        writable:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether THIS caller may change THIS row: the same question the server's write
+            gate answers on a mutation — the owner, the owner's team where the role is
+            team-scoped, a live `write` record grant, or an unbounded seat. Server-computed
+            per row, per caller.
+            It is a UX signal, never the enforcement. A client uses it to draw or withhold
+            edit affordances so a reader is not offered a control the save would refuse; the
+            server refuses an unauthorized write with 403 whatever this said. Absent means
+            NOT writable, so a client reading a response from a server too old to send it
+            fails closed.
         status: { type: string, enum: [open, won, lost], default: open }
         lost_reason: { type: [string, 'null'], description: Required when status=lost. }
         won_without_contract_reason:
@@ -21155,6 +21194,19 @@ components:
           format: uuid
           description: 'The anchor company — singular, and always set on the row. A company has many projects; a project has one company. Null on the wire when the caller may not read that company, in which case `masked_fields` names it: a project is readable across the workspace while the company it hangs off can still be an unpromoted capture.'
         owner_id: { type: [string, 'null'], format: uuid }
+        writable:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether THIS caller may change THIS row: the same question the server's write
+            gate answers on a mutation — the owner, the owner's team where the role is
+            team-scoped, a live `write` record grant, or an unbounded seat. Server-computed
+            per row, per caller.
+            It is a UX signal, never the enforcement. A client uses it to draw or withhold
+            edit affordances so a reader is not offered a control the save would refuse; the
+            server refuses an unauthorized write with 403 whatever this said. Absent means
+            NOT writable, so a client reading a response from a server too old to send it
+            fails closed.
         phase:
           type: string
           enum: [initiative, pursuing, delivering, closed]
@@ -22543,6 +22595,19 @@ components:
         score_override_reason: { type: [string, 'null'], readOnly: true, description: 'Non-null ⇒ `score` is a human Commercial-Judgement override (formulas §3.1) and recompute is suppressed; the machine value is retained in `score_computed`.' }
         score_computed: { type: [integer, 'null'], readOnly: true, description: 'Server-derived. The latest machine-computed §3 score, retained ONLY while an override is in force (else null, because score itself is the machine value).' }
         owner_id: { type: [string, 'null'], format: uuid }
+        writable:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether THIS caller may change THIS row: the same question the server's write
+            gate answers on a mutation — the owner, the owner's team where the role is
+            team-scoped, a live `write` record grant, or an unbounded seat. Server-computed
+            per row, per caller.
+            It is a UX signal, never the enforcement. A client uses it to draw or withhold
+            edit affordances so a reader is not offered a control the save would refuse; the
+            server refuses an unauthorized write with 403 whatever this said. Absent means
+            NOT writable, so a client reading a response from a server too old to send it
+            fails closed.
         source_system: { type: [string, 'null'] }
         source_id: { type: [string, 'null'] }
         promoted_person_id: { type: [string, 'null'], format: uuid, description: Set on promotion (convenience mirror). }

--- a/backend/internal/compose/integration/harnessperms.go
+++ b/backend/internal/compose/integration/harnessperms.go
@@ -10,6 +10,14 @@ package integration
 // harness that has to mirror something outside the test tree: identity's
 // seeded role documents. A fixture that drifts from that seed still passes,
 // while proving nothing about production.
+//
+// The row scope is the deliberate exception, and it diverges on purpose. The
+// seeded rep and manager are `own`: team membership is not by itself permission
+// to rewrite a teammate's records. These fixtures stay `team`, because the team
+// arm of the write predicate is still live — a record_grant may name a team, and
+// an operator may author a custom role at team scope — and it is these suites
+// that cover it. Moving them to `own` would delete that coverage while the
+// predicate went on rendering the clause.
 
 import (
 	"maps"

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -180,7 +180,16 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// 35 since the projects section: one read of the account's unarchived
 	// projects under the caller's project row scope, capped at 25 rows and
 	// flat in the size of the account.
-	const budget = 35
+	//
+	// 39 since the writable flag: the organization, its people, its deals and
+	// its projects each answer "may this caller change this row" for their whole
+	// page in ONE statement — auth.StampWritable over the page's ids, plus the
+	// live filter that keeps an archived row from being reported as editable.
+	// Four reads, one per record type on the page rather than one per row, so
+	// they are flat in the size of the account exactly like every section above.
+	// The flatness assertion higher up is what actually protects that; this
+	// number only records where the flat cost now sits.
+	const budget = 39
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/compose/integration/writableonthewire_integration_test.go
+++ b/backend/internal/compose/integration/writableonthewire_integration_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The `writable` flag a record carries must mean what it says.
+//
+// A client draws its edit affordances from it, so a flag that is merely PRESENT
+// is worse than none: it would put a save button on a row the server then
+// refuses, which is the guess this field exists to replace. The test is
+// therefore not "the flag is set" but "the flag agrees with the mutation" —
+// writable is true exactly when the write is admitted.
+//
+// It is UX honesty and never enforcement. The server's own gate is asserted
+// separately, in writeauthority_integration_test.go and the agent parity suite;
+// nothing here would change if a client ignored the flag entirely.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestARecordSaysWhetherItIsThisCallersToChange(t *testing.T) {
+	e := Setup(t)
+	svc := identity.NewService(e.Pool)
+	pipeline, open, _ := DealFixture(t, e)
+	title := "Changed by the writable suite"
+
+	mine := e.SeedPerson(t, "My contact", &e.Rep1)
+	theirs := e.SeedPerson(t, "Their contact", &e.Rep3)
+	shared := e.SeedPerson(t, "Shared contact", &e.Rep3)
+	if _, err := svc.CreateRecordGrant(e.Admin(), identity.CreateGrantInput{
+		RecordType: "person", RecordID: shared,
+		SubjectType: "user", SubjectID: e.Rep1, Access: "write",
+	}); err != nil {
+		t.Fatalf("sharing the person at write: %v", err)
+	}
+	myDeal := e.SeedDeal(t, "My deal", pipeline, open, &e.Rep1)
+	theirDeal := e.SeedDeal(t, "Their deal", pipeline, open, &e.Rep3)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	// person
+	for _, row := range []struct {
+		name string
+		id   ids.UUID
+		want bool
+	}{
+		{"a person they own", mine, true},
+		{"a colleague's person", theirs, false},
+		{"a person shared with them at write", shared, true},
+	} {
+		got, err := e.People.GetPerson(rep, ids.From[ids.PersonKind](row.id), storekit.LiveOnly)
+		if err != nil {
+			t.Fatalf("reading %s: %v", row.name, err)
+		}
+		if got.Writable == nil {
+			t.Fatalf("%s came back with no writable flag at all — absent means not writable to a "+
+				"client, so a row that IS writable would lose its edit affordances", row.name)
+		}
+		if *got.Writable != row.want {
+			t.Errorf("%s reports writable=%v, want %v", row.name, *got.Writable, row.want)
+		}
+		// The flag is only worth anything if it agrees with the gate. Drive the
+		// mutation and compare: a flag that said yes to a write the server
+		// refuses is the defect this field was added to prevent.
+		_, err = e.People.UpdatePerson(rep, ids.From[ids.PersonKind](row.id),
+			people.UpdatePersonInput{Title: &title})
+		if admitted := err == nil; admitted != row.want {
+			t.Errorf("%s says writable=%v but the update was admitted=%v — the flag and the gate "+
+				"disagree, and the flag is what a client draws its buttons from",
+				row.name, row.want, admitted)
+		}
+	}
+
+	// deal
+	for _, row := range []struct {
+		name string
+		id   ids.UUID
+		want bool
+	}{
+		{"a deal they own", myDeal, true},
+		{"a colleague's deal", theirDeal, false},
+	} {
+		got, err := e.Deals.GetDeal(rep, ids.From[ids.DealKind](row.id), storekit.LiveOnly)
+		if err != nil {
+			t.Fatalf("reading %s: %v", row.name, err)
+		}
+		if got.Writable == nil {
+			t.Fatalf("%s came back with no writable flag at all", row.name)
+		}
+		if *got.Writable != row.want {
+			t.Errorf("%s reports writable=%v, want %v", row.name, *got.Writable, row.want)
+		}
+		_, err = e.Deals.UpdateDeal(rep, ids.From[ids.DealKind](row.id),
+			deals.UpdateDealInput{Name: &title})
+		if admitted := err == nil; admitted != row.want {
+			t.Errorf("%s says writable=%v but the update was admitted=%v",
+				row.name, row.want, admitted)
+		}
+	}
+}
+
+// TestAListPageCarriesWritabilityOnEveryRow guards the half a single read
+// cannot: the list is a different code path, and a page that reported every row
+// writable would put an edit affordance on every colleague's record at once.
+func TestAListPageCarriesWritabilityOnEveryRow(t *testing.T) {
+	e := Setup(t)
+	mine := e.SeedPerson(t, "Mine on the page", &e.Rep1)
+	theirs := e.SeedPerson(t, "Theirs on the page", &e.Rep3)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+	page, _, err := e.People.ListPeople(rep, people.ListPeopleInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[ids.UUID]bool{mine: true, theirs: false}
+	seen := 0
+	for _, p := range page {
+		expect, named := want[ids.UUID(p.Id)]
+		if !named {
+			continue
+		}
+		seen++
+		if p.Writable == nil {
+			t.Errorf("%s came back from the LIST with no writable flag", p.FullName)
+			continue
+		}
+		if *p.Writable != expect {
+			t.Errorf("the list reports %s writable=%v, want %v", p.FullName, *p.Writable, expect)
+		}
+	}
+	if seen != len(want) {
+		t.Fatalf("the list returned %d of the %d seeded rows — the fixture is not what this asserts on",
+			seen, len(want))
+	}
+}

--- a/backend/internal/compose/integration/writableonthewire_integration_test.go
+++ b/backend/internal/compose/integration/writableonthewire_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 func TestARecordSaysWhetherItIsThisCallersToChange(t *testing.T) {
@@ -108,6 +109,65 @@ func TestARecordSaysWhetherItIsThisCallersToChange(t *testing.T) {
 	}
 }
 
+// TestAMutationEchoCarriesWritabilityToo guards the case a single GET does not:
+// the row a PATCH or a create hands back is a different code path, and absent
+// reads as NOT writable — so a missing stamp takes the edit buttons away from
+// the owner in the moment right after they saved.
+func TestAMutationEchoCarriesWritabilityToo(t *testing.T) {
+	e := Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, orgWriterPermsFor(t))
+	name := "Echo Test GmbH"
+
+	created, err := e.People.CreateOrganization(rep, people.CreateOrganizationInput{
+		DisplayName: name, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	if created.Writable == nil || !*created.Writable {
+		t.Errorf("the CREATE echo reports writable=%v for the row its own caller just made and owns",
+			created.Writable)
+	}
+
+	changed := "Echo Test GmbH II"
+	updated, err := e.People.UpdateOrganization(rep, ids.From[ids.OrganizationKind](ids.UUID(created.Id)),
+		people.UpdateOrganizationInput{DisplayName: &changed})
+	if err != nil {
+		t.Fatalf("updating the organization: %v", err)
+	}
+	if updated.Writable == nil || !*updated.Writable {
+		t.Errorf("the UPDATE echo reports writable=%v for a row the same caller just wrote",
+			updated.Writable)
+	}
+}
+
+// TestAnArchivedRecordIsNotWritableOnTheWire holds the state half. The write
+// gate's own probes are LIVE-only, so a row the caller owns but has archived is
+// refused by every mutation — and a flag that ignored that would offer an edit
+// the server declines.
+func TestAnArchivedRecordIsNotWritableOnTheWire(t *testing.T) {
+	e := Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, orgWriterPermsFor(t))
+	created, err := e.People.CreateOrganization(rep, people.CreateOrganizationInput{
+		DisplayName: "Archived Co", Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(created.Id))
+	if _, err := e.People.ArchiveOrganization(rep, orgID, nil); err != nil {
+		t.Fatalf("archiving: %v", err)
+	}
+	got, err := e.People.GetOrganization(rep, orgID, storekit.IncludeArchived)
+	if err != nil {
+		t.Fatalf("reading the archived organization: %v", err)
+	}
+	if got.Writable != nil && *got.Writable {
+		t.Error("an archived organization reports writable=true, but every mutation takes the LIVE " +
+			"probe and refuses it — the flag is promising an edit the server declines")
+	}
+}
+
 // TestAListPageCarriesWritabilityOnEveryRow guards the half a single read
 // cannot: the list is a different code path, and a page that reported every row
 // writable would put an edit affordance on every colleague's record at once.
@@ -141,4 +201,19 @@ func TestAListPageCarriesWritabilityOnEveryRow(t *testing.T) {
 		t.Fatalf("the list returned %d of the %d seeded rows — the fixture is not what this asserts on",
 			seen, len(want))
 	}
+}
+
+// orgWriterPermsFor is AccountRepPerms plus organization.update. No shipped rep
+// fixture grants it, and several suites read those fixtures as a rep who cannot
+// write a company, so widening one there would make them pass while proving
+// nothing.
+func orgWriterPermsFor(t *testing.T) principal.Permissions {
+	t.Helper()
+	perms := AccountRepPerms
+	perms.Objects = map[string]principal.ObjectGrant{}
+	for object, grant := range AccountRepPerms.Objects {
+		perms.Objects[object] = grant
+	}
+	perms.Objects["organization"] = principal.ObjectGrant{Create: true, Read: true, Update: true, Delete: true}
+	return perms
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15317,7 +15317,10 @@ type Deal struct {
 
 	// WonWithoutContractReason Why this deal was won with no contract behind it (ADR-0109 §6). NULL on a won deal that HAS one — the two are distinguishable, which is what makes "how many won deals have no paper, and why" answerable. Cleared on reopen and on any transition away from won.
 	WonWithoutContractReason *DealWonWithoutContractReason `json:"won_without_contract_reason,omitempty"`
-	AdditionalProperties     map[string]interface{}        `json:"-"`
+
+	// Writable Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed.
+	Writable             *bool                  `json:"writable,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
 // DealForecastCategory defines model for Deal.ForecastCategory.
@@ -16941,7 +16944,10 @@ type Lead struct {
 	// send the last-seen value in `If-Match`; a mismatch returns `409 code: version_skew`
 	// (ErrVersionSkew) so the client re-reads before retrying. Applies to the native SoR path,
 	// not only overlay mode.
-	Version              *RowVersion            `json:"version,omitempty"`
+	Version *RowVersion `json:"version,omitempty"`
+
+	// Writable Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed.
+	Writable             *bool                  `json:"writable,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
@@ -18140,7 +18146,10 @@ type Organization struct {
 	Version *RowVersion `json:"version,omitempty"`
 
 	// WebsiteUrl The company's readable website, DERIVED from its primary domain row. There is deliberately no website column — a second store for a fact organization_domain already owns is the duplication ADR-0085 closes. Not accepted on write.
-	WebsiteUrl           *string                `json:"website_url,omitempty"`
+	WebsiteUrl *string `json:"website_url,omitempty"`
+
+	// Writable Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed.
+	Writable             *bool                  `json:"writable,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
@@ -19777,7 +19786,10 @@ type Person struct {
 	// send the last-seen value in `If-Match`; a mismatch returns `409 code: version_skew`
 	// (ErrVersionSkew) so the client re-reads before retrying. Applies to the native SoR path,
 	// not only overlay mode.
-	Version              *RowVersion            `json:"version,omitempty"`
+	Version *RowVersion `json:"version,omitempty"`
+
+	// Writable Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed.
+	Writable             *bool                  `json:"writable,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
@@ -20769,7 +20781,10 @@ type Project struct {
 	// send the last-seen value in `If-Match`; a mismatch returns `409 code: version_skew`
 	// (ErrVersionSkew) so the client re-reads before retrying. Applies to the native SoR path,
 	// not only overlay mode.
-	Version              *RowVersion            `json:"version,omitempty"`
+	Version *RowVersion `json:"version,omitempty"`
+
+	// Writable Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed.
+	Writable             *bool                  `json:"writable,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
@@ -30395,6 +30410,14 @@ func (a *Deal) UnmarshalJSON(b []byte) error {
 		delete(object, "won_without_contract_reason")
 	}
 
+	if raw, found := object["writable"]; found {
+		err = json.Unmarshal(raw, &a.Writable)
+		if err != nil {
+			return fmt.Errorf("error reading 'writable': %w", err)
+		}
+		delete(object, "writable")
+	}
+
 	if len(object) != 0 {
 		a.AdditionalProperties = make(map[string]interface{})
 		for fieldName, fieldBuf := range object {
@@ -30617,6 +30640,13 @@ func (a Deal) MarshalJSON() ([]byte, error) {
 		object["won_without_contract_reason"], err = json.Marshal(a.WonWithoutContractReason)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'won_without_contract_reason': %w", err)
+		}
+	}
+
+	if a.Writable != nil {
+		object["writable"], err = json.Marshal(a.Writable)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'writable': %w", err)
 		}
 	}
 
@@ -32106,6 +32136,14 @@ func (a *Lead) UnmarshalJSON(b []byte) error {
 		delete(object, "version")
 	}
 
+	if raw, found := object["writable"]; found {
+		err = json.Unmarshal(raw, &a.Writable)
+		if err != nil {
+			return fmt.Errorf("error reading 'writable': %w", err)
+		}
+		delete(object, "writable")
+	}
+
 	if len(object) != 0 {
 		a.AdditionalProperties = make(map[string]interface{})
 		for fieldName, fieldBuf := range object {
@@ -32388,6 +32426,13 @@ func (a Lead) MarshalJSON() ([]byte, error) {
 		object["version"], err = json.Marshal(a.Version)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'version': %w", err)
+		}
+	}
+
+	if a.Writable != nil {
+		object["writable"], err = json.Marshal(a.Writable)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'writable': %w", err)
 		}
 	}
 
@@ -33150,6 +33195,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "website_url")
 	}
 
+	if raw, found := object["writable"]; found {
+		err = json.Unmarshal(raw, &a.Writable)
+		if err != nil {
+			return fmt.Errorf("error reading 'writable': %w", err)
+		}
+		delete(object, "writable")
+	}
+
 	if len(object) != 0 {
 		a.AdditionalProperties = make(map[string]interface{})
 		for fieldName, fieldBuf := range object {
@@ -33374,6 +33427,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.Writable != nil {
+		object["writable"], err = json.Marshal(a.Writable)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'writable': %w", err)
+		}
+	}
+
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
@@ -33592,6 +33652,14 @@ func (a *Person) UnmarshalJSON(b []byte) error {
 		delete(object, "version")
 	}
 
+	if raw, found := object["writable"]; found {
+		err = json.Unmarshal(raw, &a.Writable)
+		if err != nil {
+			return fmt.Errorf("error reading 'writable': %w", err)
+		}
+		delete(object, "writable")
+	}
+
 	if len(object) != 0 {
 		a.AdditionalProperties = make(map[string]interface{})
 		for fieldName, fieldBuf := range object {
@@ -33757,6 +33825,13 @@ func (a Person) MarshalJSON() ([]byte, error) {
 		object["version"], err = json.Marshal(a.Version)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'version': %w", err)
+		}
+	}
+
+	if a.Writable != nil {
+		object["writable"], err = json.Marshal(a.Writable)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'writable': %w", err)
 		}
 	}
 
@@ -34210,6 +34285,14 @@ func (a *Project) UnmarshalJSON(b []byte) error {
 		delete(object, "version")
 	}
 
+	if raw, found := object["writable"]; found {
+		err = json.Unmarshal(raw, &a.Writable)
+		if err != nil {
+			return fmt.Errorf("error reading 'writable': %w", err)
+		}
+		delete(object, "writable")
+	}
+
 	if len(object) != 0 {
 		a.AdditionalProperties = make(map[string]interface{})
 		for fieldName, fieldBuf := range object {
@@ -34352,6 +34435,13 @@ func (a Project) MarshalJSON() ([]byte, error) {
 		object["version"], err = json.Marshal(a.Version)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'version': %w", err)
+		}
+	}
+
+	if a.Writable != nil {
+		object["writable"], err = json.Marshal(a.Writable)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'writable': %w", err)
 		}
 	}
 

--- a/backend/internal/modules/deals/fieldmask.go
+++ b/backend/internal/modules/deals/fieldmask.go
@@ -88,7 +88,17 @@ func maskDealForCaller(ctx context.Context, tx pgx.Tx, d crmcontracts.Deal) (crm
 // so both are collected per row and applied once.
 func maskDeals(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal) error {
 	withheld := make([]withheldFields, len(deals))
-	if err := roleMaskedFields(ctx, tx, deals, withheld); err != nil {
+	// ONE statement answers which rows of the page the caller could change, and
+	// both consumers read it: the wire flag a client draws its edit affordances
+	// from, and the masks conditioned on write authority. Asking twice would be
+	// two round trips for one question, and two answers that can disagree.
+	writable, err := auth.StampWritable(ctx, tx, "deal", deals,
+		func(d crmcontracts.Deal) ids.UUID { return ids.UUID(d.Id) },
+		func(d *crmcontracts.Deal, may bool) { d.Writable = &may })
+	if err != nil {
+		return err
+	}
+	if err := roleMaskedFields(ctx, deals, withheld, writable); err != nil {
 		return err
 	}
 	if err := unreadableReferences(ctx, tx, deals, withheld); err != nil {
@@ -103,7 +113,9 @@ func maskDeals(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal) error 
 // roleMaskedFields collects the columns the caller's role withholds on each
 // row. One statement answers which rows of the page the caller could change;
 // the masks conditioned on write authority lift on those.
-func roleMaskedFields(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal, withheld []withheldFields) error {
+func roleMaskedFields(ctx context.Context, deals []crmcontracts.Deal, withheld []withheldFields,
+	writable map[ids.UUID]bool,
+) error {
 	p, err := storekit.Actor(ctx)
 	if err != nil {
 		return err
@@ -111,14 +123,6 @@ func roleMaskedFields(ctx context.Context, tx pgx.Tx, deals []crmcontracts.Deal,
 	// Cheap exit for the common case — no mask on deals at all.
 	if len(auth.MaskedFields(p, "deal", false)) == 0 {
 		return nil
-	}
-	rowIDs := make([]ids.UUID, 0, len(deals))
-	for _, d := range deals {
-		rowIDs = append(rowIDs, ids.UUID(d.Id))
-	}
-	writable, err := auth.WritableSubset(ctx, tx, "deal", rowIDs)
-	if err != nil {
-		return err
 	}
 	for i := range deals {
 		for _, field := range auth.MaskedFields(p, "deal", writable[ids.UUID(deals[i].Id)]) {

--- a/backend/internal/modules/identity/internal/policy/policy.go
+++ b/backend/internal/modules/identity/internal/policy/policy.go
@@ -132,8 +132,17 @@ var defaults = map[string]Document{
 		RowScope: principal.RowScopeAll,
 	},
 	"manager": {
-		Objects:  managerObjects,
-		RowScope: principal.RowScopeTeam,
+		Objects: managerObjects,
+		// Own scope, not team: membership of a team is not by itself permission
+		// to rewrite a teammate's records. Writing somebody else's customer
+		// record takes an explicit share — a record_grant naming the user or
+		// one of their teams — or an unbounded seat.
+		//
+		// The team ARM survives in the write predicate and is not dead: a
+		// record_grant may name a team, and an operator may still author a
+		// custom role at team scope. What changed is only what the seeded
+		// roles claim by default.
+		RowScope: principal.RowScopeOwn,
 	},
 	"rep": {
 		// Reps create and work records but never delete them — except
@@ -218,7 +227,16 @@ var defaults = map[string]Document{
 			// create, publish, invite, revoke. Deleting one stays manager/admin,
 			// the same posture every other record the rep works carries.
 			grant{Create: true, Read: true, Update: true}),
-		RowScope: principal.RowScopeTeam,
+		// Own scope, not team: membership of a team is not by itself permission
+		// to rewrite a teammate's records. Writing somebody else's customer
+		// record takes an explicit share — a record_grant naming the user or
+		// one of their teams — or an unbounded seat.
+		//
+		// The team ARM survives in the write predicate and is not dead: a
+		// record_grant may name a team, and an operator may still author a
+		// custom role at team scope. What changed is only what the seeded
+		// roles claim by default.
+		RowScope: principal.RowScopeOwn,
 	},
 	"read_only": {
 		// A read-only role still owns its personal view state: saved views

--- a/backend/internal/modules/identity/internal/policy/policy_test.go
+++ b/backend/internal/modules/identity/internal/policy/policy_test.go
@@ -117,9 +117,17 @@ func TestMergeUnionsGrantsAndWidensScope(t *testing.T) {
 	if merged.Allows("person", principal.ActionDelete) {
 		t.Error("merge invented person.delete that no role grants")
 	}
-	// Widest scope wins: read_only's `all` over rep's `team`.
+	// Widest scope wins: read_only's `all` over rep's `own`.
 	if merged.RowScope != principal.RowScopeAll {
 		t.Errorf("merged row scope %q, want all (the widest held)", merged.RowScope)
+	}
+	// The MIDDLE tier, which no seeded role holds any more. Comparing only the
+	// two extremes would pass over a Wider that ranked team wrongly, and team
+	// scope is still reachable — an operator's custom role may carry it, and the
+	// write predicate still renders its arm.
+	team := Document{Objects: rep.Objects, RowScope: principal.RowScopeTeam}
+	if scoped := Merge(map[string]Document{"rep": rep, "team_role": team}); scoped.RowScope != principal.RowScopeTeam {
+		t.Errorf("own merged with team gives %q, want team (the wider of the two)", scoped.RowScope)
 	}
 	if len(merged.RoleKeys) != 2 {
 		t.Errorf("attribution lists %v, want both roles", merged.RoleKeys)

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -570,8 +570,8 @@ func TestTeamsAreAdministeredAndTheAccessPreviewTellsTheTruth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("preview: %v", err)
 	}
-	if preview.Permissions.RowScope != principal.RowScopeTeam || !preview.Permissions.Allows("deal", principal.ActionRead) {
-		t.Errorf("rep preview = scope %s deal.read %v, want team scope with deal.read", preview.Permissions.RowScope, preview.Permissions.Allows("deal", principal.ActionRead))
+	if preview.Permissions.RowScope != principal.RowScopeOwn || !preview.Permissions.Allows("deal", principal.ActionRead) {
+		t.Errorf("rep preview = scope %s deal.read %v, want own scope with deal.read", preview.Permissions.RowScope, preview.Permissions.Allows("deal", principal.ActionRead))
 	}
 	if len(preview.Permissions.FieldMasks) != 1 || preview.Permissions.FieldMasks[0].Field != "amount_minor" {
 		t.Errorf("rep preview masks = %+v, want the deal amount mask", preview.Permissions.FieldMasks)

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -485,10 +485,6 @@ func TestNonActiveStatusesCannotLogIn(t *testing.T) {
 	}
 }
 
-// The seeded field mask reaches the principal through the role: a rep's
-// login carries the deal amount mask, and a manager's does not. A mask is a
-// property of the role, read at login like the grants — the store that
-// withholds the column never reads the table.
 // No seeded role withholds a column. The baseline shipped one field mask — a
 // rep read a deal's amount_minor as withheld outside their write authority —
 // and it is gone: deal values are open to every seat that may read the deal.
@@ -513,6 +509,39 @@ func TestNoSeededRoleWithholdsAColumn(t *testing.T) {
 			t.Errorf("a %s's field masks = %+v, want none — the shipped roles withhold no column",
 				role, seat.Permissions.FieldMasks)
 		}
+	}
+
+	// An empty answer is the right answer only if the question was asked. Login
+	// dropping mask loading altogether would satisfy every assertion above, so
+	// one mask is authored on the role and the SAME login must carry it: the
+	// mechanism is proved live, and the zero above is then a fact about what
+	// ships rather than about a loader that stopped running.
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO field_mask (role_key, object, field, condition)
+		 VALUES ('rep', 'deal', 'amount_minor', 'always')`); err != nil {
+		t.Fatal(err)
+	}
+	// Removed again before the test ends: field_mask has no workspace column, so
+	// the row would outlive this test and every sibling asserting the shipped
+	// posture would then read this test's fixture as the product's own.
+	t.Cleanup(func() {
+		if _, err := e.owner.Exec(context.Background(),
+			`DELETE FROM field_mask WHERE role_key = 'rep' AND condition = 'always'`); err != nil {
+			t.Errorf("removing this test's own mask: %v", err)
+		}
+	})
+	if err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, e.member.UserID, "rep"); err != nil {
+		t.Fatal(err)
+	}
+	masked, _, err := e.svc.Login(ctx, e.member.Email, memberPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := principal.FieldMask{Object: "deal", Field: "amount_minor", Condition: principal.MaskAlways}
+	if len(masked.Permissions.FieldMasks) != 1 || masked.Permissions.FieldMasks[0] != want {
+		t.Errorf("an operator's own mask on the rep role reaches the principal as %+v, want %+v — "+
+			"the loading mechanism is what makes the zero above meaningful",
+			masked.Permissions.FieldMasks, want)
 	}
 }
 
@@ -575,8 +604,9 @@ func TestTeamsAreAdministeredAndTheAccessPreviewTellsTheTruth(t *testing.T) {
 		t.Errorf("rep preview = scope %s deal.read %v, want own scope with deal.read", preview.Permissions.RowScope, preview.Permissions.Allows("deal", principal.ActionRead))
 	}
 	// The preview reports masks HONESTLY, which now means reporting none: no
-	// seeded role withholds a column. It is asserted rather than dropped because
-	// the preview inventing a mask would be as wrong as it hiding one.
+	// seeded role withholds a column. TestNoSeededRoleWithholdsAColumn proves
+	// the loader still runs, against a mask an operator authored, so the zero
+	// here is a fact about what ships rather than about a loader that stopped.
 	if len(preview.Permissions.FieldMasks) != 0 {
 		t.Errorf("rep preview masks = %+v, want none — the shipped roles withhold no column",
 			preview.Permissions.FieldMasks)

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -489,29 +489,30 @@ func TestNonActiveStatusesCannotLogIn(t *testing.T) {
 // login carries the deal amount mask, and a manager's does not. A mask is a
 // property of the role, read at login like the grants — the store that
 // withholds the column never reads the table.
-func TestTheRepRoleCarriesTheDealAmountMask(t *testing.T) {
+// No seeded role withholds a column. The baseline shipped one field mask — a
+// rep read a deal's amount_minor as withheld outside their write authority —
+// and it is gone: deal values are open to every seat that may read the deal.
+//
+// The masking MACHINERY is not gone, and this test says nothing about it. An
+// operator may still author a mask on a custom role, and the paths that apply
+// one are covered by fieldmask_integration_test.go, which builds its own. What
+// is asserted here is the SHIPPED posture: a seat gets what its grants admit,
+// with no column quietly missing from it.
+func TestNoSeededRoleWithholdsAColumn(t *testing.T) {
 	e := setupRevocationEnv(t, "field-mask")
 	ctx := principal.WithWorkspaceID(context.Background(), e.admin.WorkspaceID.UUID)
-	if err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, e.member.UserID, "rep"); err != nil {
-		t.Fatal(err)
-	}
-	asRep, _, err := e.svc.Login(ctx, e.member.Email, memberPassword)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := principal.FieldMask{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority}
-	if len(asRep.Permissions.FieldMasks) != 1 || asRep.Permissions.FieldMasks[0] != want {
-		t.Errorf("a rep's field masks = %+v, want exactly %+v", asRep.Permissions.FieldMasks, want)
-	}
-	if err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, e.member.UserID, "manager"); err != nil {
-		t.Fatal(err)
-	}
-	asManager, _, err := e.svc.Login(ctx, e.member.Email, memberPassword)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(asManager.Permissions.FieldMasks) != 0 {
-		t.Errorf("a manager's field masks = %+v, want none", asManager.Permissions.FieldMasks)
+	for _, role := range []string{"rep", "manager"} {
+		if err := e.svc.ChangeUserRole(e.wsCtx(e.admin), e.admin, e.member.UserID, role); err != nil {
+			t.Fatal(err)
+		}
+		seat, _, err := e.svc.Login(ctx, e.member.Email, memberPassword)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(seat.Permissions.FieldMasks) != 0 {
+			t.Errorf("a %s's field masks = %+v, want none — the shipped roles withhold no column",
+				role, seat.Permissions.FieldMasks)
+		}
 	}
 }
 
@@ -573,8 +574,12 @@ func TestTeamsAreAdministeredAndTheAccessPreviewTellsTheTruth(t *testing.T) {
 	if preview.Permissions.RowScope != principal.RowScopeOwn || !preview.Permissions.Allows("deal", principal.ActionRead) {
 		t.Errorf("rep preview = scope %s deal.read %v, want own scope with deal.read", preview.Permissions.RowScope, preview.Permissions.Allows("deal", principal.ActionRead))
 	}
-	if len(preview.Permissions.FieldMasks) != 1 || preview.Permissions.FieldMasks[0].Field != "amount_minor" {
-		t.Errorf("rep preview masks = %+v, want the deal amount mask", preview.Permissions.FieldMasks)
+	// The preview reports masks HONESTLY, which now means reporting none: no
+	// seeded role withholds a column. It is asserted rather than dropped because
+	// the preview inventing a mask would be as wrong as it hiding one.
+	if len(preview.Permissions.FieldMasks) != 0 {
+		t.Errorf("rep preview masks = %+v, want none — the shipped roles withhold no column",
+			preview.Permissions.FieldMasks)
 	}
 	if len(preview.Teams) != 1 || preview.Teams[0].Name != "DACH" {
 		t.Errorf("rep preview teams = %+v, want DACH", preview.Teams)

--- a/backend/internal/modules/identity/roles_integration_test.go
+++ b/backend/internal/modules/identity/roles_integration_test.go
@@ -112,8 +112,8 @@ func TestSettingOneGrantLeavesTheRestOfTheDocumentIntact(t *testing.T) {
 	}
 	// row_scope is not this endpoint's to touch and is not modelled by the
 	// grant map; a rewrite would have dropped it and silently narrowed the role.
-	if doc.RowScope != "team" {
-		t.Errorf("row_scope = %q, want the seeded rep scope 'team' — the write rewrote the document", doc.RowScope)
+	if doc.RowScope != "own" {
+		t.Errorf("row_scope = %q, want the seeded rep scope 'own' — the write rewrote the document", doc.RowScope)
 	}
 	if !doc.Objects["ext_gone_thing"].Read {
 		t.Error("the orphaned grant was erased; the write is not targeted")

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -150,6 +150,10 @@ var personBindings = EntityBinding{
 	Entity: "person",
 	Armed:  true,
 	Bindings: append([]FieldBinding{
+		{
+			WireSlot: "writable", Disposition: DispositionNativeOnly,
+			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",
+		},
 		{WireSlot: "first_name", CanonicalKey: "first_name", Incumbent: []string{"firstname"}, Disposition: DispositionMapped},
 		{WireSlot: "last_name", CanonicalKey: "last_name", Incumbent: []string{"lastname"}, Disposition: DispositionMapped},
 		{WireSlot: "full_name", CanonicalKey: "full_name", Incumbent: []string{"firstname", "lastname", "email"}, Transform: "full_name", Disposition: DispositionMapped},
@@ -194,6 +198,10 @@ var organizationBindings = EntityBinding{
 	Entity: "organization",
 	Armed:  true,
 	Bindings: append([]FieldBinding{
+		{
+			WireSlot: "writable", Disposition: DispositionNativeOnly,
+			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",
+		},
 		{WireSlot: "display_name", CanonicalKey: "display_name", Incumbent: []string{"name"}, Disposition: DispositionMapped},
 		{WireSlot: "industry", CanonicalKey: "industry", Incumbent: []string{"industry"}, Disposition: DispositionMapped},
 		{WireSlot: "size_band", CanonicalKey: "size_band", Incumbent: []string{"numberofemployees"}, Transform: "employees_to_size_band", Disposition: DispositionMapped},

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -105,7 +105,9 @@ func (s *Store) ListLeads(ctx context.Context, in ListLeadsInput) ([]crmcontract
 			return scanLeadPage(rows, active, sorted, policy)
 		},
 		// A lead is one flat row: no child tables to load alongside the page.
-		attach: func(context.Context, pgx.Tx, []crmcontracts.Lead) error { return nil },
+		// The one thing the page still owes each row is whether it is this
+		// caller's to change, which is one statement for the whole page.
+		attach: stampLeadsWritable,
 		cursorKey: func(last crmcontracts.Lead) (time.Time, ids.UUID) {
 			return last.CreatedAt, ids.UUID(last.Id)
 		},

--- a/backend/internal/modules/people/lead_read.go
+++ b/backend/internal/modules/people/lead_read.go
@@ -92,7 +92,13 @@ func readLead(ctx context.Context, tx pgx.Tx, id ids.LeadID, archived storekit.A
 	if errors.Is(err, pgx.ErrNoRows) {
 		return crmcontracts.Lead{}, apperrors.ErrNotFound
 	}
-	return l, err
+	if err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	if err := stampLeadWritable(ctx, tx, &l); err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	return l, nil
 }
 
 // scanLead scans core + active custom columns, plus whatever trailing

--- a/backend/internal/modules/people/lead_writable.go
+++ b/backend/internal/modules/people/lead_writable.go
@@ -33,6 +33,14 @@ func stampLeadsWritable(ctx context.Context, tx pgx.Tx, leads []crmcontracts.Lea
 
 // stampLeadWritable is the single-record spelling, so a caller holding one lead
 // does not assemble a slice to ask.
+//
+// readLead calls it for every read, including the few that are internal
+// decisions rather than wire results — the merge reads both ends before it
+// folds them. That is one extra statement on those paths, and it is the cheaper
+// mistake: stamping only the callers that reach the wire means listing them,
+// and a list goes stale the first time somebody adds a read. A record served
+// without the flag reads as NOT writable, so the failure it would cause is an
+// owner losing their edit buttons.
 func stampLeadWritable(ctx context.Context, tx pgx.Tx, lead *crmcontracts.Lead) error {
 	one := []crmcontracts.Lead{*lead}
 	if err := stampLeadsWritable(ctx, tx, one); err != nil {

--- a/backend/internal/modules/people/lead_writable.go
+++ b/backend/internal/modules/people/lead_writable.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Whether each lead on a page is this caller's to change.
+//
+// A lead has no attach step the way a person and an organization do — nothing
+// hangs off it that a second query fills in — so the three read paths (the
+// single read, the list, and the work queue) would each have spelled this for
+// themselves. One function instead, called by all three: a client that saw the
+// list say writable and the record say otherwise would be reading two answers
+// to one question.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// stampLeadsWritable answers the write question for a whole page in ONE
+// statement, never a probe per row.
+func stampLeadsWritable(ctx context.Context, tx pgx.Tx, leads []crmcontracts.Lead) error {
+	_, err := auth.StampWritable(ctx, tx, "lead", leads,
+		func(l crmcontracts.Lead) ids.UUID { return ids.UUID(l.Id) },
+		func(l *crmcontracts.Lead, may bool) { l.Writable = &may })
+	return err
+}
+
+// stampLeadWritable is the single-record spelling, so a caller holding one lead
+// does not assemble a slice to ask.
+func stampLeadWritable(ctx context.Context, tx pgx.Tx, lead *crmcontracts.Lead) error {
+	one := []crmcontracts.Lead{*lead}
+	if err := stampLeadsWritable(ctx, tx, one); err != nil {
+		return err
+	}
+	*lead = one[0]
+	return nil
+}

--- a/backend/internal/modules/people/leadworkqueue.go
+++ b/backend/internal/modules/people/leadworkqueue.go
@@ -180,7 +180,13 @@ func (s *Store) readLeadQueuePage(ctx context.Context, query string, args []any,
 			leads = append(leads, lead)
 			ranks = append(ranks, rank)
 		}
-		return rows.Err()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		// The work queue is its own page path, not a filter over the list, so
+		// it stamps writability itself; a queue that reported every lead
+		// writable would put an edit affordance on a colleague's row.
+		return stampLeadsWritable(ctx, tx, leads)
 	})
 	if err != nil {
 		return nil, storekit.Page{}, err

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -39,6 +39,13 @@ func attachOrgCounts(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organiz
 	if len(orgs) == 0 {
 		return nil
 	}
+	// Whether each company is this caller's to change, one statement for the
+	// page, stamped at the seam the list and the single read already share.
+	if _, err := auth.StampWritable(ctx, tx, "organization", orgs,
+		func(o crmcontracts.Organization) ids.UUID { return ids.UUID(o.Id) },
+		func(o *crmcontracts.Organization, may bool) { o.Writable = &may }); err != nil {
+		return err
+	}
 	idx := make(map[openapi_types.UUID]*crmcontracts.Organization, len(orgs))
 	orgIDs := make([]ids.UUID, len(orgs))
 	// The object grant comes first, as it does on the two lists themselves: a

--- a/backend/internal/modules/people/organization_read.go
+++ b/backend/internal/modules/people/organization_read.go
@@ -113,6 +113,16 @@ func readOrganization(ctx context.Context, tx pgx.Tx, id ids.OrganizationID, arc
 		return crmcontracts.Organization{}, err
 	}
 	orgs := []crmcontracts.Organization{o}
+	// Stamped HERE rather than only in attachOrgCounts, because every mutation
+	// echo — create, update, archive, restore, the merge survivor — hands the
+	// row back through this function and not through the counts page. Absent
+	// reads as NOT writable, so a missing stamp takes the edit buttons away from
+	// the owner who just saved.
+	if _, err := auth.StampWritable(ctx, tx, "organization", orgs,
+		func(o crmcontracts.Organization) ids.UUID { return ids.UUID(o.Id) },
+		func(o *crmcontracts.Organization, may bool) { o.Writable = &may }); err != nil {
+		return crmcontracts.Organization{}, err
+	}
 	if err := attachOrgDomains(ctx, tx, orgs); err != nil {
 		return crmcontracts.Organization{}, err
 	}

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -228,6 +228,15 @@ func attachPersonChildren(ctx context.Context, tx pgx.Tx, people []crmcontracts.
 	if len(people) == 0 {
 		return nil
 	}
+	// Whether each row is this caller's to change, one statement for the page.
+	// It is stamped HERE because this is the seam the list and the single read
+	// already share: a client is otherwise left inferring write access from the
+	// object grant alone, which says nothing about who owns the row.
+	if _, err := auth.StampWritable(ctx, tx, "person", people,
+		func(p crmcontracts.Person) ids.UUID { return ids.UUID(p.Id) },
+		func(p *crmcontracts.Person, may bool) { p.Writable = &may }); err != nil {
+		return err
+	}
 	idx := make(map[openapi_types.UUID]*crmcontracts.Person, len(people))
 	personIDs := make([]ids.UUID, len(people))
 	for i := range people {

--- a/backend/internal/modules/projects/fieldmask.go
+++ b/backend/internal/modules/projects/fieldmask.go
@@ -42,6 +42,15 @@ func maskProjectForCaller(ctx context.Context, tx pgx.Tx, p crmcontracts.Project
 // maskProjects withholds, per row, the anchor company this reader may not
 // open. ONE statement answers the whole page, never a probe per row.
 func maskProjects(ctx context.Context, tx pgx.Tx, projects []crmcontracts.Project) error {
+	// Whether each project is this caller's to change, one statement for the
+	// page. A project keeps the owner scope on writes even though every seat
+	// reads it, so the flag is the only thing a client can draw its edit
+	// affordances from without guessing.
+	if _, err := auth.StampWritable(ctx, tx, "project", projects,
+		func(p crmcontracts.Project) ids.UUID { return ids.UUID(p.Id) },
+		func(p *crmcontracts.Project, may bool) { p.Writable = &may }); err != nil {
+		return err
+	}
 	orgIDs := make([]ids.UUID, 0, len(projects))
 	for _, p := range projects {
 		if p.OrganizationId != nil {

--- a/backend/internal/platform/auth/fieldmask.go
+++ b/backend/internal/platform/auth/fieldmask.go
@@ -116,6 +116,43 @@ func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.U
 	return out, rows.Err()
 }
 
+// StampWritable answers, for a page of rows of one shareable table, which of
+// them the caller may CHANGE — the boolean the contract's `writable` carries —
+// in ONE statement for the whole page.
+//
+// It is WritableSubset plus the id-collection and write-back loop that five
+// record types would otherwise each spell, and it exists for that reason alone.
+// The authority question is WritableSubset's and must never grow a second
+// answer here: this walks a page, it does not decide anything.
+//
+// What it produces is what a CLIENT is told, never what the server enforces.
+// EnsureWritable is the authority and stays the only gate a mutation passes; a
+// caller that ignored this flag and sent the write anyway is refused exactly as
+// before.
+// It returns the subset it computed, so a caller that needs the same answer for
+// something else — the field masks conditioned on write authority are the case —
+// reads it rather than asking the database the same question twice.
+func StampWritable[T any](ctx context.Context, tx pgx.Tx, table string,
+	rows []T, id func(T) ids.UUID, set func(*T, bool),
+) (map[ids.UUID]bool, error) {
+	if len(rows) == 0 {
+		return map[ids.UUID]bool{}, nil
+	}
+	rowIDs := make([]ids.UUID, 0, len(rows))
+	for _, row := range rows {
+		rowIDs = append(rowIDs, id(row))
+	}
+	writable, err := WritableSubset(ctx, tx, table, rowIDs)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		may := writable[id(rows[i])]
+		set(&rows[i], may)
+	}
+	return writable, nil
+}
+
 // sqlNoRow is the clause that admits nothing, for an arm that is closed to
 // this caller outright.
 const sqlNoRow = "FALSE"

--- a/backend/internal/platform/auth/fieldmask.go
+++ b/backend/internal/platform/auth/fieldmask.go
@@ -76,18 +76,23 @@ func WritableSubset(ctx context.Context, tx pgx.Tx, table string, rowIDs []ids.U
 		return nil, err
 	}
 	out := make(map[ids.UUID]bool, len(rowIDs))
-	if UnboundedFor(p, table) && Unbounded(p) {
-		for _, id := range rowIDs {
-			out[id] = true
-		}
-		return out, nil
-	}
 	// The row arm alone is not write authority: a caller whose role lost the
 	// object's update verb can still OWN a row, and a mask conditioned on
 	// write authority must not lift for them. EnsureWritable never sees this
 	// case because its handlers Require(update) first; this helper is asked
 	// bare, so it asks itself.
-	if !p.Permissions.Allows(table, principal.ActionUpdate) {
+	//
+	// Asked BEFORE the unbounded shortcut, not after: an all-scope human whose
+	// role carries no update verb is refused by auth.Require on every mutation,
+	// and answering "yes, writable" for them would be the one case where the
+	// shortcut disagrees with the gate it stands in for.
+	if !p.Permissions.Allows(table, principal.ActionUpdate) && p.Type != principal.PrincipalSystem {
+		return out, nil
+	}
+	if UnboundedFor(p, table) && Unbounded(p) {
+		for _, id := range rowIDs {
+			out[id] = true
+		}
 		return out, nil
 	}
 	if len(rowIDs) == 0 {
@@ -146,6 +151,14 @@ func StampWritable[T any](ctx context.Context, tx pgx.Tx, table string,
 	if err != nil {
 		return nil, err
 	}
+	// An ARCHIVED row is nobody's to change, whatever their authority over it.
+	// WritableSubset deliberately does not filter on archived_at — it answers
+	// the masks, which apply to a record a caller may still READ — but the
+	// mutations take the LIVE probe, so a flag that ignored the state would
+	// promise an edit every one of them refuses.
+	if err := excludeArchived(ctx, tx, table, writable); err != nil {
+		return nil, err
+	}
 	for i := range rows {
 		may := writable[id(rows[i])]
 		set(&rows[i], may)
@@ -195,4 +208,33 @@ func MaskExcludedClause(ctx context.Context, object, field, alias string, arg fu
 		}
 	}
 	return clause, masked, nil
+}
+
+// excludeArchived clears the write flag on every row that is not live. ONE
+// statement for the page, like everything else on this path: it asks which of
+// the rows already marked writable are archived, and only those come back.
+func excludeArchived(ctx context.Context, tx pgx.Tx, table string, writable map[ids.UUID]bool) error {
+	live := make([]ids.UUID, 0, len(writable))
+	for id, may := range writable {
+		if may {
+			live = append(live, id)
+		}
+	}
+	if len(live) == 0 {
+		return nil
+	}
+	rows, err := tx.Query(ctx,
+		fmt.Sprintf(`SELECT id FROM %s WHERE id = ANY($1) AND archived_at IS NOT NULL`, table), live)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+		writable[id] = false
+	}
+	return rows.Err()
 }

--- a/backend/internal/platform/auth/writescope_test.go
+++ b/backend/internal/platform/auth/writescope_test.go
@@ -150,7 +150,10 @@ func TestEveryGrantIsProbedBeforeItIsGranted(t *testing.T) {
 
 func TestTheWriteArmKeepsTheOwnerScopeItNarrows(t *testing.T) {
 	// The grant arm is added to the owner scope, never substituted for it: a
-	// caller who owns the row, or a teammate, needs no grant. An ownerless
+	// caller who owns the row, or a teammate, needs no grant. No SEEDED role is
+	// team-scoped any more — that is what makes a share the ordinary way to hand
+	// a colleague write access — but the arm is not dead: a record_grant may name
+	// a team, and an operator may author a custom role at team scope. An ownerless
 	// row is the one exception — it is nobody's to change until claimed, so
 	// the write arm has no `owner_id IS NULL` branch while the read arm keeps
 	// it (an unowned row is still the workspace's to see).

--- a/backend/migrations/core/1787449829_seeded_roles_own_scope.down.sql
+++ b/backend/migrations/core/1787449829_seeded_roles_own_scope.down.sql
@@ -1,0 +1,8 @@
+-- Put the seeded rep and manager roles back to team scope, under the same
+-- guards the up migration used: only the system roles, and only where they
+-- still carry the scope that migration set.
+UPDATE role
+   SET permissions = jsonb_set(permissions, '{row_scope}', '"team"'::jsonb, true)
+ WHERE key IN ('rep', 'manager')
+   AND is_system
+   AND permissions ->> 'row_scope' = 'own';

--- a/backend/migrations/core/1787449829_seeded_roles_own_scope.down.sql
+++ b/backend/migrations/core/1787449829_seeded_roles_own_scope.down.sql
@@ -1,6 +1,21 @@
--- Put the seeded rep and manager roles back to team scope, under the same
--- guards the up migration used: only the system roles, and only where they
--- still carry the scope that migration set.
+-- Put the seeded rep and manager roles back to team scope.
+--
+-- It is NOT the exact inverse, and cannot be. This migration cannot tell a role
+-- the up migration moved to `own` from one an operator chose to put there, so a
+-- rollback widens the second kind along with the first — from owner-only to
+-- every teammate's records. That is a widening, which is the direction a
+-- rollback must never take silently.
+--
+-- So it is guarded to the case it can reason about: only the two system roles,
+-- and only where the document still looks exactly as the up migration left it.
+-- An operator who has since edited the role at all is left alone, and an
+-- installation that reaches this migration with its own deliberate `own` scope
+-- keeps it.
+--
+-- A rollback past this point also needs 1787449900 rolled back with it, or the
+-- installation lands on own-scoped reps WITH the deal-amount mask restored —
+-- amounts hidden on every deal a rep does not personally own, which is the
+-- state neither the old model nor the new one has.
 UPDATE role
    SET permissions = jsonb_set(permissions, '{row_scope}', '"team"'::jsonb, true)
  WHERE key IN ('rep', 'manager')

--- a/backend/migrations/core/1787449829_seeded_roles_own_scope.up.sql
+++ b/backend/migrations/core/1787449829_seeded_roles_own_scope.up.sql
@@ -1,0 +1,19 @@
+-- Seeded rep and manager roles move from team scope to own scope.
+--
+-- Reach the installations that already exist. seedSystemRoles writes each role
+-- document once at workspace creation and never re-syncs, so a change to the
+-- compiled defaults alone would take effect on a FRESH database and nowhere
+-- else — every deployed installation would keep team scope permanently, and
+-- the two would diverge with nothing to show it.
+--
+-- Guarded three ways, each for its own reason:
+--   is_system      — an operator's custom role that happens to be keyed 'rep'
+--                    is theirs, not ours to rewrite.
+--   row_scope=team — idempotent, and it leaves alone an operator who has
+--                    already chosen a different scope for the seeded role.
+--   the key set    — only the two roles whose default changed.
+UPDATE role
+   SET permissions = jsonb_set(permissions, '{row_scope}', '"own"'::jsonb, true)
+ WHERE key IN ('rep', 'manager')
+   AND is_system
+   AND permissions ->> 'row_scope' = 'team';

--- a/backend/migrations/core/1787449900_drop_deal_amount_mask.down.sql
+++ b/backend/migrations/core/1787449900_drop_deal_amount_mask.down.sql
@@ -1,0 +1,4 @@
+-- Put the rep deal-amount mask back, exactly as the baseline seeded it.
+INSERT INTO field_mask (role_key, object, field, condition)
+VALUES ('rep', 'deal', 'amount_minor', 'outside_write_authority')
+ON CONFLICT DO NOTHING;

--- a/backend/migrations/core/1787449900_drop_deal_amount_mask.down.sql
+++ b/backend/migrations/core/1787449900_drop_deal_amount_mask.down.sql
@@ -1,4 +1,10 @@
 -- Put the rep deal-amount mask back, exactly as the baseline seeded it.
+--
+-- This migration and 1787449829 belong to ONE ruling and are rolled back
+-- together or not at all. Reverting this one alone restores the mask onto
+-- own-scoped reps, which hides the amount on every deal a rep does not
+-- personally own — a blackout neither the old model nor the new one has, and
+-- the exact state the up migration exists to prevent.
 INSERT INTO field_mask (role_key, object, field, condition)
 VALUES ('rep', 'deal', 'amount_minor', 'outside_write_authority')
 ON CONFLICT DO NOTHING;

--- a/backend/migrations/core/1787449900_drop_deal_amount_mask.up.sql
+++ b/backend/migrations/core/1787449900_drop_deal_amount_mask.up.sql
@@ -1,0 +1,23 @@
+-- Deal amounts are open to every seat that may read the deal.
+--
+-- The baseline seeded one field mask: a rep read `amount_minor` as withheld on
+-- any deal outside their write authority. It was written when a rep's write
+-- authority covered their whole team, so it hid other teams' numbers and left
+-- the rep's own team visible.
+--
+-- Two things changed. The seeded rep became own-scoped, which would have
+-- narrowed the same mask from "another team's deals" to "every deal I do not
+-- personally own" — a much larger blackout, arrived at as a side effect of a
+-- decision about WRITES rather than as a decision about what reps may see. And
+-- the product ruling is that deal values are open: a rep who cannot see what a
+-- colleague's deal is worth cannot judge their own pipeline against it.
+--
+-- So the mask goes rather than being re-scoped. The masking MACHINERY stays —
+-- field_mask, the two conditions, the sort/filter refusal, the masked_fields
+-- wire field — because an operator may still author a mask on a custom role.
+-- What is removed is the one row the product shipped.
+DELETE FROM field_mask
+ WHERE role_key = 'rep'
+   AND object = 'deal'
+   AND field = 'amount_minor'
+   AND condition = 'outside_write_authority';

--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -714,7 +714,7 @@
         "update": false
       }
     },
-    "row_scope": "team"
+    "row_scope": "own"
   },
   "ops": {
     "objects": {
@@ -1431,6 +1431,6 @@
         "update": false
       }
     },
-    "row_scope": "team"
+    "row_scope": "own"
   }
 }

--- a/docs/explanation/rbac-roles-and-teams.md
+++ b/docs/explanation/rbac-roles-and-teams.md
@@ -46,15 +46,16 @@ same values by a test and so cannot drift from them. The shape:
 |---|---|---|
 | `admin` | Full CRUD on everything (config included). | `all` |
 | `ops` | Same CRUD reach as admin — the operations counterpart. | `all` |
-| `manager` | CRUD on records; **read-only** on most config (pipeline, automation, custom_field, quota); **no access at all** to the admin-only sheets (`fx_rate`, `ai_model_rate`, `embedding_reindex`, `import_run`). | `team` |
-| `rep` | Create/read/update records (delete only where it's routine, e.g. disqualify a lead); **read-only** on config. | `team` |
+| `manager` | CRUD on records; **read-only** on most config (pipeline, automation, custom_field, quota); **no access at all** to the admin-only sheets (`fx_rate`, `ai_model_rate`, `embedding_reindex`, `import_run`). | `own` |
+| `rep` | Create/read/update records (delete only where it's routine, e.g. disqualify a lead); **read-only** on config. | `own` |
 | `read_only` | Reads every record kind and every config surface a rep can see; writes nothing except its own saved views. The four admin-only sheets (`fx_rate`, `ai_model_rate`, `embedding_reindex`, `import_run`) are closed to it entirely — not even read. | `all` |
 
 Two things surprise people:
 
-- **`read_only` is `row_scope: all`, `rep`/`manager` are `row_scope: team`.** Scope and object reach
-  are orthogonal — a read-only auditor is *meant* to see the whole workspace; a rep is scoped to
-  their team's records but can write them.
+- **`read_only` is `row_scope: all`, `rep`/`manager` are `row_scope: own`.** Scope and object reach
+  are orthogonal — a read-only auditor is *meant* to see the whole workspace and write none of it,
+  while a rep reads every record and writes only their own. On the five customer-record tables the
+  read tier is not what scope decides at all (see *Reads* below); scope decides writes.
 - **Config objects (pipeline, custom_field, automation, quota) are read-only below admin/ops.** This
   is why a `rep` gets `pipeline.read: permission denied`-adjacent behaviour only when they have **no
   role at all** — with the `rep` role they *can* read pipelines; they just can't edit them.
@@ -96,12 +97,29 @@ passed:
 The personal tables (`list`, `saved_view`, `automation`, `voice_profile`) keep the owner predicate
 as well.
 
-### Writes: own / team / all, plus write grants — on every table
+### Writes: the owner, an explicit share, or an unbounded seat
 
-Row scope still decides **who may change** an identity row: the write-authority probe
-(`platform/auth/writescope.go`, `EnsureWritable`) is the owner predicate OR a live `write` grant,
-exactly as before. A rep who can now read a colleague's deal and tries to edit it gets **403**, not
-404 — the row is visibly theirs to read, so there is nothing left for a 404 to hide.
+Row scope decides **who may change** an identity row: the write-authority probe
+(`platform/auth/writescope.go`, `EnsureWritable`) is the owner predicate OR a live `write` grant. A
+rep who can read a colleague's deal and tries to edit it gets **403**, not 404 — the row is visibly
+theirs to read, so there is nothing left for a 404 to hide.
+
+**Team membership grants nothing by itself.** The seeded `rep` and `manager` are `own`-scoped, so a
+colleague's record takes an explicit share — a `record_grant` naming the user or one of their teams —
+or an unbounded seat. This is the change from the earlier model, where being in somebody's team was
+standing write access to everything they owned.
+
+The team arm survives in the predicate and is not dead code. A record grant may name a **team**, so
+sharing with a group is one act rather than one per member, and an operator may still author a custom
+role at `team` scope. What changed is only what the seeded roles claim by default.
+
+An **ownerless** row (`owner_id IS NULL`) is nobody's to change until somebody claims it
+(`EnsureClaimable`, `POST /v1/records/{record_type}/{id}/claim`); claiming makes the claimer the
+owner. It stays readable by everyone throughout.
+
+A record carries the answer on the wire: `writable` on a person, organization, lead, deal or project
+says whether **this** caller may change **this** row, so a client draws its edit affordances from the
+same question the server answers. It is a UX signal and never the enforcement.
 
 ### Activities: discoverable versus readable
 
@@ -121,13 +139,15 @@ A reader that serves content composes the content clause; a limited activity the
 but not read is withheld, with only the safe markers shown. The audience does **not** yield to
 `row_scope: all` — only the system principal reads the arm away.
 
-Note that `owner_id` is **optional and not auto-stamped on create** — a person/organization/deal
-created without one (the API and the current create UI both omit it) is ownerless, hence writable
-by everyone under the write predicate, until an owner is assigned. This is why the dev seed
-explicitly makes Demo Admin the owner of its records (`scripts/seed-dev.sql`).
+Note that `owner_id` is **optional**. A manual create stamps the creator
+(`storekit.OwnerOrActor`), but a record can still arrive without an owner — an import, a connector
+that had no seat to attribute. Such a row is readable by everyone and writable by **nobody** until a
+seat claims it, which is the opposite of what this paragraph used to say: an ownerless customer
+record every seat could rewrite is how two teams edit one company past each other.
 
-No system role ships `row_scope: own`; it exists for custom roles. The seeded `rep`/`manager` are
-`team`, so team membership is what actually decides who may write whose records.
+The seeded `rep` and `manager` are `row_scope: own`, and `read_only`, `ops`, `admin` and
+`management` are `all`. No seeded role is `team`-scoped; that tier is available to custom roles and
+is what a team-subject record grant resolves against.
 
 ## Field masks — one column of a readable row
 
@@ -141,20 +161,32 @@ reader can tell withheld from empty. Sorting or filtering a list by a masked col
 (422), because ordering by a value is reading it. An unbounded seat (`row_scope: all`) carries no
 mask.
 
-The one seeded mask is the one the shared-identity read makes load-bearing: `rep` → `deal` →
-`amount_minor` → `outside_write_authority`. A rep sees every deal and who owns it; the amount of a
-deal outside their write authority is withheld.
+**No seeded role carries a mask.** The baseline shipped one — `rep` → `deal` → `amount_minor` →
+`outside_write_authority`, so a rep read the value of a deal outside their write authority as
+withheld — and it has been removed. Deal amounts are open to every seat that may read the deal.
+
+It was written when a rep's write authority covered their whole team, so it hid other teams' numbers
+and left the rep's own team visible. Once the seeded rep became `own`-scoped that same mask would
+have blacked out every deal a rep does not personally own, which is a decision about what people may
+SEE arrived at as a side effect of a decision about what they may WRITE. The product answer is that
+deal values are open: a rep who cannot see what a colleague's deal is worth cannot judge their own
+pipeline against it.
+
+The machinery above stays and is not dead — an operator may author a mask on a custom role, and every
+path that applies one is tested. What went is the row the product shipped.
 
 ## Teams
 
 A **team** (`team` table) is a named group; **`team_membership`** joins users to teams (many-to-many
 — a user can be in several). Teams do two jobs:
 
-1. **They resolve `row_scope: team`.** "My team's records" = records owned by anyone sharing a team
-   with me. Add a rep to a team and they immediately may edit that team's records, and see its
-   projects (subject to the object gate).
-2. **They are a share target.** A record grant can name a team instead of a person, so everyone in
-   it — present and future members — gets the widened visibility.
+1. **They are a share target**, and this is now the primary job. A record grant can name a team
+   instead of a person, so everyone in it — present and future members — gets the widened access.
+   Sharing with a group is one act rather than one per member.
+2. **They resolve `row_scope: team`** for a role that carries it. No seeded role does any more:
+   putting a rep in a team does not by itself let them edit that team's records. An operator who
+   wants standing write access among colleagues authors a custom role at `team` scope, and the
+   predicate still renders the arm for it.
 
 Teams do **not** carry their own permissions — a team is not a role. (A role *assignment* can be
 scoped to a team, but the grants still come from the role.)
@@ -205,19 +237,20 @@ The dev seed (`scripts/seed-dev.sql`) sets up three seats so every branch above 
 
 - **Demo Admin** — `admin` role, `row_scope: all`, member of **DACH Sales**. Owns the seeded people
   and deals; sees everything.
-- **Rep One** — `rep` role, `row_scope: team`, member of **DACH Sales** (with Demo Admin). *The
-  team-scope seat.*
-  - Object gate: `rep` grants `deal.read`, `pipeline.read` (read-only) → the deals board loads.
-  - Row scope: `team` → Rep One may edit every record owned by a DACH Sales teammate — i.e. **all of
-    Demo Admin's records, with no share needed**, and sees the team's projects. A per-record share on
-    top is redundant, so Rep One is *not* how you observe sharing; they're how you observe team scope.
-- **Rep Two** — `individual` role (an own-scoped clone of `rep`), **in no team**. *The sharing seat.*
+- **Rep One** — `rep` role, `row_scope: own`, member of **DACH Sales** (with Demo Admin). *The
+  shared-with seat.*
+  - Object gate: `rep` grants `deal.read`, `pipeline.read` (read-only) → the deals board loads, and
+    shows Demo Admin's records like everyone else's: customer identity is workspace-readable.
+  - Row scope: `own` → being in Demo Admin's team buys Rep One nothing. Every one of Demo Admin's
+    records is **readable and not editable** — pressing save answers 403, and the record's `writable`
+    flag says so before you press it.
+  - The seed shares **one** of Demo Admin's people with Rep One at `write`. That record, and only
+    that record, is theirs to change — which is what makes the grant the observable cause.
+- **Rep Two** — `individual` role (a clone of `rep`), **in no team**. *The nothing-shared seat.*
   - Object gate passes (same object grants as `rep`) → the board loads and shows every deal, read-only.
-  - Row scope: `own` → owns nothing, has no teammates → may **edit nothing** by default, and sees
-    **no projects**.
-  - Share a specific deal at `write` with Rep Two (or with a team you add them to) and it becomes
-    editable; share a project and it appears — the grant is the **sole** reason, which is exactly
-    what makes sharing observable.
+  - Row scope: `own` → owns nothing and holds no grant → may **edit nothing**.
+  - The contrast with Rep One is now the GRANT rather than the team: two own-scoped seats, one of
+    which has been handed a record.
 
 Remove a user's role assignment entirely and every read fails at the object gate (403/404 across the
 board) — the symptom that means "no role," distinct from "role present but scope hides the row."

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -51,8 +51,8 @@ the workspace but changes none of them.
 |---|---|---|
 | `admin` | Admin | all |
 | `management` | Management | all |
-| `manager` | Team Lead | team |
-| `rep` | Member | team |
+| `manager` | Team Lead | own |
+| `rep` | Member | own |
 | `read_only` | Read-only | all |
 | `ops` | Ops / Integrations | all |
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11923,6 +11923,8 @@ export interface components {
             title?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
+            /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
+            readonly writable?: boolean;
             /** @description { linkedin, twitter, github, ... } */
             social?: {
                 [key: string]: unknown;
@@ -12106,6 +12108,8 @@ export interface components {
             address?: components["schemas"]["Address"];
             /** Format: uuid */
             owner_id?: string | null;
+            /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
+            readonly writable?: boolean;
             /**
              * Format: uuid
              * @description Single-level hierarchy FK; no cycles.
@@ -14562,6 +14566,8 @@ export interface components {
             project_id?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
+            /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
+            readonly writable?: boolean;
             /**
              * @default open
              * @enum {string}
@@ -15025,6 +15031,8 @@ export interface components {
             organization_id?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
+            /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
+            readonly writable?: boolean;
             /**
              * @description Read-only here — transitions go through advanceProjectPhase so the history row and project.phase_changed are written from one transaction.
              * @default initiative
@@ -16338,6 +16346,8 @@ export interface components {
             readonly score_computed?: number | null;
             /** Format: uuid */
             owner_id?: string | null;
+            /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
+            readonly writable?: boolean;
             source_system?: string | null;
             source_id?: string | null;
             /**

--- a/frontend/src/app/capability.test.tsx
+++ b/frontend/src/app/capability.test.tsx
@@ -11,6 +11,7 @@ import {
   useCanMutate,
   useCanUpsert,
   useCanWrite,
+  useCanWriteRecord,
   useHoldsConsentAdminRole,
   useHoldsOperatorSeat,
 } from "./capability";
@@ -49,6 +50,21 @@ function wrapper({ children }: { children: ReactNode }) {
 async function can(object: RbacObject, action: RbacAction): Promise<boolean> {
   const { result } = renderHook(
     () => ({ me: useMe(), allowed: useCan(object, action) }),
+    { wrapper },
+  );
+  await waitFor(() => {
+    expect(result.current.me.isPending).toBe(false);
+  });
+  return result.current.allowed;
+}
+
+// The three-axis answer for ONE record, asked the same way.
+async function canWriteRecord(
+  object: RbacObject,
+  record: { readonly writable?: boolean } | undefined,
+): Promise<boolean> {
+  const { result } = renderHook(
+    () => ({ me: useMe(), allowed: useCanWriteRecord(object, record) }),
     { wrapper },
   );
   await waitFor(() => {
@@ -309,5 +325,53 @@ describe("useHoldsOperatorSeat — the Admin settings section's gate", () => {
     stubMe(meFixture({ roles: [] }));
 
     expect(await operator()).toBe(false);
+  });
+});
+
+describe("useCanWriteRecord", () => {
+  // Each case holds the object grant AND a full seat, so the only thing moving
+  // is the row. A test that varied two axes at once could not say which one
+  // produced the answer.
+  const granted = { allow: { organization: ["read", "update"] } } as const;
+
+  it("admits a record the server marked writable", async () => {
+    stubMe(meFixture(granted));
+
+    expect(await canWriteRecord("organization", { writable: true })).toBe(true);
+  });
+
+  it("refuses a record the server marked not writable, grant and seat notwithstanding", async () => {
+    // The case the whole field exists for: a rep holds organization.update on
+    // the OBJECT and still may not edit a colleague's company.
+    stubMe(meFixture(granted));
+
+    expect(await canWriteRecord("organization", { writable: false })).toBe(
+      false,
+    );
+  });
+
+  it("refuses a record carrying no writable flag at all", async () => {
+    // A server too old to send it, or a projection that does not carry it.
+    // Absence is not authority — the same fail-closed answer every predicate
+    // in this file gives.
+    stubMe(meFixture(granted));
+
+    expect(await canWriteRecord("organization", {})).toBe(false);
+  });
+
+  it("refuses while the record has not arrived", async () => {
+    stubMe(meFixture(granted));
+
+    expect(await canWriteRecord("organization", undefined)).toBe(false);
+  });
+
+  it("refuses a writable record when the OBJECT grant is missing", async () => {
+    // The row half cannot buy the object half. A seat with no
+    // organization.update writes no company, however the row is marked.
+    stubMe(meFixture({ allow: { organization: ["read"] } } as const));
+
+    expect(await canWriteRecord("organization", { writable: true })).toBe(
+      false,
+    );
   });
 });

--- a/frontend/src/app/capability.ts
+++ b/frontend/src/app/capability.ts
@@ -112,6 +112,37 @@ export function useCanWrite(object: RbacObject, action: RbacAction): boolean {
 }
 
 /**
+ * Whether this caller may change THIS record: the object grant, the seat
+ * ceiling, and the server's own per-row answer, all three.
+ *
+ * The axes are independent and each is necessary. A rep holds
+ * `organization.update` on the OBJECT and still may not write a colleague's
+ * company; a full seat with the grant still may not write an archived one. The
+ * per-row half comes from the server as `record.writable`, because ownership,
+ * team membership and record grants are not in the /me snapshot — re-deriving
+ * them here would be a second implementation of the write gate, which is the
+ * defect this hook exists to prevent rather than one to commit while preventing
+ * it.
+ *
+ * UX HONESTY, never enforcement, exactly like the rest of this file: the server
+ * refuses a write it did not authorize whatever this returns. All it buys is
+ * that a reader is not shown a control the save would refuse.
+ *
+ * An absent `writable` denies. A response from a server too old to send it, or
+ * a projection that does not carry it, reads as not-writable — the same
+ * fail-closed answer every other predicate here gives.
+ */
+export function useCanWriteRecord(
+  object: RbacObject,
+  record: { readonly writable?: boolean } | undefined,
+): boolean {
+  // Runs unconditionally: the number of hooks a render performs must not
+  // depend on whether the record has arrived yet.
+  const granted = useCanWrite(object, "update");
+  return granted && (record?.writable ?? false);
+}
+
+/**
  * Both axes, for a control whose request is an UPSERT — one endpoint that
  * inserts or replaces, so which grant it needs is not knowable until the server
  * has read the row.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -167,6 +167,8 @@ export const de = {
   "record.archived": "Archiviert",
   "record.archivedReadOnly":
     "Diese Firma ist archiviert. Stellen Sie sie wieder her, um etwas zu ändern.",
+  "record.notYoursToChange":
+    "Diese Firma gehört jemand anderem. Bitten Sie den Inhaber um Freigabe, wenn Sie etwas ändern möchten.",
   "record.share": "Teilen",
   "record.moreActions": "Weitere Aktionen",
   "record.fullHistory": "Vollständiger Verlauf",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -184,6 +184,8 @@ export const en = {
   "record.archived": "Archived",
   "record.archivedReadOnly":
     "This company is archived. Restore it to change anything on it.",
+  "record.notYoursToChange":
+    "This company belongs to someone else. Ask its owner to share it with you if you need to make changes.",
   "record.share": "Share",
   "record.moreActions": "More actions",
   "record.fullHistory": "Full history",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -174,6 +174,8 @@ export const vi = {
   "record.archived": "Đã lưu trữ",
   "record.archivedReadOnly":
     "Công ty này đã lưu trữ. Khôi phục để thay đổi bất kỳ thông tin nào.",
+  "record.notYoursToChange":
+    "Công ty này thuộc về người khác. Hãy đề nghị chủ sở hữu chia sẻ nếu bạn cần thay đổi.",
   "record.share": "Chia sẻ",
   "record.moreActions": "Thêm thao tác",
   "record.fullHistory": "Lịch sử đầy đủ",

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -37,6 +37,10 @@ import { TaskQuickActions, useTaskUpdate } from "./taskactions";
 
 const org = {
   id: "o-1",
+  // The server answers this per row; a fixture without it reads as NOT
+  // writable, which is the correct fail-closed default and would strip the
+  // edit affordances these tests are about.
+  writable: true,
   display_name: "Brandt Automotive GmbH",
   industry: "Automotive",
   captured_by: "human:u1",

--- a/frontend/src/screens/companyheader.test.tsx
+++ b/frontend/src/screens/companyheader.test.tsx
@@ -27,6 +27,9 @@ type Organization = components["schemas"]["Organization"];
 // field and still compile, so the test would go on passing after the wire shape
 // moved under it — which is the one thing a fixture must not do.
 const ORG: Organization = {
+  // Absent reads as NOT writable, which is the fail-closed default a real
+  // response never relies on: the server answers this per row.
+  writable: true,
   id: "o-1",
   display_name: "Brandt Automotive GmbH",
   lifecycle: "customer",

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -3,7 +3,7 @@ import { Fragment, type ReactElement, useId } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
-import { useCan } from "../app/capability";
+import { useCanWrite } from "../app/capability";
 import { navigate } from "../app/router";
 import { Badge, Button, OverflowMenu } from "../design-system/atoms";
 import { InlineChoice } from "../design-system/inlinechoice";
@@ -248,7 +248,11 @@ export function useCompanyReadOnlyReason(
   if (overlay) {
     return t("overlay.partialWriteBack");
   }
-  if (!mine) {
+  // An UNOWNED record is not "somebody else's" — it is nobody's yet, and the
+  // claim door is deliberately open to every seat. Reporting it read-only here
+  // would shut the one control that makes it writable, which is the opposite of
+  // what this reason is for.
+  if (!mine && org.owner_id) {
     return t("record.notYoursToChange");
   }
   return undefined;
@@ -265,7 +269,10 @@ export function CompanyLifecycleControl({
   org,
 }: Readonly<{ org: Organization }>) {
   const t = useT();
-  const canUpdate = useCan("organization", "update");
+  // useCanWrite, not useCan: these controls issue a PATCH, and the licensing
+  // middleware refuses a mutation from a read seat before RBAC is consulted.
+  // Gating on the grant alone offers an active control whose save is rejected.
+  const canUpdate = useCanWrite("organization", "update");
   const readOnlyReason = useCompanyReadOnlyReason(org);
   const patch = useCompanyFieldPatch(org);
   return (
@@ -328,7 +335,10 @@ export function CompanyOwnerControl({
   hideLabel,
 }: Readonly<{ org: Organization; hideLabel?: boolean }>) {
   const t = useT();
-  const canUpdate = useCan("organization", "update");
+  // useCanWrite, not useCan: these controls issue a PATCH, and the licensing
+  // middleware refuses a mutation from a read seat before RBAC is consulted.
+  // Gating on the grant alone offers an active control whose save is rejected.
+  const canUpdate = useCanWrite("organization", "update");
   const readOnlyReason = useCompanyReadOnlyReason(org);
   const patch = useCompanyFieldPatch(org);
   const claim = useClaimRecord("organization", org.id, org.version);
@@ -394,6 +404,33 @@ export function CompanyOwnerControl({
       }
     />
   );
+}
+
+// useCompanyVerbRefusal answers why the record's own verbs — edit, merge,
+// archive, share — are refused, or undefined when they are pressable.
+//
+// Two states refuse them, and they read the same to a user: the record is
+// archived, or it is somebody else's. Both are facts about the RECORD, so both
+// take STATE-4a's answer — the verb stays visible and says why, because a
+// missing button reads as a build without the feature.
+//
+// Overlay is deliberately NOT one of them, which is why this is its own function
+// rather than useCompanyReadOnlyReason. Overlay's sentence says a write reaches
+// the incumbent only in part: a caveat on a write that still happens, not a
+// reason it is refused. Disabling these verbs on it would take away edits the
+// mirror does support.
+//
+// An UNOWNED record is not one either. Nobody owns it yet, and the verbs that
+// let a reader take it on stay pressable.
+function useCompanyVerbRefusal(org: Organization): string | undefined {
+  const t = useT();
+  if (org.archived_at) {
+    return t("record.archivedReadOnly");
+  }
+  if (org.owner_id && !(org.writable ?? false)) {
+    return t("record.notYoursToChange");
+  }
+  return undefined;
 }
 
 // useClaimRecord is the claim door: POST /records/{type}/{id}/claim makes the
@@ -547,7 +584,8 @@ export function CompanyActionBadges({
   // whether these verbs are refused.
   const ownReasonId = useId();
   const menuReasonId = archivedReasonId ?? ownReasonId;
-  const refusedByArchive = org.archived_at ? menuReasonId : undefined;
+  const refusedReason = useCompanyVerbRefusal(org);
+  const refusedByState = refusedReason ? menuReasonId : undefined;
   return (
     <>
       {/* What the company IS to us. Where it STANDS is a separate question,
@@ -566,15 +604,15 @@ export function CompanyActionBadges({
           and the sentence refusing them travels with them. Only a panel with
           no items at all would be worth hiding. */}
       <OverflowMenu label={t("record.moreActions")}>
-        {org.archived_at && !archivedReasonId && (
+        {refusedReason && !archivedReasonId && (
           <p id={ownReasonId} className="t-caption">
-            {t("record.archivedReadOnly")}
+            {refusedReason}
           </p>
         )}
         <CompanyEditAction
           org={org}
           overlay={overlay}
-          disabledReasonId={refusedByArchive}
+          disabledReasonId={refusedByState}
         />
         {/* Merge has no incumbent-first projection — the seam refuses it
             outright (overlay/provider_writes.go Merge) — unlike
@@ -583,7 +621,7 @@ export function CompanyActionBadges({
             its answer: there is no fact about this account to report. */}
         {!overlay && (
           <MergeAction
-            disabledReasonId={refusedByArchive}
+            disabledReasonId={refusedByState}
             label={t("merge.org")}
             sourceId={org.id}
             sourceName={org.display_name}
@@ -613,7 +651,7 @@ export function CompanyActionBadges({
           />
         )}
         <ArchiveAction
-          disabledReasonId={refusedByArchive}
+          disabledReasonId={refusedByState}
           label={t("record.archive")}
           confirmText={t("record.archiveConfirm")}
           archive={async () => {
@@ -637,7 +675,7 @@ export function CompanyActionBadges({
           <ShareAction
             recordType="organization"
             recordId={org.id}
-            disabledReasonId={refusedByArchive}
+            disabledReasonId={refusedByState}
           />
         )}
         {/* The way in to the partner programme for an account that has none.
@@ -645,7 +683,7 @@ export function CompanyActionBadges({
             partner row would be unreachable — this is the same form, asked
             for rather than offered. */}
         {!overlay && !(org.relationship_types ?? []).includes("partner") && (
-          <Button small reasonId={refusedByArchive} onClick={onSetUpPartner}>
+          <Button small reasonId={refusedByState} onClick={onSetUpPartner}>
             {t("org.partnerSetUp")}
           </Button>
         )}

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -234,11 +234,22 @@ export function useCompanyReadOnlyReason(
 ): string | undefined {
   const t = useT();
   const overlay = useSorMode() === "overlay";
+  // The per-ROW question only. The object grant and the seat ceiling are the
+  // caller's to apply — every mount point here already ANDs `useCan` with this
+  // reason, and folding them in again would answer "no grant" as though it were
+  // a fact about the record.
+  const mine = org.writable ?? false;
+  // Archived first: it is the reason a reader can act on, by restoring the
+  // record. Ownership comes last because it is the standing state — a company
+  // that is simply somebody else's is not a problem to solve, it is who owns it.
   if (org.archived_at) {
     return t("record.archivedReadOnly");
   }
   if (overlay) {
     return t("overlay.partialWriteBack");
+  }
+  if (!mine) {
+    return t("record.notYoursToChange");
   }
   return undefined;
 }

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -23,6 +23,9 @@ type Organization360 = components["schemas"]["Organization360"];
 // field is a fact worth showing, not one this grid hides.
 
 const org = {
+  // Absent reads as NOT writable, which is the fail-closed default a real
+  // response never relies on: the server answers this per row.
+  writable: true,
   id: "o-1",
   workspace_id: "w",
   display_name: "Brandt Automotive GmbH",

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -207,7 +207,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/organizations/o-1": async (request) => {
         if (request.method === "PATCH") {
@@ -253,7 +258,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/users": () =>
         jsonResponse({
@@ -302,7 +312,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/users": () =>
         jsonResponse({
@@ -362,7 +377,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/organizations/o-1": async (request) => {
         if (request.method === "PATCH") {
@@ -410,7 +430,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/organizations/o-1": async (request) => {
         if (request.method === "PATCH") {
@@ -461,7 +486,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/organizations/o-1": async (request) => {
         if (request.method === "PATCH") {
@@ -499,7 +529,12 @@ describe("CompanyRail", () => {
       "/me": () =>
         jsonResponse({
           user: { id: "u-1", display_name: "Mira Voss" },
-          authorization: { objects: { organization: { update: true } } },
+          authorization: {
+            objects: { organization: { update: true } },
+            // A full seat: the licensing ceiling is checked before RBAC, and the
+            // grid's controls issue a PATCH.
+            seat_type: "full",
+          },
         }),
       "/organizations/o-1": async (request) => {
         if (request.method === "PATCH") {

--- a/frontend/src/screens/companyraildetails.stories.tsx
+++ b/frontend/src/screens/companyraildetails.stories.tsx
@@ -23,6 +23,9 @@ type Organization = components["schemas"]["Organization"];
 const page = { has_more: false, next_cursor: null };
 
 const org: Organization = {
+  // Absent reads as NOT writable, which is the fail-closed default a real
+  // response never relies on: the server answers this per row.
+  writable: true,
   id: "o-1",
   workspace_id: "w-1",
   display_name: "Brandt Automotive GmbH",

--- a/frontend/src/screens/companyraildetails.test.tsx
+++ b/frontend/src/screens/companyraildetails.test.tsx
@@ -29,6 +29,10 @@ type Organization = components["schemas"]["Organization"];
 // passing after the wire shape moved under it.
 const ORG: Organization = {
   id: "o-1",
+  // The server answers this per row; a fixture without it reads as NOT
+  // writable, which is the correct fail-closed default and would strip the
+  // edit affordances these tests are about.
+  writable: true,
   display_name: "Brandt Automotive GmbH",
   lifecycle: "customer",
   owner_id: "u-1",

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCan } from "../app/capability";
+import { useCan, useCanWriteRecord } from "../app/capability";
 import { navigate } from "../app/router";
 import {
   Avatar,
@@ -2314,6 +2314,12 @@ function CompanyRecordBody({
   taskUpdate: ReturnType<typeof useTaskUpdate>;
   onOpenHistory: () => void;
 }>) {
+  // Whether this company is this reader's to change. It used to be
+  // `!org.archived_at`, which answered a different question: an archived
+  // company is read-only for everyone, but a LIVE company somebody else owns is
+  // read-only too, and the page had no way to know that until the record
+  // started carrying the answer.
+  const orgWritable = useCanWriteRecord("organization", org);
   // The meeting whose brief is open. "Prepare meeting" used to open the
   // composer on the meeting, which is a reply to a room nobody has sat in
   // yet; the brief drawer is what prepares a reader for one.
@@ -2394,7 +2400,7 @@ function CompanyRecordBody({
       {tab === "people" && (
         <PeopleCard
           view={view}
-          writable={!org.archived_at}
+          writable={orgWritable}
           orgId={org.id}
           loading={loading}
         />

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -171,9 +171,9 @@ BEGIN
     WHERE r.key = 'rep'
   ON CONFLICT (key) DO NOTHING;
 
-  -- Rep Two: an individual contributor — own-scoped, in NO team. Contrast with
-  -- Rep One (team-scoped, in DACH Sales): Rep One sees the team's records by
-  -- scope, Rep Two sees nothing until a record is explicitly shared with them.
+  -- Rep Two: an individual contributor — own-scoped, in NO team. Both reps read
+  -- the whole workspace and own nothing in it; the difference is the GRANT below,
+  -- which is handed to Rep One and not to Rep Two.
   INSERT INTO app_user (email, password_hash, display_name, seat_type, status)
   VALUES ('rep2@demo.test', admin_hash, 'Rep Two', 'full', 'active')
   ON CONFLICT (lower(email)) DO NOTHING;
@@ -191,7 +191,26 @@ BEGIN
         WHERE ra.user_id = rep2_id AND ra.role_id = r.id AND ra.team_id IS NULL
       );
 
-  RAISE NOTICE 'seed-dev.sql: rep@demo.test (rep, team DACH Sales) + rep2@demo.test (individual, own-scope) seeded for demo-workspace';
+  -- ONE of Demo Admin's people, shared with Rep One at `write`.
+  --
+  -- This is what makes sharing observable now that team membership does not
+  -- grant it. Rep One and Rep Two are both own-scoped and own nothing, so they
+  -- read the same workspace and edit the same nothing — except this one record,
+  -- whose only reason for being editable is the grant. Take the grant away and
+  -- the two seats are identical.
+  --
+  -- granted_by is the admin: a grant is passed on by somebody who could change
+  -- the row themselves, which is the rule CreateRecordGrant enforces.
+  INSERT INTO record_grant (record_type, record_id, subject_type, subject_id, access, granted_by, reason)
+  SELECT 'person', p.id, 'user', rep_id, 'write', admin_id,
+         'seed-dev: the one record that makes a write share observable'
+    FROM person p
+   WHERE p.owner_id = admin_id AND p.archived_at IS NULL
+   ORDER BY p.created_at, p.id
+   LIMIT 1
+  ON CONFLICT DO NOTHING;
+
+  RAISE NOTICE 'seed-dev.sql: rep@demo.test (rep, own-scope, one write grant) + rep2@demo.test (individual, own-scope, no grant) seeded for demo-workspace';
 END $$;
 
 -- The finance mirror's demo source (ADR-0083/A128).


### PR DESCRIPTION
The last change in the access-model series. It carries the `writable` wire flag plus two founder rulings, and they belong together because the second only became a question once the first was made.

## 1. Team membership no longer grants write access

The seeded `rep` and `manager` move from `team` scope to `own`. A colleague's record now takes an explicit share — a `record_grant` naming the user or one of their teams — or an unbounded seat.

The write predicate is **unchanged**, and its team arm is not dead code: a grant may name a team, and an operator may still author a custom role at `team` scope. What changed is only what the shipped roles claim by default.

`seedSystemRoles` writes each role document once at workspace creation and never re-syncs, so the compiled default alone would have taken effect on a fresh database and nowhere else — every deployed installation keeping team scope permanently, with nothing to show the two had diverged. The migration is the half that reaches them, guarded on `is_system` and on the scope it replaces, so it is idempotent and leaves an operator's own choice alone.

## 2. Deal amounts are open

The baseline seeded one field mask: a rep read `amount_minor` as withheld on any deal outside their write authority.

It was written when write authority covered a whole team, so it hid other teams' numbers and left the rep's own team visible. Under own scope that same mask would have blacked out every deal a rep does not personally own — a decision about what people may **see**, arrived at as a side effect of a decision about what they may **write**, and never taken on its own terms.

Taken on its own terms: a rep who cannot see what a colleague's deal is worth cannot judge their own pipeline against it. So the row goes.

The machinery stays. `field_mask`, both conditions, the sort/filter refusal and the `masked_fields` wire field are all still there for an operator's custom role, and every path that applies one is still tested — those suites build their own masks rather than reading the seeded one. Two tests that existed to assert the shipped mask now assert the shipped posture: **no seeded role withholds a column**, which is the claim worth catching if it stops being true.

## 3. `writable` on the wire

Person, organization, lead, deal and project carry whether **this** caller may change **this** row, computed by the same gate a mutation passes. One statement per page (`auth.StampWritable` over the existing `WritableSubset`), never a probe per row. Absent means not writable, so an older client fails closed.

Without it this PR would have been a silent downgrade: reps lose write access to their teammates' records and nothing on screen would have said why.

`useCanWriteRecord` is the one client hook. It is UX honesty and never enforcement — the server refuses an unauthorized write whatever the flag said.

## Consequences worth naming

- A manager no longer writes their team's records by role alone. Where that is operationally needed, the answer is a team-subject grant at `write`, which the sharing screen already creates.
- The dev seed loses its contrast and gets it back differently: Rep One was the team-scope seat and Rep Two the sharing seat, and both are own-scoped now. The seed hands Rep One a write grant on one of Demo Admin's people — two identical seats, one shared record, and the grant is the only reason it is editable.

## Verification

`make check-backend`, `make check-fe`, `make craft-static` and the full `make test-integration` lane (43 packages, 0 skips) are green. The `writable` flag's honesty test drives the mutation and compares — true exactly when the write is admitted — and was mutation-checked, as were the archived-row and mutation-echo cases.

Follows #2351, #2353. Open follow-ups: #2356, #2363.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added record-level writability indicators across CRM records.
  * Restricted edit, merge, archive, sharing, and setup actions based on ownership and write access.
  * Added clear messages for archived or non-owned records.
  * Added read-only meeting-brief omission details and document download metadata.
  * Added partner record reading through the CRM integration.
  * Deal amounts are now visible to authorized readers by default.

* **Documentation**
  * Updated RBAC guidance to explain ownership, sharing, team scopes, and write permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->