### PR TITLE
fix(frontend): the native-control gate derives its pre-filter from its own list

### DIFF
--- a/frontend/src/design-system/native-controls.test.ts
+++ b/frontend/src/design-system/native-controls.test.ts
@@ -83,6 +83,24 @@ const SUBST = "$" + "{id}";
 // The elements a native dropdown is made of.
 const nativeControls = new Set(["select", "option", "optgroup"]);
 
+// The pre-filter's alternation, DERIVED from the set above rather than restated
+// beside it.
+//
+// It was restated, and that is the defect this file's own subject describes
+// wearing different clothes: the prefilter was a second copy of the element
+// list, inside the gate whose job is finding second copies. Both lists were
+// individually correct, so nothing failed — until a fourth element was added to
+// the set and the gate went silently blind to it, because a file spelling only
+// `<datalist>` was skipped before it was ever parsed.
+//
+// The backslash arm is NOT part of the derivation and stays hand-written: it is
+// a property of ESCAPES, not of any element name. `'<sel\u0065ct>'` holds no
+// verbatim `select` in its raw text but cooks to one, and every escape begins
+// with a backslash — so a file with neither a name nor a backslash cannot spell
+// one. Deriving it from the set would be wrong, which is why it is stated once
+// with its reason instead.
+const prefilter = new RegExp(`${[...nativeControls].join("|")}|\\\\`);
+
 // Tests and stories are scanned too: a test that drives a native control is a
 // test of the wrong control, and a story catalogues what we ship. Which files
 // those are is ../../scripts/lib/source-tree.ts's answer, shared with the
@@ -116,7 +134,7 @@ function findNativeControls(path: string, text: string): string[] {
   // character reaches cooked text only by appearing raw or by coming from an
   // escape, and every escape begins with a backslash — so a file with neither a
   // name nor a backslash cannot spell one, and skipping it costs no coverage.
-  if (!/select|option|optgroup|\\/.test(text)) return [];
+  if (!prefilter.test(text)) return [];
   const source = ts.createSourceFile(
     path,
     text,
@@ -520,4 +538,28 @@ describe("the native-control detector sees what it claims to", () => {
       if (tc.expect) expect(hits).toEqual(tc.expect);
     });
   }
+
+  // The case that is actually owed, and it is not "the prefilter is right".
+  //
+  // Both lists were individually correct while nothing bound them, so every
+  // test anybody would think to write passed. What has to be asserted is the
+  // DERIVATION: that a name added to the declared set reaches the prefilter
+  // without anybody remembering to edit a regex.
+  //
+  // Written against the set rather than against a literal, so it cannot itself
+  // become a third copy.
+  it("derives its pre-filter from the declared set, so a fourth element is not invisible", () => {
+    for (const tag of nativeControls) {
+      expect(
+        prefilter.test(`const a = <${tag} />;`),
+        `the pre-filter does not admit a file spelling <${tag}>`,
+      ).toBe(true);
+    }
+    // And a name that is NOT in the set must not be admitted by the name arm —
+    // otherwise "derived" would be satisfied by a regex matching everything.
+    expect(prefilter.test("const a = <div />;")).toBe(false);
+    // The backslash arm is separate and stays: an escape can spell any of the
+    // names without their letters appearing raw.
+    expect(prefilter.test("const a = '<sel\\u0065ct>';")).toBe(true);
+  });
 });

--- a/frontend/src/design-system/native-controls.test.ts
+++ b/frontend/src/design-system/native-controls.test.ts
@@ -539,27 +539,49 @@ describe("the native-control detector sees what it claims to", () => {
     });
   }
 
-  // The case that is actually owed, and it is not "the prefilter is right".
+  // Every element the rule declares is one the census can actually reach.
   //
-  // Both lists were individually correct while nothing bound them, so every
-  // test anybody would think to write passed. What has to be asserted is the
-  // DERIVATION: that a name added to the declared set reaches the prefilter
-  // without anybody remembering to edit a regex.
+  // Asserted through `findNativeControls` — the real entry point — rather than
+  // against the pre-filter directly, so it holds whatever stops a declared
+  // element being seen: the pre-filter, the parse, the boundary rule. A test of
+  // one component passes while the path through it is broken.
   //
-  // Written against the set rather than against a literal, so it cannot itself
-  // become a third copy.
-  it("derives its pre-filter from the declared set, so a fourth element is not invisible", () => {
+  // Keyed on the SET, so it is three assertions today and four the moment
+  // somebody adds a fourth, naming the new element without anybody remembering
+  // to write a case for it. That is the property worth having: the pre-filter
+  // was a hand-restated copy of this list, and the failure it produced was a
+  // file skipped before it was ever parsed — no finding, no error, and
+  // indistinguishable from a clean tree.
+  //
+  // What it does NOT do, stated because this file's standard is to say so:
+  // while the two lists agree it cannot detect that one is a restatement of the
+  // other. It goes red on the new element the instant the set grows.
+  it("can reach every element its own rule declares", () => {
     for (const tag of nativeControls) {
       expect(
-        prefilter.test(`const a = <${tag} />;`),
-        `the pre-filter does not admit a file spelling <${tag}>`,
-      ).toBe(true);
+        findNativeControls("probe.tsx", `const a = <${tag} />;`),
+        `<${tag}> is in the rule, but the census would never parse a file that only mentions it`,
+      ).not.toEqual([]);
     }
-    // And a name that is NOT in the set must not be admitted by the name arm —
-    // otherwise "derived" would be satisfied by a regex matching everything.
+  });
+
+  // The line between what is derived and what is hand-written, which is the
+  // whole of this fix and belongs here rather than only in the pull request:
+  // DERIVE what is a restatement of the rule, HAND-WRITE what is a property of
+  // the language.
+  //
+  // The names are the rule, so the pre-filter derives them. The backslash is
+  // not: it is a property of ESCAPES. `'<sel\u0065ct>'` holds no verbatim
+  // `select` in its raw text but cooks to one, and every escape begins with a
+  // backslash — so a file with neither a name nor a backslash cannot spell one.
+  // Deriving that arm from the set would be a second bug wearing the fix's
+  // clothes.
+  it("admits an escaped spelling, and does not admit an unrelated element", () => {
+    expect(
+      findNativeControls("probe.tsx", "const a = '<sel\\u0065ct>';"),
+    ).not.toEqual([]);
+    // Without this, "derived" would be satisfied by a pre-filter matching
+    // everything.
     expect(prefilter.test("const a = <div />;")).toBe(false);
-    // The backslash arm is separate and stays: an escape can spell any of the
-    // names without their letters appearing raw.
-    expect(prefilter.test("const a = '<sel\\u0065ct>';")).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #2425.

## The defect

`native-controls.test.ts` states its rule once:

```ts
const nativeControls = new Set(["select", "option", "optgroup"]);
```

and then **restates those three names by hand** in the pre-filter that decides
which files get parsed at all:

```ts
if (!/select|option|optgroup|\\/.test(text)) return [];
```

Both lists are individually correct, so nothing failed. Add a fourth element to
the declared set and the gate goes **silently blind** to it — a file spelling
only `<datalist>` is skipped before it is ever parsed, and a skipped file
produces no finding and no error. That is indistinguishable from a clean file.

Measured both directions, with each mutation verified **by diff** rather than
by a string match that might not have applied:

| | `nativeControls` + `"datalist"`, plus a probe case for it |
|---|---|
| before | **1 failed \| 33 passed** — `× reports a datalist` |
| after | **35 passed** |

## Why it survived review

This is the gate's own subject wearing different clothes: the pre-filter is a
second copy of the element list, **inside the census whose job is finding second
copies**. It sat on the axis nobody was watching — that file has no exemptions,
and exemptions were where we had been looking after #2419.

## The fix, and the test that is actually owed

The alternation is derived: `` new RegExp(`${[...nativeControls].join("|")}|\\\\`) ``.

The **backslash arm stays hand-written**, with the reason beside it: it is a
property of ESCAPES, not of any element name. `'<select>'` holds no
verbatim `select` in its raw text but cooks to one, and every escape begins with
a backslash. Deriving that from the set would be wrong.

The assertion is **not** "the pre-filter is right today" — two lists that agree
while nothing binds them pass every test anybody would think to write. It
asserts the **derivation**:

- every name in the declared set is admitted by the pre-filter;
- a name outside it is *not* (otherwise "derived" would be satisfied by a regex
  matching everything);
- the escape arm still holds.

Written against the set rather than against a literal, so it cannot itself
become a third copy.

**Honest about its reach**, since that is this file's own standard: with the
pre-filter hand-restated but the set unchanged, the new test does **not** fire —
the two lists agree and there is nothing yet to catch. It fires the moment the
set grows, naming the element:

```
AssertionError: the pre-filter does not admit a file spelling <datalist>
```

## Provenance and scope

Found by a sibling session from a note about the same defect class in
`consumermailonelist_test.go` (#2419), where a gate carried a hand-written
*sample* of the set it judged. `ext-imports.test.ts` was checked against this
class and is **clean** — its allowed set is read from `package.json`'s `exports`
rather than restated.

Test-file only; no product code changes. `make check-fe` green, **4396 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the native-control pre-filter from the declared set and verifies reachability through the real detector. Previously the pre-filter hardcoded tag names, so expanding the set could skip files silently; now the alternation tracks the set while preserving the explicit escape arm.

- Builds the pre-filter regex from `nativeControls`; keeps the backslash escape as a hand-written arm with rationale.
- Asserts through `findNativeControls` that every declared tag is reachable, an unrelated tag is not, and escaped spellings still match.
- Test-only change; no product code impacted.

<sup>Written for commit 8dcd1df67b4771afd2bbb7009532ccbc57ae3f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for native control detection across all declared controls.
  * Added validation that escaped control names are recognized correctly.
  * Added checks to ensure unrelated elements are not classified as native controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->