### PR TITLE
fix(import): a refused mapping names the fields the object accepts

### DIFF
--- a/backend/internal/compose/csvimport_test.go
+++ b/backend/internal/compose/csvimport_test.go
@@ -145,6 +145,41 @@ func TestMappingFromRefusesATargetTheObjectDoesNotHave(t *testing.T) {
 	}
 }
 
+// Both refusals below are dead ends without the vocabulary: the mapping targets
+// are a closed set that no error, schema or tool description spells out, so a
+// caller who guesses wrong has nowhere to look. An agent driving this over MCP
+// cannot open the field catalog the way a screen can.
+func TestMappingRefusalsNameTheFieldsTheObjectAccepts(t *testing.T) {
+	targets, err := importTargets(migration.ObjectOrganization)
+	if err != nil {
+		t.Fatalf("importTargets: %v", err)
+	}
+
+	cases := map[string]map[string]string{
+		// "city" reads like an obvious company field and is not one.
+		"unknown target": {"City": "city"},
+		// A header whose columns match nothing: SuggestMapping proposes
+		// nothing by design, so the caller arrives here having sent no mapping.
+		"nothing mapped": {},
+	}
+
+	for name, mapping := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := mappingFrom(migration.ObjectOrganization, crmcontracts.CreateImportRunRequest{
+				Mapping: mapping,
+			})
+			if err == nil {
+				t.Fatal("the mapping was accepted; expected a refusal")
+			}
+			for _, target := range targets {
+				if !strings.Contains(err.Error(), target) {
+					t.Errorf("the refusal does not name %q, so the caller cannot act on it: %v", target, err)
+				}
+			}
+		})
+	}
+}
+
 func TestMappingFromNeedsAColumnThatIdentifiesARow(t *testing.T) {
 	// Nothing maps to email, and no explicit source key is given, so no row
 	// could be recognized on a re-import or found by an undo.

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -43,8 +43,15 @@ func mappingFrom(object string, req crmcontracts.CreateImportRunRequest) (migrat
 	claimed := map[string]string{}
 	for column, target := range req.Mapping {
 		if !allowed[target] {
+			// The set is closed, small, and invisible from where the caller
+			// stands. Naming the target that failed without naming the ones
+			// that would have worked leaves them guessing at a list this
+			// function is already holding. `city` is the case that forces it:
+			// it reads like an obvious field on a company, is not one, and the
+			// refusal alone gives no path to the answer.
 			return migration.RunMapping{}, httperr.Validation("mapping", "unknown_target",
-				fmt.Sprintf("%q is not a field a %s can receive.", target, object))
+				fmt.Sprintf("%q is not a field a %s can receive. It takes: %s.",
+					target, object, strings.Join(targets, ", ")))
 		}
 		if other, taken := claimed[target]; taken {
 			// Two columns onto one field: whichever the row builder happened to
@@ -57,8 +64,16 @@ func mappingFrom(object string, req crmcontracts.CreateImportRunRequest) (migrat
 		fields[column] = target
 	}
 	if len(fields) == 0 {
+		// Reached two ways that feel different to a caller: they sent no
+		// mapping and the proposal came back empty, or they sent one whose
+		// columns all fell away. Either way the next move is the same and it
+		// needs the vocabulary, because a header like "Company,Website,City"
+		// matches none of these by name and the proposal is deliberately
+		// timid about guessing (migration.SuggestMapping).
 		return migration.RunMapping{}, httperr.Validation("mapping", "empty",
-			"A run with no mapped column would import nothing.")
+			fmt.Sprintf("A run with no mapped column would import nothing. "+
+				"Map at least one column onto a field a %s can receive: %s.",
+				object, strings.Join(targets, ", ")))
 	}
 
 	sourceKey := csvSourceKeyDefault[object]


### PR DESCRIPTION
## What was wrong

The CSV import mapping targets are a closed set of five fields per object, and nothing a caller can see spells them out — not the refusal, not the tool schema, not the tool description. Both ways a mapping can fail ended in a dead end.

Found while driving the import chain over MCP against a live server.

**`city` is the case that forces it.** It reads like an obvious field on a company, is not one, and the old refusal read:

```
"city" is not a field a organization can receive.
```

That gives no path to the answer — the address fields are not importable at all, and the caller has no way to learn what to write instead.

**The empty case is worse.** A header like `Company,Website,City` matches no target by name, and `migration.SuggestMapping` is deliberately timid (exact normalized-name matches only). So a caller who sends no mapping — exactly as the tool schema invites, *"Omit to accept the proposal this call would make"* — gets:

```
A run with no mapped column would import nothing.
```

No mention of the columns it saw, or of the fields it would have taken.

## What changed

Both refusals in `mappingFrom` now carry the accepted list, which the function is already holding from `importTargets(object)`:

```
"city" is not a field a organization can receive. It takes: display_name,
legal_name, industry, size_band, description.
```

An agent driving this over MCP cannot open the field catalog the way a screen can, so the error is the only place the vocabulary can reach it.

## Test

`TestMappingRefusalsNameTheFieldsTheObjectAccepts` covers both paths and asserts every accepted target is named. Verified it fails against the old code and passes against the new.

## Not in this change

`preview_import` itself is unchanged — it already merges `SuggestedMapping` with the caller's mapping. The proposal being empty for a header like `Company,Website,City` is `SuggestMapping`'s documented timidity, not a wiring gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refused CSV import mappings now list the fields an object accepts, so callers can fix mappings without external docs. Previously, unknown-target and empty-mapping errors gave no guidance; now both include the allowed targets for that object.

- `mappingFrom` adds the accepted target list from `importTargets(object)` to errors for unknown targets and empty mappings.
- Adds `TestMappingRefusalsNameTheFieldsTheObjectAccepts` to assert all accepted targets are named in both paths.
- No changes to `preview_import`; `migration.SuggestMapping` remains conservative by design.

<sup>Written for commit 589fc28939878344636ea2aaa57d9fcfb2066881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import validation messages for unknown or missing column mappings.
  * Error messages now identify the invalid target, object type, and all valid target fields, making corrections easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->