### PR TITLE
test(capture): the attribution fixture holds what capture holds, and no more

### DIFF
--- a/backend/internal/compose/projectattribution_integration_test.go
+++ b/backend/internal/compose/projectattribution_integration_test.go
@@ -83,15 +83,6 @@ func seedAttributionAccount(t *testing.T, e *integration.Env) attributionAccount
 				"organization": {Create: true, Read: true},
 				"project":      {Read: true},
 				"deal":         {Read: true},
-				// The candidate set is reached THROUGH the project's company
-				// edge, so naming a project is an edge read. A real connector
-				// carries the mailbox owner's RBAC verbatim (extingress.go
-				// copies rbac.Permissions onto it), and every seeded rep role
-				// grants relationship — see integration.RepPerms. Leaving it
-				// out modelled a connector production does not issue, and this
-				// suite passed only while attribution reached projects without
-				// the edge.
-				"relationship": {Read: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},


### PR DESCRIPTION
Reverting a mistake of mine from #2390. `main` is **not** red — this removes a fixture grant that is now both untrue and inert, before it costs somebody a real defect.

## What I got wrong

#2390 added `"relationship": {Read: true}` to the attribution suite's connector principal, with a comment asserting:

> A real connector carries the mailbox owner's RBAC verbatim (extingress.go copies rbac.Permissions onto it)

**That is false, and #2397 says so from the authority of the person who wrote the path:**

> this walk runs as the CAPTURE principal — a connector acting for the mailbox's owner, holding activity, person, organization, project and deal, and no relationship grant, because reading edges is not what capture does.

`extingress.go` is the **extension** ingress. Generalising it to every connector was the error: the two build their principals differently, and capture's is the narrower one the fixture already had. I had the right instinct in #2383 — that granting the fixture principal "would turn main green while possibly leaving attribution dead in production" — and then talked myself out of it on evidence from the wrong call site.

## Why it still matters now that #2397 has fixed the real defect

#2397 fixed both production causes — a partial-index `ON CONFLICT` that could never match, and the candidate walk demanding an edge read capture does not hold — so the grant is now **inert**.

Inert is the dangerous half. A fixture carrying authority production withholds keeps passing, and would keep passing the moment the walk asks for an edge again — which is precisely the failure #2397 describes:

> "the ladder has nothing to propose" is indistinguishable from the feature working

The fixture is supposed to be the thing that notices. It cannot notice while it holds a grant the real principal does not.

## Verification

All seven attribution suites pass **without** the grant, against real Postgres:

```
--- PASS: TestUncertainRungOffersTheSoleLiveProjectAndConfirmFilesIt
--- PASS: TestDecliningTheOfferLeavesTheMessageUnfiledAndIsNotAskedAgain
--- PASS: TestUncertainRungAsksNothingBetweenSeveralProjectsWithoutEmbeddings
--- PASS: TestConfirmStandsDownWhenAHumanFiledTheMessageElsewhere
--- PASS: TestADeciderWithoutTheProjectGrantCannotSeeOrDecideTheOffer
--- PASS: TestADeciderWithReadOnlyAuthorityOverTheMessageCannotConfirmIt
--- PASS: TestAnExpiredOfferFreesTheCandidateAndMayBeAskedAgain
ok  github.com/gradionhq/margince/backend/internal/compose  1.642s
```

Nine lines out; nothing else touched.

Found by an hourly main-status watch, reading #2397 after it landed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `relationship: Read` grant from the attribution connector fixture so it matches the capture principal’s real permissions. Previously the fixture had an edge-read grant; now it does not, preventing an inert, incorrect permission from masking edge-read regressions.

- Scope: tests only; `backend/internal/compose/projectattribution_integration_test.go` (-9 lines).
- Behavior: no production change; attribution suites pass against real Postgres without the grant.
- Risk: low; the fixture now mirrors capture’s actual grants (activity, person, organization, project, deal) and no `relationship`.

<sup>Written for commit 4e8dc0b3cb9a83702963b49663053821d807e5f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated attribution integration test setup by removing an unnecessary relationship-read permission from the seeded test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->