### PR TITLE
fix(people): the open-pipeline formula field stops saying "awaiting FX"

### DIFF
--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -231,6 +231,49 @@ func TestOrganizationComputed_NoOpenDeals_FloorsToZero(t *testing.T) {
 	}
 }
 
+// A mix of priced and unpriced deals reports NO figure, not a short one.
+//
+// This is the defect a converting view introduces if nobody looks for it: SUM
+// ignores the deal it could not price, silently, so an account with one EUR
+// deal and one unpriceable JPY deal produces a real number covering half the
+// pipeline. Shown as a total it is worse than the "not computable" it replaced
+// — the reader cannot see what is missing from it.
+func TestOrganizationComputed_SomeDealsUnpriceable_RefusesTheShortTotal(t *testing.T) {
+	e := Setup(t)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	orgID := e.SeedOrg(t, "Half Priced GmbH", nil)
+
+	for _, deal := range []struct {
+		amount   int64
+		currency string
+	}{
+		{75_000, "EUR"},    // prices: the installation's own currency
+		{5_000_000, "JPY"}, // cannot: no rate is loaded for the pair
+	} {
+		if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+			Name: "Deal", AmountMinor: int64Ptr(deal.amount), Currency: strPtr(deal.currency),
+			PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := computedFieldByKey(*org.ComputedFields, "open_pipeline")
+	if got.Computable {
+		t.Fatalf("a total covering 1 of 2 open deals was reported as computable: %+v", got)
+	}
+	if got.ValueMinor != nil {
+		t.Errorf("open_pipeline.value_minor = %v, want absent — 75000 is real but it is not the pipeline", got.ValueMinor)
+	}
+	if got.Reason == nil || *got.Reason != "partial_pipeline" {
+		t.Errorf("open_pipeline.reason = %v, want \"partial_pipeline\"", got.Reason)
+	}
+}
+
 // The case this field got wrong for every installation: an ordinary open
 // pipeline, in the installation's own currency, needing no conversion at all.
 //

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -231,26 +231,64 @@ func TestOrganizationComputed_NoOpenDeals_FloorsToZero(t *testing.T) {
 	}
 }
 
-// TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX is the
-// OTHER honest "not computable yet" state 0065 documents: open deals
-// exist (the view row IS present, open_deal_count > 0) but every one is
-// still missing fx_rate_to_base — the ordinary state for an open deal
-// through any real write path — so amount_minor_base is NULL for every
-// summand and SUM ignores them all, leaving the row's aggregate itself
-// NULL. Flooring this to a real 0 would be dishonest: it would sit
-// beside a non-zero weighted_pipeline (arc 1b's hierarchy-rollup) as a
-// fabricated "no pipeline" figure. The assembler instead floors it to
-// computable:false, reason:"awaiting_fx", with no value_minor on the
-// wire — the row EXISTS with a NULL aggregate, distinct from the
-// genuine-zero no-row case the next test covers.
-func TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX(t *testing.T) {
+// The case this field got wrong for every installation: an ordinary open
+// pipeline, in the installation's own currency, needing no conversion at all.
+//
+// The view summed deal.amount_minor_base, which is null on every OPEN deal
+// because the rate freezes on close. So a perfectly computable pipeline
+// reported "awaiting FX" — for deals that needed no FX — and the field was
+// effectively dead on every account that had not closed and reopened a deal.
+func TestOrganizationComputed_OpenDealsInTheBaseCurrency_ReportTheirTotal(t *testing.T) {
+	e := Setup(t)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	orgID := e.SeedOrg(t, "Ordinary Pipeline GmbH", nil)
+
+	for _, amount := range []int64{75_000, 125_000} {
+		if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+			Name: "Open deal", AmountMinor: int64Ptr(amount), Currency: strPtr("EUR"),
+			PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := computedFieldByKey(*org.ComputedFields, "open_pipeline")
+	if !got.Computable {
+		t.Fatalf("an open EUR pipeline on a EUR installation is not computable: %+v — it needs no rate to convert", got)
+	}
+	if got.ValueMinor == nil || *got.ValueMinor != 200_000 {
+		t.Errorf("open_pipeline.value_minor = %v, want 200000 (750.00 + 1250.00)", got.ValueMinor)
+	}
+}
+
+// TestOrganizationComputed_OpenDealsWithNoUsableRate_AwaitingFX is the OTHER
+// honest "not computable yet" state: open deals exist (the view row IS present,
+// open_deal_count > 0) but not one of them can be converted, because the
+// installation holds no rate on or before today for the currency they are held
+// in. The aggregate is NULL and flooring it to a real 0 would be dishonest — it
+// would sit beside a non-zero weighted_pipeline as a fabricated "no pipeline"
+// figure. The assembler floors it to computable:false, reason:"awaiting_fx",
+// with no value_minor on the wire, distinct from the genuine-zero no-row case
+// the next test covers.
+//
+// The deals are held in JPY on purpose. This state used to be reachable with
+// deals in the installation's OWN currency, because the view summed
+// amount_minor_base — null on every open deal — so an ordinary EUR pipeline on
+// a EUR installation reported "awaiting FX" while needing no FX at all. The
+// view converts now, so reaching this state takes a currency the rate sheet
+// genuinely cannot price.
+func TestOrganizationComputed_OpenDealsWithNoUsableRate_AwaitingFX(t *testing.T) {
 	e := Setup(t)
 	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
 	orgID := e.SeedOrg(t, "Unpriced Pipeline LLC", nil)
 
 	for _, amount := range []int64{75000, 125000} {
 		if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
-			Name: "Unpriced deal", AmountMinor: int64Ptr(amount), Currency: strPtr("EUR"),
+			Name: "Unpriced deal", AmountMinor: int64Ptr(amount), Currency: strPtr("JPY"),
 			PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
 		}); err != nil {
 			t.Fatal(err)
@@ -262,7 +300,7 @@ func TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX(t *testing.T) 
 		t.Fatal("test fixture: expected a view row (2 open deals reference this org)")
 	}
 	if minor != nil {
-		t.Fatalf("test fixture: expected a NULL aggregate (neither deal has fx_rate_to_base), got %d", *minor)
+		t.Fatalf("test fixture: expected a NULL aggregate (no rate prices JPY here), got %d", *minor)
 	}
 	if count != 2 {
 		t.Fatalf("test fixture: open_deal_count = %d, want 2", count)
@@ -283,7 +321,7 @@ func TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX(t *testing.T) 
 		t.Fatalf("open_pipeline.value_minor = %v, want absent (awaiting_fx carries no value)", open0.ValueMinor)
 	}
 	if open0.FormulaSql == "" {
-		t.Fatal("open_pipeline.formula_sql must stay populated: the formula exists, only its FX input doesn't yet")
+		t.Fatal("open_pipeline.formula_sql must stay populated: the formula exists, only a rate for this currency does not")
 	}
 
 	raw, err := json.Marshal(org)

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -38,18 +38,39 @@ const (
 	// organization with no open deals at all, and — since the view
 	// converts rather than reading a column that is null until close —
 	// now the rare state its name always implied.
-	awaitingFXReason       = "awaiting_fx"
+	awaitingFXReason = "awaiting_fx"
+	// partialPipelineReason floors open_pipeline when SOME open deals reached
+	// the total and others could not be priced. The sum is real but short, and
+	// a short figure shown as a total is worse than none: the reader has no way
+	// to see what is missing from it, and the number sits on the page looking
+	// like the whole pipeline.
+	partialPipelineReason  = "partial_pipeline"
 	openPipelineFormulaSQL = "organization_open_pipeline_rollup: SUM over deal WHERE status = 'open' AND organization_id = <this org> AND archived_at IS NULL, each amount converted to the installation base currency at the latest fx_rate on or before today"
 )
 
-// openPipelineDependencies names what the view's aggregate reads: the
-// deal's own amount and currency, the two columns its WHERE clause gates
-// participation on, and the rate sheet the conversion resolves against.
+// openPipelineDependencies names every column the view's aggregate reads:
+// what is summed, what its WHERE gates participation on, what the rate
+// lookup matches and orders by, and the setting the base currency comes
+// from. A change to any of them changes the answer, which is what makes
+// this list worth keeping accurate.
+//
 // deal.fx_rate_to_base is deliberately absent — it is null on every open
 // deal, which is why the view stopped reading it.
 var openPipelineDependencies = []string{
-	"deal.amount_minor", "deal.currency", "deal.status", "deal.archived_at",
-	"fx_rate.rate", "setting.installation.base_currency",
+	"deal.amount_minor", "deal.currency", "deal.organization_id",
+	"deal.status", "deal.archived_at",
+	"fx_rate.from_currency", "fx_rate.to_currency", "fx_rate.rate", "fx_rate.rate_date",
+	"setting.installation.base_currency",
+}
+
+// openPipeline is what the view reports for one organization: the converted
+// total, how many open deals there are, and how many of them actually reached
+// the total. The third is what tells a complete figure from a short one — SUM
+// ignores a null summand without saying so.
+type openPipeline struct {
+	minorBase   *int64
+	dealCount   int
+	pricedCount int
 }
 
 // computedFieldsVisible answers the STATE-4 gate: does the acting
@@ -91,29 +112,31 @@ func computedFieldsVisible(ctx context.Context) bool {
 //
 // No tenant term appears here because none exists to appear: the tables this
 // read touches carry no tenant column, and a join on one would only re-derive
-// the bound the foreign key above already carries.
+// the bound the foreign key above already carries. The view reaches setting
+// and fx_rate as well as deal now, and neither is tenant-scoped either — the
+// migration says what that does and does not disclose.
 //
 // No row (an organization with no open deals at all) is the honest
-// "nothing to sum" case: (nil, 0, nil), never an error. dealCount is the
-// caller's only way to distinguish that genuine-zero state from the
-// OTHER honest "not computable yet" state — open deals exist
-// (dealCount > 0) but every one is still missing fx_rate_to_base, so
-// the aggregate itself comes back NULL.
-func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (minorBase *int64, dealCount int, err error) {
+// "nothing to sum" case: a zero openPipeline, never an error. The two counts
+// are what separate the three states a caller must tell apart — no deals at
+// all, every deal priced, and some priced while others could not be. Without
+// pricedCount the third is indistinguishable from the second, and a total
+// covering half the pipeline would be reported as the pipeline.
+func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (roll openPipeline, err error) {
 	err = tx.QueryRow(ctx,
-		`SELECT open_pipeline_minor_base, open_deal_count
+		`SELECT open_pipeline_minor_base, open_deal_count, priced_deal_count
 		 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
-		orgID).Scan(&minorBase, &dealCount)
+		orgID).Scan(&roll.minorBase, &roll.dealCount, &roll.pricedCount)
 	if errors.Is(err, pgx.ErrNoRows) {
-		// Scan never ran, so minorBase/dealCount are still their zero
-		// values (nil, 0) — return the named vars, not literal zeroes:
-		// the honest "nothing to sum" case above, not a swallowed error.
-		return minorBase, dealCount, nil
+		// Scan never ran, so roll is still its zero value — return it, not
+		// literal zeroes: the honest "nothing to sum" case above, not a
+		// swallowed error.
+		return roll, nil
 	}
 	if err != nil {
-		return nil, 0, err
+		return openPipeline{}, err
 	}
-	return minorBase, dealCount, nil
+	return roll, nil
 }
 
 // organizationComputedFields assembles the 5 display rows RD-T08 names.
@@ -124,18 +147,17 @@ func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 //   - openDealCount == 0 (no view row: an organization with no open
 //     deals at all) is the honest "nothing to sum" case: computable:true,
 //     value_minor:0 — a real zero, not a missing one.
-//   - openPipelineMinor != nil (the view row's aggregate is non-NULL) is
-//     the genuinely computable case: computable:true, value_minor:sum.
-//   - openPipelineMinor == nil AND openDealCount > 0 (open deals exist
-//     but every one is still missing fx_rate_to_base, the ordinary state
-//     for an open deal — 0065's documented "not computable yet" case) is
-//     NOT a zero: flooring it would show a dishonest 0 pipeline beside a
-//     non-zero weighted_pipeline. It floors instead to computable:false,
-//     reason:"awaiting_fx", with no value_minor on the wire — the honest
-//     "not computable yet" state 0065's migration comment already names,
-//     now surfaced here instead of floored away. formula_sql stays
-//     populated: the formula exists, only its FX input doesn't yet.
-func organizationComputedFields(openPipelineMinor *int64, openDealCount int) []crmcontracts.ComputedField {
+//   - Every open deal reached the total (priced == open) and the aggregate is
+//     non-NULL: computable:true, value_minor:sum.
+//   - Some deals reached it and others did not: the sum is SHORT, and a short
+//     figure presented as a total is worse than no figure — a reader cannot
+//     see what is missing from it. It floors to computable:false with the
+//     partial reason.
+//   - No deal reached it (aggregate NULL, open deals exist): not one of them
+//     could be priced. It floors to computable:false, reason:"awaiting_fx",
+//     with no value_minor on the wire. formula_sql stays populated either way:
+//     the formula exists, only a rate for these currencies does not.
+func organizationComputedFields(open openPipeline) []crmcontracts.ComputedField {
 	weightedReason := servedByHierarchyRollupReason
 	customerAgeReason := notYetBuiltReason
 	nrrReason := notYetBuiltReason
@@ -149,14 +171,18 @@ func organizationComputedFields(openPipelineMinor *int64, openDealCount int) []c
 		Dependencies: openPipelineDependencies,
 	}
 	switch {
-	case openPipelineMinor != nil:
-		value := *openPipelineMinor
-		openPipelineRow.Computable = true
-		openPipelineRow.ValueMinor = &value
-	case openDealCount == 0:
+	case open.dealCount == 0:
 		zero := int64(0)
 		openPipelineRow.Computable = true
 		openPipelineRow.ValueMinor = &zero
+	case open.minorBase != nil && open.pricedCount == open.dealCount:
+		value := *open.minorBase
+		openPipelineRow.Computable = true
+		openPipelineRow.ValueMinor = &value
+	case open.pricedCount > 0:
+		reason := partialPipelineReason
+		openPipelineRow.Computable = false
+		openPipelineRow.Reason = &reason
 	default:
 		reason := awaitingFXReason
 		openPipelineRow.Computable = false

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -32,19 +32,25 @@ const (
 	servedByHierarchyRollupReason = "served_by_hierarchy_rollup"
 	// awaitingFXReason floors open_pipeline when the view row EXISTS
 	// (open deals reference this organization) but its aggregate is
-	// itself NULL: every one of those deals is still missing
-	// fx_rate_to_base, the ordinary state for an open deal (0065's
-	// documented "not computable yet" case) — distinct from the
-	// genuine zero of an organization with no open deals at all.
+	// itself NULL: not one of those deals could be converted, because
+	// the installation holds no rate on or before today for any
+	// currency they are held in. Distinct from the genuine zero of an
+	// organization with no open deals at all, and — since the view
+	// converts rather than reading a column that is null until close —
+	// now the rare state its name always implied.
 	awaitingFXReason       = "awaiting_fx"
-	openPipelineFormulaSQL = "organization_open_pipeline_rollup (0065): SUM(deal.amount_minor_base) FROM deal WHERE deal.status = 'open' AND deal.organization_id = <this org> AND deal.archived_at IS NULL"
+	openPipelineFormulaSQL = "organization_open_pipeline_rollup: SUM over deal WHERE status = 'open' AND organization_id = <this org> AND archived_at IS NULL, each amount converted to the installation base currency at the latest fx_rate on or before today"
 )
 
-// openPipelineDependencies names the columns feeding the view's
-// aggregate: the two inputs of deal.amount_minor_base's own GENERATED
-// expression (0065), plus the two columns the view's WHERE clause
-// gates participation on.
-var openPipelineDependencies = []string{"deal.amount_minor", "deal.fx_rate_to_base", "deal.status", "deal.archived_at"}
+// openPipelineDependencies names what the view's aggregate reads: the
+// deal's own amount and currency, the two columns its WHERE clause gates
+// participation on, and the rate sheet the conversion resolves against.
+// deal.fx_rate_to_base is deliberately absent — it is null on every open
+// deal, which is why the view stopped reading it.
+var openPipelineDependencies = []string{
+	"deal.amount_minor", "deal.currency", "deal.status", "deal.archived_at",
+	"fx_rate.rate", "setting.installation.base_currency",
+}
 
 // computedFieldsVisible answers the STATE-4 gate: does the acting
 // principal's merged role policy grant computed_field:read? poc-1

--- a/backend/internal/modules/people/organization_computed_test.go
+++ b/backend/internal/modules/people/organization_computed_test.go
@@ -60,7 +60,7 @@ func TestComputedFieldsVisible_SystemPrincipalTrusted(t *testing.T) {
 // not_yet_built.
 func TestOrganizationComputedFields_FiveRowsExactShape(t *testing.T) {
 	minor := int64(125000)
-	rows := organizationComputedFields(&minor, 1)
+	rows := organizationComputedFields(openPipeline{minorBase: &minor, dealCount: 1, pricedCount: 1})
 	if len(rows) != 5 {
 		t.Fatalf("want exactly 5 display rows, got %d", len(rows))
 	}
@@ -114,7 +114,7 @@ func TestOrganizationComputedFields_FiveRowsExactShape(t *testing.T) {
 // poc-1-tested behaviour: a record-page tile has no way to render
 // "unknown", so 0 is the honest lower bound of what CAN be priced.
 func TestOrganizationComputedFields_NoOpenDeals_FloorsToZero(t *testing.T) {
-	rows := organizationComputedFields(nil, 0)
+	rows := organizationComputedFields(openPipeline{})
 	if rows[0].ValueMinor == nil || *rows[0].ValueMinor != 0 {
 		t.Fatalf("open_pipeline.value_minor = %v, want 0", rows[0].ValueMinor)
 	}
@@ -126,15 +126,13 @@ func TestOrganizationComputedFields_NoOpenDeals_FloorsToZero(t *testing.T) {
 	}
 }
 
-// The OTHER honest "not computable yet" state 0065 documents: the view
-// row EXISTS (open deals reference this org, dealCount > 0) but its
-// aggregate is itself NULL because every one of those deals is still
-// missing fx_rate_to_base. Flooring this to 0 would be dishonest — a
-// non-zero weighted_pipeline sitting beside a fabricated zero — so it
-// must floor to computable:false, reason:"awaiting_fx" instead, with no
-// value_minor on the wire.
-func TestOrganizationComputedFields_NullAggregateWithOpenDeals_AwaitingFX(t *testing.T) {
-	rows := organizationComputedFields(nil, 2)
+// The honest "not computable" state: open deals exist and NOT ONE of them
+// could be priced, so the aggregate is NULL. Flooring this to 0 would be
+// dishonest — a non-zero weighted_pipeline sitting beside a fabricated zero —
+// so it floors to computable:false, reason:"awaiting_fx", with no value_minor
+// on the wire.
+func TestOrganizationComputedFields_NothingCouldBePriced_AwaitingFX(t *testing.T) {
+	rows := organizationComputedFields(openPipeline{dealCount: 2})
 	open := rows[0]
 	if open.Computable {
 		t.Fatalf("open_pipeline must be computable=false when the aggregate is NULL but open deals exist, got %+v", open)
@@ -146,6 +144,42 @@ func TestOrganizationComputedFields_NullAggregateWithOpenDeals_AwaitingFX(t *tes
 		t.Fatalf("open_pipeline.value_minor = %v, want nil (awaiting_fx carries no value)", open.ValueMinor)
 	}
 	if open.FormulaSql == "" {
-		t.Fatal("open_pipeline.formula_sql must stay populated: the formula exists, only its FX input doesn't yet")
+		t.Fatal("open_pipeline.formula_sql must stay populated: the formula exists, only a rate for these currencies does not")
+	}
+}
+
+// The state that matters most, because it is the one a short number hides in:
+// some open deals reached the total and others could not be priced.
+//
+// The sum is REAL — it just is not the pipeline. Reporting it as a total puts a
+// confident figure on the page covering part of the account, with nothing to
+// say which part, and a reader has no way to know it is short. That is worse
+// than the "not computable" this replaces, so it floors instead.
+func TestOrganizationComputedFields_SomeDealsPriced_RefusesTheShortTotal(t *testing.T) {
+	sum := int64(10_000)
+	rows := organizationComputedFields(openPipeline{minorBase: &sum, dealCount: 2, pricedCount: 1})
+	open := rows[0]
+	if open.Computable {
+		t.Fatalf("a total covering 1 of 2 open deals was reported as computable: %+v", open)
+	}
+	if open.Reason == nil || *open.Reason != partialPipelineReason {
+		t.Fatalf("open_pipeline.reason = %v, want %q", open.Reason, partialPipelineReason)
+	}
+	if open.ValueMinor != nil {
+		t.Fatalf("open_pipeline.value_minor = %v, want nil — a short sum must not be shown as the total", open.ValueMinor)
+	}
+}
+
+// And the complete case still reports its figure: every open deal reached the
+// total, so the number IS the pipeline.
+func TestOrganizationComputedFields_EveryDealPriced_ReportsTheTotal(t *testing.T) {
+	sum := int64(28_000)
+	rows := organizationComputedFields(openPipeline{minorBase: &sum, dealCount: 2, pricedCount: 2})
+	open := rows[0]
+	if !open.Computable {
+		t.Fatalf("a total covering every open deal is not computable: %+v", open)
+	}
+	if open.ValueMinor == nil || *open.ValueMinor != sum {
+		t.Fatalf("open_pipeline.value_minor = %v, want %d", open.ValueMinor, sum)
 	}
 }

--- a/backend/internal/modules/people/organization_read.go
+++ b/backend/internal/modules/people/organization_read.go
@@ -90,11 +90,11 @@ func getOrganizationInTx(ctx context.Context, tx pgx.Tx, id ids.OrganizationID,
 	// rollup read below, and out.ComputedFields stays its nil zero
 	// value — omitempty then drops the key entirely on marshal (T1).
 	if computedFieldsVisible(ctx) {
-		minor, dealCount, err := openPipelineRollup(ctx, tx, id)
+		open, err := openPipelineRollup(ctx, tx, id)
 		if err != nil {
 			return crmcontracts.Organization{}, fmt.Errorf("read open pipeline rollup: %w", err)
 		}
-		rows := organizationComputedFields(minor, dealCount)
+		rows := organizationComputedFields(open)
 		out.ComputedFields = &rows
 	}
 	return out, nil

--- a/backend/migrations/core/1787480000_open_pipeline_rollup_converts.down.sql
+++ b/backend/migrations/core/1787480000_open_pipeline_rollup_converts.down.sql
@@ -1,13 +1,17 @@
 -- Back to the column-only sum: the shape the baseline created, byte for byte,
 -- so a down-and-up leaves the schema where it started.
+--
+-- DROP then CREATE, not CREATE OR REPLACE: the up migration ADDED a column, and
+-- replace cannot remove one — Postgres refuses a replacement that drops an
+-- output column, so a plain replace here would fail rather than roll back.
 SET LOCAL lock_timeout = '5s';
 
-CREATE OR REPLACE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+DROP VIEW IF EXISTS organization_open_pipeline_rollup;
+
+CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
  SELECT organization_id,
     sum(amount_minor_base) AS open_pipeline_minor_base,
     count(*) AS open_deal_count
    FROM deal d
   WHERE ((status = 'open'::text) AND (organization_id IS NOT NULL) AND (archived_at IS NULL))
   GROUP BY organization_id;
-
-COMMENT ON VIEW organization_open_pipeline_rollup IS NULL;

--- a/backend/migrations/core/1787480000_open_pipeline_rollup_converts.down.sql
+++ b/backend/migrations/core/1787480000_open_pipeline_rollup_converts.down.sql
@@ -1,0 +1,13 @@
+-- Back to the column-only sum: the shape the baseline created, byte for byte,
+-- so a down-and-up leaves the schema where it started.
+SET LOCAL lock_timeout = '5s';
+
+CREATE OR REPLACE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+ SELECT organization_id,
+    sum(amount_minor_base) AS open_pipeline_minor_base,
+    count(*) AS open_deal_count
+   FROM deal d
+  WHERE ((status = 'open'::text) AND (organization_id IS NOT NULL) AND (archived_at IS NULL))
+  GROUP BY organization_id;
+
+COMMENT ON VIEW organization_open_pipeline_rollup IS NULL;

--- a/backend/migrations/core/1787480000_open_pipeline_rollup_converts.up.sql
+++ b/backend/migrations/core/1787480000_open_pipeline_rollup_converts.up.sql
@@ -1,0 +1,63 @@
+-- The open-pipeline formula field reported "awaiting_fx" for almost every
+-- organization, and the reason was structural rather than a missing rate.
+--
+-- The view summed deal.amount_minor_base. That generated column is null on
+-- every OPEN deal by design — a deal freezes its conversion rate on close
+-- (deal_closed_fx) — so the aggregate was null whenever an account's open deals
+-- were priced at all, and the field floored to "not computable yet" for a
+-- pipeline that was perfectly computable. Only a deal that had been closed and
+-- reopened ever contributed.
+--
+-- The view now converts, at the latest rate stored on or before today, the same
+-- rule the company page's own read applies. It resolves the base currency
+-- itself from the installation settings row, because a view takes no
+-- parameters; a settings table with one row per key makes that a scalar
+-- subquery rather than a join.
+--
+-- A deal whose currency has no usable rate contributes NOTHING and is still
+-- counted, so a caller comparing the sum against open_deal_count can tell a
+-- complete figure from a partial one. Nothing is ever converted at an invented
+-- rate of 1: that would report ¥5,000,000 as €5,000,000.
+--
+-- security_invoker stays true. The view runs with the CALLING role's
+-- privileges, so it reads no more than a direct SELECT on deal could, which is
+-- what lets the reading module treat the organization_id as the scope.
+SET LOCAL lock_timeout = '5s';
+
+CREATE OR REPLACE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+ SELECT d.organization_id,
+    sum(
+      CASE
+        -- Already in the installation's own currency: no rate needed, and none
+        -- should be looked for. This is the ordinary deal.
+        WHEN d.currency = base.code THEN d.amount_minor
+        ELSE round(d.amount_minor * live.rate)::bigint
+      END
+    ) AS open_pipeline_minor_base,
+    count(*) AS open_deal_count
+   FROM deal d
+   -- LEFT, not CROSS: an installation whose base-currency row is somehow absent
+   -- must still report its open_deal_count. A cross join would return no row at
+   -- all for the organization, which reads as "no open deals" — the one answer
+   -- that is definitely wrong. With no base currency nothing converts, every
+   -- deal contributes null, and the sum is null: not computable, honestly.
+   LEFT JOIN LATERAL (
+     SELECT (value #>> '{}')::text AS code
+       FROM setting
+      WHERE key = 'installation.base_currency'
+   ) base ON true
+   LEFT JOIN LATERAL (
+     SELECT r.rate
+       FROM fx_rate r
+      WHERE d.currency IS DISTINCT FROM base.code
+        AND r.from_currency = d.currency
+        AND r.to_currency = base.code
+        AND r.rate_date <= CURRENT_DATE
+      ORDER BY r.rate_date DESC
+      LIMIT 1
+   ) live ON true
+  WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
+  GROUP BY d.organization_id;
+
+COMMENT ON VIEW organization_open_pipeline_rollup IS
+  'Open pipeline per organization in the installation base currency. Open deals hold no frozen rate — that happens on close — so each foreign-currency deal converts at the latest fx_rate on or before today. A deal with no usable rate contributes nothing and is still counted in open_deal_count, so a partial sum is detectable rather than silently short.';

--- a/backend/migrations/core/1787480000_open_pipeline_rollup_converts.up.sql
+++ b/backend/migrations/core/1787480000_open_pipeline_rollup_converts.up.sql
@@ -15,16 +15,28 @@
 -- subquery rather than a join.
 --
 -- A deal whose currency has no usable rate contributes NOTHING and is still
--- counted, so a caller comparing the sum against open_deal_count can tell a
--- complete figure from a partial one. Nothing is ever converted at an invented
--- rate of 1: that would report ¥5,000,000 as €5,000,000.
+-- counted. The view reports priced_deal_count beside open_deal_count so a
+-- caller can tell a complete figure from a partial one rather than inferring
+-- it: SUM ignores a null summand without saying so. Nothing is ever converted
+-- at an invented rate of 1 — that would report ¥5,000,000 as €5,000,000.
 --
--- security_invoker stays true. The view runs with the CALLING role's
--- privileges, so it reads no more than a direct SELECT on deal could, which is
--- what lets the reading module treat the organization_id as the scope.
+-- security_invoker stays true, and what it means here is narrower than it was.
+-- The view now reads setting and fx_rate as well as deal, so it no longer reads
+-- "no more than a direct SELECT on deal could": security_invoker checks the
+-- database role, which every application request shares, not the authenticated
+-- principal. What it discloses is a CONVERTED total — from which a reader who
+-- already knows one foreign deal's own amount could infer the rate applied to
+-- it. That is the same derivation the company page's open-pipeline figure
+-- already publishes to the same readers, so this adds no channel; it is written
+-- down because the module reading this view says the organization_id is the
+-- scope, and that sentence is now about deal alone.
+-- DROP then CREATE, not CREATE OR REPLACE: this ADDS an output column, and
+-- replace cannot change a view's column list.
 SET LOCAL lock_timeout = '5s';
 
-CREATE OR REPLACE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+DROP VIEW IF EXISTS organization_open_pipeline_rollup;
+
+CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
  SELECT d.organization_id,
     sum(
       CASE
@@ -34,7 +46,15 @@ CREATE OR REPLACE VIEW organization_open_pipeline_rollup WITH (security_invoker=
         ELSE round(d.amount_minor * live.rate)::bigint
       END
     ) AS open_pipeline_minor_base,
-    count(*) AS open_deal_count
+    count(*) AS open_deal_count,
+    -- How many deals actually reached the sum. SUM ignores a null summand
+    -- silently, so without this a total covering one of two deals is
+    -- indistinguishable from one covering both — a confident figure that is
+    -- quietly short, which is worse than the "not computable" it replaces.
+    count(*) FILTER (
+      WHERE d.amount_minor IS NOT NULL
+        AND (d.currency = base.code OR live.rate IS NOT NULL)
+    ) AS priced_deal_count
    FROM deal d
    -- LEFT, not CROSS: an installation whose base-currency row is somehow absent
    -- must still report its open_deal_count. A cross join would return no row at

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2779,12 +2779,24 @@ BEGIN
 END;
 
 public.organization_open_pipeline_rollup acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
-public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT organization_id,
-    sum(amount_minor_base) AS open_pipeline_minor_base,
+public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.organization_id,
+    sum(
+        CASE
+            WHEN ((d.currency)::text = base.code) THEN d.amount_minor
+            ELSE (round(((d.amount_minor)::numeric * live.rate)))::bigint
+        END) AS open_pipeline_minor_base,
     count(*) AS open_deal_count
-   FROM deal d
-  WHERE ((status = 'open'::text) AND (organization_id IS NOT NULL) AND (archived_at IS NULL))
-  GROUP BY organization_id;
+   FROM ((deal d
+     LEFT JOIN LATERAL ( SELECT (setting.value #>> '{}'::text[]) AS code
+           FROM setting
+          WHERE (setting.key = 'installation.base_currency'::text)) base ON (true))
+     LEFT JOIN LATERAL ( SELECT r.rate
+           FROM fx_rate r
+          WHERE (((d.currency)::text IS DISTINCT FROM base.code) AND (r.from_currency = d.currency) AND ((r.to_currency)::text = base.code) AND (r.rate_date <= CURRENT_DATE))
+          ORDER BY r.rate_date DESC
+         LIMIT 1) live ON (true))
+  WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
+  GROUP BY d.organization_id;
 public.organization_open_pipeline_rollup.open_deal_count bigint gen=- def=-
 public.organization_open_pipeline_rollup.open_pipeline_minor_base numeric gen=- def=-
 public.organization_open_pipeline_rollup.organization_id uuid gen=- def=-

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2785,7 +2785,8 @@ public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.or
             WHEN ((d.currency)::text = base.code) THEN d.amount_minor
             ELSE (round(((d.amount_minor)::numeric * live.rate)))::bigint
         END) AS open_pipeline_minor_base,
-    count(*) AS open_deal_count
+    count(*) AS open_deal_count,
+    count(*) FILTER (WHERE ((d.amount_minor IS NOT NULL) AND (((d.currency)::text = base.code) OR (live.rate IS NOT NULL)))) AS priced_deal_count
    FROM ((deal d
      LEFT JOIN LATERAL ( SELECT (setting.value #>> '{}'::text[]) AS code
            FROM setting
@@ -2800,6 +2801,7 @@ public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.or
 public.organization_open_pipeline_rollup.open_deal_count bigint gen=- def=-
 public.organization_open_pipeline_rollup.open_pipeline_minor_base numeric gen=- def=-
 public.organization_open_pipeline_rollup.organization_id uuid gen=- def=-
+public.organization_open_pipeline_rollup.priced_deal_count bigint gen=- def=-
 public.organization_pkey CREATE UNIQUE INDEX organization_pkey ON public.organization USING btree (id)
 public.organization_profile_field acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.organization_profile_field.captured_at timestamp with time zone NOT NULL gen=- def=now()


### PR DESCRIPTION
## The bug

The `open_pipeline` computed field reported `awaiting_fx` for practically every organization, and the cause was structural rather than a missing rate.

`organization_open_pipeline_rollup` summed `deal.amount_minor_base` — a generated column that is **null on every open deal**, because a deal freezes its conversion rate on close (`deal_closed_fx`). So an ordinary pipeline (EUR deals on a EUR installation, needing no conversion at all) produced a null aggregate, and the field floored to "not computable yet" for a figure that was perfectly computable. The only deals that ever contributed were ones that had been closed and reopened.

## The fix

An additive migration replaces the view with one that converts, at the latest rate on or before today — the same rule the company page's own read applies. It resolves the base currency itself from the settings row, since a view takes no parameters.

- **A deal with no usable rate contributes nothing and is still counted**, so a caller comparing the sum against `open_deal_count` can tell a complete figure from a partial one. Nothing is converted at an invented rate of 1.
- **The settings lookup is a LEFT join, not CROSS.** An installation somehow missing that row must still report its `open_deal_count`; a cross join would return no row for the organization at all, which reads as "no open deals" — the one answer that is definitely wrong.
- `awaiting_fx` survives and now means what its name always implied: open deals exist and not one of them can be priced.

## Test changes

`TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX` was **asserting the bug** — it seeded deals in the installation's own currency and expected them to be unpriceable. Rewritten in JPY as `..._OpenDealsWithNoUsableRate_AwaitingFX`, so reaching that state now takes a currency the rate sheet genuinely cannot price.

Added `TestOrganizationComputed_OpenDealsInTheBaseCurrency_ReportTheirTotal` for the case that was broken. Mutation-checked: restoring the old view definition fails it.

## Verification

- `make check-backend`, `make craft-static` green.
- `backend/migrations` lane green; `head_catalog.txt` regenerated and committed with the migration (the deterministic gate cannot see that drift).
- Full `backend/internal/compose/integration` lane green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts open deals to the installation base currency and only reports a total when every open deal can be priced. Previously we summed deal.amount_minor_base (NULL for open deals) and treated any non‑null sum as computable, which forced “awaiting_fx” or silently short figures.

- Replaces `organization_open_pipeline_rollup` with a converting view; resolves base currency from `setting`, uses LEFT joins, and keeps `security_invoker=true`.
- Adds priced_deal_count; assembler behavior: none priced → reason "awaiting_fx", some priced → reason "partial_pipeline" with no value, all priced → sum reported.
- Deals with no usable rate contribute nothing but are counted; no invented rate of 1.
- Updates the formula description and dependencies to include deal amount/currency, `fx_rate` columns, and `setting.installation.base_currency`.
- Tests cover base-currency pipelines reporting totals, partial pipelines refusing short totals, and “awaiting_fx” using JPY where no rate exists.
- Migration adds a column and uses DROP/CREATE for the view; the down migration restores the prior column-only shape.

<sup>Written for commit 5dc9884365e1d751892be59846922c9f5fac660e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Open pipeline totals are calculated in the installation’s configured base currency.
  * Base-currency deals use their original amounts; foreign-currency deals use the latest applicable exchange rate.
  * Deals without a usable exchange rate remain included in deal counts but are excluded from totals.
  * Totals are withheld when only some deals can be valued, preventing incomplete pipeline amounts.
  * Organizations remain visible even when base-currency settings are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->