### PR TITLE
docs: a gate that reads a smaller tree still says PASS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,16 +573,19 @@ the short form:
    (integration tests live directly in `package compose` so unexported
    adapters are in scope). An unexpectedly uncovered new file usually
    means a test double stands where the real thing should.
-7. **One invariant broken in two languages is ONE item, not two.** When
-   the same rule is wrong in Go and in TypeScript, fixing one side alone
-   can be a REGRESSION rather than half a fix — a money scale wrong on
-   both sides of the wire cancels, the screen agrees with itself, and
-   making the server correct by itself prints a hundred times the price
-   on the offer a buyer signs. Find the other side before you fix this
-   one, land both in one change, and give the two suites one corpus to
-   read (`frontend/src/format/minorunits.ts` +
-   `backend/frontendminorunits_test.go`) rather than two tables that
-   agree today.
+7. **One invariant spelled on both sides of a wire is ONE item, not
+   two.** Most topics are implemented once — but where Go and TypeScript
+   each carry a spelling of the same rule, fixing one side alone can be
+   a REGRESSION rather than half a fix: a money scale wrong in both
+   directions cancels, the screen agrees with itself, and making the
+   server correct by itself prints a hundred times the price on the
+   offer a buyer signs. So check for the other side before you fix this
+   one, and land both in one change. Then make one side a DECLARED
+   mirror of the other, held by a gate that fails in BOTH directions —
+   `values.MinorUnitExceptions()` against
+   `frontend/src/format/minorunits.ts`, in
+   `backend/frontendminorunits_test.go` — rather than two tables that
+   only happen to agree today.
 8. **A census that can fail short has already failed.**
    Under-recognition is the one way a gate must not break: it reads a
    smaller tree and reports the same word for it, PASS, and there is no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,7 +416,7 @@ scope clauses in `platform/auth`): object denial →
 ## Reuse before you build (non-negotiable)
 
 A second implementation of one capability is not untidy — it is two answers to
-one question, and the two drift until they disagree in front of a user. Four
+one question, and the two drift until they disagree in front of a user. Five
 rules, each of them here because this tree has already paid for it.
 
 **1. Search the whole tree, not your directory.** Before adding a capability,
@@ -458,6 +458,17 @@ the eraser performs" — if no test fails when a second one appears, delete the
 claim or write the test. Nine of the ten claims counted in this tree were
 false. A false uniqueness claim is worse than silence: the next author greps,
 finds it, and stops looking.
+
+**5. A gate that hard-codes any part of its subject has become a second copy of
+it.** A census over consumer-mail domains that carries its own sample of them, a
+design gate that restates the element list it forbids, a parity test with a
+hand-maintained coverage map — each is the duplicate it was written to refuse,
+and it goes quietly short the day somebody extends the owner. Derive the gate's
+corpus from the owner it protects — `freemail.Domains()`, the contract, the tree
+— or say in the test why it cannot be. Every gate the duplication sweep produced
+was found, after shipping and by a reviewer, to have hard-coded part of its own
+subject; two reviewers independently named the domain sample that a
+consumer-mail gate kept inside the test forbidding second consumer-mail lists.
 
 **Two writers of one invariant either share a helper or say why they do not.**
 If you are adding the second, put the reason in the code beside it, not in the
@@ -562,4 +573,23 @@ the short form:
    (integration tests live directly in `package compose` so unexported
    adapters are in scope). An unexpectedly uncovered new file usually
    means a test double stands where the real thing should.
-
+7. **One invariant broken in two languages is ONE item, not two.** When
+   the same rule is wrong in Go and in TypeScript, fixing one side alone
+   can be a REGRESSION rather than half a fix — a money scale wrong on
+   both sides of the wire cancels, the screen agrees with itself, and
+   making the server correct by itself prints a hundred times the price
+   on the offer a buyer signs. Find the other side before you fix this
+   one, land both in one change, and give the two suites one corpus to
+   read (`frontend/src/format/minorunits.ts` +
+   `backend/frontendminorunits_test.go`) rather than two tables that
+   agree today.
+8. **A census that can fail short has already failed.**
+   Under-recognition is the one way a gate must not break: it reads a
+   smaller tree and reports the same word for it, PASS, and there is no
+   failing assertion to notice. So — no prefilter, skip-list or file
+   shortcut in front of a scan unless you have MEASURED that it buys
+   something (parsing the whole tree is usually a couple of seconds, and
+   one shortcut here was slower than the parse it avoided); match
+   STATEMENTS, not lines, and bound the join; and once the gate is green,
+   ask what shape of the defect it CANNOT see and plant that case. Prefer
+   deleting a dimension to narrowing it a seventh time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,7 +448,7 @@ scope clauses in `platform/auth`): object denial →
 ## Reuse before you build (non-negotiable)
 
 A second implementation of one capability is not untidy — it is two answers to
-one question, and the two drift until they disagree in front of a user. Four
+one question, and the two drift until they disagree in front of a user. Five
 rules, each of them here because this tree has already paid for it.
 
 **1. Search the whole tree, not your directory.** Before adding a capability,
@@ -490,6 +490,17 @@ the eraser performs" — if no test fails when a second one appears, delete the
 claim or write the test. Nine of the ten claims counted in this tree were
 false. A false uniqueness claim is worse than silence: the next author greps,
 finds it, and stops looking.
+
+**5. A gate that hard-codes any part of its subject has become a second copy of
+it.** A census over consumer-mail domains that carries its own sample of them, a
+design gate that restates the element list it forbids, a parity test with a
+hand-maintained coverage map — each is the duplicate it was written to refuse,
+and it goes quietly short the day somebody extends the owner. Derive the gate's
+corpus from the owner it protects — `freemail.Domains()`, the contract, the tree
+— or say in the test why it cannot be. Every gate the duplication sweep produced
+was found, after shipping and by a reviewer, to have hard-coded part of its own
+subject; two reviewers independently named the domain sample that a
+consumer-mail gate kept inside the test forbidding second consumer-mail lists.
 
 **Two writers of one invariant either share a helper or say why they do not.**
 If you are adding the second, put the reason in the code beside it, not in the
@@ -596,4 +607,23 @@ the short form:
    (integration tests live directly in `package compose` so unexported
    adapters are in scope). An unexpectedly uncovered new file usually
    means a test double stands where the real thing should.
-
+7. **One invariant broken in two languages is ONE item, not two.** When
+   the same rule is wrong in Go and in TypeScript, fixing one side alone
+   can be a REGRESSION rather than half a fix — a money scale wrong on
+   both sides of the wire cancels, the screen agrees with itself, and
+   making the server correct by itself prints a hundred times the price
+   on the offer a buyer signs. Find the other side before you fix this
+   one, land both in one change, and give the two suites one corpus to
+   read (`frontend/src/format/minorunits.ts` +
+   `backend/frontendminorunits_test.go`) rather than two tables that
+   agree today.
+8. **A census that can fail short has already failed.**
+   Under-recognition is the one way a gate must not break: it reads a
+   smaller tree and reports the same word for it, PASS, and there is no
+   failing assertion to notice. So — no prefilter, skip-list or file
+   shortcut in front of a scan unless you have MEASURED that it buys
+   something (parsing the whole tree is usually a couple of seconds, and
+   one shortcut here was slower than the parse it avoided); match
+   STATEMENTS, not lines, and bound the join; and once the gate is green,
+   ask what shape of the defect it CANNOT see and plant that case. Prefer
+   deleting a dimension to narrowing it a seventh time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,16 +607,19 @@ the short form:
    (integration tests live directly in `package compose` so unexported
    adapters are in scope). An unexpectedly uncovered new file usually
    means a test double stands where the real thing should.
-7. **One invariant broken in two languages is ONE item, not two.** When
-   the same rule is wrong in Go and in TypeScript, fixing one side alone
-   can be a REGRESSION rather than half a fix — a money scale wrong on
-   both sides of the wire cancels, the screen agrees with itself, and
-   making the server correct by itself prints a hundred times the price
-   on the offer a buyer signs. Find the other side before you fix this
-   one, land both in one change, and give the two suites one corpus to
-   read (`frontend/src/format/minorunits.ts` +
-   `backend/frontendminorunits_test.go`) rather than two tables that
-   agree today.
+7. **One invariant spelled on both sides of a wire is ONE item, not
+   two.** Most topics are implemented once — but where Go and TypeScript
+   each carry a spelling of the same rule, fixing one side alone can be
+   a REGRESSION rather than half a fix: a money scale wrong in both
+   directions cancels, the screen agrees with itself, and making the
+   server correct by itself prints a hundred times the price on the
+   offer a buyer signs. So check for the other side before you fix this
+   one, and land both in one change. Then make one side a DECLARED
+   mirror of the other, held by a gate that fails in BOTH directions —
+   `values.MinorUnitExceptions()` against
+   `frontend/src/format/minorunits.ts`, in
+   `backend/frontendminorunits_test.go` — rather than two tables that
+   only happen to agree today.
 8. **A census that can fail short has already failed.**
    Under-recognition is the one way a gate must not break: it reads a
    smaller tree and reports the same word for it, PASS, and there is no

--- a/README.md
+++ b/README.md
@@ -415,20 +415,27 @@ because getting it wrong once was expensive:
    already builds, and an unexpectedly uncovered new file usually means a
    test double stands where the real thing should.
 
-7. **One invariant broken in two languages is one item, not two.** A
-   topic that reaches a screen is spelled twice, and two errors on
-   opposite sides of a wire can CANCEL — which makes each half look
-   correct in place and makes fixing one half a regression rather than
-   half a fix. The frontend wrote `Math.round(amount * 100)` for every
-   currency and the backend divided by 100 for every currency, so a
-   zero-decimal price was stored a hundredfold and displayed correctly:
-   the screen agreed with itself and only the record was wrong. Making
-   the server currency-aware on its own would have printed a hundred
-   times the price on an outbound offer. Land both sides in one change,
-   and give the two suites one case corpus with a drift gate over it
-   (`frontend/src/format/minorunits.ts` +
-   `backend/frontendminorunits_test.go`) rather than two tables that
-   happen to agree today.
+7. **One invariant spelled on both sides of a wire is one item, not
+   two.** Most topics are implemented once and merely rendered by the
+   other language; this rule is about the ones that are not. Where Go
+   and TypeScript each carry a spelling of the same rule, two errors can
+   CANCEL — which makes each half look correct in place, and makes
+   fixing one half a regression rather than half a fix. The frontend
+   wrote `Math.round(amount * 100)` for every currency and the backend
+   divided by 100 for every currency, so a zero-decimal price was stored
+   a hundredfold and displayed correctly: the screen agreed with itself
+   and only the record was wrong. Making the server currency-aware on
+   its own would have printed a hundred times the price on an outbound
+   offer. So check for the other side before you fix this one, and land
+   both in one change. Then declare which side is the MIRROR and gate it
+   in both directions — `values.MinorUnitExceptions()` against
+   `frontend/src/format/minorunits.ts`, in
+   `backend/frontendminorunits_test.go`, which fails on a code present
+   on one side only and on a digit count that differs. Two tables that
+   happen to agree today is the state this replaces; note that the gate
+   covers the shared TABLE, not the two suites' cases, and reads the
+   TypeScript with hand-written regexes — so it carries the caveat in
+   the next rule rather than escaping it.
 
 8. **A census that can fail short has already failed.** Every failure
    mode of a gate is loud except one: under-recognition. A gate that

--- a/README.md
+++ b/README.md
@@ -415,6 +415,39 @@ because getting it wrong once was expensive:
    already builds, and an unexpectedly uncovered new file usually means a
    test double stands where the real thing should.
 
+7. **One invariant broken in two languages is one item, not two.** A
+   topic that reaches a screen is spelled twice, and two errors on
+   opposite sides of a wire can CANCEL — which makes each half look
+   correct in place and makes fixing one half a regression rather than
+   half a fix. The frontend wrote `Math.round(amount * 100)` for every
+   currency and the backend divided by 100 for every currency, so a
+   zero-decimal price was stored a hundredfold and displayed correctly:
+   the screen agreed with itself and only the record was wrong. Making
+   the server currency-aware on its own would have printed a hundred
+   times the price on an outbound offer. Land both sides in one change,
+   and give the two suites one case corpus with a drift gate over it
+   (`frontend/src/format/minorunits.ts` +
+   `backend/frontendminorunits_test.go`) rather than two tables that
+   happen to agree today.
+
+8. **A census that can fail short has already failed.** Every failure
+   mode of a gate is loud except one: under-recognition. A gate that
+   reads a smaller tree reports the same word for it — PASS — and there
+   is no failing assertion to notice, so a hand-written census is short
+   until proven otherwise, and each miss hides behind whatever also hid
+   it from the detector. Three consequences, each of them paid for here.
+   No prefilter, skip-list or file shortcut in front of a scan unless
+   you have MEASURED that it buys something: one such shortcut survived
+   six rounds of being found narrower than the census behind it, two of
+   the misses introduced by the fix for the one before, and deleting it
+   turned out to be FASTER than keeping it. Match statements, not lines
+   — a per-line matcher missed an entire write direction a formatter had
+   wrapped across three — and bound the join, or one statement swallows
+   a thirty-line `const (` block. And once the gate is green, ask what
+   shape of the defect it cannot see and plant that case; that is how
+   every hole found in review was found, and none by re-reading the
+   implementation.
+
 ## License
 
 **Business Source License 1.1** (`BUSL-1.1`) — see [LICENSE](LICENSE). Licensor:

--- a/docs/principles/README.md
+++ b/docs/principles/README.md
@@ -19,7 +19,7 @@ and say which.
 | [The record is the code](the-record-is-the-code.md) | What outranks what when two sources disagree, and where a finding goes once you have it. | *What decides a question here* |
 | [Every mutation leaves a trace](every-mutation-leaves-a-trace.md) | Why the domain row, the audit row and the event commit together, and what each of the two denials means. | *The write shape* |
 | [Legibility is the product](legibility-is-the-product.md) | Why the craft bar is a gate rather than taste, and what each anti-tell is defending against. | *Craftsmanship* |
-| [Derive the obligation](derive-the-obligation.md) | The six rules from the review loop and what each defends against, plus how to write a fitness function that actually holds rather than one that reads green over its own defect. | *Rules learned from the review loop* |
+| [Derive the obligation](derive-the-obligation.md) | The eight rules from the review loop and what each defends against, plus how to write a fitness function that actually holds rather than one that reads green over its own defect — including the two ways a gate becomes the duplicate it forbids. | *Rules learned from the review loop* |
 | [Nothing here is private](nothing-here-is-private.md) | Who the public reader is, what never appears in the tree, and why a working exploit takes the private path. | *This repository is public* |
 
 The rulebook sections stay where they are. `cli/craft` feeds the **whole**

--- a/docs/principles/derive-the-obligation.md
+++ b/docs/principles/derive-the-obligation.md
@@ -129,7 +129,9 @@ catch.
 
 ## Find the other side before you fix this one
 
-When the same invariant is spelled in Go and in TypeScript, it is one item until
+Most topics in this tree are implemented once and merely rendered by the other
+language, and this section is not about those. It is about the ones where Go and
+TypeScript each carry a spelling of the same rule: those are one item until
 proven otherwise, and a per-language PR is what hides that.
 
 The case that taught it: the frontend wrote `Math.round(amount * 100)` for every
@@ -141,12 +143,26 @@ backend half alone would have uncancelled them and printed a hundred times the
 price on an outbound offer.
 
 So: when a sweep finds one invariant broken on both sides of a wire, land both
-sides in one change, and give the two test suites **one corpus** — a single
-case file tagged by language, read by both, with a drift gate over it
-(`frontend/src/format/minorunits.ts` + `backend/frontendminorunits_test.go`).
-What stays singular is the rule and the case corpus; only the parser differs,
-and neither parser is hand-written. Splitting a rule into "a Go test for Go and
-a text scan for TypeScript" is the defect wearing the fix's clothes.
+sides in one change. Then declare which side is the MIRROR and gate it in both
+directions. `backend/frontendminorunits_test.go` is the worked example: it reads
+`values.MinorUnitExceptions()` and the `MINOR_UNIT_EXCEPTIONS` literal in
+`frontend/src/format/minorunits.ts` and fails on a code present in one and not
+the other, and on a digit count that differs. What stays singular there is the
+TABLE, which is what the two sides exchange; the two suites keep their own
+cases, and a shared case corpus would be a further step nothing in this tree
+takes yet. Do not read more protection into it than that.
+
+That gate also shows the cost of the shape it is in. It reads TypeScript with
+hand-written regexes, and its own comments enumerate the holes that forced each
+one: a quoted `"MGA": 0` parsing as nothing, a comment mentioning a code keeping
+the gate green after the real entry was deleted. Every one of those is a hole
+`ts.createSourceFile` does not have — see *let a parser own the grammar* above.
+It is cited here for the direction it gates, not as the parser to copy.
+
+The opposite move is the one to refuse: splitting a rule into "a Go test for Go
+and a text scan for TypeScript" leaves one rule with two implementations that
+nothing forces to be edited together. What may differ between the two sides is
+the parser; never the rule.
 
 ## What this does not ask for
 

--- a/docs/principles/derive-the-obligation.md
+++ b/docs/principles/derive-the-obligation.md
@@ -8,7 +8,7 @@ The binding form is
 [*Rules learned from the review loop*](../../CLAUDE.md#rules-learned-from-the-review-loop-binding).
 This page is the method for writing a gate that actually holds.
 
-## The six rules, and what each one is defending against
+## The eight rules, and what each one is defending against
 
 1. **Fix the invariant, not the call site.** Grep every mutation and read site
    of the same column, constraint or record, and fix them as one change. The
@@ -29,6 +29,12 @@ This page is the method for writing a gate that actually holds.
    hand-copied adapter mirroring what compose wires. Seed through the real
    writer; reach for the real wiring. An unexpectedly uncovered new file usually
    means a test double stands where the real thing should.
+7. **One invariant broken in two languages is one item.** Fixing one side of a
+   wire alone can be a regression, not half a fix. See
+   [find the other side](#find-the-other-side-before-you-fix-this-one).
+8. **A census that can fail short has already failed.** Under-recognition is
+   silent: the gate reads less and still says PASS. Everything under *Writing a
+   gate that holds* below is about this one.
 
 ## Writing a gate that holds
 
@@ -70,6 +76,77 @@ like a predicate that drops the right things. Measure what your gate *excludes*.
 
 **Write the mirror gate.** A gate can read green over its own defect reversed.
 If you assert A implies B, ask what happens when B appears without A.
+
+**The gate is part of its own subject.** A gate that hard-codes any slice of
+what it guards has become a second copy of it — and the copy inside a test is
+the worst kind, because it is invisible to the author extending the owner. A
+consumer-mail census shipped with its own 25-domain sample inside the very test
+that forbids second consumer-mail lists; two reviewers named it independently,
+and it asks `freemail.Domains()` now. Before the first assertion, ask what this
+gate hard-codes: its file list, its element list, its claim patterns, its
+domains. Derive each from the owner, or write down in the test why you cannot.
+
+**Plant the shape the detector cannot see.** One mutation proves the gate fires;
+it does not find the hole. Once the gate is green, ask what shape of the defect
+it is structurally blind to and plant that case. Every hole found in review
+during the duplication sweep was found this way, and none by re-reading the
+implementation — because the thing that hid a copy from a reader also hid it
+from the detector written to find copies. A `String(err)` hid behind being the
+fallback half of a ternary somebody had already fixed; a raw backtick string hid
+behind a prefilter that only knew double quotes.
+
+**Measure a shortcut before you defend it, and prefer deleting a dimension to
+narrowing it.** A skip-list or prefilter in front of a scan is where the gate
+goes blind, and the miss is silent: the file is dropped before anything looks at
+it — no finding, no error, indistinguishable from a clean tree. One census in
+this tree carried a cheap file-skip that six review rounds found narrower than
+the census behind it in six separate dimensions, two of them introduced by the
+fix for the one before. It was deleted rather than narrowed a seventh time,
+because measuring ended the argument: parsing every file was FASTER than the
+shortcut, and the saving originally credited to it had come from an unrelated
+map lookup.
+
+**Statements, not lines, and bound the join.** A per-line matcher misses a rule
+a formatter wrapped across three lines — the money gate missed an entire write
+direction that way. Joining lines into statements fixes it and introduces the
+opposite failure: unbounded, one join swallowed a thirty-line `const (` block
+and reported an unrelated pairing inside it.
+
+**A self-test that reads only an exit status proves nothing about a waiver.** A
+scanner that reports both the waived and the unwaived finding exits non-zero
+too. Assert on what the gate SAID, not just that it failed.
+
+**Let a parser own the grammar.** One text-matching gate produced six defect
+classes in a single PR, every one of them a defect in the matcher rather than in
+the rule: no `\b` in POSIX ERE so a guard shipped inert, a built-in name
+coerced to `-inf`, an undeclared local colliding as a global, a flat flag unable
+to express a nested template literal, a backslash meaning different things in a
+Go raw string and a TS template. A parser that already knows the language
+answers all six for nothing — `go/ast` in Go, `ts.createSourceFile` in
+TypeScript, both already used by censuses in this tree. And a parse error is not
+silence, which is the failure mode a text gate has to invent an assertion to
+catch.
+
+## Find the other side before you fix this one
+
+When the same invariant is spelled in Go and in TypeScript, it is one item until
+proven otherwise, and a per-language PR is what hides that.
+
+The case that taught it: the frontend wrote `Math.round(amount * 100)` for every
+currency and the backend divided by 100 for every currency, so the two errors
+CANCELLED — a zero-decimal price was stored a hundredfold and displayed
+correctly, the screen agreed with itself, and only the record was wrong. The
+sweep catalogued the two halves as two findings on two tiers. Shipping the
+backend half alone would have uncancelled them and printed a hundred times the
+price on an outbound offer.
+
+So: when a sweep finds one invariant broken on both sides of a wire, land both
+sides in one change, and give the two test suites **one corpus** — a single
+case file tagged by language, read by both, with a drift gate over it
+(`frontend/src/format/minorunits.ts` + `backend/frontendminorunits_test.go`).
+What stays singular is the rule and the case corpus; only the parser differs,
+and neither parser is hand-written. Splitting a rule into "a Go test for Go and
+a text scan for TypeScript" is the defect wearing the fix's clothes.
 
 ## What this does not ask for
 

--- a/docs/principles/one-source-of-truth.md
+++ b/docs/principles/one-source-of-truth.md
@@ -111,11 +111,12 @@ spelling: the domain word ("brief", "weighted", "anonymize"), the mechanism
 ("normalize", "Casefold", "ToLower"), and the artifact ("`_profile_field`",
 "system prompt", "Badge").
 
-**And grep the other language.** A topic that reaches a screen is spelled twice
-— once in Go and once in TypeScript — and the two halves are one topic, not two
-findings on two tiers. Two errors on opposite sides of a wire can CANCEL, which
-makes each half look correct in place and makes fixing one half a regression;
-the money-scale case is written up in
+**Then ask whether the other language carries a spelling of it too.** Usually it
+does not — one side computes and the other renders, which is the shape to want.
+But where both DO decide the same rule, the two halves are one topic rather than
+two findings on two tiers, because errors on opposite sides of a wire can CANCEL:
+each half looks correct in place, and fixing one half is a regression. The
+money-scale case is written up in
 [find the other side](derive-the-obligation.md#find-the-other-side-before-you-fix-this-one).
 
 ### 2. Count the writers of each table

--- a/docs/principles/one-source-of-truth.md
+++ b/docs/principles/one-source-of-truth.md
@@ -111,6 +111,13 @@ spelling: the domain word ("brief", "weighted", "anonymize"), the mechanism
 ("normalize", "Casefold", "ToLower"), and the artifact ("`_profile_field`",
 "system prompt", "Badge").
 
+**And grep the other language.** A topic that reaches a screen is spelled twice
+— once in Go and once in TypeScript — and the two halves are one topic, not two
+findings on two tiers. Two errors on opposite sides of a wire can CANCEL, which
+makes each half look correct in place and makes fixing one half a regression;
+the money-scale case is written up in
+[find the other side](derive-the-obligation.md#find-the-other-side-before-you-fix-this-one).
+
 ### 2. Count the writers of each table
 
 For a topic that ends in a row, the census is exact:
@@ -232,6 +239,37 @@ The house shape for a reuse gate, learned from `agenttoolparity_test.go` and
   fitness functions in this tree passed against the exact bug they described.
 - **Measure the before, not only the after.** A grep that returns zero after the
   fix proves nothing unless you know it returned N before.
+- **Derive the gate's own corpus too, not just its file list.** A gate that
+  hard-codes any slice of what it guards has become a second copy of it — and a
+  copy living inside a test is invisible to the author extending the owner. Ask
+  what your gate hard-codes before the first assertion.
+- **Plant the shape the gate cannot see, once it is green.** One mutation proves
+  it fires; the second finds the hole. The full method, and the failures behind
+  each clause, is in
+  [derive the obligation](derive-the-obligation.md#writing-a-gate-that-holds).
+
+### A gate is code, so it duplicates like code
+
+Two traps, both paid for here, both of them this principle's own subject wearing
+the fix's clothes:
+
+**Porting half a rule puts one rule in two homes.** Five of this tree's design
+gates scan TypeScript *and* CSS. Moving the TypeScript arm to an AST test and
+leaving the CSS arm in shell would leave one rule with two implementations that
+nothing forces to be edited together — which is the thing this page exists to
+refuse. Either both arms move or neither does; what stays singular is the rule
+and its case corpus, and only the parser may differ.
+
+**The SECOND gate of a kind is when to extract the shared traversal.** The first
+has nothing to compare against; by the third there are already three answers.
+Two source-scanning gates here each owned a copy of the extension walk and had
+already drifted before either was reviewed — they disagreed about which files a
+bundler resolves, four extensions against eight, so a unit was gated by one and
+invisible to the other for no reason either author chose. A walk is the worst
+place for a second answer: the gate with the narrower walk reads a smaller tree
+and reports the same word for it, PASS, and there is no failing assertion to
+notice. The one answer is now `frontend/scripts/lib/source-tree.ts`, with its
+test beside it rather than inside either caller.
 
 ## What this does not ask for
 


### PR DESCRIPTION
## Why

The duplication sweep closed slice A — fourteen merged PRs, each a second implementation collapsed into one owner with a gate behind it. What the sweep learned while shipping is recorded nowhere in the tree, and two of the lessons are about the gates themselves:

- **Every gate the sweep produced was found, after shipping and by a reviewer, to have hard-coded part of its own subject** — a sampled domain list, a restated element list, a prefilter narrower than the detector behind it. A consumer-mail census shipped with its own 25-domain sample *inside the test that forbids second consumer-mail lists*; two reviewers named it independently.
- **Every hand-written census was short**, and never by a little (3 → 8 disclosure sites; "8 sites" → 25 literals). Each miss had the same shape: the thing that hid a copy from a reader also hid it from the detector written to find copies.

Neither failure has an assertion. A gate that reads a smaller tree reports the same word for it — PASS. The rulebooks carried no rule against either, so the next sweep repeats them.

## What changes

Docs only. No code, no gate behaviour.

**Two binding rules** added to *Rules learned from the review loop*, byte-identical in `CLAUDE.md` and `AGENTS.md` (`TestSharedRulebookSectionsAreIdenticalInBothDocs` holds that), with the full rationale in `README.md` where rules 1–6 already have theirs:

7. **One invariant broken in two languages is ONE item, not two.** Two errors on opposite sides of a wire can cancel, so fixing one half is a regression rather than half a fix — the money scale case, where the screen agreed with itself and only the record was wrong, and making the server currency-aware alone would have printed a hundred times the price on an outbound offer.
8. **A census that can fail short has already failed.** No prefilter or skip-list without measuring what it buys; statements, not lines, with the join bounded; and once the gate is green, plant the shape it cannot see.

**A fifth reuse rule** in *Reuse before you build*: a gate that hard-codes any slice of what it guards has become a second copy of it, and a copy inside a test is invisible to the author extending the owner.

**Method, with the failure that bought each clause**, added to the two principle pages that already hold these methods rather than to the rulebooks, which stay short:

- `docs/principles/derive-the-obligation.md` — the gate is part of its own subject; plant the shape the detector cannot see; measure a shortcut before defending it (one survived six rounds of being found narrower, and deleting it was *faster* than keeping it); statements not lines, and bound the join; a self-test that reads only an exit status proves nothing about a waiver; let a parser own the grammar (six defect classes in one PR, every one of them in the matcher rather than the rule). Plus a new section on finding the other side of a wire before fixing this one.
- `docs/principles/one-source-of-truth.md` — grep the other language, because a topic that reaches a screen is spelled twice; porting half a rule puts one rule in two homes (the TS/CSS gate split, still an open decision); and the second gate of a kind is when to extract the shared traversal — two gates here each owned a copy of the extension walk and disagreed four extensions against eight, so a unit was gated by one and invisible to the other.

## Verification

- `make check-backend` — green, exit 0 (includes the rulebook parity gate, `TestPublicTreeCitesNothingPrivate`, `check-craft-doc`, and the doc-parity gates).
- Stale counts fixed: the principles index said "the six rules"; `derive-the-obligation.md` said the same.
- No private path, repository or decision-record citation added; every artifact named (`freemail.Domains()`, `frontend/src/format/minorunits.ts`, `backend/frontendminorunits_test.go`, `frontend/scripts/lib/source-tree.ts`) exists at `origin/main` and was checked there rather than in this checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents two new binding rules and a reuse rule to stop gates that silently pass while reading a smaller tree or that duplicate their subjects; clarifies cross-language invariant guidance so reviewers do not overclaim protections.

- Rulebooks (`AGENTS.md`, `CLAUDE.md`): add rule 7 (one invariant broken on both sides of a wire is one item) and rule 8 (a census that can fail short has already failed), byte‑identical; add reuse rule 5 (a gate that hard‑codes any part of its subject is a second copy).
- Principles: `docs/principles/derive-the-obligation.md` expands the method for gates that hold (derive corpus from the owner, plant blind‑spot shapes, measure shortcuts, match statements and bound joins, assert on gate output, prefer parsers). Adds “find the other side before you fix this one” with clarified scope: only when both sides actually decide the rule; the minor‑unit example gates a shared TABLE (`values.MinorUnitExceptions()` vs `frontend/src/format/minorunits.ts`) while suites keep their own cases, and it reads TS with regexes (called out as a caveat, not a parser to copy).
- Principles: `docs/principles/one-source-of-truth.md` reinforces deriving the gate’s corpus, planting unseen shapes, and when to extract a shared traversal once a second gate appears.
- `README.md` adds rationale for rules 7–8; `docs/principles/README.md` updates “six rules” to “eight”. No code or gate behavior changes.

<sup>Written for commit 62ba19554f1ac6df3441695418fdfb08ebae2424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded engineering guidance from six to eight review-loop rules.
  * Added standards for coordinating cross-language invariants, shared tables, mirror checks, and coverage.
  * Documented robust census practices, including complete scans, statement-aware matching, parser-aware validation, blind-spot tests, and waiver self-tests.
  * Clarified source-of-truth expectations and deriving guarded content from its owner.
  * Added guidance to prevent duplicated gate logic, traversal rules, and unnoticed defects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->