### PR TITLE
fix(frontend): the project page answers one question, and a company's projects sit where a reader looks

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6163,8 +6163,6 @@ export const de = {
   "project.rollups.lastActivity": "Letzte Aktivität",
   "project.rollups.never": "noch nichts",
   "project.rollups.activityCount": "Aktivitäten",
-  "project.coverage":
-    "{attributed} zugeordnet · {awaiting} warten auf Entscheidung · {nearby} bei Personen und Deals dieses Projekts nicht zugeordnet",
   "project.history.title": "Phasenverlauf",
   "project.history.empty": "Noch kein Phasenwechsel erfasst.",
   "project.history.current": "aktuell",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6230,8 +6230,6 @@ export const en = {
   "project.rollups.lastActivity": "Last activity",
   "project.rollups.never": "nothing yet",
   "project.rollups.activityCount": "Activities",
-  "project.coverage":
-    "{attributed} attributed · {awaiting} awaiting a decision · {nearby} on this project's people and deals not attributed",
   "project.history.title": "Phase history",
   "project.history.empty": "No phase change recorded yet.",
   "project.history.current": "current",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6110,8 +6110,6 @@ export const vi = {
   "project.rollups.lastActivity": "Hoạt động gần nhất",
   "project.rollups.never": "chưa có gì",
   "project.rollups.activityCount": "Hoạt động",
-  "project.coverage":
-    "{attributed} đã gán · {awaiting} chờ quyết định · {nearby} ở người và thương vụ của dự án này chưa gán",
   "project.history.title": "Lịch sử giai đoạn",
   "project.history.empty": "Chưa ghi nhận thay đổi giai đoạn nào.",
   "project.history.current": "hiện tại",

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -2370,9 +2370,12 @@ function CompanyRecordBody({
         projects={liveProjects(view?.projects)}
       />
       {/* The deliveries this company is part of — as the client, a partner or a
-          subcontractor. It sits with Deals and Tasks because all three answer
-          "what is in flight with this account". */}
-      {!overlay && (
+          subcontractor. On the OVERVIEW tab with Deals and Tasks, because all
+          three answer "what is in flight with this account" and a section on
+          every tab is a section nobody can locate: it appeared under Documents
+          and Profile, where it means nothing, and a reader scanning Overview
+          did not read it as belonging there. */}
+      {!overlay && tab === "overview" && (
         <CompanyProjects
           organizationId={org.id}
           projects={view?.projects}

--- a/frontend/src/screens/project360.test.tsx
+++ b/frontend/src/screens/project360.test.tsx
@@ -42,7 +42,7 @@ function render(ui: ReactNode) {
 }
 
 describe("ProjectScreen", () => {
-  it("renders the header, the stepper, the rollups, the coverage line and the sections", async () => {
+  it("renders the header, the stepper, the rollups and the sections", async () => {
     projectsBackend({
       view: project360({
         deals: {
@@ -83,9 +83,10 @@ describe("ProjectScreen", () => {
     expect(within(rollups).getByText("€4,500.00")).toBeTruthy();
     expect(within(rollups).getByText("4")).toBeTruthy();
     expect(within(rollups).getByText("142")).toBeTruthy();
-    expect(screen.getByTestId("project-coverage").textContent).toBe(
-      "142 attributed · 8 awaiting a decision · 23 on this project's people and deals not attributed",
-    );
+    // No coverage line: three numbers about how well the FILING SYSTEM has
+    // done its job are the machine's bookkeeping, not a reading of the work,
+    // and they were the first thing a reader met under the title.
+    expect(screen.queryByTestId("project-coverage")).toBeNull();
 
     // The sections: a linked deal row, a seated person with their role, the
     // phase history with its duration, and honest empty states elsewhere.
@@ -160,15 +161,16 @@ describe("ProjectScreen", () => {
     render(<ProjectScreen id="pr-1" />);
     await screen.findByRole("heading", { name: "CRM rollout" });
     const withheld = screen.getAllByText("Hidden — your role cannot read this");
-    // The contracts card, the rollups plate, the coverage line, the company
-    // in the subtitle and the timeline: five withheld sections, five
-    // sentences, no empty state standing in for any of them.
-    expect(withheld).toHaveLength(5);
+    // The contracts card, the rollups plate, the company in the subtitle and
+    // the timeline: four withheld sections, four sentences, no empty state
+    // standing in for any of them. The coverage line is gone from the page, so
+    // it withholds nothing.
+    expect(withheld).toHaveLength(4);
     expect(
       screen.queryByText(/No agreement is filed under this project/),
     ).toBeNull();
     expect(screen.queryByTestId("project-coverage")).toBeNull();
-    expect(screen.getByTestId("project-coverage-withheld")).toBeTruthy();
+    expect(screen.queryByTestId("project-coverage-withheld")).toBeNull();
     expect(screen.getByTestId("project-company-withheld")).toBeTruthy();
     expect(screen.queryByText("Brandt Automotive")).toBeNull();
     expect(

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -25,7 +25,7 @@ import { EditAction } from "./edit";
 import { EntityRef, OwnerName } from "./entityref";
 import { ProjectCompanies } from "./projectcompanies";
 import { AdvanceProjectModal, PhaseStepper } from "./projectphase";
-import { CoverageLine, RollupsStrip } from "./projectreadings";
+import { RollupsStrip } from "./projectreadings";
 import { PhaseBadge, ProjectKeyChip, useCompanyOptions } from "./projects";
 import {
   mapProjectUpdate,
@@ -113,15 +113,6 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
       }
       band={
         <div className="project-band">
-          {/* The key is not a form field any more — the server mints it — so
-            this line is where a reader learns what it is FOR. Without it the
-            chip is a code beside a name and nothing says that writing it in a
-            subject files the mail here. */}
-          {project.key && (
-            <p className="t-caption">
-              {t("project.keyMinted", { key: project.key })}
-            </p>
-          )}
           {project.archived_at && (
             <p id={archivedReasonId} className="t-caption">
               {t("project.archivedReadOnly")}
@@ -134,14 +125,16 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
             onMove={setMoveTo}
           />
           <RollupsStrip view={view} />
-          <CoverageLine view={view} />
         </div>
       }
+      // WHO is on this work comes first, then the paperwork. The rail used to
+      // open with the phase history — a log of moves the stepper above already
+      // shows the current state of — so a reader scanning for "whose project is
+      // this" read a changelog first. The three record-keeping cards below
+      // answer questions a reader comes looking for on purpose; the two above
+      // answer the one they arrive with.
       rail={
         <div className="project-rail">
-          <PhaseHistoryCard view={view} />
-          {/* Who is working this together, above the people on it: the reader
-              asking "whose project is this" is asking about companies first. */}
           <ProjectCompanies
             projectId={project.id}
             companies={project.organizations}
@@ -150,6 +143,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
           <StakeholdersCard view={view} />
           <ProjectContractsCard view={view} />
           <ProjectDocumentsCard view={view} />
+          <PhaseHistoryCard view={view} />
         </div>
       }
       railLabel={t("project.railLabel")}

--- a/frontend/src/screens/projectreadings.tsx
+++ b/frontend/src/screens/projectreadings.tsx
@@ -73,37 +73,3 @@ export function RollupsStrip({ view }: Readonly<{ view: Project360 }>) {
     </StatStrip>
   );
 }
-
-/**
- * CoverageLine says how well this project's correspondence is filed. It is
- * information, never a task: the unattributed count is the filing debt a rep
- * MAY work down, stated once under the figures rather than as a queue.
- */
-export function CoverageLine({ view }: Readonly<{ view: Project360 }>) {
-  const t = useT();
-  const coverage = view.coverage;
-  const state = stateOf(view, "coverage", Boolean(coverage), coverage ? 1 : 0);
-  // Withheld is a fact the line states; a section that simply did not come
-  // back has nothing honest to say and draws nothing.
-  if (state === "withheld") {
-    return (
-      <div data-testid="project-coverage-withheld">
-        <SurfaceState state={state} emptyLabel="">
-          {null}
-        </SurfaceState>
-      </div>
-    );
-  }
-  if (state !== "ready" || !coverage) {
-    return null;
-  }
-  return (
-    <p className="t-caption project-coverage" data-testid="project-coverage">
-      {t("project.coverage", {
-        attributed: coverage.attributed,
-        awaiting: coverage.awaiting_decision,
-        nearby: coverage.unattributed_nearby,
-      })}
-    </p>
-  );
-}

--- a/frontend/src/screens/projects.tsx
+++ b/frontend/src/screens/projects.tsx
@@ -85,9 +85,19 @@ export function PhaseBadge({ phase }: Readonly<{ phase: ProjectPhase }>) {
 export function ProjectKeyChip({
   projectKey,
 }: Readonly<{ projectKey: string }>) {
+  const t = useT();
   return (
     <Chip icon={Hash}>
-      <span className="t-mono">{projectKey}</span>
+      {/* What the key is FOR, on the chip rather than as a line of its own.
+        A reader learns it once by hovering the code they are already looking
+        at; a permanent sentence under the title pays every day for a lesson
+        taught once, which is what it was doing. */}
+      <span
+        className="t-mono"
+        title={t("project.keyMinted", { key: projectKey })}
+      >
+        {projectKey}
+      </span>
     </Chip>
   );
 }


### PR DESCRIPTION
Lars opened the project page and asked what he could do there. Eleven blocks
answered, nine of which nobody asked for, and two of them reported the filing
system's own bookkeeping rather than the work.

The coverage line is gone — deleted, not hidden. "142 attributed · 8 awaiting a
decision · 23 on this project's people and deals not attributed" is three
numbers about how well the machine has filed things, and it was the FIRST thing
a reader met under the title. Nobody opens a project to audit the attribution
ladder.

The key explainer moves from a permanent line to the chip it explains. A
sentence under the title paid every day for a lesson taught once; a title
attribute on the code teaches it to the reader who wonders, when they wonder.

The rail leads with WHO is on the work — companies, then people — and the three
record-keeping cards follow. It used to open with the phase history, so a reader
scanning for "whose project is this" met a changelog of moves the stepper above
already shows the current state of.

And the company page's Projects section is on the OVERVIEW tab now, with Deals
and Tasks, because those three answer "what is in flight with this account". It
rendered on all eight tabs, which is why Lars could not find it: a section that
appears under Documents and Profile, where it means nothing, is not a section a
reader locates on the tab where it belongs.

Walked, not inferred: the coverage line and the explainer are gone from the live
page, the rail reads Companies → Stakeholders → Documents → Phase history, the
project shows on the company's Overview, and Documents, Profile and People show
no projects section.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the project page to answer “who is on this work” and puts a company’s Projects where users look. Removes bookkeeping noise, moves the key explainer to the key chip, and reorders the rail for scan-first reading.

- Old: a coverage line appeared under the title (and could be “withheld”). New: the coverage line is deleted; i18n strings removed; tests updated to expect no coverage or withheld state.
- Old: a caption explained what the project key does. New: the key chip shows the explainer as a tooltip (`title`), no standalone caption.
- Old: the rail led with Phase history. New: Companies → Stakeholders → Contracts → Documents → Phase history.
- Old: the company page showed Projects on every tab. New: Projects render only on Overview, alongside Deals and Tasks; nothing renders under Documents, Profile, or People.

**Reviewer focus**
- Verify no UI or test references to coverage remain; builds pass for `en`, `de`, `vi`.
- Check the key chip tooltip matches the former explainer text and that the header has no extra line.
- Confirm rail order and that the stepper still shows the current phase.
- In Organizations, ensure Projects show only on the Overview tab and not on other tabs or overlays.

<sup>Written for commit e0d9cd130897f2912d7aa841a9fb90446e8284c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized tooltip explaining project keys when hovering over project key chips.
  * Updated the project rail layout to display project history after related project information.

* **Bug Fixes**
  * Company projects now appear only on the Overview tab, rather than every organization tab.
  * Removed the obsolete project coverage display and translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->