### PR TITLE
fix(tests): main's seven integration failures, both causes

### DIFF
--- a/backend/internal/compose/integration/capture/capture_project_attribution_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_project_attribution_integration_test.go
@@ -96,7 +96,7 @@ func newProjectSeeder(t *testing.T, e *integration.SearchEnv) projectSeeder {
 	return projectSeeder{
 		pool:  e.Pool,
 		store: deals.NewStore(e.DB(), compose.DealsInstallation()),
-		projects: projects.NewStore(e.DB()).
+		projects: integration.ProjectsStore(e.DB()).
 			WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx)),
 		ctx:        ctx,
 		orgID:      orgID,

--- a/backend/internal/compose/integration/capture/capture_project_attribution_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_project_attribution_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
-	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/projects"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -94,10 +93,9 @@ func newProjectSeeder(t *testing.T, e *integration.SearchEnv) projectSeeder {
 		t.Fatalf("seeding the pipeline a deal is born on: %v", err)
 	}
 	return projectSeeder{
-		pool:  e.Pool,
-		store: deals.NewStore(e.DB(), compose.DealsInstallation()),
-		projects: integration.ProjectsStore(e.DB()).
-			WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx)),
+		pool:       e.Pool,
+		store:      deals.NewStore(e.DB(), compose.DealsInstallation()),
+		projects:   integration.ProjectsStore(e.DB()),
 		ctx:        ctx,
 		orgID:      orgID,
 		pipelineID: ids.From[ids.PipelineKind](pipelineID),

--- a/backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go
@@ -89,7 +89,7 @@ func setupFixture(t *testing.T) fixture {
 		ctx:      e.As(e.Rep1, nil, testPerms),
 		svc:      svc,
 		people:   peoplemod.NewStore(e.DB()).WithFieldCatalog(svc),
-		projects: projects.NewStore(e.DB()).WithFieldCatalog(svc),
+		projects: integration.ProjectsStore(e.DB()).WithFieldCatalog(svc),
 		lists:    collectionsmod.NewStore(e.DB()).WithFieldCatalog(svc),
 	}
 }

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -72,7 +72,7 @@ func setupDealCFV(t *testing.T) dealCFVFixture {
 		e:     e,
 		svc:   svc,
 		store: deals.NewStore(e.DB(), installseam.Deals()).WithFieldCatalog(svc),
-		projects: projects.NewStore(e.DB()).WithFieldCatalog(svc).
+		projects: ProjectsStore(e.DB()).WithFieldCatalog(svc).
 			WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx)),
 		ctx:      e.As(e.Rep1, nil, dealCFVPerms),
 		pipeline: pipeline,

--- a/backend/internal/compose/integration/customfields_values_deal_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_deal_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/installseam"
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
-	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/projects"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -69,11 +68,10 @@ func setupDealCFV(t *testing.T) dealCFVFixture {
 	svc := customfields.NewService(e.Pool, SchemaPool(t))
 	pipeline, open, _ := DealFixture(t, e)
 	return dealCFVFixture{
-		e:     e,
-		svc:   svc,
-		store: deals.NewStore(e.DB(), installseam.Deals()).WithFieldCatalog(svc),
-		projects: ProjectsStore(e.DB()).WithFieldCatalog(svc).
-			WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx)),
+		e:        e,
+		svc:      svc,
+		store:    deals.NewStore(e.DB(), installseam.Deals()).WithFieldCatalog(svc),
+		projects: ProjectsStore(e.DB()).WithFieldCatalog(svc),
 		ctx:      e.As(e.Rep1, nil, dealCFVPerms),
 		pipeline: pipeline,
 		stage:    open,

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -126,14 +126,28 @@ func Setup(t *testing.T) *Env {
 	e.Pool = pool
 	e.People = people.NewStore(harnessDB(pool, e.WS))
 	e.Deals = deals.NewStore(harnessDB(pool, e.WS), installseam.Deals())
-	// The company edges are wired the way compose wires them: a store without
-	// them refuses every create, and a harness that skipped them would be
-	// testing a store production never builds.
-	e.Projects = projects.NewStore(harnessDB(pool, e.WS)).
-		WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx))
+	e.Projects = ProjectsStore(harnessDB(pool, e.WS))
 	e.Contracts = contracts.NewStore(harnessDB(pool, e.WS))
 	e.Activities = activities.NewStore(harnessDB(pool, e.WS))
 	return e
+}
+
+// ProjectsStore builds the projects store the way compose builds it, and is the
+// ONLY spelling a test should use.
+//
+// The company edges are the reason it exists. A store without them refuses
+// every create — deliberately, since a seam that failed open would produce
+// projects no company page can find — so a suite that calls projects.NewStore
+// directly is not testing a weaker store, it is testing one production never
+// builds. Five suites did, and every one of them broke the day the create path
+// started using the seam.
+//
+// The catalog is left to the caller: a suite that needs its own customfields
+// service chains WithFieldCatalog on the result, which is the only thing about
+// this store that legitimately varies between them.
+func ProjectsStore(db *database.DB) *projects.Store {
+	return projects.NewStore(db).
+		WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx))
 }
 
 // SchemaPool opens the owner-privileged schema-change pool the

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
-	"github.com/gradionhq/margince/backend/internal/modules/projects"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -103,7 +102,7 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	pool := tracedPool(t, tracer)
 	traced := database.BindTo(pool, ids.From[ids.WorkspaceKind](e.WS))
 	svc := org360svc.NewService(pool, people.NewStore(traced),
-		deals.NewStore(traced, installseam.Deals()), projects.NewStore(traced),
+		deals.NewStore(traced, installseam.Deals()), integration.ProjectsStore(traced),
 		approvals.NewService(traced), func() time.Time { return org360Clock })
 	ctx := e.Admin()
 

--- a/backend/internal/compose/integration/project_provider_integration_test.go
+++ b/backend/internal/compose/integration/project_provider_integration_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/installseam"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
-	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/projects"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -36,8 +35,7 @@ func projectProvider(e *Env) *projects.Provider {
 	// Built the way compose builds it, seams and all: a provider without the
 	// company edges refuses every create, and a test that wired its own would be
 	// proving something production never runs.
-	return projects.ProviderOver(ProjectsStore(e.DB()).
-		WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx)))
+	return projects.ProviderOver(ProjectsStore(e.DB()))
 }
 
 // dealProvider is the deals half of the same seam. The advance verb and the

--- a/backend/internal/compose/integration/project_provider_integration_test.go
+++ b/backend/internal/compose/integration/project_provider_integration_test.go
@@ -36,7 +36,7 @@ func projectProvider(e *Env) *projects.Provider {
 	// Built the way compose builds it, seams and all: a provider without the
 	// company edges refuses every create, and a test that wired its own would be
 	// proving something production never runs.
-	return projects.ProviderOver(projects.NewStore(e.DB()).
+	return projects.ProviderOver(ProjectsStore(e.DB()).
 		WithCompanyEdges(people.AttachCompanyToProjectTx, projects.CompaniesFrom(people.CompaniesOnProjectTx)))
 }
 

--- a/backend/internal/compose/projectattribution_integration_test.go
+++ b/backend/internal/compose/projectattribution_integration_test.go
@@ -83,6 +83,15 @@ func seedAttributionAccount(t *testing.T, e *integration.Env) attributionAccount
 				"organization": {Create: true, Read: true},
 				"project":      {Read: true},
 				"deal":         {Read: true},
+				// The candidate set is reached THROUGH the project's company
+				// edge, so naming a project is an edge read. A real connector
+				// carries the mailbox owner's RBAC verbatim (extingress.go
+				// copies rbac.Permissions onto it), and every seeded rep role
+				// grants relationship — see integration.RepPerms. Leaving it
+				// out modelled a connector production does not issue, and this
+				// suite passed only while attribution reached projects without
+				// the edge.
+				"relationship": {Read: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},


### PR DESCRIPTION
Closes #2383. **All seven of main's integration failures, in one PR** — they are two independent causes and each PR alone stayed red on the other's tests, so they land together. Test-only; no production behaviour changes.

## Cause 1 — five copies of one wiring, two of them missing (1 failure)

```
collections/segmentvocabulary_integration_test.go:337: create matching project:
  put the project's company on it: projects: the company attach seam was not
  injected; construct this store through compose, which binds modules/people's
  relationship edges to it
```

The company edges were named in **five** places: `compose/dbhandle.go`, `compose/integration/harness.go`, and three test suites carrying hand copies (`customfields_values_deal`, `project_provider`, `capture_project_attribution`). Two further suites — `collections/segmentvocabulary` and `org360/org360_querycount` — built the store without them, and broke the day #2372 made the create path use the seam.

A store without the edges is not a weaker store: it refuses every create, deliberately, since a seam failing open would produce projects no company page can find.

**The fix is one spelling, not five patches.** The harness grows `integration.ProjectsStore(db)`; every suite reaches for it, `harness.go` stops carrying its own copy, and the three hand copies go. Five namings become one on each side of the production/test line. The catalog stays with the caller — a suite's own customfields service is the one thing about this store that legitimately varies.

## Cause 2 — the attribution fixture modelled a connector production does not issue (6 failures)

```
projectattribution_integration_test.go:238: a message reaching an account with
one live project staged no project_attribution offer
```

#2372 made the candidate set reach projects *through* the company edge, and `auth.EdgeReadScope` returns an error — not an empty clause — for a caller without `relationship:read`. Measured, not inferred:

```
PROBE EdgeReadScope err: relationship.read: permission denied
```

**The refusal is right; the fixture was wrong.** I first filed this as `status: needs-decision`, because `LiveProjectsReached` refusing while `people.CompaniesOnProjectTx` returns an empty list looked like two irreconcilable positions on one edge. They are not — they answer different questions. Showing a reader a section of a record they can already see should withhold rather than refuse; *proposing* a project is itself the disclosure, so refusing is the only safe answer.

What the fixture got wrong is checkable in two greps:

- **Production copies the human's RBAC verbatim** — `extingress.go` sets `Permissions: rbac.Permissions` on the connector principal.
- **Every seeded rep role grants `relationship`** — the harness's own `RepPerms`, described as mirroring "the RBAC matrix rows the suites exercise", carries `objRelationship: {Create, Read, Update}`.
- **The fixture hand-wrote five grants** — activity, person, organization, project, deal — and omitted it.

So it passed only while attribution could reach a project *without* the edge. Nine lines state the grant and why it belongs. Nothing about the refusal, the finder or the seam changes, and #2372's disclosure rule stands as written.

## Why one PR

Each cause's fix left the other's tests failing, so neither branch could go green alone — the deadlock is visible in this PR's own earlier run, which was red on exactly the six attribution tests it did not fix.

## Verification

Against real Postgres, per package rather than per failing test name:

| | Result |
|---|---|
| `collections` — `TestAProjectCustomFieldIsFilterable` on `origin/main` | FAIL — seam not injected |
| the same, with cause-1 fix | **PASS** |
| the six `projectattribution` suites on `origin/main` | 6 failed |
| the same, with cause-2 fix | **6 passed** |
| `compose/integration` (full) | ok, 109.7s |
| `compose/integration/capture` (full) | ok, 11.0s |
| `compose/integration/org360` (full) | ok, 8.2s |

Both negative-authority tests still pass, which is the assertion that mattered for cause 2: granting the *connector* must not weaken what they prove about a *decider* lacking project or message authority.

Found by an hourly main-status watch; the seven were independently reproduced by a parallel session on a clean `origin/main` worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized integration test setup for project-related scenarios.
  * Preserved coverage for project, deal, custom-field, attribution, and organization workflows.
  * Updated attribution coverage to validate required relationship permissions.

* **Refactor**
  * Centralized project store initialization to ensure consistent production configuration across integration tests.
  * Retained support for customized field catalog settings and existing project and deal integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
