### PR TITLE
feat(compose): one project picker, on every message, that fills the subject

### DIFF
--- a/docs/how-to/run-a-project.md
+++ b/docs/how-to/run-a-project.md
@@ -124,66 +124,52 @@ see who already has access. A share never widens anything beyond this project.
 
 ### Sending
 
-Two composers, two behaviours.
+Every composer — a reply, and a message started from a company page — carries
+one control above the Subject field:
 
-**Replying (from a project, a deal or any timeline).** The composer works the
-filing out and tells you, above the Subject field:
+> **Project**  `NER-1 · Nordwind ERP rollout` ▾
 
-> ☑ **File under this project**
-> This will be filed under *Name*, this deal's project.
-> [KEY] is added to the subject so their reply files itself here.
+Open it and you get **No project**, then every live project the record's
+company reaches, as `KEY · Name`. That includes the projects the company works
+as a **partner** or a **subcontractor**, not only the ones it is the customer
+of.
 
-It derives the project the way the inbound ladder does, as far as it can: the
-thread's own project first — the line then reads *…like the rest of this
-conversation* — and the **deal's** project when the thread has none, which it
-can only offer when you are replying from a deal. Replying from a company or a
-contact has no deal to fall back on. If neither names a project, nothing is
-shown at all.
+**Choosing a project puts `[KEY]` at the front of the Subject.** Choosing **No
+project** takes it out. Switching to another project swaps the tag. There is no
+explanation printed beside it, because the Subject field shows the tag: edit or
+delete it like any other text, and it stays as you left it.
 
-The **Subject** field is stamped with `[KEY]`.
+**What it starts on.** The picker suggests, in this order:
 
-**The tickbox appears only when the project came from the DEAL.** There it is a
-real choice: nothing else is carrying that project, so unticking both drops the
-filing and removes the tag. Tick it again and the tag comes back in front of
-whatever you have typed. A tag you delete by hand stays deleted.
+1. the **thread's own project**, when the conversation is already filed;
+2. the **deal's project**, when you are replying from a deal that names one;
+3. the company's **only live project**, when it has exactly one and neither of
+   the above applies.
 
-**A thread already filed under a project gets no tickbox** — only the sentence
-and the tag. The reply inherits that project from the message it answers and no
-control on this form can undo it, so offering one would be offering a choice
-the send does not honour. To move a filed conversation, use **Relink** on its
-timeline row, which moves the whole thread rather than one message.
+Otherwise it starts on **No project**. A suggestion is a starting point, not a
+decision — set it to None or to a different project whenever the suggestion is
+wrong.
 
-If the subject already carries a **different** project's key, sending under this
-one removes it — two keys in a subject make the inbound rule ambiguous, so it
-files under neither. Be aware that the rule is shape-based, not a lookup: any
-bracketed word that *could* be a key goes, `[FYI]` included. Only a group that
-could never be one — `[2026]`, which is not letter-led — survives.
+Nothing is shown at all when the company reaches no live project: a list whose
+only entry is None asks a question with one answer.
 
-> **When the project came from the DEAL, the subject tag is the only thing
-> carrying it.** A reply inherits the links of the message it answers and can
-> add none of its own, so a reply on a thread the project never reached does
-> not put your sent copy on the project's timeline — the customer's tagged
-> answer is what brings the conversation in. A thread already filed does not
-> have this problem: its reply inherits the project link.
+**On a message started from a company page**, the choice does one extra job:
+**Draft with AI** then reads only what is filed under that project or under no
+project, and the **Based on:** line lists what it drew from.
+
+If the subject already carries a **different** project's key, choosing this one
+removes it — two keys in a subject make the inbound rule ambiguous, so it files
+under neither. The rule is shape-based rather than a lookup: any bracketed word
+that *could* be a key goes, `[FYI]` included. Only a group that could never be
+one — `[2026]`, which is not letter-led — survives.
+
+> **On a reply, the tag may be the only thing carrying the project.** A reply
+> inherits the record links of the message it answers and can add none of its
+> own, so a reply on a thread the project never reached does not put your sent
+> copy on the project's timeline — the customer's tagged answer is what brings
+> the conversation in. A thread already filed does not have this problem, and
+> neither does a message started from a company page, which sends the link.
 > Tracked as [issue #2422](https://github.com/margince/margince/issues/2422).
-
-**Writing to an account (company page → Write email).** A new conversation has
-no thread to inherit from, so this composer asks. Under **Draft to** — and
-under **Related to**, when the account has deals — is the **Project** picker:
-**No project**, then the account's live projects as `KEY · Name`. One live
-project is pre-selected; several start at **No project**. Closed projects are
-not offered.
-
-Picking one shows **Scoped to KEY** and does two things:
-
-1. **Draft with AI** reads only what is filed under that project or under no
-   project. Mail filed under another project on the same account is left out of
-   the draft and of its **Based on:** line.
-2. The sent message is **linked** to the project — this composer does send the
-   link — so it appears on the project's timeline straight away.
-
-You can also file without either control: put the key in square brackets in the
-subject — `[NER-1] kickoff agenda` — and the rule below does the rest.
 
 ### Receiving
 

--- a/docs/tutorials/run-your-first-project.md
+++ b/docs/tutorials/run-your-first-project.md
@@ -259,48 +259,40 @@ one if you give it.
 
 ## 7. Email, and how it finds the project
 
-There are two composers, and they behave differently on purpose.
-
-### Replying from the deal or the project
-
 Open the project (or the deal) and press **Reply** on a message in the
-timeline. Above the Subject field you will see:
+timeline. Above the Subject field is one control:
 
-> ☑ **File under this project**
-> This will be filed under Nordwind ERP rollout, this deal's project.
-> [NER-1] is added to the subject so their reply files itself here.
+> **Project**  `NER-1 · Nordwind ERP rollout` ▾
 
 And the **Subject** field already contains `[NER-1]`.
 
-Nothing was asked of you. The composer worked out where this message belongs
-and said so, in this order:
+Open the picker and you get **No project**, then every live project Nordwind
+reaches — including any it works as a partner or a subcontractor, not only the
+ones it is the customer of.
 
-1. **The thread's own project**, if the conversation is already filed. Then the
-   first line reads *…like the rest of this conversation* instead.
-2. **The deal's project**, when the thread carries none — and only when you are
-   replying from a **deal**. This is the ordinary case for a conversation that
-   started before the project was attached, and the line names the reason —
-   *this deal's project* — because you never put that project on this
-   conversation and deserve to be told where it came from. Replying from a
-   company or a contact page has no deal to fall back on, so only rung 1
-   applies there.
+- **Choosing a project** puts its `[KEY]` at the front of the Subject.
+- **Choosing No project** takes the tag out.
+- **Switching projects** swaps the tag.
 
-If neither names a project, **nothing appears at all**: no line, no tickbox, no
-tag. A message that belongs to no project is the common case and says so by
-staying quiet.
+Nothing explains this on screen, and nothing needs to: the tag is right there
+in the Subject field. Edit it, delete it, type your own — it is ordinary text
+and Margince leaves your version alone.
 
-**To decline**, untick the box. The two lines disappear and `[NER-1]` is taken
-back out of the Subject — the tag would otherwise promise a routing that will
-not happen. Tick it again and the tag returns, in front of whatever you have
-since typed. You can also just delete the tag yourself; it stays deleted.
+### What it starts on
 
-**The box only appears when the project came from the deal**, as it does here.
-Reply to a conversation that is *already* filed under a project and you get the
-sentence and the tag but no box: that reply lands on the project whatever you
-do, because it inherits the filing of the message it answers. Rather than offer
-you a switch that would not be honoured, Margince states the fact. Moving a
-filed conversation is **Relink**, on the message's own timeline row, and it
-moves the whole thread at once.
+The picker suggests rather than decides:
+
+1. **The thread's own project**, when the conversation is already filed. A
+   conversation is one body of work, and a sibling message settled it.
+2. **The deal's project**, when the thread carries none and you are replying
+   from a deal. This is the ordinary case for a conversation that started
+   before the project was attached.
+3. **The company's only live project**, when it has exactly one and neither of
+   the above applies.
+
+Otherwise it starts on **No project**. Every one of those is a starting point
+you can change — and when the company reaches no live project at all, the
+picker does not appear.
 
 > **The tag is doing real work, not decoration.** Your customer's mail client
 > keeps `[NER-1]` in the subject when they reply. Margince reads it back on the
@@ -308,35 +300,39 @@ moves the whole thread at once.
 > broken by a forward, a new subject, or a colleague brought in on a fresh
 > message. This is what makes the filing survive leaving your installation.
 
-One limit, stated plainly: **when the project came from the deal, the tag is
-the only thing carrying it.** A reply is filed under whatever the message you
-are answering was filed under, and it cannot add a link of its own. So on a
-conversation the project never reached, your sent copy does not appear on the
-project's timeline — the customer's tagged answer is what brings the whole
-thread in. A conversation already filed does not have this problem. This is
-[issue #2422](https://github.com/margince/margince/issues/2422); the
-account-started composer below does not have it either.
+One limit worth knowing: **on a reply, the tag may be the only thing carrying
+the project.** A reply is filed under whatever the message you are answering
+was filed under, and it cannot add a link of its own. So on a conversation the
+project never reached, your sent copy does not appear on the project's timeline
+— the customer's tagged answer is what brings the whole thread in. A
+conversation already filed does not have this problem, and neither does the
+composer below. This is
+[issue #2422](https://github.com/margince/margince/issues/2422).
 
 ### Writing to an account from the company page
 
 Open the company page (**Companies** → *Nordwind Logistik*) and press
-**Write email**. This composer starts a new conversation rather than continuing
-one, so there is no thread to inherit from and it **asks** instead of stating:
+**Write email**. A fresh mail is filed under a project exactly the same way: the
+**Project** picker is the same control, in the same place, filling the Subject
+with the same tag. There is no thread to inherit from, so it starts on the
+company's only live project when it has one, and on **No project** otherwise.
+
+Two more pickers sit above it here, because a new conversation needs what a
+reply already knows:
 
 - **Draft to** — which contact.
 - **Related to** — which deal, when the account has any.
-- **Project** — **No project**, then the projects on this account as
-  `NER-1 · Nordwind ERP rollout`. With exactly one live project it is
-  pre-selected; with several it starts at **No project**.
 
-Choosing one shows **Scoped to NER-1** beneath it, and that does two things:
+Choosing a project shows **Scoped to NER-1** beneath the picker, and here it
+does one extra thing beyond filing the mail:
 
-- **What the AI reads.** Press **Draft with AI**. The draft is grounded only in
-  what is filed under this project or under no project at all; mail filed under
-  a *different* project on the same account is left out, and the **Based on:**
-  line lists what it did draw from.
-- **Where the mail is filed.** The sent message is linked to the project, so it
-  appears on the project's timeline and replies inherit that filing.
+**What the AI reads.** Press **Draft with AI**. The draft is grounded only in
+what is filed under this project or under no project at all; mail filed under a
+*different* project on the same account is left out, and the **Based on:** line
+lists what it did draw from.
+
+The sent message is also **linked** to the project — this composer does send the
+link — so it appears on the project's timeline straight away.
 
 ### One more thing the composer does quietly
 

--- a/frontend/src/design-system/projectpicker.tsx
+++ b/frontend/src/design-system/projectpicker.tsx
@@ -76,7 +76,7 @@ export function useSoleProjectDefault(
 // every request, so the rep reads an unscoped surface while the server
 // answers for a project they can no longer see. Cleared through the same
 // setter a pick uses, so the surface re-reads unscoped like any other change.
-function useClearVanishedChoice(
+export function useClearVanishedChoice(
   projects: readonly PickableProject[],
   projectId: string,
   onChange: (next: string) => void,
@@ -98,6 +98,12 @@ function useClearVanishedChoice(
 // projects after a draft arrived must not read the previous project's counts
 // under the new project's key. Until a counted report arrives the line names
 // the chosen project alone.
+// The picker RENDERS a value; it does not decide one. Both of the rules that
+// choose a value — defaulting to a sole project, and clearing one the list no
+// longer offers — are hooks the caller runs, in the order its own state needs.
+// They lived in here until a caller grew a second source of defaults (a
+// reply's own thread) and the two decided the same value on the same render,
+// each undoing the other.
 export function ProjectPicker({
   projects,
   projectId,
@@ -110,7 +116,6 @@ export function ProjectPicker({
   scope?: ProjectScope;
 }>) {
   const t = useT();
-  useClearVanishedChoice(projects, projectId, onChange);
   if (projects.length === 0) {
     return null;
   }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2352,13 +2352,6 @@ export const de = {
   "compose.multiRecipientWarning":
     "Dieser Zweck führt einen Abmeldelink mit sich; ein Versand an mehr als eine Adresse wird deshalb abgelehnt. Senden Sie einzeln, ohne Cc.",
   "compose.relinkTitle": "Diese Aktivität neu verknüpfen",
-  "compose.filedUnder":
-    "Diese Antwort wird unter {project} abgelegt, wie der Rest dieser Konversation.",
-  "compose.filedUnderDeal":
-    "Wird unter {project} abgelegt, dem Projekt dieses Deals.",
-  "compose.subjectTagged":
-    "{tag} wird dem Betreff hinzugefügt, damit die Antwort sich hier einordnet.",
-  "compose.fileUnderProject": "Unter diesem Projekt ablegen",
   "compose.relinkTarget":
     "Person, Organisation, Deal, Lead oder Projekt suchen",
   "compose.relinkReplace": "Verschieben statt zusätzlich verknüpfen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2375,23 +2375,6 @@ export const en = {
   "compose.multiRecipientWarning":
     "This purpose carries an unsubscribe link, so a send to more than one addressee will be refused. Send it once per recipient, with no Cc.",
   "compose.relinkTitle": "Relink this activity",
-  "compose.filedUnder":
-    "This reply will be filed under {project}, like the rest of this conversation.",
-  // The filing line, in its two readings. The THREAD reading is the settled
-  // case: a sibling message already said where this conversation belongs. The
-  // DEAL reading is the fallback, and it names its reason, because a rep who
-  // sees a project they did not put on this conversation deserves to know why
-  // it is being offered.
-  "compose.filedUnderDeal":
-    "This will be filed under {project}, this deal's project.",
-  // The subject tag, explained where it is applied. It says what the tag is
-  // FOR — the reply coming back — because a bracketed code in a subject line
-  // reads as noise until you know it routes the answer.
-  "compose.subjectTagged":
-    "{tag} is added to the subject so their reply files itself here.",
-  // The opt-out. Not "remove" or "delete": nothing is destroyed, the message
-  // simply is not filed under this project.
-  "compose.fileUnderProject": "File under this project",
   "compose.relinkTarget":
     "Search a person, organization, deal, lead, or project",
   "compose.relinkReplace": "Move instead of also-link",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2327,13 +2327,6 @@ export const vi = {
   "compose.multiRecipientWarning":
     "Mục đích này mang liên kết huỷ đăng ký, nên lượt gửi cho nhiều hơn một người nhận sẽ bị từ chối. Hãy gửi riêng cho từng người, không dùng Cc.",
   "compose.relinkTitle": "Liên kết lại hoạt động này",
-  "compose.filedUnder":
-    "Thư trả lời này sẽ được xếp vào {project}, giống phần còn lại của cuộc trò chuyện.",
-  "compose.filedUnderDeal":
-    "Sẽ được lưu vào {project}, dự án của giao dịch này.",
-  "compose.subjectTagged":
-    "{tag} được thêm vào tiêu đề để thư trả lời tự động vào đúng dự án.",
-  "compose.fileUnderProject": "Lưu vào dự án này",
   "compose.relinkTarget": "Tìm một người, tổ chức, deal, lead hay dự án",
   "compose.relinkReplace": "Chuyển hẳn thay vì liên kết thêm",
   "compose.relinkReplaceHint":

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -23,6 +23,7 @@ import {
   liveProjects,
   type PickableProject,
   ProjectPicker,
+  useClearVanishedChoice,
   useSoleProjectDefault,
 } from "../design-system/projectpicker";
 import { Select } from "../design-system/select";
@@ -2069,6 +2070,7 @@ export function AskSection({
   const [projectId, setProjectId] = useState("");
   const live = liveProjects(projects);
   useSoleProjectDefault(live, projectId, setProjectId);
+  useClearVanishedChoice(live, projectId, setProjectId);
   const ask = useMutation({
     // The project travels as the mutation variable beside the question, so
     // a stale closure cannot ask about a project the picker no longer shows.

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -2,6 +2,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
+  fireEvent,
   render as rtlRender,
   screen,
   waitFor,
@@ -1929,11 +1930,14 @@ describe("ComposeModal started from an account", () => {
     ).toBeTruthy();
   });
 
-  // A reply inherits its thread's project on its own (capture's stickiness
-  // rung), so the composer offers no picker for it — and used to say nothing
-  // either, which is why a rep pressing "Draft a reply" concluded projects were
-  // not wired at all. It says where the message is going now.
-  it("says which project a reply will be filed under", async () => {
+  // The composer's project control, on a reply. A reply inherits its thread's
+  // project on its own (capture's stickiness rung), and the composer suggests
+  // that project so the rep does not retype what is already true — but it is a
+  // SUGGESTION in a picker they can set to None, not a fact stated at them.
+  const replyBackend = (
+    links: { entity_type: string; entity_id: string }[],
+    projects: { project_id: string; name: string; key: string }[],
+  ) =>
     stubRoutes({
       "GET /activities/act-1": () =>
         jsonResponse({
@@ -1944,197 +1948,154 @@ describe("ComposeModal started from an account", () => {
           created_at: "2026-08-09T09:00:00Z",
           updated_at: "2026-08-09T09:00:00Z",
           version: 1,
-          links: [
-            { entity_type: "person", entity_id: "p-1" },
-            { entity_type: "project", entity_id: "pr-1" },
-          ],
+          links,
         }),
+      "GET /deals/d-1": () =>
+        jsonResponse({
+          id: "d-1",
+          name: "netcare",
+          organization_id: "o-1",
+          project_id: "pr-9",
+        }),
+      "GET /organizations/o-1/360": () =>
+        jsonResponse({
+          as_of: "2026-08-09T09:00:00Z",
+          organization: {
+            id: "o-1",
+            display_name: "netcare",
+            source: "manual",
+            captured_by: "human:u1",
+            created_at: "2026-08-01T00:00:00Z",
+            updated_at: "2026-08-01T00:00:00Z",
+          },
+          sections_omitted: [],
+          people: { data: [], page: { next_cursor: null } },
+          deals: { data: [], page: { next_cursor: null } },
+          projects: projects.map((one) => ({
+            ...one,
+            phase: "delivering",
+          })),
+        }),
+      "GET /projects/pr-9": () =>
+        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
       "GET /projects/pr-1": () =>
         jsonResponse({ id: "pr-1", name: "ERP rollout Acme", key: "ERP-27" }),
     });
+
+  const openReply = async () => {
     render(
       <ComposeModal
         activityId="act-1"
-        entityType="person"
-        entityId="p-1"
+        entityType="deal"
+        entityId="d-1"
         open
         onClose={vi.fn()}
       />,
     );
+    return () => screen.getByPlaceholderText("Subject") as HTMLInputElement;
+  };
 
-    expect(
-      await screen.findByText(/filed under ERP rollout Acme/),
-    ).toBeTruthy();
-    // It SAYS rather than offers: a picker here would file one message of a
-    // conversation away from the rest of it.
-    expect(screen.queryByRole("combobox", { name: /Project/ })).toBeNull();
-    // And no tickbox either. The send inherits the thread's links whatever
-    // this form says, so a box here would offer a choice that is not honoured
-    // — unticking it would remove the tag and file the reply anyway.
-    expect(screen.queryByLabelText("File under this project")).toBeNull();
-    // The subject is still stamped: the tag is what carries the project out to
-    // the customer's reply, and nothing above declined it.
-    await waitFor(() =>
-      expect(
-        (screen.getByPlaceholderText("Subject") as HTMLInputElement).value,
-      ).toBe("[ERP-27]"),
+  it("offers the company's projects and defaults to the thread's own", async () => {
+    replyBackend(
+      [
+        { entity_type: "deal", entity_id: "d-1" },
+        { entity_type: "project", entity_id: "pr-1" },
+      ],
+      [
+        { project_id: "pr-1", name: "ERP rollout Acme", key: "ERP-27" },
+        { project_id: "pr-9", name: "Netcare 2 project", key: "N2P-1" },
+      ],
     );
+    const subject = await openReply();
+
+    const picker = await screen.findByLabelText("Project");
+    // The thread's own project is the default, not the deal's: a conversation
+    // already filed settled this.
+    await waitFor(() =>
+      expect(picker.textContent).toContain("ERP rollout Acme"),
+    );
+    // Both of the company's projects are on offer, plus None.
+    await userEvent.setup().click(picker);
+    expect(
+      (await screen.findAllByRole("option")).map((o) => o.textContent),
+    ).toEqual([
+      "No project",
+      "ERP-27 · ERP rollout Acme",
+      "N2P-1 · Netcare 2 project",
+    ]);
+    await userEvent.setup().keyboard("{Escape}");
+    // And the tag is already in the subject — nothing explains it, because the
+    // field shows it.
+    await waitFor(() => expect(subject().value).toBe("[ERP-27]"));
   });
 
-  // A thread filed under no project has nothing to announce, and "filed under
-  // nothing" tells a reader less than silence.
-  it("says nothing when the reply's thread carries no project", async () => {
-    stubRoutes({
-      "GET /activities/act-1": () =>
-        jsonResponse({
-          id: "act-1",
-          kind: "email",
-          occurred_at: "2026-08-09T09:00:00Z",
-          source: "gmail",
-          created_at: "2026-08-09T09:00:00Z",
-          updated_at: "2026-08-09T09:00:00Z",
-          version: 1,
-          links: [{ entity_type: "person", entity_id: "p-1" }],
-        }),
-    });
-    render(
-      <ComposeModal
-        activityId="act-1"
-        entityType="person"
-        entityId="p-1"
-        open
-        onClose={vi.fn()}
-      />,
+  it("defaults to the deal's project when the thread names none", async () => {
+    replyBackend(
+      [{ entity_type: "deal", entity_id: "d-1" }],
+      [
+        { project_id: "pr-1", name: "ERP rollout Acme", key: "ERP-27" },
+        { project_id: "pr-9", name: "Netcare 2 project", key: "N2P-1" },
+      ],
     );
+    const subject = await openReply();
+
+    const picker = await screen.findByLabelText("Project");
+    await waitFor(() =>
+      expect(picker.textContent).toContain("Netcare 2 project"),
+    );
+    await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
+  });
+
+  it("takes the tag out when the rep picks None, and puts another one in", async () => {
+    const user = userEvent.setup();
+    replyBackend(
+      [{ entity_type: "deal", entity_id: "d-1" }],
+      [
+        { project_id: "pr-1", name: "ERP rollout Acme", key: "ERP-27" },
+        { project_id: "pr-9", name: "Netcare 2 project", key: "N2P-1" },
+      ],
+    );
+    const subject = await openReply();
+    const picker = await screen.findByLabelText("Project");
+    await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
+    // `[` opens a key descriptor in user-event's parser, so the tag is typed
+    // through fireEvent rather than escaped into unreadability.
+    await user.clear(subject());
+    fireEvent.change(subject(), {
+      target: { value: "[N2P-1] Re: Angebot" },
+    });
+
+    await pickOption(user, picker, "No project");
+    await waitFor(() => expect(subject().value).toBe("Re: Angebot"));
+
+    // Choosing a different project stamps that one instead.
+    await pickOption(user, picker, "ERP-27 · ERP rollout Acme");
+    await waitFor(() => expect(subject().value).toBe("[ERP-27] Re: Angebot"));
+  });
+
+  it("offers nothing when the company reaches no live project", async () => {
+    replyBackend([{ entity_type: "deal", entity_id: "d-1" }], []);
+    const subject = await openReply();
 
     await screen.findByRole("button", { name: "Draft with AI" });
-    expect(screen.queryByText(/will be filed under/)).toBeNull();
-  });
-
-  // The case this behaviour was built for: a deal whose project was attached
-  // AFTER the conversation started, so the mail being answered names no
-  // project while the deal does.
-  it("falls back to the deal's project when the thread names none, and says why", async () => {
-    stubRoutes({
-      "GET /activities/act-1": () =>
-        jsonResponse({
-          id: "act-1",
-          kind: "email",
-          occurred_at: "2026-08-09T09:00:00Z",
-          source: "gmail",
-          created_at: "2026-08-09T09:00:00Z",
-          updated_at: "2026-08-09T09:00:00Z",
-          version: 1,
-          links: [{ entity_type: "deal", entity_id: "d-1" }],
-        }),
-      "GET /deals/d-1": () =>
-        jsonResponse({ id: "d-1", name: "netcare", project_id: "pr-9" }),
-      "GET /projects/pr-9": () =>
-        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
-    });
-    render(
-      <ComposeModal
-        activityId="act-1"
-        entityType="deal"
-        entityId="d-1"
-        open
-        onClose={vi.fn()}
-      />,
-    );
-
-    // It names the project AND the reason, because the rep never put this
-    // project on this conversation.
-    expect(
-      await screen.findByText(/filed under Netcare 2 project, this deal/),
-    ).toBeTruthy();
-    // And the key lands in the subject, where the customer's reply carries it
-    // back to the same project.
-    await waitFor(() =>
-      expect(
-        (screen.getByPlaceholderText("Subject") as HTMLInputElement).value,
-      ).toBe("[N2P-1]"),
-    );
-    expect(screen.getByText(/\[N2P-1\] is added to the subject/)).toBeTruthy();
-  });
-
-  it("takes the tag back out of the subject when the rep declines the filing", async () => {
-    const user = userEvent.setup();
-    stubRoutes({
-      "GET /activities/act-1": () =>
-        jsonResponse({
-          id: "act-1",
-          kind: "email",
-          occurred_at: "2026-08-09T09:00:00Z",
-          source: "gmail",
-          created_at: "2026-08-09T09:00:00Z",
-          updated_at: "2026-08-09T09:00:00Z",
-          version: 1,
-          links: [{ entity_type: "deal", entity_id: "d-1" }],
-        }),
-      "GET /deals/d-1": () =>
-        jsonResponse({ id: "d-1", name: "netcare", project_id: "pr-9" }),
-      "GET /projects/pr-9": () =>
-        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
-    });
-    render(
-      <ComposeModal
-        activityId="act-1"
-        entityType="deal"
-        entityId="d-1"
-        open
-        onClose={vi.fn()}
-      />,
-    );
-    const subject = () =>
-      screen.getByPlaceholderText("Subject") as HTMLInputElement;
-    await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
-
-    await user.click(screen.getByLabelText("File under this project"));
-
-    // A tag promising a routing that will not happen is worse than no tag.
-    await waitFor(() => expect(subject().value).toBe(""));
-    expect(screen.queryByText(/is added to the subject/)).toBeNull();
+    // A list whose only entry is None asks a question with one answer.
+    expect(screen.queryByLabelText("Project")).toBeNull();
+    expect(subject().value).toBe("");
   });
 
   it("leaves a tag the rep deleted by hand deleted", async () => {
     const user = userEvent.setup();
-    stubRoutes({
-      "GET /activities/act-1": () =>
-        jsonResponse({
-          id: "act-1",
-          kind: "email",
-          occurred_at: "2026-08-09T09:00:00Z",
-          source: "gmail",
-          created_at: "2026-08-09T09:00:00Z",
-          updated_at: "2026-08-09T09:00:00Z",
-          version: 1,
-          links: [{ entity_type: "deal", entity_id: "d-1" }],
-        }),
-      "GET /deals/d-1": () =>
-        jsonResponse({ id: "d-1", name: "netcare", project_id: "pr-9" }),
-      "GET /projects/pr-9": () =>
-        jsonResponse({ id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }),
-    });
-    render(
-      <ComposeModal
-        activityId="act-1"
-        entityType="deal"
-        entityId="d-1"
-        open
-        onClose={vi.fn()}
-      />,
+    replyBackend(
+      [{ entity_type: "deal", entity_id: "d-1" }],
+      [{ project_id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }],
     );
-    const subject = () =>
-      screen.getByPlaceholderText("Subject") as HTMLInputElement;
+    const subject = await openReply();
     await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
 
-    // Deleting the tag is a second way to say "not this one". The composer
-    // must not put it back under the rep's cursor.
     await user.clear(subject());
     await user.type(subject(), "Re: ohne Tag");
 
     await waitFor(() => expect(subject().value).toBe("Re: ohne Tag"));
-    // And it stays gone rather than reappearing on the next render.
     await new Promise((resolve) => setTimeout(resolve, 150));
     expect(subject().value).toBe("Re: ohne Tag");
   });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -23,6 +23,7 @@ import { ChoiceList } from "../design-system/choicelist";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import {
   liveProjects,
+  type PickableProject,
   ProjectPicker,
   type ProjectScope,
   useSoleProjectDefault,
@@ -45,15 +46,12 @@ import {
 import { useOrganization360 } from "./company360";
 import { useConsentPurposes } from "./consent";
 import {
-  type Filing,
-  filingFor,
   stripEveryKeyTag,
   stripSubjectTag,
   subjectTag,
   useProjectRecord,
   withSubjectTag,
 } from "./projectrecord";
-import type { Project } from "./projects.form";
 import { useVoiceProfile } from "./voice-profile";
 import "./compose.css";
 
@@ -344,84 +342,32 @@ function keptTag(subject: string): string {
 }
 
 /**
- * Where this send will file, stated rather than asked, with the one control
- * that matters: the rep can decline it.
+ * The one control that says which project a message belongs to — on a reply
+ * and on a message started from an account alike.
  *
- * The thread's own project settles it when it has one. A deal's project is the
- * fallback for a conversation that predates it, and the copy names that reason
- * — a rep seeing a project they never put on this thread should be told where
- * it came from.
+ * It carries no explanation of its own. The tag it puts in the Subject field
+ * is visible there, and a rep who does not want it deletes it like any other
+ * text; a sentence saying so would restate what the field already shows.
  *
- * Declining files the message under no project and takes the subject tag back
- * off. It does NOT move the thread: the control that does that is Relink, on
- * the message's own timeline row, and it moves every message at once. Two
- * spellings of "move this conversation" is what this component exists to avoid.
+ * Choosing None takes the tag out. Choosing a project puts it in. Nothing
+ * renders when the record reaches no live project, because a list whose only
+ * entry is None asks a question with one answer.
  */
-// NOTE ON THE REPLY PATH: a reply posts to /activities/{id}/send-email, which
-// takes NO links — the server files the reply under the links its ANCHOR
-// carries (activities/sendorigin.go, FromActivity). So on a reply this section
-// states a filing the client cannot itself perform, and it is honest only
-// because of the subject tag: the tag is what carries the project, and capture
-// reads it back on the way in. The `filed` flag still governs the tag, so
-// declining genuinely changes what is sent.
-//
-// The account-started path DOES send links, and there the project link travels
-// (composedLinks). Making a reply send one needs `links` on the reply request —
-// a contract change, tracked as its own piece of work.
 function ProjectFiling({
-  filing,
-  project,
-  filed,
-  onFiledChange,
+  projects,
+  projectId,
+  onChange,
 }: Readonly<{
-  filing: Filing;
-  project: Project | null;
-  filed: boolean;
-  onFiledChange: (next: boolean) => void;
+  projects: readonly PickableProject[];
+  projectId: string;
+  onChange: (next: string) => void;
 }>) {
-  const t = useT();
-  if (filing.kind !== "derived" || !project?.name) {
-    return null;
-  }
-  const tag = subjectTag(project);
-  // A THREAD already filed under a project settles this reply too: the send
-  // inherits the anchor's links, and no control on this form can undo that.
-  // So the thread reading states the filing and offers nothing — a tickbox
-  // here would promise a choice the send does not honour, and unticking it
-  // would still file. Moving a filed conversation is Relink, on the message's
-  // own timeline row, which moves the whole thread rather than one message.
-  //
-  // The DEAL reading is a genuine choice: nothing else carries that project,
-  // so the box decides both the filing and the tag.
-  if (filing.from === "thread") {
-    return (
-      <div className="stack-2xs">
-        <p className="t-caption">
-          {t("compose.filedUnder", { project: project.name })}
-        </p>
-        {tag && (
-          <p className="t-caption">{t("compose.subjectTagged", { tag })}</p>
-        )}
-      </div>
-    );
-  }
   return (
-    <div className="stack-2xs">
-      <Checkbox
-        className="t-body"
-        label={t("compose.fileUnderProject")}
-        checked={filed}
-        onChange={(event) => onFiledChange(event.target.checked)}
-      />
-      {filed && (
-        <p className="t-caption">
-          {t("compose.filedUnderDeal", { project: project.name })}
-        </p>
-      )}
-      {filed && tag && (
-        <p className="t-caption">{t("compose.subjectTagged", { tag })}</p>
-      )}
-    </div>
+    <ProjectPicker
+      projects={projects}
+      projectId={projectId}
+      onChange={onChange}
+    />
   );
 }
 
@@ -732,18 +678,12 @@ function AccountDraftContext({
   onRecipientChange,
   dealId,
   onDealChange,
-  projectId,
-  onProjectChange,
-  scope,
 }: Readonly<{
   orgId: string;
   recipientId: string;
   onRecipientChange: (next: string) => void;
   dealId: string;
   onDealChange: (next: string) => void;
-  projectId: string;
-  onProjectChange: (next: string) => void;
-  scope?: ProjectScope;
 }>) {
   const t = useT();
   const query = useOrganization360(orgId);
@@ -752,8 +692,7 @@ function AccountDraftContext({
   const view = query.data?.state === "ready" ? query.data.view : undefined;
   const contacts = view?.people?.data ?? [];
   const deals = view?.deals?.data ?? [];
-  const projects = liveProjects(view?.projects);
-  useSoleProjectDefault(projects, projectId, onProjectChange);
+
   // No contact on the account is an honest dead end for the DRAFT — the model
   // has no relationship to write from — and saying so beats an empty picker the
   // rep tries and cannot use. They can still type an address into To and write
@@ -767,19 +706,7 @@ function AccountDraftContext({
   // thread to inherit a project from. It would land unfiled, and the ladder
   // would ask about it in Approvals afterwards instead.
   if (query.isSuccess && contacts.length === 0) {
-    return (
-      <>
-        <p className="t-caption">{t("compose.noGroundableRecipient")}</p>
-        {projects.length > 0 && (
-          <ProjectPicker
-            projects={projects}
-            projectId={projectId}
-            onChange={onProjectChange}
-            scope={scope}
-          />
-        )}
-      </>
-    );
+    return <p className="t-caption">{t("compose.noGroundableRecipient")}</p>;
   }
   return (
     <>
@@ -815,12 +742,6 @@ function AccountDraftContext({
           />
         </label>
       )}
-      <ProjectPicker
-        projects={projects}
-        projectId={projectId}
-        onChange={onProjectChange}
-        scope={scope}
-      />
     </>
   );
 }
@@ -1409,7 +1330,7 @@ function useDraftMutation({
 function useAnchorProject(
   entityType: RelinkKind,
   entityId: string,
-): { projectId?: string | null; settled: boolean } {
+): { projectId?: string | null; companyId?: string; settled: boolean } {
   const query = useQuery({
     // The SAME key the deal page's own read uses, so opening the composer on a
     // deal costs no request and cannot disagree with the page behind it. A
@@ -1429,6 +1350,15 @@ function useAnchorProject(
   });
   return {
     projectId: query.data?.project_id,
+    // The company whose projects the picker offers. A deal names one; a
+    // company page IS one; the other anchors reach none this composer can ask
+    // about.
+    companyId:
+      entityType === "deal"
+        ? (query.data?.organization_id ?? undefined)
+        : entityType === "organization"
+          ? entityId
+          : undefined,
     // A read that failed says nothing about this deal's project. Reporting it
     // as "no project" would drop the filing silently; unsettled keeps the
     // composer quiet instead, which is the same rule the thread read follows.
@@ -1437,89 +1367,78 @@ function useAnchorProject(
 }
 
 /**
- * The filing this composer will perform, and the subject tag that goes with it.
+ * Which project this message files under, and the subject tag that follows it.
  *
- * Kept as one hook because the two move together: the tag is only in the
- * subject while the filing is on, so a rep who declines the filing must not be
- * left with the bracketed key still in their subject line, promising a routing
- * that will not happen.
+ * The rep chooses; the composer only SUGGESTS. The suggestion is the thread's
+ * own project when the conversation is already filed — a conversation is one
+ * body of work and a sibling settled it — and otherwise the anchor's, which is
+ * a deal's project. It is adopted once, when it first arrives, so a rep who
+ * then picks None is not overruled on the next render.
  *
- * The subject is rewritten only when the FILING changes, never on a keystroke.
- * A rep who deletes the tag by hand keeps it deleted — that is a second way to
- * say the same "not this one", and re-adding it under their cursor would be the
- * composer arguing with them.
+ * The tag is written only when the CHOICE changes, never on a keystroke, so a
+ * tag the rep deletes by hand stays deleted.
  */
 function useProjectFiling(input: {
   activityId?: string;
   anchorProjectId?: string | null;
-  reachable: readonly { id: string }[];
-  // Whether the anchor's own read has answered. False keeps the composer quiet
-  // rather than reporting a failed read as "no project".
   anchorSettled: boolean;
+  projects: readonly PickableProject[];
   subject: string;
   setSubject: (next: string) => void;
-}): {
-  filing: Filing;
-  project: Project | null;
-  filed: boolean;
-  setFiled: (next: boolean) => void;
-} {
+}): { projectId: string; setProjectId: (next: string) => void } {
   const thread = useThreadProject(input.activityId);
-  const [declined, setDeclined] = useState(false);
-  // Nothing is derived until the thread has answered. The thread outranks the
-  // deal, so guessing while its read is in flight is guessing the loser: the
-  // composer would announce the deal's project, then swap under the rep, or —
-  // when the read failed — announce one the send will not use.
-  const filing =
-    thread.settled && input.anchorSettled
-      ? filingFor({
-          threadProjectId: thread.projectId,
-          dealProjectId: input.anchorProjectId,
-          reachable: input.reachable,
-        })
-      : ({ kind: "none" } as const);
-  const derived = filing.kind === "derived" ? filing.projectId : undefined;
-  const { project } = useProjectRecord(derived);
-  // A thread's filing is not declinable — the send inherits it whatever this
-  // form says — so the thread reading shows no tickbox, and a `declined` left
-  // over from a deal reading must not silently strip the tag here.
-  const declinable = filing.kind === "derived" && filing.from === "deal";
-  const filed = Boolean(derived) && (!declinable || !declined);
+  // Empty string is a real answer ("None"), so unanswered is undefined.
+  const [picked, setPicked] = useState<string | undefined>(undefined);
+  const settled = thread.settled && input.anchorSettled;
+  const suggested = settled
+    ? (thread.projectId ?? input.anchorProjectId ?? "")
+    : "";
+  // Adopted once, when the suggestion first arrives. `picked` then holds it, so
+  // a rep who chooses None is not overruled on the next render.
+  const adopted = useRef("");
+  useEffect(() => {
+    if (suggested && adopted.current !== suggested) {
+      adopted.current = suggested;
+      setPicked(suggested);
+    }
+  }, [suggested]);
+  const chosen = picked ?? suggested;
+  // The account path has no thread and no deal to suggest from, so its rule is
+  // the older one: a company with exactly ONE live project defaults to it. The
+  // two never both fire — a suggestion above means there was something to
+  // inherit, and this only applies when there was not.
+  useSoleProjectDefault(input.projects, chosen, setPicked);
+  // A value the option list does not carry is not shown as chosen — the control
+  // would render blank while the subject claimed a filing nobody can see named.
+  // Read rather than written: writing it back would race the adoption above,
+  // clearing the suggestion on the render before the list arrives and leaving
+  // `adopted` unwilling to try again. The list settling is what makes it
+  // appear.
+  const offered =
+    chosen === "" ||
+    input.projects.some((project) => project.project_id === chosen);
+  const projectId = offered ? chosen : "";
+  const { project } = useProjectRecord(projectId || undefined);
   const tag = subjectTag(project);
-  // The tag follows the filing, applied once per change rather than on every
-  // render: `applied` remembers what this composer last wrote, so a rerender
-  // with the same answer leaves the rep's subject alone.
   const applied = useRef<string>("");
-  const want = filed && thread.settled ? tag : "";
-  // In an effect, not during render: setting the subject inline would be a
-  // state write inside another component's render pass, the shape that drives
-  // React into an update loop. The subject is read through a ref so a rep's
-  // typing never re-runs this.
   const subjectRef = useRef(input.subject);
   subjectRef.current = input.subject;
   const setSubject = input.setSubject;
-
+  // In an effect, not during render: setting the subject inline would be a
+  // state write inside another component's render pass, the shape that drives
+  // React into an update loop.
   useEffect(() => {
-    // Re-apply when the tag CHANGED, and also when the subject no longer holds
-    // the tag this hook believes it wrote — discarding a draft clears the field
-    // programmatically, and without this the checkbox would keep claiming a tag
-    // the subject does not carry.
-    if (applied.current === want) {
+    if (applied.current === tag) {
       return;
     }
     const previous = applied.current;
-    applied.current = want;
+    applied.current = tag;
     const bare = previous
       ? stripSubjectTag(subjectRef.current, previous)
       : subjectRef.current;
-    setSubject(want ? withSubjectTag(bare, want) : bare);
-  }, [want, setSubject]);
-  return {
-    filing,
-    project,
-    filed,
-    setFiled: (next: boolean) => setDeclined(!next),
-  };
+    setSubject(tag ? withSubjectTag(bare, tag) : bare);
+  }, [tag, setSubject]);
+  return { projectId, setProjectId: setPicked };
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this modal was already at the ceiling; the account-started origin (ADR-0087/A132) adds three necessary branches — the recipient/deal pickers, the grounded-draft gate and the drawer placement. The drafting call, the form fill, the body edit and both draft controls are already extracted; what is left is one dialog's own wiring, and splitting the send/consent/refusal/voice flow apart from the fields it gates would scatter it.
@@ -1605,13 +1524,21 @@ export function ComposeModal({
   // inheriting one), so this covers the anchored sends: a reply, and a message
   // started from a deal.
   const anchorProject = useAnchorProject(entityType, entityId);
+  // The projects this message may be filed under: the live ones the anchor's
+  // company reaches. That set already includes the projects the company works
+  // as a partner or a subcontractor, because the 360's own section is built
+  // from the company edges rather than from a project's anchor column.
+  const anchorCompany = useOrganization360(anchorProject.companyId ?? "");
+  const reachableProjects = liveProjects(
+    anchorCompany.data?.state === "ready"
+      ? anchorCompany.data.view.projects
+      : undefined,
+  );
   const projectFiling = useProjectFiling({
     activityId,
-    anchorProjectId: groundable ? null : anchorProject.projectId,
+    anchorProjectId: anchorProject.projectId,
     anchorSettled: anchorProject.settled,
-    // The reachable set only decides between "ask" and "say nothing", and the
-    // anchored path never asks — the account path owns that question.
-    reachable: [],
+    projects: reachableProjects,
     subject,
     setSubject,
   });
@@ -1730,7 +1657,7 @@ export function ComposeModal({
         links: composedLinks(
           { entityType, entityId },
           grounding,
-          projectFiling.filed ? (projectFiling.project?.id ?? "") : "",
+          projectFiling.projectId,
         ),
       });
       if (response.status === 501) return { sent: false as const };
@@ -1789,7 +1716,14 @@ export function ComposeModal({
   // picker directly above it, rather than running and coming back with a
   // refusal about a field already on screen.
   const draftControl = {
-    run: () => draft.mutate(account.grounding),
+    // The project the PICKER holds, not the account hook's own copy: one
+    // control owns that answer now, and the draft must be grounded in the
+    // project the reader can see chosen.
+    run: () =>
+      draft.mutate({
+        ...account.grounding,
+        projectId: projectFiling.projectId,
+      }),
     pending: draft.isPending,
     disabled:
       draft.isPending ||
@@ -1813,9 +1747,6 @@ export function ComposeModal({
       onRecipientChange={account.setRecipientId}
       dealId={account.dealId}
       onDealChange={account.setDealId}
-      projectId={account.projectId}
-      onProjectChange={account.setProjectId}
-      scope={account.scope}
     />
   ) : null;
   const accountReasons = (
@@ -1860,7 +1791,13 @@ export function ComposeModal({
       placement={groundable ? "right" : "center"}
       confirmLabel={t(scheduling ? "compose.schedule" : "compose.send")}
       confirmDisabled={!canSend || rejectionInFlight}
-      onConfirm={() => send.mutate(groundable ? account.grounding : null)}
+      onConfirm={() =>
+        send.mutate(
+          groundable
+            ? { ...account.grounding, projectId: projectFiling.projectId }
+            : null,
+        )
+      }
       pending={send.isPending}
       error={sendError}
     >
@@ -1870,10 +1807,9 @@ export function ComposeModal({
             account-started message, which has no thread to inherit from. */}
         {!isChannelReply && (
           <ProjectFiling
-            filing={projectFiling.filing}
-            project={projectFiling.project}
-            filed={projectFiling.filed}
-            onFiledChange={projectFiling.setFiled}
+            projects={reachableProjects}
+            projectId={projectFiling.projectId}
+            onChange={projectFiling.setProjectId}
           />
         )}
         {/* AI drafting is mail-only — there is no draft-message endpoint, and


### PR DESCRIPTION
feat(compose): one project picker, on every message, that fills the subject

A message says which project it belongs to through a picker: None, then the
live projects the record's company reaches, as KEY · Name. It is the same
control on a reply and on a message started from an account, so the answer is
given the same way wherever a rep meets it.

Choosing a project puts [KEY] in the Subject field. Choosing None takes it out.
Nothing explains either, because the subject line shows the tag and a rep who
does not want it deletes it like any other text. The four captions that used to
narrate this are gone, and their message keys with them.

The picker suggests rather than states: the thread's own project when the
conversation is already filed, otherwise the anchor deal's, and the older
sole-live-project rule when there is neither. A suggestion is adopted once, so
choosing None is not overruled on the next render.

This replaces the tickbox. A tickbox could only offer or withhold ONE project —
it could not move a message to a sibling project, which is the thing a rep on a
company with two engagements actually needs.

The value now has one owner. `ProjectPicker` renders what it is told and no
longer clears a vanished choice on its own: that rule and the sole-project
default are hooks the caller runs, in the order its own state needs. They lived
inside the picker until a caller grew a second source of defaults — a reply's
own thread — and the two decided the same value on the same render, each
undoing the other. The account composer's separate project state is gone for
the same reason; its draft grounding and its send now read the picker.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies project selection across reply and account compose: a single `ProjectPicker` sets or clears the `[KEY]` subject tag, replacing the tickbox and captions. This lets reps switch to any live sibling project and removes conflicting defaults.

- Shows “No project” plus live projects for the company (including partner/subcontractor roles) as `KEY · Name`.
- Suggestion order: thread’s project → deal’s project → sole live project; adopted once so choosing “No project” persists.
- On account-started messages, the chosen project scopes drafting and the sent message is linked; on replies, link inheritance is unchanged and the subject tag routes inbound.
- `ProjectPicker` now only renders a value; defaulting and clearing moved to callers via `useSoleProjectDefault` and exported `useClearVanishedChoice`. Callers updated (`compose`, `company360`).
- Removed tickbox-related i18n strings; updated docs and tests to match the picker and subject-tag behavior.

<sup>Written for commit fde048247b482abd70dc7db979ca7dd264dd26eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified Project picker for replies and messages started from company pages.
  * Choose no project or any live project connected through the company, including partner and subcontractor relationships.
  * Project selection updates subject tags and supports switching or removing project filing.
  * AI drafting can now be scoped to the selected project or unfiled records.
  * Project suggestions consider the conversation, deal, and the company’s sole live project.

* **Documentation**
  * Updated email and project tutorials with the new project-selection workflow and related limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->