### PR TITLE
fix(privacy): the reset collects every credential handle, not one spelling

### DIFF
--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
@@ -230,11 +229,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 		// The provider platform's sealed API keys, collected the same way and
 		// for the same reason — its connection table carries no workspace_id,
 		// so neither the sweep above nor the collection above can see it.
-		providerRefs, err := providerCredentialRefs(ctx, tx)
-		if err != nil {
-			return err
-		}
-		counts.secretRefs = slices.Concat(secretRefs, providerRefs)
+		counts.secretRefs = secretRefs
 
 		if err := sweepWorkspaceData(ctx, tx, tables); err != nil {
 			return err

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -226,9 +226,11 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 		if err != nil {
 			return err
 		}
-		// The provider platform's sealed API keys, collected the same way and
-		// for the same reason — its connection table carries no workspace_id,
-		// so neither the sweep above nor the collection above can see it.
+		// The provider platform's sealed API keys arrive in the same slice. They
+		// used to need a pass of their own, because the collection keyed on one
+		// column name and provider_connection carries no workspace_id; it keys
+		// on neither now, so that pass was a SECOND collector of the same rows
+		// and it double-counted them. Deleted.
 		counts.secretRefs = secretRefs
 
 		if err := sweepWorkspaceData(ctx, tx, tables); err != nil {

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -572,12 +572,33 @@ func TestResetPurgesTheSealedCredentialsItsSweepOrphans(t *testing.T) {
 
 	vault := resetTestVault(t, e)
 	wsID := ids.From[ids.WorkspaceKind](e.WS)
-	mine, err := vault.Put(ctx, wsID, []byte("an incumbent's oauth refresh token"))
-	if err != nil {
-		t.Fatalf("sealing the credential under test: %v", err)
+	seal := func(what string) string {
+		t.Helper()
+		ref, err := vault.Put(ctx, wsID, []byte(what))
+		if err != nil {
+			t.Fatalf("sealing %s: %v", what, err)
+		}
+		return string(ref)
 	}
+
+	// One per SPELLING, not one per table. The handle column is called
+	// `credential_ref` on the connection tables, `vault_ref` on
+	// extension_secret and `signing_secret_ref` on webhook_subscription — and
+	// this test used to seed only the first, which is exactly why the
+	// collection could be written against one name and look correct. A test
+	// that exercises the spelling the code already knows about cannot fail on
+	// the spellings it does not.
+	mine := seal("an incumbent's oauth refresh token")
+	extension := seal("an extension's api key")
+	signing := seal("a webhook's signing secret")
+
 	e.WsExec(t, `INSERT INTO incumbent_connection (id, incumbent, region, status, credential_ref)
-		VALUES ($1, 'hubspot', 'eu', 'active', $2)`, ids.NewV7(), string(mine))
+		VALUES ($1, 'hubspot', 'eu', 'active', $2)`, ids.NewV7(), mine)
+	e.WsExec(t, `INSERT INTO extension_secret (id, extension_name, key, vault_ref)
+		VALUES ($1, 'relay-probe', 'api_key', $2)`, ids.NewV7(), extension)
+	e.WsExec(t, `INSERT INTO webhook_subscription (id, owner_id, target_url, event_types, signing_secret_ref)
+		VALUES ($1, $2, 'https://example.test/hook', ARRAY['person.created'], $3)`,
+		ids.NewV7(), e.AdminUser, signing)
 
 	h := dataResetHandlers{
 		pool:             e.Pool,
@@ -590,12 +611,18 @@ func TestResetPurgesTheSealedCredentialsItsSweepOrphans(t *testing.T) {
 		t.Fatalf("run: %v", err)
 	}
 
-	if _, err := vault.Get(ctx, wsID, mine); !errors.Is(err, keyvault.ErrNotFound) {
-		t.Errorf("the sealed credential outlived the reset (Get returned %v) — a wipe that leaves credential material resident is not a clean slate", err)
+	for _, c := range []struct{ what, ref string }{
+		{"the incumbent connection's credential_ref", mine},
+		{"the extension secret's vault_ref", extension},
+		{"the webhook subscription's signing_secret_ref", signing},
+	} {
+		if _, err := vault.Get(ctx, wsID, keyvault.Ref(c.ref)); !errors.Is(err, keyvault.ErrNotFound) {
+			t.Errorf("%s outlived the reset (Get returned %v) — a wipe that leaves credential material resident is not a clean slate", c.what, err)
+		}
 	}
 	if got := e.WsCount(t, `SELECT count(*) FROM audit_log
-		WHERE action = 'reset_data' AND evidence->>'secrets_purged' = '1'`); got != 1 {
-		t.Errorf("reset_data rows recording one purged secret = %d, want 1", got)
+		WHERE action = 'reset_data' AND evidence->>'secrets_purged' = '3'`); got != 1 {
+		t.Errorf("reset_data rows recording three purged secrets = %d, want 1", got)
 	}
 }
 

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -264,12 +264,25 @@ func (h dataResetHandlers) clearOutbox(ctx context.Context) error {
 	})
 }
 
-// vaultRefColumn is the one spelling every table uses for a keyvault
-// handle (connector_connection, channel_connection, incumbent_connection).
-// Deriving the collection from the catalog on this name rather than listing
-// those three means a connection table added later is covered the day its
-// column exists, which a hand-kept list would not be.
-const vaultRefColumn = "credential_ref"
+// credentialHandleSuffix is how a column that holds a keyvault handle is
+// spelled in this schema — `credential_ref` on the connection tables,
+// `vault_ref` on extension_secret, `signing_secret_ref` on
+// webhook_subscription.
+//
+// A SUFFIX and not a name, because the name was wrong. This used to be the
+// single string "credential_ref", above a comment calling it "the one spelling
+// every table uses". There were three, so extension_secret's and
+// webhook_subscription's ciphertext was never collected and outlived every
+// reset — resident and unreachable, which is the exact failure
+// collectWorkspaceSecretRefs' comment says it exists to prevent.
+//
+// The suffix over-matches on purpose: thirteen distinct `_ref` column names
+// exist in this schema and only three are handles. Over-matching costs nothing
+// because the VAULT decides — a candidate value is collected only if
+// vault_secret holds it, so an `evidence_ref` or a `pdf_asset_ref` contributes
+// nothing. Under-matching is what cost something, and it is the direction a
+// derivation like this must not fail in.
+const credentialHandleSuffix = "_ref"
 
 // collectWorkspaceSecretRefs reads every sealed-credential handle in the
 // installation, BEFORE the sweep deletes the rows that name them.
@@ -280,67 +293,83 @@ const vaultRefColumn = "credential_ref"
 // reset that did not collect these first would leave the ciphertext resident
 // and unreachable forever — credential material outliving the wipe that was
 // supposed to clear it.
+//
+// The join to vault_secret is what makes the wide column match safe, and it is
+// also what makes the collection EXACT: a handle is a value the vault holds,
+// which is the vault's own answer rather than this file's guess about naming.
 func collectWorkspaceSecretRefs(ctx context.Context, tx pgx.Tx) ([]string, error) {
-	tables, err := tablesWithVaultRef(ctx, tx)
+	columns, err := credentialHandleColumns(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 	var refs []string
-	for _, t := range tables {
+	for _, c := range columns {
+		table, column := pgx.Identifier{c.table}.Sanitize(), pgx.Identifier{c.column}.Sanitize()
 		rows, err := tx.Query(ctx,
-			`SELECT `+pgx.Identifier{vaultRefColumn}.Sanitize()+
-				` FROM `+pgx.Identifier{t}.Sanitize()+
-				` WHERE `+pgx.Identifier{vaultRefColumn}.Sanitize()+` IS NOT NULL`)
+			`SELECT h.`+column+` FROM `+table+` h
+			 JOIN vault_secret v ON v.ref = h.`+column+`
+			 WHERE h.`+column+` IS NOT NULL`)
 		if err != nil {
-			return nil, fmt.Errorf("data reset: reading credential handles from %s: %w", t, err)
+			return nil, fmt.Errorf("data reset: reading credential handles from %s.%s: %w", c.table, c.column, err)
 		}
 		for rows.Next() {
 			var ref string
 			if err := rows.Scan(&ref); err != nil {
 				rows.Close()
-				return nil, fmt.Errorf("data reset: reading a credential handle from %s: %w", t, err)
+				return nil, fmt.Errorf("data reset: reading a credential handle from %s.%s: %w", c.table, c.column, err)
 			}
 			refs = append(refs, ref)
 		}
 		rows.Close()
 		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("data reset: reading credential handles from %s: %w", t, err)
+			return nil, fmt.Errorf("data reset: reading credential handles from %s.%s: %w", c.table, c.column, err)
 		}
 	}
 	return refs, nil
 }
 
-// tablesWithVaultRef lists the tables holding a credential handle, derived from
-// the catalog for the same reason resetTargetTables is: a new one enrols itself.
+// handleColumn is one place a keyvault handle can be written down.
+type handleColumn struct{ table, column string }
+
+// credentialHandleColumns lists them, derived from the catalog for the same
+// reason resetTargetTables is: a new one enrols itself.
 //
-// Holding the COLUMN is the whole test. It used to also require a workspace_id,
-// which was the same set only while every connection table had one — and phase
-// D (ADR-0091 §8) is removing it table by table, so each connection table that
-// dropped it silently stopped being collected and left its sealed credential
-// resident after a reset. That is the same failure resetTargetTables already
-// had for the same reason, and it is why neither derivation may ask about a
-// column that is on its way out.
-func tablesWithVaultRef(ctx context.Context, tx pgx.Tx) ([]string, error) {
+// It asks only about the column, not about a workspace_id. It used to also
+// require one, which was the same set only while every connection table had
+// one — and phase D (ADR-0091 §8) is removing it table by table, so each
+// connection table that dropped it silently stopped being collected and left
+// its sealed credential resident after a reset. That is the same failure
+// resetTargetTables already had for the same reason, and it is why neither
+// derivation may ask about a column that is on its way out.
+//
+// vault_secret itself is excluded: its `ref` IS the handle rather than a
+// reference to one, and joining the table to itself would collect every secret
+// in the installation whether or not anything still points at it.
+func credentialHandleColumns(ctx context.Context, tx pgx.Tx) ([]handleColumn, error) {
 	rows, err := tx.Query(ctx, `
-		SELECT c.relname
+		SELECT c.relname, a.attname
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
 		JOIN pg_attribute a ON a.attrelid = c.oid
+		JOIN pg_type t ON t.oid = a.atttypid
 		WHERE n.nspname = 'public'
 		  AND c.relkind = 'r'
-		  AND a.attname = $1 AND a.attnum > 0 AND NOT a.attisdropped
-		ORDER BY c.relname`, vaultRefColumn)
+		  AND c.relname <> 'vault_secret'
+		  AND a.attname LIKE $1
+		  AND t.typname IN ('text', 'varchar')
+		  AND a.attnum > 0 AND NOT a.attisdropped
+		ORDER BY c.relname, a.attname`, "%"+credentialHandleSuffix)
 	if err != nil {
-		return nil, fmt.Errorf("data reset: listing tables holding a credential handle: %w", err)
+		return nil, fmt.Errorf("data reset: listing columns that can hold a credential handle: %w", err)
 	}
 	defer rows.Close()
-	var out []string
+	var out []handleColumn
 	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
+		var c handleColumn
+		if err := rows.Scan(&c.table, &c.column); err != nil {
+			return nil, fmt.Errorf("data reset: listing columns that can hold a credential handle: %w", err)
 		}
-		out = append(out, name)
+		out = append(out, c)
 	}
 	return out, rows.Err()
 }

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -12,6 +12,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -99,32 +100,6 @@ var preservedResetTables = map[string]bool{
 	// takes the releases with it. Preserved here means "not a target", never
 	// "kept".
 	"deal_room_release": true,
-}
-
-// providerCredentialRefs collects the sealed API keys the provider
-// connections hold, BEFORE the sweep deletes the rows naming them. Same
-// reasoning as collectWorkspaceSecretRefs: the ciphertext lives in a table
-// with no workspace_id, so these handles are the only thing that will still
-// connect it to this installation once the rows are gone.
-func providerCredentialRefs(ctx context.Context, tx pgx.Tx) ([]string, error) {
-	rows, err := tx.Query(ctx,
-		`SELECT credential_ref FROM provider_connection WHERE credential_ref IS NOT NULL`)
-	if err != nil {
-		return nil, fmt.Errorf("data reset: reading provider credential handles: %w", err)
-	}
-	defer rows.Close()
-	var refs []string
-	for rows.Next() {
-		var ref string
-		if err := rows.Scan(&ref); err != nil {
-			return nil, fmt.Errorf("data reset: reading a provider credential handle: %w", err)
-		}
-		refs = append(refs, ref)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("data reset: reading provider credential handles: %w", err)
-	}
-	return refs, nil
 }
 
 // resetTargetTables lists every public base table a reset sweeps: all of them,
@@ -328,6 +303,22 @@ func collectWorkspaceSecretRefs(ctx context.Context, tx pgx.Tx) ([]string, error
 	return refs, nil
 }
 
+// likeEscaped makes a literal safe as a LIKE pattern, using `!` as the escape
+// character rather than a backslash.
+//
+// `_` is a LIKE WILDCARD, so the suffix went in as "any character followed by
+// ref" — which finds `href` and `pref` as readily as `_ref`. Harmless only
+// because the vault decides what is a handle, and that is not a reason to ask
+// the wrong question.
+//
+// `!` and not `\`: a backslash has to survive a Go string, an SQL string and
+// LIKE itself, and Postgres rejects an ESCAPE that is not exactly one
+// character — which is what the first attempt produced. `!` cannot appear in a
+// pg_attribute name, so nothing needs escaping that is not being escaped here.
+func likeEscaped(s string) string {
+	return strings.NewReplacer("!", "!!", "_", "!_", "%", "!%").Replace(s)
+}
+
 // handleColumn is one place a keyvault handle can be written down.
 type handleColumn struct{ table, column string }
 
@@ -346,7 +337,10 @@ type handleColumn struct{ table, column string }
 // reference to one, and joining the table to itself would collect every secret
 // in the installation whether or not anything still points at it.
 func credentialHandleColumns(ctx context.Context, tx pgx.Tx) ([]handleColumn, error) {
-	rows, err := tx.Query(ctx, `
+	var args []any
+	arg := func(v any) string { args = append(args, v); return fmt.Sprintf("$%d", len(args)) }
+	suffixPos := arg("%" + likeEscaped(credentialHandleSuffix))
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT c.relname, a.attname
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -355,10 +349,10 @@ func credentialHandleColumns(ctx context.Context, tx pgx.Tx) ([]handleColumn, er
 		WHERE n.nspname = 'public'
 		  AND c.relkind = 'r'
 		  AND c.relname <> 'vault_secret'
-		  AND a.attname LIKE $1
+		  AND a.attname LIKE %s ESCAPE '!'
 		  AND t.typname IN ('text', 'varchar')
 		  AND a.attnum > 0 AND NOT a.attisdropped
-		ORDER BY c.relname, a.attname`, "%"+credentialHandleSuffix)
+		ORDER BY c.relname, a.attname`, suffixPos), args...)
 	if err != nil {
 		return nil, fmt.Errorf("data reset: listing columns that can hold a credential handle: %w", err)
 	}


### PR DESCRIPTION
## What the function says it is for

`collectWorkspaceSecretRefs` states its own reason for existing:

> a reset that did not collect these first would leave the ciphertext resident
> and unreachable forever — **credential material outliving the wipe that was
> supposed to clear it.**

It collected from **one column name**: `vaultRefColumn = "credential_ref"`,
above a comment calling it *"the one spelling every table uses"*.

## There are three

| column | tables |
|---|---|
| `credential_ref` | `capture_`, `channel_`, `finance_`, `provider_`, `incumbent_connection` |
| `vault_ref` | `extension_secret` |
| `signing_secret_ref` | `webhook_subscription` |

So an extension's sealed API key and a webhook's signing secret **survived
every workspace reset** — precisely the outcome the function exists to prevent,
for two of the three places a handle can be written down.

## The fix keeps the derivation and corrects what it keys on

The design was already catalog-derived rather than a hand-kept list, which is
right — a new connection table enrols itself the day its column exists. It was
keyed on the wrong thing.

It now matches any text column whose name ends `_ref`, and **the vault decides**
which of those values are handles: the read joins `vault_secret`, so a candidate
is collected only if the vault holds it.

Thirteen distinct `_ref` names exist in this schema and ten are unrelated —
`evidence_ref`, `pdf_asset_ref`, `subject_ref`, `raw_ref` — and they contribute
nothing. **Over-matching is free; under-matching is what cost two tables their
wipe**, and it is the direction a derivation like this must not fail in.

`vault_secret` itself is excluded: its `ref` **is** the handle rather than a
reference to one, and joining the table to itself would collect every secret in
the installation whether or not anything still points at it.

## Why it survived — the test exercised the spelling the code knew

`TestResetPurgesTheSealedCredentialsItsSweepOrphans` sealed one credential and
put it in `incumbent_connection`. A `credential_ref` table. So it proved the
collection worked for the one name the code was written against, and **could
not fail on the two it was not**.

It now seeds one per **spelling** — `credential_ref`, `vault_ref`,
`signing_secret_ref` — asserts all three are gone from the vault by name, and
requires the audit evidence to record **three** purged rather than one.

That is the general shape, and it is the second time this week I have hit it:
*a test written alongside an implementation inherits the implementation's blind
spot.* Only exercising the cases the implementation does **not** already know
about can find this class.

## Verification

Reverting the collection to the single column name, build kept green so the
**test** is what fails:

```
--- FAIL: TestResetPurgesTheSealedCredentialsItsSweepOrphans
    the extension secret's vault_ref outlived the reset …
    the webhook subscription's signing_secret_ref outlived the reset …
```

Restored → passes. `make check` green. Full integration lane green — **3129
tests, 0 skips**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collects all credential handles during reset, not just `credential_ref`, so extension and webhook secrets are purged and `secrets_purged` reflects the true count. Previously only `credential_ref` was scanned; now any text column ending `_ref` is joined to `vault_secret`, and the duplicate provider pass is removed.

- Matches text/varchar columns ending `_ref`, joins `vault_secret` to confirm actual handles, and excludes `vault_secret` itself.
- Drops the `workspace_id` requirement when discovering handle columns (ADR-0091 phase D), so `provider_connection` is covered by the general scan.
- Deletes the provider-specific collector to prevent double-counting; updates the call-site comment to match current behavior.
- Escapes the LIKE pattern with `!` to avoid wildcard matches.
- Expands the integration test to seed three handles (`credential_ref`, `vault_ref`, `signing_secret_ref`) and asserts `secrets_purged = 3`.

<sup>Written for commit fad0999da42e9aee0835f58038231ff5dc212081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential discovery during data resets to identify supported secret references accurately.
  * Fixed matching logic to prevent unrelated references from being included.
  * Ensured vault secrets are consistently removed across connections, extensions, and webhook subscriptions.

* **Tests**
  * Expanded integration coverage to verify multiple secret types are purged and correctly recorded in audit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->