### PR TITLE
docs(projects): the project guides describe the product that shipped

### DIFF
--- a/docs/how-to/run-a-project.md
+++ b/docs/how-to/run-a-project.md
@@ -106,9 +106,10 @@ is **not** editable: it was minted from the name at creation and stays as it
 is, even if you rename the project. **Owner** offers *Me*, *Unassign*, and —
 when somebody else owns it — *Keep current owner*.
 
-The project's **customer** company cannot be changed after creation, but the
-companies working the project can: attach and detach them in the **Companies**
-section on the project page.
+The **Companies** section on the project page is where the company set is
+changed — attach, re-role and detach. The anchor `organization_id` the list
+column shows is not editable on this form, but which company holds the
+**Customer** role is: attach it again under a different role.
 
 **Archive project** asks for confirmation: *Archiving removes this project
 from the live list and frees its key. This cannot be undone from the UI.* The
@@ -132,24 +133,36 @@ filing out and tells you, above the Subject field:
 > This will be filed under *Name*, this deal's project.
 > [KEY] is added to the subject so their reply files itself here.
 
-It derives the project in the same order the inbound ladder uses: the thread's
-own project first — the line then reads *…like the rest of this conversation* —
-and the **deal's** project when the thread has none. If neither names one,
-nothing is shown at all.
+It derives the project the way the inbound ladder does, as far as it can: the
+thread's own project first — the line then reads *…like the rest of this
+conversation* — and the **deal's** project when the thread has none, which it
+can only offer when you are replying from a deal. Replying from a company or a
+contact has no deal to fall back on. If neither names a project, nothing is
+shown at all.
 
 The **Subject** field is stamped with `[KEY]`. Untick the box and both lines go
 and the tag is removed; tick it again and the tag comes back in front of
 whatever you have typed. A tag you delete by hand stays deleted.
 
+**What unticking does depends on where the project came from.** On the deal
+fallback it genuinely declines the filing: nothing else was carrying it. On a
+thread already filed under a project, the reply **still inherits that project
+link** from the message it answers — unticking removes the tag and the claim,
+not the filing. To move a filed conversation, use **Relink**, which moves the
+whole thread.
+
 If the subject already carries a **different** project's key, sending under this
 one removes it — two keys in a subject make the inbound rule ambiguous, so it
-files under neither. Bracketed text that could not be a key (`[FYI]`) is left
-alone.
+files under neither. Be aware that the rule is shape-based, not a lookup: any
+bracketed word that *could* be a key goes, `[FYI]` included. Only a group that
+could never be one — `[2026]`, which is not letter-led — survives.
 
-> **On a reply, the subject tag is the only thing carrying the project.** The
-> reply itself inherits the links of the message it answers, because the reply
-> endpoint takes none of its own. So your sent copy may not appear on the
-> project's timeline until the customer's tagged reply comes back and is filed.
+> **When the project came from the DEAL, the subject tag is the only thing
+> carrying it.** A reply inherits the links of the message it answers and can
+> add none of its own, so a reply on a thread the project never reached does
+> not put your sent copy on the project's timeline — the customer's tagged
+> answer is what brings the conversation in. A thread already filed does not
+> have this problem: its reply inherits the project link.
 > Tracked as [issue #2422](https://github.com/margince/margince/issues/2422).
 
 **Writing to an account (company page → Write email).** A new conversation has
@@ -187,7 +200,8 @@ or let the next message in the thread carry the filing.
    thread cannot inherit from a Telegram conversation, which stops a forged
    `References` header from filing mail onto a chat the sender was never in.
    Siblings under legal hold or archived settle nothing, and where siblings
-   disagree the most recently filed one wins.
+   disagree the most recent **message** wins — by when it was sent or received,
+   not by when somebody filed it.
 2. **The deal.** A message linked to a deal is filed under the deal's project.
    Two deals on the message rolling up to two *different* projects cancel out,
    the same way two keys do.
@@ -198,8 +212,11 @@ or let the next message in the thread carry the filing.
    different keys in one subject cancel out: the message says nothing reliable
    and is not filed.
 4. **An offer to a person.** When none of the above answers, Margince does not
-   file the message. It stages an approval — **File under a project** — in
-   **Approvals**, and a person confirms or declines. Confirm files the message exactly as a manual
+   file the message — and it only *asks* when it has something worth asking
+   about: exactly one live project the message could plausibly belong to, or
+   one that stands out among several. Then it stages an approval — **File under
+   a project** — in **Approvals**, and a person confirms or declines. With
+   nothing to offer it stays quiet, which is the common case. Confirm files the message exactly as a manual
    relink would; decline means the same message-and-project pairing is not
    offered again. An offer nobody answers expires, and the next message in the
    thread opens a fresh one.
@@ -242,7 +259,9 @@ exact or confirmed by a person.
 
 ## Reports
 
-Three project reports live in **Reports**:
+Three project reports are built and answer over the API
+(`GET /reports/{report}`), but the **Reports** screen does not offer them yet —
+it lists the deal reports and quotas only:
 
 - **Projects by phase** — how many projects sit in each phase, and their won
   and open deal value.

--- a/docs/how-to/run-a-project.md
+++ b/docs/how-to/run-a-project.md
@@ -28,33 +28,30 @@ knowing how the automatic filing decides.
 **Projects** in the left navigation lists every live project: name and key,
 company, phase, owner, last activity.
 
-- **All / In delivery** at the top switch between every project and the ones
-  in the **Delivering** phase.
-- **Filter** narrows by phase (**All phases** or one of the four).
+- **All / In delivery / A–Z** at the top switch between every project, the ones
+  in the **Delivering** phase, and an alphabetical listing.
+- **Phase** narrows by phase (**All phases** or one of the four).
 - **Search** matches names and keys.
 - **Show archived** includes archived projects, marked **Archived**.
-- **New project** opens the create form: **Project name**, **Key**,
-  **Company** (required), **Owner**, **Description**, **Target end date**.
+- **New project** opens the create form: **Project name**, **Company**
+  (required), **Description**, **Target end date**. There is no key field —
+  the key is minted from the name — and no owner field: a new project belongs
+  to whoever creates it, and is reassigned later on the edit form.
 
 ## The project page, section by section
 
-**Header** — name, company (click it to open the company), owner, phase and
-key. The verbs beside it: **Edit project**, **Archive project**, **Share**.
+**Header** — name, the customer company (click it to open the company), owner,
+phase and key. The verbs beside it: **Edit project**, **Archive project**, **Share**.
 
 **Phase** — the four phases in a row with the current one highlighted. Press
 another to move; see *Moving the phase* below.
 
 **Figures** — **Open deal value**, **Won deal value**, **Open commitments**,
-**Last activity**, **Activities**. Under them, the **coverage line**:
+**Last activity**, **Activities**.
 
-> *N attributed · N awaiting a decision · N on this project's people and deals
-> not attributed*
-
-Read it as: how much mail is filed under this project, how many filing offers
-are waiting in **Approvals** for somebody to confirm or decline, and how much
-mail sits on the project's contacts and deals without being filed under the
-project. A large third number on a project with a key usually means the key is
-not in the subjects.
+**Companies** (right, first card) — every company on this project with its
+role, and the **Attach company** / **Detach** verbs. See
+[set-up-projects.md](set-up-projects.md#putting-companies-and-people-on-a-project).
 
 **Phase history** (right) — every phase the project has been in, with time
 spent, and each move with date, who moved it and the reason. A move made by
@@ -103,9 +100,14 @@ project is archived and takes no changes.*
 
 ## Editing, archiving, sharing
 
-**Edit project** changes name, key, owner, description and target end date.
-The company cannot be changed after creation. **Owner** offers *Me*,
-*Unassign*, and — when somebody else owns it — *Keep current owner*.
+**Edit project** changes name, owner, description and target end date. The key
+is **not** editable: it was minted from the name at creation and stays as it
+is, even if you rename the project. **Owner** offers *Me*, *Unassign*, and —
+when somebody else owns it — *Keep current owner*.
+
+The project's **customer** company cannot be changed after creation, but the
+companies working the project can: attach and detach them in the **Companies**
+section on the project page.
 
 **Archive project** asks for confirmation: *Archiving removes this project
 from the live list and frees its key. This cannot be undone from the UI.* The
@@ -120,49 +122,90 @@ see who already has access. A share never widens anything beyond this project.
 
 ### Sending
 
-Open the composer from a company or contact page (**Write email**) or reply
-from a timeline. Beneath **Draft to** is the **Project** picker: **No
-project**, then every live project on the account as `KEY · Name`. When the
-account has exactly one live project, it is pre-selected; with several, you
-choose. Closed projects are not offered — a new message is not about history.
+Two composers, two behaviours.
 
-Picking one shows **Scoped to KEY** under the picker, and does two things:
+**Replying (from a project, a deal or any timeline).** The composer works the
+filing out and tells you, above the Subject field:
+
+> ☑ **File under this project**
+> This will be filed under *Name*, this deal's project.
+> [KEY] is added to the subject so their reply files itself here.
+
+It derives the project in the same order the inbound ladder uses: the thread's
+own project first — the line then reads *…like the rest of this conversation* —
+and the **deal's** project when the thread has none. If neither names one,
+nothing is shown at all.
+
+The **Subject** field is stamped with `[KEY]`. Untick the box and both lines go
+and the tag is removed; tick it again and the tag comes back in front of
+whatever you have typed. A tag you delete by hand stays deleted.
+
+If the subject already carries a **different** project's key, sending under this
+one removes it — two keys in a subject make the inbound rule ambiguous, so it
+files under neither. Bracketed text that could not be a key (`[FYI]`) is left
+alone.
+
+> **On a reply, the subject tag is the only thing carrying the project.** The
+> reply itself inherits the links of the message it answers, because the reply
+> endpoint takes none of its own. So your sent copy may not appear on the
+> project's timeline until the customer's tagged reply comes back and is filed.
+> Tracked as [issue #2422](https://github.com/margince/margince/issues/2422).
+
+**Writing to an account (company page → Write email).** A new conversation has
+no thread to inherit from, so this composer asks. Under **Draft to** — and
+under **Related to**, when the account has deals — is the **Project** picker:
+**No project**, then the account's live projects as `KEY · Name`. One live
+project is pre-selected; several start at **No project**. Closed projects are
+not offered.
+
+Picking one shows **Scoped to KEY** and does two things:
 
 1. **Draft with AI** reads only what is filed under that project or under no
-   project. Mail filed under another project on the same account is left out
-   of the draft and of its **Based on:** line.
-2. The sent message is filed under the project, so it appears on the project's
-   timeline and replies to it inherit the filing.
+   project. Mail filed under another project on the same account is left out of
+   the draft and of its **Based on:** line.
+2. The sent message is **linked** to the project — this composer does send the
+   link — so it appears on the project's timeline straight away.
 
-You can also file without the picker: put the key in square brackets in the
-subject — `[NW-ERP] kickoff agenda` — and the rule below does the rest.
+You can also file without either control: put the key in square brackets in the
+subject — `[NER-1] kickoff agenda` — and the rule below does the rest.
 
 ### Receiving
 
 Every captured email is run through a fixed ladder, in this order, and the
-first rule that answers wins. No model is involved; these rules are exact.
+first rule that answers wins. **No model is involved in rungs 1–3; these rules
+are exact.** A rung that finds a project the reader may not use — archived, or
+outside their access — counts as no match, and the ladder carries on to the
+next rung rather than stopping.
+
+The ladder runs just after the message is captured, not during. A message that
+arrives before its project exists is not re-filed later on its own; relink it,
+or let the next message in the thread carry the filing.
 
 1. **The thread.** A reply to a conversation already filed under a project is
-   filed under the same project.
+   filed under the same project. Matched **within one medium only** — a mail
+   thread cannot inherit from a Telegram conversation, which stops a forged
+   `References` header from filing mail onto a chat the sender was never in.
+   Siblings under legal hold or archived settle nothing, and where siblings
+   disagree the most recently filed one wins.
 2. **The deal.** A message linked to a deal is filed under the deal's project.
+   Two deals on the message rolling up to two *different* projects cancel out,
+   the same way two keys do.
 3. **The key in the subject.** A subject carrying the key **in square
    brackets** — `[ERP-27] status` — is filed under that project. A bare
    `ERP-27` in the subject is not a reference; the brackets are what stops a
    project keyed `RE` from swallowing every reply in the installation. Two
    different keys in one subject cancel out: the message says nothing reliable
    and is not filed.
-4. **An offer to a person.** When none of the above answers and the message
-   reaches an account with exactly one live project (or with several, one of
-   which is clearly the closest match by content), Margince does not file it.
-   It stages an approval — **File under a project** — in **Approvals**. A
-   person confirms or declines. Confirm files the message exactly as a manual
+4. **An offer to a person.** When none of the above answers, Margince does not
+   file the message. It stages an approval — **File under a project** — in
+   **Approvals**, and a person confirms or declines. Confirm files the message exactly as a manual
    relink would; decline means the same message-and-project pairing is not
    offered again. An offer nobody answers expires, and the next message in the
    thread opens a fresh one.
 
 Most mail belongs to no project, and that is the correct answer. A message
 that reaches none of the four rungs stays on the contact's and company's
-timeline unfiled, and the coverage line counts it in its third number.
+timeline unfiled, which is where it belongs.
 
 ### When nothing matched, or the wrong thing did
 
@@ -198,8 +241,7 @@ exact or confirmed by a person.
 
 ## Reports
 
-*Available from the next release.* Three project reports are being added to
-**Reports**:
+Three project reports live in **Reports**:
 
 - **Projects by phase** — how many projects sit in each phase, and their won
   and open deal value.
@@ -212,11 +254,13 @@ exact or confirmed by a person.
 
 An agent connected over MCP sees a project exactly as the person whose
 passport it holds would. `read_project_360` returns the page above, section by
-section, with the coverage figures. `catch_me_up_on` with a `project_id`
+section. `catch_me_up_on` with a `project_id`
 answers "what has been happening?" from what is filed under the project or
 under none. `prepare_handoff` assembles the sales-to-delivery handover and
 names each gap the records leave. `advance_project_phase` moves a phase under
-the same rules as the page, with a person approving the move before it runs.
+the same rules as the page, and runs straight away under a passport whose
+scopes admit it — the passport and the seat behind it are the confinement,
+not an approval step.
 
 ## What you can't change from the UI
 
@@ -225,7 +269,6 @@ the same rules as the page, with a person approving the move before it runs.
   switch in the app.
 - **Bulk owner transfer** — `POST /projects/transfer-ownership`, API only and
   human-only.
-- **Seating a stakeholder** — `PUT /projects/{id}/stakeholders`, API only.
 - **Un-archiving** a project.
 - **The phase and stakeholder-role lists** — fixed vocabulary; see
   [set-up-projects.md](set-up-projects.md#the-fixed-vocabularies).

--- a/docs/how-to/run-a-project.md
+++ b/docs/how-to/run-a-project.md
@@ -30,7 +30,8 @@ company, phase, owner, last activity.
 
 - **All / In delivery / A–Z** at the top switch between every project, the ones
   in the **Delivering** phase, and an alphabetical listing.
-- **Phase** narrows by phase (**All phases** or one of the four).
+- **Filter** opens the filter bar; its **Phase** chip narrows to one phase
+  (**All phases** or one of the four).
 - **Search** matches names and keys.
 - **Show archived** includes archived projects, marked **Archived**.
 - **New project** opens the create form: **Project name**, **Company**

--- a/docs/how-to/set-up-projects.md
+++ b/docs/how-to/set-up-projects.md
@@ -13,9 +13,9 @@ project) see [run-a-project.md](run-a-project.md).
 
 ## What a project is in Margince
 
-A project is **the body of work a deal is about**. It is started on a company,
-it carries several deals over time, and it outlives any one of them: it exists
-before the first deal is won and keeps running through delivery after it.
+A project is **the body of work a deal is about**. It carries several deals
+over time and outlives any one of them: it exists before the first deal is won
+and keeps running through delivery after it.
 
 It is not a folder you create at close-won. It is born in the **Initiative**
 phase while the deal is still open, so the early conversations are already
@@ -23,9 +23,15 @@ filed where the delivery team will look. Everything filed under it — mail,
 notes, tasks, contracts, documents, stakeholders — shows on one page, and the
 page carries the project's whole phase history with the reason for every move.
 
-A project has at most one company. A deal has at most one project, and the two
-must name the same company — attaching a deal to a project on another company
-is refused.
+**A project is worked by several companies.** One is its customer; the others
+are the partners and subcontractors delivering it. A project keeps at least one
+company at all times, and each company on it carries a role — **Customer**,
+**Partner** or **Subcontractor**.
+
+A deal has at most one project, and the deal's company must be **one of the
+companies on that project** — in any role. A partner's deal on a project it
+subcontracts is ordinary; a deal on a company the project has never heard of is
+refused.
 
 ## Who can do what
 
@@ -58,32 +64,71 @@ there shows, under **What this member sees**, what their role grants on
 **Projects**. The grants themselves are seeded per role and are not editable
 in the app.
 
-## Key conventions
+## Keys
 
-A key is the short handle written in email subjects — `[NW-ERP]` — and shown
-next to the project's name everywhere. The rules the product enforces:
+Every project gets a key — a short handle like `NER-1` that appears beside its
+name and, in square brackets, in email subjects. **You do not choose it.**
+Margince mints it from the project's name when the project is created, and it
+cannot be edited afterwards. An API caller that sends a `key` is refused with
+**422 `read_only`**.
 
-- Starts with a letter; then 1–23 more characters from letters, digits, `_`
-  and `-` (2–24 characters in total).
-- Unique across the installation, compared case-insensitively.
-- Optional. A project with no key is still filed by the other rules in
-  [run-a-project.md](run-a-project.md#referencing-a-project-from-email), but
-  nobody can address it from a subject line.
-- Archiving a project frees its key for reuse.
+### How a key is built
 
-Conventions the product does not enforce but that make keys work in practice:
+The **stem** comes from the name: the initials of a multi-word name, or the
+first eight letters of a single-word one. Then a hyphen and the **lowest free
+number** for that stem.
 
-- **Customer first, then the work:** `NW-ERP`, `NW-WMS`, `BRANDT-FLEET`. A
-  key is read by people who were not in the conversation.
-- **Never a common word.** Keys are matched only inside square brackets, so a
-  key like `RE` or `STATUS` cannot swallow ordinary mail — but it will still
-  confuse a reader. Keep them distinctive.
-- **Decide the key before the first email goes out.** Mail captured before
-  the key existed is not re-filed afterwards; it stays wherever the other
-  rules put it until somebody relinks it.
-- **Tell the customer.** The key only files mail when it is in the subject.
-  One line in the kickoff mail — *please keep `[NW-ERP]` in the subject* —
-  is what makes the rest automatic.
+| Project name | Key |
+|---|---|
+| `Nordwind ERP rollout` | `NER-1` |
+| `ERP rollout Acme` | `ERA-1` |
+| a second `ERP rollout Acme` | `ERA-2` |
+| `Datenmigration` | `DATENMIG-1` |
+| `7 Eleven Rollout` | `ER-1` |
+| `2026` | `PRJ-1` |
+
+Only ASCII letters and digits contribute, and leading digits are dropped so a
+name opening with a year still yields a usable stem. A name leaving fewer than
+two usable characters falls back to the stem `PRJ`.
+
+The number is the lowest one **free**, not the next one up — archiving a
+project releases its key, and the next project with that stem takes the number
+back.
+
+### The rules the product enforces
+
+- **Every live project has one.** There is no such thing as a project without a
+  key, and no way to create one.
+- **Unique among live projects**, compared case-insensitively: `ner-1` and
+  `NER-1` are the same key.
+- **Read-only** on create and on update.
+- **2–24 characters**, starting with a letter. This is the storage shape; since
+  you cannot type a key, it only matters when you read one.
+
+### Naming a project so its key reads well
+
+The key is the one thing your customer sees in every subject line, and the
+project's **name** is your only lever on it. Two habits are worth having:
+
+- **Lead with the customer, then the work.** `Nordwind ERP rollout` gives
+  `NER-1`. `ERP rollout` gives `ER-1`, which tells a reader nothing about
+  whose rollout it is once a second customer buys the same thing.
+- **Three or four words beats one.** A single-word name spends its whole key on
+  the opening letters of that word — `Datenmigration` becomes `DATENMIG-1`,
+  which is long and still says nothing about the customer.
+
+You cannot change a key by renaming the project later: the key is minted once,
+at creation. If a key is genuinely wrong, the honest fix is to archive the
+project and create it again under a better name — which also frees the old key.
+
+### Telling the customer
+
+The key only files their mail when it is in the subject, and the surest way to
+get it there is to let them reply to a message that already carries it.
+Margince puts the key in the subject of what you send from a deal or a project
+(see [run-a-project.md](run-a-project.md#sending)), and most mail clients keep
+it on the reply. One line in the kickoff mail — *please keep `[NER-1]` in the
+subject* — covers the rest.
 
 ## When to create a project
 
@@ -109,6 +154,53 @@ project moves into **Delivering** by itself — but only from **Initiative** or
 **Pursuing**. A project already delivering stays as it is, and a **Closed**
 project is never reopened silently by a win; reopening is a human move with a
 reason.
+
+## Putting companies and people on a project
+
+The same section appears on four pages, with the same two verbs, so the flow is
+learned once:
+
+| Page | Section | What it attaches |
+|---|---|---|
+| A project | **Companies** | companies onto this project |
+| A company | **Projects** | this company onto a project |
+| A contact | **Projects** | this person onto a project |
+| A deal | *(a chip, not a section)* | see below |
+
+**To attach**, press **Attach project** (or **Attach company** on a project
+page), search, pick, choose the role under **As**, and confirm. The role list
+opens on **Partner** rather than Customer, because a project already has its
+customer by the time you are adding anyone.
+
+**To detach**, press **Detach** on the row. The dialog is explicit that nothing
+is destroyed: *{name} stays as it is. Only its link to this record ends —
+nothing is deleted.* Detaching is not archiving; archiving a project is done on
+the project itself.
+
+**Attaching a company that is already on the project changes its role** rather
+than adding it twice. That is how you promote a subcontractor to a partner:
+attach it again with the new role.
+
+**Two removals are refused**, both with an explanation on screen:
+
+- **The last company.** *A project keeps at least one company; add another
+  before taking this one off.* A project belonging to nobody has no customer to
+  bill and no timeline that means anything.
+- **A company that still has deals here.** *This company still has N deal(s) on
+  the project; move or close them before taking the company off.* Otherwise the
+  deals would be left pointing at a project their company is no longer on.
+
+**A deal is different** and deliberately so: a deal carries at most **one**
+project, so it names it as a field on the deal form and shows it as a chip on
+the deal page. There is no attach/detach section, because a second control
+writing the same single value would be two ways to do one thing.
+
+### Seating a stakeholder
+
+Open the **contact**, not the project. The contact page's **Projects** section
+attaches them with a role: **Sponsor**, **Project lead**, **Delivery lead**,
+**Subject-matter expert** or **User**. The project page's **Stakeholders** card
+shows the result and is read-only.
 
 ## Visibility and sharing
 
@@ -141,10 +233,18 @@ direction is allowed; only closing needs a reason.
 | **Delivering** | a deal is won and the work is owed. Winning a deal puts the project here by itself. |
 | **Closed** | the work has ended, with a reason on record. Can be reopened later. |
 
-**Stakeholder role** — what a person is to this project. The project page
-lists the seats; seating somebody is an API write today
-(`PUT /projects/{id}/stakeholders`), not a form in the app, and no MCP tool
-offers it.
+**Company role** — what a company is to this project. The picker offers three;
+a project keeps at least one company at all times.
+
+| Role | You are here when… |
+|---|---|
+| **Customer** | they are buying the work. Usually one, and set when the project is created. |
+| **Partner** | they are delivering part of it alongside you, on their own commercial footing. |
+| **Subcontractor** | they are delivering part of it under you. |
+
+**Stakeholder role** — what a person is to this project. Seat somebody from the
+**contact's** page, in its **Projects** section; the project page's
+**Stakeholders** card shows the result and is read-only.
 
 | Role | You are here when… |
 |---|---|
@@ -152,6 +252,7 @@ offers it.
 | **Project lead** | they run it on the customer side. |
 | **Delivery lead** | they run it on your side. |
 | **Subject-matter expert** | they are consulted on a part of it. |
+| **User** | they will use what is delivered, and are consulted as one. |
 
 Neither list has a settings screen. Both are enforced end to end — in the API
 contract ([`backend/api/crm.yaml`](../../backend/api/crm.yaml), the `Project`
@@ -163,10 +264,13 @@ value is a small code change plus a migration, not a workaround.
 An agent connected over MCP works under the same grants as the person whose
 passport it carries. It can read a project (`read_project_360`, `read_record`
 with record type `project`), create or update one through the generic record
-tools, and move a phase with `advance_project_phase` — the last is staged
-for a person to approve before it runs. It can also archive one through
-`archive_record` — confirmation-required, so a person approves that too. It
-cannot transfer ownership; that endpoint is human-only.
+tools, move a phase with `advance_project_phase`, and archive one through
+`archive_record`.
+
+Those writes **execute immediately** under a passport whose grants admit them —
+they are not staged for approval. What confines an agent here is the passport's
+own scopes and the seat behind it, not a confirmation step. It cannot transfer
+ownership; that endpoint is human-only.
 
 ## What you can't change from the UI
 

--- a/docs/how-to/set-up-projects.md
+++ b/docs/how-to/set-up-projects.md
@@ -23,10 +23,15 @@ filed where the delivery team will look. Everything filed under it — mail,
 notes, tasks, contracts, documents, stakeholders — shows on one page, and the
 page carries the project's whole phase history with the reason for every move.
 
-**A project is worked by several companies.** One is its customer; the others
-are the partners and subcontractors delivering it. A project keeps at least one
-company at all times, and each company on it carries a role — **Customer**,
-**Partner** or **Subcontractor**.
+**A project is worked by several companies.** Typically one is its customer and
+the others are the partners and subcontractors delivering it. Each company on
+the project carries a role — **Customer**, **Partner** or **Subcontractor** —
+and a project keeps at least one company at all times.
+
+The roles are a description, not a constraint: nothing stops two companies both
+holding **Customer**, or none of them holding it. Where the product needs a
+single customer — the company shown in the project list's column — it takes the
+first one holding that role.
 
 A deal has at most one project, and the deal's company must be **one of the
 companies on that project** — in any role. A partner's deal on a project it
@@ -97,8 +102,9 @@ back.
 
 ### The rules the product enforces
 
-- **Every live project has one.** There is no such thing as a project without a
-  key, and no way to create one.
+- **Every project created through the product has one**, and there is no way to
+  create one without. The field is nullable in the schema, so a row from before
+  minting existed could still carry none; nothing you create today will.
 - **Unique among live projects**, compared case-insensitively: `ner-1` and
   `NER-1` are the same key.
 - **Read-only** on create and on update.
@@ -125,10 +131,13 @@ project and create it again under a better name — which also frees the old key
 
 The key only files their mail when it is in the subject, and the surest way to
 get it there is to let them reply to a message that already carries it.
-Margince puts the key in the subject of what you send from a deal or a project
-(see [run-a-project.md](run-a-project.md#sending)), and most mail clients keep
-it on the reply. One line in the kickoff mail — *please keep `[NER-1]` in the
-subject* — covers the rest.
+Margince stamps the key into the subject when you **reply** from a deal or a
+project (see [run-a-project.md](run-a-project.md#sending)); the account-started
+composer on a company page files by link instead and does not touch the
+subject, so type the key yourself when you start a conversation there. Mail
+clients generally keep the subject on a reply, but nothing guarantees it — one
+line in the kickoff mail, *please keep `[NER-1]` in the subject*, covers the
+case where somebody rewrites it.
 
 ## When to create a project
 
@@ -157,20 +166,22 @@ reason.
 
 ## Putting companies and people on a project
 
-The same section appears on four pages, with the same two verbs, so the flow is
-learned once:
+The same section appears on three pages, with the same two verbs, so the flow
+is learned once:
 
 | Page | Section | What it attaches |
 |---|---|---|
 | A project | **Companies** | companies onto this project |
 | A company | **Projects** | this company onto a project |
 | A contact | **Projects** | this person onto a project |
-| A deal | *(a chip, not a section)* | see below |
+
+A deal is the exception, and deliberately so — see below.
 
 **To attach**, press **Attach project** (or **Attach company** on a project
-page), search, pick, choose the role under **As**, and confirm. The role list
-opens on **Partner** rather than Customer, because a project already has its
-customer by the time you are adding anyone.
+page), choose the role under **As**, then search and pick. **Picking is what
+attaches** — there is no separate confirm — so set the role first. The role
+list opens on **Partner** rather than Customer, because a project already has
+its customer by the time you are adding anyone.
 
 **To detach**, press **Detach** on the row. The dialog is explicit that nothing
 is destroyed: *{name} stays as it is. Only its link to this record ends —
@@ -187,8 +198,9 @@ attach it again with the new role.
   before taking this one off.* A project belonging to nobody has no customer to
   bill and no timeline that means anything.
 - **A company that still has deals here.** *This company still has N deal(s) on
-  the project; move or close them before taking the company off.* Otherwise the
-  deals would be left pointing at a project their company is no longer on.
+  the project; move or close them before taking the company off.* The count is
+  of deals that still exist, so winning or losing one does not clear it: point
+  the deal at another project, or archive it.
 
 **A deal is different** and deliberately so: a deal carries at most **one**
 project, so it names it as a field on the deal form and shows it as a chip on

--- a/docs/tutorials/run-your-first-project.md
+++ b/docs/tutorials/run-your-first-project.md
@@ -66,8 +66,8 @@ proposal", the project exists.
 2. Fill in **Deal name** (`Nordwind ERP licences and rollout`) and **Value**
    (`180000`).
 3. Pick the **Company** — *Nordwind Logistik*. Until you do, the **Project**
-   field offers nothing but **New project…**: which projects you may file this
-   deal under is a question about its company, and there is no company yet.
+   field is disabled: which projects this deal may be filed under is a question
+   about its company, and there is no company yet.
 4. Open **Project** and choose **New project…**. One more field appears:
    **Project name**.
 5. Enter the project name — `Nordwind ERP rollout`. Give it a different name

--- a/docs/tutorials/run-your-first-project.md
+++ b/docs/tutorials/run-your-first-project.md
@@ -12,8 +12,9 @@ In Margince you can:
 
 - **Start a project while the deal is still being pursued**, so the early
   conversations are already filed where the delivery team will look for them.
-- **Give it a key** such as `NW-ERP` and have every email whose subject carries
-  `[NW-ERP]` filed under it automatically.
+- **Have Margince give it a key** such as `NER-1`, and every email whose subject
+  carries `[NER-1]` is filed under it automatically — including the ones you
+  send, which carry the key without you typing it.
 - **Win the deal and watch the project move into delivery** by itself.
 - **Write email from inside the project**, with the AI reading only what
   belongs to it.
@@ -64,11 +65,11 @@ proposal", the project exists.
 1. Open **Pipeline** and press **New deal**.
 2. Fill in **Deal name** (`Nordwind ERP licences and rollout`) and **Value**
    (`180000`).
-3. Pick the **Company** — *Nordwind Logistik*. The **Project** field below it
-   is disabled until a company is chosen, because a project is started on a
-   company.
-4. Open **Project** and choose **New project…**. Two more fields appear:
-   **Project name** and **Key**.
+3. Pick the **Company** — *Nordwind Logistik*. Until you do, the **Project**
+   field offers nothing but **New project…**: which projects you may file this
+   deal under is a question about its company, and there is no company yet.
+4. Open **Project** and choose **New project…**. One more field appears:
+   **Project name**.
 5. Enter the project name — `Nordwind ERP rollout`. Give it a different name
    from the deal: later, when you search for the project, a deal with the same
    name sits next to it in the results and the two are hard to tell apart.
@@ -77,37 +78,52 @@ proposal", the project exists.
 You land on the deal page. Beside the company name you should see a chip
 reading **Nordwind ERP rollout** — the project this deal belongs to. Click it.
 
-The project page opens. Under the name you should see the company, the owner
-(**Unassigned** unless you set one), and the phase: **Initiative**. On the
-right, the **Phase history** reads *Started in Initiative* with today's date
-and your name.
+The project page opens. Under the name you should see the company, the owner —
+**you**, because a project belongs to whoever creates it — and the phase:
+**Initiative**. On the right, the **Phase history** reads *Started in
+Initiative* with today's date and your name.
 
 Created at deal creation like this, the project is in **Initiative** — an
 idea, not yet a pursuit. That is deliberate: the project exists before you
 know whether the deal will happen.
 
-## 3. Give it a key
+## 3. The key it was given
 
-A key is the short handle you and the customer will write in email subjects.
-Set it now, before the first mail goes out.
+Look under the project's name. Beside the phase is a short chip — something
+like **NER-1**. Nobody typed it: Margince minted it from the project's name
+when the project was created, and it cannot be edited. Hover it and the
+tooltip says what it is for:
 
-1. On the project page press **Edit project**.
-2. In **Key**, type `NW-ERP`. The hint under the field says it plainly:
-   *Optional short handle, e.g. ACME-CRM. Write [KEY] in an email subject and
-   the mail is filed under this project.*
-3. Press **Save**.
+> Margince gives each project a short key. Write [NER-1] in an email subject
+> and the mail is filed under this project.
 
-The key now shows next to the phase under the project name, and in the
-**Projects** list under the project's name.
+**How the key is built.** The initials of a multi-word name, or the opening
+letters of a single-word one, then a hyphen and the lowest free number:
 
-A key must start with a letter and be 2–24 characters of letters, digits,
-`_` and `-`; it must be unique across the installation (the check is
-case-insensitive, so `nw-erp` and `NW-ERP` are the same key). The form
-refuses anything else before you can save.
+| Project name | Key |
+|---|---|
+| `Nordwind ERP rollout` | `NER-1` |
+| `Datenmigration` | `DATENMIG-1` |
+| `ERP rollout Acme` | `ERA-1` |
+| a second `ERP rollout Acme` | `ERA-2` |
 
-You can also type the key when you create the project from the deal form —
-the **Key** field is there too. This page sets it afterwards only to show
-where it lives.
+Only ASCII letters and digits are used, and a name with too few of them —
+`工事`, `2026` — falls back to `PRJ-1`. The number is the lowest one free, not
+the next one up, so a number released by archiving a project is used again.
+
+**What this means for you:** the only lever you have over a key is the
+project's **name**. A name whose initials read well gives a key that reads
+well, and the key is what your customer will see in every subject line. That
+is the whole of the naming advice — see
+[how-to/set-up-projects.md](../how-to/set-up-projects.md#naming-a-project-so-its-key-reads-well).
+
+Two properties worth knowing now, because both surface later:
+
+- **Keys are unique among live projects, compared case-insensitively.** `ner-1`
+  and `NER-1` are the same key.
+- **Archiving a project frees its key.** Which is why Margince will never stamp
+  an archived project's key into a subject line — by then the key may belong to
+  somebody else.
 
 ## 4. Work the deal phase
 
@@ -132,10 +148,9 @@ It does **not** appear on the project's timeline yet. A note on a deal is
 filed under the deal; the project's **Timeline** shows only what is filed
 under the project. To move it, press **Relink** on the note, search for
 *Nordwind ERP rollout*, pick the **project** (not the deal of the same family)
-and press **Relink**. Now open the project: the timeline shows the note, the
-**Activities** counter reads 1, and the coverage line under the figures reads
-*1 attributed · 0 awaiting a decision · …*. Email does this filing by itself
-once the key is in the subject; see step 7.
+and press **Relink**. Now open the project: the timeline shows the note and the
+**Activities** figure reads 1. Email does this filing by itself once the key is
+in the subject; see step 7.
 
 ## 5. Win the deal
 
@@ -206,41 +221,88 @@ fixed — **Initiative**, **Pursuing**, **Delivering**, **Closed** — but the
 order is not enforced. Only closing demands a reason; the other moves record
 one if you give it.
 
-## 7. The AI inside a project
+## 7. Email, and how it finds the project
+
+There are two composers, and they behave differently on purpose.
+
+### Replying from the deal or the project
+
+Open the project (or the deal) and press **Reply** on a message in the
+timeline. Above the Subject field you will see:
+
+> ☑ **File under this project**
+> This will be filed under Nordwind ERP rollout, this deal's project.
+> [NER-1] is added to the subject so their reply files itself here.
+
+And the **Subject** field already contains `[NER-1]`.
+
+Nothing was asked of you. The composer worked out where this message belongs
+and said so, in this order:
+
+1. **The thread's own project**, if the conversation is already filed. Then the
+   first line reads *…like the rest of this conversation* instead.
+2. **The deal's project**, when the thread carries none. This is the ordinary
+   case for a conversation that started before the project was attached, and
+   the line names the reason — *this deal's project* — because you never put
+   that project on this conversation and deserve to be told where it came from.
+
+If neither names a project, **nothing appears at all**: no line, no tickbox, no
+tag. A message that belongs to no project is the common case and says so by
+staying quiet.
+
+**To decline**, untick the box. The two lines disappear and `[NER-1]` is taken
+back out of the Subject — the tag would otherwise promise a routing that will
+not happen. Tick it again and the tag returns, in front of whatever you have
+since typed. You can also just delete the tag yourself; it stays deleted.
+
+> **The tag is doing real work, not decoration.** Your customer's mail client
+> keeps `[NER-1]` in the subject when they reply. Margince reads it back on the
+> way in and files their answer under the project — even if the mail thread is
+> broken by a forward, a new subject, or a colleague brought in on a fresh
+> message. This is what makes the filing survive leaving your installation.
+
+One limit, stated plainly: **on a reply, the tag is the only thing carrying the
+project.** The reply itself is filed under whatever the message you are
+answering was filed under, because the send inherits its links. So the copy of
+your own reply may not appear on the project's timeline until the customer
+answers and their tagged reply comes back. This is
+[issue #2422](https://github.com/margince/margince/issues/2422); the
+account-started composer below does not have this limitation.
+
+### Writing to an account from the company page
 
 Open the company page (**Companies** → *Nordwind Logistik*) and press
-**Write email**.
+**Write email**. This composer starts a new conversation rather than continuing
+one, so there is no thread to inherit from and it **asks** instead of stating:
 
-The composer opens with a **Draft to** picker, and beneath it a **Project**
-picker. Open it: it offers **No project** and every live project on this
-account, key first — `NW-ERP · Nordwind ERP rollout`. Choose it.
+- **Draft to** — which contact.
+- **Related to** — which deal, when the account has any.
+- **Project** — **No project**, then the projects on this account as
+  `NER-1 · Nordwind ERP rollout`. With exactly one live project it is
+  pre-selected; with several it starts at **No project**.
 
-A line appears under the picker: **Scoped to NW-ERP**. That line means two
-things at once:
+Choosing one shows **Scoped to NER-1** beneath it, and that does two things:
 
-- **What the AI reads.** Press **Draft with AI** after choosing a recipient.
-  The draft is grounded only in what is filed under this project or under no
-  project at all; mail filed under a *different* project on the same account
-  is left out. The subject it proposes names the project, and the **Based
-  on:** line under it lists the records it drew from.
-- **Where the mail is filed.** When you send, the message is linked to the
-  project, so it shows on the project's timeline and the next reply inherits
-  that filing.
+- **What the AI reads.** Press **Draft with AI**. The draft is grounded only in
+  what is filed under this project or under no project at all; mail filed under
+  a *different* project on the same account is left out, and the **Based on:**
+  line lists what it did draw from.
+- **Where the mail is filed.** The sent message is linked to the project, so it
+  appears on the project's timeline and replies inherit that filing.
 
-If the account has exactly one live project, the picker pre-selects it. With
-two or more, it starts at **No project** and you choose.
+### One more thing the composer does quietly
 
-You do not have to use the picker at all. Put `[NW-ERP]` in the subject of any
-email — from Margince or from your mail client — and the message is filed
-under the project when it is captured. Replies inherit the thread's project.
-The rules in full, and what filing does to the retention of that email, are
-in [how-to/run-a-project.md](../how-to/run-a-project.md#referencing-a-project-from-email).
+If the subject already carries **another** project's key, sending under this
+project removes it. Two keys in one subject make the inbound rule ambiguous —
+it files under neither — so leaving both would silently break the filing you
+just asked for. Bracketed text that could not be a key, like `[FYI]`, is left
+alone.
 
 > **Filing an email under a project is permanent for retention.** Under the
 > German pack an email filed under a project counts as business
 > correspondence and is kept for six years from the end of the calendar year it
-> was sent or received. Moving it off the project
-> later does not undo that. Relink deliberately.
+> was sent or received. Moving it off the project later does not undo that.
+> Relink deliberately.
 
 ## 8. Agents over MCP
 
@@ -249,14 +311,16 @@ same permissions the signed-in person holds:
 
 - `read_project_360` reads the whole project page — phase history with time
   per phase, deals, stakeholders, contracts, documents, open commitments,
-  timeline and the coverage figures.
+  timeline.
 - `catch_me_up_on` with a `project_id` answers "what has been going on?" for
   the project, reading only what is filed under it or under no project.
 - `prepare_handoff` assembles what the delivery side needs from the sales
   side — owner, client contacts, what was sold, by when, what is promised —
   and names each gap the records leave.
 - `advance_project_phase` moves a phase, with the same closing-needs-a-reason
-  rule. An agent's move is staged and a person approves it before it runs.
+  rule. It runs straight away under a passport whose scopes admit it — what
+  confines the agent is the passport and the seat behind it, not an approval
+  step.
 - The generic record tools (`create_record`, `read_record`, `update_record`,
   `list_records`, `search_records`) accept `project` as a record type, and a
   deal can be listed by its `project_id`.

--- a/docs/tutorials/run-your-first-project.md
+++ b/docs/tutorials/run-your-first-project.md
@@ -13,8 +13,8 @@ In Margince you can:
 - **Start a project while the deal is still being pursued**, so the early
   conversations are already filed where the delivery team will look for them.
 - **Have Margince give it a key** such as `NER-1`, and every email whose subject
-  carries `[NER-1]` is filed under it automatically — including the ones you
-  send, which carry the key without you typing it.
+  carries `[NER-1]` is filed under it automatically — including the replies you
+  send from the deal or the project, which carry the key without you typing it.
 - **Win the deal and watch the project move into delivery** by itself.
 - **Write email from inside the project**, with the AI reading only what
   belongs to it.
@@ -52,8 +52,8 @@ empty state:
 > A project is the body of work a deal is about. It starts during the deal,
 > in the initiative phase, and outlives close-won: once the deal is won,
 > delivery is tracked here.
-> Give a project a key and any email whose subject carries [KEY] is filed
-> under it automatically.
+> Every project gets a short key. Any email whose subject carries it in
+> brackets is filed under that project automatically.
 
 That paragraph is the whole model. The rest of this page is it in practice.
 
@@ -186,6 +186,8 @@ Two limits on this automatic move are worth knowing now:
 
 Delivery runs for months. The project page is where it is tracked:
 
+- **Companies** (first on the right) lists every company working this project
+  and what each one is to it. More on this below.
 - **Deals** lists every deal on this project, won and open, with its value.
   **New deal** here starts another deal on the same project and company.
 - **Open commitments** lists open tasks filed under the project, soonest due
@@ -197,6 +199,40 @@ Delivery runs for months. The project page is where it is tracked:
   row above it (**Activity kind**, **Search this timeline**, **From**, **To**)
   narrows it; the **Activities / Changes / All** switch shows the mail, the
   record's own field and phase changes, or both.
+
+### Nordwind brings in a partner
+
+Two months in, Nordwind subcontracts the warehouse integration to
+*DACHPartner GmbH*. The project is no longer one company's work, and Margince
+does not make you pretend otherwise.
+
+1. On the project page, in **Companies**, press **Attach company**.
+2. Under **As**, leave **Partner** — the list opens here rather than on
+   Customer, because the project already has its customer. **Set the role
+   before you pick the company**, because picking is what attaches it.
+3. Search for *DACHPartner GmbH* and pick it from the results. The dialog
+   closes and the company is on the project.
+
+The Companies card now shows both: *Nordwind Logistik — Customer* and
+*DACHPartner GmbH — Partner*.
+
+What this buys you: a deal on **DACHPartner** can now be filed under this
+project. A deal may name any project one of its companies is on, whatever role
+that company holds, so the partner's own commercial work sits on the same body
+of work as the customer's.
+
+Two things Margince will refuse, both with the reason on screen:
+
+- **Taking off the last company.** *A project keeps at least one company; add
+  another before taking this one off.*
+- **Taking off a company that still has deals here.** *This company still has 1
+  deal(s) on the project; move or close them before taking the company off.*
+  Note that winning or losing a deal does not clear this — the count is of
+  deals that still exist. Point them at another project, or archive them.
+
+Attaching a company that is already on the project **changes its role** rather
+than adding it twice — which is how you promote DACHPartner from subcontractor
+to partner later.
 
 When go-live is signed off:
 
@@ -241,10 +277,13 @@ and said so, in this order:
 
 1. **The thread's own project**, if the conversation is already filed. Then the
    first line reads *…like the rest of this conversation* instead.
-2. **The deal's project**, when the thread carries none. This is the ordinary
-   case for a conversation that started before the project was attached, and
-   the line names the reason — *this deal's project* — because you never put
-   that project on this conversation and deserve to be told where it came from.
+2. **The deal's project**, when the thread carries none — and only when you are
+   replying from a **deal**. This is the ordinary case for a conversation that
+   started before the project was attached, and the line names the reason —
+   *this deal's project* — because you never put that project on this
+   conversation and deserve to be told where it came from. Replying from a
+   company or a contact page has no deal to fall back on, so only rung 1
+   applies there.
 
 If neither names a project, **nothing appears at all**: no line, no tickbox, no
 tag. A message that belongs to no project is the common case and says so by
@@ -255,19 +294,26 @@ back out of the Subject — the tag would otherwise promise a routing that will
 not happen. Tick it again and the tag returns, in front of whatever you have
 since typed. You can also just delete the tag yourself; it stays deleted.
 
+One thing unticking does **not** do: if the conversation was already filed
+under a project, the reply still lands on that project, because a reply
+inherits the links of the message it answers. Unticking takes off the tag and
+the claim, not the filing. Moving a filed conversation is **Relink**, which
+moves all of it at once.
+
 > **The tag is doing real work, not decoration.** Your customer's mail client
 > keeps `[NER-1]` in the subject when they reply. Margince reads it back on the
 > way in and files their answer under the project — even if the mail thread is
 > broken by a forward, a new subject, or a colleague brought in on a fresh
 > message. This is what makes the filing survive leaving your installation.
 
-One limit, stated plainly: **on a reply, the tag is the only thing carrying the
-project.** The reply itself is filed under whatever the message you are
-answering was filed under, because the send inherits its links. So the copy of
-your own reply may not appear on the project's timeline until the customer
-answers and their tagged reply comes back. This is
+One limit, stated plainly: **when the project came from the deal, the tag is
+the only thing carrying it.** A reply is filed under whatever the message you
+are answering was filed under, and it cannot add a link of its own. So on a
+conversation the project never reached, your sent copy does not appear on the
+project's timeline — the customer's tagged answer is what brings the whole
+thread in. A conversation already filed does not have this problem. This is
 [issue #2422](https://github.com/margince/margince/issues/2422); the
-account-started composer below does not have this limitation.
+account-started composer below does not have it either.
 
 ### Writing to an account from the company page
 
@@ -295,8 +341,9 @@ Choosing one shows **Scoped to NER-1** beneath it, and that does two things:
 If the subject already carries **another** project's key, sending under this
 project removes it. Two keys in one subject make the inbound rule ambiguous —
 it files under neither — so leaving both would silently break the filing you
-just asked for. Bracketed text that could not be a key, like `[FYI]`, is left
-alone.
+just asked for. The rule goes by SHAPE rather than by looking each one up, so
+any bracketed word that could be a key is removed — `[FYI]` included. Only a
+group that could never be one, like `[2026]`, survives.
 
 > **Filing an email under a project is permanent for retention.** Under the
 > German pack an email filed under a project counts as business

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2359,7 +2359,8 @@ export const de = {
   "compose.subjectTagged":
     "{tag} wird dem Betreff hinzugefügt, damit die Antwort sich hier einordnet.",
   "compose.fileUnderProject": "Unter diesem Projekt ablegen",
-  "compose.relinkTarget": "Person, Organisation, Deal oder Lead suchen",
+  "compose.relinkTarget":
+    "Person, Organisation, Deal, Lead oder Projekt suchen",
   "compose.relinkReplace": "Verschieben statt zusätzlich verknüpfen",
   "compose.relinkReplaceHint":
     "Ersetzt die bestehende Verknüpfung desselben Typs, statt eine weitere hinzuzufügen.",
@@ -6118,7 +6119,7 @@ export const de = {
   "project.emptyBody":
     "Ein Projekt ist das Vorhaben, um das es in einem Deal geht. Es beginnt während des Deals in der Phase Initiative und überlebt den Abschluss: Ist der Deal gewonnen, wird die Umsetzung hier verfolgt.",
   "project.emptyKey":
-    "Gib einem Projekt ein Kürzel, und jede E-Mail mit [KÜRZEL] im Betreff wird ihm automatisch zugeordnet.",
+    "Jedes Projekt bekommt ein kurzes Kürzel. Jede E-Mail, die es in eckigen Klammern im Betreff trägt, wird dem Projekt automatisch zugeordnet.",
   "project.rollups.empty": "Noch keine Kennzahlen zu diesem Projekt.",
   "project.rollups.openValue": "Offenes Dealvolumen",
   "project.rollups.wonValue": "Gewonnenes Dealvolumen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2392,7 +2392,8 @@ export const en = {
   // The opt-out. Not "remove" or "delete": nothing is destroyed, the message
   // simply is not filed under this project.
   "compose.fileUnderProject": "File under this project",
-  "compose.relinkTarget": "Search a person, organization, deal, or lead",
+  "compose.relinkTarget":
+    "Search a person, organization, deal, lead, or project",
   "compose.relinkReplace": "Move instead of also-link",
   "compose.relinkReplaceHint":
     "Replaces the existing link of the same type rather than adding another.",
@@ -6197,7 +6198,7 @@ export const en = {
   "project.emptyBody":
     "A project is the body of work a deal is about. It starts during the deal, in the initiative phase, and outlives close-won: once the deal is won, delivery is tracked here.",
   "project.emptyKey":
-    "Give a project a key and any email whose subject carries [KEY] is filed under it automatically.",
+    "Every project gets a short key. Any email whose subject carries it in brackets is filed under that project automatically.",
   "project.rollups.empty": "No figures for this project yet.",
   "project.rollups.openValue": "Open deal value",
   "project.rollups.wonValue": "Won deal value",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2334,7 +2334,7 @@ export const vi = {
   "compose.subjectTagged":
     "{tag} được thêm vào tiêu đề để thư trả lời tự động vào đúng dự án.",
   "compose.fileUnderProject": "Lưu vào dự án này",
-  "compose.relinkTarget": "Tìm một người, tổ chức, deal hay lead",
+  "compose.relinkTarget": "Tìm một người, tổ chức, deal, lead hay dự án",
   "compose.relinkReplace": "Chuyển hẳn thay vì liên kết thêm",
   "compose.relinkReplaceHint":
     "Thay liên kết cùng loại đang có thay vì thêm một liên kết nữa.",
@@ -6066,7 +6066,7 @@ export const vi = {
   "project.emptyBody":
     "Dự án là phần việc mà một thương vụ hướng tới. Nó bắt đầu trong thương vụ, ở giai đoạn khởi xướng, và tiếp tục sau khi thắng: khi thương vụ đã thắng, việc triển khai được theo dõi ở đây.",
   "project.emptyKey":
-    "Đặt mã cho dự án thì mọi email có [MÃ] trong tiêu đề sẽ tự động được xếp vào dự án đó.",
+    "Mỗi dự án đều được cấp một mã ngắn. Mọi email có mã đó trong ngoặc vuông ở tiêu đề sẽ tự động được xếp vào dự án.",
   "project.rollups.empty": "Chưa có số liệu cho dự án này.",
   "project.rollups.openValue": "Giá trị thương vụ đang mở",
   "project.rollups.wonValue": "Giá trị thương vụ đã thắng",

--- a/frontend/src/screens/projects.test.tsx
+++ b/frontend/src/screens/projects.test.tsx
@@ -190,7 +190,12 @@ describe("ProjectsScreen", () => {
     expect(
       screen.getByText(/starts during the deal, in the initiative phase/),
     ).toBeTruthy();
-    expect(screen.getByText(/\[KEY\]/)).toBeTruthy();
+    // The plate has to explain what the key is FOR — that a subject carrying it
+    // files the mail — not merely that a key exists. Matched on the promise
+    // rather than on the bracket glyph, which the copy is free to reword.
+    expect(
+      screen.getByText(/filed under that project automatically/),
+    ).toBeTruthy();
     expect(screen.getByTestId("new-record")).toBeTruthy();
     expect(screen.queryByRole("table")).toBeNull();
   });


### PR DESCRIPTION
docs(projects): the project guides describe the product that shipped

An audit of the three project documents against the code found the tutorial
teaching a workflow the server now refuses, and both how-to pages describing a
model the product has moved past.

The largest failure was keys. All three docs told a reader to choose one — the
tutorial spent a numbered section walking through a Key field on the edit form,
and quoted a help string that no longer exists. Keys are minted from the
project's name and are read-only; a caller sending one is refused 422. The
tutorial section now explains the key it was GIVEN, with a table of worked
examples, and the naming advice in set-up-projects is rewritten around the one
lever a reader still has: the project's name.

Every key example in both documents was checked by running keyStem against it
rather than by reading the function.

A project is worked by several companies, and no user document said so. The
sentence "a project has at most one company" is replaced by the model that
shipped — a customer plus partners and subcontractors, at least one company at
all times — and a new section documents the attach/detach flow the four pages
share, including the two refusals a reader will actually hit (the last company,
and a company that still has deals here).

The composer's project filing is documented for the first time, in both the
tutorial and the how-to, including the limit that on a reply the subject tag is
the only thing carrying the project.

Corrected besides: the coverage line, removed from the product and still
described in two documents including a passage on how to read its third number;
the create form's field list (no Key, no Owner); "seating a stakeholder is API
only", which has been a form on the contact page for some time; the stakeholder
role table, missing User; the reports section still saying "available from the
next release" for three reports that shipped; and the claim in three places
that an agent's phase move is staged for approval, which the policy table
contradicts — it auto-executes.

Two product strings were wrong rather than the docs. The projects empty state
told a reader to "give a project a key", and the relink search field listed
every target except the one this work is about. Both fixed in en/de/vi.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings project docs, UI copy, and tests in line with shipped behavior so readers don’t follow blocked flows. Old guidance that users choose keys, projects have one company, and MCP phase moves are staged is replaced with the current model: keys are minted and immutable, projects span customer plus partners/subcontractors, and MCP moves execute immediately.

- Keys: minted from the project name at creation, unique among live projects, read-only (API `422 read_only` if provided), archiving frees keys; docs include the stem/numbering algorithm and naming guidance. Create/edit forms no longer show Key/Owner; creator owns initially.
- Companies: projects can include multiple companies with roles (Customer/Partner/Subcontractor); attach/detach is shared across pages, attaches on pick (no confirm), and refuses removing the last company or one with deals. Deals show a project chip and may link to any project the deal’s company is on.
- Email filing: documents the two composers. Replies show “File under this project,” stamp `[KEY]`, and on deal-fallback the tick controls filing; on already-filed threads, replies inherit the link regardless of the tick. The account-started composer links to the project and never edits the subject. Subject-key stripping is shape-based; conflicting keys are removed. The inbound ladder orders: thread (same medium, by message time) → deal → bracketed key → human offer (only when it has a plausible single choice).
- Lists and forms: Projects list has All/In delivery/A–Z and a Filter bar with a Phase chip; the deal form’s Project picker is disabled until a company is chosen.
- Reports: three project reports exist over the API but are not listed on the Reports screen.
- MCP: `advance_project_phase` runs immediately under a permitted passport; no staging step.
- i18n/tests: updates en/de/vi empty-state copy and `compose.relinkTarget` to include “project”; adjusts a test to assert the new copy.

- Rollout
  - No migrations or backend changes. Verify updated translations and the Projects screen empty-state copy.

<sup>Written for commit 7e920e46ca64f3f56d2d808cb1b8e2fa54327a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded project guides and tutorials with clearer guidance on company roles, project relationships, email filing, reply handling, subject keys, and removal safeguards.
  - Clarified automatic project assignment, relinking behavior, approval offers, reports availability, and project creation and editing rules.

- **Localization**
  - Updated English, German, and Vietnamese text to explain project search and automatic email filing using generated project short keys.

- **Tests**
  - Updated first-run project coverage to verify the revised automatic email filing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->