### PR TITLE
fix(dev): a DEV_SLUG stack gets its own Redis database

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/agentquota"
 	"github.com/gradionhq/margince/backend/internal/platform/config"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/licensecheck"
@@ -206,7 +207,23 @@ func declaredSurfaceOptions(ctx context.Context, cfg apiConfig, deployCfg deploy
 // relay's own client is the one that must ping (a stranded outbox row is a lost
 // fact, a shed force-fresh read is not).
 func sharedRedisClient(cfg apiConfig, logger *slog.Logger) (*redis.Client, func()) {
-	rdb := redis.NewClient(&redis.Options{Addr: cfg.redisAddr})
+	// Through the bus's own parser, so this client honours a `host:port/N`
+	// logical database exactly as the relay's does. Two spellings would let
+	// one of them keep landing on db 0 while the other moved, which is the
+	// event-stealing bug this suffix exists to prevent.
+	//
+	// A malformed suffix degrades to the bare address rather than refusing to
+	// boot, because this client is deliberately lazy (see above) and the relay
+	// — which parses the same string and DOES refuse — is the one that reports
+	// it. Two hard failures on one typo would be one too many; none would be
+	// silent.
+	redisOpts, err := events.ClientOptions(cfg.redisAddr)
+	if err != nil {
+		logger.Warn("the redis address names no usable logical database; using its host as given",
+			"addr", cfg.redisAddr, "err", err)
+		redisOpts = &redis.Options{Addr: cfg.redisAddr}
+	}
+	rdb := redis.NewClient(redisOpts)
 	return rdb, func() {
 		if err := rdb.Close(); err != nil {
 			logger.Warn("closing the shared redis client", "err", err)

--- a/backend/internal/platform/events/clientoptions_test.go
+++ b/backend/internal/platform/events/clientoptions_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package events
+
+// The bus address may name a logical database, and getting that wrong is
+// silent in the direction that hurts.
+//
+// One Redis serves every dev stack on a machine, and the stream names and
+// consumer groups are constants. Two stacks on one index share a consumer
+// group, so whichever worker reads an entry first consumes it, resolves it
+// against its OWN Postgres, finds nothing, and acks — the other stack's event
+// is gone and its projection simply never runs. An address that quietly fell
+// back to db 0 would restore exactly that, while looking configured.
+
+import "testing"
+
+func TestABareAddressKeepsTheDefaultDatabase(t *testing.T) {
+	opts, err := ClientOptions("localhost:16379")
+	if err != nil {
+		t.Fatalf("a bare address was refused: %v", err)
+	}
+	if opts.Addr != "localhost:16379" {
+		t.Errorf("addr = %q, want it carried through unchanged", opts.Addr)
+	}
+	// Zero is Redis's own default, and bare `make dev` relies on it so every
+	// existing redis-cli recipe still points at the same place.
+	if opts.DB != 0 {
+		t.Errorf("db = %d, want 0 for an address that names none", opts.DB)
+	}
+}
+
+func TestASuffixSelectsThatLogicalDatabase(t *testing.T) {
+	opts, err := ClientOptions("localhost:16379/7")
+	if err != nil {
+		t.Fatalf("a suffixed address was refused: %v", err)
+	}
+	if opts.Addr != "localhost:16379" {
+		t.Errorf("addr = %q, want the suffix stripped from the host", opts.Addr)
+	}
+	if opts.DB != 7 {
+		t.Errorf("db = %d, want 7", opts.DB)
+	}
+}
+
+// The refusals. Each one would otherwise land on db 0 and share a bus with
+// every other stack — the failure this parameter exists to prevent, reached
+// by way of a typo.
+func TestAnUnusableDatabaseIsRefusedRatherThanIgnored(t *testing.T) {
+	for _, addr := range []string{
+		"localhost:16379/",    // suffix present, index missing
+		"localhost:16379/x",   // not a number
+		"localhost:16379/-1",  // below the range
+		"localhost:16379/16",  // Redis ships `databases 16`, so 0..15
+		"localhost:16379/1/2", // two suffixes
+	} {
+		if _, err := ClientOptions(addr); err == nil {
+			t.Errorf("%q was accepted; a bad index must refuse rather than fall back to db 0, "+
+				"because falling back shares a consumer group with every other stack", addr)
+		}
+	}
+}
+
+// db 0 stays reachable by name: bare `make dev` uses it, and an explicit "/0"
+// is how a caller says so rather than a value to reject.
+func TestZeroIsAValidIndex(t *testing.T) {
+	opts, err := ClientOptions("localhost:16379/0")
+	if err != nil {
+		t.Fatalf("an explicit db 0 was refused: %v", err)
+	}
+	if opts.DB != 0 {
+		t.Errorf("db = %d, want 0", opts.DB)
+	}
+}

--- a/backend/internal/platform/events/clientoptions_test.go
+++ b/backend/internal/platform/events/clientoptions_test.go
@@ -51,13 +51,43 @@ func TestAnUnusableDatabaseIsRefusedRatherThanIgnored(t *testing.T) {
 		"localhost:16379/",    // suffix present, index missing
 		"localhost:16379/x",   // not a number
 		"localhost:16379/-1",  // below the range
-		"localhost:16379/16",  // Redis ships `databases 16`, so 0..15
+		"localhost:16379/80",  // Redis ships `databases 16`, so 0..15
 		"localhost:16379/1/2", // two suffixes
 	} {
 		if _, err := ClientOptions(addr); err == nil {
 			t.Errorf("%q was accepted; a bad index must refuse rather than fall back to db 0, "+
 				"because falling back shares a consumer group with every other stack", addr)
 		}
+	}
+}
+
+// A UNIX SOCKET is an address, not a suffixed host. go-redis reads a leading
+// slash as one, and every path has slashes in it — splitting those would
+// refuse a deployment that worked before this parameter existed.
+func TestAUnixSocketIsAnAddressNotADatabaseSuffix(t *testing.T) {
+	opts, err := ClientOptions("/var/run/redis.sock")
+	if err != nil {
+		t.Fatalf("a unix socket was refused: %v", err)
+	}
+	if opts.Network != "unix" {
+		t.Errorf("network = %q, want unix", opts.Network)
+	}
+	if opts.Addr != "/var/run/redis.sock" {
+		t.Errorf("addr = %q, want the path carried through whole", opts.Addr)
+	}
+	if opts.DB != 0 {
+		t.Errorf("db = %d, want 0 — a socket path names no database", opts.DB)
+	}
+}
+
+// The top of the range the dev compose actually serves.
+func TestTheHighestServedDatabaseIsAccepted(t *testing.T) {
+	opts, err := ClientOptions("localhost:16379/79")
+	if err != nil {
+		t.Fatalf("db 79 was refused, but the instance serves 80: %v", err)
+	}
+	if opts.DB != 79 {
+		t.Errorf("db = %d, want 79", opts.DB)
 	}
 }
 

--- a/backend/internal/platform/events/relay.go
+++ b/backend/internal/platform/events/relay.go
@@ -62,6 +62,14 @@ func NewClient(ctx context.Context, addr string) (*redis.Client, error) {
 // the other honoured the suffix, which is the same event-stealing bug wearing
 // a different hat.
 func ClientOptions(addr string) (*redis.Options, error) {
+	// A UNIX SOCKET is an address, not a suffixed host: go-redis reads a
+	// leading slash as one, and every path has slashes in it. Splitting those
+	// would turn /var/run/redis.sock into host "" and database
+	// "var/run/redis.sock" and refuse a deployment that worked before this
+	// parameter existed.
+	if strings.HasPrefix(addr, "/") {
+		return &redis.Options{Network: "unix", Addr: addr}, nil
+	}
 	host, index, found := strings.Cut(addr, "/")
 	if !found {
 		return &redis.Options{Addr: addr}, nil
@@ -75,10 +83,14 @@ func ClientOptions(addr string) (*redis.Options, error) {
 	return &redis.Options{Addr: host, DB: db}, nil
 }
 
-// maxRedisDB is Redis's own default `databases 16`, so 0..15. A higher index
-// would connect and then fail on the first command, which reads as an
-// unreachable bus rather than as a misconfigured one.
-const maxRedisDB = 15
+// maxRedisDB bounds the index this parser will accept. Redis's own default is
+// `databases 16`; the dev compose raises it to 80 so the integration lane and
+// the DEV_SLUG stacks each get a block. The ceiling here is deliberately the
+// higher one: an index this parser refused but the instance serves would be a
+// working configuration rejected at the door, and one it accepts that the
+// instance does not connects and then fails on the first command — which reads
+// as an unreachable bus, the error an operator can act on.
+const maxRedisDB = 79
 
 // publishedTotal counts rows shipped since process start — process-wide,
 // not per-Relay, so the metrics endpoint reads it without holding the

--- a/backend/internal/platform/events/relay.go
+++ b/backend/internal/platform/events/relay.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -29,8 +31,21 @@ import (
 // NewClient returns the Redis client the composition root hands to the
 // relay and subscribers, verified reachable — a bus that silently isn't
 // there would strand every committed outbox row.
+//
+// The address may name a logical database as `host:port/N`. One Redis serves
+// several stacks on a developer's machine, and the stream names and consumer
+// groups are constants (`gw:events:crm:*`, `cg:*`), so two stacks on db 0 share
+// ONE consumer group: whichever worker reads an entry first consumes it,
+// resolves it against its OWN database, finds nothing, and acks. The other
+// stack's event is simply gone, and the symptom — a projection that never
+// runs — is indistinguishable from a broken feature. `make dev` gives each
+// DEV_SLUG its own index for that reason.
 func NewClient(ctx context.Context, addr string) (*redis.Client, error) {
-	rdb := redis.NewClient(&redis.Options{Addr: addr})
+	opts, err := ClientOptions(addr)
+	if err != nil {
+		return nil, err
+	}
+	rdb := redis.NewClient(opts)
 	if err := rdb.Ping(ctx).Err(); err != nil {
 		//craft:ignore swallowed-errors best-effort close of a client whose ping already failed — the unreachable-bus error is the one to report
 		_ = rdb.Close()
@@ -38,6 +53,32 @@ func NewClient(ctx context.Context, addr string) (*redis.Client, error) {
 	}
 	return rdb, nil
 }
+
+// ClientOptions turns a bus address into Redis options, accepting an optional
+// `/N` logical-database suffix.
+//
+// Spelled once and exported because the api builds a client of its own beside
+// the relay's: two parsers would let one of them keep landing on db 0 while
+// the other honoured the suffix, which is the same event-stealing bug wearing
+// a different hat.
+func ClientOptions(addr string) (*redis.Options, error) {
+	host, index, found := strings.Cut(addr, "/")
+	if !found {
+		return &redis.Options{Addr: addr}, nil
+	}
+	db, err := strconv.Atoi(index)
+	if err != nil || db < 0 || db > maxRedisDB {
+		return nil, fmt.Errorf(
+			"bus: redis address %q names logical database %q, which is not an integer in 0..%d",
+			addr, index, maxRedisDB)
+	}
+	return &redis.Options{Addr: host, DB: db}, nil
+}
+
+// maxRedisDB is Redis's own default `databases 16`, so 0..15. A higher index
+// would connect and then fail on the first command, which reads as an
+// unreachable bus rather than as a misconfigured one.
+const maxRedisDB = 15
 
 // publishedTotal counts rows shipped since process start — process-wide,
 // not per-Relay, so the metrics endpoint reads it without holding the

--- a/backend/internal/platform/testdb/redis_integration_test.go
+++ b/backend/internal/platform/testdb/redis_integration_test.go
@@ -17,17 +17,24 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 )
 
-// How many logical databases the lane may use is stated in three places that
-// cannot check each other: this package's RedisDBs, REDIS_DBS in the parallel
-// runner, and --databases in the compose file. Drift between them is silent in
-// the direction that matters — the runner assigns a db the server does not
-// serve, and the suite that drew it fails with `ERR DB index is out of range`,
-// naming Redis rather than the mismatch that caused it.
+// How many logical databases exist, and who owns which, is stated in four
+// places that cannot check each other: this package's RedisDBs, REDIS_DBS in
+// the parallel runner, DEV_REDIS_DB_MIN/MAX in scripts/dev.sh, and --databases
+// in the compose file.
+//
+// Drift is silent in the direction that matters, in two ways. A lane db the
+// server does not serve fails the suite that drew it with `ERR DB index is out
+// of range`, naming Redis rather than the mismatch. And a DEV_SLUG stack
+// landing inside the lane's range is worse than that: the suite that owns the
+// db FLUSHDBs it between tests, so a developer's running stack loses its
+// streams mid-run while the suite reads that stack's events as its own. Both
+// failures point anywhere except here.
 //
 // Paths are relative to this package, which is three levels under backend/.
 const (
 	laneRunnerPath = "../../../../scripts/test-integration-parallel.sh"
 	composePath    = "../../../../infra/docker-compose.dev.yml"
+	devScriptPath  = "../../../../scripts/dev.sh"
 )
 
 // The declarations this reads. Anchored to the assignment rather than any
@@ -35,6 +42,8 @@ const (
 var (
 	laneRunnerDecl = regexp.MustCompile(`(?m)^REDIS_DBS=(\d+)$`)
 	composeDecl    = regexp.MustCompile(`--databases",\s*"(\d+)"`)
+	devMinDecl     = regexp.MustCompile(`(?m)^DEV_REDIS_DB_MIN=(\d+)$`)
+	devMaxDecl     = regexp.MustCompile(`(?m)^DEV_REDIS_DB_MAX=(\d+)$`)
 )
 
 func TestRedisDBCountAgreesWithTheLaneAndTheServer(t *testing.T) {
@@ -45,12 +54,22 @@ func TestRedisDBCountAgreesWithTheLaneAndTheServer(t *testing.T) {
 		}
 	})
 
-	// The server serves indices 0..databases-1, and db 0 is reserved for a
-	// running `make dev`, so the lane's usable count is one less than declared.
-	t.Run("the compose file provisions one more than the lane uses", func(t *testing.T) {
-		if got := declaredInt(t, composePath, composeDecl); got != testdb.RedisDBs+1 {
-			t.Errorf("--databases %d in %s but testdb.RedisDBs=%d — Redis must serve %d so that db 1..%d exist alongside the reserved db 0",
-				got, composePath, testdb.RedisDBs, testdb.RedisDBs+1, testdb.RedisDBs)
+	// Three blocks, in order and touching: db 0 is bare `make dev`, 1..RedisDBs
+	// is the lane, and DEV_REDIS_DB_MIN..MAX is the slugged dev stacks. The
+	// server must serve every index any of them can name.
+	t.Run("the slugged dev range starts above the lane", func(t *testing.T) {
+		devMin := declaredInt(t, devScriptPath, devMinDecl)
+		if devMin <= testdb.RedisDBs {
+			t.Errorf("DEV_REDIS_DB_MIN=%d in %s but the lane owns 1..%d — a slugged stack inside the lane's range has its streams FLUSHDB'd mid-run by the suite that believes it owns that db",
+				devMin, devScriptPath, testdb.RedisDBs)
+		}
+	})
+
+	t.Run("the compose file provisions every block", func(t *testing.T) {
+		devMax := declaredInt(t, devScriptPath, devMaxDecl)
+		if got := declaredInt(t, composePath, composeDecl); got != devMax+1 {
+			t.Errorf("--databases %d in %s but DEV_REDIS_DB_MAX=%d — Redis serves 0..databases-1, so it must be asked for %d for the highest slugged stack's db to exist",
+				got, composePath, devMax, devMax+1)
 		}
 	})
 
@@ -87,9 +106,10 @@ func TestRedisDBCountAgreesWithTheLaneAndTheServer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("the server reported databases=%q, which is not a number", raw)
 		}
-		if served != testdb.RedisDBs+1 {
-			t.Errorf("the server at %s serves %d databases but the lane assigns up to db %d — recreate the container (`make db-down && make db-up`); a container started before the count was raised keeps the old one",
-				addr, served, testdb.RedisDBs)
+		devMax := declaredInt(t, devScriptPath, devMaxDecl)
+		if served != devMax+1 {
+			t.Errorf("the server at %s serves %d databases but the blocks reach db %d — recreate the container (`make db-down && make db-up`); a container started before the count was raised keeps the old one",
+				addr, served, devMax)
 		}
 	})
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -402,10 +402,11 @@ the process exits.
 ## The bus address and its logical database (api, worker)
 
 `--redis` accepts a Redis logical database as a suffix: `localhost:16379/7`
-selects database 7, and a bare `localhost:16379` keeps the default 0. Valid
-indices are 0–15, Redis's own `databases 16`. A suffix that is not an index in
-that range is refused rather than ignored — falling back to 0 would put the
-process on a bus it was configured off.
+selects database 7, and a bare `localhost:16379` keeps the default 0. A suffix
+that is not an index in 0–79 is refused rather than ignored — falling back to 0
+would put the process on a bus it was configured off. A UNIX SOCKET path
+(`/var/run/redis.sock`) is an address rather than a suffixed host and is passed
+through whole.
 
 **Why it exists.** The stream names and consumer groups are constants
 (`gw:events:crm:*`, `cg:*`), so two installations pointed at one Redis database
@@ -416,8 +417,9 @@ a projection, an accrual or a notification that simply never runs — looks
 exactly like a broken feature rather than a misconfigured bus.
 
 A production installation has its own Redis and needs none of this. It matters
-on a developer machine, where `make dev` gives every `DEV_SLUG` stack its own
-index (bare `make dev` keeps 0) so parallel stacks stop stealing each other's
+on a developer machine, where one instance serves three blocks — db 0 for bare
+`make dev`, 1–63 for the parallel integration lane, 64–79 for `DEV_SLUG` stacks
+— so parallel stacks and test packages stop stealing and flushing each other's
 events. The startup banner prints which index a slugged stack took.
 
 ## Capture connector OAuth (api, worker) — Gmail / Microsoft 365

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,7 +25,7 @@ configurable logger.
 | `--config` | `MARGINCE_CONFIG` | `margince.yaml` | the deployment configuration file (bootstrap + auth — organization, bootstrap_admin, seeds, email; strict decoding, secrets as `*_file` references). A missing file boots an existing installation; bootstrapping an empty database requires `organization` + `bootstrap_admin` |
 | `--schema-dsn` | `MARGINCE_SCHEMA_DSN` | — | Postgres DSN, **owner** role, for the customfields runtime-DDL pool; unset = `createCustomField`/`updateCustomFieldOptions` answer 501 |
 | `--addr` | — | `:8080` | listen address |
-| `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus) |
+| `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus). May name a logical database as `host:port/N` (0–15) — see below |
 | `--inline-relay` | — | `true` | run the outbox relay in-process; set `false` when `cmd/worker` runs it |
 | `--webhook-key` | `MARGINCE_WEBHOOK_KEY` | — | base64 32-byte key sealing outbound-webhook signing secrets at rest; unset = the mutating `/webhook-subscriptions` paths (create/rotate, replay) answer 503, never an unsigned fallback; the read surface still lists |
 | `--geocode-base-url` | `MARGINCE_GEOCODE_BASE_URL` | — | Nominatim base URL, on the worker role. Unset = no geocoding: company addresses keep no coordinates and every `within_radius` query answers unavailable. `public` uses OpenStreetMap's own service, which is POC-only — its terms hold a client that runs on a schedule to 4 requests a minute, single-threaded, with caching, so any real volume wants a self-hosted instance. |
@@ -298,7 +298,7 @@ api's boot line says so; `cmd/worker` is load-bearing for E10 retry. See
 | `--dsn` | `MARGINCE_DSN` | — (required) | Postgres DSN, runtime app role |
 | `--public-base-url` | `MARGINCE_PUBLIC_BASE_URL` | — | canonical external scheme+host for buyer-facing links (RFC 8058 unsubscribe / preference center); required for a marketing send originated by this role's Surface-B agent run — without it that send refuses rather than emit a forgeable link |
 | `--config` | `MARGINCE_CONFIG` | `margince.yaml` | the deployment configuration file; the worker reads it for the `ai.capture_payloads` posture the Surface-B runner honors (capture applies to **both** the api and worker roles — the worker runs the richest content source, the agent runs). A missing file boots with capture off |
-| `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus) |
+| `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus). May name a logical database as `host:port/N` (0–15) — see below |
 | `--ai-routing` | `MARGINCE_AI_ROUTING` | — | path to a routing file, read **only** to seed an installation with no stored binding — see the api row. A bound installation runs the Surface-B runner + embeddings from the database, and this role re-reads it on an interval so it never serves a binding the api has replaced |
 | `--ai-fake` | — | `false` | run the Surface-B runner on the offline fake model |
 | `--runner-interval` | — | `30s` | Surface-B scheduler tick — the River periodic schedule of the `agent_scheduler` dispatcher, which enqueues one `agent_scheduler_workspace` job per live workspace. It paces the fan-out, not an agent's own schedule: the catalog's daily due hour decides when a brief runs |
@@ -398,6 +398,27 @@ embedding lane simply do not start; the relay, retention, the event-triggered
 workflow dispatch (`cg:workflows`), and the clock time-scan always run.
 Shutdown is graceful: in-flight subscriber handlers finish their ack before
 the process exits.
+
+## The bus address and its logical database (api, worker)
+
+`--redis` accepts a Redis logical database as a suffix: `localhost:16379/7`
+selects database 7, and a bare `localhost:16379` keeps the default 0. Valid
+indices are 0–15, Redis's own `databases 16`. A suffix that is not an index in
+that range is refused rather than ignored — falling back to 0 would put the
+process on a bus it was configured off.
+
+**Why it exists.** The stream names and consumer groups are constants
+(`gw:events:crm:*`, `cg:*`), so two installations pointed at one Redis database
+share one consumer group per name. Whichever worker reads a stream entry first
+consumes it, resolves it against its OWN Postgres database, finds nothing there,
+and acknowledges it. The other installation's event is gone, and the symptom —
+a projection, an accrual or a notification that simply never runs — looks
+exactly like a broken feature rather than a misconfigured bus.
+
+A production installation has its own Redis and needs none of this. It matters
+on a developer machine, where `make dev` gives every `DEV_SLUG` stack its own
+index (bare `make dev` keeps 0) so parallel stacks stop stealing each other's
+events. The startup banner prints which index a slugged stack took.
 
 ## Capture connector OAuth (api, worker) — Gmail / Microsoft 365
 

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -180,11 +180,21 @@ in `lastactivity_integration_test.go`.
 
 `make dev DEV_SLUG=<slug>` runs a full stack that won't collide with another
 worktree's: the ONE shared infra (Postgres/Redis on `15432`/`16379`), but a
-private database `margince_dev_<slug>` and api/FE ports derived
-deterministically from the slug (the FE's `/v1` proxy follows the api via
-`BACKEND_PORT`). Logs + stop handle live under `.tmp/dev/<slug>/`. Bare
-`make dev` uses the shared `margince` database with the app on the base
-`:8080`. Stop either with `make dev-stop [DEV_SLUG=<slug>] [DROP=1]`.
+private database `margince_dev_<slug>`, a private **Redis logical database**,
+and api/FE ports derived deterministically from the slug (the FE's `/v1` proxy
+follows the api via `BACKEND_PORT`). Logs + stop handle live under
+`.tmp/dev/<slug>/`. Bare `make dev` uses the shared `margince` database, Redis
+db 0, and the app on the base `:8080`. Stop either with
+`make dev-stop [DEV_SLUG=<slug>] [DROP=1]`.
+
+**The Redis index is isolation, not tidiness.** The stream names and consumer
+groups are constants (`gw:events:crm:*`, `cg:*`), so two stacks on one index
+share one consumer group: whichever worker reads an entry first consumes it,
+resolves it against its OWN Postgres, finds nothing, and acks. The other
+stack's event is gone, and a projection or accrual that never runs looks
+exactly like a broken feature — it cost a day and a wrongly-filed critical bug
+once. Slugs take 1–15; the startup banner prints which. With more than 15
+slugged stacks two will collide, which is the state bare `make dev` sweeps.
 
 A slugged stack is the one thing `make dev`'s sweep does not perform — it
 sweeps nothing itself, so it can start alongside the base stack. But the next

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -193,8 +193,17 @@ share one consumer group: whichever worker reads an entry first consumes it,
 resolves it against its OWN Postgres, finds nothing, and acks. The other
 stack's event is gone, and a projection or accrual that never runs looks
 exactly like a broken feature — it cost a day and a wrongly-filed critical bug
-once. Slugs take 1–15; the startup banner prints which. With more than 15
-slugged stacks two will collide, which is the state bare `make dev` sweeps.
+once.
+
+The instance serves 80 databases in three blocks: **0** is bare `make dev`,
+**1–63** the parallel integration lane (one per package, which `FLUSHDB`s), and
+**64–79** slugged stacks. A slug takes the lowest free index in its block,
+claimed under a lock and recorded in `.tmp/dev/<slug>/env`, so restarting a
+slug reclaims its own and two slugs never share one. Deliberately not the port
+hash: two hashes differing by a multiple of the block size would take different
+ports and the SAME database, a collision the port check cannot see. The startup
+banner prints the index. A 17th concurrent slugged stack is refused rather than
+doubled up.
 
 A slugged stack is the one thing `make dev`'s sweep does not perform — it
 sweeps nothing itself, so it can start alongside the base stack. But the next

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -160,7 +160,15 @@ services:
     # slowdown. The lane has more packages than 16 and keeps growing; keep this
     # in step with REDIS_DBS in scripts/test-integration-parallel.sh, which
     # refuses to run rather than wrap the mapping.
-    command: ["redis-server", "--databases", "64"]
+    # 80 logical databases, in three blocks that must not overlap:
+    #   0        bare `make dev`
+    #   1..63    the parallel integration lane, one per package
+    #            (REDIS_DBS in scripts/test-integration-parallel.sh,
+    #             testdb.RedisDBs — the two must agree)
+    #   64..79   DEV_SLUG stacks, one per slug (scripts/dev.sh)
+    # A slug sharing a db with a test package would have its streams FLUSHDB'd
+    # mid-run, and the test would read a dev stack's events as its own.
+    command: ["redis-server", "--databases", "80"]
     ports:
       - "16379:6379"
     healthcheck:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -101,6 +101,28 @@ fi
 fe_port=$(( 8080 + hash ))
 api_port=$(( 18080 + hash ))
 
+# The Redis LOGICAL DATABASE this stack uses, derived from the same hash.
+#
+# One Redis serves every stack on the machine, and the stream names and
+# consumer groups are constants (`gw:events:crm:*`, `cg:*`). Two stacks on the
+# same index therefore share ONE consumer group: whichever worker reads an
+# entry first consumes it, resolves it against its OWN Postgres database, finds
+# nothing, and acks. The other stack's event is gone, and the symptom — a
+# projection or an accrual that never runs — is indistinguishable from a broken
+# feature. That cost a day and a wrongly-filed critical bug once.
+#
+# Bare `make dev` keeps db 0 so every existing recipe, redis-cli one-liner and
+# habit still points at the same place. A slug takes 1..15 (Redis ships
+# `databases 16`), so slugged stacks are isolated from the base stack and, by
+# the same hash that keeps their ports apart, from each other. A collision
+# beyond 15 slugs is possible and shows up as two stacks sharing a bus, which
+# is exactly the state bare `make dev` already sweeps.
+redis_db=0
+if [[ -n "$slug" ]]; then
+  redis_db=$(( 1 + hash % 15 ))
+fi
+REDIS_ADDR="localhost:${REDIS_PORT}/${redis_db}"
+
 # with_database DSN NAME — the same connection, pointed at a different database.
 #
 # The database segment is REPLACED, never inherited. DEV_SLUG owns the name
@@ -610,7 +632,7 @@ up)
     MARGINCE_BLOBSTORE_BUCKET=margince-dev \
     MARGINCE_BLOBSTORE_REGION=us-east-1 \
     ./bin/api --addr ":${api_port}" --dsn "$dev_app_url" --config "$deploy_cfg" \
-    --redis "localhost:${REDIS_PORT}" \
+    --redis "${REDIS_ADDR}" \
     "${public_base_url_flag[@]}" \
     "${ai_flag[@]}" "${gmail_api_flags[@]+"${gmail_api_flags[@]}"}" > >(log_as api) 2>&1 &
   be_pid=$!
@@ -663,7 +685,7 @@ up)
     MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
     MARGINCE_BLOBSTORE_BUCKET=margince-dev \
     MARGINCE_BLOBSTORE_REGION=us-east-1 \
-    ./bin/worker --dsn "$dev_app_url" --redis "localhost:${REDIS_PORT}" \
+    ./bin/worker --dsn "$dev_app_url" --redis "${REDIS_ADDR}" \
     --config "$deploy_cfg" \
     --retention-interval 720h \
     "${ai_flag[@]}" "${worker_gmail_flags[@]+"${worker_gmail_flags[@]}"}" > >(log_as worker) 2>&1 &
@@ -683,6 +705,12 @@ up)
     echo "  OPEN     http://localhost:${fe_port}"
     echo ""
     echo "  api      http://localhost:${api_port}  (also proxied at :${fe_port}/v1)"
+    # Printed for a slugged stack only, and printed at all because a shared bus
+    # is invisible until something goes missing: a reader debugging a consumer
+    # needs to know which index to point redis-cli at.
+    if [[ -n "$slug" ]]; then
+      echo "  bus      redis db ${redis_db} on :${REDIS_PORT}  (this slug's own — events are not shared with other stacks)"
+    fi
     # The only seat on a cold start is the bootstrap admin, and the deployment
     # config is where it is defined — read the address back from that file
     # rather than restating it, so an edited config prints the truth.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -101,7 +101,7 @@ fi
 fe_port=$(( 8080 + hash ))
 api_port=$(( 18080 + hash ))
 
-# The Redis LOGICAL DATABASE this stack uses, derived from the same hash.
+# The Redis LOGICAL DATABASE this stack uses.
 #
 # One Redis serves every stack on the machine, and the stream names and
 # consumer groups are constants (`gw:events:crm:*`, `cg:*`). Two stacks on the
@@ -111,15 +111,76 @@ api_port=$(( 18080 + hash ))
 # projection or an accrual that never runs — is indistinguishable from a broken
 # feature. That cost a day and a wrongly-filed critical bug once.
 #
-# Bare `make dev` keeps db 0 so every existing recipe, redis-cli one-liner and
-# habit still points at the same place. A slug takes 1..15 (Redis ships
-# `databases 16`), so slugged stacks are isolated from the base stack and, by
-# the same hash that keeps their ports apart, from each other. A collision
-# beyond 15 slugs is possible and shows up as two stacks sharing a bus, which
-# is exactly the state bare `make dev` already sweeps.
+# The instance serves 80 databases in three blocks that must not overlap
+# (infra/docker-compose.dev.yml says the same): db 0 is bare `make dev`, 1..63
+# belong to the parallel integration lane one per package, and 64..79 are
+# these slugged stacks. A slug landing in the test range would have its streams
+# FLUSHDB'd mid-run by a suite that believes it owns the db.
+#
+# The index is NOT the port hash. Two hashes differing by a multiple of the
+# block size would take different ports and the same db — a collision the port
+# check cannot see, which is the failure this whole change is about. It is
+# instead the lowest free index, claimed under a lock and recorded beside the
+# stack's other state, so a running stack's db is never handed out twice and a
+# resumed slug reclaims its own.
+DEV_REDIS_DB_MIN=64
+DEV_REDIS_DB_MAX=79
+
+# claim_redis_db SLUG — the logical database this slug owns, on stdout.
+#
+# Same slug wins the same index back, so restarting a stack keeps whatever its
+# streams already hold. A NEW slug takes the lowest index no other recorded
+# stack is using; two starting at once are serialised by a lock directory, so
+# they cannot both read "64 is free" and both take it.
+#
+# Reading the recorded stacks rather than hashing is what makes the guarantee
+# real: a hash gives distinct ports and a shared db whenever two hashes differ
+# by a multiple of the block size, which the port check cannot see and which is
+# exactly the collision this change exists to remove.
+claim_redis_db() { # slug
+  local want="$1" lock=".tmp/dev/.redis-db.lock" taken=() db
+  mkdir -p .tmp/dev
+  # A stale lock from a killed run would wedge every later start, so it is
+  # cleared on exit AND bounded: mkdir is the atomic primitive here.
+  local waited=0
+  until mkdir "$lock" 2>/dev/null; do
+    (( waited++ >= 50 )) && { rm -rf "$lock"; continue; }
+    sleep 0.1
+  done
+  trap 'rm -rf "'"$lock"'"' RETURN
+
+  local state_file other_slug REDIS_DB
+  for state_file in .tmp/dev/*/env; do
+    [[ -f "$state_file" ]] || continue
+    other_slug="$(basename "$(dirname "$state_file")")"
+    REDIS_DB=''
+    # shellcheck disable=SC1090
+    . "$state_file"
+    [[ -z "$REDIS_DB" ]] && continue
+    # This slug's own recorded index is the one it reclaims.
+    if [[ "$other_slug" == "$want" ]]; then
+      printf '%s' "$REDIS_DB"
+      return 0
+    fi
+    taken+=("$REDIS_DB")
+  done
+
+  for (( db = DEV_REDIS_DB_MIN; db <= DEV_REDIS_DB_MAX; db++ )); do
+    local used=0 t
+    for t in "${taken[@]:-}"; do [[ "$t" == "$db" ]] && { used=1; break; }; done
+    (( used )) || { printf '%s' "$db"; return 0; }
+  done
+
+  # Every index in the block is spoken for. Refuse rather than double up: a
+  # shared bus is the silent failure this whole mechanism prevents, and a
+  # 17th concurrent stack is a situation to notice, not to paper over.
+  echo "FAIL: all ${DEV_REDIS_DB_MIN}..${DEV_REDIS_DB_MAX} Redis databases are claimed by other dev stacks." >&2
+  echo "  Stop one (make dev-stop DEV_SLUG=<slug>), or a bare 'make dev' to sweep them all." >&2
+  exit 1
+}
 redis_db=0
 if [[ -n "$slug" ]]; then
-  redis_db=$(( 1 + hash % 15 ))
+  redis_db=$(claim_redis_db "$slug")
 fi
 REDIS_ADDR="localhost:${REDIS_PORT}/${redis_db}"
 
@@ -696,8 +757,11 @@ up)
     echo "  worker   background relay + Surface-B runner + automation time-scan running"
   fi
 
-  printf 'SLUG=%s\nAPI_PORT=%s\nFE_PORT=%s\nDB=%s\nBACKEND_PID=%s\nFE_PID=%s\nWORKER_PID=%s\nLOG=%s\n' \
-    "$slug" "$api_port" "$fe_port" "$db" "$be_pid" "$fe_pid" "$worker_pid" "$log" >"$state"
+  # REDIS_DB is recorded because claim_redis_db reads it back: it is how this
+  # slug reclaims its own index on a restart, and how the next slug knows the
+  # index is spoken for.
+  printf 'SLUG=%s\nAPI_PORT=%s\nFE_PORT=%s\nDB=%s\nREDIS_DB=%s\nBACKEND_PID=%s\nFE_PID=%s\nWORKER_PID=%s\nLOG=%s\n' \
+    "$slug" "$api_port" "$fe_port" "$db" "$redis_db" "$be_pid" "$fe_pid" "$worker_pid" "$log" >"$state"
 
   if wait_ready "http://localhost:${fe_port}/" 90; then
     echo "$label ready"


### PR DESCRIPTION
Closes #2428.

## The problem

`DEV_SLUG` isolated the port and the Postgres database and **not the bus**. Every stack used `localhost:16379` db 0, and the stream names and consumer groups are compile-time constants (`gw:events:crm:*`, `cg:*`) — so N stacks shared ONE consumer group per name. Whichever worker read an entry first consumed it, resolved it against its OWN Postgres, found nothing, and acked. The other stack's event was gone.

**The symptom is indistinguishable from a broken feature.** Yesterday a won partner deal produced no commission on my stack, and every signal agreed with "the handler ran and did nothing": `pending 0`, a normal `entries-read`, the dedupe key present, an empty ledger, no log line. All of it was another checkout's worker taking the event. It cost a day and a critical issue filed against working code.

## The fix

`--redis` accepts `host:port/N`. `scripts/dev.sh` gives each slug an index, and the banner prints it.

**Three blocks that cannot overlap** — Redis now serves 80:

| Block | Owner |
|---|---|
| `0` | bare `make dev` |
| `1–63` | the parallel integration lane, one per package |
| `64–79` | `DEV_SLUG` stacks |

**The index is claimed, not hashed.** The lowest free one in the block, taken under a lock and recorded as `REDIS_DB` in the stack's state file, so a restart reclaims the same index and two slugs never share one.

## Review findings, all three real

Codex caught three defects in my first cut:

1. **The dev range collided with the test lane.** I took 1–15; the lane owns 1–63 and its suites `FLUSHDB`. A slugged stack there would lose its streams mid-run — the same bug from the test side.
2. **Two slugs could share a db while holding different ports.** `1 + hash % 15` collides for any two hashes differing by 15 — Codex's example was `b` and `c`, distinct ports, both db 8. Reachable with **two** stacks, not sixteen, and invisible to the port check.
3. **A unix socket stopped booting.** `strings.Cut(addr, "/")` read `/var/run/redis.sock` as host `""`. Worse, it was role-dependent: the api's lazy client fell back to the whole path and worked, the worker hard-refused.

## The fitness test grew rather than being relaxed

`TestRedisDBCountAgreesWithTheLaneAndTheServer` now holds all three blocks and asserts the dev range starts **above** the lane. Reverting `DEV_REDIS_DB_MIN` into the lane's range fails it.

## Verified

Two slugged stacks running at once, which is the whole point: db 64 and db 65, a €10,000 deal on one and €20,000 on the other, both at tier3_25 — **€2,500 and €5,000 accrued in about three seconds, neither taking the other's event.**

## On the integration lane

10 failures in `integration/agentaccess` (`mcp_tasks`). **Identical count on clean main**, so not from this change. Filing separately.

A production installation has its own Redis and is unaffected.

## Gates

`make check-backend` exit 0 · `make craft-static` 0/0/0 · `make rls-store-path` OK · 6 unit tests + the extended fitness test, both mutation-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives each `DEV_SLUG` stack its own Redis logical database and adds `host:port/N` support to `--redis`. Before: all stacks used db 0 and shared consumer groups; now: bare `make dev` stays on 0, the lane uses 1–63, and slugged stacks claim 64–79, so events are isolated.

- `events.ClientOptions` parses `host:port/N` once for both the relay and the API, refuses bad indices (outside 0–79), and treats UNIX sockets as addresses; the API’s lazy client warns and falls back to the host on malformed suffixes.
- `scripts/dev.sh` claims the lowest free db in 64–79 under a lock, records `REDIS_DB` in `.tmp/dev/<slug>/env`, prints it in the banner, and refuses a 17th concurrent slug rather than doubling up.
- `infra/docker-compose.dev.yml` now serves 80 databases; `backend/internal/platform/testdb` asserts the lane, dev ranges, and server count; docs in `docs/reference/configuration.md` and `docs/reference/make-targets.md` explain the layout.
- Production remains unchanged (each installation uses its own Redis).
- Migration: recreate the dev Redis container to pick up the new count — run: make db-down && make db-up.

<sup>Written for commit f3ca8f88b56beeea81492628ae2bf96869e39cd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting Redis logical databases using addresses such as `host:port/N`.
  * Isolated slugged development stacks with dedicated Redis databases to prevent data and consumer-group collisions.
  * Added Unix socket support and validation for Redis database selections.
  * Expanded development Redis capacity to 80 logical databases.

* **Documentation**
  * Documented Redis database selection, isolation behavior, allocation ranges, and concurrency limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->