### PR TITLE
fix(records): one writer moves a visit baseline, and person360 stops copying it

### DIFF
--- a/backend/internal/compose/org360/viewbaseline.go
+++ b/backend/internal/compose/org360/viewbaseline.go
@@ -86,11 +86,11 @@ func (s *Service) Acknowledge(ctx context.Context, orgID ids.OrganizationID) (cr
 // statement in this product that writes user_record_view.
 //
 // Exported because a SECOND record type acknowledges visits — person360 — and
-// it held a byte-identical copy of this upsert. Two writers of one table's
-// write shape drift silently: `GREATEST` is the whole correctness argument, and
-// a copy that lost it would rewind a baseline on a late-arriving ack from a
-// slow tab, consuming an unread marker nobody consumed. Nothing in the two
-// statements differed, so nothing signalled that they had to stay the same.
+// a caller reaching for its own upsert instead is what this export exists to
+// prevent. `GREATEST` is the whole correctness argument: a copy that lost it
+// would rewind a baseline on a late-arriving ack from a slow tab, consuming an
+// unread marker nobody consumed. Two writers of one write shape signal nothing
+// while they agree, and they agree right up until one of them is edited.
 //
 // What the callers keep is the part that legitimately differs: their own
 // visibility gate. org360 asks `EnsureVisible`, person360 asks

--- a/backend/internal/compose/org360/viewbaseline.go
+++ b/backend/internal/compose/org360/viewbaseline.go
@@ -69,13 +69,8 @@ func (s *Service) Acknowledge(ctx context.Context, orgID ids.OrganizationID) (cr
 		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
 			return err
 		}
-		return tx.QueryRow(ctx, `
-			INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)
-			VALUES ($1, $2, $3, $4)
-			ON CONFLICT (user_id, entity_type, entity_id)
-			DO UPDATE SET last_viewed_at = GREATEST(user_record_view.last_viewed_at, EXCLUDED.last_viewed_at)
-			RETURNING last_viewed_at`,
-			userID, entityTypeOrganization, orgID, now).Scan(&stored)
+		stored, err = RecordVisit(ctx, tx, userID, entityTypeOrganization, orgID.UUID, now)
+		return err
 	})
 	if err != nil {
 		return crmcontracts.RecordViewAck{}, err
@@ -85,6 +80,48 @@ func (s *Service) Acknowledge(ctx context.Context, orgID ids.OrganizationID) (cr
 		EntityId:     openapi_types.UUID(orgID.UUID),
 		LastViewedAt: stored,
 	}, nil
+}
+
+// RecordVisit moves one (user, record) baseline forward, and is the only
+// statement in this product that writes user_record_view.
+//
+// Exported because a SECOND record type acknowledges visits — person360 — and
+// it held a byte-identical copy of this upsert. Two writers of one table's
+// write shape drift silently: `GREATEST` is the whole correctness argument, and
+// a copy that lost it would rewind a baseline on a late-arriving ack from a
+// slow tab, consuming an unread marker nobody consumed. Nothing in the two
+// statements differed, so nothing signalled that they had to stay the same.
+//
+// What the callers keep is the part that legitimately differs: their own
+// visibility gate. org360 asks `EnsureVisible`, person360 asks
+// `EnsureVisibleLive`, because an anonymized person keeps their owner_id and
+// the plain probe would still admit them. That difference is a ruling per
+// record type; the upsert is not.
+//
+// Held by: TestUserRecordViewHasOneWriter (backend/userrecordviewwriter_test.go)
+// — it censuses every statement in the tree that writes this table and fails on
+// a second one.
+//
+// It takes the transaction rather than opening one: the caller's gate and this
+// write have to be the same transaction, or a record that stopped being visible
+// between them would still get a baseline.
+func RecordVisit(
+	ctx context.Context,
+	tx pgx.Tx,
+	userID ids.UserID,
+	entityType string,
+	entityID ids.UUID,
+	at time.Time,
+) (time.Time, error) {
+	var stored time.Time
+	err := tx.QueryRow(ctx, `
+		INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (user_id, entity_type, entity_id)
+		DO UPDATE SET last_viewed_at = GREATEST(user_record_view.last_viewed_at, EXCLUDED.last_viewed_at)
+		RETURNING last_viewed_at`,
+		userID, entityType, entityID, at).Scan(&stored)
+	return stored, err
 }
 
 // sinceLastVisit counts what changed on the account since the caller's own

--- a/backend/internal/compose/person360/handlers.go
+++ b/backend/internal/compose/person360/handlers.go
@@ -139,12 +139,10 @@ func (s *Service) Acknowledge(ctx context.Context, personID ids.PersonID) (crmco
 		if err := auth.EnsureVisibleLive(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
-		// org360's writer, not a copy of its statement. It owns
+		// org360's writer, not a copy of its statement: it owns
 		// user_record_view (tableownership_test.go names it), and the upsert's
-		// GREATEST is the whole correctness argument — a second copy that lost
-		// it would rewind a baseline on a slow tab's late ack and consume an
-		// unread marker nobody consumed. The gate ABOVE is this package's own,
-		// because that is the part that legitimately differs.
+		// GREATEST is the whole correctness argument. The gate ABOVE is this
+		// package's own, because that is the part that legitimately differs.
 		stored, err = org360.RecordVisit(ctx, tx, userID, entityTypePerson, personID.UUID, now)
 		return err
 	})

--- a/backend/internal/compose/person360/handlers.go
+++ b/backend/internal/compose/person360/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -138,13 +139,14 @@ func (s *Service) Acknowledge(ctx context.Context, personID ids.PersonID) (crmco
 		if err := auth.EnsureVisibleLive(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
-		return tx.QueryRow(ctx, `
-			INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)
-			VALUES ($1, $2, $3, $4)
-			ON CONFLICT (user_id, entity_type, entity_id)
-			DO UPDATE SET last_viewed_at = GREATEST(user_record_view.last_viewed_at, EXCLUDED.last_viewed_at)
-			RETURNING last_viewed_at`,
-			userID, entityTypePerson, personID, now).Scan(&stored)
+		// org360's writer, not a copy of its statement. It owns
+		// user_record_view (tableownership_test.go names it), and the upsert's
+		// GREATEST is the whole correctness argument — a second copy that lost
+		// it would rewind a baseline on a slow tab's late ack and consume an
+		// unread marker nobody consumed. The gate ABOVE is this package's own,
+		// because that is the part that legitimately differs.
+		stored, err = org360.RecordVisit(ctx, tx, userID, entityTypePerson, personID.UUID, now)
+		return err
 	})
 	if err != nil {
 		return crmcontracts.RecordViewAck{}, err

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -393,12 +393,6 @@ var tableOwners = map[string]string{
 // keyed "module-dir:table". Every entry carries its rationale inline so the
 // gate is self-contained on a clean checkout.
 var crossStoreWrites = gatekit.Waive(map[string]string{
-	// One visit baseline per user per record, and a person is a record. A
-	// second table keyed the same way would be the same fact under a second
-	// name, and the two would answer "when did you last look at this?"
-	// differently the first time one write path changed.
-	"internal/compose/person360:user_record_view": "the person view's visit acknowledgement rides org360's table because since-last-visit is one fact per (user, record) — migration 0184 widened its entity_type CHECK to admit a person rather than adding a parallel table that would drift",
-
 	// people's merge/promotion relink rows across aggregates inside their
 	// single transaction — the primary aggregate owns the single-tx
 	// cross-aggregate write, because a merge that could half-commit its

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -8,11 +8,6 @@ package backendarch
 // counts against it, so the mark is the baseline every "new since you were
 // here" answer is measured from.
 //
-// It was written by TWO byte-identical statements — org360's, which owns the
-// table, and person360's, which acknowledges the person view. Nothing differed
-// between them, which is exactly why nothing signalled that they had to stay
-// the same.
-//
 // THE CORRECTNESS IS IN ONE WORD. `GREATEST(stored, EXCLUDED)` is what stops a
 // slow tab's late-arriving acknowledgement rewinding a newer one: two tabs open
 // on the same record converge on the later visit instead of racing the baseline
@@ -21,8 +16,11 @@ package backendarch
 // back an unread marker they had already consumed, on a surface where "3 new"
 // and "0 new" are both plausible and neither looks like a bug.
 //
-// So the rule is that the statement lives once, and this is the test that holds
-// it. What the callers keep is the part that legitimately differs: their own
+// So the statement lives once, and this is the test that holds it. Two writers
+// of one write shape signal nothing while they agree, which is the whole
+// window: they agree right up until the moment one of them is edited.
+//
+// What the callers keep is the part that legitimately differs: their own
 // visibility gate. org360 asks `EnsureVisible`; person360 asks
 // `EnsureVisibleLive`, because Art. 17 anonymizes a person in place while
 // leaving owner_id alone and the plain probe would still admit them. That is a
@@ -51,8 +49,14 @@ const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
 // answer to "how does this mark move". A bare `UPDATE user_record_view SET
 // last_viewed_at = $1` carries no GREATEST at all and is the worst possible
 // second writer: it rewinds unconditionally.
+//
+// The name may be SCHEMA-QUALIFIED or quoted — `public.user_record_view`,
+// `"user_record_view"` — and a pattern anchored on the bare word passes those
+// exactly like a clean tree. This gate's own rule is to plant the shape it
+// cannot see, so the optional qualifier is part of the pattern and both
+// spellings are planted below.
 var writesViewBaseline = regexp.MustCompile(
-	`(?is)(INSERT\s+INTO|UPDATE)\s+user_record_view\b`)
+	`(?is)(INSERT\s+INTO|UPDATE)\s+"?(?:[\w$]+"?\.\s*"?)?user_record_view\b`)
 
 // TestUserRecordViewHasOneWriter is the census `org360.RecordVisit`'s doc
 // comment names.
@@ -157,6 +161,11 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		"UPDATE user_record_view SET last_viewed_at = $1 WHERE user_id = $2",
 		// Case and whitespace are not the subject.
 		"insert   into\n\t\tuser_record_view (user_id)",
+		// Schema-qualified, and quoted. A pattern anchored on the bare word
+		// waves both through and reports the tree clean.
+		"INSERT INTO public.user_record_view (user_id) VALUES ($1)",
+		`UPDATE "user_record_view" SET last_viewed_at = $1`,
+		`INSERT INTO "public"."user_record_view" (user_id) VALUES ($1)`,
 	}
 	for _, statement := range caught {
 		if !writesViewBaseline.MatchString(statement) {
@@ -170,6 +179,8 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		// A different table whose name merely contains this one's would be a
 		// false positive; the word boundary is what stops it.
 		"INSERT INTO user_record_view_archive (user_id) VALUES ($1)",
+		// And the qualifier must not widen the near-neighbour either.
+		"INSERT INTO public.user_record_view_archive (user_id) VALUES ($1)",
 	}
 	for _, statement := range missed {
 		if writesViewBaseline.MatchString(statement) {

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -177,7 +177,7 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		`UPDATE "user_record_view" SET last_viewed_at = $1`,
 		`INSERT INTO "public"."user_record_view" (user_id) VALUES ($1)`,
 		// A three-part name, and whitespace around the separator. Both are
-		// valid Postgres and both were silent false negatives.
+		// valid Postgres, so both are writes the census must see.
 		"INSERT INTO tenant1.public.user_record_view (user_id) VALUES ($1)",
 		`UPDATE "tenant1"."public"."user_record_view" SET last_viewed_at = $1`,
 		"INSERT INTO public . user_record_view (user_id) VALUES ($1)",

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -50,13 +50,23 @@ const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
 // last_viewed_at = $1` carries no GREATEST at all and is the worst possible
 // second writer: it rewinds unconditionally.
 //
-// The name may be SCHEMA-QUALIFIED or quoted — `public.user_record_view`,
-// `"user_record_view"` — and a pattern anchored on the bare word passes those
-// exactly like a clean tree. This gate's own rule is to plant the shape it
-// cannot see, so the optional qualifier is part of the pattern and both
-// spellings are planted below.
+// The name may be QUALIFIED and quoted in more ways than one, and a pattern
+// anchored on the bare word passes every other spelling exactly like a clean
+// tree. Postgres accepts all of these, and each is planted below:
+//
+//	public.user_record_view          one qualifier
+//	tenant1.public.user_record_view  two — so the qualifier repeats
+//	public . user_record_view        whitespace around the separator
+//	"public"."user_record_view"      quoted, in any combination
+//	UPDATE ONLY user_record_view     the inheritance-scoped form
+//
+// The repeated qualifier does not cost the word boundary that keeps the
+// near-neighbour `user_record_view_archive` out: `_` is a word character, so
+// `user_record_view\b` cannot match the longer name. Both qualified and bare
+// spellings of that table are planted as must-MISS for the same reason.
 var writesViewBaseline = regexp.MustCompile(
-	`(?is)(INSERT\s+INTO|UPDATE)\s+"?(?:[\w$]+"?\.\s*"?)?user_record_view\b`)
+	`(?is)(INSERT\s+INTO|UPDATE(?:\s+ONLY)?)\s+` +
+		`(?:"?[\w$]+"?\s*\.\s*)*"?user_record_view\b`)
 
 // TestUserRecordViewHasOneWriter is the census `org360.RecordVisit`'s doc
 // comment names.
@@ -166,6 +176,14 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		"INSERT INTO public.user_record_view (user_id) VALUES ($1)",
 		`UPDATE "user_record_view" SET last_viewed_at = $1`,
 		`INSERT INTO "public"."user_record_view" (user_id) VALUES ($1)`,
+		// A three-part name, and whitespace around the separator. Both are
+		// valid Postgres and both were silent false negatives.
+		"INSERT INTO tenant1.public.user_record_view (user_id) VALUES ($1)",
+		`UPDATE "tenant1"."public"."user_record_view" SET last_viewed_at = $1`,
+		"INSERT INTO public . user_record_view (user_id) VALUES ($1)",
+		// UPDATE ONLY: inheritance-scoped, and it rewinds just as hard.
+		"UPDATE ONLY user_record_view SET last_viewed_at = $1",
+		"UPDATE ONLY public.user_record_view SET last_viewed_at = $1",
 	}
 	for _, statement := range caught {
 		if !writesViewBaseline.MatchString(statement) {
@@ -179,8 +197,11 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		// A different table whose name merely contains this one's would be a
 		// false positive; the word boundary is what stops it.
 		"INSERT INTO user_record_view_archive (user_id) VALUES ($1)",
-		// And the qualifier must not widen the near-neighbour either.
+		// And no amount of qualifying may widen the near-neighbour: `_` is a
+		// word character, so the boundary after the name holds.
 		"INSERT INTO public.user_record_view_archive (user_id) VALUES ($1)",
+		"INSERT INTO tenant1.public.user_record_view_archive (user_id) VALUES ($1)",
+		"UPDATE ONLY user_record_view_archive SET last_viewed_at = $1",
 	}
 	for _, statement := range missed {
 		if writesViewBaseline.MatchString(statement) {

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -61,11 +61,10 @@ const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
 //	UPDATE ONLY user_record_view     the inheritance-scoped form
 //
 // The NAME's end is a delimiter, not `\b`. `$`, `.` and `"` are all legal
-// around a Postgres identifier and none is a word character, so a boundary
-// alone reported `user_record_view$archive`, `"user_record_view.extra"` and
-// `user_record_view.extra` — different relations — as this one. The delimiter
+// around a Postgres identifier and none is a word character. The delimiter
 // excludes every character that can CONTINUE or QUALIFY a name, so a trailing
-// `.` is refused whether the target was quoted or not.
+// `.` or `"` is refused whether the target was quoted or not —
+// `user_record_view$archive` and `user_record_view.extra` are other relations.
 //
 // And the quoted branch is case-SENSITIVE while the rest is not, because that
 // is Postgres: an unquoted `USER_RECORD_VIEW` folds to this table, a quoted

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -60,11 +60,12 @@ const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
 //	"public"."user_record_view"      quoted, in any combination
 //	UPDATE ONLY user_record_view     the inheritance-scoped form
 //
-// The NAME's end is a delimiter, not `\b`. `$` and `.` are legal in a Postgres
-// identifier and are not word characters, so a boundary alone matched
-// `user_record_view$archive` and `"user_record_view.extra"` — different tables,
-// reported as this one. The unquoted branch requires a character that cannot
-// continue an identifier; the quoted branch requires the closing quote.
+// The NAME's end is a delimiter, not `\b`. `$`, `.` and `"` are all legal
+// around a Postgres identifier and none is a word character, so a boundary
+// alone reported `user_record_view$archive`, `"user_record_view.extra"` and
+// `user_record_view.extra` — different relations — as this one. The delimiter
+// excludes every character that can CONTINUE or QUALIFY a name, so a trailing
+// `.` is refused whether the target was quoted or not.
 //
 // And the quoted branch is case-SENSITIVE while the rest is not, because that
 // is Postgres: an unquoted `USER_RECORD_VIEW` folds to this table, a quoted
@@ -76,7 +77,7 @@ const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
 // forms are all planted as must-MISS.
 var writesViewBaseline = regexp.MustCompile(
 	`(?is)(INSERT\s+INTO|UPDATE(?:\s+ONLY)?)\s+` +
-		`(?:"?[\w$]+"?\s*\.\s*)*(?:(?-i:"user_record_view")|user_record_view(?:[^\w$"]|$))`)
+		`(?:"?[\w$]+"?\s*\.\s*)*(?:(?-i:"user_record_view")|user_record_view)(?:[^\w$".]|$)`)
 
 // TestUserRecordViewHasOneWriter is the census `org360.RecordVisit`'s doc
 // comment names.
@@ -221,6 +222,11 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		// A QUOTED identifier is case-sensitive in Postgres, so this names a
 		// different table than the one the gate protects.
 		`INSERT INTO "USER_RECORD_VIEW" (user_id) VALUES ($1)`,
+		// A trailing qualifier names something else again: here the target is
+		// the SCHEMA, not the table.
+		"INSERT INTO user_record_view.extra (user_id) VALUES ($1)",
+		`INSERT INTO "user_record_view".extra (user_id) VALUES ($1)`,
+		`INSERT INTO "user_record_view""archive" (user_id) VALUES ($1)`,
 	}
 	for _, statement := range missed {
 		if writesViewBaseline.MatchString(statement) {

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -60,13 +60,23 @@ const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
 //	"public"."user_record_view"      quoted, in any combination
 //	UPDATE ONLY user_record_view     the inheritance-scoped form
 //
-// The repeated qualifier does not cost the word boundary that keeps the
-// near-neighbour `user_record_view_archive` out: `_` is a word character, so
-// `user_record_view\b` cannot match the longer name. Both qualified and bare
-// spellings of that table are planted as must-MISS for the same reason.
+// The NAME's end is a delimiter, not `\b`. `$` and `.` are legal in a Postgres
+// identifier and are not word characters, so a boundary alone matched
+// `user_record_view$archive` and `"user_record_view.extra"` — different tables,
+// reported as this one. The unquoted branch requires a character that cannot
+// continue an identifier; the quoted branch requires the closing quote.
+//
+// And the quoted branch is case-SENSITIVE while the rest is not, because that
+// is Postgres: an unquoted `USER_RECORD_VIEW` folds to this table, a quoted
+// `"USER_RECORD_VIEW"` is a different one. Go's regexp has no lookahead, so the
+// distinction is two branches rather than a negation.
+//
+// None of it costs the near-neighbour: `user_record_view_archive` continues
+// with `_`, which the unquoted branch refuses. Its bare, qualified and ONLY
+// forms are all planted as must-MISS.
 var writesViewBaseline = regexp.MustCompile(
 	`(?is)(INSERT\s+INTO|UPDATE(?:\s+ONLY)?)\s+` +
-		`(?:"?[\w$]+"?\s*\.\s*)*"?user_record_view\b`)
+		`(?:"?[\w$]+"?\s*\.\s*)*(?:(?-i:"user_record_view")|user_record_view(?:[^\w$"]|$))`)
 
 // TestUserRecordViewHasOneWriter is the census `org360.RecordVisit`'s doc
 // comment names.
@@ -184,6 +194,8 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		// UPDATE ONLY: inheritance-scoped, and it rewinds just as hard.
 		"UPDATE ONLY user_record_view SET last_viewed_at = $1",
 		"UPDATE ONLY public.user_record_view SET last_viewed_at = $1",
+		// The statement may simply END after the name.
+		"UPDATE user_record_view",
 	}
 	for _, statement := range caught {
 		if !writesViewBaseline.MatchString(statement) {
@@ -202,6 +214,13 @@ func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
 		"INSERT INTO public.user_record_view_archive (user_id) VALUES ($1)",
 		"INSERT INTO tenant1.public.user_record_view_archive (user_id) VALUES ($1)",
 		"UPDATE ONLY user_record_view_archive SET last_viewed_at = $1",
+		// `$` and `.` are legal in a Postgres identifier and are not word
+		// characters, so a `\b` alone reported both of these as this table.
+		"INSERT INTO user_record_view$archive (user_id) VALUES ($1)",
+		`INSERT INTO "user_record_view.extra" (user_id) VALUES ($1)`,
+		// A QUOTED identifier is case-sensitive in Postgres, so this names a
+		// different table than the one the gate protects.
+		`INSERT INTO "USER_RECORD_VIEW" (user_id) VALUES ($1)`,
 	}
 	for _, statement := range missed {
 		if writesViewBaseline.MatchString(statement) {

--- a/backend/userrecordviewwriter_test.go
+++ b/backend/userrecordviewwriter_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// user_record_view carries one fact per (user, record): the moment that human
+// last said "I have seen this". Every 360 surface reports its since-last-visit
+// counts against it, so the mark is the baseline every "new since you were
+// here" answer is measured from.
+//
+// It was written by TWO byte-identical statements — org360's, which owns the
+// table, and person360's, which acknowledges the person view. Nothing differed
+// between them, which is exactly why nothing signalled that they had to stay
+// the same.
+//
+// THE CORRECTNESS IS IN ONE WORD. `GREATEST(stored, EXCLUDED)` is what stops a
+// slow tab's late-arriving acknowledgement rewinding a newer one: two tabs open
+// on the same record converge on the later visit instead of racing the baseline
+// backwards. A copy that lost it — by being written from memory, by being
+// simplified, by a merge resolving the wrong way — would silently hand a reader
+// back an unread marker they had already consumed, on a surface where "3 new"
+// and "0 new" are both plausible and neither looks like a bug.
+//
+// So the rule is that the statement lives once, and this is the test that holds
+// it. What the callers keep is the part that legitimately differs: their own
+// visibility gate. org360 asks `EnsureVisible`; person360 asks
+// `EnsureVisibleLive`, because Art. 17 anonymizes a person in place while
+// leaving owner_id alone and the plain probe would still admit them. That is a
+// ruling per record type. The upsert is not.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// viewBaselineOwner is the file that may write the table. Keyed to the FILE and
+// not the package: a second file in org360 writing its own upsert is the same
+// defect wearing the right import path.
+const viewBaselineOwner = "internal/compose/org360/viewbaseline.go"
+
+// writesViewBaseline matches a statement that INSERTs or UPDATEs the table.
+//
+// Both verbs, because the defect is not "a second INSERT" — it is a second
+// answer to "how does this mark move". A bare `UPDATE user_record_view SET
+// last_viewed_at = $1` carries no GREATEST at all and is the worst possible
+// second writer: it rewinds unconditionally.
+var writesViewBaseline = regexp.MustCompile(
+	`(?is)(INSERT\s+INTO|UPDATE)\s+user_record_view\b`)
+
+// TestUserRecordViewHasOneWriter is the census `org360.RecordVisit`'s doc
+// comment names.
+func TestUserRecordViewHasOneWriter(t *testing.T) {
+	var findings []string
+	judged := 0
+	for _, root := range []string{".", "../extensions", "../fixtures"} {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if name := entry.Name(); name == "node_modules" || name == "testdata" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			rel := filepath.ToSlash(path)
+			if rel == viewBaselineOwner {
+				return nil
+			}
+			// This file spells the statement out in its own probes below;
+			// judging them would report the gate's own evidence as a finding.
+			if filepath.Base(path) == "userrecordviewwriter_test.go" {
+				return nil
+			}
+			source, readErr := os.ReadFile(path) // #nosec G304 -- a *.go path from walking the trusted source tree
+			if readErr != nil {
+				return readErr
+			}
+			judged++
+			for _, line := range statementsIn(t, path, string(source)) {
+				if writesViewBaseline.MatchString(line) {
+					findings = append(findings, rel+": "+firstLine(line))
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	// A walk that reads nothing passes exactly like a clean tree.
+	if judged < 500 {
+		t.Fatalf("the census read only %d Go files, so it covered almost nothing", judged)
+	}
+	if len(findings) > 0 {
+		t.Errorf("%d statement(s) write user_record_view outside %s.\n\n"+
+			"The mark's correctness is one word — GREATEST(stored, EXCLUDED) — and a second "+
+			"statement that loses it rewinds a baseline on a late-arriving ack, handing a reader "+
+			"back an unread marker they had already consumed. Call org360.RecordVisit inside your "+
+			"own transaction, after your own visibility gate:\n\n\t%s",
+			len(findings), viewBaselineOwner, strings.Join(findings, "\n\t"))
+	}
+}
+
+// statementsIn returns every string literal in the file, joined per literal so
+// a statement wrapped across source lines is still one subject.
+//
+// Per LITERAL and not per line: the upsert this gate is about spans six source
+// lines, and a line-scoped census would see `INSERT INTO user_record_view` and
+// `DO UPDATE SET …` as unrelated fragments — matching the first and never
+// asking whether the second carried GREATEST.
+func statementsIn(t *testing.T, path, source string) []string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, source, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	var out []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		if lit, ok := node.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			out = append(out, lit.Value)
+		}
+		return true
+	})
+	return out
+}
+
+func firstLine(statement string) string {
+	for _, line := range strings.Split(statement, "\n") {
+		if trimmed := strings.TrimSpace(strings.Trim(line, "`\"")); trimmed != "" {
+			return trimmed
+		}
+	}
+	return strings.TrimSpace(statement)
+}
+
+// TestTheViewBaselineCensusSeesWhatItClaimsTo plants what the census must
+// catch, and what it must not.
+//
+// A gate asserting a shape is ABSENT passes identically over a clean tree and
+// over a detector that has stopped detecting, so the detector needs its own
+// evidence.
+func TestTheViewBaselineCensusSeesWhatItClaimsTo(t *testing.T) {
+	caught := []string{
+		"INSERT INTO user_record_view (user_id, entity_type, entity_id, last_viewed_at)",
+		// The worst second writer: no GREATEST at all, so it rewinds.
+		"UPDATE user_record_view SET last_viewed_at = $1 WHERE user_id = $2",
+		// Case and whitespace are not the subject.
+		"insert   into\n\t\tuser_record_view (user_id)",
+	}
+	for _, statement := range caught {
+		if !writesViewBaseline.MatchString(statement) {
+			t.Errorf("the census does not see a write it must:\n\t%s", statement)
+		}
+	}
+	missed := []string{
+		// A READ is not a write. Every 360 reads this table to compute its
+		// since-last-visit counts, and reporting those would bury the finding.
+		"SELECT last_viewed_at FROM user_record_view WHERE user_id = $1",
+		// A different table whose name merely contains this one's would be a
+		// false positive; the word boundary is what stops it.
+		"INSERT INTO user_record_view_archive (user_id) VALUES ($1)",
+	}
+	for _, statement := range missed {
+		if writesViewBaseline.MatchString(statement) {
+			t.Errorf("the census reports something that is not a second writer:\n\t%s", statement)
+		}
+	}
+}


### PR DESCRIPTION
## What this is

`user_record_view` carries one fact per (user, record): the moment that human
last said *"I have seen this"*. Every 360 surface measures its since-last-visit
counts against it.

**Two byte-identical statements wrote it.** `org360`'s — which **owns** the
table, declared in its `doc.go` and named in `tableownership_test.go` — and
`person360`'s, which acknowledges the person view under an ownership waiver.
Nothing differed between them, which is precisely why nothing signalled that
they had to stay the same.

Duplication audit item **B6**.

## The correctness is in one word

```sql
DO UPDATE SET last_viewed_at = GREATEST(user_record_view.last_viewed_at, EXCLUDED.last_viewed_at)
```

`GREATEST` is what stops a slow tab's late-arriving acknowledgement rewinding a
newer one — two tabs open on the same record converge on the later visit instead
of racing the baseline backwards.

A copy that lost it (written from memory, simplified, a merge resolving the
wrong way) would hand a reader back an unread marker **they had already
consumed**, on a surface where "3 new" and "0 new" are both plausible and
neither looks like a bug. No error, no log line, and no way for the reader to
know.

## What moved, and what deliberately did not

`org360.RecordVisit` is the statement now, exported by the package that owns the
table. It takes the caller's **transaction** rather than opening one, so the
visibility gate and the write cannot land in different transactions — a record
that stopped being visible between them would otherwise still get a baseline.

What each caller **keeps** is the part that legitimately differs:

| caller | gate | why |
|---|---|---|
| `org360` | `EnsureVisible` | an account the caller cannot read must not be confirmed to exist |
| `person360` | `EnsureVisible**Live**` | Art. 17 anonymizes a person in place and stamps `archived_at` while **leaving `owner_id` alone**, so the plain probe still admits their owner |

That difference is a ruling per record type. The upsert is not.

## The ownership waiver is deleted, not reworded

`person360` no longer writes the table, so the exception has nothing left to
ratify. The register of exceptions in `tableownership_test.go` is one entry
shorter — the direction it should move, and a reminder that a waiver is worth
checking for whether its *subject* still exists, not only whether its reason
still reads well.

## The gate

`TestUserRecordViewHasOneWriter` censuses every string literal in the tree.

**Per LITERAL, not per line.** This upsert spans six source lines; a line-scoped
sweep would see `INSERT INTO user_record_view` and `DO UPDATE SET …` as
unrelated fragments — matching the first and never asking whether the second
carried `GREATEST`.

**It judges `UPDATE` as well as `INSERT`,** because the defect is not "a second
INSERT" but a second answer to *how the mark moves*. The worst second writer is
a bare `UPDATE … SET last_viewed_at = $1`: no `GREATEST` at all, rewinding
unconditionally.

**And it reads every spelling Postgres accepts of the name** — this took three
rounds to get right, each round a shape the pattern could not see:

| | |
|---|---|
| `public.user_record_view` | one qualifier |
| `tenant1.public.user_record_view` | two — so the qualifier repeats |
| `public . user_record_view` | whitespace around the separator |
| `"public"."user_record_view"` | quoted, in any combination |
| `UPDATE ONLY user_record_view` | inheritance-scoped, and it rewinds just as hard |

The name ends on a **delimiter, not `\b`**: `$`, `.` and `"` are all legal
around a Postgres identifier and none is a word character, so a boundary alone
reported `user_record_view$archive`, `"user_record_view.extra"` and
`user_record_view.extra` — different relations — as this one. The quoted branch
is case-**sensitive** while the rest is not, because that is Postgres: unquoted
`USER_RECORD_VIEW` folds to this table, quoted `"USER_RECORD_VIEW"` is a
different one. Go's regexp has no lookahead, so that distinction is two branches.

`TestTheViewBaselineCensusSeesWhatItClaimsTo` plants **12 must-catch and 11
must-miss**. The must-miss half carries every near-neighbour — `SELECT` (which
every 360 does), `user_record_view_archive` in bare, qualified and `ONLY` forms,
and the three false positives above — because widening a pattern is how a
boundary gets lost, and a gate that starts reporting the archive table is a gate
somebody turns off.

## Mutation-tested

| mutant | result |
|---|---|
| restore person360's copy of the statement | caught |
| a second writer that loses `GREATEST` | caught |
| drop the `ONLY` branch | caught |
| make the qualifier non-repeating | caught |

The first was re-run until it **compiled** — the initial attempt failed the
build, and a mutant that does not compile tests nothing.

## Coverage

`RecordVisit` is the only new executable code, exercised through **both** real
callers rather than by a unit test of itself:

- `TestOrganizationViewAckIsMonotonicAndPerUser` builds a second service whose
  clock **lags by an hour** and asserts the mark keeps the later instant — that
  is `GREATEST` asserted at the database, the exact property the census
  protects.
- `person360_http_integration_test.go` covers the person side through the HTTP
  door.

A unit test of `RecordVisit` in isolation would exercise the function while
proving nothing about either caller reaching it.

## One finding refused, with evidence

CodeRabbit flagged `RecordVisit` for committing a domain row without an audit
and outbox row, quoting the write-shape rule correctly. It does not apply:
`user_record_view` is ratified as audit-free in **two places predating this
change** — `moduleaudits_test.go:62` ("per-reader: one person's last-seen
cursor") and the ownership entry ("view state, not a record fact … the
saved-view ruling"). This change adds no write; it moves one. The load-bearing
part is that **the write-shape gates pass**, which is what makes it a recorded
exception rather than an asserted one.

## Verification

`make check-backend` green, with a private `GOLANGCI_LINT_CACHE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)