### PR TITLE
feat(deals): the Next-move card's fallback task is written by the model, grounded in the deal's own timeline

### DIFF
--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -180,9 +180,10 @@ tasks:
     ladder: [cheap_cloud, premium]
     execution_mode: interactive
     on_budget_exhausted: degrade
-    status: planned
+    status: shipped
+    sites: [next_move]
     company_context: none
-    doc: "Declared, not built (ADR-0074)."
+    doc: "next_move — the deal card's one next step, proposed as a concrete task when no rule already names the move: the model reads the deal's own timeline (subjects, directions, bounded excerpts the CALLER may read — the facts are assembled under the caller's row scope) and writes the task's subject and the why. The verb never moves: the answer is always create_task, the deterministic rules (booked meeting, unanswered inbound, existing open task) run first, and a missing lane, an over-budget call or a reply the grounding filter refuses degrades to the deterministic fallback task with generated_by saying so."
 
   brief_ranking:
     ladder: [premium, cheap_cloud]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20318,6 +20318,14 @@ components:
           type: array
           items: { $ref: '#/components/schemas/DealNextBestActionEvidence' }
         computed_at: { type: string, format: date-time }
+        generated_by:
+          allOf: [{ $ref: '#/components/schemas/WrittenBy' }]
+          description: |
+            Which writer produced the recommendation. `model` only on the `create_task`
+            fallback, where the deal_health lane proposes the concrete next step; every
+            rule-matched answer — and the fallback whenever the lane is absent, over
+            budget, or refused — is `deterministic`. Absent means `deterministic`, so a
+            client reading an older server fails honest.
       additionalProperties: false
 
     DealNextBestActionEvidence:

--- a/backend/cmd/api/modelwiring.go
+++ b/backend/cmd/api/modelwiring.go
@@ -131,6 +131,7 @@ func coldStartOptions(modelPath *compose.ModelPath, routingVersion string) []com
 		// The person-side draft rides the same lane for the same reason: one
 		// drafting task, a different input shape.
 		compose.WithPersonDraft(modelPath.DraftReply),
+		compose.WithNextMoveWriter(modelPath.DealHealth),
 	}
 }
 

--- a/backend/cmd/api/modelwiring_test.go
+++ b/backend/cmd/api/modelwiring_test.go
@@ -144,10 +144,11 @@ func TestColdStartOptionsRespectsResolvedPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveModelPath: %v", err)
 	}
-	if got := coldStartOptions(modelPath, ""); len(got) != 9 {
+	if got := coldStartOptions(modelPath, ""); len(got) != 10 {
 		t.Fatalf(
-			"coldStartOptions(bound path) = %d options, want 9 (cold-start, scrape, morning brief, "+
-				"account brief, company dossier, growth fit, reply draft, account draft, person draft)",
+			"coldStartOptions(bound path) = %d options, want 10 (cold-start, scrape, morning brief, "+
+				"account brief, company dossier, growth fit, reply draft, account draft, person draft, "+
+				"next move)",
 			len(got))
 	}
 }

--- a/backend/internal/compose/aicert/corpus/deal_health/next_move_empty_deal_01.yaml
+++ b/backend/internal/compose/aicert/corpus/deal_health/next_move_empty_deal_01.yaml
@@ -1,0 +1,29 @@
+name: next_move_empty_deal_opens_from_the_deals_own_fields
+task: deal_health
+site: next_move
+source: hand_authored
+sanitized_by: hand_authored/claude-fable-5
+fixture:
+  deal:
+    name: "Kessler GmbH — WMS Pilot"
+    status: open
+    stage: Qualified
+    amount: "1200000 EUR (minor units)"
+    expected_close: "2026-10-15"
+  timeline: []
+expect:
+  outcome: accepted
+  # No timeline, so no citation is owed: the deal's own fields are the
+  # grounding, and the filter accepts an uncited proposal here.
+  answer: []
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40
+  rubric: >
+    Score whether the proposed task is a real opening move for THIS deal —
+    anchored in what the fixture states (a qualified WMS pilot at Kessler
+    GmbH, closing mid-October), such as arranging the first conversation
+    about the pilot's scope. A generic checklist item that fits every deal
+    scores low. Any invented contact name, meeting or prior conversation
+    fails the scenario: the timeline is empty and the summary says so.

--- a/backend/internal/compose/aicert/corpus/deal_health/next_move_empty_deal_01.yaml
+++ b/backend/internal/compose/aicert/corpus/deal_health/next_move_empty_deal_01.yaml
@@ -7,7 +7,6 @@ fixture:
   deal:
     name: "Kessler GmbH — WMS Pilot"
     status: open
-    stage: Qualified
     amount: "1200000 EUR (minor units)"
     expected_close: "2026-10-15"
   timeline: []
@@ -22,7 +21,7 @@ expect:
     floor: 40
   rubric: >
     Score whether the proposed task is a real opening move for THIS deal —
-    anchored in what the fixture states (a qualified WMS pilot at Kessler
+    anchored in what the fixture states (a WMS pilot at Kessler
     GmbH, closing mid-October), such as arranging the first conversation
     about the pilot's scope. A generic checklist item that fits every deal
     scores low. Any invented contact name, meeting or prior conversation

--- a/backend/internal/compose/aicert/corpus/deal_health/next_move_offer_left_hanging_01.yaml
+++ b/backend/internal/compose/aicert/corpus/deal_health/next_move_offer_left_hanging_01.yaml
@@ -1,0 +1,43 @@
+name: next_move_offer_left_hanging
+task: deal_health
+site: next_move
+source: hand_authored
+sanitized_by: hand_authored/claude-fable-5
+fixture:
+  deal:
+    name: "Nordwind Logistik — Einführung"
+    status: open
+    stage: Negotiation
+    amount: "8400000 EUR (minor units)"
+    expected_close: "2026-09-30"
+  timeline:
+    # The story the timeline tells: pricing was asked for on a call, promised,
+    # and never sent. The correct move is sending it — not a check-in, not a
+    # generic "follow up".
+    - label: pricing_call
+      kind: call
+      direction: outbound
+      subject: "Call — depot rollout scope and pricing"
+      at: "2026-08-11"
+      excerpt: "They asked for a revised offer covering the two extra depots. We said it would go out this week."
+    - label: earlier_intro
+      kind: email
+      direction: outbound
+      subject: "Intro and first scope sketch"
+      at: "2026-07-28"
+      excerpt: "First outline of the rollout, five depots, pilot in Hamburg."
+expect:
+  outcome: accepted
+  # The proposal must rest on the call where the offer was promised.
+  answer: [pricing_call]
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40
+  rubric: >
+    Score whether the proposed task is the concrete move the timeline points
+    at: sending the revised offer that was promised on the call — naming the
+    offer or the depots, not a generic "follow up with the customer". The
+    reason must say why now (it was promised, days have passed). A task that
+    invents a meeting, a discount or a person the summary never mentions
+    fails the scenario.

--- a/backend/internal/compose/aicert/corpus/deal_health/next_move_offer_left_hanging_01.yaml
+++ b/backend/internal/compose/aicert/corpus/deal_health/next_move_offer_left_hanging_01.yaml
@@ -7,7 +7,6 @@ fixture:
   deal:
     name: "Nordwind Logistik — Einführung"
     status: open
-    stage: Negotiation
     amount: "8400000 EUR (minor units)"
     expected_close: "2026-09-30"
   timeline:

--- a/backend/internal/compose/aitaskregistry.go
+++ b/backend/internal/compose/aitaskregistry.go
@@ -53,6 +53,7 @@ func NewTaskCensus() (*aitasks.Registry, error) {
 	oneShot(ai.TaskSiteExtract, "profile", siteProfileCases{})
 	oneShot(ai.TaskSiteFactExtract, "page_facts", sitePageFactsCases{})
 	oneShot(ai.TaskSiteTriage, "triage", siteTriageCases{})
+	oneShot(ai.TaskDealHealth, "next_move", nextMoveCases{})
 	oneShot(ai.TaskSummarize, "org_brief", orgBriefCases{})
 	oneShot(ai.TaskSummarize, "org_ask", orgAskCases{})
 	oneShot(ai.TaskSummarize, "org_dossier", orgDossierCases{})

--- a/backend/internal/compose/brain.go
+++ b/backend/internal/compose/brain.go
@@ -65,6 +65,10 @@ type ModelPath struct {
 	// degrade to a deterministic floor, so a role without this lane still
 	// answers — just not in written prose.
 	Summarize completer
+	// DealHealth serves the deal card's next_move site: one concrete task
+	// proposed from the deal's own timeline. Its floor is the generic "agree
+	// the next step" task, so a role without this lane still answers the card.
+	DealHealth completer
 	// GrowthFit judges how well one company fits what we sell. It is the only
 	// company-view lane whose absence changes the ANSWER rather than the prose:
 	// its floor abstains, because grading is not a restatement of recorded
@@ -228,6 +232,7 @@ func modelPathForRouter(router *ai.Router, companyContext *companyContextProvide
 		RateExtract:                brain(ai.TaskRateExtract),
 		BriefRanking:               brain(ai.TaskBriefRanking),
 		Summarize:                  brain(ai.TaskSummarize),
+		DealHealth:                 brain(ai.TaskDealHealth),
 		GrowthFit:                  brain(ai.TaskGrowthFit),
 		DraftReply:                 brain(ai.TaskDraftReply),
 		OfferDraft:                 brain(ai.TaskOfferDraft),

--- a/backend/internal/compose/certcase_nextmove.go
+++ b/backend/internal/compose/certcase_nextmove.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The certification case for deal_health/next_move — the deal card's one
+// concrete task.
+//
+// It certifies the shipped path: the request is built by nextaction's own
+// writer and the reply is read by nextaction's own filter, because that
+// filter is what stands between a rep and a task grounded in nothing. A case
+// that rebuilt either would measure a copy, and a copy stays green through
+// the change that breaks the original.
+//
+// What the expectation MEANS here: the timeline entries a correct proposal
+// has to rest on. Not the wording — the subject is prose, and pinning it
+// would fail a good task for choosing different words. What production cannot
+// guarantee, and this therefore measures, is whether the model proposed the
+// move the timeline points at and cited it, rather than a generic checklist
+// item nobody can check.
+//
+// The fixture names its records by LABEL. Prepare mints the ids, so an id in
+// the reply is an id the model was handed rather than one the corpus author
+// could have written into the expected answer.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/compose/aitasks"
+	"github.com/gradionhq/margince/backend/internal/compose/nextaction"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// nextMoveFixture is one deal and its timeline as the lane reads them.
+type nextMoveFixture struct {
+	Deal     nextMoveDealFixture  `json:"deal"`
+	Timeline []nextMoveActFixture `json:"timeline"`
+}
+
+type nextMoveDealFixture struct {
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	Stage         string `json:"stage"`
+	Amount        string `json:"amount"`
+	ExpectedClose string `json:"expected_close"`
+}
+
+type nextMoveActFixture struct {
+	Label     string `json:"label"`
+	Kind      string `json:"kind"`
+	Direction string `json:"direction"`
+	Subject   string `json:"subject"`
+	At        string `json:"at"`
+	Excerpt   string `json:"excerpt"`
+}
+
+type nextMoveCases struct{}
+
+func (nextMoveCases) Site() aitasks.Site {
+	return aitasks.Site{Task: ai.TaskDealHealth, Variant: "next_move", Kind: ai.SiteKindOneShot}
+}
+
+// Prepare turns one deal, its timeline and the entries a correct proposal
+// must cite into a runnable case, minting an id per labelled record.
+//
+//nolint:ireturn // PreparedCase IS the seam: one implementation per site behind the one interface the cert lane runs.
+func (nextMoveCases) Prepare(fixture, expected json.RawMessage) (aitasks.PreparedCase, error) {
+	var f nextMoveFixture
+	if err := json.Unmarshal(fixture, &f); err != nil {
+		return nil, fmt.Errorf("deal_health/next_move: the fixture is not the shape this site takes: %w", err)
+	}
+	var want []string
+	if err := json.Unmarshal(expected, &want); err != nil {
+		return nil, fmt.Errorf(
+			"deal_health/next_move: the expected answer is not a list of timeline labels the proposal must cite: %w", err)
+	}
+	in, label, err := nextMoveInput(f)
+	if err != nil {
+		return nil, fmt.Errorf("deal_health/next_move: %w", err)
+	}
+	// An empty-timeline scenario expects no citation — the deal's own fields
+	// are the grounding there, and the filter owes none — so the ungroundable
+	// refusal applies only when the fixture carries a timeline.
+	if len(f.Timeline) > 0 {
+		if err := refuseUngroundableBrief(want, label); err != nil {
+			return nil, fmt.Errorf("deal_health/next_move: %w", err)
+		}
+	}
+	return &nextMoveCase{in: in, label: label, expected: want}, nil
+}
+
+// nextMoveInput builds the production input, minting one id per labelled
+// entry so no id in the reply can have come from the corpus.
+func nextMoveInput(f nextMoveFixture) (nextaction.Input, map[string]string, error) {
+	in := nextaction.Input{Deal: nextaction.DealIn{
+		ID:   ids.NewV7().String(),
+		Name: f.Deal.Name, Status: f.Deal.Status, Stage: f.Deal.Stage,
+		Amount: f.Deal.Amount, ExpectedClose: f.Deal.ExpectedClose,
+	}}
+	label := map[string]string{}
+	for _, act := range f.Timeline {
+		if err := refuseUnnameable(act.Label, "timeline entry", label); err != nil {
+			return in, nil, err
+		}
+		id := ids.NewV7().String()
+		label[act.Label] = id
+		in.Timeline = append(in.Timeline, nextaction.ActIn{
+			ID: id, Kind: act.Kind, Direction: act.Direction,
+			Subject: act.Subject, At: act.At, Excerpt: act.Excerpt,
+		})
+	}
+	return in, label, nil
+}
+
+// nextMoveCase certifies one proposed task for one deal.
+type nextMoveCase struct {
+	in       nextaction.Input
+	label    map[string]string
+	expected []string
+}
+
+// Run issues the one request this site sends, through the production
+// writer's own request builder.
+func (c *nextMoveCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
+	req := nextaction.NextMoveRequest(c.in)
+	trace := aitasks.Trace{Requests: []model.Request{req}}
+	resp, err := completer.Complete(ctx, req)
+	if err != nil {
+		return trace, fmt.Errorf("deal_health/next_move: %w", err)
+	}
+	trace.Output = resp.Text
+	return trace, nil
+}
+
+// Evaluate runs the production filter and asks whether the surviving
+// proposal cites the timeline entries the scenario says the move rests on.
+func (c *nextMoveCase) Evaluate(trace aitasks.Trace) aitasks.Outcome {
+	move, err := nextaction.ParseNextMove(trace.Output, c.in)
+	if err != nil {
+		// The filter refuses for exactly the reasons production would serve
+		// the deterministic fallback: unparseable, out of bounds, an id in
+		// reader text, or a citation pointing outside the timeline.
+		return aitasks.Outcome{Result: aitasks.OutcomeInvalid, Detail: err.Error()}
+	}
+	cited := map[string]bool{}
+	for _, id := range move.Evidence {
+		cited[id] = true
+	}
+	var missing []string
+	for _, name := range c.expected {
+		if !cited[c.label[name]] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return aitasks.Outcome{
+			Result: aitasks.OutcomeWrongAnswer,
+			Detail: "never cited: " + strings.Join(missing, ", "),
+		}
+	}
+	return aitasks.Outcome{Result: aitasks.OutcomeAccepted}
+}

--- a/backend/internal/compose/certcase_nextmove.go
+++ b/backend/internal/compose/certcase_nextmove.go
@@ -45,7 +45,6 @@ type nextMoveFixture struct {
 type nextMoveDealFixture struct {
 	Name          string `json:"name"`
 	Status        string `json:"status"`
-	Stage         string `json:"stage"`
 	Amount        string `json:"amount"`
 	ExpectedClose string `json:"expected_close"`
 }
@@ -99,7 +98,7 @@ func (nextMoveCases) Prepare(fixture, expected json.RawMessage) (aitasks.Prepare
 func nextMoveInput(f nextMoveFixture) (nextaction.Input, map[string]string, error) {
 	in := nextaction.Input{Deal: nextaction.DealIn{
 		ID:   ids.NewV7().String(),
-		Name: f.Deal.Name, Status: f.Deal.Status, Stage: f.Deal.Stage,
+		Name: f.Deal.Name, Status: f.Deal.Status,
 		Amount: f.Deal.Amount, ExpectedClose: f.Deal.ExpectedClose,
 	}}
 	label := map[string]string{}

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -114,9 +114,8 @@ func (s *Server) wirePerson360(pool *pgxpool.Pool) {
 	// The deal's next best action reads the deal and its timeline through
 	// their own gated stores and performs nothing; the click goes through the
 	// verb the answer names.
-	s.nextActionHandlers = nextaction.NewHandlers(
-		nextaction.NewService(s.dealsStore, activities.NewStore(InstallationDB(pool)), time.Now),
-	)
+	s.nextActionSvc = nextaction.NewService(s.dealsStore, activities.NewStore(InstallationDB(pool)), time.Now)
+	s.nextActionHandlers = nextaction.NewHandlers(s.nextActionSvc)
 	// The deal brief reads the same deal, its health, timeline and tasks,
 	// plus its Deal Room, all through their own gates, and writes nothing.
 	s.dealBriefHandlers = dealbrief.NewHandlers(

--- a/backend/internal/compose/nextaction/model.go
+++ b/backend/internal/compose/nextaction/model.go
@@ -116,7 +116,7 @@ func dealIn(d crmcontracts.Deal) DealIn {
 		out.Amount = fmt.Sprintf("%d %s (minor units)", *d.AmountMinor, *d.Currency)
 	}
 	if d.ExpectedCloseDate != nil {
-		out.ExpectedClose = d.ExpectedCloseDate.Time.Format("2006-01-02")
+		out.ExpectedClose = d.ExpectedCloseDate.Format("2006-01-02")
 	}
 	return out
 }

--- a/backend/internal/compose/nextaction/model.go
+++ b/backend/internal/compose/nextaction/model.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package nextaction
+
+// The model lane: the fallback task, made concrete.
+//
+// The deterministic rules stay the authority on WHICH verb the card offers. A
+// booked meeting, an unanswered inbound mail and an existing open task each
+// answer without a model, and this lane never runs for them. It runs only on
+// the fallback — the arm whose task the rules can only title "Agree the next
+// step" — and its whole job is to replace that shrug with a task worth
+// creating: a subject naming one concrete move, and a reason saying why that
+// move, grounded in the deal's own timeline and in nothing else.
+//
+// No lane wired, a lane over budget, or a reply the filter refuses, and the
+// reader gets the deterministic fallback exactly as before. `generated_by`
+// says which of the two they are reading.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// Completer is the model seam: the deal_health lane, or nil.
+type Completer interface {
+	Complete(ctx context.Context, req model.Request) (model.Response, error)
+}
+
+// nextMoveSystem is this site's prompt. The reply is one task, not advice: the
+// subject is what lands on the rep's list when they click, so it has to be an
+// imperative a colleague could act on without opening the card again.
+const nextMoveSystem = `You propose the single next step on one sales deal, from a JSON summary of the deal and its timeline in a CRM.
+Return ONLY a JSON object: {"subject":"...","reason":"...","evidence":["<activity id>", ...]}.
+"subject" is the task: one imperative sentence naming a concrete move — who to contact, what to send, what to clarify — at most 90 characters, no trailing period.
+"reason" is why this move and why now: at most two short sentences drawn from the summary.
+"evidence" lists the ids of the timeline entries the proposal rests on, from the summary's "id" fields. Ids belong in "evidence" only — an id must never appear in "subject" or "reason".
+Ground every word in the summary. Never invent a person, a company, a date, a number or an event. If the summary does not say it, do not write it.
+Prefer the move the timeline itself points at: an offer discussed but never sent, a question left hanging, a person who went quiet, a stage the deal has outsat.
+If the timeline is empty, propose the honest opening move for THIS deal from its own fields (its name, value, stage, close date) — not a generic checklist item.
+Voice: a calm, capable colleague. Lead with the move. No greetings, no praise, no exclamation marks, no "I recommend".`
+
+// nextMoveSystemFor names THIS call's data boundary; see promptfence.Fence.Rule.
+func nextMoveSystemFor(fence promptfence.Fence) string {
+	return nextMoveSystem + "\n" + fence.Rule("deal timeline")
+}
+
+// The reply's bounds. A subject past the cap is a paragraph pretending to be a
+// task; a reason past it is a brief, and the card already links one.
+const (
+	maxSubjectLen = 120
+	maxReasonLen  = 320
+	// maxExcerptLen bounds what one timeline row contributes to the prompt, so
+	// a pasted contract in a mail body does not become the whole context.
+	maxExcerptLen = 400
+	// maxTimelineRows bounds the summary. The newest rows carry the state of
+	// play; a deal whose signal sits 30 rows deep is not a fallback-arm deal.
+	maxTimelineRows = 12
+)
+
+// Input is the prompt's projection of the facts: the deal's own fields and
+// the timeline rows the CALLER may read. It is assembled from facts gathered
+// under the caller's row scope, so nothing reaches the model that the reader
+// could not open themselves; a row whose content is withheld contributes its
+// existence and date but no words.
+type Input struct {
+	Deal     DealIn  `json:"deal"`
+	Timeline []ActIn `json:"timeline"`
+}
+
+// DealIn is the deal as the prompt sees it.
+type DealIn struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	Stage         string `json:"stage,omitempty"`
+	Amount        string `json:"amount,omitempty"`
+	ExpectedClose string `json:"expected_close,omitempty"`
+}
+
+// ActIn is one timeline row as the prompt sees it: dated, not aged, so the
+// same facts build the same request and the router's result cache can serve a
+// repeat view instead of paying for it again.
+type ActIn struct {
+	ID        string `json:"id"`
+	Kind      string `json:"kind"`
+	Direction string `json:"direction,omitempty"`
+	Subject   string `json:"subject,omitempty"`
+	At        string `json:"at"`
+	Excerpt   string `json:"excerpt,omitempty"`
+}
+
+// NextMoveInput projects the gathered facts into the prompt's shape.
+func NextMoveInput(f facts) Input {
+	in := Input{Deal: dealIn(f.deal)}
+	for _, a := range f.timeline {
+		if len(in.Timeline) == maxTimelineRows {
+			break
+		}
+		in.Timeline = append(in.Timeline, actIn(a))
+	}
+	return in
+}
+
+func dealIn(d crmcontracts.Deal) DealIn {
+	out := DealIn{ID: d.Id.String(), Name: d.Name, Status: string(d.Status)}
+	if d.AmountMinor != nil && d.Currency != nil && *d.Currency != "" {
+		out.Amount = fmt.Sprintf("%d %s (minor units)", *d.AmountMinor, *d.Currency)
+	}
+	if d.ExpectedCloseDate != nil {
+		out.ExpectedClose = d.ExpectedCloseDate.Time.Format("2006-01-02")
+	}
+	return out
+}
+
+func actIn(a crmcontracts.Activity) ActIn {
+	out := ActIn{ID: a.Id.String(), Kind: string(a.Kind), At: a.OccurredAt.Format("2006-01-02")}
+	if a.Direction != nil {
+		out.Direction = string(*a.Direction)
+	}
+	// A withheld row keeps its place in the story — contact happened on this
+	// date — and gives up its words: the reader may not open them, so the
+	// model may not read them.
+	if withheld(a) {
+		return out
+	}
+	if a.Subject != nil {
+		out.Subject = *a.Subject
+	}
+	if a.Body != nil {
+		out.Excerpt = excerpt(*a.Body)
+	}
+	return out
+}
+
+// excerpt bounds one body's contribution, cutting on a rune so a multi-byte
+// character is never split into an invalid tail.
+func excerpt(body string) string {
+	trimmed := strings.TrimSpace(body)
+	runes := []rune(trimmed)
+	if len(runes) <= maxExcerptLen {
+		return trimmed
+	}
+	return string(runes[:maxExcerptLen]) + "…"
+}
+
+// writeNextMove asks the lane for the concrete task and folds it over the
+// deterministic fallback. The verb, the links and the source stay the floor's:
+// the model writes WHAT the task says, never what clicking it does.
+func writeNextMove(ctx context.Context, lane Completer, f facts, floor crmcontracts.DealNextBestAction) (crmcontracts.DealNextBestAction, error) {
+	in := NextMoveInput(f)
+	resp, err := lane.Complete(ctx, NextMoveRequest(in))
+	if err != nil {
+		return crmcontracts.DealNextBestAction{}, err
+	}
+	move, err := ParseNextMove(resp.Text, in)
+	if err != nil {
+		return crmcontracts.DealNextBestAction{}, err
+	}
+	out := floor
+	args := map[string]any{}
+	for k, v := range *floor.Arguments {
+		args[k] = v
+	}
+	args["subject"] = move.Subject
+	out.Arguments = &args
+	out.Reason = move.Reason
+	out.Evidence = append([]crmcontracts.DealNextBestActionEvidence{}, floor.Evidence...)
+	for _, cited := range move.Evidence {
+		if row, ok := timelineRow(f, cited); ok {
+			out.Evidence = append(out.Evidence, evidenceOf(row, "Grounds: "+subjectOf(row)))
+		}
+	}
+	return out, nil
+}
+
+func timelineRow(f facts, id string) (crmcontracts.Activity, bool) {
+	for _, a := range f.timeline {
+		if a.Id.String() == id {
+			return a, true
+		}
+	}
+	return crmcontracts.Activity{}, false
+}
+
+// NextMoveRequest builds the one request this site sends. Exported because the
+// certification case must issue the SAME request production does — a case that
+// rebuilt it would measure a copy, and a copy stays green through the change
+// that breaks the original.
+//
+// The summary carries mail subjects and body excerpts — text written by people
+// outside this workspace. It is fenced with a nonce the writer has never seen,
+// so no subject line can close the span and be read as instruction.
+func NextMoveRequest(in Input) model.Request {
+	fence := promptfence.New()
+	return model.Request{
+		System:         nextMoveSystemFor(fence),
+		Messages:       []model.Message{{Role: "user", Content: fence.Wrap(encodeInput(in))}},
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
+		SecretStripper: ai.NewSecretStripper(),
+	}
+}
+
+// encodeInput renders the assembled facts as the JSON the prompt reads. Every
+// field is a plain value this package built, so a marshal failure is a
+// programming error; it is still surfaced as text rather than dropped, so a
+// malformed request fails the model call loudly.
+func encodeInput(in Input) string {
+	encoded, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Sprintf("{%q:%q}", "encoding_error", err.Error())
+	}
+	return string(encoded)
+}
+
+// NextMove is what the lane proposes once the filter has kept it.
+type NextMove struct {
+	Subject  string
+	Reason   string
+	Evidence []string
+}
+
+// ParseNextMove reads the reply, keeping it only when it is grounded and
+// within bounds. Exported for the same reason as NextMoveRequest: the
+// certification case must run the filter production runs.
+func ParseNextMove(reply string, in Input) (NextMove, error) {
+	var parsed struct {
+		Subject  string   `json:"subject"`
+		Reason   string   `json:"reason"`
+		Evidence []string `json:"evidence"`
+	}
+	if err := json.Unmarshal([]byte(reply), &parsed); err != nil {
+		return NextMove{}, fmt.Errorf("parse next move: %w", err)
+	}
+	subject := strings.TrimSpace(parsed.Subject)
+	reason := strings.TrimSpace(parsed.Reason)
+	if subject == "" || reason == "" {
+		return NextMove{}, errors.New("next move reply carries no task")
+	}
+	if len([]rune(subject)) > maxSubjectLen || len([]rune(reason)) > maxReasonLen {
+		return NextMove{}, errors.New("next move reply exceeds the card's bounds")
+	}
+	known := knownIDs(in)
+	// An id in reader-visible text is either a leak or filler; either way the
+	// reply is not the one the prompt asked for.
+	for id := range known {
+		if strings.Contains(subject, id) || strings.Contains(reason, id) {
+			return NextMove{}, errors.New("next move reply spells a record id in reader text")
+		}
+	}
+	move := NextMove{Subject: subject, Reason: reason}
+	// A citation pointing outside the input is invented; the ones that remain
+	// still say where the proposal came from. When the timeline was empty the
+	// deal's own fields are the grounding, and no citation is owed.
+	for _, cited := range parsed.Evidence {
+		if known[cited] && cited != in.Deal.ID {
+			move.Evidence = append(move.Evidence, cited)
+		}
+	}
+	if len(in.Timeline) > 0 && len(move.Evidence) == 0 {
+		return NextMove{}, errors.New("next move reply cites nothing on the timeline it was written from")
+	}
+	return move, nil
+}
+
+// knownIDs is every id this input carried — the set a citation must come from
+// and reader text must be free of.
+func knownIDs(in Input) map[string]bool {
+	known := map[string]bool{in.Deal.ID: true}
+	for _, a := range in.Timeline {
+		known[a.ID] = true
+	}
+	return known
+}

--- a/backend/internal/compose/nextaction/model.go
+++ b/backend/internal/compose/nextaction/model.go
@@ -76,12 +76,14 @@ type Input struct {
 	Timeline []ActIn `json:"timeline"`
 }
 
-// DealIn is the deal as the prompt sees it.
+// DealIn is the deal as the prompt sees it. No stage field on purpose: the
+// facts carry only the stage's id, and a certification fixture supplying a
+// stage NAME production never sends would certify a better-informed model
+// than the one readers get.
 type DealIn struct {
 	ID            string `json:"id"`
 	Name          string `json:"name"`
 	Status        string `json:"status"`
-	Stage         string `json:"stage,omitempty"`
 	Amount        string `json:"amount,omitempty"`
 	ExpectedClose string `json:"expected_close,omitempty"`
 }

--- a/backend/internal/compose/nextaction/model_test.go
+++ b/backend/internal/compose/nextaction/model_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package nextaction
+
+// The model lane, driven through the same answer path production runs: a
+// grounded proposal replaces the fallback task, everything else — an erroring
+// lane, an ungrounded citation, an id in reader text — serves the
+// deterministic fallback unchanged, and generated_by says which happened.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// laneReturning is the model seam scripted: one reply, or one error, and a
+// record of what was sent so a test can hold the request's own properties.
+type laneReturning struct {
+	reply string
+	err   error
+	sent  []model.Request
+}
+
+func (l *laneReturning) Complete(_ context.Context, req model.Request) (model.Response, error) {
+	l.sent = append(l.sent, req)
+	if l.err != nil {
+		return model.Response{}, l.err
+	}
+	return model.Response{Text: l.reply}, nil
+}
+
+func fallbackFacts() facts {
+	past := outbound(now.Add(-9 * 24 * time.Hour))
+	return facts{
+		deal:     crmcontracts.Deal{Name: "Kessler GmbH — WMS Pilot", Status: crmcontracts.DealStatusOpen},
+		timeline: []crmcontracts.Activity{past},
+		now:      now,
+	}
+}
+
+func serviceWith(lane Completer) *Service {
+	s := NewService(nil, nil, func() time.Time { return now })
+	if lane != nil {
+		s = s.WithLane(lane)
+	}
+	return s
+}
+
+func TestAGroundedProposalReplacesTheFallbackTask(t *testing.T) {
+	f := fallbackFacts()
+	cited := f.timeline[0].Id.String()
+	lane := &laneReturning{reply: fmt.Sprintf(
+		`{"subject":"Send Kessler the revised pilot offer","reason":"They asked for it on the last call and nothing went out.","evidence":[%q]}`, cited)}
+
+	out := serviceWith(lane).answer(context.Background(), f)
+
+	if out.Action != ActionCreateTask {
+		t.Fatalf("action = %q; the lane may never move the verb", out.Action)
+	}
+	if got := (*out.Arguments)["subject"]; got != "Send Kessler the revised pilot offer" {
+		t.Errorf("task subject = %v, want the lane's proposal", got)
+	}
+	if !strings.Contains(out.Reason, "nothing went out") {
+		t.Errorf("reason = %q, want the lane's why", out.Reason)
+	}
+	if out.GeneratedBy == nil || *out.GeneratedBy != crmcontracts.Model {
+		t.Errorf("generated_by = %v, want model", out.GeneratedBy)
+	}
+	// The floor's links and source survive: the model writes what the task
+	// SAYS, never what clicking it does.
+	if _, ok := (*out.Arguments)["links"]; !ok {
+		t.Error("the proposal dropped the task's deal link")
+	}
+	if len(lane.sent) != 1 {
+		t.Fatalf("lane calls = %d, want exactly 1", len(lane.sent))
+	}
+	if !strings.Contains(lane.sent[0].Messages[0].Content, "untrusted-") {
+		t.Error("the timeline reached the model outside a nonce fence")
+	}
+}
+
+func TestARefusedOrFailedLaneServesTheDeterministicFallback(t *testing.T) {
+	f := fallbackFacts()
+	strangerID := "01a00000-0000-7000-8000-000000000000"
+	for name, lane := range map[string]*laneReturning{
+		"lane error":         {err: errors.New("over budget")},
+		"unparseable":        {reply: "Sure! Here is my suggestion:"},
+		"empty task":         {reply: `{"subject":"","reason":""}`},
+		"uncited proposal":   {reply: `{"subject":"Call them","reason":"Because.","evidence":[]}`},
+		"invented citation":  {reply: fmt.Sprintf(`{"subject":"Call them","reason":"Because.","evidence":[%q]}`, strangerID)},
+		"id in reader text":  {reply: fmt.Sprintf(`{"subject":"Call them about %s","reason":"Because.","evidence":[%q]}`, f.timeline[0].Id.String(), f.timeline[0].Id.String())},
+		"past the size caps": {reply: fmt.Sprintf(`{"subject":%q,"reason":"Because.","evidence":[%q]}`, strings.Repeat("x", 200), f.timeline[0].Id.String())},
+	} {
+		out := serviceWith(lane).answer(context.Background(), f)
+		floor := decide(f)
+		if out.Reason != floor.Reason {
+			t.Errorf("%s: reason = %q, want the deterministic fallback %q", name, out.Reason, floor.Reason)
+		}
+		if out.GeneratedBy == nil || *out.GeneratedBy != crmcontracts.Deterministic {
+			t.Errorf("%s: generated_by = %v, want deterministic", name, out.GeneratedBy)
+		}
+	}
+}
+
+func TestARuleMatchedAnswerNeverConsultsTheLane(t *testing.T) {
+	lane := &laneReturning{reply: `{"subject":"x","reason":"y"}`}
+	f := fallbackFacts()
+	f.timeline = append([]crmcontracts.Activity{booked(now.Add(24 * time.Hour))}, f.timeline...)
+
+	out := serviceWith(lane).answer(context.Background(), f)
+
+	if out.Action != ActionOpenMeetingBrief {
+		t.Fatalf("action = %q, want the booked-meeting rule to win", out.Action)
+	}
+	if len(lane.sent) != 0 {
+		t.Errorf("the lane was consulted %d times on a rule-matched answer", len(lane.sent))
+	}
+	if out.GeneratedBy == nil || *out.GeneratedBy != crmcontracts.Deterministic {
+		t.Errorf("generated_by = %v, want deterministic on a rule-matched answer", out.GeneratedBy)
+	}
+}
+
+func TestNoLaneMeansTheDeterministicAnswerStamped(t *testing.T) {
+	f := fallbackFacts()
+	out := serviceWith(nil).answer(context.Background(), f)
+	if out.GeneratedBy == nil || *out.GeneratedBy != crmcontracts.Deterministic {
+		t.Errorf("generated_by = %v, want deterministic with no lane wired", out.GeneratedBy)
+	}
+}
+
+func TestAnEmptyTimelineProposalNeedsNoCitation(t *testing.T) {
+	f := fallbackFacts()
+	f.timeline = nil
+	lane := &laneReturning{reply: `{"subject":"Book the first scope conversation for the WMS pilot","reason":"The deal is qualified and nothing has happened yet.","evidence":[]}`}
+
+	out := serviceWith(lane).answer(context.Background(), f)
+
+	if out.GeneratedBy == nil || *out.GeneratedBy != crmcontracts.Model {
+		t.Fatalf("generated_by = %v, want model: an empty timeline owes no citation", out.GeneratedBy)
+	}
+	if got := (*out.Arguments)["subject"]; got != "Book the first scope conversation for the WMS pilot" {
+		t.Errorf("task subject = %v, want the lane's proposal", got)
+	}
+}
+
+func TestAWithheldRowContributesItsDateAndNoWords(t *testing.T) {
+	f := fallbackFacts()
+	body := "the content this reader may not open"
+	subject := "withheld subject"
+	held := crmcontracts.ActivityContentStateWithheld
+	f.timeline[0].Body = &body
+	f.timeline[0].Subject = &subject
+	f.timeline[0].ContentState = &held
+
+	in := NextMoveInput(f)
+
+	if len(in.Timeline) != 1 {
+		t.Fatalf("timeline rows = %d, want the withheld row to keep its place", len(in.Timeline))
+	}
+	if in.Timeline[0].Subject != "" || in.Timeline[0].Excerpt != "" {
+		t.Errorf("a withheld row's words reached the prompt: %+v", in.Timeline[0])
+	}
+}

--- a/backend/internal/compose/nextaction/service.go
+++ b/backend/internal/compose/nextaction/service.go
@@ -30,6 +30,11 @@ const (
 // brief is the thing to open; beyond it the deal still needs a move today.
 const meetingHorizon = 72 * time.Hour
 
+// laneDeadline caps the model call. The card is read inline on the deal page
+// and the API's write window is 30s: the lane must give up early enough that
+// the deterministic fallback still reaches the reader.
+const laneDeadline = 15 * time.Second
+
 // How many timeline rows the rules read. The timeline is ordered by
 // occurred_at DESC, which is when a thing happened OR is scheduled — a booked
 // meeting sits at the top with a future time — so the window holds the nearest
@@ -101,7 +106,13 @@ func (s *Service) answer(ctx context.Context, f facts) crmcontracts.DealNextBest
 	out := decide(f)
 	by := crmcontracts.Deterministic
 	if s.lane != nil && out.Action == ActionCreateTask {
-		if written, err := writeNextMove(ctx, s.lane, f, out); err == nil {
+		// The lane gets a deadline well inside the HTTP write window: a
+		// stalled provider must leave time for the deterministic fallback to
+		// still reach the reader, or the degrade posture is a response nobody
+		// receives. Expiry is an ordinary lane error and serves the floor.
+		laneCtx, cancel := context.WithTimeout(ctx, laneDeadline)
+		defer cancel()
+		if written, err := writeNextMove(laneCtx, s.lane, f, out); err == nil {
 			// A refused lane is the declared degrade posture, not a swallowed
 			// error: unavailable, over budget, or a reply the grounding filter
 			// emptied all serve the deterministic fallback unchanged.

--- a/backend/internal/compose/nextaction/service.go
+++ b/backend/internal/compose/nextaction/service.go
@@ -43,12 +43,21 @@ type Service struct {
 	deals      *deals.Store
 	activities *activities.Store
 	now        func() time.Time
+	lane       Completer
 }
 
 // NewService binds the reads. Both stores carry their own gates, so a deal
 // the caller cannot see is absent here exactly as it is on its own routes.
 func NewService(d *deals.Store, a *activities.Store, now func() time.Time) *Service {
 	return &Service{deals: d, activities: a, now: now}
+}
+
+// WithLane binds the deal_health lane that makes the fallback task concrete.
+// Without it the fallback stays deterministic rather than failing: a role
+// that runs no model still answers the endpoint.
+func (s *Service) WithLane(lane Completer) *Service {
+	s.lane = lane
+	return s
 }
 
 // facts are the inputs the rules fold. Gathered once, so the rules are a pure
@@ -80,7 +89,27 @@ func (s *Service) Get(ctx context.Context, dealID ids.DealID) (crmcontracts.Deal
 	if err != nil {
 		return crmcontracts.DealNextBestAction{}, fmt.Errorf("next action: reading the deal's open tasks: %w", err)
 	}
-	return decide(facts{deal: deal, timeline: timeline, openTasks: open, now: s.now().UTC()}), nil
+	f := facts{deal: deal, timeline: timeline, openTasks: open, now: s.now().UTC()}
+	return s.answer(ctx, f), nil
+}
+
+// answer runs the rules and, on the one arm whose task the rules can only
+// title generically, offers the lane a rewrite. Every path stamps who wrote
+// it: the rule-matched answers are deterministic by construction, and the
+// fallback is deterministic unless the lane's proposal survived the filter.
+func (s *Service) answer(ctx context.Context, f facts) crmcontracts.DealNextBestAction {
+	out := decide(f)
+	by := crmcontracts.Deterministic
+	if s.lane != nil && out.Action == ActionCreateTask {
+		if written, err := writeNextMove(ctx, s.lane, f, out); err == nil {
+			// A refused lane is the declared degrade posture, not a swallowed
+			// error: unavailable, over budget, or a reply the grounding filter
+			// emptied all serve the deterministic fallback unchanged.
+			out, by = written, crmcontracts.Model
+		}
+	}
+	out.GeneratedBy = &by
+	return out
 }
 
 // decide is the rule set, in priority order. The first rule whose facts hold

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/briefs"
 	"github.com/gradionhq/margince/backend/internal/compose/meetingbrief"
 	"github.com/gradionhq/margince/backend/internal/compose/network"
+	"github.com/gradionhq/margince/backend/internal/compose/nextaction"
 	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	"github.com/gradionhq/margince/backend/internal/compose/orgbrief"
 	"github.com/gradionhq/margince/backend/internal/compose/orgdossier"
@@ -327,6 +328,9 @@ type Server struct {
 	// meetingBriefSvc is held so an option can bind its model lane after the
 	// handler sets are built.
 	meetingBriefSvc *meetingbrief.Service
+	// nextActionSvc is held for the same reason: WithNextMoveWriter binds the
+	// deal_health lane onto the service the handler set already wraps.
+	nextActionSvc *nextaction.Service
 
 	// orgDossierSvc and orgGrowthFitSvc are the company view's other two
 	// generated surfaces. They are held for WithGrowthFit's sake: rebinding one

--- a/backend/internal/compose/serveroptions_companyview.go
+++ b/backend/internal/compose/serveroptions_companyview.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/accountdraft"
 	"github.com/gradionhq/margince/backend/internal/compose/meetingbrief"
+	"github.com/gradionhq/margince/backend/internal/compose/nextaction"
 	"github.com/gradionhq/margince/backend/internal/compose/orgbrief"
 	"github.com/gradionhq/margince/backend/internal/compose/orgdossier"
 )
@@ -124,5 +125,21 @@ func WithMeetingBriefWriter(brain completer) Option {
 		}
 		s.meetingBriefHandlers = meetingbrief.NewHandlers(
 			s.meetingBriefSvc.WithLane(brain), s.sorDispatch.isOverlay)
+	}
+}
+
+// WithNextMoveWriter binds the deal_health lane that turns the Next-move
+// card's fallback task into a concrete one.
+//
+// Without it the card serves its deterministic fallback rather than failing: a
+// role that runs no model still answers the endpoint, and generated_by tells
+// the reader which writer they have. Nothing is cached, so there is no routing
+// version to carry.
+func WithNextMoveWriter(brain completer) Option {
+	return func(s *Server, _ *pgxpool.Pool) {
+		if s.nextActionSvc == nil {
+			return
+		}
+		s.nextActionHandlers = nextaction.NewHandlers(s.nextActionSvc.WithLane(brain))
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15538,6 +15538,13 @@ type DealNextBestAction struct {
 	DealId     openapi_types.UUID           `json:"deal_id"`
 	Evidence   []DealNextBestActionEvidence `json:"evidence"`
 
+	// GeneratedBy Which writer produced the recommendation. `model` only on the `create_task`
+	// fallback, where the deal_health lane proposes the concrete next step; every
+	// rule-matched answer — and the fallback whenever the lane is absent, over
+	// budget, or refused — is `deterministic`. Absent means `deterministic`, so a
+	// client reading an older server fails honest.
+	GeneratedBy *WrittenBy `json:"generated_by,omitempty"`
+
 	// Reason One sentence, in the user's terms, saying why this and not something else.
 	Reason string `json:"reason"`
 }

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -18,7 +18,7 @@ const (
 	TaskCertJudge Task = "cert_judge"
 	// TaskColdStart is Four sites, not one: three conversational onboarding lanes plus the evidence-extraction pass the read-back rides. The extraction site is the consequential one and had no name before ADR-0074.
 	TaskColdStart Task = "cold_start"
-	// TaskDealHealth is Declared, not built (ADR-0074).
+	// TaskDealHealth is next_move — the deal card's one next step, proposed as a concrete task when no rule already names the move: the model reads the deal's own timeline (subjects, directions, bounded excerpts the CALLER may read — the facts are assembled under the caller's row scope) and writes the task's subject and the why. The verb never moves: the answer is always create_task, the deterministic rules (booked meeting, unanswered inbound, existing open task) run first, and a missing lane, an over-budget call or a reply the grounding filter refuses degrades to the deterministic fallback task with generated_by saying so.
 	TaskDealHealth Task = "deal_health"
 	// TaskDocumentExtract is read ONE attached document — a scanned form, an invoice, an order confirmation — for the four deal facts a human may then accept onto the deal (records-depth RD-PARAM-N-3), each carrying the quote it was read from. premium-only BY CONTRACT for site_extract's reason and one of its own: a rung that cannot carry the document is not a degraded answer to this question, it is a different question, so there is no rung to degrade to. no_payload BY CONTRACT: a scanned contract or invoice is exactly the content that must never reach ai_call_payload, whatever the deployment's capture posture says. A reading takes seconds and can fail, so it is a durable record its surface polls (records-depth RD-DDL-4), never work done inside the request that asks for it.
 	TaskDocumentExtract Task = "document_extract"
@@ -75,7 +75,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "f14023a33138c094bb0b911d3a905f482702ce40ab757aed94227f8fbd2d4d96"
+const TaskContractHash = "95a58934674cb0122426d36ed42aad211d3cf822fa63e7c35d05a58bf80a3d61"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -197,7 +197,7 @@ var taskStatus = map[Task]string{
 	TaskCaptureCounterpartyVerdict: "shipped",
 	TaskCertJudge:                  "shipped",
 	TaskColdStart:                  "shipped",
-	TaskDealHealth:                 "planned",
+	TaskDealHealth:                 "shipped",
 	TaskDocumentExtract:            "shipped",
 	TaskDraftReply:                 "shipped",
 	TaskEnrich:                     "shipped",
@@ -255,6 +255,9 @@ var taskSites = map[Task][]Site{
 		{Name: "sitereadmessage", Kind: "multi_turn"},
 		{Name: "acts", Kind: "multi_turn"},
 		{Name: "field_extract", Kind: "one_shot"},
+	},
+	TaskDealHealth: {
+		{Name: "next_move", Kind: "one_shot"},
 	},
 	TaskDocumentExtract: {
 		{Name: "fields", Kind: "one_shot"},

--- a/backend/internal/modules/ai/tasks_gen_test.go
+++ b/backend/internal/modules/ai/tasks_gen_test.go
@@ -12,11 +12,11 @@ func TestGeneratedDeclarationAccessors(t *testing.T) {
 	if got := Status(TaskCaptureCounterpartyVerdict); got != StatusShipped {
 		t.Errorf("Status(verdict) = %q, want %q", got, StatusShipped)
 	}
-	// deal_health stands in for the planned half of the table. summarize
-	// used to: it shipped with the account brief, which is exactly the
+	// nl_search stands in for the planned half of the table. summarize and
+	// deal_health each used to: both shipped, which is exactly the
 	// transition this accessor exists to report.
-	if got := Status(TaskDealHealth); got != StatusPlanned {
-		t.Errorf("Status(deal_health) = %q, want %q", got, StatusPlanned)
+	if got := Status(TaskNlSearch); got != StatusPlanned {
+		t.Errorf("Status(nl_search) = %q, want %q", got, StatusPlanned)
 	}
 	if !NoPayload(TaskCaptureCounterpartyVerdict) {
 		t.Error("NoPayload(verdict) = false; the contract pins it true")
@@ -35,7 +35,7 @@ func TestGeneratedDeclarationAccessors(t *testing.T) {
 	if loop := SitesFor(TaskAgentLoop); len(loop) != 1 || loop[0].Kind != SiteKindAgentLoop {
 		t.Errorf("SitesFor(agent_loop) = %+v, want one agent_loop site", loop)
 	}
-	if got := SitesFor(TaskDealHealth); len(got) != 0 {
+	if got := SitesFor(TaskNlSearch); len(got) != 0 {
 		t.Errorf("a planned task declares sites: %+v", got)
 	}
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14105,6 +14105,14 @@ export interface components {
             evidence: components["schemas"]["DealNextBestActionEvidence"][];
             /** Format: date-time */
             computed_at: string;
+            /**
+             * @description Which writer produced the recommendation. `model` only on the `create_task`
+             *     fallback, where the deal_health lane proposes the concrete next step; every
+             *     rule-matched answer — and the fallback whenever the lane is absent, over
+             *     budget, or refused — is `deterministic`. Absent means `deterministic`, so a
+             *     client reading an older server fails honest.
+             */
+            generated_by?: components["schemas"]["WrittenBy"];
         };
         DealNextBestActionEvidence: {
             text: string;

--- a/frontend/src/screens/dealnextaction.tsx
+++ b/frontend/src/screens/dealnextaction.tsx
@@ -7,6 +7,7 @@ import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useT } from "../i18n";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
+import { WrittenBy } from "./company360";
 import { ComposeModal } from "./compose";
 import { PersonMeetingBrief } from "./persondrawers";
 import "./dealnextaction.css";
@@ -58,6 +59,7 @@ function Recommendation({
             ))}
           </ul>
         ) : null}
+        <WrittenBy by={nba.generated_by ?? "deterministic"} />
       </div>
     </PanelBody>
   );


### PR DESCRIPTION
## What

The deal page's **Next move** card no longer answers an empty or stalled deal with "Agree the next step on X" — a task telling the rep to decide what to do. The fallback arm now asks a model lane for one concrete task: a subject naming a real move and a reason saying why now, both grounded in the timeline rows the caller may read. Clicking **Add this task** creates exactly that task, as before.

Seen working against the live Anthropic lane on a dev stack:
- Deal with a call whose notes promised an offer → *"Send the revised offer including the two extra depots in Hamburg and Bremen"*, citing the call, `generated_by: model` (~2s).
- Brand-new deal, empty timeline → a real opening move written from the deal's own fields.
- The click creates the task verbatim (201), and the card then answers deterministically with "an open task already says what is next".

## How

- The deterministic rules keep authority over the verb: booked meeting, unanswered inbound, existing open task never consult the lane, and the model can never change `action`, the deal link, or `source` — it writes what the task *says*, not what clicking does.
- `deal_health` flips planned→shipped with the one site `next_move`; the lane follows the meetingbrief shape: nonce prompt fence over the untrusted timeline text, secret stripper, output caps, a filter refusing unparseable/oversized replies, ids in reader text, or citations outside the input. Every refusal — and an unwired or over-budget lane — serves today's deterministic fallback unchanged.
- `generated_by` is new on `DealNextBestAction` (absent = deterministic); the card renders the same **WrittenBy** badge as the other generated surfaces.
- A withheld timeline row keeps its date and gives up its words. Prompt input is dated, not aged, so the router's result cache serves repeat views.
- Certification: `deal_health/next_move` registered in the census with its case (`certcase_nextmove.go`) and two corpus scenarios (offer-left-hanging, empty deal).

## Gates

`make check-backend` and `make check-fe` green; `craft static` clean; unit tests drive the lane through the production answer path (grounded proposal wins; error/unparseable/uncited/invented-citation/id-in-text/oversized each degrade to the floor; rule-matched answers never consult the lane; withheld rows contribute no words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Next‑move card’s fallback concrete. Previously it said “Agree the next step on X”; now the `deal_health` lane (`next_move` site) writes a specific task subject and reason grounded in the deal’s own timeline. Deterministic verbs are unchanged, and the card shows who wrote it via `generated_by`.

- The write is fenced and filtered: nonce prompt fence, secret stripper, caps on subject/reason, rejects unparseable/oversized replies, ids in reader text, and citations outside the input; requires a citation when the timeline is non‑empty; withheld rows contribute date only; input is dated (cache‑friendly), and no stage field is sent.
- Deterministic rules remain authoritative and short‑circuit; the lane never changes `action`, links, or `source`—only the task’s subject and reason.
- A 15s lane deadline leaves time to serve the deterministic fallback within the HTTP window; absence, timeout, over‑budget, or a refused reply all serve the floor unchanged.
- `generated_by` added to `DealNextBestAction` (absent/`deterministic` vs `model`); frontend renders the existing `WrittenBy` badge. API/types updated.
- Contract and wiring: `deal_health` flips to shipped with site `next_move`; router path `ModelPath.DealHealth`; server option `compose.WithNextMoveWriter`; cold‑start options +1. Certification registers `deal_health/next_move` with two corpus scenarios; unit tests cover grounding and degrade paths.

<sup>Written for commit 5d1fd0e6df164b9164f5ea623b0fc01ac3de2516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AI-generated next-step recommendations for deal health.
  - Recommendations can include supporting evidence from deal activity.
  - Added visibility into whether recommendations came from AI or deterministic rules.
  - Added validation to ensure recommendations are specific, grounded, and supported by valid activity references.
- **Bug Fixes**
  - Added safe deterministic fallbacks when AI recommendations are unavailable, invalid, or insufficiently grounded.
  - Improved protection against unsupported or withheld activity content appearing in recommendations.
- **Tests**
  - Added coverage for grounded recommendations, evidence validation, fallback behavior, and empty timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->