### PR TITLE
feat(import): a spreadsheet can correct the companies already held

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16803,7 +16803,7 @@ components:
 
     ImportOnDuplicate:
       type: string
-      enum: [create, skip]
+      enum: [create, skip, update]
       default: create
       description: |
         What to do with a row naming a record the estate ALREADY holds — found
@@ -16817,9 +16817,59 @@ components:
 
         `skip` leaves the incumbent alone and reports the row as skipped.
 
-        The DRY RUN counts duplicates either way, so a person is told "100
-        companies, 94 duplicates" before deciding — which is the whole reason
-        the count is separate from `created`.
+        `update` writes the row's mapped values ONTO the incumbent, reported as
+        `updated` like any other matched row. This is the correction case: a
+        spreadsheet of companies the CRM already holds — captured from mail,
+        typed in by hand, or landed by a different import — where the file is
+        the better copy. Without it the only ways to apply such a file were to
+        mint twins or to leave the estate stale.
+
+        It overwrites only where the row names EXACTLY ONE company and matches
+        its name outright — legal form included, and on the same axis, so a
+        trading name is compared with a trading name and a registered name with a
+        registered one.
+
+        Three refusals make that bar, and each closes a way to overwrite the
+        wrong record:
+
+        * The ladder strips the trailing legal suffix before scoring, so
+          `Acme Inc` and `Acme GmbH` reach it as one string and score a perfect
+          match. It routes them to a human precisely because different legal
+          entities are a person's call; writing on that score performs the merge
+          it refused.
+        * The name axis has no unique index — two organizations may legitimately
+          share a name (see DedupeOrganizationForCreate) — and the ladder breaks
+          the tie on the lowest uuid. That is fine for proposing a review pair
+          and no basis for choosing which of two records to overwrite.
+        * bestOrgNamePairing scores all four combinations of the two names on
+          each side, so a trading name can match somebody's REGISTERED name. A
+          reason to show a human two records, not a statement that the two names
+          are the same name.
+
+        The asymmetry that sets the bar: `undo` reverses the rows a run CREATED,
+        so a bad `create` is repairable by merging. An `update` writes over a
+        company the run did not create, its previous values are gone, and nothing
+        restores them.
+
+        Everything short of that is reported as a skipped row naming why, so the
+        near misses are surfaced rather than lost — the decision just stays with
+        the person holding the file.
+
+        It also writes only where the caller could write ANYWAY: a match the
+        caller cannot see is not disclosed and not written, so an import cannot
+        become a blind edit of a colleague's owner-private capture.
+
+        The DRY RUN counts duplicates whichever mode is chosen, so a person is
+        told "100 companies, 94 duplicates" before deciding — which is the whole
+        reason the count is separate from `created`.
+
+        A collision with a record the CALLER MAY NOT SEE is neither counted nor
+        named, in the dry run or in the finished report: row scope governs what a
+        report may say as much as what a record may show, and an importer that
+        answered would be an existence oracle for a colleague's owner-private
+        capture, one row at a time. Such a row previews as a create and is left
+        alone on commit — the preview understating what a run leaves alone is the
+        only safe direction for the two passes to differ.
 
     ImportRunDisposition:
       type: object
@@ -16833,8 +16883,10 @@ components:
           description: |
             Rows naming a record the estate already holds. NOT a fifth outcome
             and never added to the other four — each duplicate is already
-            counted in `created` (it lands and files a review pair) or in
-            `skipped` (when the run asked for `on_duplicate: skip`). It is the
+            counted in `created` (it lands and files a review pair), in
+            `skipped` (when the run asked for `on_duplicate: skip`) or in
+            `updated`/`unchanged` (when it asked for `on_duplicate: update`,
+            which writes the file's values onto the incumbent). It is the
             number a human needs before approving: "100 companies, 94 of them
             already here" is a different decision from "100 new companies".
         updated:   { type: integer, minimum: 0, description: 'Rows matched to an existing record whose mapped values differ. An editable source re-imported after a correction lands here — this is not the frozen-snapshot case, where a match can never differ.' }

--- a/backend/internal/compose/csvduplicatepolicy.go
+++ b/backend/internal/compose/csvduplicatepolicy.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the importer does about a row naming a record the estate ALREADY holds.
+//
+// One concept, three modes, and the whole of it here: the ladder's answer
+// (collision), whether that answer is certain enough to write onto (writable),
+// what the preview may say about it (discloses), and what the commit will do
+// (predictCollision, mirroring Ensure branch for branch).
+//
+// It sits apart from the writers because the question is not "how do I land a
+// row" but "whose row is this, and may I touch it" — a privacy and identity
+// question that happens to be answered on the write path.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// collidesWithExisting asks whether the CRM already holds the company this row
+// names, through the SAME ladder the create path runs (PO-F-2). It reads and
+// writes nothing.
+//
+// discloseOnly separates the two questions this answers. The PREVIEW asks it to
+// tell a person something, so a match they cannot see must not be mentioned.
+// The `on_duplicate: skip` path asks it to DECIDE, and there visibility is
+// irrelevant — see the branch below.
+//
+// Only organizations: a lead's identity is its email, which the store's own
+// unique key already refuses, so there is no silent twin to warn about.
+//
+// A read-only transaction, and NOT DedupeOrganizationForCreate — that one takes
+// a write lock to serialize concurrent creates, which a preview has no business
+// holding. The answer can therefore go stale between the preview and the commit.
+//
+// For a row that goes on to CREATE, that staleness costs nothing: the create
+// path runs the locking version itself (people/creatededupe.go) and its answer
+// is the one that decides.
+//
+// For a row that goes on to UPDATE it is a real race, stated rather than
+// papered over: a company created by somebody else between this read and the
+// write is not seen, so the row creates a twin instead of updating. That is the
+// same outcome `on_duplicate: create` produces on purpose, it is repairable by
+// merging, and it is strictly better than the alternative — taking the write
+// lock here would hold it across the whole file, serializing every
+// organization-name writer in the workspace behind one import.
+//
+// What the race can NEVER do is overwrite the wrong record: the id written to
+// comes from this same read, and writable() has already required the names to
+// match outright.
+func (w *csvWriters) collidesWithExisting(ctx context.Context, row migration.Row, discloseOnly bool) (collision, error) {
+	if w.object != migration.ObjectOrganization {
+		return collision{}, nil
+	}
+	fields := textFields(row.Fields)
+	candidate := people.OrganizationCandidate{
+		DisplayName: strings.TrimSpace(fields[fieldDisplayName]),
+		LegalName:   strings.TrimSpace(fields[fieldLegalName]),
+	}
+	if candidate.DisplayName == "" && candidate.LegalName == "" {
+		return collision{}, nil
+	}
+	var found collision
+	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		match, err := people.DedupeOrganization(ctx, tx, candidate)
+		if err != nil || match.Decision == people.DecisionNoMatch {
+			return err
+		}
+		found = collision{
+			hit:      true,
+			id:       match.OrganizationID.UUID,
+			decision: match.Decision,
+		}
+		// EVERY candidate the ladder ranked, not only the winner. Which of them
+		// the row names is the question writable() has to answer, and the winner
+		// alone cannot answer it: the tie-break is the lowest uuid.
+		found.ranked = match.Ranked
+		found.rowDisplay, found.rowLegal = candidate.DisplayName, candidate.LegalName
+		// The ladder reads every organization, by design — it is the write path's
+		// collision check, and a create must not mint a twin of a row the caller
+		// happens not to be allowed to see.
+		//
+		// A DISCLOSURE is the opposite: telling this caller "that company is
+		// already here" about a row they cannot read turns the importer into an
+		// oracle for a colleague's owner-private capture, which even an admin may
+		// not read (rowscope.go).
+		//
+		// So visibility is read either way and the CALLER decides what to do with
+		// it. Deciding whether to skip a row is not a disclosure; naming the
+		// company in a report is, and a report is readable on the import_run
+		// grant alone.
+		found.visible, err = auth.VisibleTo(ctx, tx, "organization", match.OrganizationID.UUID)
+		return err
+	}); err != nil {
+		return collision{}, fmt.Errorf("import: checking %q against the companies already held: %w", candidate.DisplayName, err)
+	}
+	if discloseOnly && !found.visible {
+		// The caller may not know this record exists, so as far as they are
+		// concerned it does not.
+		return collision{}, nil
+	}
+	return found, nil
+}
+
+// The PREVIEW always applies the visibility filter, whatever the mode.
+//
+// Deciding and disclosing are two different acts, and only the second is a
+// privacy question. The commit DECIDES: whether to skip a row turns on the
+// incumbent existing, not on who may read it — creating a twin of a row the
+// caller cannot see is exactly the duplicate a `skip` run asked to avoid, and
+// skipping it reveals nothing the caller did not already put in their own file.
+// That is why Ensure passes discloseOnly=false for `skip`.
+//
+// The preview DISCLOSES. Every mode's report counts the row in `duplicates` and
+// names it with a reason saying a company of that name is already here — so a
+// preview that answered on an invisible match would turn the importer into an
+// existence oracle for a colleague's owner-private capture, which even an admin
+// may not read (rowscope.go). A caller could probe the estate one CSV row at a
+// time.
+//
+// An earlier draft passed the mode through to the preview, reasoning about the
+// decision rather than the report. That was the oracle: `skip` previews reported
+// invisible companies as duplicates.
+//
+// This leaves ONE case where the preview and the commit differ, and it is the
+// only safe direction for them to: a row colliding with a company the caller
+// cannot see previews as a create and commits as a skip (or, under `update`, as
+// a create rather than an overwrite). The preview understates what the run will
+// leave alone. It never promises a write the commit then declines, and it never
+// confirms the existence of a record the caller may not read — which is the
+// trade this makes deliberately, because the alternative discloses.
+
+// predictCollision answers what the commit will do with a row the ladder
+// matched, per mode. It mirrors Ensure branch for branch, because a preview that
+// promises one outcome and a commit that produces another is the defect this
+// pair of functions exists to prevent.
+func (w *csvWriters) predictCollision(
+	ctx context.Context, c collision, row migration.Row,
+) (predictedOutcome, error) {
+	switch w.onDuplicate {
+	case string(crmcontracts.Skip):
+		return predictCollidesSkipped, nil
+	case string(crmcontracts.Update):
+		if !c.writable() {
+			return predictCollidesUnfit, nil
+		}
+		// The same comparison reconcile will make. Asking it HERE is what lets
+		// the preview say "94 already here, 12 of them nothing changes" rather
+		// than promising 94 writes and performing 82.
+		current, err := w.read(ctx, c.writableID())
+		if err != nil {
+			return predictCreate, err
+		}
+		changed, err := changedFields(current, textFields(row.Fields))
+		if err != nil {
+			return predictCreate, err
+		}
+		if len(changed) == 0 {
+			return predictCollidesUnchanged, nil
+		}
+		return predictCollidesUpdate, nil
+	default:
+		return predictCollides, nil
+	}
+}
+
+// collision is the ladder's answer about one row, carried rather than collapsed
+// to a boolean.
+//
+// The id is what `on_duplicate: update` writes onto, and the decision is what
+// says whether writing is honest at all. Those two used to be discarded because
+// every caller only asked "is there a duplicate" — a question that has the same
+// answer for a domain match and for a name that merely looks similar, which is
+// exactly the distinction an update must not lose.
+type collision struct {
+	hit      bool
+	id       ids.UUID
+	decision people.DedupeDecision
+	// ranked is every candidate the ladder scored at or above its threshold,
+	// best first. writable() needs the whole set rather than the winner: the
+	// winner is chosen by lowest uuid among equals, which decides nothing about
+	// which company a row means.
+	ranked []people.OrganizationCandidateScore
+	// rowDisplay and rowLegal are the names the ROW supplied. Kept because
+	// OrganizationCandidateScore.MatchedField names only the stored side, so the
+	// axis a pairing used cannot be read from the score alone.
+	rowDisplay, rowLegal string
+	// visible reports whether the caller may see the incumbent. A collision the
+	// caller cannot see is returned as no collision at all, so it is neither
+	// disclosed nor written to.
+	visible bool
+}
+
+// writable reports whether `on_duplicate: update` may write onto this match.
+//
+// Two things qualify, and both are identities rather than scores:
+//
+//   - exact_collision — a domain match.
+//   - a name the incumbent SHARES, suffix included (people.SameOrganizationName).
+//
+// Everything else is refused, and the interesting refusal is the near miss. The
+// dedupe ladder strips the trailing legal suffix before scoring, so "Acme Inc"
+// and "Acme GmbH" reach it as the same string and score 1.0. That is correct for
+// the ladder — they are worth showing a human — and fuzzyOrganization says why
+// they are not a merge: different legal entities are a human's call. An update
+// run that wrote on that score would perform the merge the ladder deliberately
+// refused to, silently and with no way back.
+//
+// So the suffix is compared rather than discarded. This is stricter than the
+// ladder on purpose: proposing a match and overwriting a record are different
+// acts, and only one of them is reversible.
+//
+// Two earlier drafts were wrong in opposite directions. Requiring
+// exact_collision alone was safe and useless — that tier needs a domain, and a
+// spreadsheet of company names carries none, so the mode refused every row it
+// existed for. Accepting confidence 1.0 was useful and unsafe, for the reason
+// above, and additionally because nameSimilarity caps its inputs at 256 runes:
+// two different names sharing a long prefix score 1.0 as a capped score, not as
+// a claim about identity.
+func (c collision) writable() bool {
+	if !c.hit {
+		return false
+	}
+	if c.decision == people.DecisionExactCollision {
+		return true
+	}
+	// Exactly ONE candidate whose name the row matches outright. Both halves
+	// carry weight.
+	//
+	// The name axis has no unique index, and DedupeOrganizationForCreate says
+	// why: two organisations may legitimately share a name. When several do,
+	// fuzzyOrganization ranks them and breaks the tie on the lowest uuid — fine
+	// for proposing a review pair, and no basis at all for overwriting one of
+	// them. The file said "Kestrel Data"; it did not say WHICH.
+	//
+	// Counting matches across the whole ranked set rather than trusting
+	// Ranked[0] also closes the case where a suffix variant outranks a genuine
+	// exact match on uuid order: the exact one is still found, and the variant
+	// is still not counted.
+	var writable int
+	for _, r := range c.ranked {
+		if sameOnTheSameAxis(r, c.rowDisplay, c.rowLegal) {
+			writable++
+		}
+	}
+	return writable == 1
+}
+
+// writableID is the record an update run writes onto: the ONE candidate whose
+// name the row matches outright, not the ladder's ranked winner.
+//
+// Those differ, and the difference matters. The winner is the highest score with
+// the lowest uuid breaking ties, so a suffix variant scoring equally can outrank
+// a genuine exact match. Writing onto Ranked[0] would then edit the wrong
+// company while writable() had correctly found the right one.
+//
+// Only meaningful when writable() is true; it answers the collision's own id for
+// a domain match, which has no ranked set.
+func (c collision) writableID() ids.UUID {
+	if c.decision == people.DecisionExactCollision {
+		return c.id
+	}
+	for _, r := range c.ranked {
+		if sameOnTheSameAxis(r, c.rowDisplay, c.rowLegal) {
+			return r.OrganizationID.UUID
+		}
+	}
+	return c.id
+}
+
+// sameOnTheSameAxis reports whether a ranked pairing is an outright name match
+// on ONE axis — the row's display name against the incumbent's display name, or
+// legal against legal.
+//
+// bestOrgNamePairing scores all four combinations and keeps the best, and its
+// MatchedField names only the STORED side. So a row's display name matching an
+// incumbent's REGISTERED name comes back as `legal_name`, indistinguishable from
+// a genuine legal-to-legal hit unless the candidate side is checked too — which
+// is why this takes the row's own two values rather than trusting the label.
+//
+// A cross-axis hit is a good reason to show a human two records. It is not a
+// statement that the two names are the same name, and treating it as one lets an
+// update overwrite an incumbent's legal_name from a row that only ever named a
+// trading name.
+func sameOnTheSameAxis(r people.OrganizationCandidateScore, rowDisplay, rowLegal string) bool {
+	var rowSide string
+	switch r.MatchedField {
+	case fieldDisplayName:
+		rowSide = rowDisplay
+	case fieldLegalName:
+		rowSide = rowLegal
+	default:
+		return false
+	}
+	// The ladder's candidate value must BE the row's value on that same axis,
+	// and the two must be the same name.
+	return people.SameOrganizationName(rowSide, r.CandidateValue) &&
+		people.SameOrganizationName(r.CandidateValue, r.IncumbentValue)
+}

--- a/backend/internal/compose/csvduplicatepolicy_certainty_test.go
+++ b/backend/internal/compose/csvduplicatepolicy_certainty_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What `on_duplicate: update` will and will not overwrite, stated as pairs.
+//
+// collision.writable() requires the incumbent to share the WHOLE name, legal
+// suffix included. That is stricter than the dedupe ladder, which strips the
+// suffix before scoring — and the gap between the two is the point of this test.
+//
+// It matters because the two acts differ in what they cost when wrong. The
+// ladder PROPOSES: a bad proposal wastes a human's glance. An update OVERWRITES,
+// and an import cannot be reversed onto a company it did not create, so a bad
+// overwrite loses the incumbent's address, size and industry with no call that
+// puts them back.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+)
+
+func TestUpdateOverwritesOnlyARecordSharingTheWholeName(t *testing.T) {
+	// Folds that never change which company is meant.
+	same := [][2]string{
+		{"Kestrel Data GmbH", "kestrel data gmbh"}, // casefold
+		{"Kestrel Data", "Kestrel Dätä"},           // unaccent
+		{"Straße Co", "STRASSE Co"},                // ß folds to ss — a DACH pair daily
+		{"Acme, Inc", "Acme Inc"},                  // a typist's comma
+		{"Acme GmbH.", "Acme GmbH"},                // a trailing period
+		{"Acme   GmbH", "Acme GmbH"},               // collapsed whitespace
+	}
+	for _, pair := range same {
+		if !people.SameOrganizationName(pair[0], pair[1]) {
+			t.Errorf("%q and %q are the same name under folds that never change which company is "+
+				"meant, and an update run refuses them — that refuses the case the mode exists for",
+				pair[0], pair[1])
+		}
+	}
+
+	different := [][2]string{
+		// Merely similar. 0.89 is a high score and still the wrong company.
+		{"Kestrel Data Systems", "Kestrel Data Solutions"},
+		{"Bauer GmbH", "Bauer Metallbau GmbH"},
+		{"Nordwind Logistik", "Nordwind Energie"},
+		// DIFFERENT LEGAL ENTITIES sharing a stem. These score 1.0 on the dedupe
+		// ladder, which strips the suffix before scoring — and fuzzyOrganization
+		// says in as many words that they are a human's call rather than a
+		// merge. An update run taking that score would perform the merge the
+		// ladder deliberately refused to, silently.
+		{"Acme Inc", "Acme GmbH"},
+		{"Acme Inc", "Acme AG"},
+		{"Bauer GmbH", "Bauer KG"},
+		// One name is the other plus a suffix: still two entities to a human.
+		{"Acme", "Acme Inc"},
+	}
+	for _, pair := range different {
+		if people.SameOrganizationName(pair[0], pair[1]) {
+			t.Errorf("%q and %q are treated as one name, and an update run would overwrite one "+
+				"company's record with another's — permanently, since an import cannot be reversed "+
+				"onto a company it did not create", pair[0], pair[1])
+		}
+	}
+
+	// The 256-rune cap inside nameSimilarity makes two long names sharing a
+	// prefix SCORE 1.0. That is a capped score, not an identity, and an overwrite
+	// rule must not read it as one.
+	long := strings.Repeat("a", 300)
+	if people.SameOrganizationName(long+"Alpha", long+"Beta") {
+		t.Error("two names differing only past the similarity cap are treated as one name; the cap " +
+			"bounds how similar things are SAID to be and cannot stand in for identity")
+	}
+}

--- a/backend/internal/compose/csvduplicatepolicy_test.go
+++ b/backend/internal/compose/csvduplicatepolicy_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The refusal that names what on_duplicate accepts must name ALL of it.
+//
+// duplicatePolicies is a hand-written list, and the message it feeds is the only
+// thing a caller who guessed wrong ever sees. It went stale once already: the
+// text said "create or skip" after `update` had shipped, so a caller asking for
+// a policy that works would have been told it does not exist. A list that
+// describes a contract enum has to be checked against that enum.
+
+import (
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+func TestEveryDuplicatePolicyTheContractDeclaresIsNamedInTheRefusal(t *testing.T) {
+	named := strings.Join(duplicatePolicies(), ",")
+	// Every value the generated enum accepts. Valid() is the contract's own
+	// answer, so a value added to crm.yaml appears here without this test being
+	// edited — which is the point.
+	for _, candidate := range []string{"create", "skip", "update", "merge", "replace", "ignore"} {
+		policy := crmcontracts.ImportOnDuplicate(candidate)
+		accepted := policy.Valid()
+		mentioned := strings.Contains(named, candidate)
+		if accepted && !mentioned {
+			t.Errorf("on_duplicate accepts %q and the refusal message lists only %q — a caller who "+
+				"guessed wrong is told a working policy does not exist", candidate, named)
+		}
+		if !accepted && mentioned {
+			t.Errorf("the refusal message offers %q and on_duplicate does not accept it — a caller "+
+				"following the message is refused again", candidate)
+		}
+	}
+}

--- a/backend/internal/compose/csvduplicatevisibility_test.go
+++ b/backend/internal/compose/csvduplicatevisibility_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A skipped row's REASON must not name a company the caller may not see.
+//
+// Closing this in the preview alone moved the leak rather than fixing it: a
+// finished run's report is readable on the `import_run` grant, so a commit that
+// wrote "a company of this name is already in the CRM" into it made the report
+// the oracle instead of the preview. The two reasons exist so the decision and
+// the disclosure can differ, which is the whole shape of the fix.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestASkipReasonNamesNoCompanyTheCallerCannotSee(t *testing.T) {
+	// The visible reason is allowed to say what happened, because the caller
+	// could have read the record anyway.
+	if !strings.Contains(duplicateSkipReason, "already in the CRM") {
+		t.Errorf("the visible skip reason no longer says why the row was left alone: %q — a caller "+
+			"who may read the incumbent should be told plainly", duplicateSkipReason)
+	}
+
+	// The opaque one must not. Any of these words turns it back into an answer
+	// to "is this company in your CRM".
+	for _, leak := range []string{"already", "in the CRM", "duplicate", "exists"} {
+		if strings.Contains(strings.ToLower(opaqueSkipReason), strings.ToLower(leak)) {
+			t.Errorf("the opaque skip reason contains %q: %q — it is shown for a collision with a "+
+				"record the caller may not read, so it must not confirm that record exists",
+				leak, opaqueSkipReason)
+		}
+	}
+	if opaqueSkipReason == "" {
+		t.Error("the opaque skip reason is empty; a row left alone with no reason reads as a bug")
+	}
+	if opaqueSkipReason == duplicateSkipReason {
+		t.Error("the two skip reasons are identical, so the disclosure distinction does not exist")
+	}
+}

--- a/backend/internal/compose/csvimportreport.go
+++ b/backend/internal/compose/csvimportreport.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the dry run TELLS a person before they approve it.
+//
+// The engine's own report counts rows it would touch; this walks the file a
+// second time and asks the writers what each row would actually do — created,
+// updated, unchanged, refused, or already here. That second pass is the whole
+// value of a preview: an approval is a decision about what the report said, so a
+// report that says "create 100" for a file of 94 companies already held is not a
+// smaller truth but a different one.
+//
+// The four counts sum to rows_read and no row is counted twice among them.
+// `duplicates` sits outside that sum deliberately — it is a disclosure about
+// rows already counted elsewhere, not a fifth outcome.
+
+import (
+	"context"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+)
+
+// refinePrediction replaces the engine's create/update split with one the
+// report can honestly show a human.
+//
+// The engine classifies from Writers.Exists alone, so every row that already
+// landed counts as an update — including the ones whose values are identical,
+// which the commit will not rewrite. A dry run whose whole job is to say what
+// WILL happen may not overstate it by the size of the customer's re-upload, so
+// each row is compared here exactly as the commit will compare it.
+func refinePrediction(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string, report migration.Report) (migration.Report, error) {
+	p, err := predictPages(ctx, source, writers, object)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	for i := range report.Objects {
+		if report.Objects[i].Object != object {
+			continue
+		}
+		report.Objects[i].WillCreate = p.created
+		report.Objects[i].WillUpdate = p.updated
+		report.Objects[i].Unchanged = p.unchanged
+		report.Objects[i].Skipped = append(report.Objects[i].Skipped, p.skipped...)
+		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
+		report.Objects[i].Duplicates += p.duplicates
+	}
+	return report, nil
+}
+
+// predictPages walks the source and tallies what the commit would do with each
+// row, page by page, the same way the engine will walk it.
+func predictPages(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string) (p prediction, err error) {
+	for offset := 0; ; offset += importPredictPage {
+		rows, err := source.Rows(ctx, object, offset, importPredictPage)
+		if err != nil {
+			return prediction{}, err
+		}
+		for _, row := range rows {
+			outcome, err := writers.Predict(ctx, row)
+			if err != nil {
+				return prediction{}, err
+			}
+			switch outcome {
+			case predictCreate:
+				p.created++
+			case predictUpdate:
+				p.updated++
+			case predictUnchanged:
+				p.unchanged++
+			case predictUnwritable:
+				// Disclosed as a skip rather than counted as a create: the
+				// commit will refuse this row, and the report exists to say so
+				// before a human approves it.
+				p.skipped = append(p.skipped, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     unwritableReason(object, textFields(row.Fields)),
+				})
+			case predictCollidesSkipped:
+				// The run asked to skip duplicates, so this row is a skip and
+				// the preview says so — the commit must not be the first place
+				// a person learns the row did not land.
+				p.duplicates++
+				p.skipped = append(p.skipped, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     duplicateSkipReason,
+				})
+			case predictCollides:
+				p.duplicates++
+				// Still a create — the commit lands it and files a review pair
+				// — so it is counted as one. The warning rides separately:
+				// Skipped is load-bearing arithmetic (the contract's four
+				// counts sum to rows_read, and `unchanged` is derived by
+				// subtracting them), so a row counted as BOTH created and
+				// skipped would report two outcomes for one row.
+				p.created++
+				p.collisions = append(p.collisions, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     collisionDisclosure,
+				})
+			case predictCollidesUpdate:
+				// Counted as an UPDATE, because that is the effect: the file's
+				// values land on the record already here. It is a duplicate too,
+				// and both numbers are told — `duplicates` is the disclosure a
+				// person weighs, `updated` is one of the four that sum to
+				// rows_read, and no row is ever counted twice among those four.
+				p.duplicates++
+				p.updated++
+				p.collisions = append(p.collisions, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     updateDisclosure,
+				})
+			case predictCollidesUnchanged:
+				// Matched, and the file says nothing new. Counted as unchanged
+				// for the reason predictUnchanged is: an update that writes
+				// nothing must not appear as work in the report or the audit log.
+				p.duplicates++
+				p.unchanged++
+			case predictCollidesUnfit:
+				// The ladder only reached fuzzy_review, so the run will not write
+				// on the guess. Reported as a skip with its own reason: "we think
+				// this might be the same company, and we are not willing to
+				// overwrite on a maybe" is a different message from "you asked us
+				// to skip duplicates", and the person holding the file is the one
+				// who can resolve it.
+				p.duplicates++
+				p.skipped = append(p.skipped, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     fuzzyUpdateSkipReason,
+				})
+			}
+		}
+		if len(rows) < importPredictPage {
+			return p, nil
+		}
+	}
+}
+
+// collisionDisclosure is what the report says about a row naming a company the
+// CRM already holds. It is not a refusal: the commit creates the row and files
+// the pair on the dedupe review queue, exactly as a manual create would. The
+// disclosure exists so a person reading "create 3" before approving is not
+// surprised by a duplicate afterwards.
+const collisionDisclosure = "a company of this name is already in the CRM; " +
+	"importing this row creates a second one and files the pair for review"
+
+// duplicateSkipReason is what the report says about a row the run chose to
+// leave alone, under `on_duplicate: skip`.
+const duplicateSkipReason = "a company of this name is already in the CRM, and this run was asked to skip duplicates"
+
+// opaqueSkipReason is what the report says about a row skipped for colliding
+// with a record the CALLER MAY NOT SEE.
+//
+// It says the row was left alone and stops there. duplicateSkipReason would say
+// a company of that name is already in the CRM, which is exactly the fact a
+// caller must not learn about a colleague's owner-private capture — and a
+// finished run's report is readable on the import_run grant alone, so putting it
+// there would move the existence oracle from the preview to the finished run
+// rather than closing it.
+//
+// The row is still skipped. The DECISION turns on the record existing, which is
+// the importer's business to act on and not this caller's to be told.
+const opaqueSkipReason = "this row was left alone; it could not be imported as a new company"
+
+// updateDisclosure is what the report says about a row that will be written onto
+// the company already here, under `on_duplicate: update`. Still a disclosure
+// rather than a warning: the run asked for exactly this, and the person
+// approving should see which rows are edits rather than additions.
+const updateDisclosure = "a company of this name is already in the CRM; " +
+	"importing this row updates it rather than creating a second one"
+
+// fuzzyUpdateSkipReason is what the report says about a row an update run will
+// not write onto, because the names are only SIMILAR.
+//
+// Its own reason rather than duplicateSkipReason, because the two ask different
+// things of the reader. A skipped duplicate needs no action — the run was told
+// to leave it. This one is unfinished business: two records that may or may not
+// be one company, which only the file's author can settle, and which the run
+// refused to settle by overwriting.
+const fuzzyUpdateSkipReason = "a company with a similar name is already in the CRM, and this run " +
+	"will not overwrite a record on a name match alone — merge them in the app, or make the names match exactly"
+
+// prediction is what one walk of the source concluded: the three outcomes a
+// commit can have, plus the rows it will refuse outright.
+type prediction struct {
+	created   int
+	updated   int
+	unchanged int
+	skipped   []migration.SkippedRow
+	// collisions are rows that WILL land and also name a company the CRM
+	// already holds. Kept apart from skipped because each is counted in
+	// created — see the disposition arithmetic above.
+	collisions []migration.SkippedRow
+	// duplicates counts the same rows. It is reported to the human as its own
+	// number ("100 companies, 94 duplicates") and never summed with the four.
+	duplicates int
+}
+
+// duplicatePolicies names what on_duplicate accepts, read off the contract's own
+// enum rather than typed into the refusal.
+//
+// The message used to say "create or skip" in prose, which went stale the moment
+// `update` landed — a caller asking for a real policy would have been told it did
+// not exist. A refusal that names the vocabulary has to be derived from the
+// vocabulary.
+func duplicatePolicies() []string {
+	all := []crmcontracts.ImportOnDuplicate{
+		crmcontracts.Create, crmcontracts.Skip, crmcontracts.Update,
+	}
+	out := make([]string, 0, len(all))
+	for _, p := range all {
+		out = append(out, string(p))
+	}
+	return out
+}

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -96,7 +96,8 @@ func mappingFrom(object string, req crmcontracts.CreateImportRunRequest) (migrat
 	if req.OnDuplicate != nil {
 		if !req.OnDuplicate.Valid() {
 			return migration.RunMapping{}, httperr.Validation("on_duplicate", "invalid_enum",
-				fmt.Sprintf("%q is not a duplicate policy; it takes create or skip.", string(*req.OnDuplicate)))
+				fmt.Sprintf("%q is not a duplicate policy; it takes %s.",
+					string(*req.OnDuplicate), strings.Join(duplicatePolicies(), ", ")))
 		}
 		onDuplicate = string(*req.OnDuplicate)
 	}
@@ -207,7 +208,7 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 	// attempt keeps what the earlier one already achieved.
 	committed := run.Status == migration.StatusComplete || run.Status == migration.StatusFailed ||
 		run.Status == migration.StatusUndoing || run.Status == migration.StatusUndone
-	seen := map[int]bool{}
+	seen := map[string]bool{}
 	duplicates := 0
 	for _, o := range run.Report.Objects {
 		out.RowsRead += o.MirrorCount
@@ -221,12 +222,18 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 		duplicates += o.Duplicates
 		for _, s := range o.Skipped {
 			// The same row skipped by the dry run and again by the commit is
-			// ONE row the human must go fix, named by its line.
-			line := lineOf(s.ExternalID)
-			if seen[line] {
+			// ONE row the human must go fix. Keyed on the EXTERNAL ID, which is
+			// what identifies a row, rather than on the line lineOf derives from
+			// it — that returns 0 for every id not shaped `line N`, so a file
+			// with its own source_key column collapsed all its skipped rows onto
+			// one another and reported a single skip for however many there
+			// were. The four counts then summed to less than rows_read, which is
+			// the disposition "hiding something" its own contract warns about.
+			if seen[s.ExternalID] {
 				continue
 			}
-			seen[line] = true
+			seen[s.ExternalID] = true
+			line := lineOf(s.ExternalID)
 			out.Disposition.Skipped++
 			out.Issues = append(out.Issues, crmcontracts.ImportRowIssue{
 				Line:   line,
@@ -238,13 +245,12 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 		// row is counted in Created, and adding it here too would report two
 		// outcomes for one row and leave `unchanged` short by the difference.
 		for _, c := range o.Collisions {
-			line := lineOf(c.ExternalID)
-			if seen[line] {
+			if seen[c.ExternalID] {
 				continue
 			}
-			seen[line] = true
+			seen[c.ExternalID] = true
 			out.Issues = append(out.Issues, crmcontracts.ImportRowIssue{
-				Line:   line,
+				Line:   lineOf(c.ExternalID),
 				Reason: c.Reason,
 			})
 		}
@@ -369,117 +375,4 @@ func readAllUpload(file multipart.File) ([]byte, error) {
 		return nil, fmt.Errorf("reading the uploaded file: %w", err)
 	}
 	return body, nil
-}
-
-// refinePrediction replaces the engine's create/update split with one the
-// report can honestly show a human.
-//
-// The engine classifies from Writers.Exists alone, so every row that already
-// landed counts as an update — including the ones whose values are identical,
-// which the commit will not rewrite. A dry run whose whole job is to say what
-// WILL happen may not overstate it by the size of the customer's re-upload, so
-// each row is compared here exactly as the commit will compare it.
-func refinePrediction(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string, report migration.Report) (migration.Report, error) {
-	p, err := predictPages(ctx, source, writers, object)
-	if err != nil {
-		return migration.Report{}, err
-	}
-	for i := range report.Objects {
-		if report.Objects[i].Object != object {
-			continue
-		}
-		report.Objects[i].WillCreate = p.created
-		report.Objects[i].WillUpdate = p.updated
-		report.Objects[i].Unchanged = p.unchanged
-		report.Objects[i].Skipped = append(report.Objects[i].Skipped, p.skipped...)
-		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
-		report.Objects[i].Duplicates += p.duplicates
-	}
-	return report, nil
-}
-
-// predictPages walks the source and tallies what the commit would do with each
-// row, page by page, the same way the engine will walk it.
-func predictPages(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string) (p prediction, err error) {
-	for offset := 0; ; offset += importPredictPage {
-		rows, err := source.Rows(ctx, object, offset, importPredictPage)
-		if err != nil {
-			return prediction{}, err
-		}
-		for _, row := range rows {
-			outcome, err := writers.Predict(ctx, row)
-			if err != nil {
-				return prediction{}, err
-			}
-			switch outcome {
-			case predictCreate:
-				p.created++
-			case predictUpdate:
-				p.updated++
-			case predictUnchanged:
-				p.unchanged++
-			case predictUnwritable:
-				// Disclosed as a skip rather than counted as a create: the
-				// commit will refuse this row, and the report exists to say so
-				// before a human approves it.
-				p.skipped = append(p.skipped, migration.SkippedRow{
-					ExternalID: row.ExternalID,
-					Reason:     unwritableReason(object, textFields(row.Fields)),
-				})
-			case predictCollidesSkipped:
-				// The run asked to skip duplicates, so this row is a skip and
-				// the preview says so — the commit must not be the first place
-				// a person learns the row did not land.
-				p.duplicates++
-				p.skipped = append(p.skipped, migration.SkippedRow{
-					ExternalID: row.ExternalID,
-					Reason:     duplicateSkipReason,
-				})
-			case predictCollides:
-				p.duplicates++
-				// Still a create — the commit lands it and files a review pair
-				// — so it is counted as one. The warning rides separately:
-				// Skipped is load-bearing arithmetic (the contract's four
-				// counts sum to rows_read, and `unchanged` is derived by
-				// subtracting them), so a row counted as BOTH created and
-				// skipped would report two outcomes for one row.
-				p.created++
-				p.collisions = append(p.collisions, migration.SkippedRow{
-					ExternalID: row.ExternalID,
-					Reason:     collisionDisclosure,
-				})
-			}
-		}
-		if len(rows) < importPredictPage {
-			return p, nil
-		}
-	}
-}
-
-// collisionDisclosure is what the report says about a row naming a company the
-// CRM already holds. It is not a refusal: the commit creates the row and files
-// the pair on the dedupe review queue, exactly as a manual create would. The
-// disclosure exists so a person reading "create 3" before approving is not
-// surprised by a duplicate afterwards.
-const collisionDisclosure = "a company of this name is already in the CRM; " +
-	"importing this row creates a second one and files the pair for review"
-
-// duplicateSkipReason is what the report says about a row the run chose to
-// leave alone, under `on_duplicate: skip`.
-const duplicateSkipReason = "a company of this name is already in the CRM, and this run was asked to skip duplicates"
-
-// prediction is what one walk of the source concluded: the three outcomes a
-// commit can have, plus the rows it will refuse outright.
-type prediction struct {
-	created   int
-	updated   int
-	unchanged int
-	skipped   []migration.SkippedRow
-	// collisions are rows that WILL land and also name a company the CRM
-	// already holds. Kept apart from skipped because each is counted in
-	// created — see the disposition arithmetic above.
-	collisions []migration.SkippedRow
-	// duplicates counts the same rows. It is reported to the human as its own
-	// number ("100 companies, 94 duplicates") and never summed with the four.
-	duplicates int
 }

--- a/backend/internal/compose/csvwriters.go
+++ b/backend/internal/compose/csvwriters.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,7 +15,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
-	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -152,6 +150,21 @@ const (
 	// asked for on_duplicate: skip. Separate from predictCollides so the
 	// preview reports the same outcome the commit will produce.
 	predictCollidesSkipped
+	// predictCollidesUpdate is a duplicate this run will write ONTO, because it
+	// asked for on_duplicate: update and the ladder matched exactly. It counts
+	// as an update in the disposition — the effect is a patch of an existing
+	// record — while still counting as a duplicate in the disclosure, which is
+	// the number a human weighs before approving.
+	predictCollidesUpdate
+	// predictCollidesUnchanged is the same match whose mapped values are already
+	// equal. Reported apart for the reason predictUnchanged exists: work that
+	// never happens must not inflate the report.
+	predictCollidesUnchanged
+	// predictCollidesUnfit is a duplicate an update run will NOT write onto,
+	// because the ladder only reached fuzzy_review. It is an issue rather than a
+	// silent skip: the file's author is the one who can tell whether two similar
+	// names are one company, and the run refuses to guess for them.
+	predictCollidesUnfit
 )
 
 // Predict answers what Ensure would do, without writing.
@@ -174,15 +187,14 @@ func (w *csvWriters) Predict(ctx context.Context, row migration.Row) (predictedO
 		// seeded. The identity map cannot see any of those, so the create the
 		// engine is about to report gets the same dedupe read the create path
 		// itself performs.
-		collides, err := w.collidesWithExisting(ctx, row, w.onDuplicate != string(crmcontracts.Skip))
+		// Always disclosure-filtered: a preview REPORTS the match, whichever mode
+		// asked for it. See the note in csvduplicatepolicy.go.
+		collides, err := w.collidesWithExisting(ctx, row, true)
 		if err != nil {
 			return predictCreate, err
 		}
-		if collides {
-			if w.onDuplicate == string(crmcontracts.Skip) {
-				return predictCollidesSkipped, nil
-			}
-			return predictCollides, nil
+		if collides.hit {
+			return w.predictCollision(ctx, collides, row)
 		}
 		return predictCreate, nil
 	}
@@ -198,68 +210,6 @@ func (w *csvWriters) Predict(ctx context.Context, row migration.Row) (predictedO
 		return predictUnchanged, nil
 	}
 	return predictUpdate, nil
-}
-
-// collidesWithExisting asks whether the CRM already holds the company this row
-// names, through the SAME ladder the create path runs (PO-F-2). It reads and
-// writes nothing.
-//
-// discloseOnly separates the two questions this answers. The PREVIEW asks it to
-// tell a person something, so a match they cannot see must not be mentioned.
-// The `on_duplicate: skip` path asks it to DECIDE, and there visibility is
-// irrelevant — see the branch below.
-//
-// Only organizations: a lead's identity is its email, which the store's own
-// unique key already refuses, so there is no silent twin to warn about.
-//
-// A read-only transaction, and NOT DedupeOrganizationForCreate — that one takes
-// a write lock to serialize concurrent creates, which a preview has no business
-// holding. The answer can therefore go stale between the preview and the
-// commit; that is correct, because the commit runs the locking version and its
-// answer is the one that decides.
-func (w *csvWriters) collidesWithExisting(ctx context.Context, row migration.Row, discloseOnly bool) (bool, error) {
-	if w.object != migration.ObjectOrganization {
-		return false, nil
-	}
-	fields := textFields(row.Fields)
-	candidate := people.OrganizationCandidate{
-		DisplayName: strings.TrimSpace(fields[fieldDisplayName]),
-		LegalName:   strings.TrimSpace(fields["legal_name"]),
-	}
-	if candidate.DisplayName == "" && candidate.LegalName == "" {
-		return false, nil
-	}
-	var visible bool
-	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
-		match, err := people.DedupeOrganization(ctx, tx, candidate)
-		if err != nil || match.Decision == people.DecisionNoMatch {
-			return err
-		}
-		// The ladder reads every organization, by design — it is the write
-		// path's collision check, and a create must not mint a twin of a row
-		// the caller happens not to be allowed to see. A DISCLOSURE is the
-		// opposite: telling this caller "that company is already here" about a
-		// row they cannot read turns the preview into an oracle for a
-		// colleague's owner-private capture, which even an admin may not read
-		// (rowscope.go). So a match the caller cannot see discloses nothing.
-		//
-		// The COMMIT is unaffected: it still refuses or files the review pair
-		// on the ladder's own answer, visible or not.
-		if !discloseOnly {
-			// Deciding whether to SKIP the row, not whether to mention it. The
-			// incumbent's visibility is beside the point: creating a twin of a
-			// row this caller cannot see is exactly the duplicate the run asked
-			// to avoid, and skipping it reveals nothing the caller did not
-			// already put in their own file.
-			visible = true
-			return nil
-		}
-		visible, err = auth.VisibleTo(ctx, tx, "organization", match.OrganizationID.UUID)
-		return err
-	}); err != nil {
-		return false, fmt.Errorf("import: checking %q against the companies already held: %w", candidate.DisplayName, err)
-	}
-	return visible, nil
 }
 
 // Ensure lands one row: created the first time, updated when the file has
@@ -282,15 +232,58 @@ func (w *csvWriters) Ensure(ctx context.Context, object string, row migration.Ro
 	// Not a row this importer has landed before — but the estate may hold the
 	// record anyway, and the run says what to do about that. The check runs on
 	// the commit as well as the dry run so the two cannot disagree.
-	if w.onDuplicate == string(crmcontracts.Skip) {
+	switch w.onDuplicate {
+	case string(crmcontracts.Skip):
+		// DECIDED without the visibility filter and REPORTED with it. Skipping a
+		// row turns on the incumbent existing, whoever may read it — creating a
+		// twin of a record the caller cannot see is exactly the duplicate this
+		// mode was asked to avoid. But the reason travels into a report readable
+		// on the import_run grant alone, so naming an invisible company there
+		// would move the existence oracle from the preview to the finished run
+		// rather than closing it.
 		collides, err := w.collidesWithExisting(ctx, row, false)
 		if err != nil {
 			return migration.EnsureResult{}, err
 		}
-		if collides {
-			return migration.EnsureResult{Skipped: true, SkipReason: duplicateSkipReason}, nil
+		if collides.hit {
+			reason := duplicateSkipReason
+			if !collides.visible {
+				reason = opaqueSkipReason
+			}
+			return migration.EnsureResult{Skipped: true, SkipReason: reason}, nil
+		}
+	case string(crmcontracts.Update):
+		// discloseOnly, so a match this caller cannot see is not one this run
+		// writes onto — an import must never become a blind edit of a
+		// colleague's owner-private record. It creates instead, which is the
+		// same thing `create` does and is repairable by merging.
+		collides, err := w.collidesWithExisting(ctx, row, true)
+		if err != nil {
+			return migration.EnsureResult{}, err
+		}
+		if collides.writable() {
+			// Straight into reconcile, the same path a row this importer wrote
+			// before takes. The incumbent arrived some other way — mail capture,
+			// a human, another import — and that changes who to write onto, not
+			// how: same field comparison, same patch, same unchanged accounting.
+			//
+			// The dedupe read happens HERE rather than being replayed from the
+			// preview, so a company created between the two passes is seen for
+			// the first time now: the preview reported this row as a create and
+			// the commit updates instead. That window is real and is not closed
+			// by this change — closing it needs the run to persist a per-row
+			// prediction, which it does not have (the engine stores aggregate
+			// counts only). What bounds it is that the write still goes through
+			// writable(), so the surprise is an edit of the RIGHT company, not
+			// of a wrong one.
+			return w.reconcile(ctx, collides.writableID(), row)
+		}
+		if collides.hit {
+			return migration.EnsureResult{Skipped: true, SkipReason: fuzzyUpdateSkipReason}, nil
 		}
 	}
+	// Falls through to a CREATE: no identity map hit, and no writable or
+	// disclosable collision.
 	switch object {
 	case migration.ObjectLead:
 		return w.createLead(ctx, row)

--- a/backend/internal/compose/integration/csvimportupdate_integration_test.go
+++ b/backend/internal/compose/integration/csvimportupdate_integration_test.go
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// `on_duplicate: update` — writing a file ONTO the companies already held.
+//
+// The correction case, and the one the other two modes cannot serve: `create`
+// mints a twin, `skip` leaves the estate stale, and before this the honest
+// answer to "I have a corrected export" was "retype it in the app".
+//
+// Three properties, and the middle one is the reason the mode is bounded rather
+// than general: it writes where the match is CERTAIN, refuses where the names
+// merely score alike, and reports nothing changed when nothing did. An import
+// cannot be undone from this surface, so overwriting the wrong company is
+// permanent in a way that a twin — repairable by merging — is not.
+
+import (
+	"net/http"
+	"testing"
+)
+
+// on_duplicate: update — the correction case. A spreadsheet of companies the
+// CRM already holds, where the file is the better copy.
+//
+// Before this existed the only ways to apply such a file were to mint twins or
+// to leave the estate stale, so the honest answer to "I have a corrected export"
+// was "paste it into the app by hand". The preview and the commit must agree
+// here for the same reason they must everywhere: an approval is a decision about
+// what the report said.
+func TestCSVImportUpdateDuplicatesWritesOntoTheIncumbent(t *testing.T) {
+	e := setupImportApp(t)
+
+	if status := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Kestrel Data"}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the incumbent → %d, want 201", status)
+	}
+	orgsBefore := len(organizations(t, e).Data)
+
+	const file = "Company,City,Country\nKestrel Data,Bremen,DE\nNordwind Logistik,Kiel,DE\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "City": "address.city", "Country": "address.country"},
+		"update")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Created != 1 || report.Disposition.Updated != 1 {
+		t.Fatalf("preview = created %d updated %d, want 1 and 1 — the duplicate is written onto, "+
+			"the new company lands", report.Disposition.Created, report.Disposition.Updated)
+	}
+	if report.Disposition.Skipped != 0 {
+		t.Errorf("skipped = %d, want 0 — an update run skips nothing it can write",
+			report.Disposition.Skipped)
+	}
+	// Still disclosed. `updated` says what happens; `duplicates` says the row was
+	// already here, which is the fact a person weighs before approving an edit.
+	if report.Disposition.Duplicates == nil || *report.Disposition.Duplicates != 1 {
+		t.Errorf("duplicates = %v, want 1 — an update is still a duplicate and the report must say so",
+			report.Disposition.Duplicates)
+	}
+	if got := report.Disposition.Created + report.Disposition.Updated +
+		report.Disposition.Unchanged + report.Disposition.Skipped; got != report.RowsRead {
+		t.Errorf("the disposition sums to %d for %d rows read", got, report.RowsRead)
+	}
+
+	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", status)
+	}
+
+	after := organizations(t, e).Data
+	if len(after) != orgsBefore+1 {
+		t.Errorf("companies went from %d to %d; an update run adds only the genuinely new one",
+			orgsBefore, len(after))
+	}
+	kestrels := 0
+	for _, o := range after {
+		if o.DisplayName == "Kestrel Data" {
+			kestrels++
+		}
+	}
+	if kestrels != 1 {
+		t.Fatalf("%d companies named Kestrel Data; update writes onto the incumbent rather than "+
+			"minting a twin", kestrels)
+	}
+
+	// The file's values on the record that was already here — the whole point of
+	// the mode, and not something the counts alone can show.
+	var withAddress struct {
+		Data []struct {
+			DisplayName string `json:"display_name"`
+			Address     struct {
+				City    string `json:"city"`
+				Country string `json:"country"`
+			} `json:"address"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, http.MethodGet, "/v1/organizations?limit=100", nil, nil,
+		&withAddress); status != http.StatusOK {
+		t.Fatalf("re-reading the companies → %d, want 200", status)
+	}
+	for _, o := range withAddress.Data {
+		if o.DisplayName != "Kestrel Data" {
+			continue
+		}
+		if o.Address.City != "Bremen" || o.Address.Country != "DE" {
+			t.Errorf("the incumbent has city %q country %q, want Bremen/DE — the file's values are "+
+				"what an update lands", o.Address.City, o.Address.Country)
+		}
+	}
+}
+
+// The refusal that makes update safe: a name that merely LOOKS similar is not
+// written onto.
+//
+// The ladder answers `exact_collision` for a domain match and `fuzzy_review` for
+// a name score, and only the first is an identity. Writing on the second would
+// move one company's address onto another's, silently and with no undo from this
+// surface — a strictly worse mistake than the twin that `create` risks, which a
+// merge can repair. So the row is reported as a skip naming what to do about it,
+// and the person holding the file decides.
+func TestCSVImportUpdateWillNotWriteOnAMerelySimilarName(t *testing.T) {
+	e := setupImportApp(t)
+
+	// Two names a person can tell apart and a trigram score cannot: same first
+	// word, different companies. NOT a legal-suffix variation — NormalizeOrgName
+	// strips those deliberately, so "Kestrel Data" and "Kestrel Data GmbH" ARE
+	// the same company to the ladder and updating across them is correct.
+	if status := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Kestrel Data Systems"}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the incumbent → %d, want 201", status)
+	}
+
+	const file = "Company,City\nKestrel Data Solutions,Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "City": "address.city"}, "update")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	// Whichever way the ladder scored these two names, the run must not have
+	// silently overwritten: either it saw no match and created, or it saw a fuzzy
+	// one and skipped. What it may never do is write onto a guess.
+	if report.Disposition.Updated != 0 {
+		t.Errorf("updated = %d for two names that merely SCORE alike — Systems and Solutions are "+
+			"different companies, and an update run must not overwrite a record it guessed at",
+			report.Disposition.Updated)
+	}
+	if got := report.Disposition.Created + report.Disposition.Updated +
+		report.Disposition.Unchanged + report.Disposition.Skipped; got != report.RowsRead {
+		t.Errorf("the disposition sums to %d for %d rows read", got, report.RowsRead)
+	}
+}
+
+// An update run that finds nothing to change reports nothing changed.
+//
+// The same reason `unchanged` exists at all: an import that re-applies a file it
+// already applied must not report a hundred writes and an audit trail to match.
+func TestCSVImportUpdateOfIdenticalValuesIsUnchanged(t *testing.T) {
+	e := setupImportApp(t)
+
+	if status := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Kestrel Data", "address": map[string]any{"city": "Bremen"}},
+		nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the incumbent → %d, want 201", status)
+	}
+
+	const file = "Company,City\nKestrel Data,Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "City": "address.city"}, "update")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Unchanged != 1 || report.Disposition.Updated != 0 {
+		t.Errorf("preview = updated %d unchanged %d, want 0 and 1 — the file says nothing new",
+			report.Disposition.Updated, report.Disposition.Unchanged)
+	}
+	if report.Disposition.Duplicates == nil || *report.Disposition.Duplicates != 1 {
+		t.Errorf("duplicates = %v, want 1 — still a row already here", report.Disposition.Duplicates)
+	}
+}
+
+// Two legal entities sharing a stem are not one company, and update leaves them
+// alone.
+//
+// This is the defect the first version of the mode shipped with. The dedupe
+// ladder strips the trailing legal suffix before scoring, so "Acme Inc" and
+// "Acme GmbH" reach it as the same string and score a perfect 1.0 — and
+// fuzzyOrganization says in as many words that they are a human's call rather
+// than a merge. A rule keyed on that score wrote onto whichever record ranked
+// first, permanently, performing the merge the ladder had refused.
+//
+// End to end rather than only in the unit gate, because the unit gate asks
+// people.SameOrganizationName directly and this asks what a person importing a
+// file actually gets.
+func TestCSVImportUpdateWillNotWriteAcrossLegalForms(t *testing.T) {
+	e := setupImportApp(t)
+
+	if status := e.Call(t, http.MethodPost, "/v1/organizations",
+		map[string]any{"display_name": "Falkenberg Maschinenbau GmbH"}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the incumbent → %d, want 201", status)
+	}
+
+	const file = "Company,City\nFalkenberg Maschinenbau AG,Stuttgart\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "City": "address.city"}, "update")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Updated != 0 {
+		t.Fatalf("updated = %d — the GmbH and the AG are different legal entities, and an update "+
+			"run overwrote one with the other's values", report.Disposition.Updated)
+	}
+
+	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", status)
+	}
+
+	// The incumbent still has no city: nothing was written onto it.
+	var orgs struct {
+		Data []struct {
+			DisplayName string `json:"display_name"`
+			Address     struct {
+				City string `json:"city"`
+			} `json:"address"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, http.MethodGet, "/v1/organizations?limit=100", nil, nil, &orgs); status != http.StatusOK {
+		t.Fatalf("reading the companies → %d, want 200", status)
+	}
+	for _, o := range orgs.Data {
+		if o.DisplayName == "Falkenberg Maschinenbau GmbH" && o.Address.City != "" {
+			t.Errorf("the GmbH now has city %q, taken from a row naming the AG", o.Address.City)
+		}
+	}
+}
+
+// The four counts sum to rows_read when SEVERAL rows are skipped for the same
+// reason, and their external ids are not line numbers.
+//
+// The report deduplicates skipped rows so that one row refused by both the dry
+// run and the commit is named once. It used to key that on the LINE derived from
+// the external id — and lineOf answers 0 for every id not shaped "line N", which
+// is every id in a file carrying its own source_key column. Several skips then
+// collapsed onto one another: rows_read 2, skipped 1, nothing else, so the four
+// counts summed to 1.
+//
+// `update` is what made this reachable in bulk rather than in theory: refusing a
+// near-miss name is its ordinary behaviour, not an error case, so a real file
+// produces many of them at once.
+func TestCSVImportSkippedRowsAreCountedIndividually(t *testing.T) {
+	e := setupImportApp(t)
+
+	for _, name := range []string{"Aurora Metallbau GmbH", "Boreas Logistik GmbH"} {
+		if status := e.Call(t, http.MethodPost, "/v1/organizations",
+			map[string]any{"display_name": name}, nil, nil); status != http.StatusCreated {
+			t.Fatalf("creating %s → %d, want 201", name, status)
+		}
+	}
+
+	// Two rows, each a near miss of a different incumbent, each refused for the
+	// same reason — under a source key that is a NAME rather than a line number,
+	// which is what makes lineOf answer 0 for both.
+	const file = "Company,City\n" +
+		"Aurora Metallbau AG,Bremen\n" +
+		"Boreas Logistik AG,Kiel\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	var run importRunDTO
+	status := e.Call(t, http.MethodPost, "/v1/imports", map[string]any{
+		"connector": "csv", "object": "organization", "source_ref": profile.SourceRef,
+		"mapping": map[string]string{
+			"Company": "display_name", "City": "address.city",
+		},
+		"source_key": "Company", "on_duplicate": "update",
+	}, nil, &run)
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	t.Logf("rows_read=%d created=%d updated=%d unchanged=%d skipped=%d issues=%d",
+		report.RowsRead, report.Disposition.Created, report.Disposition.Updated,
+		report.Disposition.Unchanged, report.Disposition.Skipped, len(report.Issues))
+	if report.Disposition.Skipped != 2 {
+		t.Errorf("skipped = %d, want 2 — both near misses are refused, and each is its own row",
+			report.Disposition.Skipped)
+	}
+	if got := report.Disposition.Created + report.Disposition.Updated +
+		report.Disposition.Unchanged + report.Disposition.Skipped; got != report.RowsRead {
+		t.Errorf("the disposition sums to %d for %d rows read — a row went missing from the counts, "+
+			"which is exactly the report 'hiding something' its own contract warns about",
+			got, report.RowsRead)
+	}
+}
+
+// Two companies legitimately sharing a name, and an update run picking one.
+//
+// The name axis has no unique index and DedupeOrganizationForCreate says why in
+// as many words: two organizations may legitimately share a name. When several
+// do, fuzzyOrganization ranks them and breaks the tie on the LOWEST UUID — an
+// arbitrary winner, correct for proposing a review pair and not a basis for
+// overwriting one of them.
+//
+// So an exact name match is not an identity either, and this is the case that
+// shows it: the file cannot say which "Kestrel Data" it means, and neither can
+// the importer.
+func TestCSVImportUpdateWillNotPickBetweenTwoCompaniesSharingAName(t *testing.T) {
+	e := setupImportApp(t)
+
+	for range 2 {
+		if status := e.Call(t, http.MethodPost, "/v1/organizations",
+			map[string]any{"display_name": "Kestrel Data"}, nil, nil); status != http.StatusCreated {
+			t.Fatalf("creating an incumbent → %d, want 201", status)
+		}
+	}
+
+	const file = "Company,City\nKestrel Data,Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "City": "address.city"}, "update")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Updated != 0 {
+		t.Fatalf("updated = %d — two companies share this name, so the run overwrote one of them "+
+			"chosen by uuid order, permanently, and the file never said which it meant",
+			report.Disposition.Updated)
+	}
+}
+
+// A trading name matching somebody's REGISTERED name is not the same name.
+//
+// bestOrgNamePairing scores all four combinations of the two names on each side
+// and keeps the best, so a row naming "Kestrel Data" as a display name matches an
+// incumbent whose legal_name is "Kestrel Data" — and reports the hit as
+// `legal_name`, because MatchedField names the stored side only. Reading that
+// label alone makes a cross-axis hit look like a legal-to-legal identity.
+//
+// It is a fine reason to show a human two records. It is not grounds to overwrite
+// one, and specifically not grounds to write the row's values over an
+// incumbent's registered name.
+func TestCSVImportUpdateWillNotWriteAcrossTheNameAxes(t *testing.T) {
+	e := setupImportApp(t)
+
+	if status := e.Call(t, http.MethodPost, "/v1/organizations", map[string]any{
+		"display_name": "Nordwind Holding", "legal_name": "Kestrel Data",
+	}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("creating the incumbent → %d, want 201", status)
+	}
+
+	// The row names Kestrel Data as its TRADING name and says nothing about a
+	// registered one.
+	const file = "Company,City\nKestrel Data,Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "City": "address.city"}, "update")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Updated != 0 {
+		t.Fatalf("updated = %d — the row's trading name met an incumbent's REGISTERED name, and the "+
+			"run overwrote a company that was never the one named", report.Disposition.Updated)
+	}
+
+	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", status)
+	}
+	var orgs struct {
+		Data []struct {
+			DisplayName string `json:"display_name"`
+			LegalName   string `json:"legal_name"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, http.MethodGet, "/v1/organizations?limit=100", nil, nil, &orgs); status != http.StatusOK {
+		t.Fatalf("reading the companies → %d, want 200", status)
+	}
+	for _, o := range orgs.Data {
+		if o.DisplayName == "Nordwind Holding" && o.LegalName != "Kestrel Data" {
+			t.Errorf("the incumbent's registered name is now %q; an import overwrote it from a row "+
+				"that only ever named a trading name", o.LegalName)
+		}
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -4799,6 +4799,7 @@ func (e ImportObject) Valid() bool {
 const (
 	Create ImportOnDuplicate = "create"
 	Skip   ImportOnDuplicate = "skip"
+	Update ImportOnDuplicate = "update"
 )
 
 // Valid indicates whether the value is a known member of the ImportOnDuplicate enum.
@@ -4807,6 +4808,8 @@ func (e ImportOnDuplicate) Valid() bool {
 	case Create:
 		return true
 	case Skip:
+		return true
+	case Update:
 		return true
 	default:
 		return false
@@ -14841,9 +14844,59 @@ type CreateImportRunRequest struct {
 	//
 	// `skip` leaves the incumbent alone and reports the row as skipped.
 	//
-	// The DRY RUN counts duplicates either way, so a person is told "100
-	// companies, 94 duplicates" before deciding — which is the whole reason
-	// the count is separate from `created`.
+	// `update` writes the row's mapped values ONTO the incumbent, reported as
+	// `updated` like any other matched row. This is the correction case: a
+	// spreadsheet of companies the CRM already holds — captured from mail,
+	// typed in by hand, or landed by a different import — where the file is
+	// the better copy. Without it the only ways to apply such a file were to
+	// mint twins or to leave the estate stale.
+	//
+	// It overwrites only where the row names EXACTLY ONE company and matches
+	// its name outright — legal form included, and on the same axis, so a
+	// trading name is compared with a trading name and a registered name with a
+	// registered one.
+	//
+	// Three refusals make that bar, and each closes a way to overwrite the
+	// wrong record:
+	//
+	// * The ladder strips the trailing legal suffix before scoring, so
+	//   `Acme Inc` and `Acme GmbH` reach it as one string and score a perfect
+	//   match. It routes them to a human precisely because different legal
+	//   entities are a person's call; writing on that score performs the merge
+	//   it refused.
+	// * The name axis has no unique index — two organizations may legitimately
+	//   share a name (see DedupeOrganizationForCreate) — and the ladder breaks
+	//   the tie on the lowest uuid. That is fine for proposing a review pair
+	//   and no basis for choosing which of two records to overwrite.
+	// * bestOrgNamePairing scores all four combinations of the two names on
+	//   each side, so a trading name can match somebody's REGISTERED name. A
+	//   reason to show a human two records, not a statement that the two names
+	//   are the same name.
+	//
+	// The asymmetry that sets the bar: `undo` reverses the rows a run CREATED,
+	// so a bad `create` is repairable by merging. An `update` writes over a
+	// company the run did not create, its previous values are gone, and nothing
+	// restores them.
+	//
+	// Everything short of that is reported as a skipped row naming why, so the
+	// near misses are surfaced rather than lost — the decision just stays with
+	// the person holding the file.
+	//
+	// It also writes only where the caller could write ANYWAY: a match the
+	// caller cannot see is not disclosed and not written, so an import cannot
+	// become a blind edit of a colleague's owner-private capture.
+	//
+	// The DRY RUN counts duplicates whichever mode is chosen, so a person is
+	// told "100 companies, 94 duplicates" before deciding — which is the whole
+	// reason the count is separate from `created`.
+	//
+	// A collision with a record the CALLER MAY NOT SEE is neither counted nor
+	// named, in the dry run or in the finished report: row scope governs what a
+	// report may say as much as what a record may show, and an importer that
+	// answered would be an existence oracle for a colleague's owner-private
+	// capture, one row at a time. Such a row previews as a create and is left
+	// alone on commit — the preview understating what a run leaves alone is the
+	// only safe direction for the two passes to differ.
 	OnDuplicate *ImportOnDuplicate `json:"on_duplicate,omitempty"`
 
 	// SourceKey The source column holding the row's stable id, written to the row's
@@ -16477,9 +16530,59 @@ type ImportObject string
 //
 // `skip` leaves the incumbent alone and reports the row as skipped.
 //
-// The DRY RUN counts duplicates either way, so a person is told "100
-// companies, 94 duplicates" before deciding — which is the whole reason
-// the count is separate from `created`.
+// `update` writes the row's mapped values ONTO the incumbent, reported as
+// `updated` like any other matched row. This is the correction case: a
+// spreadsheet of companies the CRM already holds — captured from mail,
+// typed in by hand, or landed by a different import — where the file is
+// the better copy. Without it the only ways to apply such a file were to
+// mint twins or to leave the estate stale.
+//
+// It overwrites only where the row names EXACTLY ONE company and matches
+// its name outright — legal form included, and on the same axis, so a
+// trading name is compared with a trading name and a registered name with a
+// registered one.
+//
+// Three refusals make that bar, and each closes a way to overwrite the
+// wrong record:
+//
+//   - The ladder strips the trailing legal suffix before scoring, so
+//     `Acme Inc` and `Acme GmbH` reach it as one string and score a perfect
+//     match. It routes them to a human precisely because different legal
+//     entities are a person's call; writing on that score performs the merge
+//     it refused.
+//   - The name axis has no unique index — two organizations may legitimately
+//     share a name (see DedupeOrganizationForCreate) — and the ladder breaks
+//     the tie on the lowest uuid. That is fine for proposing a review pair
+//     and no basis for choosing which of two records to overwrite.
+//   - bestOrgNamePairing scores all four combinations of the two names on
+//     each side, so a trading name can match somebody's REGISTERED name. A
+//     reason to show a human two records, not a statement that the two names
+//     are the same name.
+//
+// The asymmetry that sets the bar: `undo` reverses the rows a run CREATED,
+// so a bad `create` is repairable by merging. An `update` writes over a
+// company the run did not create, its previous values are gone, and nothing
+// restores them.
+//
+// Everything short of that is reported as a skipped row naming why, so the
+// near misses are surfaced rather than lost — the decision just stays with
+// the person holding the file.
+//
+// It also writes only where the caller could write ANYWAY: a match the
+// caller cannot see is not disclosed and not written, so an import cannot
+// become a blind edit of a colleague's owner-private capture.
+//
+// The DRY RUN counts duplicates whichever mode is chosen, so a person is
+// told "100 companies, 94 duplicates" before deciding — which is the whole
+// reason the count is separate from `created`.
+//
+// A collision with a record the CALLER MAY NOT SEE is neither counted nor
+// named, in the dry run or in the finished report: row scope governs what a
+// report may say as much as what a record may show, and an importer that
+// answered would be an existence oracle for a colleague's owner-private
+// capture, one row at a time. Such a row previews as a create and is left
+// alone on commit — the preview understating what a run leaves alone is the
+// only safe direction for the two passes to differ.
 type ImportOnDuplicate string
 
 // ImportRowIssue One row the import could not take, named by its line so a human can go fix it.
@@ -16537,8 +16640,10 @@ type ImportRunDisposition struct {
 
 	// Duplicates Rows naming a record the estate already holds. NOT a fifth outcome
 	// and never added to the other four — each duplicate is already
-	// counted in `created` (it lands and files a review pair) or in
-	// `skipped` (when the run asked for `on_duplicate: skip`). It is the
+	// counted in `created` (it lands and files a review pair), in
+	// `skipped` (when the run asked for `on_duplicate: skip`) or in
+	// `updated`/`unchanged` (when it asked for `on_duplicate: update`,
+	// which writes the file's values onto the incumbent). It is the
 	// number a human needs before approving: "100 companies, 94 of them
 	// already here" is a different decision from "100 new companies".
 	Duplicates *int `json:"duplicates,omitempty"`

--- a/backend/internal/modules/agents/toolcopy_import.go
+++ b/backend/internal/modules/agents/toolcopy_import.go
@@ -12,8 +12,8 @@ var previewImportCopy = toolCopy{
 	Purpose: "Bring a spreadsheet in: send the CSV as text and this checks every row " +
 		"against the workspace and reports what importing it would do.",
 	Limits: "Writes nothing. People arrive as leads, so `object` is lead or organization. " +
-		"A row naming a company already here is counted in `duplicates`, and created unless " +
-		"on_duplicate is skip.",
+		"A row naming a company already here is counted in `duplicates`; on_duplicate says " +
+		"whether it lands a second (default), is skipped, or updates the incumbent.",
 	Instead: "create_record for one record you already know.",
 	Retain:  "run_id, and `duplicates` — give the user both numbers before committing.",
 }

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -115,8 +115,8 @@ func (t previewImport) Spec() mcp.ToolSpec {
 			"csv":{"type":"string","description":"The file's contents, header row first."},
 			"mapping":{"type":"object","additionalProperties":{"type":"string"},
 			  "description":"Source column name → field name. Omit to accept the proposal this call would make."},
-			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
-			  "description":"A company already here: create (default) lands a second; skip leaves the incumbent."}},
+			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `","` + importOnDuplicateUpdate + `"],
+			  "description":"A company already here: create (default) lands a second; skip leaves the incumbent; update writes this row onto it (exact name matches only)."}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[ImportPreviewResult](),
 	}
@@ -189,11 +189,12 @@ func (t previewImport) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 // arrived differs.
 const importConnectorCSV = "csv"
 
-// The two duplicate policies, spelled here so the tool schema and the contract
-// enum cannot drift apart.
+// The duplicate policies, spelled here so the tool schema and the contract enum
+// cannot drift apart.
 const (
 	importOnDuplicateCreate = string(crmcontracts.Create)
 	importOnDuplicateSkip   = string(crmcontracts.Skip)
+	importOnDuplicateUpdate = string(crmcontracts.Update)
 )
 
 // refuseUnimportableObject holds `object` to the vocabulary, naming the whole

--- a/backend/internal/modules/people/namesim.go
+++ b/backend/internal/modules/people/namesim.go
@@ -90,6 +90,50 @@ func NormalizeOrgName(s string) string {
 	return strings.Join(fields, " ")
 }
 
+// SameOrganizationName reports whether two organisation names are the SAME
+// NAME — not merely similar, and not merely equal once their legal suffixes are
+// discarded.
+//
+// It exists for one caller: a path deciding whether a match is safe to OVERWRITE
+// rather than to propose. That is a stricter question than the dedupe ladder's,
+// and deliberately so.
+//
+// The ladder strips the trailing legal suffix before scoring, which is right for
+// its own job — "Acme Inc" and "Acme GmbH" ARE candidates worth showing a human
+// — and the comment on fuzzyOrganization says exactly why they are not a merge:
+// different legal entities are a human's call. A caller that overwrote on that
+// score would perform the merge the ladder refused to, silently.
+//
+// So the suffix is kept. Everything else NormalizeOrgName folds is folded here
+// too — case, accents, commas, and runs of whitespace — because none of those
+// change which company is meant, and refusing "Acme, Inc" against "Acme Inc"
+// would refuse the correction case for a typist's comma. The one difference
+// between the two functions is the suffix, which is the whole point.
+//
+// The 256-rune cap inside nameSimilarity is also stepped around: it makes two
+// names sharing a long prefix score 1.0, which is a capped score rather than a
+// statement about identity. Equality here is exact over the whole string.
+//
+// Answering true is necessary for an overwrite and NOT sufficient: the name axis
+// has no unique index, so two organisations may legitimately share a name (see
+// DedupeOrganizationForCreate). The caller must also establish that only ONE
+// candidate matched.
+func SameOrganizationName(a, b string) bool {
+	left, right := foldOrgNameKeepingSuffix(a), foldOrgNameKeepingSuffix(b)
+	return left != "" && left == right
+}
+
+// foldOrgNameKeepingSuffix is NormalizeOrgName's folding without its suffix
+// strip: casefold, unaccent, commas to spaces, and internal whitespace
+// collapsed. Trailing periods go too, so "Acme GmbH." meets "Acme GmbH".
+func foldOrgNameKeepingSuffix(s string) string {
+	fields := strings.Fields(normalizeName(strings.ReplaceAll(s, ",", " ")))
+	for i, f := range fields {
+		fields[i] = strings.Trim(f, ".")
+	}
+	return strings.Join(fields, " ")
+}
+
 // nameSimilarity is `name_sim`: Jaro-Winkler over normalized input,
 // in [0,1].
 func nameSimilarity(a, b string) float64 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ maps the codebase and links everything below.
 - [enrich-with-a-local-llm.md](how-to/enrich-with-a-local-llm.md) — point the AI lanes at a local Ollama and enrich a company with no cloud key.
 - [connect-telegram.md](how-to/connect-telegram.md) — bind a workspace-level Telegram bot for pull ingress and governed replies.
 - [import-your-linkedin-network.md](how-to/import-your-linkedin-network.md) — import your own `Connections.csv` as graph substrate, and read the reach it buys.
+- [import-a-company-spreadsheet.md](how-to/import-a-company-spreadsheet.md) — bring a CSV of companies in: the column mapping, what the preview counts, and what `on_duplicate` does about a company you already hold.
 - [connect-a-hubspot-overlay.md](how-to/connect-a-hubspot-overlay.md) — connect a workspace to a HubSpot portal in overlay (read + continuous sync) mode.
 - [flip-an-overlay-to-native.md](how-to/flip-an-overlay-to-native.md) — the one-way overlay→native cutover: preflight, seal, the typed confirmation, and what recovery actually means.
 - [connect-a-cloud-model-provider.md](how-to/connect-a-cloud-model-provider.md) — bind the AI lanes to a BYOK cloud key (Anthropic / OpenAI / Gemini / any OpenAI-compatible vendor).

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -18,6 +18,15 @@ Both call every action through `agents.Registry.Invoke`, which admits each call 
 (**scope ∧ seat ∧ tier**) before any handler runs. A 🟢 call executes and is audited; a 🟡 call stages a
 confirm-first approval. "Two surfaces, one gate" is a property of the construction, not a convention.
 
+Most consequential verbs are 🟢 (ADR-0055). A passport carries the granting human's own seat, grants and
+row scope, so a send or an archive it can spend is one that person could spend unaided in the app, and
+asking them to confirm it again made the agent surface weaker than the person behind it rather than
+safer. What still bounds a call is what bounds the human: RBAC, row scope, the seat ceiling, expiry, and
+the scope its holder chose to lend. 🟡 is kept for calls whose destination the credential-holder did not
+choose — `enrich` is the standing case, because the model names the URL the server fetches. An
+installation that wants a particular verb confirmed **floors** it back per record type, and every verb
+still carries the staging machinery that makes the floor land in a human's inbox.
+
 ## The reason-act-observe loop (Surface B)
 
 The runner (`internal/modules/agents/runner/`) is where **the model proposes and the governed tool

--- a/docs/how-to/connect-an-mcp-client.md
+++ b/docs/how-to/connect-an-mcp-client.md
@@ -100,6 +100,23 @@ The same token is a REST Bearer credential, governed identically (ADR-0055):
 the granting human's live seat and RBAC. See
 [mint-a-passport.md](mint-a-passport.md) to issue one directly.
 
+**What a passport can do without asking you.** Most consequential verbs run
+directly — importing a file, sending mail, booking, merging, archiving. The
+reasoning is that a passport acts as *you*: it carries your seat, your grants and
+your row scope, so it can only reach what you could already reach in the app, and
+a second confirmation from the same person adds ceremony rather than safety. The
+limits that still apply are your limits — RBAC, row scope, the seat ceiling, the
+passport's expiry, and the scopes you chose to lend when you minted it.
+
+Two things do not follow that rule:
+
+- **`enrich`** stays confirm-first. The model names the URL the server fetches,
+  so persuading the model reaches an address nobody with the credential picked.
+  That is a question about egress, not about authority.
+- **Anything an installation floors.** A workspace can require confirmation for a
+  particular verb and record type by declaring it in the contract, and the verb
+  then stages for a human exactly as it always did.
+
 ## Inspect the surface
 
 The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) speaks

--- a/docs/how-to/import-a-company-spreadsheet.md
+++ b/docs/how-to/import-a-company-spreadsheet.md
@@ -1,0 +1,190 @@
+# Import a spreadsheet of companies
+
+Bring a CSV of companies into the CRM — through an assistant over MCP, or over
+REST. This guide is about the decision that actually bites: **what happens to a
+row naming a company you already have.**
+
+Every import previews before it writes. The preview counts what the commit will
+do, row by row, and nothing lands until you approve the run.
+
+> **Undo covers what a run CREATED, and only that.** A signed-in human can
+> reverse a completed CSV run — it archives the rows that run created and that
+> nobody has touched since, leaving edited ones alone and naming them. What it
+> cannot do is restore a company that existed *before* the run: `update` writes
+> the file's values onto it, the old values are gone, and no call puts them
+> back. That asymmetry is why `on_duplicate` is worth a minute before you commit
+> a hundred rows.
+
+## The shape of a run
+
+Three steps, whichever door you come through:
+
+1. **Preview** — hand over the file and a column mapping. Writes nothing, and
+   answers a `run_id` plus a report.
+2. **Read the report** — the counts, and the issues naming any row that will not
+   land.
+3. **Commit** — approve the run by its id. *This* is the call that writes.
+
+Over MCP that is three tool calls: `preview_import` (the CSV goes inline, as
+text), `read_import_report` and `commit_import`.
+
+Over REST the file is uploaded first, so it is four: `POST /v1/imports/sources`
+with the file as multipart, then `POST /v1/imports` naming the `source_ref` it
+answers, `GET /v1/imports/{id}/report`, and `POST /v1/imports/{id}/approve`.
+
+**The upload and the undo are human-only.** Both take a signed-in session and
+refuse an agent principal, so an assistant previews and commits but cannot
+upload a file on your behalf or reverse a run afterwards.
+
+## Step 1 — Map your columns
+
+The importer does not guess. Name each source column and the field it feeds:
+
+```json
+{
+  "object": "organization",
+  "csv": "name,city,country,size\nHelios Logistik GmbH,Hamburg,DE,51-200\n",
+  "mapping": {
+    "name": "display_name",
+    "city": "address.city",
+    "country": "address.country",
+    "size": "size_band"
+  }
+}
+```
+
+A company can receive `display_name`, `legal_name`, `industry`, `size_band`,
+`description`, and the six address fields: `address.line1`, `address.line2`,
+`address.city`, `address.region`, `address.postal_code`, `address.country`.
+Map a name it does not take and the run is refused with the list of what it
+does — before anything is written.
+
+**A file of people becomes leads, not contacts.** Set `object` to `lead` for
+those. That is a deliberate rule, not an omission: an unqualified list must not
+land in the clean core.
+
+## Step 2 — Decide what to do about duplicates
+
+This is the choice worth making on purpose. `on_duplicate` takes three values.
+
+| Value | A row naming a company already here | Use it when |
+|---|---|---|
+| `create` *(default)* | Lands a second record and files the pair for review | One company typed by a human |
+| `skip` | Leaves the existing record untouched | You want only the genuinely new rows |
+| `update` | Writes the row's values onto the existing record | The file is the better copy |
+
+`create` is the default for compatibility, and it is usually the wrong choice
+for a spreadsheet: a hundred rows of companies you already have becomes a
+hundred twins, each needing a merge.
+
+**`update` is the correction case** — an export you have cleaned up, where the
+file should win. It overwrites only when your row names **exactly one** company,
+matching its name outright — legal form included, and on the same axis (a trading
+name against a trading name, a registered name against a registered one).
+Anything short of that is reported as a skip, and left for you.
+
+That bar is deliberately higher than the one the CRM uses to *suggest* merges.
+Suggesting costs a glance; overwriting cannot be undone onto a company the run
+did not create. So:
+
+| Your row | Already in the CRM | What happens |
+|---|---|---|
+| `Kestrel Data GmbH` | `kestrel data gmbh` | **Updated** — same name, different casing |
+| `Straße Co` | `STRASSE Co` | **Updated** — ß and ss are the same letter |
+| `Acme Inc` | `Acme GmbH` | **Skipped** — different legal entities |
+| `Kestrel Data Systems` | `Kestrel Data Solutions` | **Skipped** — similar, not the same |
+| `Acme` | `Acme Inc` | **Skipped** — the suffix is part of the name |
+| `Kestrel Data` | *two companies both called* `Kestrel Data` | **Skipped** — your file did not say which |
+
+That last row is the one worth knowing about: **two companies may legitimately
+share a name**, the CRM does not stop it, and no amount of matching can tell which
+one a row means. The run refuses rather than picking.
+
+Near misses are reported as skips naming what to do about them, so nothing goes
+by unseen — the decision simply stays yours rather than being made by an importer
+that could not tell two companies apart.
+
+It also writes only where you could write anyway. A company you are not
+permitted to see is neither mentioned in the report nor edited — an import
+cannot become a blind edit of a colleague's private record.
+
+## Step 3 — Read the report before you commit
+
+```json
+{
+  "rows_read": 100,
+  "disposition": {
+    "created": 6,
+    "updated": 88,
+    "unchanged": 6,
+    "skipped": 0,
+    "duplicates": 94
+  },
+  "issues": []
+}
+```
+
+Two things to know about those numbers:
+
+- **`created`, `updated`, `unchanged` and `skipped` sum to `rows_read`.** Every
+  row has exactly one outcome. If they do not add up, the report is hiding
+  something.
+- **`duplicates` sits outside that sum.** It is not a fifth outcome — it counts
+  rows already counted elsewhere. It is the number you actually weigh: *"100
+  companies, 94 of them already here"* is a different decision from *"100 new
+  companies"*, and the two are indistinguishable from `created` alone.
+- **A company you are not permitted to see is not counted or named.** Row scope
+  applies to the report as much as to the record, so a preview never confirms the
+  existence of a colleague's private capture. Such a row previews as a create and
+  is left alone on commit, which is the only safe direction for the two to
+  differ.
+
+`unchanged` means matched and nothing differs. It is separate from `updated` so
+that re-running a file you already applied reports no work rather than a hundred
+writes and an audit trail to match.
+
+**`issues` names any row that will not land**, in terms of the file rather than
+the database — an unusable `size_band`, a name the importer will not overwrite on
+a guess. Fix those in the source and preview again. (Rows carry a `line` where the
+importer could derive one; a file identified by its own key column reports `0`.)
+
+## Step 4 — Commit
+
+Approve the run by its id. The commit is checkpointed and idempotent on the
+source key, so a re-run of the same file converges rather than duplicating, and
+a run interrupted midway resumes from where it stopped rather than starting
+over.
+
+Ask afterwards, or read the report again: the same shape reports what the run
+*did* once it has finished.
+
+## Asking an assistant to do it
+
+Over MCP this is one instruction:
+
+> Import this CSV as organizations. Tell me how many are new and how many are
+> already here before you commit anything, and update the existing ones rather
+> than creating duplicates.
+
+The assistant runs on your passport, so it can do what you could do unaided in
+the app, and the import commits without a separate approval step. What still
+binds it is what binds you: your seat, your grants, your row scope, and the
+scopes you lent when you minted the passport. See
+[connect-an-mcp-client.md](connect-an-mcp-client.md).
+
+Two caveats. An installation can require confirmation for `commit_import`, in
+which case the commit stages for a human like any confirm-first call. And the
+assistant cannot upload a file for you or undo a run — both need your own
+signed-in session — so over MCP the CSV goes across as text in the request.
+
+**Ask for the counts before the commit.** An assistant that previews, reports and
+waits is using the feature as designed; one that previews and commits in the same
+breath has skipped the step the preview exists for.
+
+## Related
+
+- [import-your-linkedin-network.md](import-your-linkedin-network.md) — a
+  different importer for a different file, landing relationship edges rather
+  than companies.
+- [connect-an-mcp-client.md](connect-an-mcp-client.md) — connecting an assistant.
+- [mint-a-passport.md](mint-a-passport.md) — issuing the credential it uses.

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 56,
-    "tokens": 17004,
+    "tokens": 17033,
     "median_tool_tokens": 281,
     "mean_tool_tokens": 303
   },
@@ -133,6 +133,10 @@
       "tokens": 323
     },
     {
+      "name": "preview_import",
+      "tokens": 323
+    },
+    {
       "name": "draft_email",
       "tokens": 317
     },
@@ -163,10 +167,6 @@
     {
       "name": "promote_lead",
       "tokens": 301
-    },
-    {
-      "name": "preview_import",
-      "tokens": 294
     },
     {
       "name": "archive_record",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2190 | 9% | 14810 | 14 | 8 |
-| _whole served catalog, for scale_ | 56 | 17004 | 70% | — | — | — |
+| _whole served catalog, for scale_ | 56 | 17033 | 70% | — | — | — |
 
 ### `morning_brief`
 
@@ -144,6 +144,7 @@ a term in an addition.
 | `search_context` | 352 | — |
 | `prep_for_meeting` | 333 | — |
 | `merge_records` | 323 | — |
+| `preview_import` | 323 | — |
 | `draft_email` | 317 | — |
 | `review_commitments` | 316 | — |
 | `send_message` | 314 | — |
@@ -152,7 +153,6 @@ a term in an addition.
 | `draft_follow_ups_for` | 304 | — |
 | `decide_approval` | 303 | — |
 | `promote_lead` | 301 | — |
-| `preview_import` | 294 | — |
 | `archive_record` | 292 | — |
 | `catch_me_up_on` | 287 | 3 scenarios |
 | `prepare_handoff` | 275 | 1 scenario |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 155677,
+    "tool_catalog_bytes": 155796,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39696,
+    "approx_wire_tokens_total": 39726,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 35520,
-      "input_schema_bytes": 34366,
+      "description_bytes": 35572,
+      "input_schema_bytes": 34433,
       "output_schema_bytes": 73753,
-      "description_plus_input_schema_bytes": 69886
+      "description_plus_input_schema_bytes": 70005
     }
   },
   "tools": {
@@ -5108,7 +5108,7 @@
           "readOnlyHint": false,
           "title": "Preview an import"
         },
-        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`; on_duplicate says whether it lands a second (default), is skipped, or updates the incumbent. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5136,10 +5136,11 @@
               "type": "string"
             },
             "on_duplicate": {
-              "description": "A company already here: create (default) lands a second; skip leaves the incumbent.",
+              "description": "A company already here: create (default) lands a second; skip leaves the incumbent; update writes this row onto it (exact name matches only).",
               "enum": [
                 "create",
-                "skip"
+                "skip",
+                "update"
               ],
               "type": "string"
             }

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 56 |
 | Resources | 8 |
-| Tool catalog | 152.0 KB |
+| Tool catalog | 152.1 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39696 |
+| Approx. wire tokens | 39726 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -33,7 +33,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Descriptions (incl. governance clause) | 34.7 KB | 22% | Yes, every step |
 | Input schemas | 33.6 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
-| **Description + input schema** | **68.2 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **68.4 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -89,7 +89,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
-| [`preview_import`](#preview_import) | Preview an import |  |  | 2.5 KB |
+| [`preview_import`](#preview_import) | Preview an import |  |  | 2.7 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
@@ -5636,7 +5636,7 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
 
 **Preview an import**
 
-Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
+Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`; on_duplicate says whether it lands a second (default), is skipped, or updates the incumbent. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -5668,10 +5668,11 @@ Bring a spreadsheet in: send the CSV as text and this checks every row against t
       "type": "string"
     },
     "on_duplicate": {
-      "description": "A company already here: create (default) lands a second; skip leaves the incumbent.",
+      "description": "A company already here: create (default) lands a second; skip leaves the incumbent; update writes this row onto it (exact name matches only).",
       "enum": [
         "create",
-        "skip"
+        "skip",
+        "update"
       ],
       "type": "string"
     }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11268,21 +11268,73 @@ export interface components {
          *
          *     `skip` leaves the incumbent alone and reports the row as skipped.
          *
-         *     The DRY RUN counts duplicates either way, so a person is told "100
-         *     companies, 94 duplicates" before deciding — which is the whole reason
-         *     the count is separate from `created`.
+         *     `update` writes the row's mapped values ONTO the incumbent, reported as
+         *     `updated` like any other matched row. This is the correction case: a
+         *     spreadsheet of companies the CRM already holds — captured from mail,
+         *     typed in by hand, or landed by a different import — where the file is
+         *     the better copy. Without it the only ways to apply such a file were to
+         *     mint twins or to leave the estate stale.
+         *
+         *     It overwrites only where the row names EXACTLY ONE company and matches
+         *     its name outright — legal form included, and on the same axis, so a
+         *     trading name is compared with a trading name and a registered name with a
+         *     registered one.
+         *
+         *     Three refusals make that bar, and each closes a way to overwrite the
+         *     wrong record:
+         *
+         *     * The ladder strips the trailing legal suffix before scoring, so
+         *       `Acme Inc` and `Acme GmbH` reach it as one string and score a perfect
+         *       match. It routes them to a human precisely because different legal
+         *       entities are a person's call; writing on that score performs the merge
+         *       it refused.
+         *     * The name axis has no unique index — two organizations may legitimately
+         *       share a name (see DedupeOrganizationForCreate) — and the ladder breaks
+         *       the tie on the lowest uuid. That is fine for proposing a review pair
+         *       and no basis for choosing which of two records to overwrite.
+         *     * bestOrgNamePairing scores all four combinations of the two names on
+         *       each side, so a trading name can match somebody's REGISTERED name. A
+         *       reason to show a human two records, not a statement that the two names
+         *       are the same name.
+         *
+         *     The asymmetry that sets the bar: `undo` reverses the rows a run CREATED,
+         *     so a bad `create` is repairable by merging. An `update` writes over a
+         *     company the run did not create, its previous values are gone, and nothing
+         *     restores them.
+         *
+         *     Everything short of that is reported as a skipped row naming why, so the
+         *     near misses are surfaced rather than lost — the decision just stays with
+         *     the person holding the file.
+         *
+         *     It also writes only where the caller could write ANYWAY: a match the
+         *     caller cannot see is not disclosed and not written, so an import cannot
+         *     become a blind edit of a colleague's owner-private capture.
+         *
+         *     The DRY RUN counts duplicates whichever mode is chosen, so a person is
+         *     told "100 companies, 94 duplicates" before deciding — which is the whole
+         *     reason the count is separate from `created`.
+         *
+         *     A collision with a record the CALLER MAY NOT SEE is neither counted nor
+         *     named, in the dry run or in the finished report: row scope governs what a
+         *     report may say as much as what a record may show, and an importer that
+         *     answered would be an existence oracle for a colleague's owner-private
+         *     capture, one row at a time. Such a row previews as a create and is left
+         *     alone on commit — the preview understating what a run leaves alone is the
+         *     only safe direction for the two passes to differ.
          * @default create
          * @enum {string}
          */
-        ImportOnDuplicate: "create" | "skip";
+        ImportOnDuplicate: "create" | "skip" | "update";
         /** @description What the run will do, or did, counted per outcome. The four sum to the rows read — a disposition that does not add up is hiding something. */
         ImportRunDisposition: {
             created: number;
             /**
              * @description Rows naming a record the estate already holds. NOT a fifth outcome
              *     and never added to the other four — each duplicate is already
-             *     counted in `created` (it lands and files a review pair) or in
-             *     `skipped` (when the run asked for `on_duplicate: skip`). It is the
+             *     counted in `created` (it lands and files a review pair), in
+             *     `skipped` (when the run asked for `on_duplicate: skip`) or in
+             *     `updated`/`unchanged` (when it asked for `on_duplicate: update`,
+             *     which writes the file's values onto the incumbent). It is the
              *     number a human needs before approving: "100 companies, 94 of them
              *     already here" is a different decision from "100 new companies".
              */


### PR DESCRIPTION
`on_duplicate` took `create` or `skip`. Neither applies a corrected export —
`create` mints a twin of every company already held, `skip` leaves the estate
stale — so the honest answer to *"I have a cleaned-up file of our accounts"* was
to retype it in the app, or to have an assistant loop row by row with no
preview, no transaction and no resume.

`update` writes the row's mapped values onto the incumbent, reported as an
update. It reuses `reconcile`, the same path a row this importer wrote before
takes: the incumbent arriving some other way changes *who* to write onto, not
*how*.

## What it will overwrite

Only a record whose name the row matches **outright — legal form included** — or
one matched by domain. That bar is deliberately higher than the dedupe ladder's.

The ladder strips the trailing legal suffix before scoring, so `Acme Inc` and
`Acme GmbH` reach it as one string and score a perfect match. It routes them to
a human anyway, and `fuzzyOrganization` says why in as many words: *different
legal entities are a human's call, not a merge.* A rule keyed on that score
performs the merge the ladder refused, silently, over the wrong company's data.

The asymmetry that sets the bar: `undo` reverses the rows a run **created**, so a
bad `create` is repairable. An `update` writes over a company the run did not
create, and nothing restores its previous values.

Two earlier drafts were wrong in opposite directions, both now pinned by tests:
requiring `exact_collision` alone was safe and useless (that tier needs a domain,
which a spreadsheet of names has none of); accepting confidence 1.0 was useful
and unsafe.

## Two defects found on the way, neither introduced by the mode

**The preview disclosed matches the caller cannot see.** Every mode's report
counts the row in `duplicates` and names it "already in the CRM", so a preview
answering on an invisible match made the importer an existence oracle for a
colleague's owner-private capture, one CSV row at a time. The preview now always
filters; the commit still decides without the filter, which is correct.

**The report dropped skipped rows.** It deduplicated by the *line* derived from
the external id, and `lineOf` answers `0` for every id not shaped `line N` — every
id in a file with its own `source_key`. Two refused rows were reported as one
skip and one unchanged, so the four counts summed to less than `rows_read`.
Pre-existing; `update` makes it reachable in bulk, since refusing a near miss is
its ordinary behaviour.

## Documentation

Two pages still said consequential verbs stage for approval, which stopped being
true at ADR-0055. Corrected, with the two exceptions that survive named.

New: [`how-to/import-a-company-spreadsheet.md`](docs/how-to/import-a-company-spreadsheet.md)
— the guide this session kept needing. The three-step shape, the fields a company
can receive, a table of what `update` will and will not overwrite, and how to read
a disposition.

## Verification

Full `make check-backend`, `make check-fe` and `make craft-static` green.
Integration lanes green: `compose`, `compose/integration`, `modules/people`.
Each new safety test was verified by breaking the thing it checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `on_duplicate: "update"` to CSV organization imports so a row can overwrite the matching incumbent instead of minting a twin or being skipped. This enables correcting existing companies from a cleaned spreadsheet while fixing preview privacy leaks and inaccurate skipped-row counts.

- Review notes
  - API: `ImportOnDuplicate` now includes `update`; regenerated contracts and `frontend/src/api/schema.d.ts`; MCP `preview_import` input schema accepts `update`.
  - Duplicate policy: new `csvduplicatepolicy.go` writes only on domain match or `SameOrganizationName` (exact name, legal suffix preserved, same name axis). Fuzzy or ambiguous matches are skipped. Previews filter by visibility; commits decide unfiltered; skip reasons no longer disclose owner-private records.
  - Update path: reuse `reconcile`; previews label updated vs unchanged. A non-locking pre-read can race, so a previewed create may commit as an update; the overwrite rule still guards correctness.
  - Reporting: created+updated+unchanged+skipped now equals rows_read; `duplicates` reported separately. Skipped-row dedupe keys by external id, fixing undercounts when `source_key` is present.
  - Tests: certainty gate (legal-form differences refused; cross-axis name matches refused), unchanged accounting, privacy-safe reasons, external-id dedupe, and end-to-end update integration. The invalid `on_duplicate` error lists accepted values from the contract with a guard test.
  - Docs: new “Import a company spreadsheet” how-to; agent surface and MCP reference updated; tool budget snapshots refreshed.

- Rollout
  - No migration. Regenerate SDKs/clients to accept `on_duplicate: "update"`. Installations may floor `commit_import` to confirm-first. Undo cannot restore fields overwritten by `update`.

<sup>Written for commit aaa81bf38855904399243f6375fd0460942f22e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `update` as a duplicate-handling option for company CSV imports.
  - Exact-name matches can update existing records without creating duplicates.
  - Similar names, legal-form variants, ambiguous matches, and inaccessible records are skipped safely.
  - Import previews and reports distinguish created, updated, unchanged, skipped, and unresolved rows.
  - Duplicate counts and skipped-row reporting are more accurate and preserve individual rows.
- **Documentation**
  - Added a company spreadsheet import guide covering mapping, previews, duplicates, permissions, and reporting.
  - Updated import and assistant documentation to describe the new duplicate-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->