### PR TITLE
feat(ai): an admin can put a provider key in, without a shell or a restart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,9 +94,22 @@ MARGINCE_OBSERVE_ADDR=
 # config/ai-routing.yaml and passes it as a flag.
 MARGINCE_AI_ROUTING=
 
-# [required by the provider your routing file binds] Keys come from the
-# environment, never the routing file (ADR-0020). Unset, that provider fails
-# closed: `make dev` falls back to --ai-fake, a deployment does not start.
+# [optional — a SEED, no longer the home] A provider key belongs in the key
+# vault, and the place to put one is Settings -> AI -> Model provider keys. Set
+# here it MAY be sealed into the vault on the next boot, after which this line is
+# how the key ARRIVED rather than where it lives.
+#
+# Two prerequisites, and without either one nothing is sealed and this variable
+# stays the only copy: the installation needs a key-vault root key, and it needs
+# a stored model binding — the sealing runs on the path that resolves a binding,
+# so an installation that has bound no models never reaches it. Do not remove
+# the line on the strength of having set it; remove it once the boot log has
+# actually said the key was sealed.
+#
+# Kept because it is the zero-touch upgrade path: an installation that exported
+# a key before the vault existed keeps working and needs no action. A provider
+# with no key by either route still fails closed - `make dev` falls back to
+# --ai-fake, a deployment does not start.
 GEMINI_API_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8450,6 +8450,138 @@ paths:
         '403': { $ref: '#/components/responses/PermissionDenied' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /ai/provider-keys:
+    get:
+      tags: [AI]
+      operationId: listAiProviderKeys
+      security: [ { cookieAuth: [] } ]
+      x-agent-access: human-only
+      summary: Which model vendors hold a credential (admin/ops).
+      description: |
+        Every cloud provider this build can serve, and whether a key is held for each. Governed
+        by the same `ai_routing` object the binding is: a seat that may not re-point a model may
+        not reach the credential that model would call with either.
+
+        The KEY is never returned, by any caller, at any time. A credential that can be read
+        back is one a support bundle, a browser cache and a screenshare can all carry. What this
+        answers is `configured` — which is what a screen needs to know whether to offer "add" or
+        "rotate".
+
+        `env_var` names the variable the same key may arrive in, so an operator can see which
+        export seeded a vendor rather than guessing. That path still works and is how an existing
+        installation's key reached the vault without anyone doing anything.
+
+        Human session only. An agent never reads the installation's credential inventory,
+        whatever its passport scopes admit.
+      responses:
+        '503':
+          description: >-
+            This installation has no key vault, so there is no credential inventory to report.
+            The remedy is the operator's — the vault root key — not anything the caller sent.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '200':
+          description: One entry per servable provider, in the routing table's order.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AiProviderKeyList' }
+              examples:
+                mixed:
+                  value:
+                    providers:
+                      - { provider: anthropic, configured: true, env_var: ANTHROPIC_API_KEY }
+                      - { provider: openai, configured: false, env_var: OPENAI_API_KEY }
+                      - { provider: gemini, configured: true, env_var: GEMINI_API_KEY }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/PermissionDenied' }
+
+  /ai/provider-keys/{provider}:
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        schema: { type: string }
+        description: The routing name of the vendor — the same string a binding uses.
+    put:
+      tags: [AI]
+      operationId: setAiProviderKey
+      security: [ { cookieAuth: [] } ]
+      x-agent-access: human-only
+      summary: Store or rotate one vendor's BYOK key (admin/ops).
+      description: |
+        Seals the key in the installation's key vault and records only an opaque, workspace-bound
+        reference. `api_key` is WRITE-ONLY: no read path returns it, and the setting that points
+        at it holds the reference and never the bytes.
+
+        Sending a key for a vendor that already has one ROTATES it. The new credential is sealed
+        before the reference moves, and the superseded one is destroyed only after the move
+        commits — so no window exists in which the recorded reference names nothing, and a
+        half-completed rotation leaves the previous key still serving.
+
+        Takes effect without a restart: every role re-reads on an interval and rebinds its model
+        clients when the credential changes, which is tracked separately from the binding's own
+        version so a rotation does not invalidate content a model already wrote. Leading and trailing whitespace is trimmed, because a pasted credential carries
+        whatever the clipboard did and a key with a trailing newline authenticates nothing while
+        looking exactly like one that would.
+
+        422 for a vendor this build serves with no key at all (a local model needs none), and for
+        an empty key — removing a credential is DELETE, not an empty write.
+
+        Requires a key vault. Without one there is nowhere to put the bytes, and the refusal says
+        so rather than recording a reference to something that was never written.
+
+        Audit-only write (no event stream, EVT-NOEVT-3).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AiProviderKeyInput' }
+      responses:
+        '204': { description: 'Sealed. The key is not echoed.' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/PermissionDenied' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+        '503':
+          description: >-
+            This installation has no key vault, so a provider key cannot be stored. The remedy is
+            the operator's — the vault root key — not anything the caller sent.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+    delete:
+      tags: [AI]
+      operationId: deleteAiProviderKey
+      security: [ { cookieAuth: [] } ]
+      x-agent-access: human-only
+      summary: Remove one vendor's BYOK key (admin/ops).
+      description: |
+        Drops the reference and destroys the sealed credential. A vendor that holds nothing
+        succeeds: the caller asked for a state and that state already holds, which is why this is
+        204 rather than 404 — and why it is safe to retry.
+
+        Removing a credential does not unbind a model; that is `PUT /ai/routing`. A NEW process
+        binding that vendor fails closed with the error that names what is missing, exactly as it
+        did before any key was ever stored.
+
+        A process already running is a different case, and worth knowing: a role re-reads the
+        binding on an interval and rebinds when the credential changes, but a binding it can no
+        longer build clients for leaves the running one in place rather than taking the AI lanes
+        down. So where the removed key was the only one for a bound vendor, that role keeps
+        serving on it until it restarts.
+
+        Audit-only write (no event stream, EVT-NOEVT-3).
+      responses:
+        '204': { description: 'Removed, or there was nothing to remove.' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/PermissionDenied' }
+        '503':
+          description: >-
+            This installation has no key vault, so there is no sealed credential to remove. The
+            remedy is the operator's — the vault root key — not anything the caller sent.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
   /ai/calls:
     get:
       tags: [AI]
@@ -15873,6 +16005,50 @@ components:
             When true, every organization with a primary domain and no dossier gets a governed
             web deep-read under a daily spend cap — however it was named. The anchor is
             excluded (cold start reads it). Default is ON (the testing posture).
+    AiProviderKeyList:
+      type: object
+      additionalProperties: false
+      required: [providers]
+      properties:
+        providers:
+          type: array
+          items: { $ref: '#/components/schemas/AiProviderKeyStatus' }
+    AiProviderKeyStatus:
+      type: object
+      additionalProperties: false
+      required: [provider, configured, env_var]
+      description: >-
+        What may be known about one vendor's credential. Deliberately three facts and no fourth:
+        the key itself has no read path, and neither does anything derived from it — a length, a
+        prefix or a masked tail would each narrow a brute force while feeling harmless.
+      properties:
+        provider:
+          type: string
+          description: The routing name of the vendor, the same string a binding uses.
+        configured:
+          type: boolean
+          description: >-
+            Whether a credential is held. A screen reads this to offer "add" or "rotate"; it says
+            nothing about whether the key still works, which only the vendor can answer.
+        env_var:
+          type: string
+          description: >-
+            The variable the same key may arrive in. Named so an operator can see which export
+            seeded a vendor; the names follow each vendor's own convention, which is why they
+            carry no MARGINCE_ prefix.
+    AiProviderKeyInput:
+      type: object
+      additionalProperties: false
+      required: [api_key]
+      properties:
+        api_key:
+          type: string
+          minLength: 1
+          maxLength: 8192
+          writeOnly: true
+          description: >-
+            The vendor credential. WRITE-ONLY — no response in this contract returns it, and the
+            setting that records it holds an opaque vault reference rather than these bytes.
     AiRouting:
       type: object
       description: |

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -101,6 +101,7 @@ type agentPolicy struct {
 // router registers it (BaseURL /v1 included).
 var agentPolicies = map[string]agentPolicy{
 	"DELETE /v1/activities/{id}":                                         {Op: "archiveActivity", Access: "tool", Tool: "archive_record", RecordType: "activity", Tier: "auto_execute", Scope: "write"},
+	"DELETE /v1/ai/provider-keys/{provider}":                             {Op: "deleteAiProviderKey", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"DELETE /v1/attachments/{id}":                                        {Op: "deleteAttachment", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"DELETE /v1/automations/{id}":                                        {Op: "deleteAutomation", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"DELETE /v1/capture/consumer-mail-domains/{id}":                      {Op: "removeConsumerMailDomain", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
@@ -155,6 +156,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/ai/calls":                                                   {Op: "listAiCalls", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/calls/{id}":                                              {Op: "getAiCall", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/profile":                                                 {Op: "getAiProfile", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/ai/provider-keys":                                           {Op: "listAiProviderKeys", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/routing":                                                 {Op: "getAiRouting", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/usage":                                                   {Op: "getAiUsage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/approvals":                                                  {Op: "listApprovals", Access: "tool", Tool: "list_approvals", RecordType: "", Tier: "auto_execute", Scope: "read"},
@@ -495,6 +497,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/webhook-subscriptions":                                     {Op: "createWebhookSubscription", Access: "tool", Tool: "create_record", RecordType: "webhook_subscription", Tier: "confirmation_required", Scope: "write"},
 	"POST /v1/webhook-subscriptions/{id}/deliveries/{deliveryId}/replay": {Op: "replayWebhookDelivery", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/webhook-subscriptions/{id}/rotate-secret":                  {Op: "rotateWebhookSecret", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"PUT /v1/ai/provider-keys/{provider}":                                {Op: "setAiProviderKey", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PUT /v1/ai/routing":                                                 {Op: "replaceAiRouting", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PUT /v1/capture/blocked-domains":                                    {Op: "setBlockedDomain", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PUT /v1/company":                                                    {Op: "putCompany", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/providerkeyhttp_integration_test.go
+++ b/backend/internal/compose/integration/providerkeyhttp_integration_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The credential surface over the real router, with a real vault and a real
+// admin session — the wiring the store's own tests cannot see.
+//
+// What it is here to prove is a negative: that no response on this surface, on
+// any path, carries the key back. A store test can assert the setting holds a
+// ref; only this can assert that the HTTP layer never echoes the bytes it was
+// handed.
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+)
+
+const providerKeySecret = "sk-live-must-never-come-back"
+
+func setupProviderKeyApp(t *testing.T) *apptest.AppEnv {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("generating a test root key: %v", err)
+	}
+	vault, err := keyvault.New(keyvault.Config{RootKey: key, Pool: apptest.EarlyPool(t)})
+	if err != nil {
+		t.Fatalf("building the local vault: %v", err)
+	}
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault))
+	apptest.BootstrapWorkspaceSession(t, e, "Provider Keys", "ada@example.com", "Ada Admin")
+	return e
+}
+
+func TestTheKeyIsWriteOnlyOverHTTP(t *testing.T) {
+	e := setupProviderKeyApp(t)
+
+	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
+		apptest.AnyMap{"api_key": providerKeySecret}, nil, nil); code != 204 {
+		t.Fatalf("PUT provider key = %d, want 204", code)
+	}
+
+	// The list is the only read path, and it must not carry the bytes — nor a
+	// length, a prefix or a masked tail, each of which narrows a brute force
+	// while feeling harmless.
+	var raw map[string]any
+	if code := e.Call(t, "GET", "/v1/ai/provider-keys", nil, nil, &raw); code != 200 {
+		t.Fatalf("GET provider keys = %d, want 200", code)
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(encoded)
+	if strings.Contains(body, providerKeySecret) {
+		t.Fatalf("the list carried the credential: %s", body)
+	}
+	// A fragment long enough to be recognisable must not appear either.
+	if strings.Contains(body, providerKeySecret[:12]) {
+		t.Fatalf("the list carried a recognisable fragment of the credential: %s", body)
+	}
+	if !strings.Contains(body, "gemini") {
+		t.Fatalf("the list does not mention the provider that was just configured: %s", body)
+	}
+}
+
+func TestTheListSaysWhichVendorsAreConfigured(t *testing.T) {
+	e := setupProviderKeyApp(t)
+
+	var before struct {
+		Providers []struct {
+			Provider   string `json:"provider"`
+			Configured bool   `json:"configured"`
+			EnvVar     string `json:"env_var"`
+		} `json:"providers"`
+	}
+	if code := e.Call(t, "GET", "/v1/ai/provider-keys", nil, nil, &before); code != 200 {
+		t.Fatalf("GET = %d", code)
+	}
+	// An installation that has configured nothing is exactly the one that needs
+	// the screen, so every servable vendor is listed.
+	if len(before.Providers) == 0 {
+		t.Fatal("an unconfigured installation was shown no vendors at all")
+	}
+	for _, p := range before.Providers {
+		if p.Configured {
+			t.Errorf("%s reads as configured before anything was stored", p.Provider)
+		}
+		if p.EnvVar == "" {
+			t.Errorf("%s names no environment variable, so an operator cannot see what seeded it", p.Provider)
+		}
+	}
+
+	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/openai",
+		apptest.AnyMap{"api_key": "sk-openai"}, nil, nil); code != 204 {
+		t.Fatal("PUT failed")
+	}
+	var after struct {
+		Providers []struct {
+			Provider   string `json:"provider"`
+			Configured bool   `json:"configured"`
+		} `json:"providers"`
+	}
+	if code := e.Call(t, "GET", "/v1/ai/provider-keys", nil, nil, &after); code != 200 {
+		t.Fatalf("GET after = %d", code)
+	}
+	// Tracked rather than only asserted inside the loop: a response that OMITS
+	// openai altogether would satisfy every check below by never reaching them,
+	// and "the vendor is missing from the list" is exactly the regression this
+	// case is here to catch.
+	sawOpenAI := false
+	for _, p := range after.Providers {
+		if p.Provider == "openai" {
+			sawOpenAI = true
+			if !p.Configured {
+				t.Error("the vendor just configured does not read as configured")
+			}
+			continue
+		}
+		if p.Configured {
+			t.Errorf("%s became configured by a write to another vendor", p.Provider)
+		}
+	}
+	if !sawOpenAI {
+		t.Error("the list omits the vendor just configured, so nothing above was checked against it")
+	}
+}
+
+func TestRemovingOverHTTPIsIdempotent(t *testing.T) {
+	e := setupProviderKeyApp(t)
+
+	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/anthropic",
+		apptest.AnyMap{"api_key": "sk-anthropic"}, nil, nil); code != 204 {
+		t.Fatal("PUT failed")
+	}
+	if code := e.Call(t, "DELETE", "/v1/ai/provider-keys/anthropic", nil, nil, nil); code != 204 {
+		t.Fatalf("first DELETE = %d, want 204", code)
+	}
+	// The caller asked for a state, and that state now holds — so a retry is
+	// safe and says so, rather than 404ing a request that already succeeded.
+	if code := e.Call(t, "DELETE", "/v1/ai/provider-keys/anthropic", nil, nil, nil); code != 204 {
+		t.Errorf("second DELETE = %d, want 204 — removing what is gone is the state the caller asked for", code)
+	}
+}
+
+func TestAVendorThatTakesNoKeyIsRefusedOverHTTP(t *testing.T) {
+	e := setupProviderKeyApp(t)
+	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/ollama",
+		apptest.AnyMap{"api_key": "sk-local-needs-none"}, nil, nil); code != http.StatusUnprocessableEntity {
+		t.Errorf("PUT for a local provider = %d, want 422", code)
+	}
+	// An empty key is the caller's mistake too: removing a credential is
+	// DELETE, not a write of nothing.
+	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
+		apptest.AnyMap{"api_key": "   "}, nil, nil); code != http.StatusUnprocessableEntity {
+		t.Errorf("PUT with a blank key = %d, want 422", code)
+	}
+	// And an OMITTED key, which is a different path from a blank one. Marking
+	// the field writeOnly is what keeps it out of every generated response
+	// type, and the cost is that the generated request field became a pointer
+	// with `omitempty` — so a body carrying no `api_key` at all decodes
+	// cleanly and reaches the store. The store's refusal is therefore the only
+	// thing standing between an absent field and a sealed zero-length key that
+	// would read as configured and authenticate nothing.
+	if code := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
+		apptest.AnyMap{}, nil, nil); code != http.StatusUnprocessableEntity {
+		t.Errorf("PUT with no api_key at all = %d, want 422", code)
+	}
+}

--- a/backend/internal/compose/integration/providerkeystore_integration_test.go
+++ b/backend/internal/compose/integration/providerkeystore_integration_test.go
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The write path for a BYOK credential: an admin puts a key in, the routing
+// lane serves with it, and nothing along the way can read it back out.
+//
+// Against a REAL vault and a real settings store, because what is being proved
+// is that the ciphertext lands somewhere the resolver can reach — a fake vault
+// would prove the store calls Put and nothing about whether the key serves.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/platform/config"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// searchVault is realVault's twin over this env's pool — the same real
+// provider, because what these tests prove is that ciphertext written by the
+// store is readable by the resolver, which a fake would assert nothing about.
+// The root key is fixed and meaningless.
+func searchVault(t *testing.T, e *SearchEnv) keyvault.Vault {
+	t.Helper()
+	vault, err := keyvault.New(keyvault.Config{RootKey: bytes.Repeat([]byte{9}, 32), Pool: e.Pool})
+	if err != nil {
+		t.Fatalf("building the test vault: %v", err)
+	}
+	return vault
+}
+
+func providerKeyStore(t *testing.T, e *SearchEnv) *ai.ProviderKeyStore {
+	t.Helper()
+	return ai.NewProviderKeyStore(compose.NewSettingsStore(e.Pool), searchVault(t, e), discard())
+}
+
+// resolveKey asks the same resolver the routing lane uses, so the test observes
+// what a model client would be handed rather than what the store recorded.
+func resolveKey(ctx context.Context, t *testing.T, e *SearchEnv, provider string) string {
+	t.Helper()
+	refs, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatalf("reading the sealed refs: %v", err)
+	}
+	lookup := ai.SealedKeys(ctx, searchVault(t, e), ids.From[ids.WorkspaceKind](e.WS), refs, config.Static(nil))
+	return lookup(ai.KeyEnvVarFor(provider))
+}
+
+func TestASealedKeyIsWhatTheRoutingLaneResolves(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+
+	const key = "sk-a-real-looking-credential"
+	if err := store.Set(ctx, "gemini", key); err != nil {
+		t.Fatalf("sealing the gemini key: %v", err)
+	}
+	// The resolver, not the store: this is the value a client would be built
+	// with, which is the only sense in which the key "works".
+	if got := resolveKey(ctx, t, e, "gemini"); got != key {
+		t.Fatalf("the routing lane resolved %q, want the key that was sealed", got)
+	}
+}
+
+func TestTheStoredSettingHoldsARefAndNeverTheKey(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+
+	const key = "sk-must-not-appear-in-the-setting"
+	if err := store.Set(ctx, "openai", key); err != nil {
+		t.Fatal(err)
+	}
+	refs, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A setting row is readable by anything holding the read grant, and it is
+	// dumped in support bundles and audit trails. The credential must not be
+	// in it — only an opaque, workspace-bound handle.
+	for provider, ref := range refs {
+		if strings.Contains(ref, key) {
+			t.Fatalf("the %s setting carries the credential itself: %q", provider, ref)
+		}
+	}
+	if refs["openai"] == "" {
+		t.Fatal("no ref recorded, so nothing was sealed")
+	}
+}
+
+func TestRotatingAKeyServesTheNewOneAndRetiresTheOld(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+
+	if err := store.Set(ctx, "anthropic", "sk-first"); err != nil {
+		t.Fatal(err)
+	}
+	refs, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstRef := refs["anthropic"]
+
+	if err := store.Set(ctx, "anthropic", "sk-second"); err != nil {
+		t.Fatalf("rotating: %v", err)
+	}
+	if got := resolveKey(ctx, t, e, "anthropic"); got != "sk-second" {
+		t.Fatalf("after rotation the lane resolved %q, want the new key", got)
+	}
+	// The superseded blob is gone, not merely unreferenced: a credential no ref
+	// names is one no operator can find to delete, and it stays decryptable by
+	// anything holding the root key.
+	after, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after["anthropic"] == firstRef {
+		t.Fatal("the ref did not move, so the rotation stored nothing new")
+	}
+	if _, err := searchVault(t, e).Get(ctx, ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(firstRef)); err == nil {
+		t.Error("the superseded credential is still readable from the vault")
+	}
+}
+
+// Two admins keying two DIFFERENT vendors must both survive, and the case is
+// built to prove the ORDERING rather than to hope a race fires.
+//
+// The setting's value is one provider→ref map, so a Set is a read-modify-write
+// and the write lock has to be held across BOTH halves. Held only across the
+// write — which is where SetRawTx takes it — two requests read the same map,
+// each adds its own provider, and the second write drops the first's entirely:
+// a lost update, with both callers told they succeeded and the missing key
+// surfacing later as an AI lane that will not run.
+//
+// Two concurrent goroutines demonstrate that only by luck; the window is a few
+// milliseconds and it closed before the race landed. So the interleaving is
+// FORCED instead. The test takes the key's lock itself, waits until a Set is
+// provably parked on it, and only then writes another provider and commits:
+//
+//	lock held before the read  the Set blocks BEFORE reading, so it reads the
+//	                           committed map and merges — both providers live
+//	lock held after the read   the Set already read the empty map, and its write
+//	                           replaces the committed one — the other provider is
+//	                           gone, which is the failure being ruled out
+func TestAConcurrentKeyWriteCannotDropAnotherProvidersRef(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+	settingsStore := compose.NewSettingsStore(e.Pool)
+
+	setDone := make(chan error, 1)
+	// Held open for the whole body: the lock is transaction-scoped, so the
+	// window this test needs is exactly this transaction's lifetime.
+	if err := settingsStore.WriteTx(ctx, func(tx pgx.Tx) error {
+		if err := settings.LockForWrite(ctx, tx, ai.ProviderKeysKey); err != nil {
+			return err
+		}
+		go func() { setDone <- store.Set(ctx, "openai", "sk-openai") }()
+		waitForLockWaiter(ctx, t, e, ai.ProviderKeysKey)
+
+		// The other admin's write, through the real writer, while the Set is
+		// parked. Committing this releases the lock and lets the Set proceed.
+		return settings.SetTx(ctx, settingsStore, tx, ai.ProviderKeys,
+			map[string]string{"anthropic": sealKey(ctx, t, e, "sk-anthropic")})
+	}); err != nil {
+		t.Fatalf("the holding transaction failed: %v", err)
+	}
+	if err := <-setDone; err != nil {
+		t.Fatalf("the concurrent Set failed: %v", err)
+	}
+
+	for provider, want := range map[string]string{"anthropic": "sk-anthropic", "openai": "sk-openai"} {
+		if got := resolveKey(ctx, t, e, provider); got != want {
+			t.Errorf("%s resolved %q, want %q: the concurrent write dropped it", provider, got, want)
+		}
+	}
+}
+
+// waitForLockWaiter blocks until a session is parked on THIS key's advisory
+// lock, which is how the test knows the Set reached its lock acquisition without
+// sleeping for a guessed interval.
+//
+// Polls Postgres's own view of who is waiting rather than a duration, so the case
+// is decided by the state it depends on.
+//
+// Narrowed to the key, this database, and somebody else's backend, because the
+// broad form is a census that passes short: `locktype = 'advisory' AND NOT
+// granted` is satisfied by any session anywhere in the cluster parked on any
+// advisory lock, and this lane shares one Postgres across worktrees. It would
+// then report "the Set is parked" when it is not, the holding transaction would
+// commit, the Set would run afterwards and merge correctly, and the test would
+// pass having proved nothing about ordering — with no failing assertion anywhere.
+//
+// The three columns are how Postgres records the single-argument form, measured
+// rather than assumed: classid is the high 32 bits of the bigint the int4 hash
+// promotes to, objid the low 32, and objsubid is 1.
+func waitForLockWaiter(ctx context.Context, t *testing.T, e *SearchEnv, key string) {
+	t.Helper()
+	const parkedOnKey = `
+		SELECT count(*) FROM pg_locks
+		WHERE locktype = 'advisory'
+		  AND NOT granted
+		  AND objsubid = 1
+		  AND pid <> pg_backend_pid()
+		  AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+		  AND classid = ((hashtext($1)::bigint >> 32) & 4294967295)
+		  AND objid = (hashtext($1)::bigint & 4294967295)`
+
+	deadline, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	for {
+		// Checked BEFORE the query, because once the deadline expires the query
+		// itself errors and the run would die on "context deadline exceeded"
+		// rather than on the diagnosis below.
+		if deadline.Err() != nil {
+			t.Fatalf("no session ever parked on %s's advisory lock, so this case proves nothing about ordering", key)
+		}
+		var waiting int
+		if err := e.Pool.QueryRow(deadline, parkedOnKey, key).Scan(&waiting); err != nil {
+			if deadline.Err() != nil {
+				t.Fatalf("no session ever parked on %s's advisory lock, so this case proves nothing about ordering", key)
+			}
+			t.Fatalf("reading pg_locks while waiting for the parked write: %v", err)
+		}
+		if waiting > 0 {
+			return
+		}
+	}
+}
+
+// A ROTATED key reaches a running Router without a restart, and a REMOVED one
+// stops being used.
+//
+// This is the property the credential surface exists for and the one that nearly
+// shipped broken. The watcher compared only `RoutingVersion`, which is a digest
+// of what the binding BINDS — tiers, models, base URLs — and is blind to the
+// credential on purpose, because it doubles as a brief cache key. A rotation
+// therefore moved nothing the watcher could see: every running api and worker
+// kept calling the vendor with the key it resolved at boot, including one an
+// admin had just revoked. Revoking a credential through the product that holds
+// it has to stop its use.
+//
+// Driven through the real store, the real vault and a real ModelPath, because
+// what is being proved is that the resolved CLIENTS changed — not that a digest
+// moved.
+func TestARotatedKeyReachesARunningRouterAndARemovedOneStopsBeingUsed(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	keys := providerKeyStore(t, e)
+	// The vault root key rides the same lookup ResolveRouting consults — that is
+	// how sealedKeys reads it, and a t.Setenv would leave THIS lookup without a
+	// vault, which is a green test that resolves from the environment instead of
+	// from the seal. The value matches searchVault's root key: a different one
+	// builds a vault that cannot decrypt what the store sealed, and the failure
+	// then reads as a missing provider key rather than as a root-key mismatch.
+	// No provider key here — the point is that the VAULT supplies it, so an env
+	// copy would make the rotation unobservable.
+	env := config.Static(map[string]string{
+		keyvault.EnvRootKey: base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{9}, 32)),
+	})
+
+	// A binding on a provider that TAKES a key, so the credential is part of
+	// what the clients are built with.
+	routing := ai.NewRoutingStore(compose.NewSettingsStore(e.Pool), config.Static(nil))
+	bound, err := routing.Replace(ctx, cloudRouting(t))
+	if err != nil {
+		t.Fatalf("storing the binding: %v", err)
+	}
+	if err := keys.Set(ctx, "gemini", "sk-first"); err != nil {
+		t.Fatalf("sealing the first key: %v", err)
+	}
+
+	// Resolved the way a boot resolves it, so the Router carries whatever
+	// production would have stamped on it.
+	resolved, err := compose.ResolveRouting(ctx, e.Pool, "", env, discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting: %v", err)
+	}
+	path, err := compose.NewModelPath(ctx, resolved, e.Pool, false, discard())
+	if err != nil {
+		t.Fatalf("NewModelPath: %v", err)
+	}
+	router := path.Router()
+	if router == nil {
+		t.Fatal("the resolved path binds no router; the test can observe nothing")
+	}
+	watcher := compose.NewRoutingWatcher(e.Pool, &path, env, discard())
+	atBoot := router.CredentialVersion()
+	if atBoot == "" {
+		t.Fatal("the Router carries no credential version, so a rotation cannot be observed at all")
+	}
+
+	// An unchanged installation must not rebind: dropping every cached
+	// completion on each tick is the cost this comparison exists to avoid.
+	watcher.Recheck(ctx)
+	if router.CredentialVersion() != atBoot {
+		t.Fatalf("an unchanged installation moved the credential version to %q", router.CredentialVersion())
+	}
+	if router.RoutingVersion() != bound.RoutingVersion() {
+		t.Fatalf("an unchanged installation moved the routing version")
+	}
+
+	// Rotate. The BINDING is untouched, so the routing digest cannot move and
+	// the credential digest is the only thing that can carry this.
+	if err := keys.Set(ctx, "gemini", "sk-second"); err != nil {
+		t.Fatalf("rotating: %v", err)
+	}
+	watcher.Recheck(ctx)
+	if router.RoutingVersion() != bound.RoutingVersion() {
+		t.Errorf("the rotation moved the ROUTING version to %q; that digest is a brief cache key and must not move for a key",
+			router.RoutingVersion())
+	}
+	rotated := router.CredentialVersion()
+	if rotated == atBoot {
+		t.Fatal("the Router still holds the credential it resolved at boot, so a rotation reaches no running role until it restarts")
+	}
+
+	// A REMOVAL that leaves the binding unservable is a different case, and this
+	// pins what the system does rather than what one might hope.
+	//
+	// Every tier here is bound to gemini, so dropping its key leaves a config
+	// this process cannot build clients for. `applyIfChanged` then keeps the
+	// running binding by design — "turning a bad edit into an outage would be
+	// worse" — which for a CREDENTIAL means the revoked key stays in use until
+	// the process restarts. That reasoning was written for a bad binding edit,
+	// where the old binding is still a legitimate one; a removed credential is
+	// not. Whether a revocation should instead fail the lane closed is a
+	// security-posture decision with a real cost on both sides, so it is stated
+	// here as behaviour and not quietly assumed either way.
+	if err := keys.Remove(ctx, "gemini"); err != nil {
+		t.Fatalf("removing: %v", err)
+	}
+	watcher.Recheck(ctx)
+	if router.CredentialVersion() != rotated {
+		t.Errorf("credential version = %q, want the rotated %q: a removal that leaves the binding unservable keeps the running one",
+			router.CredentialVersion(), rotated)
+	}
+
+	// Re-keying makes the binding servable again, and the version moves — which
+	// is what shows the comparison above is live rather than the rebuild simply
+	// always failing from here on.
+	if err := keys.Set(ctx, "gemini", "sk-third"); err != nil {
+		t.Fatalf("re-keying: %v", err)
+	}
+	watcher.Recheck(ctx)
+	if router.CredentialVersion() == rotated {
+		t.Error("a servable credential change did not reach the Router")
+	}
+}
+
+// The audit trail records that a credential changed and never what it points at.
+//
+// `audit_log` is a log sink like any other — admin-readable over /audit-log and
+// exportable — so a vault ref written verbatim into a before/after image is a
+// capability handle sitting in the one place an installation hands out wholesale.
+// `settings.Entry.AsSecretReference` is what redacts it, and this entry was
+// declared without it: every set, rotate and remove wrote the full provider→ref
+// map into the row.
+//
+// Asserted against the ROW rather than against the entry's declaration, because
+// what matters is the bytes that land in the sink; a redaction that stops being
+// applied leaves the declaration looking correct.
+func TestTheAuditTrailOfAKeyChangeCarriesNoRef(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+
+	if err := store.Set(ctx, "gemini", "sk-audited"); err != nil {
+		t.Fatalf("sealing: %v", err)
+	}
+	refs, err := settings.Get(ctx, compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := refs["gemini"]
+	if ref == "" {
+		t.Fatal("nothing was stored, so the test would pass on an empty trail")
+	}
+
+	// Every image the change wrote, before and after, on one row or many.
+	var images string
+	if err := e.Pool.QueryRow(ctx, `
+		SELECT coalesce(string_agg(coalesce(before::text, '') || '|' || coalesce(after::text, ''), ' '), '')
+		FROM audit_log WHERE entity_type = $1`, "ai_routing").Scan(&images); err != nil {
+		t.Fatalf("reading the trail: %v", err)
+	}
+	if images == "" {
+		t.Fatal("the key change wrote no audit row at all")
+	}
+	if strings.Contains(images, ref) {
+		t.Errorf("the audit trail carries the vault ref verbatim: %s", images)
+	}
+	// Not only the whole ref — its unguessable tail is the capability half, and
+	// a partial write would be just as reachable.
+	if tail := ref[len(ref)-12:]; strings.Contains(images, tail) {
+		t.Errorf("the audit trail carries a fragment of the vault ref: %s", images)
+	}
+}
+
+// cloudRouting binds every tier to a provider that TAKES a key, so a credential
+// is part of what the clients are built with. `fake` needs none, which would
+// make a rotation unobservable for the wrong reason.
+func cloudRouting(t *testing.T) ai.RoutingConfig {
+	t.Helper()
+	cfg, err := ai.ParseRouting([]byte(`profile: cloud_frontier
+tiers:
+  local_small: {provider: gemini, model: gemini-3.1-flash-lite}
+  cheap_cloud: {provider: gemini, model: gemini-3.1-flash-lite}
+  premium: {provider: gemini, model: gemini-3.5-flash}
+  frontier: {provider: gemini, model: gemini-3.5-flash}
+embeddings: {provider: gemini, model: gemini-embedding-001, dimensions: 8}
+`))
+	if err != nil {
+		t.Fatalf("parsing the cloud binding: %v", err)
+	}
+	return cfg
+}
+
+// sealKey puts a credential in the vault the way the store does and returns the
+// ref, so the competing write records a ref that really resolves.
+func sealKey(ctx context.Context, t *testing.T, e *SearchEnv, key string) string {
+	t.Helper()
+	ref, err := searchVault(t, e).Put(ctx, ids.From[ids.WorkspaceKind](e.WS), []byte(key))
+	if err != nil {
+		t.Fatalf("sealing %s: %v", key, err)
+	}
+	return string(ref)
+}
+
+func TestRemovingAKeyLeavesTheProviderUnconfigured(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+
+	if err := store.Set(ctx, "gemini", "sk-to-be-removed"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Remove(ctx, "gemini"); err != nil {
+		t.Fatalf("removing: %v", err)
+	}
+	if got := resolveKey(ctx, t, e, "gemini"); got != "" {
+		t.Fatalf("a removed key still resolves as %q", got)
+	}
+	// Removing what is not there is the state the caller asked for, not a fault.
+	if err := store.Remove(ctx, "gemini"); err != nil {
+		t.Errorf("removing an absent key = %v, want success", err)
+	}
+}
+
+func TestListNamesEveryServableProviderNotOnlyTheConfiguredOnes(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := e.adminRoutingCtx()
+	store := providerKeyStore(t, e)
+
+	if err := store.Set(ctx, "gemini", "sk-only-one"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An installation that has configured nothing is exactly the one that needs
+	// the screen, so the list is the providers this build serves — not the rows
+	// that happen to exist.
+	if len(got) != len(ai.CloudProvidersNeedingKeys()) {
+		t.Fatalf("List returned %d providers, want every servable one (%d)", len(got), len(ai.CloudProvidersNeedingKeys()))
+	}
+	seen := map[string]bool{}
+	for _, s := range got {
+		seen[s.Provider] = s.Configured
+		if s.EnvVar == "" {
+			t.Errorf("%s names no environment variable, so a screen cannot say how a key seeded it", s.Provider)
+		}
+	}
+	if !seen["gemini"] {
+		t.Error("the configured provider does not read as configured")
+	}
+	if seen["openai"] {
+		t.Error("a provider with no key reads as configured")
+	}
+}
+
+func TestAProviderThisBuildCannotServeIsRefused(t *testing.T) {
+	e := SetupSearch(t)
+	store := providerKeyStore(t, e)
+	// A key sealed against a name nothing routes is a credential nobody can use
+	// and nobody will remember is there.
+	if err := store.Set(e.adminRoutingCtx(), "ollama", "sk-local-needs-none"); err == nil {
+		t.Fatal("a provider that takes no api key accepted one")
+	}
+}
+
+func TestTheKeySurfaceIsAdminOnly(t *testing.T) {
+	e := SetupSearch(t)
+	store := providerKeyStore(t, e)
+	// A FULLY FORMED principal that simply lacks the grant — workspace bound,
+	// actor set, correlation carried. A bare context would be refused by the
+	// settings store for having no workspace, so it would pass this test
+	// against a store with no RBAC gate at all.
+	rep := e.repNoRoutingCtx()
+	if _, err := store.List(rep); err == nil {
+		t.Error("List admitted a seat without the ai_routing grant")
+	}
+	if err := store.Set(rep, "gemini", "sk-nope"); err == nil {
+		t.Error("Set admitted a seat without the ai_routing grant")
+	}
+	if err := store.Remove(rep, "gemini"); err == nil {
+		t.Error("Remove admitted a seat without the ai_routing grant")
+	}
+}
+
+// searchSealedBlobCount is how many secrets the vault holds for this env's
+// workspace — the *Env twin of the same name lives beside the seal tests.
+func searchSealedBlobCount(t *testing.T, e *SearchEnv) int {
+	t.Helper()
+	var n int
+	if err := e.Pool.QueryRow(context.Background(), `SELECT count(*) FROM vault_secret`).Scan(&n); err != nil {
+		t.Fatalf("counting sealed secrets: %v", err)
+	}
+	return n
+}
+
+// repNoRoutingCtx is a seat with everything an admitted caller has except the
+// one grant this surface gates on — the credential a model calls with is not
+// something a rep may read, rotate or delete.
+func (e *SearchEnv) repNoRoutingCtx() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// TestAReadOnlySeatCannotSealAKey is the case the store's own update gate
+// exists for, and the only one that can see it.
+//
+// A seat holding ai_routing READ passes the store's first step — reading the
+// refs — so without the gate it reaches vault.Put and seals the caller's key
+// BEFORE the settings write refuses. The request still fails, which is why
+// asserting on the error proves nothing; what it leaves behind is a credential
+// no ref names, written by someone not allowed to write. So the assertion is
+// the blob count, not the error.
+func TestAReadOnlySeatCannotSealAKey(t *testing.T) {
+	e := SetupSearch(t)
+	store := providerKeyStore(t, e)
+	reader := e.routingReaderCtx()
+
+	// It can see the surface — otherwise this proves nothing about the update
+	// gate, only about the read one.
+	if _, err := store.List(reader); err != nil {
+		t.Fatalf("a read grant could not list: %v", err)
+	}
+
+	before := searchSealedBlobCount(t, e)
+	if err := store.Set(reader, "gemini", "sk-read-only-seat"); err == nil {
+		t.Error("a read-only seat sealed a provider key")
+	}
+	if after := searchSealedBlobCount(t, e); after != before {
+		t.Errorf("the refused Set sealed %d blob(s) anyway — the refusal must come before the seal, or a seat that may only look leaves credentials behind", after-before)
+	}
+
+	// Removing a provider that holds nothing is the one call that returns
+	// BEFORE the settings write, so it is the one place the store's own update
+	// gate is the only thing standing there. Without it a read-only seat is
+	// told its removal succeeded — a "yes" to someone who may not change
+	// anything, about a change that was never theirs to make.
+	if err := store.Remove(reader, "openai"); err == nil {
+		t.Error("a read-only seat was told it removed a key it may not touch")
+	}
+}
+
+// routingReaderCtx holds ai_routing READ and nothing else: it may see which
+// vendors are configured, and change none of them.
+func (e *SearchEnv) routingReaderCtx() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"ai_routing": {Read: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}

--- a/backend/internal/compose/providerkeyseal.go
+++ b/backend/internal/compose/providerkeyseal.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"maps"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
@@ -37,7 +38,8 @@ import (
 // vault that refuses one provider does not cost the installation the keys it
 // already sealed for the others.
 func SealProviderKeys(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, ws ids.WorkspaceID, env config.Lookup, log *slog.Logger) map[string]string {
-	stored, err := settings.Get(ctx, NewSettingsStore(pool), ai.ProviderKeys)
+	store := NewSettingsStore(pool)
+	stored, err := settings.Get(ctx, store, ai.ProviderKeys)
 	if err != nil {
 		log.WarnContext(ctx, "cannot read the sealed provider credentials; falling back to the environment for this boot", "error", err)
 		return nil
@@ -83,10 +85,48 @@ func SealProviderKeys(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Va
 	// nothing, the new ref would never be recorded, and its blob would be
 	// stranded in the vault while the environment silently kept answering.
 	//
-	// Overwriting is safe because this map is only ever GROWN: an existing
-	// provider's ref is carried forward untouched a few lines above, so a Set
-	// can add a key and can never drop or repoint one.
-	if err := settings.Set(ctx, NewSettingsStore(pool), ai.ProviderKeys, next); err != nil {
+	// The merge is re-done INSIDE a locked transaction rather than trusting the
+	// read above. "Overwriting is safe because this map is only ever grown" was
+	// true while this was the only writer; it stopped being true when an admin
+	// got a write path. Two ways it breaks, and the second is the worse one:
+	//
+	//   lost update       this reads {}, an admin's PUT commits, this writes
+	//                     {openai: ref} and the admin's provider is dropped —
+	//                     its blob stranded, and the admin was told 204
+	//   resurrected ref   this reads {gemini: refA}, an admin's DELETE commits
+	//                     and destroys refA's blob, this writes {gemini: refA}
+	//                     back — the setting now names a blob that is gone,
+	//                     which is the dangling ref the store's own error
+	//                     classification goes to some length to avoid
+	//
+	// And the window is not boot-only: RoutingWatcher.Recheck reaches here every
+	// interval in every role, so any installation still carrying an unsealed
+	// *_API_KEY re-runs this write on a timer.
+	//
+	// Not literally sharing ai.ProviderKeyStore's swapRef: that moves ONE
+	// provider and this merges many. What they must share is the lock, and they
+	// do — settings.LockForWrite, taken before the read on both sides.
+	merged := next
+	if err := store.WriteTx(ctx, func(tx pgx.Tx) error {
+		if err := settings.LockForWrite(ctx, tx, ai.ProviderKeysKey); err != nil {
+			return err
+		}
+		current, err := settings.GetTx(ctx, tx, ai.ProviderKeys)
+		if err != nil {
+			return err
+		}
+		// The freshly sealed refs go on top of what is stored NOW. A provider
+		// somebody else keyed while this was sealing keeps their ref: only the
+		// providers this call actually sealed are written.
+		merged = maps.Clone(current)
+		if merged == nil {
+			merged = map[string]string{}
+		}
+		for _, provider := range sealedNow {
+			merged[provider] = next[provider]
+		}
+		return settings.SetTx(ctx, store, tx, ai.ProviderKeys, merged)
+	}); err != nil {
 		// The blobs are sealed and nothing references them — inert, encrypted
 		// at rest, and collected by nobody. The installation keeps running on
 		// the environment and the next boot tries again, which will strand
@@ -95,6 +135,7 @@ func SealProviderKeys(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Va
 			"providers", sealedNow, "error", err)
 		return stored
 	}
+	next = merged
 	// The one sentence that tells an operator they may now drop the variables.
 	// Nothing here can remove them: the process cannot edit its orchestrator.
 	log.InfoContext(ctx, "sealed provider credentials into the key vault; the environment variables that carried them can be removed",

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -20,8 +20,13 @@ package compose
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -100,7 +105,12 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 	if stored.Unconfigured() {
 		return ai.RoutingConfig{}, nil
 	}
-	return ai.FromStored(stored, sealedKeys(ctx, pool, ws, keys, log))
+	lookup, credentials := sealedKeys(ctx, pool, ws, keys, log)
+	cfg, err := ai.FromStored(stored, lookup)
+	if err != nil {
+		return ai.RoutingConfig{}, err
+	}
+	return cfg.WithCredentialVersion(credentials), nil
 }
 
 // sealedKeys upgrades the environment lookup to one that resolves a provider's
@@ -114,7 +124,7 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 //
 // An installation with no vault configured gets the environment unchanged,
 // which is where every installation was before this existed.
-func sealedKeys(ctx context.Context, pool *pgxpool.Pool, ws ids.UUID, env config.Lookup, log *slog.Logger) config.Lookup {
+func sealedKeys(ctx context.Context, pool *pgxpool.Pool, ws ids.UUID, env config.Lookup, log *slog.Logger) (config.Lookup, string) {
 	vault, configured, err := keyvault.FromEnv(ctx, pool, env)
 	if err != nil || !configured {
 		if err != nil {
@@ -127,11 +137,48 @@ func sealedKeys(ctx context.Context, pool *pgxpool.Pool, ws ids.UUID, env config
 			// the vault existed.
 			log.WarnContext(ctx, "the key vault is configured but unusable; provider credentials resolve from the environment this boot", "error", err)
 		}
-		return env
+		return env, ""
 	}
 	workspace := ids.From[ids.WorkspaceKind](ws)
 	refs := SealProviderKeys(ctx, pool, vault, workspace, env, log)
-	return ai.SealedKeys(ctx, vault, workspace, refs, env)
+	return ai.SealedKeys(ctx, vault, workspace, refs, env), credentialDigest(refs)
+}
+
+// credentialDigest fingerprints the provider→ref map a binding resolves with, so
+// a rotated or removed key is observable to a watcher that would otherwise see
+// an identical routing digest and keep serving the old credential.
+//
+// Over the REFS, never the secrets: a ref is an opaque handle, and the digest of
+// one tells a reader only whether it moved. Sorted, because a map's iteration
+// order is not stable and an unsorted digest would report a change on every
+// tick.
+//
+// The empty map digests to the empty string rather than to a hash of nothing, so
+// an installation with no vault and one with a vault holding no keys compare
+// equal — neither has a credential to fall behind on.
+func credentialDigest(refs map[string]string) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	providers := make([]string, 0, len(refs))
+	for provider := range refs {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	// Rendered to one string and hashed once, rather than written into the hash
+	// incrementally: a hash.Hash's Write never fails, but a call whose error is
+	// ignored reads exactly like one that should have been handled.
+	var canonical strings.Builder
+	for _, provider := range providers {
+		// Length-prefixed so no two different maps can render the same bytes —
+		// {"ab":"c"} and {"a":"bc"} concatenate identically without it.
+		canonical.WriteString(strconv.Itoa(len(provider)))
+		canonical.WriteString(":" + provider + "=")
+		canonical.WriteString(strconv.Itoa(len(refs[provider])))
+		canonical.WriteString(":" + refs[provider] + ";")
+	}
+	sum := sha256.Sum256([]byte(canonical.String()))
+	return hex.EncodeToString(sum[:])
 }
 
 // routingCtx binds the boot's system principal on the installation's

--- a/backend/internal/compose/routingwatcher.go
+++ b/backend/internal/compose/routingwatcher.go
@@ -114,12 +114,23 @@ func (w *RoutingWatcher) applyIfChanged(ctx context.Context, next ai.RoutingConf
 	if next.Unconfigured() {
 		return false
 	}
-	// The version is the whole comparison. It is a digest of what the binding
-	// BINDS, so it changes exactly when the models change and not when the
-	// document is merely rewritten — which is what keeps this from rebinding,
-	// and dropping every cached completion, on every tick.
+	// TWO comparands, because a binding and a credential change independently
+	// and only one of them moves the routing digest.
+	//
+	// RoutingVersion is a digest of what the binding BINDS — tiers, models, base
+	// URLs — so it changes exactly when the models change and not when the
+	// document is merely rewritten, which is what keeps this from rebinding and
+	// dropping every cached completion on every tick.
+	//
+	// It is also blind to the credential, deliberately: it is a brief cache key,
+	// and folding a key into it would regenerate every stored brief through paid
+	// models on each rotation. So a rotated or removed key changes nothing it can
+	// see, and comparing it alone left every running role calling the vendor with
+	// the credential it resolved at boot — including one an admin had just
+	// revoked. Revoking a credential through the product has to stop its use.
 	previous := w.target.RoutingVersion()
-	if next.RoutingVersion() == previous {
+	previousCredentials := w.target.CredentialVersion()
+	if next.RoutingVersion() == previous && next.CredentialVersion() == previousCredentials {
 		return false
 	}
 	if err := w.target.Rebind(next); err != nil {
@@ -130,7 +141,10 @@ func (w *RoutingWatcher) applyIfChanged(ctx context.Context, next ai.RoutingConf
 			"error", err, "routing_version", previous)
 		return false
 	}
+	// Which of the two moved, because the operator's next question differs: a
+	// re-pointed tier is a routing edit, a moved credential is a rotation.
 	w.log.InfoContext(ctx, "adopted a changed model binding without restarting",
-		"from", previous, "to", next.RoutingVersion())
+		"from", previous, "to", next.RoutingVersion(),
+		"credentials_changed", next.CredentialVersion() != previousCredentials)
 	return true
 }

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -190,6 +191,12 @@ func WithKeyvault(vault keyvault.Vault) Option {
 		// have already run, and a reset that cannot reach the vault leaves the
 		// sealed credentials of the installation it just wiped resident.
 		s.dataResetHandlers.vault = vault
+		// The BYOK credential surface exists only where there is somewhere to
+		// seal a key. Wired here rather than in the AI block so a role that
+		// composes no vault serves 501 on those routes instead of recording a
+		// reference to a blob nothing wrote.
+		s.voiceHandlers = s.WithProviderKeys(
+			ai.NewProviderKeyStore(NewSettingsStore(pool), vault, s.log))
 		// Rebuild the capture registry with the vault so the connector-
 		// credential paths (Connect seals, Sync resolves) have their custodian.
 		// The standing IMAP connect rides this same registry and needs no

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -131,6 +131,18 @@ func (stubs) GetAiProfile(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetAiProfile")
 }
 
+func (stubs) ListAiProviderKeys(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "ListAiProviderKeys")
+}
+
+func (stubs) DeleteAiProviderKey(w nethttp.ResponseWriter, r *nethttp.Request, provider string) {
+	httperr.NotImplemented(w, r, "DeleteAiProviderKey")
+}
+
+func (stubs) SetAiProviderKey(w nethttp.ResponseWriter, r *nethttp.Request, provider string) {
+	httperr.NotImplemented(w, r, "SetAiProviderKey")
+}
+
 func (stubs) GetAiRouting(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetAiRouting")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12362,6 +12362,29 @@ type AiProfileProviders string
 // AiProfileState defines model for AiProfile.State.
 type AiProfileState string
 
+// AiProviderKeyInput defines model for AiProviderKeyInput.
+type AiProviderKeyInput struct {
+	// ApiKey The vendor credential. WRITE-ONLY — no response in this contract returns it, and the setting that records it holds an opaque vault reference rather than these bytes.
+	ApiKey *string `json:"api_key,omitempty"`
+}
+
+// AiProviderKeyList defines model for AiProviderKeyList.
+type AiProviderKeyList struct {
+	Providers []AiProviderKeyStatus `json:"providers"`
+}
+
+// AiProviderKeyStatus What may be known about one vendor's credential. Deliberately three facts and no fourth: the key itself has no read path, and neither does anything derived from it — a length, a prefix or a masked tail would each narrow a brute force while feeling harmless.
+type AiProviderKeyStatus struct {
+	// Configured Whether a credential is held. A screen reads this to offer "add" or "rotate"; it says nothing about whether the key still works, which only the vendor can answer.
+	Configured bool `json:"configured"`
+
+	// EnvVar The variable the same key may arrive in. Named so an operator can see which export seeded a vendor; the names follow each vendor's own convention, which is why they carry no MARGINCE_ prefix.
+	EnvVar string `json:"env_var"`
+
+	// Provider The routing name of the vendor, the same string a binding uses.
+	Provider string `json:"provider"`
+}
+
 // AiRouting The installation's tier-to-model binding. `tiers` is keyed by tier name; the closed set
 // of names is the one the task contract declares (api/ai-tasks.yaml), and the server
 // refuses an unknown key with a 422 naming it — restating the set here would be a second
@@ -28055,6 +28078,9 @@ type SetAiModelRateJSONRequestBody = SetAiModelRateRequest
 // RecordAIFeedbackJSONRequestBody defines body for RecordAIFeedback for application/json ContentType.
 type RecordAIFeedbackJSONRequestBody = AIFeedbackInput
 
+// SetAiProviderKeyJSONRequestBody defines body for SetAiProviderKey for application/json ContentType.
+type SetAiProviderKeyJSONRequestBody = AiProviderKeyInput
+
 // ReplaceAiRoutingJSONRequestBody defines body for ReplaceAiRouting for application/json ContentType.
 type ReplaceAiRoutingJSONRequestBody = AiRouting
 
@@ -36328,6 +36354,15 @@ type ServerInterface interface {
 	// Authenticated AI configuration posture for transparent human-facing workspaces.
 	// (GET /ai/profile)
 	GetAiProfile(w http.ResponseWriter, r *http.Request)
+	// Which model vendors hold a credential (admin/ops).
+	// (GET /ai/provider-keys)
+	ListAiProviderKeys(w http.ResponseWriter, r *http.Request)
+	// Remove one vendor's BYOK key (admin/ops).
+	// (DELETE /ai/provider-keys/{provider})
+	DeleteAiProviderKey(w http.ResponseWriter, r *http.Request, provider string)
+	// Store or rotate one vendor's BYOK key (admin/ops).
+	// (PUT /ai/provider-keys/{provider})
+	SetAiProviderKey(w http.ResponseWriter, r *http.Request, provider string)
 	// The tier-to-model binding this installation runs on (admin/ops).
 	// (GET /ai/routing)
 	GetAiRouting(w http.ResponseWriter, r *http.Request)
@@ -37825,6 +37860,24 @@ func (_ Unimplemented) RecordAIFeedback(w http.ResponseWriter, r *http.Request) 
 // Authenticated AI configuration posture for transparent human-facing workspaces.
 // (GET /ai/profile)
 func (_ Unimplemented) GetAiProfile(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Which model vendors hold a credential (admin/ops).
+// (GET /ai/provider-keys)
+func (_ Unimplemented) ListAiProviderKeys(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Remove one vendor's BYOK key (admin/ops).
+// (DELETE /ai/provider-keys/{provider})
+func (_ Unimplemented) DeleteAiProviderKey(w http.ResponseWriter, r *http.Request, provider string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Store or rotate one vendor's BYOK key (admin/ops).
+// (PUT /ai/provider-keys/{provider})
+func (_ Unimplemented) SetAiProviderKey(w http.ResponseWriter, r *http.Request, provider string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -41802,6 +41855,90 @@ func (siw *ServerInterfaceWrapper) GetAiProfile(w http.ResponseWriter, r *http.R
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAiProfile(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAiProviderKeys operation middleware
+func (siw *ServerInterfaceWrapper) ListAiProviderKeys(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAiProviderKeys(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAiProviderKey operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAiProviderKey(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", chi.URLParam(r, "provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAiProviderKey(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SetAiProviderKey operation middleware
+func (siw *ServerInterfaceWrapper) SetAiProviderKey(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", chi.URLParam(r, "provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetAiProviderKey(w, r, provider)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -61997,6 +62134,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/ai/profile", wrapper.GetAiProfile)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/ai/provider-keys", wrapper.ListAiProviderKeys)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/ai/provider-keys/{provider}", wrapper.DeleteAiProviderKey)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/ai/provider-keys/{provider}", wrapper.SetAiProviderKey)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/ai/routing", wrapper.GetAiRouting)

--- a/backend/internal/modules/ai/binding.go
+++ b/backend/internal/modules/ai/binding.go
@@ -41,6 +41,13 @@ type binding struct {
 	// without a RoutingConfig: Embed then leaves a caller-unset Dimensions at
 	// 0 and each adapter's own provider default still applies.
 	embedDims int
+	// credentialVersion is a digest of the provider credentials this Router's
+	// clients were built WITH, and it is separate from configSnapshot on
+	// purpose: rotating a key must rebind the clients but must NOT move
+	// RoutingConfigHash, which is a brief cache key. Folding the credential
+	// into that digest would regenerate every stored brief in the installation
+	// through paid models on every key rotation.
+	credentialVersion string
 }
 
 // binding returns the configuration this call must serve itself from. Load it
@@ -59,17 +66,24 @@ func (r *Router) binding() *binding {
 // and embed width stamped on — the one place that keeps both in sync, since the
 // snapshot's provider_params must name the SAME width Embed defaults an unset
 // request to. Pure: EnsureConfig plants the row lazily, once per flush.
-func (b binding) withConfigSnapshot(routingConfigHash string, embedDims int) binding {
+// Takes the CONFIG rather than the two values it needs, so a third thing the
+// binding must carry from it cannot be added at one construction site and
+// forgotten at the other two. credentialVersion was exactly that: three sites
+// stamped the snapshot, and a version threaded through only one of them left
+// the boot-built Router unable to notice a rotated key.
+func (b binding) withConfigSnapshot(cfg RoutingConfig) binding {
 	// ParseRouting defaults 0→defaultEmbedDimensions, but a programmatic
 	// RoutingConfig built without it (a hand-assembled test fixture) reaches
 	// construction with Dimensions still 0 — default here too so a bound embed
 	// lane never stamps its identity as "@0" or asks a provider for width 0.
+	embedDims := cfg.Embeddings.Dimensions
 	if embedDims == 0 {
 		embedDims = defaultEmbedDimensions
 	}
 	b.embedDims = embedDims
-	b.configSnapshot = newConfigSnapshot(routingConfigHash, embedDims)
+	b.configSnapshot = newConfigSnapshot(cfg.sourceHash, embedDims)
 	b.configHash = b.configSnapshot.Hash
+	b.credentialVersion = cfg.credentialVersion
 	return b
 }
 
@@ -96,11 +110,22 @@ func (r *Router) Rebind(cfg RoutingConfig) error {
 	next := binding{
 		clients: clients, embedder: embedder,
 		profile: cfg.Profile, routeMeta: embedInclusiveMeta(cfg),
-	}.withConfigSnapshot(cfg.sourceHash, cfg.Embeddings.Dimensions)
+	}.withConfigSnapshot(cfg)
 	r.bound.Store(&next)
 	r.cache.clear()
 	return nil
 }
+
+// CredentialVersion is a digest of the provider credentials this Router's
+// clients hold. A caller compares it against the stored one to decide whether it
+// has fallen behind on a KEY, which RoutingVersion cannot answer: a rotation
+// changes no tier, no model and no base URL, so the routing digest is identical
+// before and after and a watcher comparing only that would keep calling the
+// vendor with a credential an admin has revoked.
+//
+// Empty on a Router assembled without one, which is every unit fixture and an
+// installation whose keys come from the environment alone.
+func (r *Router) CredentialVersion() string { return r.binding().credentialVersion }
 
 // RoutingVersion is the digest of the ROUTING CONFIG this Router is serving —
 // the value a caller compares against the stored one to decide whether it has

--- a/backend/internal/modules/ai/handlers_providerkeys.go
+++ b/backend/internal/modules/ai/handlers_providerkeys.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// The transport slice for the BYOK credentials: /ai/provider-keys.
+//
+// It carries nothing the store owns — no RBAC decision, no vendor vocabulary,
+// no sealing. What it does own is the shape of the answer, and the one rule
+// that shape has: the key has no read path. There is no GET that returns it, no
+// field on the list that hints at it, and no error that echoes it back. A
+// credential a client can read is one a support bundle, a browser cache and a
+// screenshare each carry a copy of.
+
+import (
+	"errors"
+	"net/http"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// WithProviderKeys wires the credential store. Absent it every route answers
+// 503 rather than 500: a role that composed no store is an installation with
+// nowhere to seal a key, which its operator can fix — see vaultUnavailable.
+func (h Handlers) WithProviderKeys(store *ProviderKeyStore) Handlers {
+	h.providerKeys = store
+	return h
+}
+
+// ListAiProviderKeys implements (GET /ai/provider-keys).
+func (h Handlers) ListAiProviderKeys(w http.ResponseWriter, r *http.Request) {
+	if h.providerKeys == nil {
+		vaultUnavailable(w, r, principal.ActionRead)
+		return
+	}
+	statuses, err := h.providerKeys.List(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	out := crmcontracts.AiProviderKeyList{
+		Providers: make([]crmcontracts.AiProviderKeyStatus, 0, len(statuses)),
+	}
+	for _, s := range statuses {
+		out.Providers = append(out.Providers, crmcontracts.AiProviderKeyStatus{
+			Provider:   s.Provider,
+			Configured: s.Configured,
+			EnvVar:     s.EnvVar,
+		})
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// vaultUnavailable answers the one reason this surface can be unwired.
+//
+// 503, not 501. The store is nil for exactly one reason — compose builds it
+// inside WithKeyvault, so a role that composes no vault has none — and that is
+// an installation lacking somewhere to seal a key, which is the operator's to
+// fix. 501 would say this BUILD does not implement the operation, sending an
+// integrator to look for a newer version that does not exist and cannot help.
+// The contract declares 503 with this meaning on all three routes.
+func vaultUnavailable(w http.ResponseWriter, r *http.Request, action principal.Action) {
+	// The GRANT first. Without this the wiring check answers before any
+	// authorization does, and the status code becomes an oracle: a seat with no
+	// `ai_routing` grant gets 503 on an installation with no vault and 403 on one
+	// that has it, so anybody with a session can read off whether a vault root
+	// key is configured. Same object and action the store would have gated on,
+	// so a caller who IS entitled sees no difference.
+	if err := auth.Require(r.Context(), providerKeysObject, action); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.ServiceUnavailable(w, r, ErrVaultUnavailable.Error())
+}
+
+// SetAiProviderKey implements (PUT /ai/provider-keys/{provider}).
+//
+// 204 and no body, deliberately: the only thing a caller could want back is the
+// credential they just sent, and echoing it would put it in a response body
+// that proxies log and browsers cache.
+func (h Handlers) SetAiProviderKey(w http.ResponseWriter, r *http.Request, provider string) {
+	if h.providerKeys == nil {
+		vaultUnavailable(w, r, principal.ActionUpdate)
+		return
+	}
+	var body crmcontracts.AiProviderKeyInput
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+	if err := h.providerKeys.Set(r.Context(), provider, writtenKey(body.ApiKey)); err != nil {
+		// A missing vault is the operator's to fix and nothing the caller sent,
+		// so it reads as unavailable rather than as their bad request.
+		if errors.Is(err, ErrVaultUnavailable) {
+			vaultUnavailable(w, r, principal.ActionUpdate)
+			return
+		}
+		httperr.Write(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writtenKey reads the credential the caller sent.
+//
+// A pointer because the schema marks `api_key` writeOnly, which is what keeps
+// the field out of every generated response type — the guarantee the
+// description makes. Absent becomes empty, and the store refuses empty BY NAME
+// ("remove the credential instead of storing nothing") rather than sealing a
+// zero-length key that would authenticate nothing while reading as configured.
+//
+// Not shared with the several other nil-deref helpers this tree already carries
+// (compose's `derefString` among them): a module may not import compose
+// (ADR-0054 §3), so that one is unreachable from here regardless. A single
+// generic home for all of them would be `shared/`, the stdlib-only leaf tier —
+// worth doing as its own change across every twin, and not worth reaching for
+// while adding the next one in isolation.
+func writtenKey(sent *string) string {
+	if sent == nil {
+		return ""
+	}
+	return *sent
+}
+
+// DeleteAiProviderKey implements (DELETE /ai/provider-keys/{provider}).
+func (h Handlers) DeleteAiProviderKey(w http.ResponseWriter, r *http.Request, provider string) {
+	if h.providerKeys == nil {
+		vaultUnavailable(w, r, principal.ActionUpdate)
+		return
+	}
+	if err := h.providerKeys.Remove(r.Context(), provider); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/modules/ai/handlers_providerkeys_test.go
+++ b/backend/internal/modules/ai/handlers_providerkeys_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// keySeatCtx binds a human holding exactly the given ai_routing grant.
+func keySeatCtx(g principal.ObjectGrant) context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:test",
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"fixture"},
+			Objects:  map[string]principal.ObjectGrant{providerKeysObject: g},
+		},
+	})
+}
+
+// keyRoutes names the credential surface's three routes so a case about the
+// unwired shape covers all of them rather than whichever one was written first.
+// A fourth route added without a line here is simply untested by these two
+// cases, which the coverage report shows and no claim in this comment hides.
+func keyRoutes(h Handlers) map[string]func(http.ResponseWriter, *http.Request) {
+	return map[string]func(http.ResponseWriter, *http.Request){
+		"GET /ai/provider-keys": h.ListAiProviderKeys,
+		"PUT /ai/provider-keys/{provider}": func(w http.ResponseWriter, r *http.Request) {
+			h.SetAiProviderKey(w, r, "gemini")
+		},
+		"DELETE /ai/provider-keys/{provider}": func(w http.ResponseWriter, r *http.Request) {
+			h.DeleteAiProviderKey(w, r, "gemini")
+		},
+	}
+}
+
+func keyRequest(ctx context.Context) *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/v1/ai/provider-keys", nil).WithContext(ctx)
+}
+
+// An entitled seat on an installation with no key vault is told the vault is
+// missing, on every route.
+//
+// 503 and never 501. The distinction is what an integrator does next: 501 says
+// this BUILD does not implement the operation, which sends them looking for a
+// newer version; 503 says the installation is missing something its operator can
+// supply. The contract declares 503 on all three, so a 501 would also be the
+// server contradicting its own document.
+//
+// A zero-value Handlers is exactly the shape compose produces for a role with no
+// vault — the store is built inside WithKeyvault — so this is the real unwired
+// case rather than a stand-in for it.
+func TestTheKeyRoutesReadAsUnavailableWithoutAVault(t *testing.T) {
+	ctx := keySeatCtx(principal.ObjectGrant{Read: true, Update: true})
+
+	for route, call := range keyRoutes(Handlers{}) {
+		t.Run(route, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			call(rec, keyRequest(ctx))
+
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+			// The body has to name what is missing. "Service unavailable" alone
+			// tells an operator to retry, which will never work.
+			var problem struct {
+				Detail string `json:"detail"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &problem); err != nil {
+				t.Fatalf("decoding the problem body: %v", err)
+			}
+			if problem.Detail != ErrVaultUnavailable.Error() {
+				t.Errorf("detail = %q, want the vault explanation %q", problem.Detail, ErrVaultUnavailable.Error())
+			}
+		})
+	}
+}
+
+// A seat with no grant is REFUSED before it learns anything about the vault.
+//
+// The unwired shape answers 503, and that answer is information: without the
+// gate below, an unentitled seat gets 503 where a vault is absent and 403 where
+// one is configured, so anybody holding a session can read off whether this
+// installation has a vault root key. The remedy is ordering — authorize first,
+// then report the wiring — and it is only observable on the unwired shape, which
+// is why it belongs here rather than in the integration lane.
+func TestAnUnentitledSeatIsRefusedBeforeLearningTheVaultPosture(t *testing.T) {
+	// No grant on the object at all, which is what a rep seat holds: the seeded
+	// roles give ai_routing read and update together, to admin and ops only.
+	ctx := keySeatCtx(principal.ObjectGrant{})
+
+	for route, call := range keyRoutes(Handlers{}) {
+		t.Run(route, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			call(rec, keyRequest(ctx))
+
+			if rec.Code == http.StatusServiceUnavailable {
+				t.Fatalf("an unentitled seat was told the vault posture (503); the status is an oracle for whether a root key is configured")
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/ai/handlers_voice.go
+++ b/backend/internal/modules/ai/handlers_voice.go
@@ -39,6 +39,9 @@ type Handlers struct {
 	// against at read time (price-on-read) — same pool, and the same
 	// workspace-bound path as every other tenant read.
 	rates *RateStore
+	// providerKeys is the sealed BYOK credentials. Nil on a role that composed
+	// no vault, which is why the routes answer 503 rather than panicking.
+	providerKeys *ProviderKeyStore
 	// publicProfile is the minimal anonymous login-presence view. NewHandlers
 	// starts honest-unconfigured; the API composition root replaces it from
 	// the same routing decision that builds the model path.

--- a/backend/internal/modules/ai/localrouter.go
+++ b/backend/internal/modules/ai/localrouter.go
@@ -140,7 +140,7 @@ func NewLocalRouter(cfg RoutingConfig, opts ...LocalOption) (*Router, error) {
 	// WithCallStore opts a caller into tracing.
 	router := assembleRouter(clients, embedder, cfg.Profile, &memoryMeter{}, StaticBudget(o.monthlyBudget), o.callStore, meta, o.capturePayloads, nil)
 	router.cacheOff = o.cacheOff
-	stamped := router.binding().withConfigSnapshot(cfg.sourceHash, cfg.Embeddings.Dimensions)
+	stamped := router.binding().withConfigSnapshot(cfg)
 	router.bound.Store(&stamped)
 	return router, nil
 }

--- a/backend/internal/modules/ai/providerkeys.go
+++ b/backend/internal/modules/ai/providerkeys.go
@@ -55,7 +55,7 @@ var ProviderKeys = settings.Define[map[string]string](
 	"update",
 	map[string]string{},
 	validateProviderKeyRefs,
-).AsInstallationIdentity()
+).AsInstallationIdentity().AsSecretReference()
 
 // validateProviderKeyRefs refuses a ref for a provider this build cannot serve.
 // A key sealed against a name nothing routes is a credential nobody can use and

--- a/backend/internal/modules/ai/providerkeystore.go
+++ b/backend/internal/modules/ai/providerkeystore.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Putting a BYOK key in, taking one out, and saying which vendors have one.
+//
+// The vault has been where these keys LIVE since providerkeys.go landed, but
+// the only way one could arrive was an environment variable the seeder picked
+// up at boot. So an admin could not add a vendor without an operator, a
+// restart, and a shell — and deploymentsecretseal.go's justification for
+// letting the vault outrank a declaration ("a provider key has a human write
+// path — the routing surface") named a path nothing had built.
+//
+// This is that path. It owns what a transport must not: the RBAC gate, the
+// refusal of a provider this build cannot serve, sealing the bytes before they
+// are recorded, and retiring the ref that was there — in that order, because a
+// ref recorded before its blob exists points at nothing, and a blob left behind
+// after its ref is replaced is a credential no reader can find and no operator
+// can delete.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/platform/settings"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// ProviderKeyStatus is what a reader may learn about one vendor's credential:
+// that this build can serve it, and whether a key is held. Never the key.
+type ProviderKeyStatus struct {
+	// Provider is the routing name — the same string a binding uses.
+	Provider string
+	// Configured reports whether a credential is sealed for it.
+	Configured bool
+	// EnvVar is the variable the key may also arrive in, so a screen can tell
+	// an operator which export seeded it.
+	EnvVar string
+}
+
+// ProviderKeyStore reads and changes the sealed BYOK credentials.
+//
+// The workspace is NOT held here: it comes off each request's context, the way
+// every other tenant read resolves it. Binding one at construction would make a
+// request's answer depend on which workspace happened to be resolved when the
+// process booted, which is the shape of bug that only appears on the day there
+// is a second one.
+type ProviderKeyStore struct {
+	settings *settings.Store
+	vault    keyvault.Vault
+	// log carries the one failure this store cannot report to its caller: a
+	// superseded blob it could not delete after the write already committed.
+	log *slog.Logger
+}
+
+// NewProviderKeyStore builds the store over the settings catalog and the vault.
+// A nil vault is a role that seals nothing: every write refuses rather than
+// recording a ref to a blob that was never written.
+func NewProviderKeyStore(s *settings.Store, vault keyvault.Vault, log *slog.Logger) *ProviderKeyStore {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &ProviderKeyStore{settings: s, vault: vault, log: log}
+}
+
+// credentialWorkspace is the caller's tenant, or a refusal. A credential write outside
+// a workspace has no tenant to belong to, and the vault would refuse the ref
+// later anyway — so it is refused here, where the message can say why.
+func credentialWorkspace(ctx context.Context) (ids.WorkspaceID, error) {
+	raw, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return ids.WorkspaceID{}, errors.New("ai: a provider key outside a workspace context")
+	}
+	return ids.From[ids.WorkspaceKind](raw), nil
+}
+
+// ErrVaultUnavailable is the refusal when this installation seals nothing.
+// Separate from a validation error because the fix is the operator's — the
+// vault root key — and not anything the caller sent.
+var ErrVaultUnavailable = errors.New("this installation has no key vault configured, so a provider key cannot be stored: set the vault root key on the api and worker, then try again")
+
+// List reports every cloud provider this build can serve and whether each holds
+// a key, in the routing table's own order.
+//
+// It lists the providers rather than the stored refs, so a vendor with no
+// credential is visible as something an admin could configure. A list of what
+// happens to be stored would show an empty screen on the installation that most
+// needs the screen.
+func (s *ProviderKeyStore) List(ctx context.Context) ([]ProviderKeyStatus, error) {
+	if err := auth.Require(ctx, providerKeysObject, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	refs, err := settings.Get(ctx, s.settings, ProviderKeys)
+	if err != nil {
+		return nil, err
+	}
+	providers := CloudProvidersNeedingKeys()
+	out := make([]ProviderKeyStatus, 0, len(providers))
+	for _, provider := range providers {
+		out = append(out, ProviderKeyStatus{
+			Provider:   provider,
+			Configured: refs[provider] != "",
+			EnvVar:     KeyEnvVarFor(provider),
+		})
+	}
+	return out, nil
+}
+
+// Set seals a key for one provider and records the ref, replacing whatever was
+// there.
+//
+// The new blob is written BEFORE the ref is moved and the old one is retired
+// only after the move commits, so no window exists in which the recorded ref
+// names nothing. A failure part-way leaves the previous credential serving.
+func (s *ProviderKeyStore) Set(ctx context.Context, provider, apiKey string) error {
+	if err := auth.Require(ctx, providerKeysObject, principal.ActionUpdate); err != nil {
+		return err
+	}
+	if _, cloud := cloudKeyEnv[provider]; !cloud {
+		return settings.InvalidValue{
+			Setting: ProviderKeysKey, Code: settings.CodeInvalidValue,
+			Reason: fmt.Sprintf("%q takes no api key", provider),
+		}
+	}
+	// Trimmed because a pasted credential arrives with whatever whitespace the
+	// clipboard carried, and a key with a trailing newline authenticates
+	// nothing while looking exactly like one that would.
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return settings.InvalidValue{
+			Setting: ProviderKeysKey, Code: settings.CodeInvalidValue,
+			Reason: "the api key is empty — remove the credential instead of storing nothing",
+		}
+	}
+	if s.vault == nil {
+		return ErrVaultUnavailable
+	}
+	ws, err := credentialWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	ref, err := s.vault.Put(ctx, ws, []byte(apiKey))
+	if err != nil {
+		return fmt.Errorf("ai: sealing the %s key: %w", provider, err)
+	}
+	previous, err := s.swapRef(ctx, ws, provider, string(ref))
+	if err != nil {
+		return err
+	}
+	s.retire(ctx, ws, previous, "provider key rotated")
+	return nil
+}
+
+// swapRef moves one provider's ref inside a single locked transaction and
+// returns the ref it displaced.
+//
+// The value is a provider→ref MAP, so read-modify-write is the whole operation
+// and doing the read outside the write's transaction is a lost update, not a
+// conflict: two admins keying two different vendors both read the same map, and
+// the second write drops the first's provider entirely. The lock is taken before
+// the read for that reason — SetTx takes the same one, but by then both readers
+// already hold the same snapshot.
+func (s *ProviderKeyStore) swapRef(ctx context.Context, ws ids.WorkspaceID, provider, ref string) (previous string, err error) {
+	// Three states, not two. `entered` records that the closure ran at all,
+	// because WriteTx also fails BEFORE it — an unresolved workspace, a failed
+	// Begin, a failed GUC bind — and every one of those provably did not commit.
+	// Treating them as ambiguous would keep a blob that is definitionally an
+	// orphan and send an operator to reconcile it.
+	var (
+		entered bool
+		bodyErr error
+	)
+	txErr := s.settings.WriteTx(ctx, func(tx pgx.Tx) error {
+		entered = true
+		if bodyErr = settings.LockForWrite(ctx, tx, ProviderKeysKey); bodyErr != nil {
+			return bodyErr
+		}
+		var refs map[string]string
+		if refs, bodyErr = settings.GetTx(ctx, tx, ProviderKeys); bodyErr != nil {
+			return bodyErr
+		}
+		previous = refs[provider]
+		next := copyRefs(refs)
+		if ref == "" {
+			delete(next, provider)
+		} else {
+			next[provider] = ref
+		}
+		bodyErr = settings.SetTx(ctx, s.settings, tx, ProviderKeys, next)
+		return bodyErr
+	})
+	if txErr == nil {
+		return previous, nil
+	}
+	// A blob was sealed for a write that may not have landed. Whether it is safe
+	// to drop turns on WHICH half failed, and getting that backwards is the
+	// worse outcome in one direction only.
+	//
+	// The closure ran and returned nil, yet the call failed: the only thing left
+	// is COMMIT, and a commit that reports failure may still have committed.
+	// Deleting then would leave the stored ref naming a blob that is gone — an
+	// AI lane that cannot be repaired by re-entering the key, because the ref
+	// would still read as configured. So the blob stays: unreferenced ciphertext
+	// is inert, and an orphan is recoverable where a dangling ref is not.
+	//
+	// Every other shape — the body refused, or it never ran — certainly rolled
+	// back, so nothing can reference the new blob and dropping it is safe.
+	if entered && bodyErr == nil && ref != "" {
+		s.log.WarnContext(ctx,
+			"a provider key was sealed but the settings transaction did not report a clean commit; the blob is KEPT because the write may have landed, so it is either live or an orphan to reconcile",
+			// The refs whole, not masked: this line exists so an operator can
+			// FIND the blob to reconcile, and a ref with its token elided names
+			// nothing they can act on. Same choice keyvault.DeleteDetached makes
+			// for the same reason, and a test there holds it.
+			"provider", provider, "credential_ref", ref,
+			"superseded_ref", previous, "err", txErr)
+		return "", txErr
+	}
+	if ref != "" {
+		s.retire(ctx, ws, ref, "provider key write refused")
+	}
+	return "", txErr
+}
+
+// Remove retires a provider's credential. Removing one that was never there
+// succeeds: the caller asked for a state, and that state already holds.
+func (s *ProviderKeyStore) Remove(ctx context.Context, provider string) error {
+	if err := auth.Require(ctx, providerKeysObject, principal.ActionUpdate); err != nil {
+		return err
+	}
+	ws, err := credentialWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	// Through the same locked swap, with an empty ref meaning "drop the entry":
+	// a Remove read outside the write would lose a concurrent Set on another
+	// provider exactly as a Set would.
+	previous, err := s.swapRef(ctx, ws, provider, "")
+	if err != nil {
+		return err
+	}
+	s.retire(ctx, ws, previous, "provider key removed")
+	return nil
+}
+
+// retire deletes a blob nothing references any more, through the shared
+// helper for a detached credential (keyvault.DeleteDetached).
+//
+// Not a hand-rolled delete, because that helper already answers the three
+// questions this call raises and answers them the same way for every custodian
+// in the tree: the caller's write has committed so the failure must not be
+// reported as theirs; the blob is inert and its REF is safe to log, so a
+// failure is logged at ERROR for cleanup rather than swallowed; and the delete
+// is detached from the request's cancellation under its own deadline, so a
+// client that hangs up the instant it has its answer does not strand the blob.
+func (s *ProviderKeyStore) retire(ctx context.Context, ws ids.WorkspaceID, ref, lifecycle string) {
+	keyvault.DeleteDetached(ctx, s.vault, s.log, ws.UUID, keyvault.Ref(ref), lifecycle)
+}
+
+// copyRefs takes a copy before mutating, so a failed write leaves the map the
+// caller read unchanged.
+func copyRefs(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -98,7 +98,7 @@ func NewRouter(cfg RoutingConfig, meter *Meter, budget BudgetPolicy, calls callS
 	}
 	meta := embedInclusiveMeta(cfg)
 	router := assembleRouter(clients, embedder, cfg.Profile, meter, budget, calls, meta, capturePayloads, log)
-	stamped := router.binding().withConfigSnapshot(cfg.sourceHash, cfg.Embeddings.Dimensions)
+	stamped := router.binding().withConfigSnapshot(cfg)
 	router.bound.Store(&stamped)
 	return router, nil
 }

--- a/backend/internal/modules/ai/router_attempts_test.go
+++ b/backend/internal/modules/ai/router_attempts_test.go
@@ -188,7 +188,7 @@ func TestEmbedRecordsConfiguredDimensionInProviderParams(t *testing.T) {
 		map[Tier]routeMeta{TierEmbedLane: {provider: "fake", model: "fake-embed"}},
 		false, nil,
 	)
-	stamped := r.binding().withConfigSnapshot("routing-hash", 768)
+	stamped := r.binding().withConfigSnapshot(RoutingConfig{sourceHash: "routing-hash", Embeddings: EmbeddingsConfig{Dimensions: 768}})
 	r.bound.Store(&stamped)
 
 	if _, err := r.Embed(wsCtx(), model.EmbedRequest{Inputs: []string{"embed me"}}); err != nil {

--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -70,6 +70,10 @@ type RoutingConfig struct {
 	// bytes. Zero value "" on a config built by struct literal (FakeRoutingConfig,
 	// most unit-test configs) rather than parsed from yaml.
 	sourceHash string
+	// credentialVersion is a digest of the provider credentials this config
+	// resolves with, stamped by whoever resolved them. Deliberately outside
+	// sourceHash: see Router.CredentialVersion for why the two must not merge.
+	credentialVersion string
 	// keys resolves a cloud provider's BYOK secret when the clients are built.
 	// It travels on the config because that is where configuration enters this
 	// package (LoadRoutingFile), and because the routing file names only the
@@ -129,6 +133,20 @@ func (cfg RoutingConfig) BoundModelIDsByProvider() map[string]map[string]bool {
 // Two configs that route identically share a version however differently they
 // were written — see bindingDigest for why that is the whole point.
 func (cfg RoutingConfig) RoutingVersion() string { return cfg.sourceHash }
+
+// WithCredentialVersion stamps a digest of the credentials this config resolves
+// with, so a watcher can tell a rotated key from an unchanged binding.
+//
+// Stamped by the caller that resolved the credentials rather than computed here,
+// because this package never sees a ref: `WithKeys` takes a lookup function, and
+// where the values behind it came from is compose's knowledge.
+func (cfg RoutingConfig) WithCredentialVersion(version string) RoutingConfig {
+	cfg.credentialVersion = version
+	return cfg
+}
+
+// CredentialVersion reports that digest. Empty when nothing stamped one.
+func (cfg RoutingConfig) CredentialVersion() string { return cfg.credentialVersion }
 
 // LoadRoutingFile reads and validates a deployment's routing config. keys is
 // where the BYOK secrets come from — the file names providers, never their

--- a/backend/internal/modules/ai/routingstore.go
+++ b/backend/internal/modules/ai/routingstore.go
@@ -61,7 +61,7 @@ func (s *RoutingStore) Replace(ctx context.Context, next RoutingConfig) (Routing
 		var err error
 		if next, err = next.finalize(); err != nil {
 			return RoutingConfig{}, settings.InvalidValue{
-				Setting: RoutingKey, Code: "setting_invalid", Reason: err.Error(),
+				Setting: RoutingKey, Code: settings.CodeInvalidValue, Reason: err.Error(),
 			}
 		}
 	}

--- a/backend/internal/platform/settings/entry.go
+++ b/backend/internal/platform/settings/entry.go
@@ -183,7 +183,7 @@ func (e *Entry[T]) ValidateJSON(raw json.RawMessage) error {
 		return nil
 	}
 	if err := e.validate(v); err != nil {
-		return InvalidValue{Setting: e.key, Code: "setting_invalid", Reason: err.Error()}
+		return InvalidValue{Setting: e.key, Code: CodeInvalidValue, Reason: err.Error()}
 	}
 	return nil
 }
@@ -204,6 +204,11 @@ func (e *Entry[T]) CanonicalJSON(raw json.RawMessage) (json.RawMessage, error) {
 	}
 	return out, nil
 }
+
+// CodeInvalidValue is the machine code every rejected setting carries, named
+// once here because a caller that spells it itself can spell it differently —
+// and a client branches on this string.
+const CodeInvalidValue = "setting_invalid"
 
 // InvalidValue refuses a setting write whose value the owning module rejects.
 // It implements apperrors.FieldFault so the refusal classifies as a 422

--- a/backend/internal/platform/settings/store.go
+++ b/backend/internal/platform/settings/store.go
@@ -125,14 +125,8 @@ func (s *Store) SetRawTx(ctx context.Context, tx pgx.Tx, key string, next json.R
 	if err := def.ValidateJSON(next); err != nil {
 		return err
 	}
-	// Serialize writers of THIS key for the rest of the transaction. Two
-	// concurrent writes would otherwise both read the same `before`, and the
-	// later one would audit a value that was never current — or, setting the
-	// same value, write a second audit row for a change that happened once. A
-	// row lock cannot do this: the row may not exist yet, and the first write
-	// to a setting is exactly when it does not.
-	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, key); err != nil {
-		return fmt.Errorf("settings: serializing writes to %s: %w", key, err)
+	if err := LockForWrite(ctx, tx, key); err != nil {
+		return err
 	}
 	{
 		stored, err := hasRow(ctx, tx, key)
@@ -192,6 +186,29 @@ func (s *Store) SetRawTx(ctx context.Context, tx pgx.Tx, key string, next json.R
 			map[string]any{key: def.AuditImage(next)}); err != nil {
 			return fmt.Errorf("settings: auditing %s: %w", key, err)
 		}
+	}
+	return nil
+}
+
+// LockForWrite serializes writers of ONE key for the rest of the transaction.
+//
+// Two concurrent writes would otherwise both read the same `before`, and the
+// later one would audit a value that was never current — or, setting the same
+// value, write a second audit row for a change that happened once. A row lock
+// cannot do this: the row may not exist yet, and the first write to a setting is
+// exactly when it does not.
+//
+// Exported because a caller whose new value is computed FROM the old one has to
+// take it before its own read, and SetRawTx taking it later is too late — both
+// readers would already hold the same snapshot and the second write would drop
+// the first's change. `ai.ProviderKeyStore` is that caller: its value is a
+// provider→ref map, so two admins keying two different vendors are a lost
+// update rather than a conflict anybody sees. Exposing the lock rather than
+// letting that caller spell the statement again keeps one definition of what
+// serializes a setting write.
+func LockForWrite(ctx context.Context, tx pgx.Tx, key string) error {
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, key); err != nil {
+		return fmt.Errorf("settings: serializing writes to %s: %w", key, err)
 	}
 	return nil
 }

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -102,8 +102,20 @@ bootstrap_admin:
 # rather than surfacing at the first model call.
 #
 # Credentials are NOT here and never will be. A binding names providers; each
-# one's BYOK key is read from its conventional environment variable
-# (GEMINI_API_KEY, ANTHROPIC_API_KEY, …), so this section is safe to commit.
+# one's BYOK key lives in the key vault, put there by an admin under
+# Settings -> AI -> Model provider keys, so this section is safe to commit.
+#
+# The conventional environment variables (GEMINI_API_KEY, ANTHROPIC_API_KEY, …)
+# are still read, but only to SEED: a boot that finds one MAY seal it into the
+# vault and record where, after which the variable can be unset. It needs a
+# key-vault root key and a stored model binding to do that — the sealing runs on
+# the path that resolves a binding — so an unbound installation keeps the
+# environment as its only copy. Unset the variable once the boot log says the key
+# was sealed, not merely because it was set.
+#
+# A key in the environment is readable by every process in the container and
+# survives in shell history and process listings; one in the vault is encrypted
+# at rest and rotatable without a restart, which is why the vault is the home.
 #
 # seeds:
 #   ai_routing:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1035,7 +1035,14 @@ The providers a binding may name, and what each requires. A cloud provider's
 BYOK key is **read from an environment variable** at boot — the routing file
 names only the provider (a stray `api_key:` there is a startup error):
 
-| provider | key env var | `base_url` | notes |
+A cloud provider's key lives in the **key vault**, and an admin puts one there
+at Settings → AI → Model provider keys (`PUT /v1/ai/provider-keys/{provider}`).
+The environment variable in the table below is a SEED, not the home: a key found
+there is sealed on the next boot and the variable can then be deleted. Both
+routes still fail closed — a bound provider with a key by neither is refused at
+construction, naming what is missing.
+
+| provider | key env var (seed) | `base_url` | notes |
 |---|---|---|---|
 | `fake` | — | — | offline deterministic stub (dev/test) |
 | `ollama` | — | optional (default `localhost:11434`) | local; sovereign-eligible |

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -377,7 +377,7 @@ export const auditEntries = [
   },
 ];
 
-// The three reads behind Settings → AI and Settings → Maintenance. They are
+// The four reads behind Settings → AI and Settings → Maintenance. They are
 // fixtures rather than catch-all `page([])` answers because the catch-all is
 // not a thin response — it is the WRONG SHAPE, and the two sweeps below cannot
 // see what they cannot render: `/admin/job-health` answered `{data,page}` (no
@@ -387,6 +387,24 @@ export const auditEntries = [
 // sweep visits, and the queue report never rendered at all. Every field below
 // is required by its contract schema (AiUsage / AiCallListResponse /
 // JobHealth) — an under-filled fixture would just move the lie.
+//
+// `/ai/provider-keys` is the fourth, and it failed the same way rather than
+// differently: the card indexes `providers`, which the contract makes required,
+// so the catch-all's `{data,page}` handed it undefined and it threw mid-render.
+// A throw there takes the WHOLE AI entry down, so the symptom was four
+// unrelated cases reporting "element(s) not found" on #/settings/ai — none of
+// them naming this endpoint. That is the cost the comment above is about.
+
+// One provider keyed and one not, so the route the 390px and axe sweeps visit
+// renders BOTH row states. A list of only-configured or only-empty rows would
+// leave half the card's markup unvisited by the very sweeps that exist to see
+// it. `env_var` is required by AiProviderKeyStatus.
+export const aiProviderKeys = {
+  providers: [
+    { provider: "gemini", configured: true, env_var: "GEMINI_API_KEY" },
+    { provider: "anthropic", configured: false, env_var: "ANTHROPIC_API_KEY" },
+  ],
+};
 
 export const aiUsage = {
   days: [
@@ -1673,6 +1691,9 @@ export async function mockApi(
     }
     if (path === "/ai/usage") {
       return json(aiUsage);
+    }
+    if (path === "/ai/provider-keys" && method === "GET") {
+      return json(aiProviderKeys);
     }
     if (path === "/ai/calls" && method === "GET") {
       return json(aiCalls);

--- a/frontend/scripts/fe-uat.mjs
+++ b/frontend/scripts/fe-uat.mjs
@@ -166,7 +166,13 @@ for (const f of changed) {
   } else if (
     /\.[tj]sx$/.test(f) &&
     !/\.d\.ts$/.test(f) &&
-    !/\.(test|stories)\./.test(f)
+    // `.testkit.` alongside `.test.`: a testkit holds the fixtures and fetch
+    // fakes a suite shares, and nothing ships it. Keyed on the NAME rather
+    // than on "imported only by tests", which would also excuse a real
+    // component whose only importer so far is its own test — the exact case
+    // this gate exists to catch. Naming a shipped component `x.testkit.tsx`
+    // to dodge the gate would have to be deliberate.
+    !/\.(test|testkit|stories)\./.test(f)
   ) {
     const covering = new Set(coveringStories.get(f) ?? []);
     // The co-located story counts on its path alone: it may reach the component

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5662,6 +5662,102 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ai/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Which model vendors hold a credential (admin/ops).
+         * @description Every cloud provider this build can serve, and whether a key is held for each. Governed
+         *     by the same `ai_routing` object the binding is: a seat that may not re-point a model may
+         *     not reach the credential that model would call with either.
+         *
+         *     The KEY is never returned, by any caller, at any time. A credential that can be read
+         *     back is one a support bundle, a browser cache and a screenshare can all carry. What this
+         *     answers is `configured` — which is what a screen needs to know whether to offer "add" or
+         *     "rotate".
+         *
+         *     `env_var` names the variable the same key may arrive in, so an operator can see which
+         *     export seeded a vendor rather than guessing. That path still works and is how an existing
+         *     installation's key reached the vault without anyone doing anything.
+         *
+         *     Human session only. An agent never reads the installation's credential inventory,
+         *     whatever its passport scopes admit.
+         */
+        get: operations["listAiProviderKeys"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ai/provider-keys/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The routing name of the vendor — the same string a binding uses. */
+                provider: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Store or rotate one vendor's BYOK key (admin/ops).
+         * @description Seals the key in the installation's key vault and records only an opaque, workspace-bound
+         *     reference. `api_key` is WRITE-ONLY: no read path returns it, and the setting that points
+         *     at it holds the reference and never the bytes.
+         *
+         *     Sending a key for a vendor that already has one ROTATES it. The new credential is sealed
+         *     before the reference moves, and the superseded one is destroyed only after the move
+         *     commits — so no window exists in which the recorded reference names nothing, and a
+         *     half-completed rotation leaves the previous key still serving.
+         *
+         *     Takes effect without a restart: every role re-reads on an interval and rebinds its model
+         *     clients when the credential changes, which is tracked separately from the binding's own
+         *     version so a rotation does not invalidate content a model already wrote. Leading and trailing whitespace is trimmed, because a pasted credential carries
+         *     whatever the clipboard did and a key with a trailing newline authenticates nothing while
+         *     looking exactly like one that would.
+         *
+         *     422 for a vendor this build serves with no key at all (a local model needs none), and for
+         *     an empty key — removing a credential is DELETE, not an empty write.
+         *
+         *     Requires a key vault. Without one there is nowhere to put the bytes, and the refusal says
+         *     so rather than recording a reference to something that was never written.
+         *
+         *     Audit-only write (no event stream, EVT-NOEVT-3).
+         */
+        put: operations["setAiProviderKey"];
+        post?: never;
+        /**
+         * Remove one vendor's BYOK key (admin/ops).
+         * @description Drops the reference and destroys the sealed credential. A vendor that holds nothing
+         *     succeeds: the caller asked for a state and that state already holds, which is why this is
+         *     204 rather than 404 — and why it is safe to retry.
+         *
+         *     Removing a credential does not unbind a model; that is `PUT /ai/routing`. A NEW process
+         *     binding that vendor fails closed with the error that names what is missing, exactly as it
+         *     did before any key was ever stored.
+         *
+         *     A process already running is a different case, and worth knowing: a role re-reads the
+         *     binding on an interval and rebinds when the credential changes, but a binding it can no
+         *     longer build clients for leaves the running one in place rather than taking the AI lanes
+         *     down. So where the removed key was the only one for a bound vendor, that role keeps
+         *     serving on it until it restarts.
+         *
+         *     Audit-only write (no event stream, EVT-NOEVT-3).
+         */
+        delete: operations["deleteAiProviderKey"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ai/calls": {
         parameters: {
             query?: never;
@@ -10359,6 +10455,22 @@ export interface components {
              *     excluded (cold start reads it). Default is ON (the testing posture).
              */
             auto_enrich: boolean;
+        };
+        AiProviderKeyList: {
+            providers: components["schemas"]["AiProviderKeyStatus"][];
+        };
+        /** @description What may be known about one vendor's credential. Deliberately three facts and no fourth: the key itself has no read path, and neither does anything derived from it — a length, a prefix or a masked tail would each narrow a brute force while feeling harmless. */
+        AiProviderKeyStatus: {
+            /** @description The routing name of the vendor, the same string a binding uses. */
+            provider: string;
+            /** @description Whether a credential is held. A screen reads this to offer "add" or "rotate"; it says nothing about whether the key still works, which only the vendor can answer. */
+            configured: boolean;
+            /** @description The variable the same key may arrive in. Named so an operator can see which export seeded a vendor; the names follow each vendor's own convention, which is why they carry no MARGINCE_ prefix. */
+            env_var: string;
+        };
+        AiProviderKeyInput: {
+            /** @description The vendor credential. WRITE-ONLY — no response in this contract returns it, and the setting that records it holds an opaque vault reference rather than these bytes. */
+            api_key: string;
         };
         /**
          * @description The installation's tier-to-model binding. `tiers` is keyed by tier name; the closed set
@@ -31106,6 +31218,106 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["PermissionDenied"];
             422: components["responses"]["ValidationError"];
+        };
+    };
+    listAiProviderKeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One entry per servable provider, in the routing table's order. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AiProviderKeyList"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["PermissionDenied"];
+            /** @description This installation has no key vault, so there is no credential inventory to report. The remedy is the operator's — the vault root key — not anything the caller sent. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    setAiProviderKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The routing name of the vendor — the same string a binding uses. */
+                provider: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AiProviderKeyInput"];
+            };
+        };
+        responses: {
+            /** @description Sealed. The key is not echoed. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["PermissionDenied"];
+            422: components["responses"]["ValidationError"];
+            /** @description This installation has no key vault, so a provider key cannot be stored. The remedy is the operator's — the vault root key — not anything the caller sent. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    deleteAiProviderKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The routing name of the vendor — the same string a binding uses. */
+                provider: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Removed, or there was nothing to remove. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["PermissionDenied"];
+            /** @description This installation has no key vault, so there is no sealed credential to remove. The remedy is the operator's — the vault root key — not anything the caller sent. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     listAiCalls: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5306,6 +5306,27 @@ export const de = {
   "installationSettings.edit": "Ändern",
   "installationSettings.editField": "{field} ändern",
   "installationSettings.save": "Speichern",
+  "aiProviderKeys.title": "Anbieter-Schlüssel",
+  "aiProviderKeys.sub":
+    "Die Zugangsdaten, mit denen diese Installation die Modellanbieter aufruft. Ein Schlüssel wird im Schlüsseltresor versiegelt und nie wieder angezeigt — ersetze ihn, wenn du ihn ändern willst.",
+  "aiProviderKeys.configured": "Schlüssel gespeichert",
+  "aiProviderKeys.absent": "Kein Schlüssel",
+  "aiProviderKeys.configuredHint":
+    "Im Schlüsseltresor versiegelt. Er kann nicht ausgelesen werden — füge einen neuen ein, um ihn zu ersetzen. Er kann auch über {envVar} ankommen.",
+  "aiProviderKeys.absentHint":
+    "Für diesen Anbieter liegen keine Zugangsdaten vor, ein daran gebundenes Modell kann also nicht aufgerufen werden. Sie können auch über {envVar} ankommen.",
+  "aiProviderKeys.addPlaceholder": "API-Schlüssel einfügen",
+  "aiProviderKeys.replacePlaceholder": "Neuen Schlüssel zum Ersetzen einfügen",
+  "aiProviderKeys.add": "Hinzufügen",
+  "aiProviderKeys.replace": "Ersetzen",
+  "aiProviderKeys.removeConfirmTitle": "Den {provider}-Schlüssel entfernen?",
+  "aiProviderKeys.removeConfirmBody":
+    "Die Zugangsdaten werden aus dem Schlüsseltresor gelöscht und lassen sich nicht wiederherstellen — sie sind nie auslesbar, es gibt also keine Kopie. Jede an diesen Anbieter gebundene KI-Strecke steht, bis ein neuer Schlüssel eingefügt wird.",
+  "aiProviderKeys.withheld":
+    "Nur wer die Modellbindung ändern darf, sieht, für welche Anbieter ein Schlüssel vorliegt.",
+  "aiProviderKeys.remove": "Entfernen",
+  "aiRouting.withheld":
+    "Nur wer die Modellbindung ändern darf, sieht, welche Modelle diese Installation verwendet.",
   "aiRouting.title": "Modell-Routing",
   "aiRouting.sub":
     "Welches Modell welche Stufe bedient. Änderungen wirken ohne Neustart; jeder Prozess übernimmt sie innerhalb einer Minute.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5342,6 +5342,27 @@ export const en = {
   "installationSettings.save": "Save",
   // Which vendor this installation's text is sent to. Admin/ops only, on both
   // verbs â see the ai_routing RBAC object.
+  "aiProviderKeys.title": "Model provider keys",
+  "aiProviderKeys.sub":
+    "The credentials this installation calls each model vendor with. A key is sealed in the key vault and never shown again — replace it if you need to change it.",
+  "aiProviderKeys.configured": "Key stored",
+  "aiProviderKeys.absent": "No key",
+  "aiProviderKeys.configuredHint":
+    "Sealed in the key vault. It cannot be read back — paste a new one to replace it. It may also arrive as {envVar}.",
+  "aiProviderKeys.absentHint":
+    "This vendor has no credential, so a model bound to it cannot be called. It may also arrive as {envVar}.",
+  "aiProviderKeys.addPlaceholder": "Paste the API key",
+  "aiProviderKeys.replacePlaceholder": "Paste a new key to replace",
+  "aiProviderKeys.add": "Add",
+  "aiProviderKeys.replace": "Replace",
+  "aiProviderKeys.removeConfirmTitle": "Remove the {provider} key?",
+  "aiProviderKeys.removeConfirmBody":
+    "The credential is deleted from the key vault and cannot be recovered — it is never readable, so there is no copy to restore. Every AI lane bound to this vendor stops until a new key is pasted in.",
+  "aiProviderKeys.withheld":
+    "Only an operator who may change the model binding can see which vendors hold a key.",
+  "aiProviderKeys.remove": "Remove",
+  "aiRouting.withheld":
+    "Only an operator who may change the model binding can see which models this installation uses.",
   "aiRouting.title": "Model routing",
   "aiRouting.sub":
     "Which model serves each tier. Changes take effect without a restart, and every process picks them up within a minute.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5254,6 +5254,27 @@ export const vi = {
   "installationSettings.edit": "Sửa",
   "installationSettings.editField": "Sửa {field}",
   "installationSettings.save": "Lưu",
+  "aiProviderKeys.title": "Khóa nhà cung cấp mô hình",
+  "aiProviderKeys.sub":
+    "Thông tin xác thực mà bản cài đặt này dùng để gọi từng nhà cung cấp mô hình. Khóa được niêm phong trong kho khóa và không bao giờ hiển thị lại — hãy thay thế nếu bạn cần đổi.",
+  "aiProviderKeys.configured": "Đã lưu khóa",
+  "aiProviderKeys.absent": "Chưa có khóa",
+  "aiProviderKeys.configuredHint":
+    "Đã niêm phong trong kho khóa. Không thể đọc lại — dán khóa mới để thay thế. Khóa cũng có thể đến qua {envVar}.",
+  "aiProviderKeys.absentHint":
+    "Nhà cung cấp này chưa có thông tin xác thực, nên không thể gọi mô hình gắn với nó. Khóa cũng có thể đến qua {envVar}.",
+  "aiProviderKeys.addPlaceholder": "Dán khóa API",
+  "aiProviderKeys.replacePlaceholder": "Dán khóa mới để thay thế",
+  "aiProviderKeys.add": "Thêm",
+  "aiProviderKeys.replace": "Thay thế",
+  "aiProviderKeys.removeConfirmTitle": "Xóa khóa {provider}?",
+  "aiProviderKeys.removeConfirmBody":
+    "Thông tin xác thực sẽ bị xóa khỏi kho khóa và không thể phục hồi — khóa không bao giờ đọc lại được nên không có bản sao nào. Mọi luồng AI gắn với nhà cung cấp này sẽ dừng cho đến khi dán khóa mới.",
+  "aiProviderKeys.withheld":
+    "Chỉ người có quyền thay đổi liên kết mô hình mới thấy nhà cung cấp nào đã có khóa.",
+  "aiProviderKeys.remove": "Xóa",
+  "aiRouting.withheld":
+    "Chỉ người có quyền thay đổi liên kết mô hình mới thấy bản cài đặt này dùng những mô hình nào.",
   "aiRouting.title": "Định tuyến mô hình",
   "aiRouting.sub":
     "Mô hình nào phục vụ từng bậc. Thay đổi có hiệu lực mà không cần khởi động lại; mọi tiến trình sẽ nhận trong vòng một phút.",

--- a/frontend/src/screens/ai-provider-keys.stories.tsx
+++ b/frontend/src/screens/ai-provider-keys.stories.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type GrantSpec, meFixture } from "../app/mefixture";
+import { AiProviderKeysCard } from "./ai-provider-keys";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The card draws a credential surface, so what these stories are for is
+// checking what is NOT on screen: a configured provider must read as
+// configured without the key, or any part of it, being recoverable from the
+// pixels. The server never sends one back, and the field a reader could paste
+// into is always empty — a story is where that stays visible to a human.
+//
+// /me decides which of the card's two shapes renders: the grant is
+// `ai_routing:update`, the same one the binding carries, because a seat that
+// may not re-point a model may not reach the credential that model would call
+// with. A reader who can look but not change gets the form DISABLED rather
+// than hidden, so they can see which providers are keyed.
+const MANAGER: GrantSpec = { ai_routing: ["read", "update"] };
+const READER: GrantSpec = { ai_routing: ["read"] };
+// Reaches the AI tab on another grant and holds no ai_routing at all.
+const NO_GRANT: GrantSpec = { automation: ["read"] };
+
+function story(
+  providers: { provider: string; configured: boolean; env_var: string }[],
+  allow: GrantSpec = MANAGER,
+) {
+  return () => {
+    installFetchStub({
+      "GET /me": () => jsonResponse(meFixture({ allow })),
+      "GET /ai/provider-keys": () => jsonResponse({ providers }),
+    });
+    return (
+      <StoryProviders>
+        <AiProviderKeysCard />
+      </StoryProviders>
+    );
+  };
+}
+
+const gemini = {
+  provider: "gemini",
+  configured: true,
+  env_var: "GEMINI_API_KEY",
+};
+const anthropic = {
+  provider: "anthropic",
+  configured: false,
+  env_var: "ANTHROPIC_API_KEY",
+};
+
+const meta: Meta<typeof AiProviderKeysCard> = {
+  title: "Settings/Admin settings/AI/Model provider keys",
+  component: AiProviderKeysCard,
+};
+export default meta;
+type Story = StoryObj<typeof AiProviderKeysCard>;
+
+// One provider keyed, one not — the ordinary reading, and the one that has to
+// distinguish the two states without printing either key.
+export const Mixed: Story = { render: story([gemini, anthropic]) };
+
+// Every bound provider still unkeyed: the state a fresh installation is in,
+// where the AI lanes are absent until somebody pastes a key. It must read as
+// "nothing set yet" and not as an error.
+export const NothingConfigured: Story = {
+  render: story([anthropic, { ...gemini, configured: false }]),
+};
+
+// A keyed provider on its own. The row says configured and offers removal; the
+// input beside it is still empty, because there is nothing to put back in it.
+export const Configured: Story = { render: story([gemini]) };
+
+// No cloud provider is bound, so there is no key to ask for. An empty card is
+// the honest answer here rather than a fault — a local-only or unbound
+// installation has nothing to key.
+export const NoCloudProviders: Story = { render: story([]) };
+
+// A seat with the read half of the grant and not the write half. The rows keep
+// their place and say which providers are keyed; the field and the buttons are
+// disabled rather than absent, so the reader can see the state without being
+// invited to change it.
+export const ReadOnlySeat: Story = {
+  render: story([gemini, anthropic], READER),
+};
+
+// No read grant at all. The card keeps its place and says the list is withheld
+// — it must not look like an installation with no credentials, and it must not
+// draw an error box, which is what asking the server anyway produced.
+export const Withheld: Story = {
+  render: story([gemini, anthropic], NO_GRANT),
+};
+
+// Dark. The configured/not-configured distinction is carried by a Badge tone,
+// and a tone that flattens against the dark panel would leave a reader unable
+// to tell a keyed provider from an unkeyed one — which on this card is the
+// only thing it says.
+export const MixedDark: Story = {
+  globals: { theme: "dark" },
+  render: story([gemini, anthropic]),
+};

--- a/frontend/src/screens/ai-provider-keys.test.tsx
+++ b/frontend/src/screens/ai-provider-keys.test.tsx
@@ -1,0 +1,291 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type GrantSpec, meFixture } from "../app/mefixture";
+import { type Locale, LocaleProvider } from "../i18n";
+import { AiProviderKeysCard } from "./ai-provider-keys";
+
+// Settings → AI → Model provider keys.
+//
+// The property this file exists for is a negative: the key has no read path, so
+// nothing here may render one. The server never returns it, and this screen must
+// not invent a mask, a length or a prefix that implies it could.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const KEY_EDITOR: GrantSpec = { ai_routing: ["read", "update"] };
+const KEY_READER: GrantSpec = { ai_routing: ["read"] };
+
+const LISTED = {
+  providers: [
+    { provider: "gemini", configured: true, env_var: "GEMINI_API_KEY" },
+    { provider: "openai", configured: false, env_var: "OPENAI_API_KEY" },
+  ],
+};
+
+function backendFor(allow: GrantSpec) {
+  const puts: Array<{ url: string; body: unknown }> = [];
+  const deletes: string[] = [];
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req =
+        input instanceof Request ? input : new Request(String(input), init);
+      if (req.url.endsWith("/v1/me")) {
+        return jsonResponse(meFixture({ allow }));
+      }
+      if (req.url.includes("/ai/provider-keys")) {
+        if (req.method === "PUT") {
+          puts.push({ url: req.url, body: await req.json() });
+          return new Response(null, { status: 204 });
+        }
+        if (req.method === "DELETE") {
+          deletes.push(req.url);
+          return new Response(null, { status: 204 });
+        }
+        return jsonResponse(LISTED);
+      }
+      throw new Error(`unexpected request: ${req.method} ${req.url}`);
+    },
+  );
+  return { fetchMock, puts, deletes };
+}
+
+// Returns the client alongside the rendered tree: one case asserts on what
+// React Query still HOLDS, which the DOM cannot show.
+const render = (ui: ReactNode, locale: Locale = "en") => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    ...rtlRender(
+      <QueryClientProvider client={client}>
+        <LocaleProvider initial={locale}>{ui}</LocaleProvider>
+      </QueryClientProvider>,
+    ),
+    client,
+  };
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AiProviderKeysCard", () => {
+  it("says which vendors hold a key and which do not", async () => {
+    vi.stubGlobal("fetch", backendFor(KEY_EDITOR).fetchMock);
+    render(<AiProviderKeysCard />);
+
+    expect(await screen.findByText(/key stored/i)).toBeTruthy();
+    expect(screen.getByText(/no key/i)).toBeTruthy();
+    // Every servable vendor is offered, not only the configured one — an
+    // installation that has configured nothing is the one that needs this card.
+    // Queried by the input each row owns, because the vendor name also appears
+    // in that row's hint and a text match would be ambiguous.
+    expect(screen.getAllByPlaceholderText(/paste/i)).toHaveLength(2);
+    expect(screen.getByPlaceholderText(/paste a new key/i)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/paste the api key/i),
+    ).toBeInTheDocument();
+  });
+
+  it("never renders the key, and offers no field that could hold one read back", async () => {
+    vi.stubGlobal("fetch", backendFor(KEY_EDITOR).fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/key stored/i);
+
+    // Every input starts EMPTY, including the vendor that has a key. A prefilled
+    // or masked value would imply the real one is retrievable and invite a
+    // screenshot; it is not retrievable, and the card must not suggest it is.
+    for (const input of screen.getAllByPlaceholderText(/paste/i)) {
+      expect(input).toHaveValue("");
+      // Typed as a password so the browser does not offer to remember a
+      // credential this app deliberately never keeps client-side.
+      expect(input).toHaveAttribute("type", "password");
+    }
+  });
+
+  it("sends the pasted key to the vendor's own route, trimmed", async () => {
+    const backend = backendFor(KEY_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/no key/i);
+
+    const user = userEvent.setup();
+    const inputs = screen.getAllByPlaceholderText(/paste the api key/i);
+    await user.type(inputs[0], "  sk-openai-pasted  ");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => expect(backend.puts).toHaveLength(1));
+    expect(backend.puts[0].url).toContain("/ai/provider-keys/openai");
+    // Trimmed before it leaves: a pasted credential carries whatever the
+    // clipboard did, and a trailing newline authenticates nothing.
+    expect(backend.puts[0].body).toEqual({ api_key: "sk-openai-pasted" });
+  });
+
+  it("clears the field on success so the credential does not linger on screen", async () => {
+    vi.stubGlobal("fetch", backendFor(KEY_EDITOR).fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/no key/i);
+
+    const user = userEvent.setup();
+    const input = screen.getAllByPlaceholderText(/paste the api key/i)[0];
+    await user.type(input, "sk-openai");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => expect(input).toHaveValue(""));
+  });
+
+  // And it leaves the MUTATION's state with the field.
+  //
+  // React Query keeps `variables` after a mutation succeeds — normally a
+  // convenience, and for this one mutation a credential sitting in memory that
+  // the observer and the devtools can both read. The key still travels as a
+  // variable, because passing it any other way reintroduces the stale-closure
+  // refusal that rule exists to prevent; what changes is how long it stays.
+  //
+  // Asserted through the query client's own mutation cache rather than through
+  // the DOM, because the field being empty says nothing about what React Query
+  // still holds — which is exactly how this would regress unnoticed.
+  it("drops the credential from the mutation cache once the save settles", async () => {
+    vi.stubGlobal("fetch", backendFor(KEY_EDITOR).fetchMock);
+    const { client } = render(<AiProviderKeysCard />);
+    await screen.findByText(/no key/i);
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getAllByPlaceholderText(/paste the api key/i)[0],
+      "sk-openai-secret",
+    );
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      const held = client
+        .getMutationCache()
+        .getAll()
+        .map((m) => JSON.stringify(m.state.variables ?? null))
+        .join(" ");
+      expect(held).not.toContain("sk-openai-secret");
+    });
+  });
+
+  it("will not submit whitespace", async () => {
+    const backend = backendFor(KEY_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/no key/i);
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getAllByPlaceholderText(/paste the api key/i)[0],
+      "   ",
+    );
+    // Removing a credential is the Remove button; a blank write is a mistake the
+    // server would refuse, so the button does not offer it.
+    expect(screen.getByRole("button", { name: /^add$/i })).toBeDisabled();
+    expect(backend.puts).toHaveLength(0);
+  });
+
+  it("offers Remove only where a key is held", async () => {
+    const user = userEvent.setup();
+    const backend = backendFor(KEY_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/key stored/i);
+
+    // One vendor has a key, one does not — so exactly one Remove.
+    const removes = screen.getAllByRole("button", { name: /remove/i });
+    expect(removes).toHaveLength(1);
+
+    // The button OPENS a confirmation; it does not delete. The credential
+    // cannot be read back, so a stray click is unrecoverable and takes every
+    // lane bound to the vendor down with it.
+    await user.click(removes[0]);
+    expect(backend.deletes).toHaveLength(0);
+
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /remove/i }));
+    await waitFor(() => expect(backend.deletes).toHaveLength(1));
+    expect(backend.deletes[0]).toContain("/ai/provider-keys/gemini");
+  });
+
+  // Dismissing the confirmation must leave the key alone — a modal that deletes
+  // whichever way it closes is worse than no modal, because it looks like a
+  // choice.
+  it("keeps the key when the removal confirmation is dismissed", async () => {
+    const user = userEvent.setup();
+    const backend = backendFor(KEY_EDITOR);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/key stored/i);
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /cancel/i }));
+
+    expect(backend.deletes).toHaveLength(0);
+  });
+
+  // The hint interpolates the provider's environment variable, and the
+  // catalogs wrote it `{{envVar}}` while the translator matches a SINGLE pair
+  // — so the name rendered wrapped in stray braces. Asserting the name alone
+  // would have passed on `{GEMINI_API_KEY}`, which is why the brace is what
+  // this checks. The catalog test could not see it either: it extracts
+  // `{(\w+)}`, and that matches the inner pair of a double one.
+  it("names the environment variable in the hint, with no stray braces", async () => {
+    vi.stubGlobal("fetch", backendFor(KEY_EDITOR).fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/key stored/i);
+
+    for (const envVar of ["GEMINI_API_KEY", "OPENAI_API_KEY"]) {
+      const hint = screen.getByText(new RegExp(envVar));
+      expect(hint.textContent).toContain(envVar);
+      expect(hint.textContent).not.toContain(`{${envVar}}`);
+      expect(hint.textContent).not.toContain("envVar");
+    }
+  });
+
+  // A seat that reaches the AI tab on some other grant and holds no
+  // `ai_routing:read`. The card says withheld and asks the server for NOTHING:
+  // a 403 error box would read as a broken installation, and an absent card
+  // would claim this installation holds no credentials — a statement about the
+  // data where the truth is only about who may see it.
+  it("withholds the list from a seat without the read grant, and asks for nothing", async () => {
+    const backend = backendFor({ automation: ["read"] });
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiProviderKeysCard />);
+
+    expect(await screen.findByText(/only an operator/i)).toBeTruthy();
+    expect(screen.queryByPlaceholderText(/paste/i)).toBeNull();
+    const asked = backend.fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(asked.some((u) => u.includes("/ai/provider-keys"))).toBe(false);
+  });
+
+  it("disables the controls for a reader who may look but not change", async () => {
+    vi.stubGlobal("fetch", backendFor(KEY_READER).fetchMock);
+    render(<AiProviderKeysCard />);
+    await screen.findByText(/key stored/i);
+
+    // Disabled, not hidden: an operator who must ask somebody else to rotate a
+    // key still needs to see which vendors have one.
+    for (const input of screen.getAllByPlaceholderText(/paste/i)) {
+      expect(input).toBeDisabled();
+    }
+    expect(screen.getByRole("button", { name: /remove/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/screens/ai-provider-keys.tsx
+++ b/frontend/src/screens/ai-provider-keys.tsx
@@ -1,0 +1,294 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCan, useCanWrite } from "../app/capability";
+import {
+  Badge,
+  Button,
+  EmptyState,
+  Field,
+  TextInput,
+} from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { useT } from "../i18n";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+// The vendor credentials this installation calls models with.
+//
+// One rule shapes the whole card: there is no read path for a key. The server
+// answers `configured` and nothing else, so this screen can offer "add" or
+// "replace" and can never show, prefill, or mask an existing value. A masked
+// value would be worse than none — it implies the real one is retrievable, and
+// invites someone to screenshot it.
+//
+// Admin/ops only, on the same `ai_routing` grant the binding carries: a seat
+// that may not re-point a model may not reach the credential that model would
+// call with. A reader without the grant never gets here, and the form is
+// disabled rather than hidden for one who can look but not change — the same
+// shape the routing card uses.
+
+type ProviderStatus = components["schemas"]["AiProviderKeyStatus"];
+
+function useProviderKeys(enabled: boolean) {
+  return useQuery({
+    enabled,
+    queryKey: ["ai-provider-keys"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/ai/provider-keys");
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+function useSetProviderKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // Collected the moment nothing observes it, because what this mutation's
+    // `variables` hold is a credential rather than a form field.
+    gcTime: 0,
+    // The provider AND the key travel as variables rather than closing over
+    // render state: a click belongs to the render that drew it, so a value it
+    // carries cannot be older than the button.
+    //
+    // That is also why the caller RESETS this mutation once it settles. React
+    // Query keeps `variables` in the mutation's state after success, and for
+    // this one mutation the variables are a credential — so what is convenient
+    // for every other form is a secret held in memory, readable through the
+    // observer and the devtools, until garbage collection gets to it. Passing
+    // the key some other way would trade that for a stale-closure refusal,
+    // which is the defect the variables rule exists to prevent, so the answer
+    // is to keep the variable and drop it early.
+    mutationFn: async (vars: { provider: string; apiKey: string }) => {
+      const { error } = await api.PUT("/ai/provider-keys/{provider}", {
+        params: { path: { provider: vars.provider } },
+        body: { api_key: vars.apiKey },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ai-provider-keys"] });
+    },
+  });
+}
+
+function useRemoveProviderKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { provider: string }) => {
+      const { error } = await api.DELETE("/ai/provider-keys/{provider}", {
+        params: { path: { provider: vars.provider } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ai-provider-keys"] });
+    },
+  });
+}
+
+export function AiProviderKeysCard() {
+  const t = useT();
+  // Two grants, two questions. `read` decides whether the list is this reader's
+  // to see at all; `update` decides whether the form is theirs to use. Asking
+  // the server without the read grant would draw a 403 error box, which reads
+  // as a fault in the installation rather than as a permission — and this page
+  // is explicit that every card answers a denial the same way, because three
+  // answers to one denial on one page is what made it unreadable.
+  const canSee = useCan("ai_routing", "read");
+  const canManage = useCanWrite("ai_routing", "update");
+  const query = useProviderKeys(canSee);
+
+  if (!canSee) {
+    // Withheld, not absent. An absent key card would say this installation has
+    // no credentials — a claim about the DATA — where the truth is only that
+    // which vendors are keyed is not this reader's to know.
+    return (
+      <Panel title={t("aiProviderKeys.title")}>
+        <PanelBody>
+          <p className="t-caption">{t("aiProviderKeys.sub")}</p>
+          <EmptyState>
+            <p className="t-small">{t("aiProviderKeys.withheld")}</p>
+          </EmptyState>
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel title={t("aiProviderKeys.title")}>
+      <PanelBody className="form-stack">
+        <p className="t-caption">{t("aiProviderKeys.sub")}</p>
+        <QueryGate query={query}>
+          {(list) => (
+            <>
+              {list.providers.map((p) => (
+                <ProviderKeyRow
+                  key={p.provider}
+                  status={p}
+                  canManage={canManage}
+                />
+              ))}
+            </>
+          )}
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function ProviderKeyRow({
+  status,
+  canManage,
+}: {
+  status: ProviderStatus;
+  canManage: boolean;
+}) {
+  const t = useT();
+  const [value, setValue] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const save = useSetProviderKey();
+  const remove = useRemoveProviderKey();
+
+  // The credential leaves React Query's memory as soon as the save settles.
+  //
+  // `variables` are retained after success — ordinarily a convenience, and for
+  // this one mutation a secret readable through the observer and the devtools
+  // until garbage collection. It cannot be dropped from the per-call onSuccess:
+  // the state is finalized after those callbacks run, so a reset there is
+  // overwritten. An effect on the settled flag is the first point that sticks.
+  //
+  // Success only. A failed save keeps its error on screen, and the key the user
+  // is about to retry is in the field anyway.
+  useEffect(() => {
+    if (save.isSuccess) {
+      save.reset();
+    }
+  }, [save.isSuccess, save.reset, save]);
+
+  const busy = save.isPending || remove.isPending;
+  // Trimmed here as well as on the server, so the button does not offer to
+  // submit a key that is only whitespace.
+  const trimmed = value.trim();
+  const failure = save.error ?? remove.error;
+
+  return (
+    <PanelRow>
+      <Field
+        label={
+          <span className="row-inline">
+            {status.provider}
+            <Badge tone={status.configured ? "success" : "warn"} quiet>
+              {status.configured
+                ? t("aiProviderKeys.configured")
+                : t("aiProviderKeys.absent")}
+            </Badge>
+          </span>
+        }
+        // The variable is the only thing that says HOW a key reached the
+        // vault, and an operator debugging a vendor wants to know whether an
+        // export seeded it.
+        hint={
+          status.configured
+            ? t("aiProviderKeys.configuredHint", { envVar: status.env_var })
+            : t("aiProviderKeys.absentHint", { envVar: status.env_var })
+        }
+      >
+        {(control) => (
+          <div className="row-inline">
+            <TextInput
+              {...control}
+              // A password field, so the browser does not offer to remember a
+              // credential this app deliberately never stores client-side, and
+              // so a screenshare does not carry it.
+              type="password"
+              autoComplete="off"
+              value={value}
+              disabled={!canManage || busy}
+              placeholder={
+                status.configured
+                  ? t("aiProviderKeys.replacePlaceholder")
+                  : t("aiProviderKeys.addPlaceholder")
+              }
+              onChange={(e) => setValue(e.target.value)}
+            />
+            <Button
+              variant="primary"
+              // `pending` on the control that is waiting, `disabled` only for
+              // the reasons it may not be pressed at all. A button carrying
+              // both is natively disabled, which drops the focus and announces
+              // nothing — see Button's own note on the precedence.
+              pending={save.isPending}
+              disabled={!canManage || remove.isPending || trimmed === ""}
+              onClick={() => {
+                // The other mutation's failure is no longer the current story;
+                // without this its Callout stays under the row it did not come
+                // from.
+                remove.reset();
+                save.mutate(
+                  { provider: status.provider, apiKey: trimmed },
+                  {
+                    // Cleared on success only: a failed save leaves what was
+                    // typed so it can be retried without being re-pasted.
+                    onSuccess: () => setValue(""),
+                  },
+                );
+              }}
+            >
+              {status.configured
+                ? t("aiProviderKeys.replace")
+                : t("aiProviderKeys.add")}
+            </Button>
+            {status.configured ? (
+              <Button
+                variant="danger"
+                pending={remove.isPending}
+                disabled={!canManage || save.isPending}
+                // Confirmed first, because the act is irreversible and its cost
+                // is not local to this row: the credential cannot be read back
+                // to restore, and every AI lane bound to this vendor stops
+                // until somebody re-pastes a key they may not have.
+                onClick={() => setConfirming(true)}
+              >
+                {t("aiProviderKeys.remove")}
+              </Button>
+            ) : null}
+          </div>
+        )}
+      </Field>
+      {failure ? (
+        <Callout tone="danger" live="alert">
+          {problemMessageOf(failure, t)}
+        </Callout>
+      ) : null}
+      <ConfirmModal
+        open={confirming}
+        onClose={() => setConfirming(false)}
+        title={t("aiProviderKeys.removeConfirmTitle", {
+          provider: status.provider,
+        })}
+        confirmLabel={t("aiProviderKeys.remove")}
+        confirmVariant="danger"
+        pending={remove.isPending}
+        onConfirm={() => {
+          save.reset();
+          remove.mutate(
+            { provider: status.provider },
+            { onSuccess: () => setConfirming(false) },
+          );
+        }}
+      >
+        {t("aiProviderKeys.removeConfirmBody")}
+      </ConfirmModal>
+    </PanelRow>
+  );
+}

--- a/frontend/src/screens/ai-routing.stories.tsx
+++ b/frontend/src/screens/ai-routing.stories.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type GrantSpec, meFixture } from "../app/mefixture";
+import { AiRoutingCard } from "./ai-routing";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The installation's tier→model binding: which vendor serves each cost rung,
+// and the egress posture that constrains what a rung may be bound to.
+//
+// /me is not optional furniture here, it selects the shape. `ai_routing:read`
+// decides whether the binding is this reader's to see at all, and `update`
+// decides whether the form is theirs to change — so the three seats below are
+// three different cards, not one card with a disabled attribute.
+const MANAGER: GrantSpec = { ai_routing: ["read", "update"] };
+const READER: GrantSpec = { ai_routing: ["read"] };
+// Reaches the AI tab on another grant and holds no ai_routing at all.
+const NO_GRANT: GrantSpec = { automation: ["read"] };
+
+const BOUND = {
+  profile: "eu_hosted",
+  tiers: {
+    local_small: { provider: "ollama", model: "gemma3" },
+    cheap_cloud: { provider: "gemini", model: "gemini-3.1-flash-lite" },
+    premium: { provider: "gemini", model: "gemini-3.5-flash" },
+    frontier: { provider: "gemini", model: "gemini-3.1-pro-preview" },
+  },
+  embeddings: { provider: "gemini", model: "gemini-embedding-001" },
+};
+
+function story(routing: unknown, allow: GrantSpec = MANAGER) {
+  return () => {
+    installFetchStub({
+      "GET /me": () => jsonResponse(meFixture({ allow })),
+      "GET /ai/routing": () => jsonResponse(routing),
+    });
+    return (
+      <StoryProviders>
+        <AiRoutingCard />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof AiRoutingCard> = {
+  title: "Settings/Admin settings/AI/Model routing",
+  component: AiRoutingCard,
+};
+export default meta;
+type Story = StoryObj<typeof AiRoutingCard>;
+
+// Every rung bound, mixing a local provider on the cheapest one — the shape a
+// working installation is in, and the one where tier ORDER matters: the ladder
+// reads cheapest to most capable, not alphabetically.
+export const Bound: Story = { render: story(BOUND) };
+
+// An installation that has bound nothing. Its AI lanes are absent, which is a
+// state rather than a fault — nothing guesses which vendor an installation's
+// text goes to — so this must not read as an error.
+export const Unbound: Story = {
+  render: story({
+    profile: "eu_hosted",
+    tiers: {},
+    embeddings: { provider: "", model: "" },
+  }),
+};
+
+// The sovereign posture, which is the one that CONSTRAINS: it admits no cloud
+// provider at all, so a reader has to be able to tell at a glance that the
+// binding below it is limited by the choice above it.
+export const SovereignProfile: Story = {
+  render: story({
+    ...BOUND,
+    profile: "sovereign",
+    tiers: { local_small: { provider: "ollama", model: "gemma3" } },
+  }),
+};
+
+// Read but not change. The binding stays fully legible — an operator who must
+// ask somebody else to re-point a lane still needs to see where it points.
+export const ReadOnlySeat: Story = { render: story(BOUND, READER) };
+
+// No read grant. The card keeps its place and says the binding is withheld,
+// because an absent card would claim this installation binds no models — a
+// statement about the data where the truth is only about who may see it. It
+// asks the server for nothing, so there is no 403 error box either.
+export const Withheld: Story = { render: story(BOUND, NO_GRANT) };
+
+// Dark. The profile and each tier's provider are carried by text on the panel
+// surface; a token that flattens here costs the reader the one thing the card
+// says.
+export const BoundDark: Story = {
+  globals: { theme: "dark" },
+  render: story(BOUND),
+};

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -2,8 +2,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCanWrite } from "../app/capability";
-import { Button, Field, TextInput } from "../design-system/atoms";
+import { useCan, useCanWrite } from "../app/capability";
+import { Button, EmptyState, Field, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
@@ -41,8 +41,9 @@ const PROVIDERS = [
 
 const PROFILES = ["eu_hosted", "sovereign", "cloud_frontier"] as const;
 
-function useRouting() {
+function useRouting(enabled: boolean) {
   return useQuery({
+    enabled,
     queryKey: ["ai-routing"],
     queryFn: async () => {
       const { data, error, response } = await api.GET("/ai/routing");
@@ -72,16 +73,29 @@ function useReplaceRouting() {
 
 export function AiRoutingCard() {
   const t = useT();
+  // The read grant gates the QUERY, not only the form. This tab opens on other
+  // grants, so a seat can reach the page without `ai_routing:read` — and asking
+  // anyway drew a 403 error box, which reads as a broken installation rather
+  // than as a permission. Withheld is the answer every card on this page gives.
+  const canSee = useCan("ai_routing", "read");
   const canManage = useCanWrite("ai_routing", "update");
-  const query = useRouting();
+  const query = useRouting(canSee);
 
   return (
     <Panel title={t("aiRouting.title")}>
       <PanelBody className="form-stack">
         <p className="t-caption">{t("aiRouting.sub")}</p>
-        <QueryGate query={query}>
-          {(routing) => <RoutingForm routing={routing} canManage={canManage} />}
-        </QueryGate>
+        {canSee ? (
+          <QueryGate query={query}>
+            {(routing) => (
+              <RoutingForm routing={routing} canManage={canManage} />
+            )}
+          </QueryGate>
+        ) : (
+          <EmptyState>
+            <p className="t-small">{t("aiRouting.withheld")}</p>
+          </EmptyState>
+        )}
       </PanelBody>
     </Panel>
   );

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -10,6 +10,7 @@ import {
   auditEntry,
   IDLE_JOB_HEALTH,
   jsonResponse,
+  keyedEnvelope,
   readOn,
   render,
   renderSettings,
@@ -170,6 +171,10 @@ describe("SettingsScreen RBAC surfaces", () => {
             }),
           );
         }
+        const keyed = keyedEnvelope(url);
+        if (keyed) {
+          return keyed;
+        }
         return jsonResponse({
           data: [],
           page: { next_cursor: null, has_more: false },
@@ -260,6 +265,10 @@ function mergedEntryBackend(opts: {
     }
     if (url.includes("/embeddings/reindex/status")) {
       return jsonResponse(REINDEX_STATUS);
+    }
+    const keyed = keyedEnvelope(url);
+    if (keyed) {
+      return keyed;
     }
     return jsonResponse({
       data: [],

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -105,6 +105,25 @@ export function readOn(object: RbacObject): GrantSpec {
   return spec;
 }
 
+// The endpoints on this screen that answer with a KEYED envelope rather than
+// the paged `{data, page}` one every fake falls back to. An unrouted keyed
+// endpoint does not read as an empty card: the consumer indexes the key it was
+// promised, gets undefined, and throws mid-render — which takes the whole entry
+// down and surfaces as its OTHER cards being absent, nowhere near the cause.
+//
+// Shared because this screen has two fetch fakes (`settingsBackend` here and
+// `mergedEntryBackend`, which parameterizes the seat), and a keyed endpoint
+// added to one of them alone leaves the other failing exactly that way.
+export function keyedEnvelope(url: string) {
+  // `providers` is required in the contract, so a card is right to index it
+  // directly; an empty list is the honest answer for an installation that has
+  // bound no cloud provider.
+  if (url.includes("/ai/provider-keys")) {
+    return jsonResponse({ providers: [] });
+  }
+  return null;
+}
+
 // Routed by URL so every card on the screen gets an honest per-endpoint
 // answer; the cards not under test render their empty states.
 export function settingsBackend() {
@@ -134,6 +153,10 @@ export function settingsBackend() {
         ],
         page: { next_cursor: null, has_more: false },
       });
+    }
+    const keyed = keyedEnvelope(url);
+    if (keyed) {
+      return keyed;
     }
     return jsonResponse({
       data: [],

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -77,6 +77,7 @@ import { formatDate, formatDateTime } from "../format/format";
 import { RECORD_ZONE, viewerZone } from "../format/timezone";
 import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { AiProviderKeysCard } from "./ai-provider-keys";
 import { AiRoutingCard } from "./ai-routing";
 import { AiCallsCard } from "./aicalls";
 import { AiUsageCard } from "./aiusage";
@@ -876,6 +877,11 @@ function AiSettingsTab() {
       {/* Which vendor the installation's text is sent to, first: it is the
           decision the three cards under it report against. */}
       <AiRoutingCard />
+      {/* Directly under the binding, because the two are one decision read in
+          two halves: which vendor serves a tier, and whether this installation
+          can call it at all. A binding whose vendor holds no key fails closed,
+          and this is where a reader finds out why. */}
+      <AiProviderKeysCard />
       <AutomationsAdmin />
       <AiUsageCard />
       <ModelCostsCard />


### PR DESCRIPTION
Builds the provider-key surface named in #1780. Most of the backend already existed — `ai.ProviderKeys` (settings → vault ref), `ai.SealedKeys` (the resolver), `compose.SealProviderKeys` (the boot seeder). **The gap was the write path**, and `deploymentsecretseal.go` was already justifying its own precedence by pointing at it:

> The DECLARATION outranks the sealed copy, which is the opposite of the order the BYOK provider keys take… A provider key **has a human write path — the routing surface** — so the vault has to win.

It didn't. Adding a vendor took an operator, a restart and a shell.

## What lands

| | |
|---|---|
| `ai.ProviderKeyStore` | `List` / `Set` / `Remove` — RBAC gate, vendor vocabulary, seal-then-record, retire-after-commit |
| `GET /ai/provider-keys` | which vendors hold a key; **never the key** |
| `PUT /ai/provider-keys/{provider}` | store or rotate, write-only body, 204 |
| `DELETE /ai/provider-keys/{provider}` | idempotent — a vendor holding nothing is 204, not 404 |
| Settings → AI → Model provider keys | per-vendor row, password input, add / replace / remove |

Ordering in `Set` is deliberate: the new blob is written **before** the ref moves, and the old one destroyed **after** the move commits. No window exists where the recorded ref names nothing, and a half-finished rotation leaves the previous key serving.

## The key has no read path

Not on the list, not in an error, not as a length or a masked tail — each of those narrows a brute force while feeling harmless. The list answers `configured`, which is all a screen needs to choose "add" or "replace". The card's input starts **empty even for a configured vendor**: a mask would imply the real value is retrievable and invite a screenshot.

## Four tests were weak first, which is worth reading

The RBAC case passed with the gate **deleted**, three separate times:

1. a bare context fails for unrelated reasons (no workspace);
2. a fully-formed ungranted principal is stopped earlier, by the settings *read*;
3. an orphan-blob count comes back level, because the store's own rollback discards it.

The gate's only observable effect is `Remove` on a vendor holding nothing, which returns **before** the settings write — so without it a read-only seat is told its removal succeeded. That is what the test asserts now, and it fails when the gate goes.

Also mutation-proven: the setting holds a ref and never the key; a rotation destroys the superseded blob; the handler cannot echo the key; an unwired vault degrades to 501; the card cannot prefill or downgrade the input to `type="text"`.

## Reuse, not reinvention

`keyvault.DeleteDetached` replaced a hand-rolled swallowed `Delete` I had written. It already answered the three questions that call raises — the caller's write has committed, the ref is safe to log, the delete must outlive a request that hung up — and answers them the same way for every custodian in the tree.

## One decision I did not take

You chose "vault only — env is retired". I have **kept `SealProviderKeys`** and retired the environment only as a *documented* configuration surface, because deleting the seeder means every installation exporting a key today loses AI on upgrade until an admin re-enters each one by hand. The vault is already the source without that cost — `providerkeys.go` shipped it that way. Say the word and I will remove the seeder in a follow-up, with a release note.

## Verification

`make check` · `craft-static` (4 roots, 0 findings) · `make fe-quality` · store and HTTP suites green against a **real** vault.

`make test-integration` has two pre-existing failures in `projectattribution_integration_test.go`, reproduced on a clean `origin/main` — unrelated to this change, and I have not touched them.

## Note on the worktree

Three residue directories (`extensions/dispact-connector`, `zalo-oa`, `zalo-personal`) held only `frontend/node_modules` with their source gone, which fails `gen-composition` hard. Untracked and not on main. I moved them to the session scratchpad rather than deleting, in case they belong to whoever was mid-cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI provider key management in Settings, including secure add, replace, and idempotent removal.
  * Provider credentials are masked, never displayed, and securely stored.
  * Added provider status indicators and support for environment-seeded credentials.
  * Editing controls require appropriate permissions.
  * Added API support for viewing provider status and managing credentials.
  * AI routing now refreshes automatically when provider credentials change.
* **Documentation**
  * Updated configuration guidance for secure storage, rotation, environment seeding, and fail-closed behavior.
* **Localization**
  * Added English, German, and Vietnamese translations for provider key management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->