### PR TITLE
fix(frontend): a company joining a project is a partner, and the mirror says company

### DIFF
--- a/frontend/src/design-system/projectlinks.test.tsx
+++ b/frontend/src/design-system/projectlinks.test.tsx
@@ -178,4 +178,34 @@ describe("ProjectLinks", () => {
       ).toBeNull(),
     );
   });
+
+  it("says what it links, so a mirror cannot half-rename itself", () => {
+    render(
+      <LocaleProvider initial="en">
+        <ProjectLinks
+          adapter={{
+            linked: [{ project_id: "o1", name: "Beta Systeme" }],
+            allowsMany: true,
+            search: async () => [],
+            roles: [{ value: "partner", label: "Partner" }],
+            attach: async () => undefined,
+            detach: async () => undefined,
+          }}
+          titleKey="projectCompanies.title"
+          emptyBody="projectCompanies.empty"
+          words={{
+            attach: "Attach company",
+            move: "Attach company",
+            detachTitle: "Take this company off?",
+            search: "Search companies by name",
+          }}
+        />
+      </LocaleProvider>,
+    );
+    // The project page's mirror links COMPANIES: a verb reading "Attach
+    // project" there is wrong on screen and wrong in the dialog's accessible
+    // name, which is what a screen reader announces.
+    expect(screen.getByRole("button", { name: "Attach company" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Attach project" })).toBeNull();
+  });
 });

--- a/frontend/src/design-system/projectlinks.tsx
+++ b/frontend/src/design-system/projectlinks.tsx
@@ -27,6 +27,15 @@ import "./projectlinks.css";
 // One project as this section shows it: enough to name it, phase it, and open
 // it. The same four fields the 360 sections already carry, so a page hands in
 // what it already has rather than fetching a second shape.
+// What a section calls the thing it links. Every string a reader or a screen
+// reader meets, so the mirror cannot half-rename itself.
+export type LinkWords = Readonly<{
+  attach: string;
+  move: string;
+  detachTitle: string;
+  search: string;
+}>;
+
 // One role a link may hold, with the words the reader sees.
 export type LinkRole = Readonly<{ value: string; label: string }>;
 
@@ -91,7 +100,7 @@ export function ProjectLinks({
   adapter,
   titleKey,
   emptyBody,
-  searchLabel,
+  words,
 }: Readonly<{
   adapter: ProjectLinksAdapter;
   // The section's own heading, because a project page saying "Companies" and a
@@ -100,10 +109,12 @@ export function ProjectLinks({
   // One line saying how a link of this kind comes to exist, shown when there
   // are none. A bare "nothing here" tells a reader what they can already see.
   emptyBody: MessageKey;
-  // What the picker asks for, already translated. Defaulted rather than
-  // required because the projects case is every caller but one, and a label
-  // saying "search projects" on the company mirror would be wrong.
-  searchLabel?: string;
+  // The words this section uses for the thing being linked, already
+  // translated. Defaulted to the projects wording because that is every caller
+  // but one — the project page's own mirror links COMPANIES, and a section
+  // saying "Attach project" about a company is wrong on screen and wrong in the
+  // dialog's accessible name.
+  words?: LinkWords;
 }>) {
   const t = useT();
   const [picking, setPicking] = useState(false);
@@ -111,6 +122,15 @@ export function ProjectLinks({
   const [busy, setBusy] = useState(false);
   const [refusal, setRefusal] = useState<string | null>(null);
   const [role, setRole] = useState(adapter.roles[0]?.value ?? "");
+  // The projects wording, which every caller but the project page's own mirror
+  // wants. Spelled once so a caller overriding one string cannot leave the
+  // other three saying "project" about a company.
+  const said: LinkWords = words ?? {
+    attach: t("projectLinks.attach"),
+    move: t("projectLinks.move"),
+    detachTitle: t("projectLinks.detachTitle"),
+    search: t("projectLinks.searchLabel"),
+  };
   // Focus returns to the SECTION rather than to the row's own verb: a
   // successful detach removes that button, and focus restored to a node that
   // is about to unmount leaves a keyboard reader nowhere.
@@ -162,7 +182,7 @@ export function ProjectLinks({
               )}
               {canAdd || moving ? (
                 <Button variant="ghost" onClick={() => setPicking(true)}>
-                  {t(moving ? "projectLinks.move" : "projectLinks.attach")}
+                  {moving ? said.move : said.attach}
                 </Button>
               ) : null}
             </div>
@@ -216,7 +236,7 @@ export function ProjectLinks({
           moving={moving}
           busy={busy}
           refusal={refusal}
-          searchLabel={searchLabel}
+          words={said}
           onClose={closeWhenIdle(() => setPicking(false))}
           onPick={(id) =>
             run(
@@ -231,6 +251,7 @@ export function ProjectLinks({
           busy={busy}
           refusal={refusal}
           returnFocusTo={() => section.current}
+          words={said}
           onClose={closeWhenIdle(() => setDetaching(null))}
           onConfirm={(id) =>
             run(
@@ -259,7 +280,7 @@ function AttachDialog({
   moving,
   busy,
   refusal,
-  searchLabel,
+  words,
   onClose,
   onPick,
 }: Readonly<{
@@ -270,7 +291,7 @@ function AttachDialog({
   moving: boolean;
   busy: boolean;
   refusal: string | null;
-  searchLabel?: string;
+  words: LinkWords;
   onClose: () => void;
   onPick: (projectID: string) => void;
 }>) {
@@ -282,8 +303,8 @@ function AttachDialog({
     <ConfirmModal
       open
       onClose={onClose}
-      title={t(moving ? "projectLinks.move" : "projectLinks.attach")}
-      confirmLabel={t("projectLinks.attach")}
+      title={moving ? words.move : words.attach}
+      confirmLabel={words.attach}
       confirmDisabled
       onConfirm={() => undefined}
       pending={busy}
@@ -307,7 +328,7 @@ function AttachDialog({
         </Field>
       )}
       <RecordPicker
-        label={searchLabel ?? t("projectLinks.searchLabel")}
+        label={words.search}
         searchTargets={adapter.search}
         disabled={busy}
         onPick={(candidate) => onPick(candidate.id)}
@@ -323,6 +344,7 @@ function DetachDialog({
   busy,
   refusal,
   returnFocusTo,
+  words,
   onClose,
   onConfirm,
 }: Readonly<{
@@ -331,6 +353,7 @@ function DetachDialog({
   busy: boolean;
   refusal: string | null;
   returnFocusTo: () => HTMLElement | null;
+  words: LinkWords;
   onClose: () => void;
   onConfirm: (projectID: string) => void;
 }>) {
@@ -343,7 +366,7 @@ function DetachDialog({
       open
       onClose={onClose}
       returnFocusTo={returnFocusTo}
-      title={t("projectLinks.detachTitle")}
+      title={words.detachTitle}
       confirmLabel={t("projectLinks.detachConfirm")}
       confirmVariant="danger"
       pending={busy}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6104,6 +6104,8 @@ export const de = {
   "projectCompanies.title": "Unternehmen",
   "projectCompanies.empty":
     "Ein Projekt ist Arbeit, die mehrere Unternehmen gemeinsam leisten — der Kunde und jeder Partner oder Subunternehmer, der liefert.",
+  "projectCompanies.attach": "Unternehmen verknüpfen",
+  "projectCompanies.detachTitle": "Dieses Unternehmen entfernen?",
   "projectCompanies.searchLabel": "Unternehmen nach Name suchen",
   "personProjects.title": "Projekte",
   "personProjects.empty":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6171,6 +6171,8 @@ export const en = {
   "projectCompanies.title": "Companies",
   "projectCompanies.empty":
     "A project is work several companies do together — the client, and any partner or subcontractor delivering it.",
+  "projectCompanies.attach": "Attach company",
+  "projectCompanies.detachTitle": "Take this company off?",
   "projectCompanies.searchLabel": "Search companies by name",
   "personProjects.title": "Projects",
   "personProjects.empty":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6051,6 +6051,8 @@ export const vi = {
   "projectCompanies.title": "Công ty",
   "projectCompanies.empty":
     "Dự án là công việc nhiều công ty cùng làm — khách hàng, cùng mọi đối tác hoặc nhà thầu phụ tham gia.",
+  "projectCompanies.attach": "Liên kết công ty",
+  "projectCompanies.detachTitle": "Bỏ công ty này khỏi dự án?",
   "projectCompanies.searchLabel": "Tìm công ty theo tên",
   "personProjects.title": "Dự án",
   "personProjects.empty":

--- a/frontend/src/screens/companyprojects.test.ts
+++ b/frontend/src/screens/companyprojects.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { COMPANY_ROLES, roleKey } from "./companyprojects";
+
+describe("the roles a company holds on a project", () => {
+  it("leads with partner, because the first role is the picker's default", () => {
+    // A project already has its customer by the time anybody reaches the
+    // section — creating one attaches its company as the customer — so a
+    // company joining afterwards is a partner or a subcontractor. Defaulting to
+    // customer hands the project two, which is what the reports group by and
+    // what organization_id resolves to.
+    expect(COMPANY_ROLES[0]).toBe("partner");
+    expect(COMPANY_ROLES).toContain("customer");
+  });
+
+  it("names every role it offers", () => {
+    // A role with no label renders as a blank option, which is a choice a
+    // reader cannot make.
+    for (const role of COMPANY_ROLES) {
+      expect(roleKey(role)).toMatch(/^projectRole\./);
+    }
+  });
+
+  it("does not silently call an unknown role a partner", () => {
+    // roleKey falls back, and the fallback is only safe while every role it can
+    // be handed is in the list above.
+    expect(new Set(COMPANY_ROLES.map(roleKey)).size).toBe(COMPANY_ROLES.length);
+  });
+});

--- a/frontend/src/screens/companyprojects.tsx
+++ b/frontend/src/screens/companyprojects.tsx
@@ -21,10 +21,16 @@ import type { ProjectPhase } from "./projects.form";
 
 type Organization360Project = components["schemas"]["Organization360Project"];
 
-// What a company can BE to a project. The vocabulary the server records and the
-// reports group by, so a reader picks from it rather than every attach landing
-// as one guessed role.
-export const COMPANY_ROLES = ["customer", "partner", "subcontractor"] as const;
+// What a company can BE to a project, PARTNER FIRST because the first role is
+// the picker's default and a default is a claim.
+//
+// A project has one customer — the account the work is for — and it already has
+// one by the time anybody reaches this section, since creating a project
+// attaches its company as the customer. So a company joining afterwards is a
+// partner or a subcontractor; defaulting it to customer would hand a project two
+// customers on a reader who took the default, which is what the reports group
+// by and what organization_id resolves to.
+export const COMPANY_ROLES = ["partner", "subcontractor", "customer"] as const;
 
 // The message key for one role, spelled once so the picker and any row that
 // renders a role cannot disagree about the words.

--- a/frontend/src/screens/personprojects.tsx
+++ b/frontend/src/screens/personprojects.tsx
@@ -114,7 +114,6 @@ export function PersonProjects({
       adapter={adapter}
       titleKey="personProjects.title"
       emptyBody="personProjects.empty"
-      searchLabel={t("projectLinks.searchLabel")}
     />
   );
 }

--- a/frontend/src/screens/projectcompanies.tsx
+++ b/frontend/src/screens/projectcompanies.tsx
@@ -104,7 +104,14 @@ export function ProjectCompanies({
       adapter={adapter}
       titleKey="projectCompanies.title"
       emptyBody="projectCompanies.empty"
-      searchLabel={t("projectCompanies.searchLabel")}
+      // The mirror links COMPANIES, so every word it shows says so — the verb
+      // on screen and the dialog's accessible name alike.
+      words={{
+        attach: t("projectCompanies.attach"),
+        move: t("projectCompanies.attach"),
+        detachTitle: t("projectCompanies.detachTitle"),
+        search: t("projectCompanies.searchLabel"),
+      }}
     />
   );
 }


### PR DESCRIPTION
Two defects found by walking the merged product rather than by a gate.

The project page's Companies section said "Attach project" — its verbs were
hardcoded to the projects wording, so the one caller that links COMPANIES read
wrong on screen and wrong in the dialog's accessible name, which is what a
screen reader announces. The words a section uses are the caller's now, as one
set: a mirror cannot rename half of them and leave the rest saying project.

And attaching a second company defaulted it to CUSTOMER, because the first role
in the list is the picker's default and the list led with customer. A project
already has its customer by the time anybody reaches this section — creating one
attaches its company as the customer — so a company joining afterwards is a
partner or a subcontractor. The default handed the project two customers on a
reader who took it, which is what the reports group by and what organization_id
resolves to. Partner leads now, and a test holds the order, because the position
of an item in that list is a product claim rather than a formatting choice.

Both were live on main. The walkthrough is what found them: the create dialog
offers no key, the server minted JRA-1 then JRA-2 from one name, and the section
drew — every claim a report would have made was true, and these two were not.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes company linking wording and default role on project pages. Old: the Companies section showed “Attach project” and defaulted a second company to Customer; New: the mirror uses company terms in UI and accessible names, and the default role is Partner to avoid duplicate customers.

- Notes for reviewers
  - `ProjectLinks` now accepts a `words` prop to supply consistent terms for the linked entity; it defaults to project words. The project Companies mirror passes company words so buttons and dialog titles read “company.”
  - Reordered `COMPANY_ROLES` to ["partner", "subcontractor", "customer"] and added tests to lock order, require labels, and ensure uniqueness. This prevents creating a second customer by default and keeps reporting correct.
  - Added i18n keys for company attach/detach in `en`, `de`, and `vi`.

- Migration
  - Replace any `searchLabel` usage on `ProjectLinks` with `words`, or remove it to use the defaults. The project Companies mirror must pass company `words`.

<sup>Written for commit 6958f74a19948017f2e9954ac917125a3b463405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized wording for attaching and removing companies from projects in English, German, and Vietnamese.
  - Company linking dialogs now support customized attach, move, detach, and search labels.
  - Partner is now the default company project role, with subcontractor and customer options still available.

- **Bug Fixes**
  - Improved company-specific terminology throughout project linking actions.

- **Tests**
  - Added coverage for customized linking text and company project role ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->