### PR TITLE
fix(ai-models): main compiles again — the status prompt digest takes a language

### DIFF
--- a/backend/internal/compose/dealstatus/input.go
+++ b/backend/internal/compose/dealstatus/input.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 // projectionVersion changes when the PROJECTION changes — the shape the facts
@@ -29,7 +31,16 @@ const projectionVersion = "deal-status-projection-1"
 // promptVersion is DERIVED from the prompt as it is SENT — boundary rule
 // included — so rewording it rewrites the cards whether or not anybody
 // remembers to bump anything.
-var promptVersion = ai.PromptDigest(statusSystemFor)
+//
+// Digested at ONE fixed language rather than the installation's. The language
+// is its own component of Fingerprint below, so folding it in here too would
+// say the same thing twice; worse, the digest is a package-level var computed
+// at init, where no installation's setting is readable at all. What this has to
+// capture is the WORDING, and English captures every change to it — a reword
+// moves this digest whichever language the prompt is later asked for.
+var promptVersion = ai.PromptDigest(func(fence promptfence.Fence) string {
+	return statusSystemFor(fence, string(textlang.English))
+})
 
 // project renders the gathered facts into the prompt's shape. Only what the
 // caller may read reaches it: the facts were gathered under their row scope,


### PR DESCRIPTION
## main is red

`origin/main` does not build:

```
internal/compose/dealstatus/input.go:32:37: cannot use statusSystemFor
(value of type func(promptfence.Fence, string) string) as
func(promptfence.Fence) string value in argument to ai.PromptDigest
```

## How it happened

Two PRs, each green on its own branch, whose merge does not compile:

- **#2486** made `promptVersion` derive from `statusSystemFor`.
- **#2490** gave `statusSystemFor` a `lang` parameter.

Neither branch could see the other's half. Both merged with `--admin`, so **no gate ever ran on the combination**. This is the failure mode admin-merge trades away, and it landed exactly where the two PRs touched the same function.

## The fix

The digest renders the prompt at a **fixed** language rather than the installation's, and compiling is not the only reason.

- The language already rides `Fingerprint` as its own component, so folding it into the digest too would say the same thing twice.
- `promptVersion` is a package-level `var` computed at init, where no installation's setting is readable at all.
- What the digest has to capture is the **wording**, and English captures every change to it: a reword moves the digest whichever language the prompt is later asked for.

No cache key changes meaning. A card is still rewritten when the prompt is reworded, and still rewritten when the installation changes language — those are now two independent components instead of one confused one.

## Verification

`make check-backend` green, `make craft-static` green, `go test ./...` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes red `main` by adapting `promptVersion` to `statusSystemFor`’s new language parameter and computing the status prompt digest in a fixed language (English). Previously the digest used `statusSystemFor` without a language; now it passes English so `ai.PromptDigest` gets a `func(promptfence.Fence) string`. This compiles and ensures the digest tracks wording only.

- Cache semantics stay the same: language remains a separate `Fingerprint` component; the digest no longer varies by installation language.
- No migration or config changes. Backend build and tests pass.

<sup>Written for commit 604d8671a24e7752836c2f0d6aaccdb37a73b80a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when generating deal status updates by ensuring the system prompt is always rendered in English.
  * Prompt version tracking is now more reliable, helping prevent unintended changes in status-processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->