### PR TITLE
fix(frontend): an unshipped locale costs the reader their language, not the app

### DIFF
--- a/frontend/e2e/projects.spec.ts
+++ b/frontend/e2e/projects.spec.ts
@@ -144,7 +144,7 @@ test("a project is created, a deal is attached, the win starts delivery, the tim
   await timeline.getByRole("button", { name: "Neu verknüpfen" }).click();
   await dialog
     .getByRole("searchbox", {
-      name: "Person, Organisation, Deal oder Lead suchen",
+      name: "Person, Organisation, Deal, Lead oder Projekt suchen",
     })
     .fill("Brandt ERP");
   await dialog.getByRole("button", { name: "Brandt ERP" }).click();

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -832,7 +832,10 @@ export async function mockApi(
           ...me.user,
           id: "u1",
           email: "lars@brandt.example",
-          locale: "de-DE",
+          // "de", not "de-DE": the contract declares this field as en | de | vi,
+          // and the catalogs are keyed by exactly those. A regional tag here is
+          // a key the catalogs have no entry for.
+          locale: "de",
         },
         system_of_record: { mode: sorMode },
       });

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -222,14 +222,17 @@ export function LocaleProvider({
       // as a key it has no entry for. Every lookup then throws, including the
       // error boundary's own, so a single unknown string costs the reader the
       // whole application rather than just their language.
-      if (!isLocale(next)) {
+      // An unshipped value FALLS BACK rather than being ignored. Ignoring it
+      // would keep whatever is on screen, and after a sign-out the provider
+      // outlives the account — so the previous person's server-chosen language
+      // would stay up for the next one. Detection is what "no usable answer
+      // from the server" already means everywhere else in this file.
+      const usable = isLocale(next) ? next : (storedLocale() ?? detectLocale());
+      if (usable === adopted) {
         return;
       }
-      if (next === adopted) {
-        return;
-      }
-      setAdopted(next);
-      setLocaleState(next);
+      setAdopted(usable);
+      setLocaleState(usable);
     },
     [adopted],
   );

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -216,6 +216,15 @@ export function LocaleProvider({
   const [adopted, setAdopted] = useState<Locale | undefined>(initial);
   const adoptLocale = useCallback(
     (next: Locale) => {
+      // Validated for the same reason the stored pick is: this value comes off
+      // the wire, and a locale we do not ship — an older release's, a regional
+      // tag, a server that widened the field — would otherwise reach `catalogs`
+      // as a key it has no entry for. Every lookup then throws, including the
+      // error boundary's own, so a single unknown string costs the reader the
+      // whole application rather than just their language.
+      if (!isLocale(next)) {
+        return;
+      }
       if (next === adopted) {
         return;
       }

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -225,8 +225,14 @@ export function LocaleProvider({
       // An unshipped value FALLS BACK rather than being ignored. Ignoring it
       // would keep whatever is on screen, and after a sign-out the provider
       // outlives the account — so the previous person's server-chosen language
-      // would stay up for the next one. Detection is what "no usable answer
-      // from the server" already means everywhere else in this file.
+      // would stay up for the next one.
+      //
+      // It falls back to the SAME resolution the mount path uses: this
+      // machine's stored pick first, then detection. Detection alone would
+      // discard a choice the reader made here and is still entitled to; the
+      // stored value is only ever written by an explicit pick, never by a
+      // detected default, so preferring it cannot resurrect something nobody
+      // chose.
       const usable = isLocale(next) ? next : (storedLocale() ?? detectLocale());
       if (usable === adopted) {
         return;

--- a/frontend/src/i18n/locale-persistence.test.tsx
+++ b/frontend/src/i18n/locale-persistence.test.tsx
@@ -12,22 +12,33 @@ import { LocaleProvider, storedLocale, useLocale } from "./index";
 
 const STORAGE_KEY = "margince.locale";
 
-function Probe() {
-  const { locale, setLocale } = useLocale();
+function Probe({ adopt }: Readonly<{ adopt?: string }>) {
+  const { locale, setLocale, adoptLocale } = useLocale();
   return (
     <>
       <span data-testid="locale">{locale}</span>
       <button type="button" onClick={() => setLocale("de")}>
         pick de
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          // The cast is the POINT: this value comes off the wire, where the
+          // compiler's guarantee ends. A server that widens the field, an older
+          // release's value or a regional tag arrives here as a plain string.
+          adoptLocale(adopt as Parameters<typeof adoptLocale>[0])
+        }
+      >
+        adopt
+      </button>
     </>
   );
 }
 
-const mount = (initial?: "en" | "de" | "vi") =>
+const mount = (initial?: "en" | "de" | "vi", adopt?: string) =>
   render(
     <LocaleProvider initial={initial}>
-      <Probe />
+      <Probe adopt={adopt} />
     </LocaleProvider>,
   );
 
@@ -92,5 +103,34 @@ describe("a locale nobody picked", () => {
 
   it("reads as absent when nothing is stored", () => {
     expect(storedLocale()).toBeNull();
+  });
+});
+
+// A locale the server reports that this release does not ship must cost the
+// reader their language and nothing else. It reached `catalogs` as a key they
+// had no entry for once (#2469): every lookup threw, including the error
+// boundary's own, so the whole application went blank rather than one section.
+describe("a locale the server reports but this release does not ship", () => {
+  it("falls back instead of reaching the catalogs, and never blanks the app", async () => {
+    localStorage.setItem(STORAGE_KEY, "de");
+    mount(undefined, "de-DE");
+
+    await userEvent.click(screen.getByRole("button", { name: "adopt" }));
+
+    // "de", the reader's own pick on this machine — never "de-DE", which is
+    // not a key the catalogs have.
+    expect(shown()).toBe("de");
+  });
+
+  it("does not leave the previous account's language up after a sign-out", async () => {
+    // Nobody has picked on this machine, so detection decides — and the point
+    // is that an unusable answer resolves rather than being ignored, which
+    // would have kept whatever the last account was reading.
+    mount("de", "de-DE");
+
+    await userEvent.click(screen.getByRole("button", { name: "adopt" }));
+
+    expect(shown()).not.toBe("de-DE");
+    expect(shown()).toBe("en");
   });
 });

--- a/frontend/src/i18n/locale-persistence.test.tsx
+++ b/frontend/src/i18n/locale-persistence.test.tsx
@@ -52,10 +52,9 @@ afterEach(() => {
 
 describe("a locale a reader picked", () => {
   it("is read back by the next mount, which is what a reload is", async () => {
+    const user = userEvent.setup();
     mount();
-    await userEvent
-      .setup()
-      .click(screen.getByRole("button", { name: "pick de" }));
+    await user.click(screen.getByRole("button", { name: "pick de" }));
     expect(shown()).toBe("de");
     cleanup();
 
@@ -64,10 +63,9 @@ describe("a locale a reader picked", () => {
   });
 
   it("is the value that reaches storage, under a namespaced key", async () => {
+    const user = userEvent.setup();
     mount();
-    await userEvent
-      .setup()
-      .click(screen.getByRole("button", { name: "pick de" }));
+    await user.click(screen.getByRole("button", { name: "pick de" }));
     expect(localStorage.getItem(STORAGE_KEY)).toBe("de");
   });
 
@@ -112,10 +110,11 @@ describe("a locale nobody picked", () => {
 // boundary's own, so the whole application went blank rather than one section.
 describe("a locale the server reports but this release does not ship", () => {
   it("falls back instead of reaching the catalogs, and never blanks the app", async () => {
+    const user = userEvent.setup();
     localStorage.setItem(STORAGE_KEY, "de");
     mount(undefined, "de-DE");
 
-    await userEvent.click(screen.getByRole("button", { name: "adopt" }));
+    await user.click(screen.getByRole("button", { name: "adopt" }));
 
     // "de", the reader's own pick on this machine — never "de-DE", which is
     // not a key the catalogs have.
@@ -126,9 +125,10 @@ describe("a locale the server reports but this release does not ship", () => {
     // Nobody has picked on this machine, so detection decides — and the point
     // is that an unusable answer resolves rather than being ignored, which
     // would have kept whatever the last account was reading.
+    const user = userEvent.setup();
     mount("de", "de-DE");
 
-    await userEvent.click(screen.getByRole("button", { name: "adopt" }));
+    await user.click(screen.getByRole("button", { name: "adopt" }));
 
     expect(shown()).not.toBe("de-DE");
     expect(shown()).toBe("en");


### PR DESCRIPTION
Fixes the **uat** lane, red on every pull request since #2429 — including docs-only ones (#2445), which is what proves it is `main`'s and nobody's diff. Closes #2469.

## What was happening

Roughly 60 of 80 specs failed with:

```
locator('nav.rail .navlevel a.navitem')  →  resolved to 0 elements
getByRole('heading')                     →  element(s) not found
```

**Zero**, not a wrong count. The application renders nothing. Probing the page:

```
PAGEERROR Cannot read properties of undefined (reading 'app.errorTitle')
```

## Cause

The catalogs are keyed `en`, `de`, `vi`. The e2e mock answers `/v1/me` with `locale: "de-DE"` — a value **the contract does not allow**, which declares the field as `en | de | vi`.

#2429 added `adoptLocale` so a person's stored language follows them between browsers, and it takes the server's word. `catalogs["de-DE"]` is `undefined`, so **every** lookup throws — including the error boundary's own `t("app.errorTitle")`. The boundary sits inside the locale provider, so it crashes rendering its own message, and the reader gets a white page instead of a caught error.

## Both halves are fixed, because either alone leaves a hole

**The fixture** now says `"de"`. It was asserting a value the contract forbids, which is how a mock quietly stops modelling the product.

**`adoptLocale` now validates**, exactly as `storedLocale` already does — and that function's own comment states the rule the new path skipped:

> The stored string is validated rather than trusted. […] a locale we have since stopped shipping — or a hand-edited value — must fall back to detection instead of reaching the catalogs as a key they have no entry for.

The stored path was guarded; the new wire path was not. Fixing only the mock would leave the app one unexpected server value away from a blank page — a widened field, an older release's value, a regional tag. The point of the guard is that an unknown locale costs the reader **their language**, not the whole application.

## One stale expectation the blank page was hiding

With the shell rendering again, `projects.spec.ts` failed further along: the relink search box is `"Person, Organisation, Deal, Lead oder Projekt suchen"` now — projects joined the searchable kinds and the spec still named the old four. Same class as #2412 and #2460: a user-visible string moved and nothing derived the copy the spec asserts.

## Verification

| | Result |
|---|---|
| `origin/main`, `ac.spec.ts` `-g AC-shell-1` | shell renders **0** rail items |
| with this change, `ac.spec.ts` + `projects.spec.ts` | **87 passed** |

`biome check` clean, `tsc -b` exit 0.

## Note on how long this took to surface

`uat` blocks no merge — `ci` does not aggregate it — and `main-health` cannot see it (#2325). So it stayed red across five merges with nothing reporting it, and was found by a third session asking whether `main` was safe to branch from. That is #2325's predicted consequence arriving, and its fourth instance.

Reported by a parallel session; diagnosed and fixed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a server-sent unsupported locale from blanking the app by falling back to a usable language. Old behavior: `adoptLocale("de-DE")` was accepted, lookups threw, and the error boundary crashed. New behavior: `adoptLocale` validates input; unsupported values resolve to `storedLocale() ?? detectLocale()`, so the UI renders in a fallback language and does not keep a previous user’s language after sign-out.

- i18n: `adoptLocale` now computes a usable locale and updates state with it.
- e2e: `/v1/me` mock returns `locale: "de"` (not `"de-DE"`), matching the contract and catalog keys.
- Tests: add coverage for the unshipped-locale guard; fix German relink search placeholder to include “Projekt”; use one `userEvent` instance per test to avoid shared state leaks.

<sup>Written for commit 17d29673a23fccf94e8e081b0acbbd012d65927f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale handling by falling back to a supported stored or browser-detected language when an unsupported regional setting is provided.
  * Updated relinking search behavior so projects are included among searchable items.
  * Corrected German language detection and default handling to use a supported locale code, providing more consistent language selection across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->