### PR TITLE
fix(frontend): the projects spec lets the server mint the key

### DIFF
--- a/frontend/e2e/projectmock.ts
+++ b/frontend/e2e/projectmock.ts
@@ -74,6 +74,10 @@ export function projectMock(input: {
 }) {
   const projects: MockProject[] = [{ ...input.seeded }];
   const history = new Map<string, Transition[]>();
+  // What this fake hands back as a newly minted key. Any well-formed key does:
+  // the assertion it serves is that the client SHOWS the key the server chose,
+  // not that this file can rederive the server's stem.
+  const MOCK_MINTED_KEY = "BE-1";
   let minted = 0;
 
   const record = (
@@ -188,7 +192,13 @@ export function projectMock(input: {
           ...input.seeded,
           id: `pr-new-${minted}`,
           name: String(body.name),
-          key: body.key ?? null,
+          // The SERVER mints this now (projects/keymint.go): a create carries
+          // no key at all, and the stem-plus-lowest-free-number rule is the
+          // server's to own. The fake deliberately does not reproduce that
+          // rule — it returns A key so the spec can prove the client renders
+          // what it was handed, and a second implementation of the stem
+          // algorithm here would drift from the real one silently.
+          key: body.key ?? MOCK_MINTED_KEY,
           organization_id: String(body.organization_id),
           owner_id: body.owner_id ?? null,
           description: body.description ?? null,

--- a/frontend/e2e/projectmock.ts
+++ b/frontend/e2e/projectmock.ts
@@ -14,6 +14,13 @@ import type { Route } from "@playwright/test";
 
 type Json = (body: unknown, status?: number) => Promise<void>;
 
+// What this fake hands back as a newly minted key. Any well-formed key does:
+// the assertion it serves is that the client SHOWS the key the server chose,
+// not that this file can rederive the server's stem (projects/keymint.go owns
+// that rule). Exported because the spec asserts on it: one spelling, so a
+// change here cannot leave the assertion quietly matching nothing.
+export const MOCK_MINTED_KEY = "BE-1";
+
 export type MockProject = {
   id: string;
   workspace_id: string;
@@ -74,10 +81,6 @@ export function projectMock(input: {
 }) {
   const projects: MockProject[] = [{ ...input.seeded }];
   const history = new Map<string, Transition[]>();
-  // What this fake hands back as a newly minted key. Any well-formed key does:
-  // the assertion it serves is that the client SHOWS the key the server chose,
-  // not that this file can rederive the server's stem.
-  const MOCK_MINTED_KEY = "BE-1";
   let minted = 0;
 
   const record = (

--- a/frontend/e2e/projects.spec.ts
+++ b/frontend/e2e/projects.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { MOCK_MINTED_KEY } from "./projectmock";
 import { mockApi } from "./seed";
 
 /**
@@ -54,7 +55,9 @@ test("a project is created, a deal is attached, the win starts delivery, the tim
   // Scoped to the mono chip: the key also appears in the prose that explains
   // what a key is for, and a bare text match would pass on the explanation
   // alone — which renders whether or not the project actually got a key.
-  await expect(page.locator(".t-mono").filter({ hasText: "BE-1" })).toBeVisible();
+  await expect(
+    page.locator(".t-mono").filter({ hasText: new RegExp(`^${MOCK_MINTED_KEY}$`) }),
+  ).toBeVisible();
   await expect(
     page.getByRole("heading", { level: 1, name: "Brandt ERP" }),
   ).toBeVisible();

--- a/frontend/e2e/projects.spec.ts
+++ b/frontend/e2e/projects.spec.ts
@@ -37,7 +37,6 @@ test("a project is created, a deal is attached, the win starts delivery, the tim
   await page.getByRole("button", { name: "Neues Projekt" }).click();
   const dialog = page.getByRole("dialog");
   await dialog.getByRole("textbox", { name: "Projektname" }).fill("Brandt ERP");
-  await dialog.getByRole("textbox", { name: "Kürzel" }).fill("BRANDT-ERP");
   await choose(
     page,
     dialog.getByRole("combobox", { name: "Unternehmen" }),
@@ -48,6 +47,14 @@ test("a project is created, a deal is attached, the win starts delivery, the tim
   // The create lands on the project's own page, born in Initiative with the
   // birth row in its history and nothing filed under it yet.
   await expect(page).toHaveURL(/#\/projects\/pr-new-1$/);
+  // The dialog never asked for a key — the server mints one — so the page must
+  // SHOW the key it was given. This is the half a create form could not prove
+  // once the field was removed: without it, a create that came back with no key
+  // at all would look exactly like a success.
+  // Scoped to the mono chip: the key also appears in the prose that explains
+  // what a key is for, and a bare text match would pass on the explanation
+  // alone — which renders whether or not the project actually got a key.
+  await expect(page.locator(".t-mono").filter({ hasText: "BE-1" })).toBeVisible();
   await expect(
     page.getByRole("heading", { level: 1, name: "Brandt ERP" }),
   ).toBeVisible();


### PR DESCRIPTION
## What broke

`main`'s **`uat`** lane is red on the projects journey:

```
e2e/projects.spec.ts:29 › a project is created, a deal is attached, the win starts
delivery, the timeline fills, and the close records its reason
    Error: locator.fill: Test timeout of 30000ms exceeded.
    at e2e/projects.spec.ts:40
```

Reproduced on a clean detached worktree at `origin/main`.

**Cause:** #2358 (`feat(projects): the server mints a project's key`) removed the key field from the create dialog — the server derives it now — and updated `projects.form.test.ts` and `projects.test.tsx` beside it, but not `e2e/projects.spec.ts`, which still does:

```ts
await dialog.getByRole("textbox", { name: "Kürzel" }).fill("BRANDT-ERP");
```

The field is gone, the fill times out, and the whole journey dies at step one.

It failed on #2358's own run and **merged anyway** (`1da948477`), then re-failed on every later PR that ran the lane — a finding on work nobody did. Same structure as the gofumpt literal in #2357, one lane over: `uat` neither gates the merge nor is re-run by `main-health`, so a break there has nowhere to be reported afterwards.

## Removing the fill is only half

The e2e mock still answered `key: body.key ?? null`, echoing a key the client no longer sends. With the fill removed and nothing else changed, the spec would have walked a create that produced a project with **no key at all** and called it a success — precisely the outcome #2358 exists to prevent.

So the fake mints one and the spec asserts the page shows it:

- **The fake deliberately does not reproduce the server's rule.** `projects/keymint.go` derives a stem from the name's initials and appends the lowest free number; a second implementation of that here would drift from the real one silently. The assertion needs only that the client renders the key it was handed.
- **The assertion is scoped to the mono chip**, not the page text: the key also appears in the prose explaining what a key is for, and that prose renders whether or not the project got one. A bare text match passed on the explanation alone (strict-mode violation: two matches).

## Verification

| | Result |
|---|---|
| `origin/main`, `e2e/projects.spec.ts` | **1 failed** — `locator.fill` timeout at line 40 |
| With this change | **1 passed** |
| With this change, `projects.spec.ts` + `ac.spec.ts` | **87 passed** |
| Mutation: fake returns `key: null` again | **1 failed** — the new assertion catches a create that lost its key |

`biome check` clean on both changed files.

Found by an hourly main-status watch; reported by a parallel session whose diff is nine shell scripts and a Makefile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the projects e2e with server-minted keys and enforces that the UI shows the exact minted key. Previously the spec filled a removed “Kürzel” field and a loose substring match could pass; now it relies on the server/mocked value and requires an exact chip match.

- Stop filling the removed key field; assert the key on the `.t-mono` chip after create.
- The mock returns `MOCK_MINTED_KEY` when `body.key` is absent; it does not reimplement the server’s rule.
- The spec imports `MOCK_MINTED_KEY` and uses an anchored regex so the test fails if the key is missing or different (e.g., “BE-10” no longer satisfies “BE-1”).

<sup>Written for commit 6e117b384ddac2efd55f3b590f5445e67e01a46e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project creation now supports automatic project-key assignment when no key is provided.
  * The generated project key is displayed after creation.

* **Tests**
  * Updated project creation coverage to verify automatic key assignment and confirm the generated key appears correctly in the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->