### PR TITLE
feat(frontend): a commission can be approved, paid and reversed from the panel

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -292,6 +292,7 @@ export const de = {
   "commission.status.void": "Storniert",
   "commission.outstanding": "Noch offen",
   "commission.column.actions": "Entscheidung",
+  "commission.decide.withheld": "Nicht Ihre Entscheidung",
   "commission.decide.approve": "Freigeben",
   "commission.decide.pay": "Als ausgezahlt markieren",
   "commission.decide.void": "Stornieren",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -290,6 +290,25 @@ export const de = {
   "commission.status.approved": "Freigegeben",
   "commission.status.paid": "Ausgezahlt",
   "commission.status.void": "Storniert",
+  "commission.outstanding": "Noch offen",
+  "commission.column.actions": "Entscheidung",
+  "commission.decide.approve": "Freigeben",
+  "commission.decide.pay": "Als ausgezahlt markieren",
+  "commission.decide.void": "Stornieren",
+  "commission.decide.approveConfirm":
+    "Mit der Freigabe halten Sie fest, dass diese Provision vereinbart ist. Ausgezahlt wird dadurch nichts — zahlen Sie in Ihrem Finanzsystem und markieren Sie es danach hier.",
+  "commission.decide.payConfirm":
+    "Markieren Sie erst als ausgezahlt, wenn Ihr Finanzsystem tatsächlich gezahlt hat. Margince hält die Tatsache fest und bewegt kein Geld.",
+  "commission.decide.voidConfirm":
+    "Eine Stornierung schreibt eine Gegenbuchung daneben. Nichts wird gelöscht, der ursprüngliche Eintrag bleibt lesbar.",
+  "commission.decide.reasonLabel": "Warum wird storniert?",
+  "commission.decide.reasonRequired":
+    "Eine Stornierung braucht einen Grund — damit lässt sie sich dem Partner später erklären.",
+  "commission.decide.approved": "Provision freigegeben",
+  "commission.decide.paid": "Provision als ausgezahlt markiert",
+  "commission.decide.voided": "Provision storniert",
+  "commission.decide.settledElsewhere":
+    "Ausgezahlt wird im Finanzsystem. Hier wird festgehalten, was dort passiert ist.",
   "partner.setup": "Zum Partner machen",
   "partner.edit": "Partner bearbeiten",
   "partner.none": "Noch kein Partner",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -306,6 +306,7 @@ export const en = {
   "commission.status.void": "Reversed",
   "commission.outstanding": "Still owed",
   "commission.column.actions": "Decision",
+  "commission.decide.withheld": "Not yours to decide",
   "commission.decide.approve": "Approve",
   "commission.decide.pay": "Mark as paid",
   "commission.decide.void": "Reverse",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -304,6 +304,25 @@ export const en = {
   "commission.status.approved": "Approved",
   "commission.status.paid": "Paid",
   "commission.status.void": "Reversed",
+  "commission.outstanding": "Still owed",
+  "commission.column.actions": "Decision",
+  "commission.decide.approve": "Approve",
+  "commission.decide.pay": "Mark as paid",
+  "commission.decide.void": "Reverse",
+  "commission.decide.approveConfirm":
+    "Approving records that this commission is agreed. It does not pay anything — settle the payment in your finance system, then mark it paid here.",
+  "commission.decide.payConfirm":
+    "Mark this as paid once your finance system has actually paid it. Margince records the fact; it does not move money.",
+  "commission.decide.voidConfirm":
+    "Reversing writes a cancelling row beside this one. Nothing is deleted, and the original stays readable.",
+  "commission.decide.reasonLabel": "Why is it reversed?",
+  "commission.decide.reasonRequired":
+    "A reversal needs a reason — it is what explains the entry to the partner later.",
+  "commission.decide.approved": "Commission approved",
+  "commission.decide.paid": "Commission marked as paid",
+  "commission.decide.voided": "Commission reversed",
+  "commission.decide.settledElsewhere":
+    "Paying happens in your finance system. This records what it did.",
   "partner.setup": "Make this a partner",
   "partner.edit": "Edit partner",
   "partner.none": "Not a partner yet",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -297,6 +297,7 @@ export const vi = {
   "commission.status.void": "Đã đảo",
   "commission.outstanding": "Còn nợ",
   "commission.column.actions": "Quyết định",
+  "commission.decide.withheld": "Không thuộc quyền quyết định của bạn",
   "commission.decide.approve": "Duyệt",
   "commission.decide.pay": "Đánh dấu đã thanh toán",
   "commission.decide.void": "Đảo",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -295,6 +295,25 @@ export const vi = {
   "commission.status.approved": "Đã duyệt",
   "commission.status.paid": "Đã thanh toán",
   "commission.status.void": "Đã đảo",
+  "commission.outstanding": "Còn nợ",
+  "commission.column.actions": "Quyết định",
+  "commission.decide.approve": "Duyệt",
+  "commission.decide.pay": "Đánh dấu đã thanh toán",
+  "commission.decide.void": "Đảo",
+  "commission.decide.approveConfirm":
+    "Duyệt là ghi nhận rằng khoản hoa hồng này đã được thống nhất. Việc này không thanh toán gì — hãy thanh toán trong hệ thống tài chính rồi đánh dấu tại đây.",
+  "commission.decide.payConfirm":
+    "Chỉ đánh dấu đã thanh toán khi hệ thống tài chính thực sự đã trả. Margince ghi nhận sự việc, không chuyển tiền.",
+  "commission.decide.voidConfirm":
+    "Đảo sẽ ghi một dòng hủy bên cạnh dòng này. Không có gì bị xóa và bản gốc vẫn đọc được.",
+  "commission.decide.reasonLabel": "Vì sao đảo?",
+  "commission.decide.reasonRequired":
+    "Một khoản đảo cần có lý do — đó là điều giải thích được với đối tác sau này.",
+  "commission.decide.approved": "Đã duyệt hoa hồng",
+  "commission.decide.paid": "Đã đánh dấu hoa hồng là đã thanh toán",
+  "commission.decide.voided": "Đã đảo hoa hồng",
+  "commission.decide.settledElsewhere":
+    "Việc thanh toán diễn ra trong hệ thống tài chính. Ở đây chỉ ghi nhận điều đó.",
   "partner.setup": "Đặt làm đối tác",
   "partner.edit": "Sửa đối tác",
   "partner.none": "Chưa phải đối tác",

--- a/frontend/src/screens/commissiondecide.tsx
+++ b/frontend/src/screens/commissiondecide.tsx
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ifMatch } from "../api/version";
+import { Button, Field, Modal, Textarea } from "../design-system/atoms";
+import { useToast } from "../design-system/toast";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, throwProblem } from "./common";
+
+// Moving one commission entry through the ledger's lifecycle.
+//
+// MARGINCE DOES NOT PAY ANYBODY. Paying a partner happens in a finance system
+// and always will; what this records is what that system already did. The copy
+// says so at the point of the decision rather than in a doc nobody opens,
+// because "Mark as paid" beside a money figure reads like a payment button and
+// exactly once is enough for somebody to believe it.
+//
+// The three transitions are the store's, not this file's opinion of them
+// (commissions/decide.go, legalTransitions): accrued may be approved, approved
+// may be paid, and anything still live may be reversed. Offering a fourth here
+// would put a control on screen the server refuses.
+
+type CommissionEntry = components["schemas"]["CommissionEntry"];
+type Decision = "approve" | "pay" | "void";
+
+// What each decision is called, what it says before you commit, and the
+// confirmation it leaves behind.
+const DECISION_COPY: Record<
+  Decision,
+  { label: MessageKey; confirm: MessageKey; done: MessageKey }
+> = {
+  approve: {
+    label: "commission.decide.approve",
+    confirm: "commission.decide.approveConfirm",
+    done: "commission.decide.approved",
+  },
+  pay: {
+    label: "commission.decide.pay",
+    confirm: "commission.decide.payConfirm",
+    done: "commission.decide.paid",
+  },
+  void: {
+    label: "commission.decide.void",
+    confirm: "commission.decide.voidConfirm",
+    done: "commission.decide.voided",
+  },
+};
+
+/**
+ * decisionsFor names what this entry's CURRENT state admits.
+ *
+ * It mirrors `legalTransitions` in the commissions store. A control the server
+ * would refuse is worse than a missing one: the reader presses it, gets a 422,
+ * and learns the rule from a refusal instead of from the screen.
+ */
+export function decisionsFor(status: CommissionEntry["status"]): Decision[] {
+  switch (status) {
+    case "accrued":
+      return ["approve", "void"];
+    case "approved":
+      return ["pay", "void"];
+    // A paid entry can still be reversed — money going out and coming back is
+    // a thing that happens, and the reversal row is the record of it.
+    case "paid":
+      return ["void"];
+    // Void is terminal. Nothing follows it, which is what makes the ledger
+    // readable a year later.
+    default:
+      return [];
+  }
+}
+
+async function decide(
+  entry: CommissionEntry,
+  decision: Decision,
+  reason: string,
+): Promise<CommissionEntry> {
+  const { data, error } = await api.POST("/commissions/{id}/decide", {
+    params: {
+      path: { id: entry.id },
+      // The entry carries its own version, so two people deciding the same
+      // row at once get a 409 rather than the second one silently winning.
+      ...ifMatch(entry.version ?? 0),
+    },
+    body: {
+      decision,
+      // Only void takes a reason, and the server requires it. Sending an
+      // empty string on the other two would be a value nobody asked for.
+      ...(decision === "void" ? { reason } : {}),
+    },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+/**
+ * CommissionDecision is one verb on one ledger row: the trigger, the confirm
+ * step a money decision deserves, and the write.
+ *
+ * Every decision confirms. None of these is reversible by pressing the same
+ * button again — approve and pay move forward only, and void is terminal — so
+ * there is no state where a misclick costs nothing.
+ */
+export function CommissionDecision({
+  entry,
+  decision,
+  organizationId,
+}: Readonly<{
+  entry: CommissionEntry;
+  decision: Decision;
+  organizationId: string;
+}>) {
+  const t = useT();
+  const { show: showToast } = useToast();
+  const queryClient = useQueryClient();
+  const headingId = useId();
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  // Only shown after a submit is attempted: a required-field message that
+  // appears while the reader is still typing is telling them off for not
+  // having finished.
+  const [showReasonFault, setShowReasonFault] = useState(false);
+
+  const copy = DECISION_COPY[decision];
+  const needsReason = decision === "void";
+  const reasonGiven = reason.trim() !== "";
+
+  const mutation = useMutation({
+    mutationFn: () => decide(entry, decision, reason.trim()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["partner-commissions", organizationId],
+      });
+      // The liability figure on the same page is derived from these rows, so
+      // it goes stale the moment one moves.
+      queryClient.invalidateQueries({
+        queryKey: ["commission-summary", organizationId],
+      });
+      setOpen(false);
+      setReason("");
+      setShowReasonFault(false);
+      showToast(t(copy.done));
+    },
+  });
+
+  function submit() {
+    if (needsReason && !reasonGiven) {
+      setShowReasonFault(true);
+      return;
+    }
+    mutation.mutate();
+  }
+
+  return (
+    <>
+      <Button
+        small
+        variant={decision === "void" ? "danger" : "primary"}
+        onClick={() => setOpen(true)}
+        data-testid={`commission-${decision}`}
+      >
+        {t(copy.label)}
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)} labelledBy={headingId}>
+        <h2
+          id={headingId}
+          className="t-h2"
+          style={{ marginBottom: "var(--space-3)" }}
+        >
+          {t(copy.label)}
+        </h2>
+        <p style={{ marginBottom: "var(--space-4)" }}>{t(copy.confirm)}</p>
+        {needsReason && (
+          <div style={{ marginBottom: "var(--space-4)" }}>
+            <Field
+              label={t("commission.decide.reasonLabel")}
+              required
+              error={
+                showReasonFault && !reasonGiven
+                  ? t("commission.decide.reasonRequired")
+                  : undefined
+              }
+            >
+              {(control) => (
+                <Textarea
+                  {...control}
+                  value={reason}
+                  rows={3}
+                  onChange={(e) => setReason(e.target.value)}
+                  data-testid="commission-void-reason"
+                />
+              )}
+            </Field>
+          </div>
+        )}
+        {mutation.isError && (
+          // role="alert" so a refused decision is announced: the dialog stays
+          // open either way, and without this the only difference between "it
+          // failed" and "it is still working" is a line of red text.
+          <p
+            className="t-caption"
+            role="alert"
+            style={{ color: "var(--danger)" }}
+          >
+            {problemMessageOf(mutation.error, t)}
+          </p>
+        )}
+        <div className="actions">
+          <Button
+            small
+            onClick={() => setOpen(false)}
+            disabled={mutation.isPending}
+          >
+            {t("create.cancel")}
+          </Button>
+          <Button
+            small
+            variant={decision === "void" ? "danger" : "primary"}
+            onClick={submit}
+            pending={mutation.isPending}
+            data-testid={`commission-${decision}-confirm`}
+          >
+            {t(copy.label)}
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/screens/commissiondecide.tsx
+++ b/frontend/src/screens/commissiondecide.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -10,7 +10,12 @@ import { Button, Field, Modal, Textarea } from "../design-system/atoms";
 import { useToast } from "../design-system/toast";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { problemMessageOf, throwProblem } from "./common";
+import {
+  isVersionSkew,
+  ProblemError,
+  problemMessageOf,
+  throwProblem,
+} from "./common";
 
 // Moving one commission entry through the ledger's lifecycle.
 //
@@ -122,6 +127,10 @@ export function CommissionDecision({
   const queryClient = useQueryClient();
   const headingId = useId();
   const [open, setOpen] = useState(false);
+  // Where focus goes when the dialog closes. On success the row re-renders
+  // into its new status and the verb that opened this is gone, so without a
+  // named target a keyboard reader is dropped to the top of the document.
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const [reason, setReason] = useState("");
   // Only shown after a submit is attempted: a required-field message that
   // appears while the reader is still typing is telling them off for not
@@ -134,14 +143,25 @@ export function CommissionDecision({
 
   const mutation = useMutation({
     mutationFn: () => decide(entry, decision, reason.trim()),
+    onError: (err) => {
+      // A 409 means somebody else moved this entry while the dialog was open,
+      // so the version in hand is stale and pressing again resends it. Refetch
+      // so the retry carries the version the server now holds, and say what
+      // happened rather than showing the server's own "apply commission
+      // decision: version skew".
+      if (err instanceof ProblemError && isVersionSkew(err.problem)) {
+        queryClient.invalidateQueries({
+          queryKey: ["partner-commissions", organizationId],
+        });
+      }
+    },
     onSuccess: () => {
+      // One key, because the outstanding figure above the ledger is derived
+      // from these same rows rather than fetched separately — invalidating a
+      // second key nothing reads would be a line that looks like caution and
+      // does nothing.
       queryClient.invalidateQueries({
         queryKey: ["partner-commissions", organizationId],
-      });
-      // The liability figure on the same page is derived from these rows, so
-      // it goes stale the moment one moves.
-      queryClient.invalidateQueries({
-        queryKey: ["commission-summary", organizationId],
       });
       setOpen(false);
       setReason("");
@@ -161,6 +181,7 @@ export function CommissionDecision({
   return (
     <>
       <Button
+        ref={triggerRef}
         small
         variant={decision === "void" ? "danger" : "primary"}
         onClick={() => setOpen(true)}
@@ -168,7 +189,25 @@ export function CommissionDecision({
       >
         {t(copy.label)}
       </Button>
-      <Modal open={open} onClose={() => setOpen(false)} labelledBy={headingId}>
+      <Modal
+        open={open}
+        // A write in flight refuses the dismissal too, not only the Cancel
+        // button. Escape and the backdrop reach past a disabled button, and
+        // closing here would hide the dialog without cancelling the POST —
+        // leaving the row's other verb clickable and two conflicting
+        // decisions racing. If-Match stops both committing; which one wins
+        // would be luck.
+        onClose={() => {
+          if (!mutation.isPending) {
+            setOpen(false);
+          }
+        }}
+        labelledBy={headingId}
+        // On success the row re-renders into its new status and the verb that
+        // opened this is gone, so a keyboard reader would be dropped to the
+        // top of the document without a named target.
+        returnFocusTo={() => triggerRef.current}
+      >
         <h2
           id={headingId}
           className="t-h2"
@@ -209,7 +248,10 @@ export function CommissionDecision({
             role="alert"
             style={{ color: "var(--danger)" }}
           >
-            {problemMessageOf(mutation.error, t)}
+            {mutation.error instanceof ProblemError &&
+            isVersionSkew(mutation.error.problem)
+              ? t("edit.versionSkew")
+              : problemMessageOf(mutation.error, t)}
           </p>
         )}
         <div className="actions">

--- a/frontend/src/screens/partnercommissions.test.tsx
+++ b/frontend/src/screens/partnercommissions.test.tsx
@@ -41,13 +41,40 @@ function render(ui: ReactNode) {
   );
 }
 
-function stubCommissions(entries: unknown[]) {
+// The principal the decision controls ask about. `useCanWrite` folds two
+// questions — does this role hold the grant, and is this a full seat — so a
+// double answering only one of them would let a control through that the real
+// page refuses.
+function me(mayDecide: boolean) {
+  return {
+    user: { id: "u1" },
+    authorization: {
+      seat_type: mayDecide ? "full" : "read_only",
+      objects: {
+        commission: {
+          create: false,
+          read: true,
+          update: mayDecide,
+          delete: false,
+        },
+      },
+    },
+  };
+}
+
+// Routes /me separately from the ledger: answering both from one payload is
+// how a capability check ends up reading a commission page and silently
+// deciding nobody may do anything.
+function stubCommissions(entries: unknown[], mayDecide = true) {
   const urls: string[] = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: Request) => {
       urls.push(request.url);
-      return new Response(JSON.stringify({ data: entries, page: {} }), {
+      const body = new URL(request.url).pathname.endsWith("/me")
+        ? me(mayDecide)
+        : { data: entries, page: {} };
+      return new Response(JSON.stringify(body), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -239,6 +266,9 @@ describe("deciding a commission entry", () => {
 
     render(<PartnerCommissions organizationId="o-1" />);
     await screen.findByTestId("commission-ledger");
+    // The seat snapshot is its own query, so the verbs appear a tick after
+    // the rows do.
+    await screen.findByTestId("commission-approve");
 
     expect(screen.getByTestId("commission-approve")).toBeTruthy();
     expect(screen.getByTestId("commission-void")).toBeTruthy();
@@ -261,6 +291,7 @@ describe("deciding a commission entry", () => {
 
     render(<PartnerCommissions organizationId="o-1" />);
     await screen.findByTestId("commission-ledger");
+    await screen.findByTestId("commission-approve");
     const before = urls.length;
     await act(async () => {
       screen.getByTestId("commission-approve").click();
@@ -316,5 +347,34 @@ describe("the outstanding figure", () => {
     const strip = await screen.findByTestId("commission-outstanding");
 
     expect(strip.textContent).toContain("€200.00");
+  });
+});
+
+// A permission denial is WITHHELD, not absent (design-system README, "Absent,
+// disabled, or withheld — decided by CAUSE"). An empty cell and a refused one
+// make the same shape on screen and mean opposite things: nothing to decide
+// here, versus not yours to decide.
+describe("a reader who may not decide", () => {
+  it("is told the decision is withheld rather than shown controls that 403", async () => {
+    stubCommissions([accrued], false);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    await screen.findByTestId("commission-ledger");
+    await screen.findByTestId("commission-withheld");
+
+    // The verbs are gone, and something stands in their place saying why.
+    expect(screen.queryByTestId("commission-approve")).toBeNull();
+    expect(screen.queryByTestId("commission-void")).toBeNull();
+  });
+
+  it("gets an empty cell on a row with nothing to decide, not a withheld note", async () => {
+    // Void is terminal for everybody, so the reason this cell is empty is the
+    // entry's state and not the reader's grant.
+    stubCommissions([{ ...accrued, status: "void" }], false);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    await screen.findByTestId("commission-ledger");
+
+    expect(screen.queryByTestId("commission-withheld")).toBeNull();
   });
 });

--- a/frontend/src/screens/partnercommissions.test.tsx
+++ b/frontend/src/screens/partnercommissions.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  act,
   cleanup,
   render as rtlRender,
   screen,
@@ -8,8 +9,17 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { formatRate, PartnerCommissions } from "./partnercommissions";
+
+type CommissionEntry = components["schemas"]["CommissionEntry"];
+
+import { decisionsFor } from "./commissiondecide";
+import {
+  formatRate,
+  outstandingByCurrency,
+  PartnerCommissions,
+} from "./partnercommissions";
 
 // The commission panel on a partner's company page: what the margin tier one
 // card up has actually produced. A tier shown without the money it earned is a
@@ -46,7 +56,7 @@ function stubCommissions(entries: unknown[]) {
   return urls;
 }
 
-const accrued = {
+const accrued: CommissionEntry = {
   id: "c-1",
   deal_id: "d-1",
   partner_org_id: "o-1",
@@ -199,5 +209,112 @@ describe("formatRate", () => {
   // decimal point, which is the kind of wrong that reads as a different number.
   it("writes the separator the reader's locale uses", () => {
     expect(formatRate(1250, "de")).toContain(",");
+  });
+});
+
+// What a reader may DO to an entry, and what the ledger's own lifecycle admits.
+//
+// The rules live in the commissions store (legalTransitions) and decisionsFor
+// mirrors them. Getting the mirror wrong puts a control on screen the server
+// refuses, so the reader learns the rule from a 422 instead of from the page.
+describe("deciding a commission entry", () => {
+  it("offers approve and reverse on an accrued entry, and not pay", () => {
+    expect(decisionsFor("accrued")).toEqual(["approve", "void"]);
+  });
+
+  it("offers pay once it is approved, and never approve twice", () => {
+    expect(decisionsFor("approved")).toEqual(["pay", "void"]);
+  });
+
+  it("still lets a paid entry be reversed — money goes out and comes back", () => {
+    expect(decisionsFor("paid")).toEqual(["void"]);
+  });
+
+  it("offers nothing on a reversed entry, because void is terminal", () => {
+    expect(decisionsFor("void")).toEqual([]);
+  });
+
+  it("puts the approve control on an accrued row", async () => {
+    stubCommissions([accrued]);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    await screen.findByTestId("commission-ledger");
+
+    expect(screen.getByTestId("commission-approve")).toBeTruthy();
+    expect(screen.getByTestId("commission-void")).toBeTruthy();
+    // Paying something nobody approved is the transition the ledger refuses.
+    expect(screen.queryByTestId("commission-pay")).toBeNull();
+  });
+
+  it("draws no decision control on a reversed row", async () => {
+    stubCommissions([{ ...accrued, status: "void" }]);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    await screen.findByTestId("commission-ledger");
+
+    expect(screen.queryByTestId("commission-approve")).toBeNull();
+    expect(screen.queryByTestId("commission-void")).toBeNull();
+  });
+
+  it("confirms before it writes — a money decision never fires on one click", async () => {
+    const urls = stubCommissions([accrued]);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    await screen.findByTestId("commission-ledger");
+    const before = urls.length;
+    await act(async () => {
+      screen.getByTestId("commission-approve").click();
+    });
+
+    // The dialog is up and nothing has been sent.
+    expect(screen.getByTestId("commission-approve-confirm")).toBeTruthy();
+    expect(urls.length).toBe(before);
+  });
+});
+
+// What is still OWED, which is the figure somebody running the programme opens
+// this panel for.
+describe("the outstanding figure", () => {
+  it("counts accrued and approved, and neither paid nor reversed", () => {
+    const owed = outstandingByCurrency([
+      { ...accrued, status: "accrued", amount_minor: 20000 },
+      { ...accrued, id: "c-2", status: "approved", amount_minor: 5000 },
+      { ...accrued, id: "c-3", status: "paid", amount_minor: 99900 },
+      { ...accrued, id: "c-4", status: "void", amount_minor: 99900 },
+    ]);
+
+    expect(owed).toEqual([{ currency: "EUR", amountMinor: 25000 }]);
+  });
+
+  it("keeps currencies apart rather than adding them", () => {
+    const owed = outstandingByCurrency([
+      { ...accrued, amount_minor: 20000, currency: "EUR" },
+      { ...accrued, id: "c-2", amount_minor: 3000, currency: "USD" },
+    ]);
+
+    // Two slots, not one sum: EUR 200 plus USD 30 is not 230 of anything.
+    expect(owed).toEqual([
+      { currency: "EUR", amountMinor: 20000 },
+      { currency: "USD", amountMinor: 3000 },
+    ]);
+  });
+
+  it("draws nothing when every entry is settled", async () => {
+    stubCommissions([{ ...accrued, status: "paid" }]);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    await screen.findByTestId("commission-ledger");
+
+    // A slot reading "0" spends a slot saying there is nothing to say.
+    expect(screen.queryByTestId("commission-outstanding")).toBeNull();
+  });
+
+  it("shows what is owed when something is", async () => {
+    stubCommissions([accrued]);
+
+    render(<PartnerCommissions organizationId="o-1" />);
+    const strip = await screen.findByTestId("commission-outstanding");
+
+    expect(strip.textContent).toContain("€200.00");
   });
 });

--- a/frontend/src/screens/partnercommissions.tsx
+++ b/frontend/src/screens/partnercommissions.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
 import { Badge, DataTable, EmptyState, StatCard } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { StatStrip } from "../design-system/statstrip";
 import { formatMoney, INTL_LOCALE } from "../format/format";
-
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { CommissionDecision, decisionsFor } from "./commissiondecide";
@@ -188,6 +188,21 @@ function CommissionLedger({
   organizationId: string;
 }>) {
   const t = useT();
+  // The object grant decides whether the verbs are drawn at all. Without this
+  // a read-only seat sees Approve and Reverse on every row and learns from a
+  // 403 that they were never theirs — a control nobody may press is not a
+  // control, it is a promise the server breaks.
+  //
+  // WITHHELD, not absent: the column keeps its place and says the decision is
+  // not this reader's. Dropping it would leave a reader unable to tell "there
+  // is nothing to decide here" from "you may not decide it", which are
+  // opposite facts that make the same shape on screen.
+  //
+  // The object grant is the half a client can know. Row scope is the server's
+  // — a `read` share of the deal carries no authority over its partner's money
+  // (decide.go's write probe) — so a grant-holder can still be refused, and
+  // the dialog surfaces that refusal rather than pretending it cannot happen.
+  const canDecide = useCanWrite("commission", "update");
   return (
     <div data-testid="commission-ledger">
       <DataTable
@@ -240,18 +255,33 @@ function CommissionLedger({
             // there is no precondition the reader could clear.
             key: "decision",
             header: t("commission.column.actions"),
-            render: (entry) => (
-              <div style={{ display: "flex", gap: "var(--space-2)" }}>
-                {decisionsFor(entry.status).map((decision) => (
-                  <CommissionDecision
-                    key={decision}
-                    entry={entry}
-                    decision={decision}
-                    organizationId={organizationId}
-                  />
-                ))}
-              </div>
-            ),
+            render: (entry) => {
+              const decisions = decisionsFor(entry.status);
+              if (decisions.length === 0) {
+                // Terminal or settled: there is genuinely nothing to decide,
+                // and that is a different fact from being refused.
+                return null;
+              }
+              if (!canDecide) {
+                return (
+                  <span className="t-caption" data-testid="commission-withheld">
+                    {t("commission.decide.withheld")}
+                  </span>
+                );
+              }
+              return (
+                <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                  {decisions.map((decision) => (
+                    <CommissionDecision
+                      key={decision}
+                      entry={entry}
+                      decision={decision}
+                      organizationId={organizationId}
+                    />
+                  ))}
+                </div>
+              );
+            },
           },
         ]}
       />

--- a/frontend/src/screens/partnercommissions.tsx
+++ b/frontend/src/screens/partnercommissions.tsx
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { Badge, DataTable, EmptyState } from "../design-system/atoms";
+import { Badge, DataTable, EmptyState, StatCard } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
+import { StatStrip } from "../design-system/statstrip";
 import { formatMoney, INTL_LOCALE } from "../format/format";
 
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { CommissionDecision, decisionsFor } from "./commissiondecide";
 import { QueryGate, throwProblem } from "./common";
 import { EntityRef } from "./entityref";
 
@@ -67,6 +69,38 @@ async function fetchPartnerCommissions(
 }
 
 /**
+ * outstandingByCurrency totals what is still OWED, per currency.
+ *
+ * Accrued and approved are both money this partner has not been paid; paid is
+ * settled and void is money that came back, so neither counts. Never summed
+ * ACROSS currencies — the schema's own summary row says why, and two currencies
+ * added together is a number that means nothing.
+ *
+ * Derived from the entries already on screen rather than from
+ * GET /commissions/summary: that endpoint answers for every partner at once and
+ * this panel is about one, so a second request would fetch the whole ledger to
+ * show a subset of what is already here — and the two could disagree while one
+ * of them was stale.
+ */
+export function outstandingByCurrency(
+  entries: CommissionEntry[],
+): Array<{ currency: string; amountMinor: number }> {
+  const totals = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.status !== "accrued" && entry.status !== "approved") {
+      continue;
+    }
+    totals.set(
+      entry.currency,
+      (totals.get(entry.currency) ?? 0) + entry.amount_minor,
+    );
+  }
+  return [...totals.entries()]
+    .map(([currency, amountMinor]) => ({ currency, amountMinor }))
+    .sort((a, b) => a.currency.localeCompare(b.currency));
+}
+
+/**
  * PartnerCommissions lists what this partner earned, newest first.
  *
  * A reversal keeps its own row rather than being folded into the entry it
@@ -93,7 +127,12 @@ export function PartnerCommissions({
             </PanelBody>
           ) : (
             <PanelBody>
-              <CommissionLedger entries={entries} locale={locale} />
+              <OutstandingStrip entries={entries} locale={locale} />
+              <CommissionLedger
+                entries={entries}
+                locale={locale}
+                organizationId={organizationId}
+              />
             </PanelBody>
           )
         }
@@ -102,12 +141,51 @@ export function PartnerCommissions({
   );
 }
 
+/**
+ * OutstandingStrip is the one figure somebody running the programme opens this
+ * panel for: what is still owed.
+ *
+ * One slot per currency, because they are not addable. Nothing is drawn when
+ * everything is settled — a strip reading "0" is a slot spent saying there is
+ * nothing to say, and the ledger below already shows the entries are paid.
+ */
+function OutstandingStrip({
+  entries,
+  locale,
+}: Readonly<{ entries: CommissionEntry[]; locale: Locale }>) {
+  const t = useT();
+  const outstanding = outstandingByCurrency(entries);
+  if (outstanding.length === 0) {
+    return null;
+  }
+  return (
+    <div
+      data-testid="commission-outstanding"
+      style={{ marginBottom: "var(--space-4)" }}
+    >
+      <StatStrip>
+        {outstanding.map(({ currency, amountMinor }) => (
+          <StatCard
+            key={currency}
+            numeric
+            label={t("commission.outstanding")}
+            value={formatMoney(amountMinor, currency, locale)}
+            detail={t("commission.decide.settledElsewhere")}
+          />
+        ))}
+      </StatStrip>
+    </div>
+  );
+}
+
 function CommissionLedger({
   entries,
   locale,
+  organizationId,
 }: Readonly<{
   entries: CommissionEntry[];
   locale: Locale;
+  organizationId: string;
 }>) {
   const t = useT();
   return (
@@ -152,6 +230,27 @@ function CommissionLedger({
               <Badge tone={STATUS_TONES[entry.status]} quiet>
                 {t(STATUS_LABELS[entry.status])}
               </Badge>
+            ),
+          },
+          {
+            // Only what this row's state actually admits — decisionsFor
+            // mirrors the store's legalTransitions, so a control here is one
+            // the server will accept. A settled or reversed row offers
+            // nothing and renders an empty cell rather than a disabled verb:
+            // there is no precondition the reader could clear.
+            key: "decision",
+            header: t("commission.column.actions"),
+            render: (entry) => (
+              <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                {decisionsFor(entry.status).map((decision) => (
+                  <CommissionDecision
+                    key={decision}
+                    entry={entry}
+                    decision={decision}
+                    organizationId={organizationId}
+                  />
+                ))}
+              </div>
             ),
           },
         ]}


### PR DESCRIPTION
Closes #2143. Also delivers the open-liability tile that had no issue.

## What it does

The Commission panel showed four statuses and offered no way to reach three of them. Every entry sat at Accrued forever, so the ledger could not be reconciled against what finance had actually paid.

Three verbs now, offered only where the ledger admits them.

## Margince does not pay anybody

Per Lars's ruling: this is a CRM, not a financial tool. Paying a partner happens in a finance system and always will — what this records is what that system already did.

The copy says so at the point of the decision rather than in a doc nobody opens. "Mark as paid" beside a money figure reads like a payment button, and once is enough for somebody to believe it.

## The transitions are the store's, not the UI's opinion

`decisionsFor` mirrors `legalTransitions` in [commissions/decide.go](backend/internal/modules/commissions/decide.go): accrued may be approved, approved may be paid, anything still live may be reversed, void is terminal. Codex verified the two match exactly.

A control the server would refuse is worse than a missing one — the reader presses it, gets a 422, and learns the rule from a refusal instead of from the screen.

## Also: what is still owed

A `StatStrip` above the ledger. Accrued and approved count; paid and reversed do not. One slot per currency and never a sum across them.

Derived from the entries already loaded rather than from `GET /commissions/summary`, which answers for every partner at once: a second request would fetch the whole ledger to show a subset of what is on screen, and the two could disagree while one was stale. The fetch follows every page, so the total cannot under-report.

## Review findings, all addressed

Codex found six. Four fixed in the second commit:

1. **A read-only seat saw all three buttons** and got a 403 from each. Now gated on `useCanWrite("commission", "update")`, rendering **withheld** rather than nothing — per the design system's absent/disabled/withheld rule, an empty cell and a refused one mean opposite things.
2. **Escape and the backdrop dismissed a dialog mid-write**, freeing the row's other verb so two conflicting decisions could race.
3. **A 409 left the reader resending the stale version.** Now refetches and shows `edit.versionSkew`.
4. **Focus was dropped after success**, since the verb that opened the dialog is gone by then.

Plus a dead `["commission-summary"]` invalidation that nothing queries.

Two needed no change: the transition parity above, and the pagination.

## Gates

`make check-fe` exit 0 · `make craft-static` 0/0/0 · 22 vitest tests, mutation-checked on both the transition guard and the withheld gate · no e2e spec touches commissions, so no German strings at risk

Backend untouched — zero Go files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add approve, mark-as-paid, and reverse actions to the partner commission panel so finance reconciliation matches what was actually settled. Previously entries stayed Accrued with no actions; now actions appear only when legal and record what the finance system already did.

- Offers actions per state: Accrued → Approve/Reverse; Approved → Mark as paid/Reverse; Paid → Reverse; Reversed is terminal. UI mirrors backend legal transitions.
- Confirms every action. Reverse requires a reason. Prevents dismissing while a write is in flight and returns focus after success.
- Gates actions by `useCanWrite("commission", "update")`. Shows “Not yours to decide” when withheld. Terminal rows render an empty cell.
- Adds an outstanding strip above the ledger, derived from loaded entries: sums Accrued and Approved only, per currency, never cross-currency.
- Handles 409 version skew by refetching and showing the existing version-skew message. Invalidates only `["partner-commissions", organizationId]`. No backend changes.
- Updates copy in `en`, `de`, and `vi`. Adds tests for transition rules, outstanding totals, and withheld gating.

<sup>Written for commit ec616903f5d5dc2c82059c6ad25c37f7c53400bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commission workflow actions to approve, pay, or void commissions.
  * Added confirmation prompts, reversal-reason validation, and clear success or error messages.
  * Added outstanding commission totals grouped by currency.
  * Added permission-aware action controls, with appropriate messaging for unavailable actions.
  * Added German, English, and Vietnamese translations for the new commission workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->