### PR TITLE
fix(ai-models): a prompt versions itself, and a gate keeps it that way

### DIFF
--- a/backend/internal/compose/dealstatus/input.go
+++ b/backend/internal/compose/dealstatus/input.go
@@ -15,14 +15,20 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// promptVersion changes whenever the prompt or the projection changes, so a
-// card written by the old wording is rewritten rather than served forever. It
-// is part of the fingerprint for exactly that reason.
-const promptVersion = "deal-status-2"
+// projectionVersion changes when the PROJECTION changes — the shape the facts
+// are rendered into, which is Go code and so the half a digest cannot reach. It
+// rides the fingerprint so a card built from the old shape is rewritten rather
+// than served forever.
+const projectionVersion = "deal-status-projection-1"
+
+// promptVersion is DERIVED from the prompt it versions, so rewording the prompt
+// rewrites the cards whether or not anybody remembers to bump anything.
+var promptVersion = ai.PromptDigest(statusSystem)
 
 // project renders the gathered facts into the prompt's shape. Only what the
 // caller may read reaches it: the facts were gathered under their row scope,
@@ -152,7 +158,7 @@ func Fingerprint(in StatusInput, userID ids.UUID, routingVersion string, day tim
 		Reader  string      `json:"reader"`
 		Day     string      `json:"day"`
 	}{
-		In: in, Prompt: promptVersion, Routing: routingVersion,
+		In: in, Prompt: projectionVersion + "\x00" + promptVersion, Routing: routingVersion,
 		Reader: userID.String(), Day: day.UTC().Format("2006-01-02"),
 	})
 	if err != nil {

--- a/backend/internal/compose/dealstatus/input.go
+++ b/backend/internal/compose/dealstatus/input.go
@@ -26,9 +26,10 @@ import (
 // than served forever.
 const projectionVersion = "deal-status-projection-1"
 
-// promptVersion is DERIVED from the prompt it versions, so rewording the prompt
-// rewrites the cards whether or not anybody remembers to bump anything.
-var promptVersion = ai.PromptDigest(statusSystem)
+// promptVersion is DERIVED from the prompt as it is SENT — boundary rule
+// included — so rewording it rewrites the cards whether or not anybody
+// remembers to bump anything.
+var promptVersion = ai.PromptDigest(statusSystemFor)
 
 // project renders the gathered facts into the prompt's shape. Only what the
 // caller may read reaches it: the facts were gathered under their row scope,

--- a/backend/internal/compose/orgbrief/input.go
+++ b/backend/internal/compose/orgbrief/input.go
@@ -22,18 +22,30 @@ import (
 	"unicode/utf8"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 )
 
-// promptVersion changes whenever ANYTHING about how a brief is written
-// changes: the model prompt, the shape of the assembled input, or the wording
-// the deterministic floor produces. It rides the fingerprint, so such a deploy
-// invalidates every cached brief rather than serving text written the old way.
+// floorVersion is bumped by hand when the DETERMINISTIC floor's wording
+// changes, and it is the half of the fingerprint a digest cannot reach.
 //
-// The floor's wording counts because the floor's OUTPUT is what gets cached. A
-// deploy that reworded it and left this alone kept serving the old sentences
-// to every account whose facts had not moved — which is most of them.
-const promptVersion = "org-brief-v6"
+// The floor's output is what gets cached, and its sentences are built by Go
+// code — `fmt.Sprintf` formats inside deterministic.go — so there is nothing to
+// hash. A deploy that reworded the floor and left this alone keeps serving the
+// old sentences to every account whose facts have not moved, which is most of
+// them. That has happened.
+//
+// It covers ONLY the floor. The prompts version themselves below, so the case
+// this constant used to also cover — somebody edits a prompt and forgets — is
+// no longer possible rather than merely warned about.
+const floorVersion = "org-brief-floor-v6"
+
+// promptVersion is DERIVED from the prompt text it versions, so editing a
+// prompt bumps it whether or not anybody remembers to.
+//
+// The input's SHAPE still rides the fingerprint separately: `Input` is
+// marshalled into the sum, so a changed field changes the key on its own.
+var promptVersion = ai.PromptDigest(briefSystem, askSystem)
 
 // Input is what one brief is written from: the account's identity, its
 // pipeline, its people, and what has moved recently — each already pruned
@@ -347,7 +359,7 @@ func Fingerprint(in Input, routingVersion string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("fingerprint the brief input: %w", err)
 	}
-	sum := sha256.Sum256([]byte(promptVersion + "\x00" + routingVersion + "\x00" + string(encoded)))
+	sum := sha256.Sum256([]byte(floorVersion + "\x00" + promptVersion + "\x00" + routingVersion + "\x00" + string(encoded)))
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/backend/internal/compose/orgbrief/input.go
+++ b/backend/internal/compose/orgbrief/input.go
@@ -31,21 +31,24 @@ import (
 //
 // The floor's output is what gets cached, and its sentences are built by Go
 // code — `fmt.Sprintf` formats inside deterministic.go — so there is nothing to
-// hash. A deploy that reworded the floor and left this alone keeps serving the
+// hash. A deploy that rewords the floor and leaves this alone keeps serving the
 // old sentences to every account whose facts have not moved, which is most of
-// them. That has happened.
+// them.
 //
-// It covers ONLY the floor. The prompts version themselves below, so the case
-// this constant used to also cover — somebody edits a prompt and forgets — is
-// no longer possible rather than merely warned about.
+// It covers ONLY the floor. The model prompt versions itself below.
 const floorVersion = "org-brief-floor-v6"
 
-// promptVersion is DERIVED from the prompt text it versions, so editing a
-// prompt bumps it whether or not anybody remembers to.
+// promptVersion is DERIVED from the prompt as it is SENT — boundary rule
+// included — so editing that wording bumps it whether or not anybody remembers
+// to.
+//
+// The ask prompt is deliberately absent. Ask answers are not cached (see
+// Service.Ask), so binding them to the brief's key would rewrite every cached
+// brief for a change that cannot affect one.
 //
 // The input's SHAPE still rides the fingerprint separately: `Input` is
 // marshalled into the sum, so a changed field changes the key on its own.
-var promptVersion = ai.PromptDigest(briefSystem, askSystem)
+var promptVersion = ai.PromptDigest(briefSystemFor)
 
 // Input is what one brief is written from: the account's identity, its
 // pipeline, its people, and what has moved recently — each already pruned

--- a/backend/internal/compose/orgdossier/growthfitservice.go
+++ b/backend/internal/compose/orgdossier/growthfitservice.go
@@ -27,15 +27,26 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// growthFitPromptVersion identifies the assembly RULES in the fingerprint.
-// Bumping it invalidates every cached assessment, which is the point: a change
-// to the required inputs or the abstention floor must not leave yesterday's
-// bands being served beside today's (DOSS-AC-14).
-const growthFitPromptVersion = "growth-fit-v2"
+// growthFitAssemblyVersion identifies the assembly RULES in the fingerprint —
+// the required inputs and the abstention floor, which are Go code and so the
+// half a digest cannot reach. Bumping it invalidates every cached assessment,
+// which is the point: yesterday's bands must not be served beside today's
+// (DOSS-AC-14).
+const growthFitAssemblyVersion = "growth-fit-assembly-v2"
+
+// growthFitPromptVersion is DERIVED from the prompt it versions, so editing
+// that prompt bumps it whether or not anybody remembers to.
+//
+// Its own digest rather than the dossier's: the two surfaces keep separate
+// fingerprints, and folding both prompts into one would rewrite every cached
+// dossier whenever the growth-fit wording moved, and every cached assessment
+// whenever the dossier's did.
+var growthFitPromptVersion = ai.PromptDigest(growthFitSystem)
 
 // growthFitStoredVersion is the payload SHAPE this build writes and can read.
 // v2 adds the sub-scores (DOSS-AC-17): a v1 payload has none, and serving one
@@ -219,8 +230,9 @@ func growthFitFingerprint(in Input, routingVersion string, offering Offering) (s
 	if err != nil {
 		return "", fmt.Errorf("fingerprint the growth-fit input: %w", err)
 	}
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s\x00%s\x00%t\x00%s\x00%s",
-		growthFitPromptVersion, routingVersion, offering.Confirmed, offering.Fingerprint, encoded))
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s\x00%s\x00%s\x00%t\x00%s\x00%s",
+		growthFitAssemblyVersion, growthFitPromptVersion, routingVersion,
+		offering.Confirmed, offering.Fingerprint, encoded))
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/backend/internal/compose/orgdossier/growthfitservice.go
+++ b/backend/internal/compose/orgdossier/growthfitservice.go
@@ -39,14 +39,15 @@ import (
 // (DOSS-AC-14).
 const growthFitAssemblyVersion = "growth-fit-assembly-v2"
 
-// growthFitPromptVersion is DERIVED from the prompt it versions, so editing
-// that prompt bumps it whether or not anybody remembers to.
+// growthFitPromptVersion is DERIVED from the prompt as it is SENT — boundary
+// rule included — so editing that wording bumps it whether or not anybody
+// remembers to.
 //
 // Its own digest rather than the dossier's: the two surfaces keep separate
 // fingerprints, and folding both prompts into one would rewrite every cached
 // dossier whenever the growth-fit wording moved, and every cached assessment
 // whenever the dossier's did.
-var growthFitPromptVersion = ai.PromptDigest(growthFitSystem)
+var growthFitPromptVersion = ai.PromptDigest(growthFitSystemFor)
 
 // growthFitStoredVersion is the payload SHAPE this build writes and can read.
 // v2 adds the sub-scores (DOSS-AC-17): a v1 payload has none, and serving one

--- a/backend/internal/compose/orgdossier/service.go
+++ b/backend/internal/compose/orgdossier/service.go
@@ -24,17 +24,23 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// promptVersion identifies the assembly RULES in the fingerprint. Bumping it
-// invalidates every cached dossier, which is the point: a change to how a
-// dossier is written must not leave yesterday's assemblies being served beside
-// today's (DOSS-AC-14).
-const promptVersion = "dossier-v1"
+// assemblyVersion identifies the assembly RULES in the fingerprint, and is the
+// half a digest cannot reach: the rules are Go code. Bumping it invalidates
+// every cached dossier, which is the point — a change to how a dossier is
+// written must not leave yesterday's assemblies being served beside today's
+// (DOSS-AC-14).
+const assemblyVersion = "dossier-assembly-v1"
+
+// promptVersion is DERIVED from the prompt text it versions, so editing a
+// prompt bumps it whether or not anybody remembers to.
+var promptVersion = ai.PromptDigest(dossierSystem)
 
 // storedVersion is the payload SHAPE this build writes and can read. A row
 // written by an older shape unmarshals cleanly into a newer envelope with its
@@ -223,7 +229,7 @@ func Fingerprint(in Input, routingVersion string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("fingerprint the dossier input: %w", err)
 	}
-	sum := sha256.Sum256([]byte(promptVersion + "\x00" + routingVersion + "\x00" + string(encoded)))
+	sum := sha256.Sum256([]byte(assemblyVersion + "\x00" + promptVersion + "\x00" + routingVersion + "\x00" + string(encoded)))
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/backend/internal/compose/orgdossier/service.go
+++ b/backend/internal/compose/orgdossier/service.go
@@ -38,9 +38,10 @@ import (
 // (DOSS-AC-14).
 const assemblyVersion = "dossier-assembly-v1"
 
-// promptVersion is DERIVED from the prompt text it versions, so editing a
-// prompt bumps it whether or not anybody remembers to.
-var promptVersion = ai.PromptDigest(dossierSystem)
+// promptVersion is DERIVED from the prompt as it is SENT — boundary rule
+// included — so editing that wording bumps it whether or not anybody remembers
+// to.
+var promptVersion = ai.PromptDigest(dossierSystemFor)
 
 // storedVersion is the payload SHAPE this build writes and can read. A row
 // written by an older shape unmarshals cleanly into a newer envelope with its

--- a/backend/internal/modules/ai/promptdigest.go
+++ b/backend/internal/modules/ai/promptdigest.go
@@ -5,8 +5,8 @@ package ai
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
-	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
 )
@@ -42,15 +42,23 @@ import (
 // assembly. This one hashes the prompt, because a cache key only has to move
 // when the wording does.
 //
+// Each prompt is length-prefixed rather than joined by a separator. A separator
+// only works while no prompt can contain it, and nothing enforces that: under a
+// join, ("a\x00b", "c") and ("a", "b\x00c") hash alike, as do no prompts at all
+// and one empty one. Two different prompt sets sharing a key is the stale-answer
+// defect this exists to prevent, reached from the inside.
+//
 // The prefix keeps the value readable in a stored row, and eight bytes is ample
 // for a key that only has to differ.
 func PromptDigest(build ...func(promptfence.Fence) string) string {
 	fence := promptfence.New()
-	sent := make([]string, 0, len(build))
+	var framed []byte
 	for _, buildPrompt := range build {
 		prompt := buildPrompt(fence)
-		sent = append(sent, promptfence.Canonicalize(prompt, prompt))
+		canonical := promptfence.Canonicalize(prompt, prompt)
+		framed = binary.AppendUvarint(framed, uint64(len(canonical)))
+		framed = append(framed, canonical...)
 	}
-	sum := sha256.Sum256([]byte(strings.Join(sent, "\x00")))
+	sum := sha256.Sum256(framed)
 	return "prompts-" + hex.EncodeToString(sum[:8])
 }

--- a/backend/internal/modules/ai/promptdigest.go
+++ b/backend/internal/modules/ai/promptdigest.go
@@ -7,34 +7,50 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
 )
 
-// PromptDigest fingerprints the prompts a surface sends, so a cache key moves
-// when the wording does.
+// PromptDigest fingerprints the system prompts a surface SENDS, so a cache key
+// moves when the wording does.
 //
-// It exists because the alternative is a hand-typed constant somebody has to
-// remember to bump, and that does not hold. A surface's own docblock recorded
-// the failure in its own words: a deploy reworded the text, left the constant
-// alone, and kept serving the old sentences to every record whose facts had not
-// moved — which is most of them. Nothing errors, nothing is logged, and the
-// reader has no way to tell they are looking at yesterday's writing.
+// A cached answer is keyed by a fingerprint. If the fingerprint does not move
+// when the prompt does, a deploy that rewords one keeps serving text written
+// the old way to every record whose facts have not changed — which is most of
+// them. Nothing errors and nothing is logged, so the reader has no way to tell.
+//
+// It takes the BUILDERS rather than the prompt constants, because a constant is
+// not what reaches the model: each surface appends its data-boundary rule to
+// one, and that sentence rides every prompt in the product. A digest over the
+// constants alone holds still while the text actually sent changes, which is
+// the same defect reached by a different route.
+//
+// The boundary's marker is a fresh nonce per call, so a built prompt is
+// canonicalized before hashing. Without that the digest would differ on every
+// process start and the cache would never hit.
 //
 // WHAT IT CANNOT COVER, so a caller does not mistake it for the whole answer:
-// wording built by Go code — a `fmt.Sprintf` in a deterministic floor — is not
-// a string this can hash. A surface with such a floor keeps an explicit
-// constant for that half, and the two ride the fingerprint together.
+// wording built by Go code from runtime facts — a `fmt.Sprintf` in a
+// deterministic floor — is not reachable from a builder that takes only a
+// fence. A surface with such a floor keeps an explicit constant for that half,
+// and the two ride the fingerprint together.
 //
 // NOT to be confused with `aicert.PromptVersion`, which answers a different
 // question: whether a stored certification record still describes the request
-// the tree builds today. That one hashes the BUILT REQUEST through the task
-// census, because a cert record has to notice a change anywhere in assembly.
-// This one hashes the prompt text, because a cache key only has to move when
-// the wording does.
+// the tree builds today. That one hashes the whole built REQUEST through the
+// task census, because a cert record has to notice a change anywhere in
+// assembly. This one hashes the prompt, because a cache key only has to move
+// when the wording does.
 //
-// The prefix keeps the value readable in a stored row. A fingerprint that
-// changed for a reason nobody can name is worse than one that is merely long,
-// and eight bytes is ample for a cache key that only has to differ.
-func PromptDigest(prompts ...string) string {
-	sum := sha256.Sum256([]byte(strings.Join(prompts, "\x00")))
+// The prefix keeps the value readable in a stored row, and eight bytes is ample
+// for a key that only has to differ.
+func PromptDigest(build ...func(promptfence.Fence) string) string {
+	fence := promptfence.New()
+	sent := make([]string, 0, len(build))
+	for _, buildPrompt := range build {
+		prompt := buildPrompt(fence)
+		sent = append(sent, promptfence.Canonicalize(prompt, prompt))
+	}
+	sum := sha256.Sum256([]byte(strings.Join(sent, "\x00")))
 	return "prompts-" + hex.EncodeToString(sum[:8])
 }

--- a/backend/internal/modules/ai/promptdigest.go
+++ b/backend/internal/modules/ai/promptdigest.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// PromptDigest fingerprints the prompts a surface sends, so a cache key moves
+// when the wording does.
+//
+// It exists because the alternative is a hand-typed constant somebody has to
+// remember to bump, and that does not hold. A surface's own docblock recorded
+// the failure in its own words: a deploy reworded the text, left the constant
+// alone, and kept serving the old sentences to every record whose facts had not
+// moved — which is most of them. Nothing errors, nothing is logged, and the
+// reader has no way to tell they are looking at yesterday's writing.
+//
+// WHAT IT CANNOT COVER, so a caller does not mistake it for the whole answer:
+// wording built by Go code — a `fmt.Sprintf` in a deterministic floor — is not
+// a string this can hash. A surface with such a floor keeps an explicit
+// constant for that half, and the two ride the fingerprint together.
+//
+// NOT to be confused with `aicert.PromptVersion`, which answers a different
+// question: whether a stored certification record still describes the request
+// the tree builds today. That one hashes the BUILT REQUEST through the task
+// census, because a cert record has to notice a change anywhere in assembly.
+// This one hashes the prompt text, because a cache key only has to move when
+// the wording does.
+//
+// The prefix keeps the value readable in a stored row. A fingerprint that
+// changed for a reason nobody can name is worse than one that is merely long,
+// and eight bytes is ample for a cache key that only has to differ.
+func PromptDigest(prompts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(prompts, "\x00")))
+	return "prompts-" + hex.EncodeToString(sum[:8])
+}

--- a/backend/internal/modules/ai/promptdigest_test.go
+++ b/backend/internal/modules/ai/promptdigest_test.go
@@ -59,3 +59,26 @@ func TestTextMovingAcrossThePromptBoundaryIsNotTheSameInput(t *testing.T) {
 		t.Errorf("(%q,%q) and (%q,%q) share the digest %s", "ab", "c", "a", "bc", joined)
 	}
 }
+
+// A separator only works while no prompt can contain it, and nothing enforces
+// that. Under a join these two prompt sets hash alike, so one would be served
+// the other's cached answer.
+func TestAPromptContainingTheSeparatorDoesNotCollide(t *testing.T) {
+	fixed := func(text string) func(promptfence.Fence) string {
+		return func(promptfence.Fence) string { return text }
+	}
+	left := PromptDigest(fixed("a\x00b"), fixed("c"))
+	right := PromptDigest(fixed("a"), fixed("b\x00c"))
+	if left == right {
+		t.Errorf("prompts differing only in where a NUL falls share the digest %s", left)
+	}
+}
+
+// No prompts at all and one empty prompt are different inputs. A join maps both
+// to zero bytes.
+func TestNoPromptsAndOneEmptyPromptDigestDifferently(t *testing.T) {
+	empty := func(promptfence.Fence) string { return "" }
+	if none, one := PromptDigest(), PromptDigest(empty); none == one {
+		t.Errorf("no prompts and one empty prompt share the digest %s", none)
+	}
+}

--- a/backend/internal/modules/ai/promptdigest_test.go
+++ b/backend/internal/modules/ai/promptdigest_test.go
@@ -3,41 +3,59 @@
 
 package ai
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
+)
+
+func briefLike(fence promptfence.Fence) string {
+	return "You write a brief.\n" + fence.Rule("account summary")
+}
 
 // A digest that does not move when the wording does is worse than no digest at
 // all: the surface reads as versioned, and serves yesterday's writing anyway.
 func TestARewordedPromptDigestsDifferently(t *testing.T) {
-	before := PromptDigest("You write a brief.")
-	after := PromptDigest("You write a short brief.")
-	if before == after {
+	reworded := func(fence promptfence.Fence) string {
+		return "You write a short brief.\n" + fence.Rule("account summary")
+	}
+	if before, after := PromptDigest(briefLike), PromptDigest(reworded); before == after {
 		t.Errorf("rewording the prompt left the digest at %s, so a cache key would not move", before)
 	}
 }
 
-// Same input, same key — otherwise every deploy rewrites every cached answer
-// and the fingerprint stops meaning anything.
-func TestTheSamePromptsDigestTheSameWay(t *testing.T) {
-	if first, second := PromptDigest("a", "b"), PromptDigest("a", "b"); first != second {
-		t.Errorf("the digest is unstable: %s then %s", first, second)
+// The boundary marker is a fresh nonce per call, so an uncanonicalized digest
+// would differ on every process start and the cache would never hit — a defect
+// that looks like nothing at all, just a cache that stopped earning its keep.
+func TestTheSamePromptDigestsAlikeUnderDifferentBoundaries(t *testing.T) {
+	if first, second := PromptDigest(briefLike), PromptDigest(briefLike); first != second {
+		t.Errorf("the digest is unstable across calls: %s then %s", first, second)
 	}
 }
 
-// The separator is the whole reason this joins rather than concatenates. Two
-// prompts where text shifts across the boundary are a DIFFERENT pair of
-// prompts, and a digest that cannot tell them apart would hold a stale key for
-// one of them — the exact failure it exists to prevent, reached by a route
-// nobody would think to test for.
+// The boundary RULE is prompt wording too. It is appended by Go code rather
+// than typed into the constant, and it rides every prompt in the product — so a
+// digest that covered only the constant would hold still while the text
+// actually sent changed.
+func TestTheBoundaryRuleRidesTheDigest(t *testing.T) {
+	otherKind := func(fence promptfence.Fence) string {
+		return "You write a brief.\n" + fence.Rule("deal timeline")
+	}
+	if same, other := PromptDigest(briefLike), PromptDigest(otherKind); same == other {
+		t.Errorf("two prompts whose boundary rules differ share the digest %s", same)
+	}
+}
+
+// Text moving across the boundary between two prompts is a DIFFERENT input. A
+// digest that could not tell them apart would hold a stale key for one of them,
+// by a route nobody would think to test for.
 func TestTextMovingAcrossThePromptBoundaryIsNotTheSameInput(t *testing.T) {
-	if joined, shifted := PromptDigest("ab", "c"), PromptDigest("a", "bc"); joined == shifted {
-		t.Errorf("(%q,%q) and (%q,%q) share the digest %s", "ab", "c", "a", "bc", joined)
+	fixed := func(text string) func(promptfence.Fence) string {
+		return func(promptfence.Fence) string { return text }
 	}
-}
-
-// One prompt and two are different inputs even when the text is identical, so
-// a surface that grows a second prompt gets a new key without editing either.
-func TestAddingASecondPromptMovesTheDigest(t *testing.T) {
-	if one, two := PromptDigest("a"), PromptDigest("a", ""); one == two {
-		t.Errorf("adding an empty second prompt left the digest at %s", one)
+	joined := PromptDigest(fixed("ab"), fixed("c"))
+	shifted := PromptDigest(fixed("a"), fixed("bc"))
+	if joined == shifted {
+		t.Errorf("(%q,%q) and (%q,%q) share the digest %s", "ab", "c", "a", "bc", joined)
 	}
 }

--- a/backend/internal/modules/ai/promptdigest_test.go
+++ b/backend/internal/modules/ai/promptdigest_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import "testing"
+
+// A digest that does not move when the wording does is worse than no digest at
+// all: the surface reads as versioned, and serves yesterday's writing anyway.
+func TestARewordedPromptDigestsDifferently(t *testing.T) {
+	before := PromptDigest("You write a brief.")
+	after := PromptDigest("You write a short brief.")
+	if before == after {
+		t.Errorf("rewording the prompt left the digest at %s, so a cache key would not move", before)
+	}
+}
+
+// Same input, same key — otherwise every deploy rewrites every cached answer
+// and the fingerprint stops meaning anything.
+func TestTheSamePromptsDigestTheSameWay(t *testing.T) {
+	if first, second := PromptDigest("a", "b"), PromptDigest("a", "b"); first != second {
+		t.Errorf("the digest is unstable: %s then %s", first, second)
+	}
+}
+
+// The separator is the whole reason this joins rather than concatenates. Two
+// prompts where text shifts across the boundary are a DIFFERENT pair of
+// prompts, and a digest that cannot tell them apart would hold a stale key for
+// one of them — the exact failure it exists to prevent, reached by a route
+// nobody would think to test for.
+func TestTextMovingAcrossThePromptBoundaryIsNotTheSameInput(t *testing.T) {
+	if joined, shifted := PromptDigest("ab", "c"), PromptDigest("a", "bc"); joined == shifted {
+		t.Errorf("(%q,%q) and (%q,%q) share the digest %s", "ab", "c", "a", "bc", joined)
+	}
+}
+
+// One prompt and two are different inputs even when the text is identical, so
+// a surface that grows a second prompt gets a new key without editing either.
+func TestAddingASecondPromptMovesTheDigest(t *testing.T) {
+	if one, two := PromptDigest("a"), PromptDigest("a", ""); one == two {
+		t.Errorf("adding an empty second prompt left the digest at %s", one)
+	}
+}

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -227,6 +227,7 @@ func hasHandTypedVersion(pkg promptPackage) bool {
 // follow fails loudly rather than silently covering nothing.
 func digestCoverage(pkg promptPackage) (reached map[string]bool, derives bool, unsupported []string) {
 	reached = map[string]bool{}
+	var follow []string
 	for _, file := range pkg.files {
 		ast.Inspect(file, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
@@ -251,8 +252,10 @@ func digestCoverage(pkg promptPackage) (reached map[string]bool, derives bool, u
 				switch builder := arg.(type) {
 				case *ast.Ident:
 					reached[builder.Name] = true
+					follow = append(follow, builder.Name)
 				case *ast.FuncLit:
 					collectIdents(builder.Body, reached)
+					follow = append(follow, returnedNames(builder.Body)...)
 				default:
 					unsupported = append(unsupported, types.ExprString(arg))
 				}
@@ -260,19 +263,29 @@ func digestCoverage(pkg promptPackage) (reached map[string]bool, derives bool, u
 			return true
 		})
 	}
-	followFunctions(pkg, reached)
+	followBuilders(pkg, follow, reached)
 	return reached, derives, unsupported
 }
 
-// followFunctions widens reached through the package's own functions, to a
-// fixed point.
+// followBuilders widens reached through the functions a builder RETURNS THROUGH,
+// to a fixed point.
 //
 // A builder is free to delegate — a literal that calls a named builder, a named
 // builder that calls another — and the prompt is sent at the bottom of that
-// chain, not at the top. Following one hop would clear the shape this tree
-// happens to write today and miss the next one; following to a fixed point
-// answers "does this digest send that prompt" whatever the chain.
-func followFunctions(pkg promptPackage, reached map[string]bool) {
+// chain, not the top. Following one hop would clear the shape this tree happens
+// to write today and miss the next one.
+//
+// Only the RETURN position is followed. A body may also call a helper for an
+// unrelated effect, and following that would let a prompt the helper merely
+// mentions count as sent — which would weaken the census whose whole point is to
+// fail when a prompt rides no digest. What a builder returns is what reaches the
+// model.
+//
+// Identifiers in a followed body still all count toward reached, so a prompt
+// bound to a local before being returned is not missed. Being generous about the
+// prompt and strict about the chain keeps the census from reporting a covered
+// prompt as uncovered, which is the failure that teaches a reader to ignore it.
+func followBuilders(pkg promptPackage, follow []string, reached map[string]bool) {
 	bodies := map[string]*ast.BlockStmt{}
 	for _, file := range pkg.files {
 		for _, decl := range file.Decls {
@@ -281,22 +294,39 @@ func followFunctions(pkg promptPackage, reached map[string]bool) {
 			}
 		}
 	}
-	for {
-		widened := false
-		for name := range reached {
-			body, isFunction := bodies[name]
-			if !isFunction {
-				continue
-			}
-			delete(bodies, name) // each body contributes once
-			collectIdents(body, reached)
-			widened = true
-			break // reached was mutated; restart the scan
+	for len(follow) > 0 {
+		name := follow[len(follow)-1]
+		follow = follow[:len(follow)-1]
+		body, isFunction := bodies[name]
+		if !isFunction {
+			continue
 		}
-		if !widened {
-			return
-		}
+		delete(bodies, name) // each body contributes once; this also ends a cycle
+		collectIdents(body, reached)
+		follow = append(follow, returnedNames(body)...)
 	}
+}
+
+// returnedNames are the identifiers a body's return statements name — the
+// functions and constants its value is built from.
+func returnedNames(body *ast.BlockStmt) []string {
+	var names []string
+	ast.Inspect(body, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, result := range ret.Results {
+			ast.Inspect(result, func(inner ast.Node) bool {
+				if ident, ok := inner.(*ast.Ident); ok {
+					names = append(names, ident.Name)
+				}
+				return true
+			})
+		}
+		return true
+	})
+	return names
 }
 
 func collectIdents(node ast.Node, into map[string]bool) {

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -39,10 +39,10 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"io/fs"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -77,14 +77,25 @@ var uncachedPrompts = gatekit.Waive(map[string]string{
 	"internal/compose/orgbrief:askSystem": "Ask answers are not cached (orgbrief.Service.Ask says so and explains why: a question is asked once and read once). Binding the ask prompt to the BRIEF's key would rewrite every cached brief for a change that cannot affect one.",
 })
 
-// promptSurfaceFiles returns the product files of each prompt surface, grouped
-// by package directory.
+// promptPackage is one package directory: its product files, and the string
+// constants they declare, resolved once.
 //
-// Grouped rather than visited one at a time because Go constants are
-// package-scoped: a prompt lives in `write.go` while the version that caches its
-// output lives in `input.go`, and a census that resolved names file by file
-// would not see across that.
-func promptSurfaceFiles(t *testing.T) map[string][]*ast.File {
+// Grouped by package rather than visited file by file because Go constants are
+// package-scoped — a prompt lives in `write.go` while the version caching its
+// output lives in `input.go`, and a census resolving names per file cannot see
+// across that.
+type promptPackage struct {
+	dir    string
+	files  []*ast.File
+	consts map[string]string
+}
+
+// promptSurfacePackages returns every package under the prompt surfaces.
+//
+// The traversal lives here alone. Each census below states only its own check;
+// a walk copied into three of them is three chances for one to drift into
+// reading a smaller tree than its siblings and reporting clean.
+func promptSurfacePackages(t *testing.T) []promptPackage {
 	t.Helper()
 	byDir := map[string][]*ast.File{}
 	fset := token.NewFileSet()
@@ -107,164 +118,220 @@ func promptSurfaceFiles(t *testing.T) map[string][]*ast.File {
 			if parseErr != nil {
 				return parseErr
 			}
-			dir := filepath.ToSlash(filepath.Dir(path))
-			byDir[dir] = append(byDir[dir], file)
+			byDir[filepath.ToSlash(filepath.Dir(path))] = append(byDir[filepath.ToSlash(filepath.Dir(path))], file)
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
-	return byDir
+	packages := make([]promptPackage, 0, len(byDir))
+	for dir, files := range byDir {
+		packages = append(packages, promptPackage{dir: dir, files: files, consts: stringConstants(files)})
+	}
+	sort.Slice(packages, func(i, j int) bool { return packages[i].dir < packages[j].dir })
+	return packages
 }
 
-// declaredPrompts returns, per package directory, the prompt constants it
-// declares.
-func declaredPrompts(t *testing.T) map[string][]string {
-	t.Helper()
-	prompts := map[string][]string{}
-	for dir, files := range promptSurfaceFiles(t) {
-		consts := stringConstants(files)
-		for _, file := range files {
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || gen.Tok != token.CONST {
+// eachDeclaredString calls visit once per NAME a package binds, at the grain Go
+// declares them.
+//
+// `const unused, briefSystem = "x", theLongPrompt` binds two names in one spec,
+// and reading only the first hides the second — which is a way to declare a
+// prompt, or a hand-typed version, that a census keyed on `Names[0]` cannot see.
+//
+// A spec whose names and values do not align one-to-one (a multi-return call, an
+// iota run) binds no string this can read. Such a spec is reported to unreadable
+// rather than skipped, so a shape this cannot judge fails loudly instead of
+// passing quietly.
+func eachDeclaredString(
+	pkg promptPackage, allow func(token.Token) bool,
+	visit func(name string, value ast.Expr), unreadable func(name string),
+) {
+	for _, file := range pkg.files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || !allow(gen.Tok) {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Values) == 0 {
 					continue
 				}
-				for _, spec := range gen.Specs {
-					value, ok := spec.(*ast.ValueSpec)
-					if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
-						continue
+				if len(value.Names) != len(value.Values) {
+					for _, name := range value.Names {
+						unreadable(name.Name)
 					}
-					text, ok := stringValue(value.Values[0], consts)
-					if !ok || len(text) < promptFloor {
-						continue
-					}
-					if promptConstantName.MatchString(value.Names[0].Name) {
-						prompts[dir] = append(prompts[dir], value.Names[0].Name)
-					}
+					continue
+				}
+				for i, name := range value.Names {
+					visit(name.Name, value.Values[i])
 				}
 			}
 		}
 	}
+}
+
+func isConst(tok token.Token) bool { return tok == token.CONST }
+
+func isConstOrVar(tok token.Token) bool { return tok == token.CONST || tok == token.VAR }
+
+func namesAVersion(name string) bool {
+	return strings.Contains(strings.ToLower(name), "promptversion")
+}
+
+// declaredPrompts returns the prompt constants a package declares.
+func declaredPrompts(pkg promptPackage) []string {
+	var prompts []string
+	eachDeclaredString(pkg, isConst, func(name string, value ast.Expr) {
+		if !promptConstantName.MatchString(name) {
+			return
+		}
+		if text, ok := stringValue(value, pkg.consts); ok && len(text) >= promptFloor {
+			prompts = append(prompts, name)
+		}
+	}, func(string) {})
+	sort.Strings(prompts)
 	return prompts
 }
 
-// handTypedPromptVersions are the directories declaring a `promptVersion` as a
-// hand-typed STRING, whether spelled `const` or `var`.
+// hasHandTypedVersion reports whether a package declares a `promptVersion` bound
+// to a string this can read, whether spelled `const` or `var`.
 //
-// Both spellings, because the compliant form is a `var` — so `var
-// promptVersion = "v2"` is the shape a regression naturally takes, and a census
-// that only read `const` would be blind to exactly the thing it guards.
-func handTypedPromptVersions(t *testing.T) map[string]bool {
-	t.Helper()
-	out := map[string]bool{}
-	for dir, files := range promptSurfaceFiles(t) {
-		consts := stringConstants(files)
-		for _, file := range files {
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
-					continue
-				}
-				for _, spec := range gen.Specs {
-					value, ok := spec.(*ast.ValueSpec)
-					if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
-						continue
-					}
-					if !strings.Contains(strings.ToLower(value.Names[0].Name), "promptversion") {
-						continue
-					}
-					if _, resolved := stringValue(value.Values[0], consts); resolved {
-						out[dir] = true
-					}
-				}
-			}
+// Both spellings, because the compliant form is a `var` — so `var promptVersion
+// = "v2"` is the shape a regression naturally takes, and a census reading only
+// `const` would be blind to exactly the thing it guards.
+func hasHandTypedVersion(pkg promptPackage) bool {
+	handTyped := false
+	eachDeclaredString(pkg, isConstOrVar, func(name string, value ast.Expr) {
+		if !namesAVersion(name) {
+			return
 		}
-	}
-	return out
+		if _, resolved := stringValue(value, pkg.consts); resolved {
+			handTyped = true
+		}
+	}, func(string) {})
+	return handTyped
 }
 
-// digestedBuilders returns, per package directory, the identifiers handed to
-// ai.PromptDigest there.
-func digestedBuilders(t *testing.T) map[string][]string {
-	t.Helper()
-	out := map[string][]string{}
-	for dir, files := range promptSurfaceFiles(t) {
-		for _, file := range files {
-			ast.Inspect(file, func(node ast.Node) bool {
-				call, ok := node.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "PromptDigest" {
-					return true
-				}
-				if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "ai" {
-					return true
-				}
-				for _, arg := range call.Args {
-					if ident, ok := arg.(*ast.Ident); ok {
-						out[dir] = append(out[dir], ident.Name)
-					}
-				}
+// digestCoverage reports which prompts a package's ai.PromptDigest calls reach,
+// and whether it makes any such call at all.
+//
+// Resolved through the BUILDER rather than by trusting an argument's name: the
+// digest takes a function, and what that function sends is the only thing that
+// says which prompt it covered. A named builder is followed to its declaration;
+// a function literal is read where it stands.
+//
+// unsupported names an argument of neither shape, so a spelling this cannot
+// follow fails loudly rather than silently covering nothing.
+func digestCoverage(pkg promptPackage) (reached map[string]bool, derives bool, unsupported []string) {
+	reached = map[string]bool{}
+	for _, file := range pkg.files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
 				return true
-			})
-		}
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "PromptDigest" {
+				return true
+			}
+			if pkgName, ok := sel.X.(*ast.Ident); !ok || pkgName.Name != "ai" {
+				return true
+			}
+			derives = true
+			if call.Ellipsis.IsValid() {
+				// A spread hands over a slice built elsewhere; its elements are
+				// not in this call to follow.
+				unsupported = append(unsupported, types.ExprString(call.Args[len(call.Args)-1])+"...")
+				return true
+			}
+			for _, arg := range call.Args {
+				switch builder := arg.(type) {
+				case *ast.Ident:
+					reached[builder.Name] = true
+				case *ast.FuncLit:
+					collectIdents(builder.Body, reached)
+				default:
+					unsupported = append(unsupported, types.ExprString(arg))
+				}
+			}
+			return true
+		})
 	}
-	return out
+	followFunctions(pkg, reached)
+	return reached, derives, unsupported
 }
 
-// promptsReachedByDigest returns, per directory, the prompt constants the
-// digested builders actually name in their bodies.
+// followFunctions widens reached through the package's own functions, to a
+// fixed point.
 //
-// Resolved through the builder rather than by trusting its name: the digest
-// takes a function, and what that function sends is the only thing that says
-// which prompt got covered.
-func promptsReachedByDigest(t *testing.T, builders map[string][]string) map[string]map[string]bool {
-	t.Helper()
-	reached := map[string]map[string]bool{}
-	for dir, files := range promptSurfaceFiles(t) {
-		wanted := builders[dir]
-		if len(wanted) == 0 {
-			continue
-		}
-		reached[dir] = map[string]bool{}
-		for _, file := range files {
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok || fn.Body == nil || !slices.Contains(wanted, fn.Name.Name) {
-					continue
-				}
-				ast.Inspect(fn.Body, func(node ast.Node) bool {
-					if ident, ok := node.(*ast.Ident); ok {
-						reached[dir][ident.Name] = true
-					}
-					return true
-				})
+// A builder is free to delegate — a literal that calls a named builder, a named
+// builder that calls another — and the prompt is sent at the bottom of that
+// chain, not at the top. Following one hop would clear the shape this tree
+// happens to write today and miss the next one; following to a fixed point
+// answers "does this digest send that prompt" whatever the chain.
+func followFunctions(pkg promptPackage, reached map[string]bool) {
+	bodies := map[string]*ast.BlockStmt{}
+	for _, file := range pkg.files {
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+				bodies[fn.Name.Name] = fn.Body
 			}
 		}
 	}
-	return reached
+	for {
+		widened := false
+		for name := range reached {
+			body, isFunction := bodies[name]
+			if !isFunction {
+				continue
+			}
+			delete(bodies, name) // each body contributes once
+			collectIdents(body, reached)
+			widened = true
+			break // reached was mutated; restart the scan
+		}
+		if !widened {
+			return
+		}
+	}
+}
+
+func collectIdents(node ast.Node, into map[string]bool) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok {
+			into[ident.Name] = true
+		}
+		return true
+	})
 }
 
 func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
-	prompts := declaredPrompts(t)
-	if len(prompts) == 0 {
-		t.Fatal("the census found no prompt constant at all, so it is judging nothing")
-	}
-	handTyped := handTypedPromptVersions(t)
-
-	var findings []string
-	for dir := range handTyped {
-		if len(prompts[dir]) == 0 {
+	packages := promptSurfacePackages(t)
+	var findings, unreadable []string
+	declaring := 0
+	for _, pkg := range packages {
+		prompts := declaredPrompts(pkg)
+		if len(prompts) == 0 {
 			// No prompt to digest: the declaration versions something a digest
 			// cannot see, which is a legitimate reason to keep it by hand.
 			continue
 		}
-		findings = append(findings, dir+": promptVersion is hand-typed beside "+
-			strings.Join(prompts[dir], ", "))
+		declaring++
+		eachDeclaredString(pkg, isConstOrVar, func(string, ast.Expr) {}, func(name string) {
+			if namesAVersion(name) || promptConstantName.MatchString(name) {
+				unreadable = append(unreadable, pkg.dir+": "+name)
+			}
+		})
+		if hasHandTypedVersion(pkg) {
+			findings = append(findings, pkg.dir+": promptVersion is hand-typed beside "+
+				strings.Join(prompts, ", "))
+		}
+	}
+	if declaring == 0 {
+		t.Fatal("the census found no package declaring a prompt, so it is judging nothing")
 	}
 	sort.Strings(findings)
 	if len(findings) > 0 {
@@ -275,6 +342,14 @@ func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
 			"and keep a separate constant for any wording built in Go code, which a digest cannot "+
 			"reach.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
 	}
+	// A declaration this cannot read is not a declaration this has cleared.
+	if len(unreadable) > 0 {
+		sort.Strings(unreadable)
+		t.Errorf("%d prompt-or-version declaration(s) bind names and values that do not align "+
+			"one-to-one, so the census cannot read them and cannot vouch for them. Split the "+
+			"declaration, or teach eachDeclaredString the shape:\n\n\t%s",
+			len(unreadable), strings.Join(unreadable, "\n\t"))
+	}
 }
 
 func TestEveryPromptOfADerivingPackageRidesItsDigest(t *testing.T) {
@@ -282,21 +357,26 @@ func TestEveryPromptOfADerivingPackageRidesItsDigest(t *testing.T) {
 	// been folded in, and leaving it quietly re-exempts whatever takes its name.
 	defer uncachedPrompts.AssertAllMatched(t)
 
-	prompts := declaredPrompts(t)
-	builders := digestedBuilders(t)
-	if len(builders) == 0 {
-		t.Fatal("no package derives a prompt version, so this census is vouching for nothing")
-	}
-	reached := promptsReachedByDigest(t, builders)
-
-	var findings []string
-	for dir := range builders {
-		for _, prompt := range prompts[dir] {
-			if reached[dir][prompt] || uncachedPrompts.Waived(t, dir+":"+prompt) {
+	var findings, unsupported []string
+	deriving := 0
+	for _, pkg := range promptSurfacePackages(t) {
+		reached, derives, unreadableArgs := digestCoverage(pkg)
+		if !derives {
+			continue
+		}
+		deriving++
+		for _, arg := range unreadableArgs {
+			unsupported = append(unsupported, pkg.dir+": ai.PromptDigest("+arg+")")
+		}
+		for _, prompt := range declaredPrompts(pkg) {
+			if reached[prompt] || uncachedPrompts.Waived(t, pkg.dir+":"+prompt) {
 				continue
 			}
-			findings = append(findings, dir+": "+prompt)
+			findings = append(findings, pkg.dir+": "+prompt)
 		}
+	}
+	if deriving == 0 {
+		t.Fatal("no package derives a prompt version, so this census is vouching for nothing")
 	}
 	sort.Strings(findings)
 	if len(findings) > 0 {
@@ -306,6 +386,14 @@ func TestEveryPromptOfADerivingPackageRidesItsDigest(t *testing.T) {
 			"sibling: rewording it moves nothing, and its cached output is served unchanged. Add its "+
 			"builder to the ai.PromptDigest call, or ratify it in uncachedPrompts with the reason its "+
 			"output is not cached.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
+	}
+	// An argument this cannot follow covers nothing, and silence would read as
+	// coverage.
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		t.Errorf("%d ai.PromptDigest argument(s) are neither a named builder nor a function "+
+			"literal, so the census cannot tell which prompt they send:\n\n\t%s",
+			len(unsupported), strings.Join(unsupported, "\n\t"))
 	}
 }
 
@@ -327,8 +415,8 @@ func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
 	}
 	// A `+` chain is one prompt. The shared reader in this package handles that
 	// (and parenthesised and `string(...)` spellings); this asserts the census
-	// actually goes through it, since reading only the first fragment would let
-	// a prompt escape by being split across lines.
+	// goes through it, since reading only the first fragment would let a prompt
+	// escape by being split across lines.
 	joined, ok := stringValue(&ast.BinaryExpr{
 		Op: token.ADD,
 		X:  &ast.BasicLit{Kind: token.STRING, Value: `"You write "`},
@@ -339,10 +427,9 @@ func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
 	}
 	// The tree really does hold the constants the rule is written for, so the
 	// naming it keys on is the tree's rather than an invention.
-	prompts := declaredPrompts(t)
 	found := map[string]bool{}
-	for _, names := range prompts {
-		for _, name := range names {
+	for _, pkg := range promptSurfacePackages(t) {
+		for _, name := range declaredPrompts(pkg) {
 			found[name] = true
 		}
 	}

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -472,33 +472,33 @@ func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
 		t.Errorf("a prompt assembled with `+` is not read whole: %q", joined)
 	}
 	// The tree really does hold the constants the rule is written for, so the
-	// naming it keys on is the tree's rather than an invention.
+	// naming it keys on is the tree's rather than an invention — and it does NOT
+	// count a provenance label that ends in the same word, which would fire on a
+	// package whose hand-typed version is legitimate.
+	//
+	// Both maps come from ONE walk. Parsing the whole prompt surface twice to
+	// answer two questions about the same declarations is the cost this gate pays
+	// on every `make check-backend`.
 	found := map[string]bool{}
+	namedLikeAPrompt := map[string]bool{}
 	for _, pkg := range promptSurfacePackages(t) {
 		for _, name := range declaredPrompts(pkg) {
 			found[name] = true
 		}
-	}
-	for _, want := range []string{"briefSystem", "dossierSystem", "growthFitSystem"} {
-		if !found[want] {
-			t.Errorf("the census no longer finds %s — the naming rule has drifted from the tree", want)
-		}
-	}
-	// And it does NOT count a provenance label that ends in the same word, which
-	// would fire on a package whose hand-typed version is legitimate.
-	//
-	// Each label is asserted to EXIST before it is asserted to be excluded. A
-	// name that has been renamed away is absent from `found` for the wrong
-	// reason, and the check would go on passing while proving nothing about the
-	// floor it exists to test.
-	namedLikeAPrompt := map[string]bool{}
-	for _, pkg := range promptSurfacePackages(t) {
 		eachDeclaredString(pkg, isConst, func(name string, value ast.Expr) {
 			if _, isString := stringValue(value, pkg.consts); isString && promptConstantName.MatchString(name) {
 				namedLikeAPrompt[name] = true
 			}
 		}, func(string) {})
 	}
+	for _, want := range []string{"briefSystem", "dossierSystem", "growthFitSystem"} {
+		if !found[want] {
+			t.Errorf("the census no longer finds %s — the naming rule has drifted from the tree", want)
+		}
+	}
+	// Each label is asserted to EXIST before it is asserted to be excluded. A name
+	// renamed away is absent from `found` for the wrong reason, and the check would
+	// go on passing while proving nothing about the floor it exists to test.
 	for _, label := range []string{"trustSystem", "roleSystem", "actorTypeSystem", "transcriptSourceSystem"} {
 		if !namedLikeAPrompt[label] {
 			t.Errorf("%s is gone from the tree, so it no longer tests that the floor excludes a "+

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -486,7 +486,25 @@ func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
 	}
 	// And it does NOT count a provenance label that ends in the same word, which
 	// would fire on a package whose hand-typed version is legitimate.
+	//
+	// Each label is asserted to EXIST before it is asserted to be excluded. A
+	// name that has been renamed away is absent from `found` for the wrong
+	// reason, and the check would go on passing while proving nothing about the
+	// floor it exists to test.
+	namedLikeAPrompt := map[string]bool{}
+	for _, pkg := range promptSurfacePackages(t) {
+		eachDeclaredString(pkg, isConst, func(name string, value ast.Expr) {
+			if _, isString := stringValue(value, pkg.consts); isString && promptConstantName.MatchString(name) {
+				namedLikeAPrompt[name] = true
+			}
+		}, func(string) {})
+	}
 	for _, label := range []string{"trustSystem", "roleSystem", "actorTypeSystem", "transcriptSourceSystem"} {
+		if !namedLikeAPrompt[label] {
+			t.Errorf("%s is gone from the tree, so it no longer tests that the floor excludes a "+
+				"provenance label — name one that is still there", label)
+			continue
+		}
 		if found[label] {
 			t.Errorf("the census counts %s as a prompt; it names where a record came from", label)
 		}

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -6,39 +6,34 @@ package backendarch
 // A cached answer is keyed by a fingerprint, and the fingerprint has to move
 // when the prompt that produced the answer moves. Otherwise a deploy that
 // rewords a prompt keeps serving text written the old way to every record whose
-// facts have not changed — which is most of them.
+// facts have not changed — which is most of them. Nothing errors, nothing is
+// logged, and the reader cannot tell.
 //
-// That is not hypothetical. `orgbrief`'s own docblock recorded it happening, in
-// its own words: a deploy reworded the floor, left the version constant alone,
-// and kept serving the old sentences. The remedy chosen at the time was a
-// comment telling the next author to remember. This is the test that replaces
-// remembering.
+// THE RULE: in a package that DECLARES A PROMPT, a `promptVersion` declaration
+// must be derived — `ai.PromptDigest(theBuilder)` — never a hand-typed string.
+// A hand-typed one depends on somebody remembering, and remembering is the
+// thing that fails.
 //
-// THE RULE: a `promptVersion` declaration in a package that DECLARES A PROMPT
-// must be derived — `ai.PromptDigest(theSystemPrompt)` — never a hand-typed
-// string constant.
+// THE SECOND RULE: every prompt such a package declares must be REACHED by one
+// of the digested builders. Deriving one prompt's version and leaving a sibling
+// prompt out of the digest reintroduces the same defect for that sibling.
 //
-// That is the subject precisely, and it took two wrong ones to find. "Every
-// declared prompt must be digested" reports 28 surfaces, most of which cache
-// nothing — a prompt with no cached output has no key to go stale, and
-// reporting them buries the few that matter. "Every package that declares a
-// prompt AND computes a fingerprint" still reports 18, because `internal/compose`
-// is one directory holding a dozen unrelated surfaces and a directory is the
-// wrong grain for coupling a prompt to the key that caches ITS output.
-//
-// What is exactly derivable is the thing being replaced: a constant named
-// `promptVersion`. There are two in the tree, and one of them is correct —
-// `personbrief` declares no prompt at all and writes its whole output from Go
-// code, so there is nothing for a digest to see. The rule does not need a
-// waiver for it; it simply does not apply.
+// The subject is a `promptVersion` declaration rather than "every declared
+// prompt", because a prompt whose output is not cached has no key to go stale
+// and reporting it buries the ones that matter.
 //
 // WHAT THE RULE DOES NOT COVER, stated because a reader will otherwise assume
-// it does: wording built by Go code — a `fmt.Sprintf` inside a deterministic
-// floor — is not a string anything can hash. Those surfaces keep an explicit
-// version constant for that half, and the two ride the fingerprint together.
-// `personbrief` is the pure case: it declares no prompt at all, writes its
-// whole output from code, and is correctly absent from this census. "Adopt it
-// everywhere" would have been the wrong answer for exactly one of the four.
+// it does:
+//
+//   - Wording built by Go code from runtime facts — a `fmt.Sprintf` inside a
+//     deterministic floor — is not a string anything can hash. Those surfaces
+//     keep an explicit version constant for that half, and the two ride the
+//     fingerprint together. `personbrief` is the pure case: it declares no
+//     prompt at all and writes its whole output from code, so the rule does not
+//     apply to it and it needs no waiver.
+//   - A prompt declared in a different package from the version that caches its
+//     output. Both censuses key on the declaring directory, so such a split is
+//     invisible here.
 
 import (
 	"go/ast"
@@ -47,25 +42,45 @@ import (
 	"io/fs"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
-// promptConstant is a declared prompt: a package-level string constant whose
-// name ends in `System` or `Prompt`. That is this tree's own naming — every one
-// of them is `briefSystem`, `askSystem`, `dossierSystem`, `growthFitSystem` —
-// and a census keyed on the naming is a census that finds the next one.
+// promptConstantName is this tree's own naming for a model instruction — every
+// one of them is `briefSystem`, `askSystem`, `dossierSystem`, `growthFitSystem`
+// — and a census keyed on the naming is one that finds the next one.
 var promptConstantName = regexp.MustCompile(`(?:System|Prompt)$`)
 
-// promptSurfaces are the trees where a prompt may be declared.
+// promptFloor separates a model instruction from a provenance LABEL that ends
+// in the same word. `trustSystem`, `roleSystem`, `actorTypeSystem`,
+// `fieldSourceSystem` and `transcriptSourceSystem` name where a record came
+// from and are 2 to 19 characters; the shortest real prompt in the tree is 239.
+// Reporting a label would fire on a package whose hand-typed version is
+// legitimate, which teaches a reader to ignore this census.
+//
+// Length rather than "contains a newline": `judgeSystemPrompt` is a genuine
+// prompt written on one line.
+const promptFloor = 100
+
+// promptSurfaceRoots are the trees where a prompt may be declared.
 var promptSurfaceRoots = []string{"internal/compose", "internal/modules"}
 
-// declaredPrompts returns, per package directory, the prompt constants it
-// declares.
-func declaredPrompts(t *testing.T) map[string][]string {
+// uncachedPrompts are prompts a deriving package declares but deliberately
+// keeps OUT of its digest. Ratified by name because the reason is a property of
+// the surface, not of the syntax: nothing in the declaration says whether its
+// output is cached.
+var uncachedPrompts = gatekit.Waive(map[string]string{
+	"internal/compose/orgbrief:askSystem": "Ask answers are not cached (orgbrief.Service.Ask says so and explains why: a question is asked once and read once). Binding the ask prompt to the BRIEF's key would rewrite every cached brief for a change that cannot affect one.",
+})
+
+// promptSurfaceFiles walks the prompt surfaces and hands each parsed product file to
+// visit, keyed by its directory.
+func promptSurfaceFiles(t *testing.T, visit func(dir string, file *ast.File)) {
 	t.Helper()
-	prompts := map[string][]string{}
 	fset := token.NewFileSet()
 	for _, root := range promptSurfaceRoots {
 		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -86,33 +101,136 @@ func declaredPrompts(t *testing.T) map[string][]string {
 			if parseErr != nil {
 				return parseErr
 			}
-			dir := filepath.ToSlash(filepath.Dir(path))
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || gen.Tok != token.CONST {
-					continue
-				}
-				for _, spec := range gen.Specs {
-					value, ok := spec.(*ast.ValueSpec)
-					if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
-						continue
-					}
-					lit, ok := value.Values[0].(*ast.BasicLit)
-					if !ok || lit.Kind != token.STRING {
-						continue
-					}
-					if promptConstantName.MatchString(value.Names[0].Name) {
-						prompts[dir] = append(prompts[dir], value.Names[0].Name)
-					}
-				}
-			}
+			visit(filepath.ToSlash(filepath.Dir(path)), file)
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
+}
+
+// declaredPrompts returns, per package directory, the prompt constants it
+// declares.
+func declaredPrompts(t *testing.T) map[string][]string {
+	t.Helper()
+	prompts := map[string][]string{}
+	promptSurfaceFiles(t, func(dir string, file *ast.File) {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+					continue
+				}
+				text, ok := stringValue(value.Values[0], nil)
+				if !ok || len(text) < promptFloor {
+					continue
+				}
+				if promptConstantName.MatchString(value.Names[0].Name) {
+					prompts[dir] = append(prompts[dir], value.Names[0].Name)
+				}
+			}
+		}
+	})
 	return prompts
+}
+
+// handTypedPromptVersions are the directories declaring a `promptVersion` as a
+// hand-typed STRING, whether spelled `const` or `var`.
+//
+// Both spellings, because the compliant form is a `var` — so `var
+// promptVersion = "v2"` is the shape a regression naturally takes, and a census
+// that only read `const` would be blind to exactly the thing it guards.
+func handTypedPromptVersions(t *testing.T) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	promptSurfaceFiles(t, func(dir string, file *ast.File) {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+					continue
+				}
+				if !strings.Contains(strings.ToLower(value.Names[0].Name), "promptversion") {
+					continue
+				}
+				if _, literal := stringValue(value.Values[0], nil); literal {
+					out[dir] = true
+				}
+			}
+		}
+	})
+	return out
+}
+
+// digestedBuilders returns, per package directory, the identifiers handed to
+// ai.PromptDigest there.
+func digestedBuilders(t *testing.T) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	promptSurfaceFiles(t, func(dir string, file *ast.File) {
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "PromptDigest" {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "ai" {
+				return true
+			}
+			for _, arg := range call.Args {
+				if ident, ok := arg.(*ast.Ident); ok {
+					out[dir] = append(out[dir], ident.Name)
+				}
+			}
+			return true
+		})
+	})
+	return out
+}
+
+// promptsReachedByDigest returns, per directory, the prompt constants the
+// digested builders actually name in their bodies.
+//
+// Resolved through the builder rather than by trusting its name: the digest
+// takes a function, and what that function sends is the only thing that says
+// which prompt got covered.
+func promptsReachedByDigest(t *testing.T, builders map[string][]string) map[string]map[string]bool {
+	t.Helper()
+	reached := map[string]map[string]bool{}
+	promptSurfaceFiles(t, func(dir string, file *ast.File) {
+		wanted := builders[dir]
+		if len(wanted) == 0 {
+			return
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !slices.Contains(wanted, fn.Name.Name) {
+				continue
+			}
+			if reached[dir] == nil {
+				reached[dir] = map[string]bool{}
+			}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				if ident, ok := node.(*ast.Ident); ok {
+					reached[dir][ident.Name] = true
+				}
+				return true
+			})
+		}
+	})
+	return reached
 }
 
 func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
@@ -121,146 +239,90 @@ func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
 		t.Fatal("the census found no prompt constant at all, so it is judging nothing")
 	}
 	handTyped := handTypedPromptVersions(t)
-	derived := promptVersionArguments(t)
 
 	var findings []string
 	for dir := range handTyped {
 		if len(prompts[dir]) == 0 {
-			// No prompt to digest: the constant versions something a digest
+			// No prompt to digest: the declaration versions something a digest
 			// cannot see, which is a legitimate reason to keep it by hand.
 			continue
 		}
-		findings = append(findings, dir+": promptVersion is a constant beside "+
+		findings = append(findings, dir+": promptVersion is hand-typed beside "+
 			strings.Join(prompts[dir], ", "))
 	}
 	sort.Strings(findings)
 	if len(findings) > 0 {
-		t.Errorf("%d hand-typed promptVersion constant(s) sit in a package that declares a prompt.\n\n"+
-			"A key keyed on a constant serves yesterday's writing after a deploy that reworded the "+
-			"prompt and left the constant alone — silently, to every record whose facts have not "+
-			"moved. Derive it:\n\n\tvar promptVersion = ai.PromptDigest(theSystemPrompt)\n\n"+
+		t.Errorf("%d hand-typed promptVersion declaration(s) sit in a package that declares a prompt.\n\n"+
+			"A key keyed on a typed string serves yesterday's writing after a deploy that reworded the "+
+			"prompt and left it alone — silently, to every record whose facts have not moved. Derive "+
+			"it:\n\n\tvar promptVersion = ai.PromptDigest(theSystemPromptBuilder)\n\n"+
 			"and keep a separate constant for any wording built in Go code, which a digest cannot "+
 			"reach.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
 	}
-	// The derived side has to be real, or every arm above passes over a tree
-	// where nothing is derived at all.
-	if len(derived) == 0 {
-		t.Error("no package derives a prompt version, so this census is vouching for nothing")
-	}
 }
 
-// handTypedPromptVersions are the directories declaring `promptVersion` as a
-// string CONSTANT rather than deriving it.
-func handTypedPromptVersions(t *testing.T) map[string]bool {
-	t.Helper()
-	out := map[string]bool{}
-	fset := token.NewFileSet()
-	for _, root := range promptSurfaceRoots {
-		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
+func TestEveryPromptOfADerivingPackageRidesItsDigest(t *testing.T) {
+	// A ratification that stops matching is one for a prompt that has moved or
+	// been folded in, and leaving it quietly re-exempts whatever takes its name.
+	defer uncachedPrompts.AssertAllMatched(t)
+
+	prompts := declaredPrompts(t)
+	builders := digestedBuilders(t)
+	if len(builders) == 0 {
+		t.Fatal("no package derives a prompt version, so this census is vouching for nothing")
+	}
+	reached := promptsReachedByDigest(t, builders)
+
+	var findings []string
+	for dir := range builders {
+		for _, prompt := range prompts[dir] {
+			if reached[dir][prompt] || uncachedPrompts.Waived(t, dir+":"+prompt) {
+				continue
 			}
-			if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
-				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
-				return nil
-			}
-			file, parseErr := parser.ParseFile(fset, path, nil, 0)
-			if parseErr != nil {
-				return parseErr
-			}
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || gen.Tok != token.CONST {
-					continue
-				}
-				for _, spec := range gen.Specs {
-					value, ok := spec.(*ast.ValueSpec)
-					if !ok || len(value.Names) == 0 {
-						continue
-					}
-					if strings.Contains(strings.ToLower(value.Names[0].Name), "promptversion") {
-						out[filepath.ToSlash(filepath.Dir(path))] = true
-					}
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("walking %s: %v", root, err)
+			findings = append(findings, dir+": "+prompt)
 		}
 	}
-	return out
-}
-
-// promptVersionArguments returns, per package directory, the identifiers handed
-// to ai.PromptVersion there.
-func promptVersionArguments(t *testing.T) map[string][]string {
-	t.Helper()
-	out := map[string][]string{}
-	fset := token.NewFileSet()
-	for _, root := range promptSurfaceRoots {
-		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
-				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
-				return nil
-			}
-			file, parseErr := parser.ParseFile(fset, path, nil, 0)
-			if parseErr != nil {
-				return parseErr
-			}
-			dir := filepath.ToSlash(filepath.Dir(path))
-			ast.Inspect(file, func(node ast.Node) bool {
-				callExpr, ok := node.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				sel, ok := callExpr.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "PromptDigest" {
-					return true
-				}
-				pkg, ok := sel.X.(*ast.Ident)
-				if !ok || pkg.Name != "ai" {
-					return true
-				}
-				for _, arg := range callExpr.Args {
-					if ident, ok := arg.(*ast.Ident); ok {
-						out[dir] = append(out[dir], ident.Name)
-					}
-				}
-				return true
-			})
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("walking %s: %v", root, err)
-		}
+	sort.Strings(findings)
+	if len(findings) > 0 {
+		t.Errorf("%d prompt(s) are declared by a package that derives its version, but no digested "+
+			"builder sends them.\n\n"+
+			"Deriving one prompt's version and leaving a sibling out reintroduces the defect for the "+
+			"sibling: rewording it moves nothing, and its cached output is served unchanged. Add its "+
+			"builder to the ai.PromptDigest call, or ratify it in uncachedPrompts with the reason its "+
+			"output is not cached.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
 	}
-	return out
 }
 
-// TestThePromptCensusSeesWhatItClaimsTo proves the naming rule the census is
-// keyed on, in both directions.
+// TestThePromptCensusSeesWhatItClaimsTo proves the rules the censuses are keyed
+// on, in both directions.
 //
 // A census asserting a shape is ABSENT passes identically over a clean tree and
 // over a detector that has stopped detecting.
 func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
-	for _, name := range []string{"briefSystem", "askSystem", "dossierSystem", "growthFitSystem", "replyPrompt"} {
+	for _, name := range []string{"briefSystem", "askSystem", "dossierSystem", "growthFitSystem", "judgeSystemPrompt"} {
 		if !promptConstantName.MatchString(name) {
 			t.Errorf("the census does not recognise %q as a prompt constant", name)
 		}
 	}
-	// Names that end in neither word are not prompts, and reporting them would
-	// bury the finding under every string constant in the tree.
 	for _, name := range []string{"storedVersion", "auditKeyDomain", "entityTypePerson", "systemOfRecord"} {
 		if promptConstantName.MatchString(name) {
 			t.Errorf("the census reports %q, which is not a prompt constant", name)
 		}
 	}
-	// And the tree really does hold the ones the rule is written for, so the
-	// naming convention it keys on is the tree's rather than an invention.
+	// A `+` chain is one prompt. The shared reader in this package handles that
+	// (and parenthesised and `string(...)` spellings); this asserts the census
+	// actually goes through it, since reading only the first fragment would let
+	// a prompt escape by being split across lines.
+	joined, ok := stringValue(&ast.BinaryExpr{
+		Op: token.ADD,
+		X:  &ast.BasicLit{Kind: token.STRING, Value: `"You write "`},
+		Y:  &ast.BasicLit{Kind: token.STRING, Value: `"a brief."`},
+	}, nil)
+	if !ok || joined != "You write a brief." {
+		t.Errorf("a prompt assembled with `+` is not read whole: %q", joined)
+	}
+	// The tree really does hold the constants the rule is written for, so the
+	// naming it keys on is the tree's rather than an invention.
 	prompts := declaredPrompts(t)
 	found := map[string]bool{}
 	for _, names := range prompts {
@@ -271,6 +333,13 @@ func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
 	for _, want := range []string{"briefSystem", "dossierSystem", "growthFitSystem"} {
 		if !found[want] {
 			t.Errorf("the census no longer finds %s — the naming rule has drifted from the tree", want)
+		}
+	}
+	// And it does NOT count a provenance label that ends in the same word, which
+	// would fire on a package whose hand-typed version is legitimate.
+	for _, label := range []string{"trustSystem", "roleSystem", "actorTypeSystem", "transcriptSourceSystem"} {
+		if found[label] {
+			t.Errorf("the census counts %s as a prompt; it names where a record came from", label)
 		}
 	}
 }

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -77,10 +77,16 @@ var uncachedPrompts = gatekit.Waive(map[string]string{
 	"internal/compose/orgbrief:askSystem": "Ask answers are not cached (orgbrief.Service.Ask says so and explains why: a question is asked once and read once). Binding the ask prompt to the BRIEF's key would rewrite every cached brief for a change that cannot affect one.",
 })
 
-// promptSurfaceFiles walks the prompt surfaces and hands each parsed product file to
-// visit, keyed by its directory.
-func promptSurfaceFiles(t *testing.T, visit func(dir string, file *ast.File)) {
+// promptSurfaceFiles returns the product files of each prompt surface, grouped
+// by package directory.
+//
+// Grouped rather than visited one at a time because Go constants are
+// package-scoped: a prompt lives in `write.go` while the version that caches its
+// output lives in `input.go`, and a census that resolved names file by file
+// would not see across that.
+func promptSurfaceFiles(t *testing.T) map[string][]*ast.File {
 	t.Helper()
+	byDir := map[string][]*ast.File{}
 	fset := token.NewFileSet()
 	for _, root := range promptSurfaceRoots {
 		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -101,13 +107,15 @@ func promptSurfaceFiles(t *testing.T, visit func(dir string, file *ast.File)) {
 			if parseErr != nil {
 				return parseErr
 			}
-			visit(filepath.ToSlash(filepath.Dir(path)), file)
+			dir := filepath.ToSlash(filepath.Dir(path))
+			byDir[dir] = append(byDir[dir], file)
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
+	return byDir
 }
 
 // declaredPrompts returns, per package directory, the prompt constants it
@@ -115,27 +123,30 @@ func promptSurfaceFiles(t *testing.T, visit func(dir string, file *ast.File)) {
 func declaredPrompts(t *testing.T) map[string][]string {
 	t.Helper()
 	prompts := map[string][]string{}
-	promptSurfaceFiles(t, func(dir string, file *ast.File) {
-		for _, decl := range file.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok || gen.Tok != token.CONST {
-				continue
-			}
-			for _, spec := range gen.Specs {
-				value, ok := spec.(*ast.ValueSpec)
-				if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+	for dir, files := range promptSurfaceFiles(t) {
+		consts := stringConstants(files)
+		for _, file := range files {
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
 					continue
 				}
-				text, ok := stringValue(value.Values[0], nil)
-				if !ok || len(text) < promptFloor {
-					continue
-				}
-				if promptConstantName.MatchString(value.Names[0].Name) {
-					prompts[dir] = append(prompts[dir], value.Names[0].Name)
+				for _, spec := range gen.Specs {
+					value, ok := spec.(*ast.ValueSpec)
+					if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+						continue
+					}
+					text, ok := stringValue(value.Values[0], consts)
+					if !ok || len(text) < promptFloor {
+						continue
+					}
+					if promptConstantName.MatchString(value.Names[0].Name) {
+						prompts[dir] = append(prompts[dir], value.Names[0].Name)
+					}
 				}
 			}
 		}
-	})
+	}
 	return prompts
 }
 
@@ -148,26 +159,29 @@ func declaredPrompts(t *testing.T) map[string][]string {
 func handTypedPromptVersions(t *testing.T) map[string]bool {
 	t.Helper()
 	out := map[string]bool{}
-	promptSurfaceFiles(t, func(dir string, file *ast.File) {
-		for _, decl := range file.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
-				continue
-			}
-			for _, spec := range gen.Specs {
-				value, ok := spec.(*ast.ValueSpec)
-				if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+	for dir, files := range promptSurfaceFiles(t) {
+		consts := stringConstants(files)
+		for _, file := range files {
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
 					continue
 				}
-				if !strings.Contains(strings.ToLower(value.Names[0].Name), "promptversion") {
-					continue
-				}
-				if _, literal := stringValue(value.Values[0], nil); literal {
-					out[dir] = true
+				for _, spec := range gen.Specs {
+					value, ok := spec.(*ast.ValueSpec)
+					if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+						continue
+					}
+					if !strings.Contains(strings.ToLower(value.Names[0].Name), "promptversion") {
+						continue
+					}
+					if _, resolved := stringValue(value.Values[0], consts); resolved {
+						out[dir] = true
+					}
 				}
 			}
 		}
-	})
+	}
 	return out
 }
 
@@ -176,27 +190,29 @@ func handTypedPromptVersions(t *testing.T) map[string]bool {
 func digestedBuilders(t *testing.T) map[string][]string {
 	t.Helper()
 	out := map[string][]string{}
-	promptSurfaceFiles(t, func(dir string, file *ast.File) {
-		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "PromptDigest" {
-				return true
-			}
-			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "ai" {
-				return true
-			}
-			for _, arg := range call.Args {
-				if ident, ok := arg.(*ast.Ident); ok {
-					out[dir] = append(out[dir], ident.Name)
+	for dir, files := range promptSurfaceFiles(t) {
+		for _, file := range files {
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
 				}
-			}
-			return true
-		})
-	})
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "PromptDigest" {
+					return true
+				}
+				if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "ai" {
+					return true
+				}
+				for _, arg := range call.Args {
+					if ident, ok := arg.(*ast.Ident); ok {
+						out[dir] = append(out[dir], ident.Name)
+					}
+				}
+				return true
+			})
+		}
+	}
 	return out
 }
 
@@ -209,27 +225,27 @@ func digestedBuilders(t *testing.T) map[string][]string {
 func promptsReachedByDigest(t *testing.T, builders map[string][]string) map[string]map[string]bool {
 	t.Helper()
 	reached := map[string]map[string]bool{}
-	promptSurfaceFiles(t, func(dir string, file *ast.File) {
+	for dir, files := range promptSurfaceFiles(t) {
 		wanted := builders[dir]
 		if len(wanted) == 0 {
-			return
+			continue
 		}
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || !slices.Contains(wanted, fn.Name.Name) {
-				continue
-			}
-			if reached[dir] == nil {
-				reached[dir] = map[string]bool{}
-			}
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				if ident, ok := node.(*ast.Ident); ok {
-					reached[dir][ident.Name] = true
+		reached[dir] = map[string]bool{}
+		for _, file := range files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil || !slices.Contains(wanted, fn.Name.Name) {
+					continue
 				}
-				return true
-			})
+				ast.Inspect(fn.Body, func(node ast.Node) bool {
+					if ident, ok := node.(*ast.Ident); ok {
+						reached[dir][ident.Name] = true
+					}
+					return true
+				})
+			}
 		}
-	})
+	}
 	return reached
 }
 

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -307,17 +307,33 @@ func followBuilders(pkg promptPackage, follow []string, reached map[string]bool)
 	}
 }
 
-// returnedNames are the identifiers a body's return statements name — the
-// functions and constants its value is built from.
+// returnedNames are the identifiers this body's OWN return statements name —
+// the constants its value is built from, and the functions it delegates to.
+//
+// A nested closure's return is not this function's, so the walk does not descend
+// into one. Otherwise a helper defined inline and never called would put its
+// prompt on the chain, which is the same over-reach as following a call made for
+// an unrelated effect. A literal handed to the digest is a builder in its own
+// right and is walked as one, from its own body.
+//
+// A function called INSIDE a return expression is followed on purpose: `return
+// statusSystemFor(fence)` sends what that builder sends, and delegation is the
+// shape this has to see through.
 func returnedNames(body *ast.BlockStmt) []string {
 	var names []string
 	ast.Inspect(body, func(node ast.Node) bool {
+		if _, nested := node.(*ast.FuncLit); nested {
+			return false
+		}
 		ret, ok := node.(*ast.ReturnStmt)
 		if !ok {
 			return true
 		}
 		for _, result := range ret.Results {
 			ast.Inspect(result, func(inner ast.Node) bool {
+				if _, nested := inner.(*ast.FuncLit); nested {
+					return false
+				}
 				if ident, ok := inner.(*ast.Ident); ok {
 					names = append(names, ident.Name)
 				}

--- a/backend/promptversionderived_test.go
+++ b/backend/promptversionderived_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A cached answer is keyed by a fingerprint, and the fingerprint has to move
+// when the prompt that produced the answer moves. Otherwise a deploy that
+// rewords a prompt keeps serving text written the old way to every record whose
+// facts have not changed — which is most of them.
+//
+// That is not hypothetical. `orgbrief`'s own docblock recorded it happening, in
+// its own words: a deploy reworded the floor, left the version constant alone,
+// and kept serving the old sentences. The remedy chosen at the time was a
+// comment telling the next author to remember. This is the test that replaces
+// remembering.
+//
+// THE RULE: a `promptVersion` declaration in a package that DECLARES A PROMPT
+// must be derived — `ai.PromptDigest(theSystemPrompt)` — never a hand-typed
+// string constant.
+//
+// That is the subject precisely, and it took two wrong ones to find. "Every
+// declared prompt must be digested" reports 28 surfaces, most of which cache
+// nothing — a prompt with no cached output has no key to go stale, and
+// reporting them buries the few that matter. "Every package that declares a
+// prompt AND computes a fingerprint" still reports 18, because `internal/compose`
+// is one directory holding a dozen unrelated surfaces and a directory is the
+// wrong grain for coupling a prompt to the key that caches ITS output.
+//
+// What is exactly derivable is the thing being replaced: a constant named
+// `promptVersion`. There are two in the tree, and one of them is correct —
+// `personbrief` declares no prompt at all and writes its whole output from Go
+// code, so there is nothing for a digest to see. The rule does not need a
+// waiver for it; it simply does not apply.
+//
+// WHAT THE RULE DOES NOT COVER, stated because a reader will otherwise assume
+// it does: wording built by Go code — a `fmt.Sprintf` inside a deterministic
+// floor — is not a string anything can hash. Those surfaces keep an explicit
+// version constant for that half, and the two ride the fingerprint together.
+// `personbrief` is the pure case: it declares no prompt at all, writes its
+// whole output from code, and is correctly absent from this census. "Adopt it
+// everywhere" would have been the wrong answer for exactly one of the four.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// promptConstant is a declared prompt: a package-level string constant whose
+// name ends in `System` or `Prompt`. That is this tree's own naming — every one
+// of them is `briefSystem`, `askSystem`, `dossierSystem`, `growthFitSystem` —
+// and a census keyed on the naming is a census that finds the next one.
+var promptConstantName = regexp.MustCompile(`(?:System|Prompt)$`)
+
+// promptSurfaces are the trees where a prompt may be declared.
+var promptSurfaceRoots = []string{"internal/compose", "internal/modules"}
+
+// declaredPrompts returns, per package directory, the prompt constants it
+// declares.
+func declaredPrompts(t *testing.T) map[string][]string {
+	t.Helper()
+	prompts := map[string][]string{}
+	fset := token.NewFileSet()
+	for _, root := range promptSurfaceRoots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if name := entry.Name(); name == "testdata" || name == "contracts" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			dir := filepath.ToSlash(filepath.Dir(path))
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					value, ok := spec.(*ast.ValueSpec)
+					if !ok || len(value.Names) == 0 || len(value.Values) == 0 {
+						continue
+					}
+					lit, ok := value.Values[0].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					if promptConstantName.MatchString(value.Names[0].Name) {
+						prompts[dir] = append(prompts[dir], value.Names[0].Name)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	return prompts
+}
+
+func TestEveryPromptVersionIsDerivedFromItsPrompt(t *testing.T) {
+	prompts := declaredPrompts(t)
+	if len(prompts) == 0 {
+		t.Fatal("the census found no prompt constant at all, so it is judging nothing")
+	}
+	handTyped := handTypedPromptVersions(t)
+	derived := promptVersionArguments(t)
+
+	var findings []string
+	for dir := range handTyped {
+		if len(prompts[dir]) == 0 {
+			// No prompt to digest: the constant versions something a digest
+			// cannot see, which is a legitimate reason to keep it by hand.
+			continue
+		}
+		findings = append(findings, dir+": promptVersion is a constant beside "+
+			strings.Join(prompts[dir], ", "))
+	}
+	sort.Strings(findings)
+	if len(findings) > 0 {
+		t.Errorf("%d hand-typed promptVersion constant(s) sit in a package that declares a prompt.\n\n"+
+			"A key keyed on a constant serves yesterday's writing after a deploy that reworded the "+
+			"prompt and left the constant alone — silently, to every record whose facts have not "+
+			"moved. Derive it:\n\n\tvar promptVersion = ai.PromptDigest(theSystemPrompt)\n\n"+
+			"and keep a separate constant for any wording built in Go code, which a digest cannot "+
+			"reach.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
+	}
+	// The derived side has to be real, or every arm above passes over a tree
+	// where nothing is derived at all.
+	if len(derived) == 0 {
+		t.Error("no package derives a prompt version, so this census is vouching for nothing")
+	}
+}
+
+// handTypedPromptVersions are the directories declaring `promptVersion` as a
+// string CONSTANT rather than deriving it.
+func handTypedPromptVersions(t *testing.T) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	fset := token.NewFileSet()
+	for _, root := range promptSurfaceRoots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
+				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					value, ok := spec.(*ast.ValueSpec)
+					if !ok || len(value.Names) == 0 {
+						continue
+					}
+					if strings.Contains(strings.ToLower(value.Names[0].Name), "promptversion") {
+						out[filepath.ToSlash(filepath.Dir(path))] = true
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	return out
+}
+
+// promptVersionArguments returns, per package directory, the identifiers handed
+// to ai.PromptVersion there.
+func promptVersionArguments(t *testing.T) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	fset := token.NewFileSet()
+	for _, root := range promptSurfaceRoots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") ||
+				strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			dir := filepath.ToSlash(filepath.Dir(path))
+			ast.Inspect(file, func(node ast.Node) bool {
+				callExpr, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := callExpr.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "PromptDigest" {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "ai" {
+					return true
+				}
+				for _, arg := range callExpr.Args {
+					if ident, ok := arg.(*ast.Ident); ok {
+						out[dir] = append(out[dir], ident.Name)
+					}
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	return out
+}
+
+// TestThePromptCensusSeesWhatItClaimsTo proves the naming rule the census is
+// keyed on, in both directions.
+//
+// A census asserting a shape is ABSENT passes identically over a clean tree and
+// over a detector that has stopped detecting.
+func TestThePromptCensusSeesWhatItClaimsTo(t *testing.T) {
+	for _, name := range []string{"briefSystem", "askSystem", "dossierSystem", "growthFitSystem", "replyPrompt"} {
+		if !promptConstantName.MatchString(name) {
+			t.Errorf("the census does not recognise %q as a prompt constant", name)
+		}
+	}
+	// Names that end in neither word are not prompts, and reporting them would
+	// bury the finding under every string constant in the tree.
+	for _, name := range []string{"storedVersion", "auditKeyDomain", "entityTypePerson", "systemOfRecord"} {
+		if promptConstantName.MatchString(name) {
+			t.Errorf("the census reports %q, which is not a prompt constant", name)
+		}
+	}
+	// And the tree really does hold the ones the rule is written for, so the
+	// naming convention it keys on is the tree's rather than an invention.
+	prompts := declaredPrompts(t)
+	found := map[string]bool{}
+	for _, names := range prompts {
+		for _, name := range names {
+			found[name] = true
+		}
+	}
+	for _, want := range []string{"briefSystem", "dossierSystem", "growthFitSystem"} {
+		if !found[want] {
+			t.Errorf("the census no longer finds %s — the naming rule has drifted from the tree", want)
+		}
+	}
+}


### PR DESCRIPTION
## The defect

A cached answer is keyed by a fingerprint, and the fingerprint has to move when the prompt that produced it moves. Four surfaces keyed theirs on a hand-typed constant somebody had to remember to bump.

That does not hold, and this is not hypothetical — `orgbrief`'s own docblock recorded it happening, in its own words:

> A deploy that reworded it and left this alone kept serving the old sentences to every account whose facts had not moved — which is most of them.

Nothing errors. Nothing is logged. The reader has no way to tell they are looking at yesterday's writing. **The remedy on record was a comment telling the next author to remember.** This replaces remembering.

## The change

`ai.PromptDigest(prompts...)` fingerprints the prompt text, so editing a prompt moves the key whether or not anybody bumps anything.

Each surface keeps a **separate** hand-bumped constant for the half a digest cannot reach — wording built by Go code, a `fmt.Sprintf` in a deterministic floor, is not a string anything can hash — and the two ride the fingerprint together.

| surface | derived from the prompt | still bumped by hand |
|---|---|---|
| `orgbrief` | `briefSystem`, `askSystem` | `floorVersion` — the deterministic floor's sentences |
| `orgdossier` | `dossierSystem` | `assemblyVersion` — the assembly rules |
| `orgdossier` growth-fit | `growthFitSystem` | `growthFitAssemblyVersion` — required inputs, abstention floor |
| `dealstatus` | `statusSystem` | `projectionVersion` — the shape facts render into |
| `personbrief` | — | **correctly absent, see below** |

Splitting them is the point. The half that can be derived stops depending on memory, and the half that cannot is now named for what it actually versions instead of a `promptVersion` that claimed to cover the prompt too.

## `personbrief` is not an oversight

It declares no prompt at all and writes its whole output from Go code, so there is nothing for a digest to see. The gate does not waive it — the rule simply does not apply. **"Adopt it everywhere" would have been the wrong answer for exactly one of the four**, which is why the gate is keyed on a condition rather than a list.

## Choosing the gate's subject

Two broader subjects were tried and discarded, because a gate that reports things nobody can act on buries the ones they can:

| candidate subject | reports | why not |
|---|---|---|
| every declared prompt must be digested | 28 | most cache nothing; a prompt with no cached output has no key to go stale |
| every package that declares a prompt AND computes a fingerprint | 18 | `internal/compose` is one directory holding a dozen unrelated surfaces — the wrong grain for coupling a prompt to the key caching *its* output |
| **a `promptVersion` CONSTANT in a package that also declares a prompt** | **the 4 real ones** | exactly the thing being replaced |

## Why `PromptDigest` and not `PromptVersion`

`aicert.PromptVersion` already exists and answers a **different question**: whether a stored certification record still describes the request the tree builds today. It hashes the *built request* through the task census, because a cert record has to notice a change anywhere in assembly. This one hashes prompt text, because a cache key only has to move when the wording does.

Two functions of one name computing different things is the legibility trap this sweep exists to remove, so mine is named for what it fingerprints and its docblock names the neighbour.

## Blast radius: every cached answer is rewritten once

The fingerprints change, so the first read of each account's brief, dossier, growth-fit assessment and deal-status card after deploy is a miss and gets rewritten. **That is a one-time cost and it is the correct behaviour** — these caches hold text written by prompt wording that is now versioned differently, and serving it beside newly-keyed text is the thing being fixed.

## No aicert re-run is owed

Checked rather than assumed. **No prompt text changes in this PR** — only the cache-key constants that were never part of a model request. `aicert` stamps `prompt_version` from the scenarios and the request each site's own code builds through the census, so an unchanged request digests identically. The `aicert` package passes in `make check-backend`, including the record-currency gate that goes red exactly when a corpus or prompt edit needs the paid lane re-run.

## Verification

`make check-backend` green on `a92cfcfcf`.

The census asserts a shape is ABSENT, which passes identically over a clean tree and over a detector that has stopped detecting — so both mutants were verified to **apply and compile** before their result was believed:

| mutant | result |
|---|---|
| a hand-typed `const promptVersion` returns to `orgdossier` | **FAIL** — `orgdossier: promptVersion is a constant beside growthFitSystem, dossierSystem` |
| every `ai.PromptDigest` call replaced by a literal | **FAIL** — `no package derives a prompt version, so this census is vouching for nothing` |
| the digest's `"\x00"` separator replaced by `""` | **FAIL** — `("ab","c") and ("a","bc") share the digest prompts-ba7816bf8f01cfea` |

`TestThePromptCensusSeesWhatItClaimsTo` proves the naming rule in both directions, and checks the tree really holds the constants the rule is written for, so the convention it keys on is the tree's rather than an invention.

`PromptDigest` is at **100% statement coverage**. Its tests prove the digest moves when wording moves, is stable when it does not, and — the one worth having — that text shifting across the prompt boundary is a different input, since `("ab","c")` and `("a","bc")` would otherwise collide and hold a stale key by a route nobody would think to test for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives cache-key prompt versions from the prompts actually sent and enforces it with a gate. Old behavior used hand-typed promptVersion constants that could serve stale text; new behavior uses `ai.PromptDigest(builders...)` (boundary rule canonicalized and length‑framed) plus explicit constants for Go-built wording so keys move when either half changes.

- Reviewer focus
  - `internal/compose/orgbrief`: `Fingerprint` now uses `floorVersion + "\x00" + promptVersion + "\x00" + routing + "\x00" + input`; `promptVersion` is `ai.PromptDigest(briefSystemFor)`.
  - `internal/compose/orgdossier/service.go`: `Fingerprint` now uses `assemblyVersion + "\x00" + promptVersion + "\x00" + routing + "\x00" + input`; `promptVersion` is `ai.PromptDigest(dossierSystemFor)`.
  - `internal/compose/orgdossier/growthfitservice.go`: `growthFitFingerprint` now uses `growthFitAssemblyVersion + "\x00" + growthFitPromptVersion + "\x00" + routing + ...`; `growthFitPromptVersion` is `ai.PromptDigest(growthFitSystemFor)` (separate from the dossier).
  - `internal/compose/dealstatus/input.go`: `Fingerprint` now includes `projectionVersion + "\x00" + promptVersion`; `promptVersion = ai.PromptDigest(statusSystemFor)`.
  - `internal/modules/ai/promptdigest.go`: new `PromptDigest` takes builders, canonicalizes the boundary rule, and length‑frames each prompt to prevent collisions; returns a stable `"prompts-"` digest.
  - Gate `backend/promptversionderived_test.go`: rejects hand-typed or aliased `promptVersion` (`const` or `var`), resolves per‑package aliases, reads every name a const spec binds, ensures every declared prompt in a deriving package is reached by a digested builder, follows builders only through returned values (no nested‑closure descent), flags spread args, separates prompts from provenance labels via a length floor, asserts those labels exist before excluding them, and now builds both prompt and label maps in one walk.

- Rollout
  - One-time cache rewrite on first read for affected surfaces; no `aicert` re-run required.

<sup>Written for commit 6349fd45b1222f39bf6db0b4f6d42e787adc0bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching for generated deal statuses, briefs, growth assessments, and dossiers.
  * Generated content now refreshes when prompt wording, formatting boundaries, or assembly rules change, reducing stale results.
  * Improved handling of distinct prompt inputs to prevent cache collisions.

* **Tests**
  * Expanded coverage for prompt changes, boundary behavior, separator handling, and cache-version updates.
  * Added safeguards to ensure prompt-driven cache versions are tracked and updated consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->