### PR TITLE
fix(compose): the filing tickbox appears only where it decides something

### DIFF
--- a/docs/how-to/run-a-project.md
+++ b/docs/how-to/run-a-project.md
@@ -140,16 +140,18 @@ can only offer when you are replying from a deal. Replying from a company or a
 contact has no deal to fall back on. If neither names a project, nothing is
 shown at all.
 
-The **Subject** field is stamped with `[KEY]`. Untick the box and both lines go
-and the tag is removed; tick it again and the tag comes back in front of
+The **Subject** field is stamped with `[KEY]`.
+
+**The tickbox appears only when the project came from the DEAL.** There it is a
+real choice: nothing else is carrying that project, so unticking both drops the
+filing and removes the tag. Tick it again and the tag comes back in front of
 whatever you have typed. A tag you delete by hand stays deleted.
 
-**What unticking does depends on where the project came from.** On the deal
-fallback it genuinely declines the filing: nothing else was carrying it. On a
-thread already filed under a project, the reply **still inherits that project
-link** from the message it answers — unticking removes the tag and the claim,
-not the filing. To move a filed conversation, use **Relink**, which moves the
-whole thread.
+**A thread already filed under a project gets no tickbox** — only the sentence
+and the tag. The reply inherits that project from the message it answers and no
+control on this form can undo it, so offering one would be offering a choice
+the send does not honour. To move a filed conversation, use **Relink** on its
+timeline row, which moves the whole thread rather than one message.
 
 If the subject already carries a **different** project's key, sending under this
 one removes it — two keys in a subject make the inbound rule ambiguous, so it

--- a/docs/tutorials/run-your-first-project.md
+++ b/docs/tutorials/run-your-first-project.md
@@ -294,11 +294,13 @@ back out of the Subject — the tag would otherwise promise a routing that will
 not happen. Tick it again and the tag returns, in front of whatever you have
 since typed. You can also just delete the tag yourself; it stays deleted.
 
-One thing unticking does **not** do: if the conversation was already filed
-under a project, the reply still lands on that project, because a reply
-inherits the links of the message it answers. Unticking takes off the tag and
-the claim, not the filing. Moving a filed conversation is **Relink**, which
-moves all of it at once.
+**The box only appears when the project came from the deal**, as it does here.
+Reply to a conversation that is *already* filed under a project and you get the
+sentence and the tag but no box: that reply lands on the project whatever you
+do, because it inherits the filing of the message it answers. Rather than offer
+you a switch that would not be honoured, Margince states the fact. Moving a
+filed conversation is **Relink**, on the message's own timeline row, and it
+moves the whole thread at once.
 
 > **The tag is doing real work, not decoration.** Your customer's mail client
 > keeps `[NER-1]` in the subject when they reply. Margince reads it back on the

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1950,7 +1950,7 @@ describe("ComposeModal started from an account", () => {
           ],
         }),
       "GET /projects/pr-1": () =>
-        jsonResponse({ id: "pr-1", name: "ERP rollout Acme" }),
+        jsonResponse({ id: "pr-1", name: "ERP rollout Acme", key: "ERP-27" }),
     });
     render(
       <ComposeModal
@@ -1968,6 +1968,17 @@ describe("ComposeModal started from an account", () => {
     // It SAYS rather than offers: a picker here would file one message of a
     // conversation away from the rest of it.
     expect(screen.queryByRole("combobox", { name: /Project/ })).toBeNull();
+    // And no tickbox either. The send inherits the thread's links whatever
+    // this form says, so a box here would offer a choice that is not honoured
+    // — unticking it would remove the tag and file the reply anyway.
+    expect(screen.queryByLabelText("File under this project")).toBeNull();
+    // The subject is still stamped: the tag is what carries the project out to
+    // the customer's reply, and nothing above declined it.
+    await waitFor(() =>
+      expect(
+        (screen.getByPlaceholderText("Subject") as HTMLInputElement).value,
+      ).toBe("[ERP-27]"),
+    );
   });
 
   // A thread filed under no project has nothing to announce, and "filed under

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -384,6 +384,27 @@ function ProjectFiling({
     return null;
   }
   const tag = subjectTag(project);
+  // A THREAD already filed under a project settles this reply too: the send
+  // inherits the anchor's links, and no control on this form can undo that.
+  // So the thread reading states the filing and offers nothing — a tickbox
+  // here would promise a choice the send does not honour, and unticking it
+  // would still file. Moving a filed conversation is Relink, on the message's
+  // own timeline row, which moves the whole thread rather than one message.
+  //
+  // The DEAL reading is a genuine choice: nothing else carries that project,
+  // so the box decides both the filing and the tag.
+  if (filing.from === "thread") {
+    return (
+      <div className="stack-2xs">
+        <p className="t-caption">
+          {t("compose.filedUnder", { project: project.name })}
+        </p>
+        {tag && (
+          <p className="t-caption">{t("compose.subjectTagged", { tag })}</p>
+        )}
+      </div>
+    );
+  }
   return (
     <div className="stack-2xs">
       <Checkbox
@@ -394,12 +415,7 @@ function ProjectFiling({
       />
       {filed && (
         <p className="t-caption">
-          {t(
-            filing.from === "deal"
-              ? "compose.filedUnderDeal"
-              : "compose.filedUnder",
-            { project: project.name },
-          )}
+          {t("compose.filedUnderDeal", { project: project.name })}
         </p>
       )}
       {filed && tag && (
@@ -1464,7 +1480,11 @@ function useProjectFiling(input: {
       : ({ kind: "none" } as const);
   const derived = filing.kind === "derived" ? filing.projectId : undefined;
   const { project } = useProjectRecord(derived);
-  const filed = Boolean(derived) && !declined;
+  // A thread's filing is not declinable — the send inherits it whatever this
+  // form says — so the thread reading shows no tickbox, and a `declined` left
+  // over from a deal reading must not silently strip the tag here.
+  const declinable = filing.kind === "derived" && filing.from === "deal";
+  const filed = Boolean(derived) && (!declinable || !declined);
   const tag = subjectTag(project);
   // The tag follows the filing, applied once per change rather than on every
   // render: `applied` remembers what this composer last wrote, so a rerender


### PR DESCRIPTION
fix(compose): the filing tickbox appears only where it decides something

A reply inherits the record links of the message it answers, so a conversation
already filed under a project files its replies there whatever this form says.
The tickbox was offered anyway, and unticking it removed the subject tag and
the sentence while the reply still landed on the project — a control that read
as a choice and was not one.

It is now shown only for the DEAL fallback, where it is a genuine choice:
nothing else carries that project, so unticking both drops the filing and
removes the tag. A thread-derived filing states the fact and offers the tag,
with no switch to throw.

`declined` is confined to the case that offers it, so a decline made on one
reading cannot silently strip the tag on the other.

The control that moves a filed conversation is unchanged and is the right one:
Relink, on the message's own timeline row, which moves the whole thread rather
than filing one message away from the rest of it.

Both guides are corrected to describe the tickbox as it now behaves.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the project filing tickbox only when it can decide filing. Previously the checkbox appeared even on replies in already-filed threads; unticking removed the subject tag while the reply still filed, which misled users.

- Compose: thread-derived filing shows a statement and applies the subject tag; no checkbox and no decline. Moving a filed conversation remains via Relink on the timeline row.
- Compose: deal fallback shows the checkbox; it controls both filing and the tag. Unticking drops the filing and removes the tag.
- Constrain `declined` to the deal context so it cannot strip tags when viewing a thread-derived filing.
- Update tests to expect no checkbox on thread-derived replies and a stamped subject tag; update guides to match the new behavior.

<sup>Written for commit da7a5237806e5db0963e8e1c59993c3f90998429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified project filing behavior for email replies.
  * Thread-inherited project filings now appear as informational and cannot be unchecked.
  * Deal-derived filings retain the filing checkbox.
  * Project subject tags remain visible for already-filed conversations.
  * Relinking now clearly indicates that the entire thread will move.

* **Documentation**
  * Updated project and email-reply guidance to explain filing and relinking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->