### PR TITLE
fix(compose): a check-in mail can name its project even when the account has no contact

### DIFF
--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1877,4 +1877,55 @@ describe("ComposeModal started from an account", () => {
     expect(screen.queryByText(/Based on/)).toBeNull();
     expect(screen.queryByText(/AI assistance/)).toBeNull();
   });
+
+  // A check-in mail to an account nobody has spoken to in a while is the FIRST
+  // message on a delivery: no thread exists, so nothing files it automatically,
+  // and it is exactly the message that needs a project chosen. The account
+  // having no contact yet is a dead end for the DRAFT — the model has no
+  // relationship to write from — and it used to take the project picker with
+  // it, so the mail landed unfiled and the ladder asked about it afterwards.
+  it("still offers the project when the account has no contact yet", async () => {
+    stubRoutes({
+      "GET /organizations/org-1/360": () =>
+        jsonResponse({
+          state: "ready",
+          as_of: "2026-08-09T09:00:00Z",
+          organization: {
+            id: "org-1",
+            display_name: "Acme",
+            source: "manual",
+            captured_by: "human:u1",
+            created_at: "2026-08-01T00:00:00Z",
+            updated_at: "2026-08-01T00:00:00Z",
+          },
+          sections_omitted: [],
+          people: { data: [], page: { has_more: false } },
+          projects: [
+            {
+              project_id: "pr-1",
+              name: "Zeta migration",
+              key: "ZM-1",
+              phase: "initiative",
+            },
+          ],
+        }),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/No contact on this account yet/),
+    ).toBeTruthy();
+    // The dead end is about the DRAFT, not about which body of work the
+    // message is for.
+    expect(
+      await screen.findByRole("combobox", { name: /Project/ }),
+    ).toBeTruthy();
+  });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -574,11 +574,32 @@ function AccountDraftContext({
   const deals = view?.deals?.data ?? [];
   const projects = liveProjects(view?.projects);
   useSoleProjectDefault(projects, projectId, onProjectChange);
-  // No contact on the account is an honest dead end for a GROUNDED draft, and
-  // saying so beats an empty picker the rep tries and cannot use. They can
-  // still type an address into To and write the mail themselves.
+  // No contact on the account is an honest dead end for the DRAFT — the model
+  // has no relationship to write from — and saying so beats an empty picker the
+  // rep tries and cannot use. They can still type an address into To and write
+  // the mail themselves.
+  //
+  // The PROJECT picker survives that dead end, and must: which body of work a
+  // message is about has nothing to do with whether the account has a contact
+  // yet. Returning early here took the project choice away from exactly the
+  // message that most needs it — a check-in to an account nobody has spoken to
+  // in a while, which is the first mail on a fresh delivery and the one with no
+  // thread to inherit a project from. It would land unfiled, and the ladder
+  // would ask about it in Approvals afterwards instead.
   if (query.isSuccess && contacts.length === 0) {
-    return <p className="t-caption">{t("compose.noGroundableRecipient")}</p>;
+    return (
+      <>
+        <p className="t-caption">{t("compose.noGroundableRecipient")}</p>
+        {projects.length > 0 && (
+          <ProjectPicker
+            projects={projects}
+            projectId={projectId}
+            onChange={onProjectChange}
+            scope={scope}
+          />
+        )}
+      </>
+    );
   }
   return (
     <>


### PR DESCRIPTION
Lars asked what happens for a check-in — a mail to an account nobody has heard
from in a while. It is the case that most needs a project chosen: no thread
exists, so nothing files it automatically, and it is often the first message on
a fresh delivery.

It was the one case that could not choose one. The composer's account block
returns early when the account has no contact yet — an honest dead end for the
DRAFT, because the model has no relationship to write from — and the early
return took the project picker with it. Which body of work a message is about
has nothing to do with whether the account has a contact, so the picker stays
and only the draft controls go.

Left as it was, that mail landed unfiled and the attribution ladder asked about
it in Approvals afterwards: a question a rep could have answered in the moment,
deferred to a queue.

Walked on a live stack against a company with a project and no contacts: the
dialog says "No contact on this account yet" AND offers "Project: ZM-1 · Zeta
migration — Scoped to ZM-1". Mutation-checked: restoring the early return fails
the new test.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow project selection when composing a check-in email to an account with no contacts, preventing unfiled messages and follow-up attribution in Approvals. Previously the compose view hid the project picker; now it shows the picker while still blocking draft generation.

- Review notes:
  - In AccountDraftContext, when the account has no contacts, render the “no contact” caption and keep the Project picker (if projects exist); only draft controls remain disabled.
  - Preserves the sole-project defaulting behavior.
  - New test asserts caption is shown and the Project combobox is present; reverting the change fails the test.

<sup>Written for commit 6bc1bed5559f4750edb221c87ce6524f5e0baa14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The project selector now remains available when composing from an account with no contacts, provided projects exist.
  - The appropriate no-recipient notice continues to be displayed alongside the project selector.

- **Tests**
  - Added regression coverage for account-started composition without contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->