### PR TITLE
fix(jobs): a wait does not discard the event another wait is owed

### DIFF
--- a/backend/internal/compose/capturejobs_integration_test.go
+++ b/backend/internal/compose/capturejobs_integration_test.go
@@ -186,7 +186,10 @@ func TestCaptureOvernightJobsRegisterAndRun(t *testing.T) {
 		}
 	}()
 
-	for _, kind := range []string{"capture_classify", "capture_enrich", "capture_digest"} {
-		awaitKindCompleted(t, sub, kind)
-	}
+	// Awaited as a SET, not a sequence. All three are RunOnStart, so River
+	// enqueues them together and finishes them in whatever order the queues
+	// allow — and capture_digest is the one that usually wins, because
+	// captureDigestWorker deliberately runs on the default queue rather than
+	// behind the two model-bound workers on ai_capture.
+	awaitKindsCompleted(t, sub, "capture_classify", "capture_enrich", "capture_digest")
 }

--- a/backend/internal/compose/jobs_integration_test.go
+++ b/backend/internal/compose/jobs_integration_test.go
@@ -17,10 +17,14 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -100,19 +104,92 @@ const awaitBudget = 30 * time.Second
 //
 // This also puts the helper back in line with its two siblings, awaitRows and
 // waitUntil, which have always owned their own clocks.
+//
+// A wait CONSUMES the subscription, and an event it is not waiting for is gone
+// once read. So awaiting several kinds by calling this in sequence is only
+// sound when each kind cannot complete before the one awaited ahead of it —
+// which for jobs enqueued together is not true, and for jobs on different
+// queues is not close to true. Await a set with awaitKindsCompleted instead.
 func awaitKindCompleted(t *testing.T, sub <-chan *river.Event, kind string) {
+	t.Helper()
+	awaitKindsCompleted(t, sub, kind)
+}
+
+// awaitKindsCompleted blocks until EVERY named kind has reported completion,
+// in whatever order they finish, so no kind's event is discarded while another
+// is being waited for.
+//
+// Each retirement gets a full awaitBudget, exactly as N sequential
+// awaitKindCompleted calls would — the set costs nothing in patience, it only
+// stops the order being asserted where the scheduler never promised one.
+func awaitKindsCompleted(t *testing.T, sub <-chan *river.Event, kinds ...string) {
+	t.Helper()
+	pending := make(map[string]struct{}, len(kinds))
+	for _, kind := range kinds {
+		pending[kind] = struct{}{}
+	}
+	for len(pending) > 0 {
+		awaitOnePending(t, sub, pending)
+	}
+}
+
+// awaitOnePending blocks until one still-pending kind completes, removing it,
+// or its own deadline fires. River's other traffic is skipped without renewing
+// the budget: only progress buys more time.
+func awaitOnePending(t *testing.T, sub <-chan *river.Event, pending map[string]struct{}) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), awaitBudget)
 	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():
-			t.Fatalf("timed out waiting for %q to complete within %s: %v", kind, awaitBudget, ctx.Err())
+			t.Fatalf("timed out waiting for %s to complete within %s: %v",
+				quotedKinds(pending), awaitBudget, ctx.Err())
 		case ev := <-sub:
-			if ev != nil && ev.Job != nil && ev.Job.Kind == kind {
+			if ev == nil || ev.Job == nil {
+				continue
+			}
+			if _, wanted := pending[ev.Job.Kind]; wanted {
+				delete(pending, ev.Job.Kind)
 				return
 			}
 		}
+	}
+}
+
+// quotedKinds names what a wait is still owed, sorted so a failure message is
+// the same on every run.
+func quotedKinds(pending map[string]struct{}) string {
+	quoted := make([]string, 0, len(pending))
+	for kind := range pending {
+		quoted = append(quoted, strconv.Quote(kind))
+	}
+	slices.Sort(quoted)
+	return strings.Join(quoted, ", ")
+}
+
+// The defect this guards: a wait consumes the subscription, so a kind that
+// finishes early is read and dropped by whichever wait is holding at the time,
+// and the wait that actually wants it then waits for an event already gone.
+// The kinds are offered here in the reverse of the order the caller names —
+// the arrival order a sequential await cannot survive, and the one River
+// really produces when capture_digest's default queue beats ai_capture.
+//
+// A regression fails this rather than hanging the suite: the set is complete on
+// the buffered channel, so the only way not to return promptly is to have
+// discarded something.
+func TestAWaitDoesNotDiscardAKindAnotherWaitIsOwed(t *testing.T) {
+	sub := make(chan *river.Event, 4)
+	for _, kind := range []string{"capture_digest", "close_date_sweep", "capture_enrich", "capture_classify"} {
+		sub <- &river.Event{Kind: river.EventKindJobCompleted, Job: &rivertype.JobRow{Kind: kind}}
+	}
+
+	awaitKindsCompleted(t, sub, "capture_classify", "capture_enrich", "capture_digest")
+
+	// close_date_sweep was traffic nobody awaited. It is consumed like any
+	// other event; what matters is that consuming it retired no wanted kind.
+	if len(sub) != 0 {
+		t.Errorf("%d event(s) left unread, want 0 — the set stopped short of draining what it was offered", len(sub))
 	}
 }
 


### PR DESCRIPTION
## What broke

`main-health` went red at 18:48 UTC on `693b0ff` — one job, `integration / integration shard (2/6)`, one test:

```
capturejobs_integration_test.go:190: timed out waiting for "capture_digest" to complete within 30s
--- FAIL: TestCaptureOvernightJobsRegisterAndRun (33.10s)
```

Not caused by anything that landed since the last green (#2454, #2471, #2481 all passed their own checks). It is a latent ordering race that a contended runner exposes.

## Why

A wait **consumes** the River subscription. `awaitKindCompleted` read every event looking for its own kind and dropped the rest. `TestCaptureOvernightJobsRegisterAndRun` awaited three kinds *in sequence* off one subscription, which asserts a completion order the scheduler never promised: all three overnight capture jobs are `RunOnStart`, so River enqueues them together.

And `capture_digest` is the one that usually wins — by design. From `capturejobs.go`:

> Work fans out on the DEFAULT queue, not ai_capture, unlike its three siblings in this file: assembling a digest is a database-only pass … Queueing the morning digest behind two model workers would delay it for no reason.

So when the two model-bound jobs stall on a busy runner, digest completes first, its event is read and thrown away while the test still holds for `capture_classify`, and the third wait spends its full 30s on an event that already came and went.

This is the residual of #1554. That fix gave each wait its own deadline; a wait *discarding another wait's event* is a different defect, and the first fix reasonably looked complete.

## The fix

`awaitKindsCompleted` awaits the **set**, retiring each kind as it arrives. Every retirement still gets a full `awaitBudget`, so this costs nothing in patience — it only stops an order being asserted where none exists. `awaitKindCompleted` is now that helper holding a single kind, so there is one implementation of the wait rather than two.

I censused all six `awaitKindCompleted` call sites. Only this one was racy. The backfill test's `capture_backfill` → digest pair stays sequential and is sound: the completion *enqueues* that digest, so it cannot arrive first.

## Evidence

**A deterministic regression guard**, `TestAWaitDoesNotDiscardAKindAnotherWaitIsOwed`, offers the three kinds in the reverse of the order the caller names them — the arrival order a sequential await cannot survive — plus one unrelated kind as traffic.

Mutation-tested, with the mutant proved applied. Reverting `awaitKindsCompleted` to the old sequential shape:

```
--- FAIL: TestAWaitDoesNotDiscardAKindAnotherWaitIsOwed (30.00s)
    jobs_integration_test.go:188: timed out waiting for "capture_enrich" to complete within 30s: context deadline exceeded
```

— the production symptom exactly. Restored, it passes in 0.00s.

**Against real Postgres**, the test that broke main now passes:

```
--- PASS: TestBackfillCompletionBuildsTheDigest (7.64s)
--- PASS: TestCaptureOvernightJobsRegisterAndRun (4.90s)
--- PASS: TestAWaitDoesNotDiscardAKindAnotherWaitIsOwed (0.00s)
```

`make check-backend` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sequential waits from discarding other waits’ events in River job tests. Old behavior consumed the subscription and dropped non-matching events; new behavior awaits a set of kinds in any order so no completion event is lost, while each still gets a full `awaitBudget`.

- Introduces `awaitKindsCompleted`; `awaitKindCompleted` now delegates to it.
- Updates `TestCaptureOvernightJobsRegisterAndRun` to await the set: "capture_classify", "capture_enrich", "capture_digest".
- Adds deterministic guard `TestAWaitDoesNotDiscardAKindAnotherWaitIsOwed`.
- Test-only change; no production code paths modified.

<sup>Written for commit a6ed13895d47736f521c45ce89c721ff986981bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to support concurrent job execution and completion events arriving in any order.
  * Improved test diagnostics with deterministic timeout messages listing pending job types.
  * Added regression coverage to ensure completion events are not missed when received out of sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->