### PR TITLE
feat(compose): a message says which project it files under, and tags the subject

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2357,6 +2357,11 @@ export const de = {
   "compose.relinkTitle": "Diese Aktivität neu verknüpfen",
   "compose.filedUnder":
     "Diese Antwort wird unter {project} abgelegt, wie der Rest dieser Konversation.",
+  "compose.filedUnderDeal":
+    "Wird unter {project} abgelegt, dem Projekt dieses Deals.",
+  "compose.subjectTagged":
+    "{tag} wird dem Betreff hinzugefügt, damit die Antwort sich hier einordnet.",
+  "compose.fileUnderProject": "Unter diesem Projekt ablegen",
   "compose.relinkTarget": "Person, Organisation, Deal oder Lead suchen",
   "compose.relinkReplace": "Verschieben statt zusätzlich verknüpfen",
   "compose.relinkReplaceHint":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2380,6 +2380,21 @@ export const en = {
   "compose.relinkTitle": "Relink this activity",
   "compose.filedUnder":
     "This reply will be filed under {project}, like the rest of this conversation.",
+  // The filing line, in its two readings. The THREAD reading is the settled
+  // case: a sibling message already said where this conversation belongs. The
+  // DEAL reading is the fallback, and it names its reason, because a rep who
+  // sees a project they did not put on this conversation deserves to know why
+  // it is being offered.
+  "compose.filedUnderDeal":
+    "This will be filed under {project}, this deal's project.",
+  // The subject tag, explained where it is applied. It says what the tag is
+  // FOR — the reply coming back — because a bracketed code in a subject line
+  // reads as noise until you know it routes the answer.
+  "compose.subjectTagged":
+    "{tag} is added to the subject so their reply files itself here.",
+  // The opt-out. Not "remove" or "delete": nothing is destroyed, the message
+  // simply is not filed under this project.
+  "compose.fileUnderProject": "File under this project",
   "compose.relinkTarget": "Search a person, organization, deal, or lead",
   "compose.relinkReplace": "Move instead of also-link",
   "compose.relinkReplaceHint":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2332,6 +2332,11 @@ export const vi = {
   "compose.relinkTitle": "Liên kết lại hoạt động này",
   "compose.filedUnder":
     "Thư trả lời này sẽ được xếp vào {project}, giống phần còn lại của cuộc trò chuyện.",
+  "compose.filedUnderDeal":
+    "Sẽ được lưu vào {project}, dự án của giao dịch này.",
+  "compose.subjectTagged":
+    "{tag} được thêm vào tiêu đề để thư trả lời tự động vào đúng dự án.",
+  "compose.fileUnderProject": "Lưu vào dự án này",
   "compose.relinkTarget": "Tìm một người, tổ chức, deal hay lead",
   "compose.relinkReplace": "Chuyển hẳn thay vì liên kết thêm",
   "compose.relinkReplaceHint":

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -2084,4 +2084,47 @@ describe("ComposeModal started from an account", () => {
     await waitFor(() => expect(subject().value).toBe(""));
     expect(screen.queryByText(/is added to the subject/)).toBeNull();
   });
+
+  it("leaves a tag the rep deleted by hand deleted", async () => {
+    const user = userEvent.setup();
+    stubRoutes({
+      "GET /activities/act-1": () =>
+        jsonResponse({
+          id: "act-1",
+          kind: "email",
+          occurred_at: "2026-08-09T09:00:00Z",
+          source: "gmail",
+          created_at: "2026-08-09T09:00:00Z",
+          updated_at: "2026-08-09T09:00:00Z",
+          version: 1,
+          links: [{ entity_type: "deal", entity_id: "d-1" }],
+        }),
+      "GET /deals/d-1": () =>
+        jsonResponse({ id: "d-1", name: "netcare", project_id: "pr-9" }),
+      "GET /projects/pr-9": () =>
+        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="deal"
+        entityId="d-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    const subject = () =>
+      screen.getByPlaceholderText("Subject") as HTMLInputElement;
+    await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
+
+    // Deleting the tag is a second way to say "not this one". The composer
+    // must not put it back under the rep's cursor.
+    await user.clear(subject());
+    await user.type(subject(), "Re: ohne Tag");
+
+    await waitFor(() => expect(subject().value).toBe("Re: ohne Tag"));
+    // And it stays gone rather than reappearing on the next render.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(subject().value).toBe("Re: ohne Tag");
+  });
 });

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1999,4 +1999,89 @@ describe("ComposeModal started from an account", () => {
     await screen.findByRole("button", { name: "Draft with AI" });
     expect(screen.queryByText(/will be filed under/)).toBeNull();
   });
+
+  // The case this behaviour was built for: a deal whose project was attached
+  // AFTER the conversation started, so the mail being answered names no
+  // project while the deal does.
+  it("falls back to the deal's project when the thread names none, and says why", async () => {
+    stubRoutes({
+      "GET /activities/act-1": () =>
+        jsonResponse({
+          id: "act-1",
+          kind: "email",
+          occurred_at: "2026-08-09T09:00:00Z",
+          source: "gmail",
+          created_at: "2026-08-09T09:00:00Z",
+          updated_at: "2026-08-09T09:00:00Z",
+          version: 1,
+          links: [{ entity_type: "deal", entity_id: "d-1" }],
+        }),
+      "GET /deals/d-1": () =>
+        jsonResponse({ id: "d-1", name: "netcare", project_id: "pr-9" }),
+      "GET /projects/pr-9": () =>
+        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="deal"
+        entityId="d-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // It names the project AND the reason, because the rep never put this
+    // project on this conversation.
+    expect(
+      await screen.findByText(/filed under Netcare 2 project, this deal/),
+    ).toBeTruthy();
+    // And the key lands in the subject, where the customer's reply carries it
+    // back to the same project.
+    await waitFor(() =>
+      expect(
+        (screen.getByPlaceholderText("Subject") as HTMLInputElement).value,
+      ).toBe("[N2P-1]"),
+    );
+    expect(screen.getByText(/\[N2P-1\] is added to the subject/)).toBeTruthy();
+  });
+
+  it("takes the tag back out of the subject when the rep declines the filing", async () => {
+    const user = userEvent.setup();
+    stubRoutes({
+      "GET /activities/act-1": () =>
+        jsonResponse({
+          id: "act-1",
+          kind: "email",
+          occurred_at: "2026-08-09T09:00:00Z",
+          source: "gmail",
+          created_at: "2026-08-09T09:00:00Z",
+          updated_at: "2026-08-09T09:00:00Z",
+          version: 1,
+          links: [{ entity_type: "deal", entity_id: "d-1" }],
+        }),
+      "GET /deals/d-1": () =>
+        jsonResponse({ id: "d-1", name: "netcare", project_id: "pr-9" }),
+      "GET /projects/pr-9": () =>
+        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="deal"
+        entityId="d-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    const subject = () =>
+      screen.getByPlaceholderText("Subject") as HTMLInputElement;
+    await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
+
+    await user.click(screen.getByLabelText("File under this project"));
+
+    // A tag promising a routing that will not happen is worse than no tag.
+    await waitFor(() => expect(subject().value).toBe(""));
+    expect(screen.queryByText(/is added to the subject/)).toBeNull();
+  });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -47,6 +47,7 @@ import { useConsentPurposes } from "./consent";
 import {
   type Filing,
   filingFor,
+  stripEveryKeyTag,
   stripSubjectTag,
   subjectTag,
   useProjectRecord,
@@ -259,8 +260,16 @@ function fillFromDraft(
   }>,
 ) {
   const drafted = result.draft;
-  if (!form.subject) {
-    form.setSubject(drafted.subject);
+  // A subject holding only the project tag is a subject the rep has not written
+  // yet: the composer put it there, not them. The drafted subject fills in
+  // behind the tag rather than being dropped as "the field is taken".
+  const written = stripEveryKeyTag(form.subject).trim();
+  if (!written) {
+    form.setSubject(
+      form.subject.trim()
+        ? withSubjectTag(drafted.subject, form.subject.trim())
+        : drafted.subject,
+    );
   }
   if (!form.body) {
     form.setBody(drafted.body);
@@ -323,6 +332,18 @@ async function draftFromActivity({
 // This says where the message is going, and points at the one control that can
 // change it — which moves the whole conversation, not one message of it.
 /**
+ * What survives clearing a subject: the project tag, and nothing else.
+ *
+ * A tag is not the rep's words and not the draft's — the composer put it there
+ * to route the reply. Wiping it with the rejected draft would leave the filing
+ * checkbox asserting a routing the subject no longer performs.
+ */
+function keptTag(subject: string): string {
+  const words = stripEveryKeyTag(subject);
+  return subject.slice(0, subject.length - words.length).trim();
+}
+
+/**
  * Where this send will file, stated rather than asked, with the one control
  * that matters: the rep can decline it.
  *
@@ -371,14 +392,16 @@ function ProjectFiling({
         checked={filed}
         onChange={(event) => onFiledChange(event.target.checked)}
       />
-      <p className="t-caption">
-        {t(
-          filing.from === "deal"
-            ? "compose.filedUnderDeal"
-            : "compose.filedUnder",
-          { project: project.name },
-        )}
-      </p>
+      {filed && (
+        <p className="t-caption">
+          {t(
+            filing.from === "deal"
+              ? "compose.filedUnderDeal"
+              : "compose.filedUnder",
+            { project: project.name },
+          )}
+        </p>
+      )}
       {filed && tag && (
         <p className="t-caption">{t("compose.subjectTagged", { tag })}</p>
       )}
@@ -415,10 +438,11 @@ function useThreadProject(activityId?: string): {
     projectId: (query.data?.links ?? []).find(
       (link) => link.entity_type === "project",
     )?.entity_id,
-    // A read that has not answered is not "no project": stating a filing on a
-    // pending read would name the wrong one, or none, and then change under
-    // the rep after they had already read it.
-    settled: !activityId || !query.isPending,
+    // A read that has not answered — or FAILED — is not "no project". Treating
+    // an error as absence falls through to the deal's project, which the send
+    // would then contradict: the server re-reads the anchor and inherits the
+    // thread's own filing. Unsettled means say nothing.
+    settled: !activityId || (!query.isPending && !query.isError),
   };
 }
 
@@ -1369,22 +1393,31 @@ function useDraftMutation({
 function useAnchorProject(
   entityType: RelinkKind,
   entityId: string,
-): { projectId?: string | null } {
+): { projectId?: string | null; settled: boolean } {
   const query = useQuery({
-    queryKey: ["deal", entityId, "project"],
+    // The SAME key the deal page's own read uses, so opening the composer on a
+    // deal costs no request and cannot disagree with the page behind it. A
+    // second key would be a second answer to one question.
+    queryKey: ["deal", entityId],
     queryFn: async () => {
       const { data, error } = await api.GET("/deals/{id}", {
         params: { path: { id: entityId } },
       });
-      // A deal the reader may not open derives no filing, and that is not an
-      // error worth taking the composer down for: they can still write the
-      // message, it simply files under the record it was started from.
-      return error ? null : data;
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
     },
     enabled: entityType === "deal",
     staleTime: 60_000,
   });
-  return { projectId: query.data?.project_id };
+  return {
+    projectId: query.data?.project_id,
+    // A read that failed says nothing about this deal's project. Reporting it
+    // as "no project" would drop the filing silently; unsettled keeps the
+    // composer quiet instead, which is the same rule the thread read follows.
+    settled: entityType !== "deal" || (!query.isPending && !query.isError),
+  };
 }
 
 /**
@@ -1404,6 +1437,9 @@ function useProjectFiling(input: {
   activityId?: string;
   anchorProjectId?: string | null;
   reachable: readonly { id: string }[];
+  // Whether the anchor's own read has answered. False keeps the composer quiet
+  // rather than reporting a failed read as "no project".
+  anchorSettled: boolean;
   subject: string;
   setSubject: (next: string) => void;
 }): {
@@ -1414,11 +1450,18 @@ function useProjectFiling(input: {
 } {
   const thread = useThreadProject(input.activityId);
   const [declined, setDeclined] = useState(false);
-  const filing = filingFor({
-    threadProjectId: thread.projectId,
-    dealProjectId: input.anchorProjectId,
-    reachable: input.reachable,
-  });
+  // Nothing is derived until the thread has answered. The thread outranks the
+  // deal, so guessing while its read is in flight is guessing the loser: the
+  // composer would announce the deal's project, then swap under the rep, or —
+  // when the read failed — announce one the send will not use.
+  const filing =
+    thread.settled && input.anchorSettled
+      ? filingFor({
+          threadProjectId: thread.projectId,
+          dealProjectId: input.anchorProjectId,
+          reachable: input.reachable,
+        })
+      : ({ kind: "none" } as const);
   const derived = filing.kind === "derived" ? filing.projectId : undefined;
   const { project } = useProjectRecord(derived);
   const filed = Boolean(derived) && !declined;
@@ -1435,7 +1478,12 @@ function useProjectFiling(input: {
   const subjectRef = useRef(input.subject);
   subjectRef.current = input.subject;
   const setSubject = input.setSubject;
+
   useEffect(() => {
+    // Re-apply when the tag CHANGED, and also when the subject no longer holds
+    // the tag this hook believes it wrote — discarding a draft clears the field
+    // programmatically, and without this the checkbox would keep claiming a tag
+    // the subject does not carry.
     if (applied.current === want) {
       return;
     }
@@ -1540,6 +1588,7 @@ export function ComposeModal({
   const projectFiling = useProjectFiling({
     activityId,
     anchorProjectId: groundable ? null : anchorProject.projectId,
+    anchorSettled: anchorProject.settled,
     // The reachable set only decides between "ask" and "say nothing", and the
     // anchored path never asks — the account path owns that question.
     reachable: [],
@@ -1627,8 +1676,10 @@ export function ComposeModal({
     },
     onSuccess: () => {
       // The rejected words leave with the judgment; the recipients the rep
-      // addressed are their own work and stay.
-      setSubject("");
+      // addressed are their own work and stay. So does the project tag: it is
+      // not part of the draft being rejected, and clearing it would leave the
+      // checkbox claiming a filing the subject no longer carries.
+      setSubject((current) => keptTag(current));
       setBody("");
       setProvenance(null);
     },

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,6 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
-import { type ReactNode, useCallback, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -38,7 +44,15 @@ import {
 } from "./common";
 import { useOrganization360 } from "./company360";
 import { useConsentPurposes } from "./consent";
-import { useEntityName } from "./entityref";
+import {
+  type Filing,
+  filingFor,
+  stripSubjectTag,
+  subjectTag,
+  useProjectRecord,
+  withSubjectTag,
+} from "./projectrecord";
+import type { Project } from "./projects.form";
 import { useVoiceProfile } from "./voice-profile";
 import "./compose.css";
 
@@ -308,48 +322,104 @@ async function draftFromActivity({
 // reply", saw no project anywhere, and concluded the feature was not there.
 // This says where the message is going, and points at the one control that can
 // change it — which moves the whole conversation, not one message of it.
-function ReplyFiling({ activityId }: Readonly<{ activityId: string }>) {
+/**
+ * Where this send will file, stated rather than asked, with the one control
+ * that matters: the rep can decline it.
+ *
+ * The thread's own project settles it when it has one. A deal's project is the
+ * fallback for a conversation that predates it, and the copy names that reason
+ * — a rep seeing a project they never put on this thread should be told where
+ * it came from.
+ *
+ * Declining files the message under no project and takes the subject tag back
+ * off. It does NOT move the thread: the control that does that is Relink, on
+ * the message's own timeline row, and it moves every message at once. Two
+ * spellings of "move this conversation" is what this component exists to avoid.
+ */
+// NOTE ON THE REPLY PATH: a reply posts to /activities/{id}/send-email, which
+// takes NO links — the server files the reply under the links its ANCHOR
+// carries (activities/sendorigin.go, FromActivity). So on a reply this section
+// states a filing the client cannot itself perform, and it is honest only
+// because of the subject tag: the tag is what carries the project, and capture
+// reads it back on the way in. The `filed` flag still governs the tag, so
+// declining genuinely changes what is sent.
+//
+// The account-started path DOES send links, and there the project link travels
+// (composedLinks). Making a reply send one needs `links` on the reply request —
+// a contract change, tracked as its own piece of work.
+function ProjectFiling({
+  filing,
+  project,
+  filed,
+  onFiledChange,
+}: Readonly<{
+  filing: Filing;
+  project: Project | null;
+  filed: boolean;
+  onFiledChange: (next: boolean) => void;
+}>) {
   const t = useT();
+  if (filing.kind !== "derived" || !project?.name) {
+    return null;
+  }
+  const tag = subjectTag(project);
+  return (
+    <div className="stack-2xs">
+      <Checkbox
+        className="t-body"
+        label={t("compose.fileUnderProject")}
+        checked={filed}
+        onChange={(event) => onFiledChange(event.target.checked)}
+      />
+      <p className="t-caption">
+        {t(
+          filing.from === "deal"
+            ? "compose.filedUnderDeal"
+            : "compose.filedUnder",
+          { project: project.name },
+        )}
+      </p>
+      {filed && tag && (
+        <p className="t-caption">{t("compose.subjectTagged", { tag })}</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The project link a reply's own thread already carries, if any.
+ *
+ * Read from the anchor activity rather than assumed, because the thread is the
+ * first rung of the same ladder the capture side walks: a sibling message that
+ * was filed — by capture or by a human relink — is the settled answer, and it
+ * outranks anything the deal says.
+ */
+function useThreadProject(activityId?: string): {
+  projectId?: string;
+  settled: boolean;
+} {
   const query = useQuery({
     queryKey: ["activity", activityId, "filing"],
     queryFn: async () => {
       const { data, error } = await api.GET("/activities/{id}", {
-        params: { path: { id: activityId } },
+        params: { path: { id: activityId ?? "" } },
       });
       if (error) {
         throwProblem(error);
       }
       return data;
     },
+    enabled: Boolean(activityId),
   });
-  const projectId = (query.data?.links ?? []).find(
-    (link) => link.entity_type === "project",
-  )?.entity_id;
-  const { name } = useEntityName("project", projectId);
-  // This line makes a claim about where a send will land, so it is drawn only
-  // when both reads have actually answered. A failed or pending read looks
-  // exactly like "no project" from here, and silence is the honest rendering of
-  // both: "this will be filed under nothing" tells a reader less than nothing
-  // does, and naming a project the read never returned would be worse — the
-  // caption would assert a filing that is not the one the server will perform.
-  if (query.isPending || query.isError || !projectId) {
-    return null;
-  }
-  // The link is there but its name is not — pending, refused, or blank; the
-  // three are one case here. Same rule: say nothing rather than name the
-  // project "Unnamed project", which reads as a fact about the project instead
-  // of a gap in what this component managed to read.
-  if (!name) {
-    return null;
-  }
-  // It SAYS, and does not offer to change: the control that moves a
-  // conversation is Relink, on the message's own row in the timeline, and it
-  // moves the whole thread. A second one here would be a second spelling of one
-  // action — and the shorter path to filing a single message away from its
-  // conversation, which is the split this line exists to make visible.
-  return (
-    <p className="t-caption">{t("compose.filedUnder", { project: name })}</p>
-  );
+  return {
+    projectId: (query.data?.links ?? []).find(
+      (link) => link.entity_type === "project",
+    )?.entity_id,
+    // A read that has not answered is not "no project": stating a filing on a
+    // pending read would name the wrong one, or none, and then change under
+    // the rep after they had already read it.
+    settled: !activityId || !query.isPending,
+  };
 }
 
 // The account-started draft (ADR-0087/A132). It grounds itself in the account
@@ -523,13 +593,14 @@ export type Grounding = {
 function composedLinks(
   anchor: { entityType: RelinkKind; entityId: string },
   chosen: Grounding | null,
+  // The project this send files under when the rep CHOSE nothing — derived
+  // from the thread or from the anchor record, and already declinable in the
+  // UI. Empty means no project link, which is what a decline produces.
+  derivedProjectId = "",
 ): { entity_type: RelinkKind; entity_id: string }[] {
   const links: { entity_type: RelinkKind; entity_id: string }[] = [
     { entity_type: anchor.entityType, entity_id: anchor.entityId },
   ];
-  if (!chosen) {
-    return links;
-  }
   const add = (kind: RelinkKind, id: string) => {
     const already = links.some(
       (l) => l.entity_type === kind && l.entity_id === id,
@@ -539,6 +610,13 @@ function composedLinks(
     }
     links.push({ entity_type: kind, entity_id: id });
   };
+  if (!chosen) {
+    // An anchored send: the record it was started from, plus the filing it
+    // states. A reply that states no filing still sends anchor-only, which is
+    // the shape every existing reply has.
+    add("project", derivedProjectId);
+    return links;
+  }
   add("person", chosen.recipientId);
   add("deal", chosen.dealId);
   add("project", chosen.projectId);
@@ -1279,6 +1357,103 @@ function useDraftMutation({
   });
 }
 
+/**
+ * The project the anchor RECORD names, for the sends whose anchor can name one.
+ *
+ * Only a deal does today: it carries `project_id` as a column, and a message
+ * about a deal is a message about that deal's work. A company or a person
+ * reaches several projects at once and names none of them, so there is nothing
+ * to derive — those anchors answer nothing here and the account path's picker
+ * is what asks.
+ */
+function useAnchorProject(
+  entityType: RelinkKind,
+  entityId: string,
+): { projectId?: string | null } {
+  const query = useQuery({
+    queryKey: ["deal", entityId, "project"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/deals/{id}", {
+        params: { path: { id: entityId } },
+      });
+      // A deal the reader may not open derives no filing, and that is not an
+      // error worth taking the composer down for: they can still write the
+      // message, it simply files under the record it was started from.
+      return error ? null : data;
+    },
+    enabled: entityType === "deal",
+    staleTime: 60_000,
+  });
+  return { projectId: query.data?.project_id };
+}
+
+/**
+ * The filing this composer will perform, and the subject tag that goes with it.
+ *
+ * Kept as one hook because the two move together: the tag is only in the
+ * subject while the filing is on, so a rep who declines the filing must not be
+ * left with the bracketed key still in their subject line, promising a routing
+ * that will not happen.
+ *
+ * The subject is rewritten only when the FILING changes, never on a keystroke.
+ * A rep who deletes the tag by hand keeps it deleted — that is a second way to
+ * say the same "not this one", and re-adding it under their cursor would be the
+ * composer arguing with them.
+ */
+function useProjectFiling(input: {
+  activityId?: string;
+  anchorProjectId?: string | null;
+  reachable: readonly { id: string }[];
+  subject: string;
+  setSubject: (next: string) => void;
+}): {
+  filing: Filing;
+  project: Project | null;
+  filed: boolean;
+  setFiled: (next: boolean) => void;
+} {
+  const thread = useThreadProject(input.activityId);
+  const [declined, setDeclined] = useState(false);
+  const filing = filingFor({
+    threadProjectId: thread.projectId,
+    dealProjectId: input.anchorProjectId,
+    reachable: input.reachable,
+  });
+  const derived = filing.kind === "derived" ? filing.projectId : undefined;
+  const { project } = useProjectRecord(derived);
+  const filed = Boolean(derived) && !declined;
+  const tag = subjectTag(project);
+  // The tag follows the filing, applied once per change rather than on every
+  // render: `applied` remembers what this composer last wrote, so a rerender
+  // with the same answer leaves the rep's subject alone.
+  const applied = useRef<string>("");
+  const want = filed && thread.settled ? tag : "";
+  // In an effect, not during render: setting the subject inline would be a
+  // state write inside another component's render pass, the shape that drives
+  // React into an update loop. The subject is read through a ref so a rep's
+  // typing never re-runs this.
+  const subjectRef = useRef(input.subject);
+  subjectRef.current = input.subject;
+  const setSubject = input.setSubject;
+  useEffect(() => {
+    if (applied.current === want) {
+      return;
+    }
+    const previous = applied.current;
+    applied.current = want;
+    const bare = previous
+      ? stripSubjectTag(subjectRef.current, previous)
+      : subjectRef.current;
+    setSubject(want ? withSubjectTag(bare, want) : bare);
+  }, [want, setSubject]);
+  return {
+    filing,
+    project,
+    filed,
+    setFiled: (next: boolean) => setDeclined(!next),
+  };
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this modal was already at the ceiling; the account-started origin (ADR-0087/A132) adds three necessary branches — the recipient/deal pickers, the grounded-draft gate and the drawer placement. The drafting call, the form fill, the body edit and both draft controls are already extracted; what is left is one dialog's own wiring, and splitting the send/consent/refusal/voice flow apart from the fields it gates would scatter it.
 export function ComposeModal({
   activityId,
@@ -1357,6 +1532,20 @@ export function ComposeModal({
   // recipient server-side and has no draft endpoint at all.
   const groundable =
     !activityId && entityType === "organization" && !isChannelReply;
+  // Where this send files, and the subject tag that travels with it. The
+  // account path keeps its own picker (it chooses a project rather than
+  // inheriting one), so this covers the anchored sends: a reply, and a message
+  // started from a deal.
+  const anchorProject = useAnchorProject(entityType, entityId);
+  const projectFiling = useProjectFiling({
+    activityId,
+    anchorProjectId: groundable ? null : anchorProject.projectId,
+    // The reachable set only decides between "ask" and "say nothing", and the
+    // anchored path never asks — the account path owns that question.
+    reachable: [],
+    subject,
+    setSubject,
+  });
 
   // An emptied body no longer holds the served draft, so everything that
   // describes those words goes with it: the reference would bind the next
@@ -1467,7 +1656,11 @@ export function ComposeModal({
         isChannelReply,
         mail,
         channelBody: { body, consent_purpose: purpose },
-        links: composedLinks({ entityType, entityId }, grounding),
+        links: composedLinks(
+          { entityType, entityId },
+          grounding,
+          projectFiling.filed ? (projectFiling.project?.id ?? "") : "",
+        ),
       });
       if (response.status === 501) return { sent: false as const };
       // Only a real 202 is a send. openapi-fetch returns a falsy `error` for a
@@ -1604,8 +1797,13 @@ export function ComposeModal({
         {accountContext}
         {/* A reply says where it is going. The picker above is for the
             account-started message, which has no thread to inherit from. */}
-        {activityId && !isChannelReply && (
-          <ReplyFiling activityId={activityId} />
+        {!isChannelReply && (
+          <ProjectFiling
+            filing={projectFiling.filing}
+            project={projectFiling.project}
+            filed={projectFiling.filed}
+            onFiledChange={projectFiling.setFiled}
+          />
         )}
         {/* AI drafting is mail-only — there is no draft-message endpoint, and
             a channel reply's recipient is resolved server-side, so neither

--- a/frontend/src/screens/projectrecord.test.ts
+++ b/frontend/src/screens/projectrecord.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import {
+  filingFor,
+  stripSubjectTag,
+  subjectTag,
+  withSubjectTag,
+} from "./projectrecord";
+import type { Project } from "./projects.form";
+
+const project = (over: Partial<Project> = {}): Project =>
+  ({ id: "p-1", name: "Netcare 2 project", key: "N2P-1", ...over }) as Project;
+
+describe("the project tag a subject carries", () => {
+  it("brackets the key the capture side reads back", () => {
+    expect(subjectTag(project())).toBe("[N2P-1]");
+  });
+
+  it("is empty for a project with no key, rather than an empty bracket", () => {
+    // `[]` is not a key reference, and the inbound matcher reads nothing from
+    // it — writing one would be noise in the subject that buys nothing.
+    expect(subjectTag(project({ key: null }))).toBe("");
+    expect(subjectTag(null)).toBe("");
+  });
+
+  it("puts the tag at the front of the subject", () => {
+    expect(withSubjectTag("Re: Kurzer Austausch?", "[N2P-1]")).toBe(
+      "[N2P-1] Re: Kurzer Austausch?",
+    );
+  });
+
+  it("does not stack when the subject already carries the tag", () => {
+    // The composer re-derives the subject whenever the filing changes, so this
+    // runs more than once over the same text.
+    const once = withSubjectTag("Re: Kurzer Austausch?", "[N2P-1]");
+    expect(withSubjectTag(once, "[N2P-1]")).toBe(once);
+  });
+
+  it("tags an empty subject without leaving a leading space", () => {
+    expect(withSubjectTag("", "[N2P-1]")).toBe("[N2P-1]");
+  });
+
+  it("leaves the subject alone when there is no tag to add", () => {
+    expect(withSubjectTag("Kurzer Austausch?", "")).toBe("Kurzer Austausch?");
+  });
+
+  it("takes its own tag back off, and nobody else's", () => {
+    expect(stripSubjectTag("[N2P-1] Re: Hallo", "[N2P-1]")).toBe("Re: Hallo");
+    // A different project's tag is the rep's text, not ours to remove.
+    expect(stripSubjectTag("[OTHER-9] Re: Hallo", "[N2P-1]")).toBe(
+      "[OTHER-9] Re: Hallo",
+    );
+    // A tag in the middle is prose, not a prefix we wrote.
+    expect(stripSubjectTag("Re: [N2P-1] Hallo", "[N2P-1]")).toBe(
+      "Re: [N2P-1] Hallo",
+    );
+  });
+});
+
+describe("which project a send files under", () => {
+  const two = [{ id: "p-1" }, { id: "p-2" }];
+
+  it("takes the thread's project first, because a conversation is one body of work", () => {
+    expect(
+      filingFor({
+        threadProjectId: "p-thread",
+        dealProjectId: "p-deal",
+        reachable: two,
+      }),
+    ).toEqual({ kind: "derived", projectId: "p-thread", from: "thread" });
+  });
+
+  it("falls back to the deal's project when the thread carries none", () => {
+    // The case that sent this work: a deal whose project was attached after
+    // the conversation had already started, so the old mail names no project.
+    expect(filingFor({ dealProjectId: "p-deal", reachable: two })).toEqual({
+      kind: "derived",
+      projectId: "p-deal",
+      from: "deal",
+    });
+  });
+
+  it("asks only when several are in reach and nothing names one", () => {
+    expect(filingFor({ reachable: two })).toEqual({ kind: "choose" });
+  });
+
+  it("says nothing when there is no project at all", () => {
+    expect(filingFor({ reachable: [] })).toEqual({ kind: "none" });
+  });
+
+  it("does not ask about a single reachable project", () => {
+    // A question with one answer is not a question. Nothing names it, so
+    // nothing is stated either — the rep is simply not interrupted.
+    expect(filingFor({ reachable: [{ id: "p-1" }] })).toEqual({ kind: "none" });
+  });
+});

--- a/frontend/src/screens/projectrecord.test.ts
+++ b/frontend/src/screens/projectrecord.test.ts
@@ -46,6 +46,38 @@ describe("the project tag a subject carries", () => {
     expect(withSubjectTag("Kurzer Austausch?", "")).toBe("Kurzer Austausch?");
   });
 
+  it("is empty for an ARCHIVED project, whose key may already be somebody else's", () => {
+    // A key is unique among LIVE projects only. Stamping an archived one would
+    // route the customer's reply to whichever project holds that key now.
+    expect(subjectTag(project({ archived_at: "2026-08-01T00:00:00Z" }))).toBe(
+      "",
+    );
+  });
+
+  it("clears another project's tag rather than adding a second one", () => {
+    // Two bracketed keys make the inbound matcher ambiguous, so it resolves to
+    // NEITHER — a subject carrying both files nowhere.
+    expect(withSubjectTag("[OTHER-9] Re: Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] Re: Hallo",
+    );
+  });
+
+  it("clears a key tag the rep moved into the middle of the subject", () => {
+    expect(withSubjectTag("Re: [OTHER-9] Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] Re: Hallo",
+    );
+  });
+
+  it("leaves a bracketed group the matcher could never read as a key", () => {
+    // The letter-led rule is what excludes a bare number, so `[2026]` is a year
+    // and stays. `[FYI]` is deliberately NOT in this test: it is key-shaped to
+    // the capture matcher too, so clearing it is correct — a subject carrying
+    // it alongside a real key would file nowhere.
+    expect(withSubjectTag("[2026] Budget", "[N2P-1]")).toBe(
+      "[N2P-1] [2026] Budget",
+    );
+  });
+
   it("takes its own tag back off, and nobody else's", () => {
     expect(stripSubjectTag("[N2P-1] Re: Hallo", "[N2P-1]")).toBe("Re: Hallo");
     // A different project's tag is the rep's text, not ours to remove.

--- a/frontend/src/screens/projectrecord.ts
+++ b/frontend/src/screens/projectrecord.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { Project } from "./projects.form";
+
+/**
+ * One project, whole — for the callers that need more of it than its name.
+ *
+ * `useEntityName` answers the question every EntityRef asks ("what do I call
+ * this id?") and caches a bare string under a key they all share. The composer
+ * needs the project KEY as well, to put in a subject line, and widening that
+ * cache entry would change what every other reference holds. So this is a
+ * second reader with its own key rather than a wider first one.
+ *
+ * Undefined id means no read: a caller with nothing to look up asks nothing.
+ */
+export function useProjectRecord(id?: string): {
+  project: Project | null;
+  settled: boolean;
+} {
+  const query = useQuery({
+    queryKey: ["project", "record", id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/projects/{id}", {
+        params: { path: { id: id ?? "" } },
+      });
+      // A project the reader may not open is not an error to shout about here:
+      // the caller draws nothing either way, and a throw would take the
+      // composer down over a record it only wanted to name.
+      return error ? null : data;
+    },
+    enabled: Boolean(id),
+    staleTime: 60_000,
+  });
+  return {
+    project: query.data ?? null,
+    // Whether the read has finished, however it finished. A caller that states
+    // a filing must not state it while the answer is still on its way.
+    settled: Boolean(id) && !query.isPending,
+  };
+}
+
+/**
+ * The bracketed key a subject carries so the customer's reply files itself.
+ *
+ * The capture side reads `[KEY]` out of an inbound subject (the T1 rung of the
+ * attribution ladder) and matches it case-insensitively against live project
+ * keys. Writing the same shape on the way out is what closes that loop: a
+ * conversation started here comes back filed under the project it started in,
+ * even when the mail thread is broken by a forward or a new subject.
+ *
+ * A project with no key gets no tag rather than an empty `[]`, which the
+ * matcher reads as nothing anyway.
+ */
+export function subjectTag(project: Project | null): string {
+  return project?.key ? `[${project.key}]` : "";
+}
+
+/**
+ * `subject` carrying `tag` exactly once, at the front.
+ *
+ * Idempotent on purpose: the composer re-derives the subject whenever the
+ * filing changes, and a rep may also have typed the tag themselves. Re-applying
+ * must not produce `[N2P-1] [N2P-1] Re: …`. A tag the rep DELETED stays
+ * deleted — that is the opt-out, and this function is only called when the
+ * filing itself changes, never on every keystroke.
+ */
+export function withSubjectTag(subject: string, tag: string): string {
+  if (!tag) {
+    return subject;
+  }
+  const already = stripSubjectTag(subject, tag);
+  return already ? `${tag} ${already}` : tag;
+}
+
+/** `subject` with a leading `tag` removed, if it carries one. */
+export function stripSubjectTag(subject: string, tag: string): string {
+  if (!tag) {
+    return subject;
+  }
+  const trimmed = subject.trimStart();
+  return trimmed.startsWith(tag)
+    ? trimmed.slice(tag.length).trimStart()
+    : subject;
+}
+
+/** Where a send files, and what the composer should say about it. */
+export type Filing =
+  /** Nothing to say: no project is in reach. */
+  | { kind: "none" }
+  /**
+   * One project, derived rather than chosen — the thread's own, or the deal's
+   * when the thread carries none. The composer STATES it and offers to opt out.
+   */
+  | { kind: "derived"; projectId: string; from: "thread" | "deal" }
+  /** Several in reach and none derivable: the rep is asked. */
+  | { kind: "choose" };
+
+/**
+ * Which project a send files under, before the rep touches anything.
+ *
+ * The order is the one the capture ladder already uses on the way in, so a
+ * message this composer sends lands where a message it captured would: the
+ * thread's own filing wins, because a conversation is about one body of work
+ * and a sibling already settled it. A deal's project is the fallback for a
+ * thread that predates it — the common case for a deal whose project was
+ * attached after the conversation started.
+ *
+ * `choose` is reserved for genuine ambiguity: several projects in reach and
+ * nothing naming one of them. A single reachable project is not ambiguous, and
+ * asking about it would be a question with one answer.
+ */
+export function filingFor(input: {
+  threadProjectId?: string | null;
+  dealProjectId?: string | null;
+  reachable: readonly { id: string }[];
+}): Filing {
+  if (input.threadProjectId) {
+    return {
+      kind: "derived",
+      projectId: input.threadProjectId,
+      from: "thread",
+    };
+  }
+  if (input.dealProjectId) {
+    return { kind: "derived", projectId: input.dealProjectId, from: "deal" };
+  }
+  return input.reachable.length > 1 ? { kind: "choose" } : { kind: "none" };
+}

--- a/frontend/src/screens/projectrecord.ts
+++ b/frontend/src/screens/projectrecord.ts
@@ -21,7 +21,11 @@ export function useProjectRecord(id?: string): {
   settled: boolean;
 } {
   const query = useQuery({
-    queryKey: ["project", "record", id],
+    // Under the ["project", id] prefix the edit and archive paths already
+    // invalidate, so a renamed or archived project reaches this reader too. A
+    // key outside that prefix would keep serving the old record for its whole
+    // freshness window.
+    queryKey: ["project", id, "record"],
     queryFn: async () => {
       const { data, error } = await api.GET("/projects/{id}", {
         params: { path: { id: id ?? "" } },
@@ -55,7 +59,14 @@ export function useProjectRecord(id?: string): {
  * matcher reads as nothing anyway.
  */
 export function subjectTag(project: Project | null): string {
-  return project?.key ? `[${project.key}]` : "";
+  // An ARCHIVED project's key is not ours to write. A key is unique among LIVE
+  // projects only, so an archived one may already have been taken by a new
+  // project — stamping it would route the customer's reply to whichever project
+  // holds that key now, which is not the one this message is about.
+  if (!project?.key || project.archived_at) {
+    return "";
+  }
+  return `[${project.key}]`;
 }
 
 /**
@@ -71,8 +82,30 @@ export function withSubjectTag(subject: string, tag: string): string {
   if (!tag) {
     return subject;
   }
-  const already = stripSubjectTag(subject, tag);
-  return already ? `${tag} ${already}` : tag;
+  return prefixed(stripEveryKeyTag(subject), tag);
+}
+
+/**
+ * `subject` with every bracketed project key removed, wherever it sits.
+ *
+ * Not only the leading one, and not only ours: the inbound matcher reads EVERY
+ * `[...]` group in a subject, and two live keys make the attribution ambiguous
+ * — it resolves to neither. So a subject that already names another project, or
+ * names one mid-line, has to be cleared before this one is written, or the tag
+ * added here silently cancels itself out.
+ *
+ * Only key-SHAPED groups go. `[FYI]` is prose to the matcher and prose here.
+ */
+export function stripEveryKeyTag(subject: string): string {
+  return (
+    subject
+      .replace(/\[[^\]]*\]/g, (group) =>
+        keyShaped(group.slice(1, -1)) ? "" : group,
+      )
+      // Removing a tag from mid-line leaves the spaces that surrounded it, and a
+      // subject reading "Re:  Hallo" is a tell that something was cut out of it.
+      .replace(/\s{2,}/g, " ")
+  );
 }
 
 /** `subject` with a leading `tag` removed, if it carries one. */
@@ -84,6 +117,22 @@ export function stripSubjectTag(subject: string, tag: string): string {
   return trimmed.startsWith(tag)
     ? trimmed.slice(tag.length).trimStart()
     : subject;
+}
+
+/** `body` behind `tag`, with one space and no leading blank. */
+function prefixed(body: string, tag: string): string {
+  const rest = body.trim();
+  return rest ? `${tag} ${rest}` : tag;
+}
+
+/**
+ * Whether one bracketed token could be a project key — the frontend reading of
+ * the rule the capture side applies (`project_key_shape`): letter-led, then
+ * letters, digits and hyphens, bounded in length. A bare number is deliberately
+ * excluded, so `[2026]` and `[4711]` stay prose.
+ */
+function keyShaped(token: string): boolean {
+  return /^[a-z][a-z0-9-]{1,23}$/i.test(token.trim());
 }
 
 /** Where a send files, and what the composer should say about it. */


### PR DESCRIPTION
feat(compose): a message says which project it files under, and tags the subject

A reply from a deal now states where it will be filed and stamps the project's
key into the subject line, so the answer that comes back files itself.

Three rules, in one place (frontend/src/screens/projectrecord.ts):

- The thread's own project wins. A conversation is about one body of work and a
  sibling message already settled it — the same order the capture ladder walks
  on the way in.
- A deal's project is the fallback for a thread that carries none. That is the
  ordinary case for a deal whose project was attached after the mail started,
  and the copy names the reason: the rep never put this project on this
  conversation, so being told where it came from is the difference between a
  fact and a surprise.
- Several in reach and nothing naming one is the only case that asks. A single
  reachable project is not ambiguous, and a question with one answer is not a
  question.

The subject tag is `[KEY]`, the shape capture already reads back
(capture/projectkeytoken.go). Writing it on the way out closes a loop that was
open at one end: a conversation started here returns filed under the project it
started in, even when the mail thread is broken by a forward or a new subject.
It is applied to the Subject field itself rather than at send, so the rep sees
it and can delete it.

Declining the filing takes the tag out and leaves the rep's own words. The
subject is rewritten only when the FILING changes, never on a keystroke, so a
tag deleted by hand stays deleted — a second way to say the same thing.

Known limit, stated beside the component and tracked as its own work: the reply
endpoint takes no links, so on a reply the tag is what carries the project
rather than a link on the outbound row. The account-started path does send the
link.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replies and deal-anchored sends now state which project they will file under and stamp the project key into the subject so replies auto-file to the same project. Previously replies carried no project context; now we derive it and propagate it via a subject tag with an opt-out.

- Filing rules: thread project wins; otherwise fall back to the deal’s project; ask only when several projects are in reach and none is named. Pending/failed reads are treated as unsettled and render nothing. A checkbox (“File under this project”) controls filing and the tag.
- Subject tag: adds “[KEY]” at the start of the Subject, clears any existing key-shaped bracket before adding, and never tags archived or keyless projects. Opting out removes the tag; manual deletion stays deleted. AI draft subjects fill in behind an existing tag; rejecting a draft preserves the tag.
- Reply path limitation: the reply endpoint does not accept `links`; the subject tag carries the project. For deal-anchored new messages, we include the project link via `composedLinks`.
- Code/tests/i18n: new `projectrecord.ts` holds filing logic, subject-tag helpers, and `useProjectRecord`/`useProjectFiling`; `compose.tsx` integrates them and shares the deal read key with the deal page. Unit tests added; i18n strings in `en`, `de`, and `vi`.

<sup>Written for commit 477cffaafec5084e40cd046028d726cf71866663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project filing support when composing and replying to messages.
  * Messages can be filed under a deal’s project or the current project.
  * Added automatic subject tags indicating project filing, with options to add or remove them.
  * Added localized filing messages in English, German, and Vietnamese.

* **Bug Fixes**
  * Replies now fall back to the linked deal’s project when no thread project is available.
  * Improved subject-tag handling to prevent duplicates and exclude archived projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->