### PR TITLE
fix(projects): a project created without an owner belongs to its creator

### DIFF
--- a/backend/internal/compose/integration/project_integration_test.go
+++ b/backend/internal/compose/integration/project_integration_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // seedProject creates a project on a fresh company, owned by the given
-// user (nil = ownerless).
+// user (nil = the creating admin, since a project defaults to its creator).
 type projectFixture struct {
 	ID      ids.ProjectID
 	Version int64
@@ -908,5 +908,47 @@ func TestTheMintedNumberIsTheLowestFreeOneForItsStem(t *testing.T) {
 	fourth := seedProject(e.Admin(), t, e, "Warehouse revamp", org, nil)
 	if k := mintedKey(e.Admin(), t, e, fourth.ID); strings.EqualFold(k, "wr-9") {
 		t.Errorf("minted %q over a live lower-cased key; the index would refuse it", k)
+	}
+}
+
+// A project created without a requested owner belongs to its creator — the
+// same birth default person, organization, lead and deal already apply. The
+// stake is the New-deal form's "New project…" flow: write authority reads an
+// unowned row as nobody's to change, so an ownerless project could never be
+// attached to a deal by the very rep who had just created it.
+func TestAProjectCreatedWithoutAnOwnerBelongsToItsCreator(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	org := e.SeedOrg(t, "BAER Pharma", &e.Rep1)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"project":      {Create: true, Read: true, Update: true},
+			"deal":         {Create: true, Read: true, Update: true},
+			"organization": {Read: true},
+		},
+		RowScope: principal.RowScopeTeam,
+	})
+
+	p, err := e.Projects.CreateProject(rep, projects.CreateProjectInput{
+		Name: "ERP rollout", OrganizationID: orgIDOf(org), Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("a rep creating a project on their own company: %v", err)
+	}
+	if p.OwnerId == nil || ids.UUID(*p.OwnerId) != e.Rep1 {
+		t.Fatalf("owner = %v, want the creating rep %s", p.OwnerId, e.Rep1)
+	}
+
+	// The flow that exposed the gap: the same rep immediately binds a new
+	// deal to the project they just created.
+	orgID := orgIDOf(org)
+	projID := projectIDOf(ids.UUID(p.Id))
+	if _, err := e.Deals.CreateDeal(rep, deals.CreateDealInput{
+		Name: "ERP rollout deal", PipelineID: pipeline, StageID: open,
+		OrganizationID: &orgID, ProjectID: &projID, Source: "manual",
+	}); err != nil {
+		t.Fatalf("the creating rep attaching their new project to a new deal: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/project_integration_test.go
+++ b/backend/internal/compose/integration/project_integration_test.go
@@ -912,7 +912,7 @@ func TestTheMintedNumberIsTheLowestFreeOneForItsStem(t *testing.T) {
 }
 
 // A project created without a requested owner belongs to its creator — the
-// same birth default person, organization, lead and deal already apply. The
+// same birth default person, organization and deal already apply. The
 // stake is the New-deal form's "New project…" flow: write authority reads an
 // unowned row as nobody's to change, so an ownerless project could never be
 // attached to a deal by the very rep who had just created it.

--- a/backend/internal/modules/projects/project.go
+++ b/backend/internal/modules/projects/project.go
@@ -69,7 +69,7 @@ func (s *Store) CreateProject(ctx context.Context, in CreateProjectInput) (crmco
 		return crmcontracts.Project{}, err
 	}
 	// A project with no requested owner belongs to its creator, the same
-	// default person/organization/lead/deal births apply. Ownerless matters
+	// default person/organization/deal births apply. Ownerless matters
 	// more here than elsewhere: write authority reads an unowned row as
 	// nobody's to change, so an ownerless project can never be attached to a
 	// deal by the rep who just created it (projects.EnsureAttachable).

--- a/backend/internal/modules/projects/project.go
+++ b/backend/internal/modules/projects/project.go
@@ -68,6 +68,12 @@ func (s *Store) CreateProject(ctx context.Context, in CreateProjectInput) (crmco
 	if err != nil {
 		return crmcontracts.Project{}, err
 	}
+	// A project with no requested owner belongs to its creator, the same
+	// default person/organization/lead/deal births apply. Ownerless matters
+	// more here than elsewhere: write authority reads an unowned row as
+	// nobody's to change, so an ownerless project can never be attached to a
+	// deal by the rep who just created it (projects.EnsureAttachable).
+	in.OwnerID = storekit.OwnerOrActor(ctx, in.OwnerID)
 	active, err := s.catalogColumns(ctx)
 	if err != nil {
 		return crmcontracts.Project{}, err

--- a/frontend/src/screens/projects.form.test.ts
+++ b/frontend/src/screens/projects.form.test.ts
@@ -45,14 +45,16 @@ describe("projectFields", () => {
       currentOwner: "u-other",
       mode: "edit",
     });
+    // No owner picker at birth: the server stamps the creator, and the only
+    // choices a create could offer would both resolve to them anyway.
     expect(create.map((field) => field.key)).toEqual([
       "name",
       "organization_id",
-      "owner_id",
       "description",
       "target_end_date",
     ]);
     expect(edit.map((field) => field.key)).not.toContain("organization_id");
+    expect(edit.map((field) => field.key)).toContain("owner_id");
   });
 
   it("lets an edit keep an owner who is not the reader", () => {

--- a/frontend/src/screens/projects.form.ts
+++ b/frontend/src/screens/projects.form.ts
@@ -87,12 +87,21 @@ export function projectFields(
           },
         ]
       : []),
-    {
-      key: "owner_id",
-      label: "project.owner",
-      type: "select",
-      options: ownerOptions,
-    },
+    // Owner is an edit-only field. On create the server stamps the creator
+    // (an unowned project would be nobody's to change, so the write gate
+    // could never attach it to a deal), and the only choices a create could
+    // offer — "Me" and "Unassign" — would both resolve to the creator, a
+    // choice that is no choice. Reassigning and unassigning stay on edit.
+    ...(opts.mode === "edit"
+      ? [
+          {
+            key: "owner_id",
+            label: "project.owner" as const,
+            type: "select" as const,
+            options: ownerOptions,
+          },
+        ]
+      : []),
     { key: "description", label: "project.description", type: "textarea" },
     { key: "target_end_date", label: "project.targetEnd", type: "date" },
   ];


### PR DESCRIPTION
## What

`POST /v1/projects` with no `owner_id` now stamps the acting user as the project's owner — the same `storekit.OwnerOrActor` fallback person, organization, lead and deal births already use.

## Why

The New-deal form's "New project…" flow creates the project first, then creates the deal pointing at it. The project was born ownerless, and write authority reads an unowned row as nobody's to change — so `projects.EnsureAttachable` refused the deal create with 403 for the very rep who had just created the project. Every retry left another orphaned, ownerless project behind. Admins never hit it because an unbounded principal skips the write-authority probe.

## Test

`TestAProjectCreatedWithoutAnOwnerBelongsToItsCreator` (compose integration) drives the exact broken flow as a team-scoped rep: create a project with no owner in the body, read the rep's own id back as owner, bind a new deal to it. Verified the test fails without the fix.

Full local gate (`make check-backend`), `make craft-static`, and the compose + projects integration lanes are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Projects created without `owner_id` now default to the acting user. Previously ownerless projects blocked reps from attaching them to new deals (403) and left orphaned rows.

- Apply `storekit.OwnerOrActor` fallback in `projects.CreateProject` to match person/organization/deal creation (leads remain unassigned by design). Add compose test `TestAProjectCreatedWithoutAnOwnerBelongsToItsCreator` that drives the New-deal “New project…” flow and verifies the creator is stamped as owner and can attach the project to a new deal.
- Remove the owner picker from project create; owner is now edit-only. The server stamps the creator, and reassign/unassign remain on edit to avoid an “Unassign” that would silently assign.

<sup>Written for commit ed97779ffafdcbab16dcd1e7e3cbb2a3fe0b6ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects created without a specified owner are now automatically assigned to the person creating them.
  * Newly created projects can be immediately attached to deals by their creator.
  * Project creation forms no longer require selecting an owner; owners can still be changed when editing a project.

* **Bug Fixes**
  * Improved project ownership handling for projects created without an explicit owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->