### PR TITLE
test(capture): the attribution connector carries its human's edge grant

### DIFF
--- a/backend/internal/compose/projectattribution_integration_test.go
+++ b/backend/internal/compose/projectattribution_integration_test.go
@@ -83,6 +83,15 @@ func seedAttributionAccount(t *testing.T, e *integration.Env) attributionAccount
 				"organization": {Create: true, Read: true},
 				"project":      {Read: true},
 				"deal":         {Read: true},
+				// The candidate set is reached THROUGH the project's company
+				// edge, so naming a project is an edge read. A real connector
+				// carries the mailbox owner's RBAC verbatim (extingress.go
+				// copies rbac.Permissions onto it), and every seeded rep role
+				// grants relationship — see integration.RepPerms. Leaving it
+				// out modelled a connector production does not issue, and this
+				// suite passed only while attribution reached projects without
+				// the edge.
+				"relationship": {Read: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},


### PR DESCRIPTION
Closes the other half of #2383 — the six `projectattribution` failures. **It needed no product ruling after all**, and the evidence for that is below; #2390 clears the seventh.

## What broke

```
projectattribution_integration_test.go:238: a message reaching an account with
one live project staged no project_attribution offer
```

#2372 made `projectCandidateFinder.LiveProjectsReached` reach candidates *through* the company edge, and `auth.EdgeReadScope` returns an error — not an empty clause — for a caller without `relationship:read`. Measured on the failing test rather than inferred:

```
PROBE EdgeReadScope err: relationship.read: permission denied
```

## Why the refusal is right and the fixture was wrong

I opened #2383 as `status: needs-decision` because two positions on one edge looked irreconcilable: `LiveProjectsReached` refuses, while `people.CompaniesOnProjectTx` returns an empty list and argues at length that refusing would refuse the project. Choosing between them looked like a product call.

It is not, because the fixture never modelled a real connector:

- **Production copies the human's RBAC verbatim** — `extingress.go` sets `Permissions: rbac.Permissions` on the connector principal.
- **Every seeded rep role grants `relationship`** — which is why the harness's own `RepPerms`, described as mirroring "the RBAC matrix rows the suites exercise", carries `objRelationship: {Create, Read, Update}`.
- **This fixture hand-wrote five object grants** — activity, person, organization, project, deal — and omitted `relationship`.

So it modelled a connector production does not issue. The suite passed only while attribution could reach a project *without* the edge, and stopped the moment reaching one became an edge read. That is CLAUDE.md's rule 6 exactly: a test that supplies its own version of production proves nothing about production.

## The change

Nine lines: the grant, and why it belongs there. **Nothing about the refusal, the candidate finder, or the seam changes** — no production behaviour is touched, and the disclosure rule #2372 wrote stands as written.

## Verification

Against real Postgres:

| | Result |
|---|---|
| `origin/main` | 6 failed |
| With this change | **6 passed** — `TestUncertainRungOffersTheSoleLiveProjectAndConfirmFilesIt`, `TestDecliningTheOfferLeavesTheMessageUnfiledAndIsNotAskedAgain`, `TestConfirmStandsDownWhenAHumanFiledTheMessageElsewhere`, `TestADeciderWithoutTheProjectGrantCannotSeeOrDecideTheOffer`, `TestADeciderWithReadOnlyAuthorityOverTheMessageCannotConfirmIt`, `TestAnExpiredOfferFreesTheCandidateAndMayBeAskedAgain` |

The two negative-authority tests in that list still pass, which is the part worth checking: adding a grant to the *connector* does not weaken what they assert about a *decider* who lacks project or message authority.

Found by an hourly main-status watch; the seven were independently reproduced by a parallel session on a clean `origin/main` worktree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grants `relationship:read` to the attribution connector in the test fixture to match production RBAC. Previously the fixture omitted this grant, so reaching project candidates through the company edge caused `auth.EdgeReadScope` to refuse and six `projectattribution` tests failed; they now pass.

- Only `backend/internal/compose/projectattribution_integration_test.go` changes; adds `"relationship": {Read: true}` to the connector principal.
- Mirrors production where `extingress.go` copies `rbac.Permissions` and seeded rep roles include `relationship`.
- No production behavior changes; negative-authority tests remain intact.

<sup>Written for commit f5aa80090189c7ceca2c683f6b1ea649f4daeb2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project attribution candidate lookup through project-company relationships by ensuring the required relationship access is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->