### PR TITLE
fix(deals): a deal can be filed under a project its company only partners on

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2355,6 +2355,8 @@ export const de = {
   "compose.multiRecipientWarning":
     "Dieser Zweck führt einen Abmeldelink mit sich; ein Versand an mehr als eine Adresse wird deshalb abgelehnt. Senden Sie einzeln, ohne Cc.",
   "compose.relinkTitle": "Diese Aktivität neu verknüpfen",
+  "compose.filedUnder":
+    "Diese Antwort wird unter {project} abgelegt, wie der Rest dieser Konversation.",
   "compose.relinkTarget": "Person, Organisation, Deal oder Lead suchen",
   "compose.relinkReplace": "Verschieben statt zusätzlich verknüpfen",
   "compose.relinkReplaceHint":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2378,6 +2378,8 @@ export const en = {
   "compose.multiRecipientWarning":
     "This purpose carries an unsubscribe link, so a send to more than one addressee will be refused. Send it once per recipient, with no Cc.",
   "compose.relinkTitle": "Relink this activity",
+  "compose.filedUnder":
+    "This reply will be filed under {project}, like the rest of this conversation.",
   "compose.relinkTarget": "Search a person, organization, deal, or lead",
   "compose.relinkReplace": "Move instead of also-link",
   "compose.relinkReplaceHint":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2330,6 +2330,8 @@ export const vi = {
   "compose.multiRecipientWarning":
     "Mục đích này mang liên kết huỷ đăng ký, nên lượt gửi cho nhiều hơn một người nhận sẽ bị từ chối. Hãy gửi riêng cho từng người, không dùng Cc.",
   "compose.relinkTitle": "Liên kết lại hoạt động này",
+  "compose.filedUnder":
+    "Thư trả lời này sẽ được xếp vào {project}, giống phần còn lại của cuộc trò chuyện.",
   "compose.relinkTarget": "Tìm một người, tổ chức, deal hay lead",
   "compose.relinkReplace": "Chuyển hẳn thay vì liên kết thêm",
   "compose.relinkReplaceHint":

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1928,4 +1928,75 @@ describe("ComposeModal started from an account", () => {
       await screen.findByRole("combobox", { name: /Project/ }),
     ).toBeTruthy();
   });
+
+  // A reply inherits its thread's project on its own (capture's stickiness
+  // rung), so the composer offers no picker for it — and used to say nothing
+  // either, which is why a rep pressing "Draft a reply" concluded projects were
+  // not wired at all. It says where the message is going now.
+  it("says which project a reply will be filed under", async () => {
+    stubRoutes({
+      "GET /activities/act-1": () =>
+        jsonResponse({
+          id: "act-1",
+          kind: "email",
+          occurred_at: "2026-08-09T09:00:00Z",
+          source: "gmail",
+          created_at: "2026-08-09T09:00:00Z",
+          updated_at: "2026-08-09T09:00:00Z",
+          version: 1,
+          links: [
+            { entity_type: "person", entity_id: "p-1" },
+            { entity_type: "project", entity_id: "pr-1" },
+          ],
+        }),
+      "GET /projects/pr-1": () =>
+        jsonResponse({ id: "pr-1", name: "ERP rollout Acme" }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/filed under ERP rollout Acme/),
+    ).toBeTruthy();
+    // It SAYS rather than offers: a picker here would file one message of a
+    // conversation away from the rest of it.
+    expect(screen.queryByRole("combobox", { name: /Project/ })).toBeNull();
+  });
+
+  // A thread filed under no project has nothing to announce, and "filed under
+  // nothing" tells a reader less than silence.
+  it("says nothing when the reply's thread carries no project", async () => {
+    stubRoutes({
+      "GET /activities/act-1": () =>
+        jsonResponse({
+          id: "act-1",
+          kind: "email",
+          occurred_at: "2026-08-09T09:00:00Z",
+          source: "gmail",
+          created_at: "2026-08-09T09:00:00Z",
+          updated_at: "2026-08-09T09:00:00Z",
+          version: 1,
+          links: [{ entity_type: "person", entity_id: "p-1" }],
+        }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("button", { name: "Draft with AI" });
+    expect(screen.queryByText(/will be filed under/)).toBeNull();
+  });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -38,6 +38,7 @@ import {
 } from "./common";
 import { useOrganization360 } from "./company360";
 import { useConsentPurposes } from "./consent";
+import { useEntityName } from "./entityref";
 import { useVoiceProfile } from "./voice-profile";
 import "./compose.css";
 
@@ -288,6 +289,55 @@ async function draftFromActivity({
     throwProblem(error || { title: t("compose.actionFailed") });
   }
   return { available: true as const, draft: data };
+}
+
+// Where a REPLY will be filed, said rather than chosen.
+//
+// A reply inherits its thread's project on its own — capture's stickiness rung,
+// "a conversation is about one body of work" — so a picker here would offer a
+// choice the product has already made, and offer it wrongly: filing ONE message
+// of a conversation under a different project is the split that rule exists to
+// prevent.
+//
+// What was missing is not the choice but the SENTENCE. A rep pressed "Draft a
+// reply", saw no project anywhere, and concluded the feature was not there.
+// This says where the message is going, and points at the one control that can
+// change it — which moves the whole conversation, not one message of it.
+function ReplyFiling({ activityId }: Readonly<{ activityId: string }>) {
+  const t = useT();
+  const query = useQuery({
+    queryKey: ["activity", activityId, "filing"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/activities/{id}", {
+        params: { path: { id: activityId } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+  const projectId = (query.data?.links ?? []).find(
+    (link) => link.entity_type === "project",
+  )?.entity_id;
+  const { name } = useEntityName("project", projectId);
+  // Nothing is drawn while the read is in flight, and nothing when the thread
+  // is filed under no project: "this will be filed under nothing" is a sentence
+  // that tells a reader less than silence does, and the unfiled case is what
+  // the attribution ladder already asks about.
+  if (!projectId) {
+    return null;
+  }
+  // It SAYS, and does not offer to change: the control that moves a
+  // conversation is Relink, on the message's own row in the timeline, and it
+  // moves the whole thread. A second one here would be a second spelling of one
+  // action — and the shorter path to filing a single message away from its
+  // conversation, which is the split this line exists to make visible.
+  return (
+    <p className="t-caption">
+      {t("compose.filedUnder", { project: name ?? t("deal.projectUnnamed") })}
+    </p>
+  );
 }
 
 // The account-started draft (ADR-0087/A132). It grounds itself in the account
@@ -1540,6 +1590,11 @@ export function ComposeModal({
     >
       <div className="compose-fields">
         {accountContext}
+        {/* A reply says where it is going. The picker above is for the
+            account-started message, which has no thread to inherit from. */}
+        {activityId && !isChannelReply && (
+          <ReplyFiling activityId={activityId} />
+        )}
         {/* AI drafting is mail-only — there is no draft-message endpoint, and
             a channel reply's recipient is resolved server-side, so neither
             the draft controls nor the To/Cc/Subject fields apply to it. */}

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -169,6 +169,11 @@ export function RelinkModal({
       for (const queryKey of entityTimelineKeys(entityType, entityId)) {
         queryClient.invalidateQueries({ queryKey });
       }
+      // A relink is exactly the write that changes where a reply files, and the
+      // composer's filing line reads the activity to say so. Without this the
+      // line keeps naming the project the activity was moved AWAY from, which
+      // is a wrong answer to the one question it exists to answer.
+      queryClient.invalidateQueries({ queryKey: ["activity", activityId] });
       onClose();
     },
   });
@@ -321,11 +326,20 @@ function ReplyFiling({ activityId }: Readonly<{ activityId: string }>) {
     (link) => link.entity_type === "project",
   )?.entity_id;
   const { name } = useEntityName("project", projectId);
-  // Nothing is drawn while the read is in flight, and nothing when the thread
-  // is filed under no project: "this will be filed under nothing" is a sentence
-  // that tells a reader less than silence does, and the unfiled case is what
-  // the attribution ladder already asks about.
-  if (!projectId) {
+  // This line makes a claim about where a send will land, so it is drawn only
+  // when both reads have actually answered. A failed or pending read looks
+  // exactly like "no project" from here, and silence is the honest rendering of
+  // both: "this will be filed under nothing" tells a reader less than nothing
+  // does, and naming a project the read never returned would be worse — the
+  // caption would assert a filing that is not the one the server will perform.
+  if (query.isPending || query.isError || !projectId) {
+    return null;
+  }
+  // The link is there but its name is not — pending, refused, or blank; the
+  // three are one case here. Same rule: say nothing rather than name the
+  // project "Unnamed project", which reads as a fact about the project instead
+  // of a gap in what this component managed to read.
+  if (!name) {
     return null;
   }
   // It SAYS, and does not offer to change: the control that moves a
@@ -334,9 +348,7 @@ function ReplyFiling({ activityId }: Readonly<{ activityId: string }>) {
   // action — and the shorter path to filing a single message away from its
   // conversation, which is the split this line exists to make visible.
   return (
-    <p className="t-caption">
-      {t("compose.filedUnder", { project: name ?? t("deal.projectUnnamed") })}
-    </p>
+    <p className="t-caption">{t("compose.filedUnder", { project: name })}</p>
   );
 }
 

--- a/frontend/src/screens/dealproject.test.tsx
+++ b/frontend/src/screens/dealproject.test.tsx
@@ -17,6 +17,7 @@ import { meFixture } from "../app/mefixture";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { jsonResponse } from "./company.fixtures";
+import { dealProjectFields } from "./dealproject";
 import { DealScreen, DealsScreen } from "./deals";
 import { project } from "./projects.fixtures";
 
@@ -412,5 +413,44 @@ describe("the deal page", () => {
     render(<DealScreen id="d1" />);
     await screen.findByRole("heading", { name: "Fleet retrofit" });
     expect(screen.queryByTestId("deal-start-delivery")).toBeNull();
+  });
+
+  // The bug Lars hit: many projects exist, and editing a deal offers only "New
+  // project…".
+  //
+  // The picker used to fetch EVERY project and filter on organization_id, which
+  // names a project's CUSTOMER. A deal on a company that is on the project as a
+  // PARTNER matched nothing, so the list came back empty on an installation
+  // full of projects.
+  //
+  // The edit form asks the server for its own company's projects now — the
+  // server matches ANY of a project's companies — and passes narrowedByServer,
+  // which is what stops the second filter from undoing the answer.
+  it("does not re-filter a list the server already narrowed to one company", () => {
+    const partnerProject = project({
+      id: "pr-1",
+      name: "Joint rollout",
+      // The CUSTOMER is a different company: this deal's company is on the
+      // project as a partner, which organization_id cannot say.
+      organization_id: "o-customer",
+    });
+    const t = (key: string) => key;
+
+    const narrowed = dealProjectFields(t, [partnerProject], undefined, true);
+    const asked = narrowed.find((field) => field.key === "project_id");
+    expect(
+      asked?.optionsFor?.({ organization_id: "o-partner" }).map((o) => o.label),
+    ).toContain("Joint rollout");
+
+    // And the create form, which has no company to ask about and narrows here,
+    // still keeps its own filter: it would otherwise offer every project in the
+    // installation under whichever company was picked.
+    const unnarrowed = dealProjectFields(t, [partnerProject]);
+    const client = unnarrowed.find((field) => field.key === "project_id");
+    expect(
+      client
+        ?.optionsFor?.({ organization_id: "o-partner" })
+        .map((o) => o.label),
+    ).not.toContain("Joint rollout");
   });
 });

--- a/frontend/src/screens/dealproject.test.tsx
+++ b/frontend/src/screens/dealproject.test.tsx
@@ -436,7 +436,13 @@ describe("the deal page", () => {
     });
     const t = (key: string) => key;
 
-    const narrowed = dealProjectFields(t, [partnerProject], undefined, true);
+    const narrowed = dealProjectFields(
+      t,
+      [partnerProject],
+      undefined,
+      true,
+      "o-partner",
+    );
     const asked = narrowed.find((field) => field.key === "project_id");
     expect(
       asked?.optionsFor?.({ organization_id: "o-partner" }).map((o) => o.label),
@@ -452,5 +458,38 @@ describe("the deal page", () => {
         ?.optionsFor?.({ organization_id: "o-partner" })
         .map((o) => o.label),
     ).not.toContain("Joint rollout");
+  });
+
+  it("offers nothing once the form names a company the list was not read for", () => {
+    const partnerProject = project({
+      id: "pr-1",
+      name: "Joint rollout",
+      organization_id: "o-customer",
+    });
+    const t = (key: string) => key;
+    // The list was read for o-partner; the reader has since changed the form's
+    // company to o-other. Nothing on a project row says whether o-other is on
+    // this project, so the only honest answer is none — offering the old
+    // company's projects is what lets a save carry a pairing the server
+    // refuses (deal_project_same_org, 422).
+    const fields = dealProjectFields(
+      t,
+      [partnerProject],
+      { id: "pr-1", label: "Joint rollout" },
+      true,
+      "o-partner",
+    );
+    const asked = fields.find((field) => field.key === "project_id");
+    const labels = asked
+      ?.optionsFor?.({ organization_id: "o-other" })
+      .map((o) => o.label);
+    expect(labels).not.toContain("Joint rollout");
+    // The current-project fallback is withdrawn too, so `submittedValues`
+    // blanks it rather than carrying it into the new company.
+    expect(labels).toEqual(["deal.projectNew"]);
+
+    // Same list, same company it was read for: still offered.
+    const same = asked?.optionsFor?.({ organization_id: "o-partner" });
+    expect(same?.map((o) => o.label)).toContain("Joint rollout");
   });
 });

--- a/frontend/src/screens/dealproject.tsx
+++ b/frontend/src/screens/dealproject.tsx
@@ -35,12 +35,29 @@ export const NEW_PROJECT = "__new_project__";
  * server refuses a project on another company (422). A closed project is not
  * offered: a deal born into a closed project would reopen nothing.
  */
-export function useOpenProjects(): Project[] {
+// The live projects of ONE company, asked of the server rather than filtered
+// here.
+//
+// A project is worked by several companies now, and `organization_id` names
+// only its CUSTOMER — so filtering a full page of projects on that field in the
+// browser hides every project this company is on as a partner or a
+// subcontractor. The list endpoint matches ANY of a project's companies, which
+// is the question the deal form is actually asking.
+//
+// It also stops paging past the answer: the old read took the first 200
+// projects and filtered them, so an installation with more than 200 offered an
+// empty picker to whichever company sorted last.
+export function useOpenProjects(organizationId?: string): Project[] {
   const projects = useQuery({
-    queryKey: ["projects", "open"],
+    queryKey: ["projects", "open", organizationId ?? "all"],
     queryFn: async () => {
       const { data, error } = await api.GET("/projects", {
-        params: { query: { limit: 200 } },
+        params: {
+          query: {
+            ...(organizationId ? { organization_id: organizationId } : {}),
+            limit: 200,
+          },
+        },
       });
       if (error) {
         throwProblem(error);
@@ -68,6 +85,14 @@ export function dealProjectFields(
   // form shows the value it has rather than a blank picker whose save would
   // clear it.
   current?: { id: string; label: string },
+  // Whether `projects` was already narrowed to one company by the SERVER. The
+  // edit form asks for its deal's company and gets the projects that company is
+  // on, whatever role it holds; the create form has no company until the reader
+  // picks one, so it asks for all of them and narrows here — on the anchor,
+  // which is the only company a list row names. That is a known narrower answer
+  // for the create form, and the honest fix is a per-company read once the form
+  // can report which company is chosen.
+  narrowedByServer = false,
 ): CreateField[] {
   return [
     {
@@ -79,9 +104,16 @@ export function dealProjectFields(
         if (!company) {
           return [];
         }
-        const options = projects
-          .filter((project) => project.organization_id === company)
-          .map((project) => ({ value: project.id, label: project.name }));
+        const reachable = narrowedByServer
+          ? projects
+          : projects.filter((project) => project.organization_id === company);
+        // The NAME alone. The key belongs where a reader needs to recognise it
+        // — a subject line, the project's own chip — and a picker of one
+        // company's projects is already unambiguous without it.
+        const options = reachable.map((project) => ({
+          value: project.id,
+          label: project.name,
+        }));
         return [
           ...(current && !options.some((option) => option.value === current.id)
             ? [{ value: current.id, label: current.label }]
@@ -164,11 +196,11 @@ export function DealProjectChip({ deal }: Readonly<{ deal: Deal }>) {
 export function StartDeliveryPrompt({ deal }: Readonly<{ deal: Deal }>) {
   const t = useT();
   const queryClient = useQueryClient();
-  const candidates = useOpenProjects().filter(
-    (project) =>
-      deal.organization_id != null &&
-      project.organization_id === deal.organization_id,
-  );
+  // The server answers with the projects this deal's company is on — as the
+  // customer, a partner or a subcontractor — so there is nothing left to filter
+  // here. Comparing organization_id would drop every project the company works
+  // as anything but the customer.
+  const candidates = useOpenProjects(deal.organization_id ?? undefined);
   const attach = useMutation({
     mutationFn: async (input: {
       dealId: string;

--- a/frontend/src/screens/dealproject.tsx
+++ b/frontend/src/screens/dealproject.tsx
@@ -48,6 +48,28 @@ export const NEW_PROJECT = "__new_project__";
 // projects and filtered them, so an installation with more than 200 offered an
 // empty picker to whichever company sorted last.
 export function useOpenProjects(organizationId?: string): Project[] {
+  return useProjectPage(organizationId, true);
+}
+
+/**
+ * The live projects of ONE company, asked of the server, and NOTHING when there
+ * is no company to ask about.
+ *
+ * The difference from `useOpenProjects` is which question is being asked. "What
+ * projects exist" has an answer without a company, and the create form pages
+ * them and narrows on the anchor itself. "What may THIS deal take" does not: a
+ * deal with no company shares a company with no project, so answering with the
+ * whole installation offers pairings the server refuses
+ * (deal_project_same_org, 422). A caller acting on one deal uses this.
+ */
+export function useProjectsOfCompany(organizationId?: string): Project[] {
+  return useProjectPage(organizationId, Boolean(organizationId));
+}
+
+function useProjectPage(
+  organizationId: string | undefined,
+  enabled: boolean,
+): Project[] {
   const projects = useQuery({
     queryKey: ["projects", "open", organizationId ?? "all"],
     queryFn: async () => {
@@ -64,6 +86,7 @@ export function useOpenProjects(organizationId?: string): Project[] {
       }
       return data.data;
     },
+    enabled,
     staleTime: 60_000,
   });
   return (projects.data ?? []).filter((project) => project.phase !== "closed");
@@ -93,6 +116,12 @@ export function dealProjectFields(
   // for the create form, and the honest fix is a per-company read once the form
   // can report which company is chosen.
   narrowedByServer = false,
+  // The company `projects` was read for, when the server narrowed it. The form
+  // can change its company while the list stands, and the list is keyed on the
+  // company the record HAD; comparing the two lets the picker go empty rather
+  // than offer the old company's projects under the new one, which the server
+  // refuses (deal_project_same_org, 422).
+  narrowedFor?: string,
 ): CreateField[] {
   return [
     {
@@ -104,9 +133,17 @@ export function dealProjectFields(
         if (!company) {
           return [];
         }
-        const reachable = narrowedByServer
-          ? projects
-          : projects.filter((project) => project.organization_id === company);
+        // A list the server narrowed is trustworthy only for the company it
+        // was narrowed FOR. Once the form names a different one, this page
+        // answers the wrong question and the honest answer is none: a list row
+        // names only a project's anchor company, so nothing here can tell
+        // which of the new company's projects belong.
+        const stale = narrowedByServer && narrowedFor !== company;
+        const reachable = stale
+          ? []
+          : narrowedByServer
+            ? projects
+            : projects.filter((project) => project.organization_id === company);
         // The NAME alone. The key belongs where a reader needs to recognise it
         // — a subject line, the project's own chip — and a picker of one
         // company's projects is already unambiguous without it.
@@ -115,7 +152,16 @@ export function dealProjectFields(
           label: project.name,
         }));
         return [
-          ...(current && !options.some((option) => option.value === current.id)
+          // The project the deal already names, kept on the list so the edit
+          // form shows the value it has. NOT when the form has moved to
+          // another company: that project belongs to the one it left, and
+          // keeping it offered is what lets a save carry the old pairing into
+          // the new company. Dropping it here is what withdraws it —
+          // `submittedValues` blanks a dependent value the options no longer
+          // offer.
+          ...(current &&
+          !stale &&
+          !options.some((option) => option.value === current.id)
             ? [{ value: current.id, label: current.label }]
             : []),
           ...options,
@@ -200,7 +246,7 @@ export function StartDeliveryPrompt({ deal }: Readonly<{ deal: Deal }>) {
   // customer, a partner or a subcontractor — so there is nothing left to filter
   // here. Comparing organization_id would drop every project the company works
   // as anything but the customer.
-  const candidates = useOpenProjects(deal.organization_id ?? undefined);
+  const candidates = useProjectsOfCompany(deal.organization_id ?? undefined);
   const attach = useMutation({
     mutationFn: async (input: {
       dealId: string;

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -113,6 +113,7 @@ import {
   resolveDealProject,
   StartDeliveryPrompt,
   useOpenProjects,
+  useProjectsOfCompany,
 } from "./dealproject";
 import { DealRoomAside } from "./dealroom";
 import { EditAction } from "./edit";
@@ -127,6 +128,7 @@ import {
 } from "./listquery";
 import { LogActivity } from "./logactivity";
 import { DealCoverageCard } from "./network";
+import type { Project } from "./projects.form";
 import { SaveViewAction, useSavedViewTabs } from "./savedviews";
 import { ShareAction } from "./share";
 import { groupChronology } from "./timelinegroups";
@@ -2683,6 +2685,30 @@ function ReopenAction({
 // archived deal is read-only (no edit/archive/advance path exists server-side
 // for a non-live row), so its verbs render REFUSED rather than missing: the
 // page's one sentence about the archive says why, and each of them points at
+// The edit form's project fields, or none when the reader may not see which
+// project this deal names. Named rather than inlined so `DealBadges` stays
+// under the complexity ceiling, and so the masked case reads as one decision.
+function editProjectFields(
+  t: (key: MessageKey) => string,
+  opts: Readonly<{
+    masked: readonly string[];
+    openProjects: readonly Project[];
+    currentProject?: { id: string; label: string };
+    company?: string;
+  }>,
+): CreateField[] {
+  if (opts.masked.includes("project_id")) {
+    return [];
+  }
+  return dealProjectFields(
+    t,
+    opts.openProjects,
+    opts.currentProject,
+    true,
+    opts.company,
+  );
+}
+
 // it (STATE-4a). A missing control says nothing about the deal, while a
 // refused one names the reason.
 function DealBadges({
@@ -2743,7 +2769,7 @@ function DealBadges({
   // as customer, partner or subcontractor. The server decides which; asking for
   // every project and filtering here on organization_id would show only the
   // ones it is the CUSTOMER of.
-  const openProjects = useOpenProjects(deal.organization_id ?? undefined);
+  const openProjects = useProjectsOfCompany(deal.organization_id ?? undefined);
   const projectById = useEntityName("project", deal.project_id);
   const currentProject = deal.project_id
     ? { id: deal.project_id, label: projectById.name ?? deal.project_id }
@@ -2770,9 +2796,12 @@ function DealBadges({
             // nobody has priced has none to put there.
             currency: deal.currency ?? "",
           }),
-          ...(masked.includes("project_id")
-            ? []
-            : dealProjectFields(t, openProjects, currentProject, true)),
+          ...editProjectFields(t, {
+            masked,
+            openProjects,
+            currentProject,
+            company: deal.organization_id ?? undefined,
+          }),
           ...cf.formFields,
         ]}
         record={{ ...dealEditRecord(deal), ...cf.recordSlice(deal) }}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1736,6 +1736,9 @@ export function DealsScreen({
 
   const partnerOptions = usePartnerOptions(orgsQuery.data?.data ?? []);
 
+  // The picker asks the server for ONE company's projects, so the form's chosen
+  // company is what it is keyed on: a project is worked by several companies,
+  // and only the server can say which of them this one is on.
   const openProjects = useOpenProjects();
 
   const createDeal = async (values: Record<string, string>) => {
@@ -2736,7 +2739,11 @@ function DealBadges({
   // One fact refuses every write below, so it is named once. Undefined while
   // the deal is live, which is what leaves the verbs pressable.
   const refusedByArchive = deal.archived_at ? archivedReasonId : undefined;
-  const openProjects = useOpenProjects();
+  // This deal's company, so the picker offers the projects that company is on —
+  // as customer, partner or subcontractor. The server decides which; asking for
+  // every project and filtering here on organization_id would show only the
+  // ones it is the CUSTOMER of.
+  const openProjects = useOpenProjects(deal.organization_id ?? undefined);
   const projectById = useEntityName("project", deal.project_id);
   const currentProject = deal.project_id
     ? { id: deal.project_id, label: projectById.name ?? deal.project_id }
@@ -2765,7 +2772,7 @@ function DealBadges({
           }),
           ...(masked.includes("project_id")
             ? []
-            : dealProjectFields(t, openProjects, currentProject)),
+            : dealProjectFields(t, openProjects, currentProject, true)),
           ...cf.formFields,
         ]}
         record={{ ...dealEditRecord(deal), ...cf.recordSlice(deal) }}


### PR DESCRIPTION
fix(deals): a deal can be filed under a project its company only partners on

The project picker on the deal form fetched every project and filtered them
in the browser on `organization_id`. That column names a project's CUSTOMER,
so a project worked by several companies carries only one of them there — and
a deal on a company that is a partner or a subcontractor matched nothing. The
picker offered "New project…" and nothing else on an installation full of
projects.

The edit form now asks the server for its own company's projects; the list
endpoint matches ANY of a project's companies, which is the question the form
is actually asking. `dealProjectFields` takes `narrowedByServer` so it does
not re-apply the filter the server already applied.

The create form has no company until the reader picks one, so it still fetches
all and narrows locally on the anchor. That is a known narrower answer, said
so in a comment beside it rather than left for the next reader to discover.

Also: a reply now says which project it will be filed under, rather than
offering a picker. A reply inherits its thread's project, and a picker there
would let one conversation split across two projects. The relink control stays
on the timeline row, where it moves the whole thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deal project selection and reply filing. The edit form and delivery prompt now ask the server for projects the deal’s company is on; the picker refuses stale options when the form’s company changes. Replies no longer offer a project picker and instead state the thread’s project to avoid splitting a conversation.

- Deal project selection
  - Edit form and prompts use `useProjectsOfCompany` to fetch live projects for the deal’s company (customer, partner, or subcontractor); `useOpenProjects` remains for the create form’s “what exists” read.
  - `dealProjectFields` adds `narrowedByServer` and `narrowedFor`. When the form’s company differs from the company the list was read for, the picker offers nothing and withdraws the current-project fallback; saves cannot carry a refused pairing.
  - Server-side reads avoid pagination/filter gaps and partner-only omissions; closed projects are still excluded. Tests cover server-narrowed lists, company changes, and local filtering on create.

- Reply composer
  - Shows “This reply will be filed under {project}…” for message replies, rendering only after both the activity and project name resolve; says nothing when no project is linked.
  - Relink invalidates the activity so the filing line updates; relink remains on the timeline row and moves the whole thread. i18n strings and tests added.

<sup>Written for commit a8372abbaab5d332e2ff458d3cfce2d46576b8e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reply composers now show the project a reply is filed under when applicable.
  - Added English, German, and Vietnamese translations for the project filing notice.

- **Bug Fixes**
  - Project pickers now display all relevant projects associated with a deal or company.
  - Improved project selection when switching companies, preventing stale or unavailable projects from remaining selected.

- **Tests**
  - Added coverage for reply project notices and project picker results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->