### PR TITLE
fix(frontend): the projects journey stops asserting a strip the page dropped

### DIFF
--- a/frontend/e2e/projects.spec.ts
+++ b/frontend/e2e/projects.spec.ts
@@ -155,8 +155,13 @@ test("a project is created, a deal is attached, the win starts delivery, the tim
   // moment ago; reload so the page reads the relinked state afresh.
   await page.goto("/#/projects/pr-new-1");
   await page.reload();
+  // The timeline row IS the proof the relink landed. The coverage strip that
+  // used to be asserted here — "{attributed} zugeordnet · {awaiting} warten
+  // auf Entscheidung · …" — was removed by #2408 so the page answers one
+  // question, and project360.test.tsx now asserts its absence twice. An e2e
+  // assertion on copy the product deliberately dropped tests nothing about the
+  // relink and fails for a reason that has nothing to do with it.
   await expect(timeline.getByText("Kickoff mit Brandt IT")).toBeVisible();
-  await expect(page.getByText(/^1 zugeordnet ·/)).toBeVisible();
 
   // 6. Advance by hand: a non-closing move takes an optional reason and
   // lands in the history with it.


### PR DESCRIPTION
`main`'s **`uat`** lane is red and has been since #2408 merged. The last two merged PRs — #2409 and #2410 — both carry the same failure, and neither caused it.

```
e2e/projects.spec.ts:30 › a project is created, a deal is attached, the win starts
delivery, the timeline fills, and the close records its reason

  projects.spec.ts:159: expect(locator).toBeVisible() failed
  Locator: getByText(/^1 zugeordnet ·/)
  element(s) not found
  93 passed, 1 failed
```

## Cause

#2408 (`fix(frontend): the project page answers one question…`) removed the project **coverage strip**: `project.coverage` deleted from all three locales, 34 lines out of `projectreadings.tsx`, and its own unit tests now assert the strip's absence — `expect(screen.queryByTestId("project-coverage")).toBeNull()`, twice.

The e2e assertion outlived the thing it asserted. It is not testing a regression; it is asserting copy the product deliberately dropped.

## Why deleting it loses nothing

The line immediately above is what proves the relink landed:

```ts
await expect(timeline.getByText("Kickoff mit Brandt IT")).toBeVisible();
```

The strip was a second, weaker reading of that same fact — and once removed, it fails for a reason with nothing to do with the relink. A comment now says so at the site, so the next reader does not restore it as "missing coverage".

## Verification

| | Result |
|---|---|
| `origin/main`, `e2e/projects.spec.ts` | 1 failed — `element(s) not found` |
| with this change | **1 passed** |
| with this change, `projects.spec.ts` + `ac.spec.ts` | **87 passed** |

`biome check` clean.

## Note on how this was found

`main-health` cannot see the `uat` lane (#2325), so a break there is reported by nothing on `main` — the only evidence is merged PRs' own checks, which is where this surfaced. Third occurrence of that pattern in a day; #2310 cost three merges, #2358 cost three more, this one two.

Found by an hourly main-status watch, prompted by a third session asking whether `main` was safe to branch from.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale e2e assertion for the project coverage strip removed in #2408. Aligns the journey test with the current UI and clears the red `uat` lane.

- Delete the coverage strip assertion (/^1 zugeordnet ·/) from frontend/e2e/projects.spec.ts and rely on the timeline row “Kickoff mit Brandt IT” as the proof that the relink landed.
- Add an inline comment explaining the removal; unit tests already assert the strip’s absence. No app behavior, locale, or component changes.

<sup>Written for commit c28aa5f378c5a890ced6f0adb0ac2dc534dcc743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated project relinking coverage to verify the relinked timeline entry remains visible.
  * Removed an outdated assertion for deleted project timeline coverage text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->