### PR TITLE
docs(partners): the tutorial stops calling shipped features missing

### DIFF
--- a/docs/how-to/set-up-a-partner-program.md
+++ b/docs/how-to/set-up-a-partner-program.md
@@ -106,9 +106,13 @@ partners so filtering stays useful.
   companies that came through this partner. A partner-sourced deal appears only in the second,
   because the deal belongs to the customer.
 - **Commission** sits under that, one row per entry, naming the deal it was earned on. Entries
-  appear on their own when a partner-sourced deal is won; nobody creates them by hand. The
-  statuses (accrued → approved → paid, or reversed) are shown but **cannot yet be changed from
-  the app** — deciding a commission exists in the API only.
+  appear on their own when a partner-sourced deal is won; nobody creates them by hand. Each row
+  offers the steps its state allows — **Approve** an accrued entry, **Mark as paid** an approved
+  one, **Reverse** anything still live — and every one confirms first. Reversing asks why, and
+  the reason stays with the entry. **Marking paid records what your finance system already did;
+  Margince moves no money.** Above the ledger sits what is **still owed**, per currency.
+- **Deciding needs the grant.** A seat without `commission: update` sees the entries and no
+  controls, with the column saying so rather than going blank.
 - **A simple weekly loop:** filter the list for **Applied** and push certifications forward;
   scan for partners whose stage is behind reality and correct it; make sure every in-flight
   partner has a next step with a due date.

--- a/docs/how-to/work-your-pipeline.md
+++ b/docs/how-to/work-your-pipeline.md
@@ -150,7 +150,14 @@ Pipeline narrows either view to them.
 ## Narrow the list, and keep the narrowing
 
 Filters, on both views: **Stage**, **Company**, **Stalled only**, **My deals**,
-**Partner-sourced**, the **Pipeline** picker, and a **Show archived** toggle.
+**Partner-sourced**, **Partner**, the **Pipeline** picker, and a **Show archived**
+toggle.
+
+**Partner-sourced** and **Partner** answer different questions: the first asks
+whether a deal came through any partner at all, the second narrows to one named
+partner. **Partner** appears only once a company has been made a partner — with
+no partner program there is nothing to pick from. The board's column totals
+narrow with the list.
 
 **There is no search box on this screen.** To find a deal by name, use the global
 **Search everything…** at the top, or narrow with the filters.

--- a/docs/tutorials/run-a-partner-program.md
+++ b/docs/tutorials/run-a-partner-program.md
@@ -18,9 +18,13 @@ Margince you can:
 - **Answer "what have we earned?"** — the question every partner eventually
   asks — from one screen on their company page.
 
-It is a prototype. Two things are missing, and both are covered at the end:
-you cannot mark a commission as paid from the app, and partners cannot log in
-to see their own numbers.
+One thing is deliberately absent and is covered at the end: partners cannot
+log in to see their own numbers.
+
+**Margince does not pay anybody.** You settle a partner in whatever system you
+pay people from; what Margince holds is the record of what was earned, agreed
+and settled. Marking an entry *Paid* here says your finance system already
+paid it.
 
 **This page explains how partner programs work and shows you one deal from
 start to finish.** For the setup form field by field — every role, every
@@ -133,8 +137,23 @@ Every entry has a status:
 |---|---|
 | **Accrued** | earned, not yet agreed — where every entry starts |
 | **Approved** | signed off |
-| **Paid** | the money has gone out |
-| **Reversed** | cancelled, because the deal was reopened |
+| **Paid** | your finance system has paid it |
+| **Reversed** | cancelled — by you, or because the deal was reopened |
+
+**Moving an entry along.** Each row offers the steps its current state allows:
+an accrued entry can be **Approved**, an approved one **Marked as paid**, and
+anything still live can be **Reversed**. Every one asks you to confirm first,
+because none of them is undone by pressing the same button again. Reversing
+asks why, and the reason travels with the entry so it can be explained to the
+partner later.
+
+You will see no buttons at all if your seat cannot decide commissions — the
+column says so rather than going blank, so you can tell "nothing to decide
+here" from "not yours to decide".
+
+**What is still owed** sits above the ledger: everything accrued or approved,
+totalled per currency. Two currencies are never added together, because the
+sum would mean nothing.
 
 **Reopening a won deal does not delete the commission.** Margince adds a
 reversal row and marks the original *Reversed*, leaving both on the page. Win
@@ -146,18 +165,22 @@ The rate is fixed at the moment a deal is won. Move a partner to a different
 tier and it changes what their *next* deals earn; it never rewrites what an
 old one already paid.
 
-## What this prototype cannot do yet
+## What this cannot do
 
-- **You cannot approve or pay from the app.** Those steps exist behind the
-  scenes but have no buttons. Use the Commission panel as the record of what
-  is owed, and pay it however you normally pay people.
-- **Partners cannot see any of this.** There is no partner login. Everything
-  here is yours internally.
-- **The API is more permissive than the app.** Deals created through the API
-  can name any company as the partner, even one that is not a partner — in
-  which case nothing is ever earned. The web form only offers real partners.
-- **Assistants can read a deal's partner** and what they did, but cannot yet
-  read or change the partner record itself.
+- **Margince does not move money.** Approving and marking paid are record
+  keeping: they say what your finance system has agreed and settled. Nothing
+  here pays anybody.
+- **Partners cannot see any of this.** There is no partner login, and none is
+  planned. When a partner asks what they have earned, somebody on your side
+  opens their company page and tells them — that is the intended workflow, not
+  a gap.
+- **A partner with no margin tier earns nothing, quietly.** Win a deal they
+  sourced and no entry appears, because there is no rate to apply. That is
+  correct for a partner you never agreed a rate with; if you expected a
+  commission and see none, check the tier on their Partner tab.
+- **Assistants can READ partners now** — a partner's tier, certification and
+  stage, and the list of partners — but cannot change any of it. Setting a
+  partner's terms is a human act.
 
 ## Where next
 


### PR DESCRIPTION
Three user-facing pages described a partner programme that no longer exists.

## The tutorial

Opened by calling itself a prototype whose two gaps were "you cannot mark a commission as paid from the app" and "partners cannot log in". The first shipped in #2385. It also carried a **"What this prototype cannot do yet"** section listing three things that are now done — the worst kind of stale, because a reader who believes it will not go looking for the button.

Now says how to move an entry along (which steps each state allows, that every one confirms, that reversing asks why), and what the **Still owed** figure means.

The "cannot do" section keeps what is genuinely true and says **why** rather than "not yet":
- partners have no login and none is planned — that was a decision, not a gap
- a partner with no margin tier earning nothing is correct for a partner you never agreed a rate with

## Margince does not move money

Now stated where a reader meets the word *Paid*, not in a footnote. Marking an entry paid records what a finance system already did.

## The how-to

Said the statuses "cannot yet be changed from the app — deciding a commission exists in the API only". Both halves are false since #2385. Also gains the line that a seat without `commission: update` sees the entries and no controls.

## The pipeline page

Its filter list was missing **Partner**. The distinction is worth a sentence: *Partner-sourced* asks whether a deal came through any partner, *Partner* narrows to one.

## Verification

Every control named is checked against the **shipped i18n string**, not the code's own name for it — Approve, Mark as paid, Reverse, Still owed, Partner, Any partner. That is the failure mode a walkthrough written from memory of the code has.

Docs-only. `TestPublicTreeCitesNothingPrivate` and the rulebook-parity gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates partner program docs to match shipped behavior and avoid implying features are missing. Readers now see how commissions move through states, what “Paid” means, and how to filter by partner.

- Tutorial: removes “prototype” framing; adds step-by-step actions per state (Approve, Mark as paid, Reverse with reason and confirm); explains Still owed; clarifies that “Paid” records what finance already did; states no partner login is planned; notes no-tier partners earn nothing by design; clarifies assistants are read-only for partner records.
- How-to: replaces “cannot yet be changed from the app” with current controls; documents that seats without `commission: update` see entries but no buttons.
- Pipeline: adds the missing Partner filter and explains Partner-sourced (any partner) vs Partner (one partner); notes column totals narrow with filters.
- Terminology: aligns with shipped UI strings (Approve, Mark as paid, Reverse, Still owed, Partner, Any partner). Docs-only change; no product behavior changes.

<sup>Written for commit 78b10a7cf59428f18db0a6c89498f97c868c43ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified commission approval, payment, and reversal workflows, including confirmations, reversal reasons, permissions, and currency-specific owed totals.
  * Explained that payment status records settlement completed elsewhere; the app does not make partner payments.
  * Documented commission status transitions, partner access limitations, and assistant permissions.
  * Added guidance for the named Partner pipeline filter and clarified when it appears and how filters affect board totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->