### PR TITLE
fix(contract-api): one answer when a page token is not one we minted

### DIFF
--- a/backend/cursorrefusal_test.go
+++ b/backend/cursorrefusal_test.go
@@ -8,21 +8,21 @@ package backendarch
 // `422 code: malformed_cursor`, which tells the caller to re-issue the request
 // without the token.
 //
-// A module that invents its own refusal answers a different question. The two
-// spellings this tree carried said `required` — of a field the caller had just
-// supplied, so acting on it means sending the token again — and `invalid`, which
-// names no remedy at all. Neither is reachable from the contract, so a client
-// written against the contract cannot recognise either.
+// A module that invents its own refusal answers a different question. `required`
+// tells a caller to supply a field it just supplied, so acting on it means
+// sending the same token again; `invalid` and `invalid_query` name no remedy.
+// None of them is reachable from the contract, so a client written against the
+// contract cannot recognise any of them.
 //
 // THE RULE: a refusal about a cursor is `storekit.MalformedCursorError`.
 // `platform/httperr` maps that one type to the contract's code, and mapping is
 // the only place the wire code is decided.
 //
-// Two arms, because the site that escaped the first sweep escaped it by not
-// having the shape the first arm reads. `people/dedupequeue.go` decodes base64
-// rather than parsing a UUID, and it was found only when a test named the error
-// it expected. A census keyed on one spelling of "parse" would have reported a
-// clean tree over it.
+// TWO ARMS, because a refusal and a decode are visible to different readers. The
+// first reads the refusal's shape and sees nothing when the error names no
+// field. The second reads the decode and sees nothing when the refusal is built
+// somewhere the decode is not. A cursor read by base64 and refused without
+// naming a field is invisible to either arm alone.
 
 import (
 	"go/ast"
@@ -43,25 +43,48 @@ import (
 // because the distinction is what the token IS, which its shape does not say —
 // both are bytes carrying JSON.
 var connectorCursors = gatekit.Waive(map[string]string{
-	"internal/modules/capture/backfillpager.go:backfillPageCursor":   "reads the provider page token stored on a backfill run, handed back to the provider's own API. A caller never sends it, and an unreadable one is a server-side fault the run reports, not a 422.",
-	"internal/modules/capture/offlinedemo/offlinedemo.go:readCursor": "reads the demo generator's own resume state and returns no error at all — an unreadable or stale-generation cursor restarts the generator rather than refusing anything.",
+	"internal/modules/capture/gmail/gmail.go:parseCursor":          "reads the Gmail history id this connector stored on its own last sync. The provider mints it, the server persists and hands it back; a caller never sends one.",
+	"internal/modules/capture/gcal/gcal.go:parseCursor":            "reads the Google Calendar sync token this connector stored on its own last sync — the provider's resume state, never request input.",
+	"internal/modules/capture/graph/graph.go:parseCursor":          "reads the Microsoft Graph delta link this connector stored on its own last sync — the provider's resume state, never request input.",
+	"internal/modules/capture/imap/standing.go:parseIMAPCursor":    "reads the IMAP UID watermark this connector stored on its own last sync — server-minted resume state, never request input.",
+	"internal/modules/overlay/fake/adapter.go:parseCursor":         "the overlay fake incumbent's own paging offset, minted and read by the fake. It stands in for a third-party CRM's cursor, not for one of ours.",
+	"internal/modules/capture/backfillpager.go:backfillPageCursor": "reads the provider page token stored on a backfill run, handed back to the provider's own API. A caller never sends it, and an unreadable one is a server-side fault the run reports, not a 422.",
 })
 
 // refusalSurfaceRoots are the trees where a cursor may be refused.
 var refusalSurfaceRoots = []string{"internal/modules", "internal/compose", "../extensions"}
 
-// cursorDecoders are the primitives a cursor is read WITH. A function calling
-// one of these on a cursor is deciding whether the token is well-formed, which
+// cursorDecoders are the primitives a page token is read WITH. A function
+// calling one of these on a token is deciding whether it is well-formed, which
 // is the decision this file governs.
-var cursorDecoders = []string{"Parse", "DecodeString", "Unmarshal", "DecodeCursor"}
+//
+// Wider than the shapes this tree happens to use today, because a census that
+// recognises only those reports a clean tree over the next one.
+var cursorDecoders = []string{
+	"Parse", "ParseUUID", "DecodeString", "Unmarshal", "Sscanf", "Cut", "Atoi", "DecodeCursor",
+}
+
+// namesAToken reports whether an identifier is what this tree calls a page
+// token. `cur` is here because the connector decoders spell it that way; a
+// census keyed only on whichever spelling its author was looking at leaves the
+// rest invisible.
+//
+// Bare `token` is NOT: it is the ordinary word for a lexeme, so it reaches
+// parsers with no page token in them. A census that cries wolf teaches its
+// readers to skip the output.
+func namesAToken(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "cursor") || strings.Contains(lower, "pagetoken") || lower == "cur"
+}
 
 // refusalFile is one parsed product file with its package's string constants,
 // so a field named through a constant (`Field: fieldCursor`) reads the same as
 // one named literally.
 type refusalFile struct {
-	path   string
-	file   *ast.File
-	consts map[string]string
+	path       string
+	file       *ast.File
+	consts     map[string]string
+	constNames map[string]bool
 }
 
 func refusalFiles(t *testing.T) []refusalFile {
@@ -100,18 +123,34 @@ func refusalFiles(t *testing.T) []refusalFile {
 	var out []refusalFile
 	for _, files := range byDir {
 		consts := stringConstants(files)
+		names := declaredConstNames(files)
 		for _, f := range files {
-			out = append(out, refusalFile{path: paths[f], file: f, consts: consts})
+			out = append(out, refusalFile{path: paths[f], file: f, consts: consts, constNames: names})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
 	return out
 }
 
-// namesACursorField reports whether a composite literal binds a field whose
-// value is the string "cursor" — the shape an error uses to say WHICH argument
-// it is refusing.
-func namesACursorField(lit *ast.CompositeLit, consts map[string]string) bool {
+// fieldVerdict is what a composite literal's `Field:` says about the argument it
+// refuses.
+type fieldVerdict int
+
+const (
+	fieldIsSomethingElse fieldVerdict = iota
+	fieldIsACursor
+	fieldIsUnreadable
+)
+
+// cursorFieldVerdict reads a composite literal's `Field:` — the shape an error
+// uses to say WHICH argument it is refusing.
+//
+// A value that will not resolve is reported rather than passed over. The field
+// is named through a constant in this tree, and a constant the resolver cannot
+// fold (bound twice in one package, or built from something it does not follow)
+// would silently read as "not a cursor" — a false pass in the one place this
+// census is trusted to look.
+func cursorFieldVerdict(lit *ast.CompositeLit, consts map[string]string, constNames map[string]bool) fieldVerdict {
 	for _, element := range lit.Elts {
 		pair, ok := element.(*ast.KeyValueExpr)
 		if !ok {
@@ -121,11 +160,50 @@ func namesACursorField(lit *ast.CompositeLit, consts map[string]string) bool {
 		if !ok || !strings.EqualFold(key.Name, "field") {
 			continue
 		}
-		if text, resolved := stringValue(pair.Value, consts); resolved && text == "cursor" {
-			return true
+		text, resolved := stringValue(pair.Value, consts)
+		switch {
+		case resolved && text == "cursor":
+			return fieldIsACursor
+		case resolved:
+			return fieldIsSomethingElse
+		case namesADeclaredConst(pair.Value, constNames):
+			return fieldIsUnreadable
 		}
 	}
-	return false
+	return fieldIsSomethingElse
+}
+
+// namesADeclaredConst reports whether a Field: value is an identifier the
+// package declares as a constant — one the resolver was meant to fold.
+//
+// A parameter or local carrying a field name at runtime (`Field: field`, in the
+// search refusals) is not something any census could read, and reporting it
+// would ask an author to change correct code.
+func namesADeclaredConst(value ast.Expr, constNames map[string]bool) bool {
+	ident, named := value.(*ast.Ident)
+	return named && constNames[ident.Name]
+}
+
+// declaredConstNames are the names a package binds with `const`, whether or not
+// the resolver could fold their values.
+func declaredConstNames(files []*ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				if value, ok := spec.(*ast.ValueSpec); ok {
+					for _, name := range value.Names {
+						names[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+	return names
 }
 
 func literalTypeName(lit *ast.CompositeLit) string {
@@ -148,16 +226,22 @@ func TestARefusalAboutACursorIsTheContractsRefusal(t *testing.T) {
 	if len(files) < 300 {
 		t.Fatalf("the census read only %d files, so it covered almost nothing", len(files))
 	}
-	var findings []string
+	var findings, unreadable []string
 	for _, source := range files {
 		ast.Inspect(source.file, func(node ast.Node) bool {
 			lit, ok := node.(*ast.CompositeLit)
-			if !ok || !namesACursorField(lit, source.consts) {
+			if !ok {
 				return true
 			}
-			if name := literalTypeName(lit); name != "MalformedCursorError" &&
-				name != "storekit.MalformedCursorError" {
-				findings = append(findings, source.path+": "+name)
+			switch cursorFieldVerdict(lit, source.consts, source.constNames) {
+			case fieldIsUnreadable:
+				unreadable = append(unreadable, source.path+": "+literalTypeName(lit))
+			case fieldIsACursor:
+				if name := literalTypeName(lit); name != "MalformedCursorError" &&
+					name != "storekit.MalformedCursorError" {
+					findings = append(findings, source.path+": "+name)
+				}
+			case fieldIsSomethingElse:
 			}
 			return true
 		})
@@ -172,60 +256,298 @@ func TestARefusalAboutACursorIsTheContractsRefusal(t *testing.T) {
 			"httperr maps it to 422 malformed_cursor.\n\n\t%s",
 			len(findings), strings.Join(findings, "\n\t"))
 	}
+	if len(unreadable) > 0 {
+		sort.Strings(unreadable)
+		t.Errorf("%d refusal(s) name their field through a constant this census cannot resolve, "+
+			"so it cannot tell whether they are about a cursor.\n\n"+
+			"An unreadable field reads as \"not a cursor\" and passes for the wrong reason. Bind the "+
+			"constant once per package, or name the field literally.\n\n\t%s",
+			len(unreadable), strings.Join(unreadable, "\n\t"))
+	}
 }
 
 // TestEveryCursorDecoderCanAnswerMalformed is the second arm: a function that
 // READS a cursor must be able to give that answer, however it parses.
 //
 // Keyed on the decode rather than on the error's shape, because a refusal that
-// names no field is invisible to the first arm — and that is exactly how the
-// base64 decoder in the dedupe queue survived a sweep of the UUID-parsing ones.
+// names no field is invisible to the first arm.
 func TestEveryCursorDecoderCanAnswerMalformed(t *testing.T) {
 	// A ratification that stops matching is one for a function that has moved or
 	// been folded in, and leaving it quietly re-exempts whatever takes its name.
 	defer connectorCursors.AssertAllMatched(t)
 
 	var findings []string
-	decoders := 0
+	branches := 0
 	for _, source := range refusalFiles(t) {
 		for _, decl := range source.file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || !readsACursor(fn) {
+			if !ok || fn.Body == nil {
 				continue
 			}
-			decoders++
+			refusals := cursorRefusals(fn)
+			if len(refusals) == 0 {
+				continue
+			}
 			if connectorCursors.Waived(t, source.path+":"+fn.Name.Name) {
 				continue
 			}
-			if !mentionsMalformedCursor(fn.Body) {
-				findings = append(findings, source.path+": "+fn.Name.Name)
+			for _, refusal := range refusals {
+				branches++
+				if !refusal.answersTheContract() {
+					findings = append(findings, source.path+": "+fn.Name.Name)
+				}
 			}
 		}
 	}
-	// A census that recognises no decoder is judging nothing.
-	if decoders < 10 {
-		t.Fatalf("the census found only %d cursor decoders, so it is not reading the tree", decoders)
+	// A census that recognises no refusal branch is judging nothing.
+	if branches < 15 {
+		t.Fatalf("the census found only %d cursor refusal branches, so it is not reading the tree", branches)
 	}
 	sort.Strings(findings)
 	if len(findings) > 0 {
-		t.Errorf("%d function(s) decide whether a cursor is well-formed without being able to "+
-			"say so in the contract's words.\n\n"+
-			"Answer &storekit.MalformedCursorError{} on the bad-token path, or delegate to "+
-			"storekit.DecodeCursor.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
+		t.Errorf("%d failure branch(es) refuse a page token without saying so in the contract's "+
+			"words.\n\n"+
+			"Return &storekit.MalformedCursorError{} from the branch itself, or delegate the decode "+
+			"to storekit.DecodeCursor and hand its error on.\n\n\t%s",
+			len(findings), strings.Join(findings, "\n\t"))
 	}
 }
 
-// readsACursor reports whether fn hands a value the code itself calls a cursor
-// to a parsing primitive.
-func readsACursor(fn *ast.FuncDecl) bool {
-	found := false
+// cursorRefusals returns, for each place fn decodes a page token, the error
+// expressions its IMMEDIATE failure branch returns — and whether that decode
+// delegated to storekit.
+//
+// The branch, not the function. A compound decoder that answers the contract on
+// one failure and a module error on another passes any check asking only whether
+// the symbol appears somewhere in the body, while the second failure still
+// reaches a client as the wrong code. What a caller receives is decided by the
+// branch it lands in.
+//
+// A decode with no failure branch refuses nothing, so there is nothing here to
+// misclassify and it yields no entry.
+func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
+	carries := tokenCarriers(fn)
+	var found []cursorRefusal
 	ast.Inspect(fn.Body, func(node ast.Node) bool {
-		call, ok := node.(*ast.CallExpr)
-		if !ok || !callsADecoder(call) {
+		block, ok := node.(*ast.BlockStmt)
+		if !ok {
 			return true
 		}
+		for i, stmt := range block.List {
+			// `x, err := decode(cursor)` followed by `if err != nil { ... }`.
+			assign, isAssign := stmt.(*ast.AssignStmt)
+			if !isAssign || i+1 >= len(block.List) {
+				continue
+			}
+			delegated, decodes := decodesAToken(assign.Rhs, carries)
+			if !decodes {
+				continue
+			}
+			guard, isGuard := block.List[i+1].(*ast.IfStmt)
+			if !isGuard || !guardsAnError(guard.Cond) {
+				continue
+			}
+			if returns := returnedErrors(guard.Body); refuses(returns) {
+				found = append(found, cursorRefusal{returns: returns, delegated: delegated})
+			}
+		}
+		return true
+	})
+	// `if x, err := decode(cursor); err != nil { ... }` — the same decision with
+	// the assignment inside the guard.
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		guard, ok := node.(*ast.IfStmt)
+		if !ok || guard.Init == nil || !guardsAnError(guard.Cond) {
+			return true
+		}
+		assign, isAssign := guard.Init.(*ast.AssignStmt)
+		if !isAssign {
+			return true
+		}
+		if delegated, decodes := decodesAToken(assign.Rhs, carries); decodes {
+			if returns := returnedErrors(guard.Body); refuses(returns) {
+				found = append(found, cursorRefusal{returns: returns, delegated: delegated})
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// cursorRefusal is one failure branch: what it returns, and whether the decode
+// it guards came from storekit.
+type cursorRefusal struct {
+	returns   []ast.Expr
+	delegated bool
+}
+
+// answersTheContract reports whether this branch gives the caller the contract's
+// refusal.
+//
+// A branch guarding storekit.DecodeCursor may simply hand the error on: that
+// error already IS the contract's, and re-wrapping it would be the second
+// spelling this file exists to prevent. Every other branch has to say so itself.
+func (r cursorRefusal) answersTheContract() bool {
+	for _, returned := range r.returns {
+		if r.delegated && mentionsAnError(returned) {
+			return true
+		}
+		if buildsMalformedCursor(returned) {
+			return true
+		}
+	}
+	return false
+}
+
+// decodesAToken reports whether an assignment's right-hand side reads a page
+// token, and whether it did so through storekit.
+//
+// A call named DecodeCursor is a cursor decode whatever its argument is called —
+// the function name is the evidence, and requiring the argument to be named too
+// would drop the sites that spell it `token`. A general-purpose primitive
+// (`Atoi`, `Cut`, `Parse`) needs the argument to say what it is reading.
+func decodesAToken(rhs []ast.Expr, carries map[string]bool) (delegated, decodes bool) {
+	for _, expr := range rhs {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok || !callsADecoder(call) {
+			continue
+		}
+		if decoderName(call) == "DecodeCursor" {
+			return true, true
+		}
 		for _, arg := range call.Args {
-			if namesACursor(arg) {
+			if namesACursor(arg) || carriesAToken(arg, carries) {
+				decodes = true
+			}
+		}
+	}
+	return delegated, decodes
+}
+
+// tokenCarriers are the locals a function has copied a page token into, to a
+// fixed point.
+//
+// Without this, one assignment launders the token out of the census: `t :=
+// in.Cursor`, and every later mention is of `t`, which no vocabulary of names
+// recognises. A rule a rename defeats is not a rule.
+func tokenCarriers(fn *ast.FuncDecl) map[string]bool {
+	carries := map[string]bool{}
+	for {
+		learned := false
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			assign, ok := node.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for i, target := range assign.Lhs {
+				name, isIdent := target.(*ast.Ident)
+				if !isIdent || carries[name.Name] || i >= len(assign.Rhs) {
+					continue
+				}
+				if namesACursor(assign.Rhs[i]) || carriesAToken(assign.Rhs[i], carries) {
+					carries[name.Name] = true
+					learned = true
+				}
+			}
+			return true
+		})
+		if !learned {
+			return carries
+		}
+	}
+}
+
+func carriesAToken(expr ast.Expr, carries map[string]bool) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if ident, ok := node.(*ast.Ident); ok && carries[ident.Name] {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+func decoderName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		return fun.Sel.Name
+	}
+	return ""
+}
+
+func guardsAnError(cond ast.Expr) bool {
+	binary, ok := cond.(*ast.BinaryExpr)
+	if !ok {
+		return false
+	}
+	return mentionsAnError(binary.X) || mentionsAnError(binary.Y)
+}
+
+func mentionsAnError(expr ast.Expr) bool {
+	named := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if ident, ok := node.(*ast.Ident); ok && strings.Contains(strings.ToLower(ident.Name), "err") {
+			named = true
+		}
+		return true
+	})
+	return named
+}
+
+// refuses reports whether a branch hands an ERROR back. A branch that recovers
+// instead — returning a zero value, or the token unchanged — declines nothing,
+// so there is no code for it to get wrong. `splitCappedCursor` reads that way on
+// purpose: a cursor without the count prefix is the start of paging.
+func refuses(returns []ast.Expr) bool {
+	for _, returned := range returns {
+		if looksLikeAnError(returned) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeAnError(expr ast.Expr) bool {
+	switch node := expr.(type) {
+	case *ast.Ident:
+		return strings.Contains(strings.ToLower(node.Name), "err")
+	case *ast.UnaryExpr:
+		return looksLikeAnError(node.X)
+	case *ast.CompositeLit:
+		return strings.HasSuffix(literalTypeName(node), "Error")
+	case *ast.CallExpr:
+		name := decoderName(node)
+		return name == "New" || name == "Errorf" || strings.Contains(strings.ToLower(name), "err")
+	case *ast.SelectorExpr:
+		return strings.Contains(strings.ToLower(node.Sel.Name), "err")
+	}
+	return false
+}
+
+func returnedErrors(body *ast.BlockStmt) []ast.Expr {
+	var out []ast.Expr
+	ast.Inspect(body, func(node ast.Node) bool {
+		if ret, ok := node.(*ast.ReturnStmt); ok {
+			out = append(out, ret.Results...)
+		}
+		return true
+	})
+	return out
+}
+
+func buildsMalformedCursor(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.Ident:
+			if n.Name == "MalformedCursorError" {
+				found = true
+			}
+		case *ast.SelectorExpr:
+			if n.Sel.Name == "MalformedCursorError" {
 				found = true
 			}
 		}
@@ -235,13 +557,7 @@ func readsACursor(fn *ast.FuncDecl) bool {
 }
 
 func callsADecoder(call *ast.CallExpr) bool {
-	name := ""
-	switch fun := call.Fun.(type) {
-	case *ast.Ident:
-		name = fun.Name
-	case *ast.SelectorExpr:
-		name = fun.Sel.Name
-	}
+	name := decoderName(call)
 	for _, decoder := range cursorDecoders {
 		if name == decoder {
 			return true
@@ -255,29 +571,10 @@ func callsADecoder(call *ast.CallExpr) bool {
 func namesACursor(expr ast.Expr) bool {
 	named := false
 	ast.Inspect(expr, func(node ast.Node) bool {
-		if ident, ok := node.(*ast.Ident); ok &&
-			strings.Contains(strings.ToLower(ident.Name), "cursor") {
+		if ident, ok := node.(*ast.Ident); ok && namesAToken(ident.Name) {
 			named = true
 		}
 		return true
 	})
 	return named
-}
-
-func mentionsMalformedCursor(body *ast.BlockStmt) bool {
-	found := false
-	ast.Inspect(body, func(node ast.Node) bool {
-		switch n := node.(type) {
-		case *ast.Ident:
-			if n.Name == "MalformedCursorError" || n.Name == "DecodeCursor" {
-				found = true
-			}
-		case *ast.SelectorExpr:
-			if n.Sel.Name == "MalformedCursorError" || n.Sel.Name == "DecodeCursor" {
-				found = true
-			}
-		}
-		return true
-	})
-	return found
 }

--- a/backend/cursorrefusal_test.go
+++ b/backend/cursorrefusal_test.go
@@ -327,6 +327,11 @@ func TestEveryCursorDecoderCanAnswerMalformed(t *testing.T) {
 // misclassify and it yields no entry.
 func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 	carries := tokenCarriers(fn)
+	// A function whose own name says it decodes a cursor is one, whatever it
+	// calls its argument. `decodeDedupeCursor(token string)` spells its
+	// parameter `token` and its bytes `raw`, so a census reading only argument
+	// names could not see the decoder this arm exists to guard.
+	named := namesAToken(fn.Name.Name)
 	var found []cursorRefusal
 	ast.Inspect(fn.Body, func(node ast.Node) bool {
 		block, ok := node.(*ast.BlockStmt)
@@ -340,7 +345,8 @@ func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 				continue
 			}
 			delegated, decodes := decodesAToken(assign.Rhs, carries)
-			if !decodes {
+			readsAToken := decodes || (named && callsAnyDecoder(assign.Rhs))
+			if !readsAToken {
 				continue
 			}
 			guard, isGuard := block.List[i+1].(*ast.IfStmt)
@@ -348,7 +354,7 @@ func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 				continue
 			}
 			if returns := returnedErrors(guard.Body); refuses(returns) {
-				found = append(found, cursorRefusal{returns: returns, delegated: delegated})
+				found = append(found, cursorRefusal{returns: returns, guarded: guardedName(guard.Cond), delegated: delegated})
 			}
 		}
 		return true
@@ -364,9 +370,11 @@ func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 		if !isAssign {
 			return true
 		}
-		if delegated, decodes := decodesAToken(assign.Rhs, carries); decodes {
+		delegated, decodes := decodesAToken(assign.Rhs, carries)
+		readsAToken := decodes || (named && callsAnyDecoder(assign.Rhs))
+		if readsAToken {
 			if returns := returnedErrors(guard.Body); refuses(returns) {
-				found = append(found, cursorRefusal{returns: returns, delegated: delegated})
+				found = append(found, cursorRefusal{returns: returns, guarded: guardedName(guard.Cond), delegated: delegated})
 			}
 		}
 		return true
@@ -377,23 +385,75 @@ func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 // cursorRefusal is one failure branch: what it returns, and whether the decode
 // it guards came from storekit.
 type cursorRefusal struct {
-	returns   []ast.Expr
+	// returns is one entry per return statement in the branch, each holding
+	// that statement's result expressions.
+	returns [][]ast.Expr
+	// guarded is the error variable the branch's condition tested, so a
+	// delegating branch can be checked for handing THAT error on.
+	guarded   string
 	delegated bool
 }
 
 // answersTheContract reports whether this branch gives the caller the contract's
-// refusal.
+// refusal on EVERY path out of it.
 //
-// A branch guarding storekit.DecodeCursor may simply hand the error on: that
-// error already IS the contract's, and re-wrapping it would be the second
-// spelling this file exists to prevent. Every other branch has to say so itself.
+// Every path, not any: a branch that answers the contract for one nested
+// condition and a module error for another still sends the wrong code to
+// whichever caller lands in the second, and a check satisfied by the first would
+// clear it.
+//
+// A branch guarding storekit.DecodeCursor may hand the error on rather than
+// rebuild it — that error already IS the contract's. But it must be THAT error:
+// `fmt.Errorf` without %w, or a different sentinel, loses the type httperr
+// matches on and falls through to a 500, which is the wrong-code outcome this
+// census exists to block. So the delegated case accepts the guarded variable
+// itself, not any identifier that happens to contain "err".
 func (r cursorRefusal) answersTheContract() bool {
-	for _, returned := range r.returns {
-		if r.delegated && mentionsAnError(returned) {
-			return true
+	if len(r.returns) == 0 {
+		return false
+	}
+	// Judged per RETURN STATEMENT. Within one statement only the error position
+	// carries the answer — `return nil, err` says nothing wrong with its `nil`.
+	for _, statement := range r.returns {
+		answered := false
+		for _, returned := range statement {
+			if buildsMalformedCursor(returned) || (r.delegated && handsOn(returned, r.guarded)) {
+				answered = true
+			}
 		}
-		if buildsMalformedCursor(returned) {
-			return true
+		if !answered {
+			return false
+		}
+	}
+	return true
+}
+
+// handsOn reports whether a return passes the guarded error along — the
+// variable itself, or a wrap that keeps it reachable through errors.As.
+func handsOn(returned ast.Expr, guarded string) bool {
+	if guarded == "" {
+		return false
+	}
+	switch node := returned.(type) {
+	case *ast.Ident:
+		return node.Name == guarded
+	case *ast.CallExpr:
+		if decoderName(node) != "Errorf" {
+			return false
+		}
+		wrapped := false
+		for _, arg := range node.Args {
+			if lit, ok := arg.(*ast.BasicLit); ok && strings.Contains(lit.Value, "%w") {
+				wrapped = true
+			}
+		}
+		if !wrapped {
+			return false
+		}
+		for _, arg := range node.Args {
+			if ident, ok := arg.(*ast.Ident); ok && ident.Name == guarded {
+				return true
+			}
 		}
 	}
 	return false
@@ -468,12 +528,38 @@ func carriesAToken(expr ast.Expr, carries map[string]bool) bool {
 	return found
 }
 
+// callsAnyDecoder reports whether a right-hand side reads a token at all,
+// without asking what the argument is called.
+func callsAnyDecoder(rhs []ast.Expr) bool {
+	for _, expr := range rhs {
+		if call, ok := expr.(*ast.CallExpr); ok && callsADecoder(call) {
+			return true
+		}
+	}
+	return false
+}
+
 func decoderName(call *ast.CallExpr) string {
 	switch fun := call.Fun.(type) {
 	case *ast.Ident:
 		return fun.Name
 	case *ast.SelectorExpr:
 		return fun.Sel.Name
+	}
+	return ""
+}
+
+// guardedName is the error variable a guard tested.
+func guardedName(cond ast.Expr) string {
+	binary, ok := cond.(*ast.BinaryExpr)
+	if !ok {
+		return ""
+	}
+	for _, side := range []ast.Expr{binary.X, binary.Y} {
+		if ident, isIdent := side.(*ast.Ident); isIdent &&
+			strings.Contains(strings.ToLower(ident.Name), "err") {
+			return ident.Name
+		}
 	}
 	return ""
 }
@@ -501,10 +587,12 @@ func mentionsAnError(expr ast.Expr) bool {
 // instead — returning a zero value, or the token unchanged — declines nothing,
 // so there is no code for it to get wrong. `splitCappedCursor` reads that way on
 // purpose: a cursor without the count prefix is the start of paging.
-func refuses(returns []ast.Expr) bool {
-	for _, returned := range returns {
-		if looksLikeAnError(returned) {
-			return true
+func refuses(returns [][]ast.Expr) bool {
+	for _, statement := range returns {
+		for _, returned := range statement {
+			if looksLikeAnError(returned) {
+				return true
+			}
 		}
 	}
 	return false
@@ -527,11 +615,11 @@ func looksLikeAnError(expr ast.Expr) bool {
 	return false
 }
 
-func returnedErrors(body *ast.BlockStmt) []ast.Expr {
-	var out []ast.Expr
+func returnedErrors(body *ast.BlockStmt) [][]ast.Expr {
+	var out [][]ast.Expr
 	ast.Inspect(body, func(node ast.Node) bool {
-		if ret, ok := node.(*ast.ReturnStmt); ok {
-			out = append(out, ret.Results...)
+		if ret, ok := node.(*ast.ReturnStmt); ok && len(ret.Results) > 0 {
+			out = append(out, ret.Results)
 		}
 		return true
 	})

--- a/backend/cursorrefusal_test.go
+++ b/backend/cursorrefusal_test.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A page token a caller hands back is either one this server minted or it is
+// not, and that is ONE question with one answer on the wire: the contract's
+// `422 code: malformed_cursor`, which tells the caller to re-issue the request
+// without the token.
+//
+// A module that invents its own refusal answers a different question. The two
+// spellings this tree carried said `required` — of a field the caller had just
+// supplied, so acting on it means sending the token again — and `invalid`, which
+// names no remedy at all. Neither is reachable from the contract, so a client
+// written against the contract cannot recognise either.
+//
+// THE RULE: a refusal about a cursor is `storekit.MalformedCursorError`.
+// `platform/httperr` maps that one type to the contract's code, and mapping is
+// the only place the wire code is decided.
+//
+// Two arms, because the site that escaped the first sweep escaped it by not
+// having the shape the first arm reads. `people/dedupequeue.go` decodes base64
+// rather than parsing a UUID, and it was found only when a test named the error
+// it expected. A census keyed on one spelling of "parse" would have reported a
+// clean tree over it.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// connectorCursors resume a CONNECTOR, not a caller's page. The server mints
+// these and reads its own back; no client ever supplies one, so there is no
+// request to refuse and no contract code to answer with. Ratified by name
+// because the distinction is what the token IS, which its shape does not say —
+// both are bytes carrying JSON.
+var connectorCursors = gatekit.Waive(map[string]string{
+	"internal/modules/capture/backfillpager.go:backfillPageCursor":   "reads the provider page token stored on a backfill run, handed back to the provider's own API. A caller never sends it, and an unreadable one is a server-side fault the run reports, not a 422.",
+	"internal/modules/capture/offlinedemo/offlinedemo.go:readCursor": "reads the demo generator's own resume state and returns no error at all — an unreadable or stale-generation cursor restarts the generator rather than refusing anything.",
+})
+
+// refusalSurfaceRoots are the trees where a cursor may be refused.
+var refusalSurfaceRoots = []string{"internal/modules", "internal/compose", "../extensions"}
+
+// cursorDecoders are the primitives a cursor is read WITH. A function calling
+// one of these on a cursor is deciding whether the token is well-formed, which
+// is the decision this file governs.
+var cursorDecoders = []string{"Parse", "DecodeString", "Unmarshal", "DecodeCursor"}
+
+// refusalFile is one parsed product file with its package's string constants,
+// so a field named through a constant (`Field: fieldCursor`) reads the same as
+// one named literally.
+type refusalFile struct {
+	path   string
+	file   *ast.File
+	consts map[string]string
+}
+
+func refusalFiles(t *testing.T) []refusalFile {
+	t.Helper()
+	byDir := map[string][]*ast.File{}
+	paths := map[*ast.File]string{}
+	fset := token.NewFileSet()
+	for _, root := range refusalSurfaceRoots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if name := entry.Name(); name == "testdata" || name == "node_modules" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			parsed, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			dir := filepath.ToSlash(filepath.Dir(path))
+			byDir[dir] = append(byDir[dir], parsed)
+			paths[parsed] = filepath.ToSlash(path)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	var out []refusalFile
+	for _, files := range byDir {
+		consts := stringConstants(files)
+		for _, f := range files {
+			out = append(out, refusalFile{path: paths[f], file: f, consts: consts})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out
+}
+
+// namesACursorField reports whether a composite literal binds a field whose
+// value is the string "cursor" — the shape an error uses to say WHICH argument
+// it is refusing.
+func namesACursorField(lit *ast.CompositeLit, consts map[string]string) bool {
+	for _, element := range lit.Elts {
+		pair, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := pair.Key.(*ast.Ident)
+		if !ok || !strings.EqualFold(key.Name, "field") {
+			continue
+		}
+		if text, resolved := stringValue(pair.Value, consts); resolved && text == "cursor" {
+			return true
+		}
+	}
+	return false
+}
+
+func literalTypeName(lit *ast.CompositeLit) string {
+	switch typ := lit.Type.(type) {
+	case *ast.Ident:
+		return typ.Name
+	case *ast.SelectorExpr:
+		if pkg, ok := typ.X.(*ast.Ident); ok {
+			return pkg.Name + "." + typ.Sel.Name
+		}
+		return typ.Sel.Name
+	}
+	return ""
+}
+
+// TestARefusalAboutACursorIsTheContractsRefusal is the first arm: nothing but
+// storekit's type may name a cursor as the field it refuses.
+func TestARefusalAboutACursorIsTheContractsRefusal(t *testing.T) {
+	files := refusalFiles(t)
+	if len(files) < 300 {
+		t.Fatalf("the census read only %d files, so it covered almost nothing", len(files))
+	}
+	var findings []string
+	for _, source := range files {
+		ast.Inspect(source.file, func(node ast.Node) bool {
+			lit, ok := node.(*ast.CompositeLit)
+			if !ok || !namesACursorField(lit, source.consts) {
+				return true
+			}
+			if name := literalTypeName(lit); name != "MalformedCursorError" &&
+				name != "storekit.MalformedCursorError" {
+				findings = append(findings, source.path+": "+name)
+			}
+			return true
+		})
+	}
+	sort.Strings(findings)
+	if len(findings) > 0 {
+		t.Errorf("%d refusal(s) name a cursor as the field they reject, but are not the "+
+			"contract's refusal.\n\n"+
+			"A caller cannot act on `required` for a token it just supplied, or on `invalid`, "+
+			"which names no remedy — and neither code is reachable from the contract, so a client "+
+			"written against it cannot recognise them. Return &storekit.MalformedCursorError{}; "+
+			"httperr maps it to 422 malformed_cursor.\n\n\t%s",
+			len(findings), strings.Join(findings, "\n\t"))
+	}
+}
+
+// TestEveryCursorDecoderCanAnswerMalformed is the second arm: a function that
+// READS a cursor must be able to give that answer, however it parses.
+//
+// Keyed on the decode rather than on the error's shape, because a refusal that
+// names no field is invisible to the first arm — and that is exactly how the
+// base64 decoder in the dedupe queue survived a sweep of the UUID-parsing ones.
+func TestEveryCursorDecoderCanAnswerMalformed(t *testing.T) {
+	// A ratification that stops matching is one for a function that has moved or
+	// been folded in, and leaving it quietly re-exempts whatever takes its name.
+	defer connectorCursors.AssertAllMatched(t)
+
+	var findings []string
+	decoders := 0
+	for _, source := range refusalFiles(t) {
+		for _, decl := range source.file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !readsACursor(fn) {
+				continue
+			}
+			decoders++
+			if connectorCursors.Waived(t, source.path+":"+fn.Name.Name) {
+				continue
+			}
+			if !mentionsMalformedCursor(fn.Body) {
+				findings = append(findings, source.path+": "+fn.Name.Name)
+			}
+		}
+	}
+	// A census that recognises no decoder is judging nothing.
+	if decoders < 10 {
+		t.Fatalf("the census found only %d cursor decoders, so it is not reading the tree", decoders)
+	}
+	sort.Strings(findings)
+	if len(findings) > 0 {
+		t.Errorf("%d function(s) decide whether a cursor is well-formed without being able to "+
+			"say so in the contract's words.\n\n"+
+			"Answer &storekit.MalformedCursorError{} on the bad-token path, or delegate to "+
+			"storekit.DecodeCursor.\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
+	}
+}
+
+// readsACursor reports whether fn hands a value the code itself calls a cursor
+// to a parsing primitive.
+func readsACursor(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !callsADecoder(call) {
+			return true
+		}
+		for _, arg := range call.Args {
+			if namesACursor(arg) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func callsADecoder(call *ast.CallExpr) bool {
+	name := ""
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		name = fun.Name
+	case *ast.SelectorExpr:
+		name = fun.Sel.Name
+	}
+	for _, decoder := range cursorDecoders {
+		if name == decoder {
+			return true
+		}
+	}
+	return false
+}
+
+// namesACursor reads the expression's own vocabulary. A token the code calls a
+// cursor is one, whether it arrives as `cursor`, `in.Cursor` or `*f.Cursor`.
+func namesACursor(expr ast.Expr) bool {
+	named := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if ident, ok := node.(*ast.Ident); ok &&
+			strings.Contains(strings.ToLower(ident.Name), "cursor") {
+			named = true
+		}
+		return true
+	})
+	return named
+}
+
+func mentionsMalformedCursor(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.Ident:
+			if n.Name == "MalformedCursorError" || n.Name == "DecodeCursor" {
+				found = true
+			}
+		case *ast.SelectorExpr:
+			if n.Sel.Name == "MalformedCursorError" || n.Sel.Name == "DecodeCursor" {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/backend/cursorrefusal_test.go
+++ b/backend/cursorrefusal_test.go
@@ -285,7 +285,7 @@ func TestEveryCursorDecoderCanAnswerMalformed(t *testing.T) {
 			if !ok || fn.Body == nil {
 				continue
 			}
-			refusals := cursorRefusals(fn)
+			refusals := cursorRefusals(fn, strings.Contains(source.path, "database/storekit"))
 			if len(refusals) == 0 {
 				continue
 			}
@@ -326,7 +326,7 @@ func TestEveryCursorDecoderCanAnswerMalformed(t *testing.T) {
 //
 // A decode with no failure branch refuses nothing, so there is nothing here to
 // misclassify and it yields no entry.
-func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
+func cursorRefusals(fn *ast.FuncDecl, inStorekit bool) []cursorRefusal {
 	carries := tokenCarriers(fn)
 	// A function whose own name says it decodes a cursor is one, whatever it
 	// calls its argument. `decodeDedupeCursor(token string)` spells its
@@ -355,7 +355,7 @@ func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 				continue
 			}
 			if returns := returnedErrors(guard.Body); refuses(returns) {
-				found = append(found, cursorRefusal{returns: returns, guarded: guardedName(guard.Cond), delegated: delegated})
+				found = append(found, cursorRefusal{returns: returns, guarded: guardedName(guard.Cond), inStorekit: inStorekit, delegated: delegated})
 			}
 		}
 		return true
@@ -375,7 +375,7 @@ func cursorRefusals(fn *ast.FuncDecl) []cursorRefusal {
 		readsAToken := decodes || (named && callsAnyDecoder(assign.Rhs))
 		if readsAToken {
 			if returns := returnedErrors(guard.Body); refuses(returns) {
-				found = append(found, cursorRefusal{returns: returns, guarded: guardedName(guard.Cond), delegated: delegated})
+				found = append(found, cursorRefusal{returns: returns, guarded: guardedName(guard.Cond), inStorekit: inStorekit, delegated: delegated})
 			}
 		}
 		return true
@@ -391,8 +391,11 @@ type cursorRefusal struct {
 	returns [][]ast.Expr
 	// guarded is the error variable the branch's condition tested, so a
 	// delegating branch can be checked for handing THAT error on.
-	guarded   string
-	delegated bool
+	guarded string
+	// inStorekit is whether this branch lives in the package that DECLARES the
+	// error, where naming it unqualified is the same type.
+	inStorekit bool
+	delegated  bool
 }
 
 // answersTheContract reports whether this branch gives the caller the contract's
@@ -418,7 +421,7 @@ func (r cursorRefusal) answersTheContract() bool {
 	for _, statement := range r.returns {
 		answered := false
 		for _, returned := range statement {
-			if buildsMalformedCursor(returned) || (r.delegated && handsOn(returned, r.guarded)) {
+			if buildsMalformedCursor(returned, r.inStorekit) || (r.delegated && handsOn(returned, r.guarded)) {
 				answered = true
 			}
 		}
@@ -471,7 +474,14 @@ func wrapsGuarded(call *ast.CallExpr, guarded string) bool {
 }
 
 // wrappedVerbIndex is which operand the %w consumes, counting the verbs before
-// it, or -1 when the format wraps nothing.
+// it, or -1 when the format wraps nothing OR when this cannot say.
+//
+// An explicit argument index (`%[2]v`) or a `*` width reassigns which operand a
+// later verb takes, and a parser that counted verbs would name the wrong one —
+// `fmt.Errorf("%[2]v: %w", ignored, err, otherErr)` wraps otherErr while a
+// naive count says err. Rather than reimplement fmt's argument selection, a
+// format carrying either is REFUSED: a format this cannot read is not one it
+// has cleared, and the branch has to say so a way this can check.
 func wrappedVerbIndex(format string) int {
 	operand := 0
 	for i := 0; i < len(format)-1; i++ {
@@ -481,6 +491,8 @@ func wrappedVerbIndex(format string) int {
 		switch next := format[i+1]; next {
 		case '%':
 			i++
+		case '[', '*':
+			return -1
 		case 'w':
 			return operand
 		default:
@@ -665,7 +677,7 @@ func returnedErrors(body *ast.BlockStmt) [][]ast.Expr {
 // throws it away: the text carries the words while errors.As finds nothing, so
 // httperr falls through to a 500. Only the construction itself, or a pointer to
 // it, is the answer.
-func buildsMalformedCursor(expr ast.Expr) bool {
+func buildsMalformedCursor(expr ast.Expr, inStorekit bool) bool {
 	if unary, ok := expr.(*ast.UnaryExpr); ok && unary.Op == token.AND {
 		expr = unary.X
 	}
@@ -673,13 +685,17 @@ func buildsMalformedCursor(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	switch typ := lit.Type.(type) {
-	case *ast.Ident:
-		return typ.Name == "MalformedCursorError"
-	case *ast.SelectorExpr:
-		return typ.Sel.Name == "MalformedCursorError"
+	// Qualified by storekit, or unqualified inside storekit itself. Matching the
+	// final name alone would accept `&other.MalformedCursorError{}` or a local
+	// type of the same name — neither is the type httperr matches on, so the
+	// caller would get a 500 while the census reported the contract answered.
+	selector, ok := lit.Type.(*ast.SelectorExpr)
+	if !ok {
+		ident, isIdent := lit.Type.(*ast.Ident)
+		return isIdent && ident.Name == "MalformedCursorError" && inStorekit
 	}
-	return false
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "storekit" && selector.Sel.Name == "MalformedCursorError"
 }
 
 func callsADecoder(call *ast.CallExpr) bool {

--- a/backend/cursorrefusal_test.go
+++ b/backend/cursorrefusal_test.go
@@ -31,6 +31,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -438,25 +439,56 @@ func handsOn(returned ast.Expr, guarded string) bool {
 	case *ast.Ident:
 		return node.Name == guarded
 	case *ast.CallExpr:
-		if decoderName(node) != "Errorf" {
-			return false
-		}
-		wrapped := false
-		for _, arg := range node.Args {
-			if lit, ok := arg.(*ast.BasicLit); ok && strings.Contains(lit.Value, "%w") {
-				wrapped = true
-			}
-		}
-		if !wrapped {
-			return false
-		}
-		for _, arg := range node.Args {
-			if ident, ok := arg.(*ast.Ident); ok && ident.Name == guarded {
-				return true
-			}
-		}
+		return wrapsGuarded(node, guarded)
 	}
 	return false
+}
+
+// wrapsGuarded reports whether an fmt.Errorf wraps THE guarded error.
+//
+// The %w's POSITION decides which argument is preserved, so `fmt.Errorf("%w
+// (%v)", otherErr, err)` wraps the other one and leaves the contract error
+// reachable by nothing. Matching "has a %w somewhere and names err somewhere"
+// would clear it.
+func wrapsGuarded(call *ast.CallExpr, guarded string) bool {
+	if decoderName(call) != "Errorf" || len(call.Args) < 2 {
+		return false
+	}
+	format, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || format.Kind != token.STRING {
+		return false
+	}
+	text, err := strconv.Unquote(format.Value)
+	if err != nil {
+		return false
+	}
+	at := wrappedVerbIndex(text)
+	if at < 0 || at+1 >= len(call.Args) {
+		return false
+	}
+	ident, isIdent := call.Args[at+1].(*ast.Ident)
+	return isIdent && ident.Name == guarded
+}
+
+// wrappedVerbIndex is which operand the %w consumes, counting the verbs before
+// it, or -1 when the format wraps nothing.
+func wrappedVerbIndex(format string) int {
+	operand := 0
+	for i := 0; i < len(format)-1; i++ {
+		if format[i] != '%' {
+			continue
+		}
+		switch next := format[i+1]; next {
+		case '%':
+			i++
+		case 'w':
+			return operand
+		default:
+			operand++
+			i++
+		}
+	}
+	return -1
 }
 
 // decodesAToken reports whether an assignment's right-hand side reads a page
@@ -626,22 +658,28 @@ func returnedErrors(body *ast.BlockStmt) [][]ast.Expr {
 	return out
 }
 
+// buildsMalformedCursor reports whether an expression IS the contract's refusal
+// — not whether it merely mentions one.
+//
+// `fmt.Errorf("cursor: %v", &storekit.MalformedCursorError{})` mentions it and
+// throws it away: the text carries the words while errors.As finds nothing, so
+// httperr falls through to a 500. Only the construction itself, or a pointer to
+// it, is the answer.
 func buildsMalformedCursor(expr ast.Expr) bool {
-	found := false
-	ast.Inspect(expr, func(node ast.Node) bool {
-		switch n := node.(type) {
-		case *ast.Ident:
-			if n.Name == "MalformedCursorError" {
-				found = true
-			}
-		case *ast.SelectorExpr:
-			if n.Sel.Name == "MalformedCursorError" {
-				found = true
-			}
-		}
-		return true
-	})
-	return found
+	if unary, ok := expr.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+		expr = unary.X
+	}
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return false
+	}
+	switch typ := lit.Type.(type) {
+	case *ast.Ident:
+		return typ.Name == "MalformedCursorError"
+	case *ast.SelectorExpr:
+		return typ.Sel.Name == "MalformedCursorError"
+	}
+	return false
 }
 
 func callsADecoder(call *ast.CallExpr) bool {

--- a/backend/cursorrefusal_test.go
+++ b/backend/cursorrefusal_test.go
@@ -53,7 +53,10 @@ var connectorCursors = gatekit.Waive(map[string]string{
 })
 
 // refusalSurfaceRoots are the trees where a cursor may be refused.
-var refusalSurfaceRoots = []string{"internal/modules", "internal/compose", "../extensions"}
+// internal/platform is here so the census also judges the package that DECLARES
+// the refusal. Skipping the owner wholesale would let a second spelling live
+// beside the first, at the one address the census trusts.
+var refusalSurfaceRoots = []string{"internal/modules", "internal/compose", "internal/platform", "../extensions"}
 
 // cursorDecoders are the primitives a page token is read WITH. A function
 // calling one of these on a token is deciding whether it is well-formed, which

--- a/backend/internal/compose/integration/cursor_integration_test.go
+++ b/backend/internal/compose/integration/cursor_integration_test.go
@@ -63,6 +63,12 @@ func TestMalformedCursorAnswersMalformedCursorEverywhere(t *testing.T) {
 		"/v1/data-subject-requests?" + garbage,
 		"/v1/approvals?" + garbage,
 	}
+	// A token that is valid base64 of valid JSON but is not a cursor. It decodes
+	// where garbage does not, so it reaches the layer that has to decide whether
+	// the SHAPE is a cursor — a different refusal from "this is not a token".
+	const notACursor = "cursor=bnVsbA"
+	endpoints = append(endpoints, "/v1/dedupe/candidates?"+notACursor)
+
 	for _, path := range endpoints {
 		var problem cursorProblem
 		status := e.Call(t, "GET", path, nil, nil, &problem)

--- a/backend/internal/compose/integration/cursor_integration_test.go
+++ b/backend/internal/compose/integration/cursor_integration_test.go
@@ -16,11 +16,15 @@ package integration
 // recognise them — yet all three are 4xx, and a test that asked only for a 4xx
 // passed over every one of them.
 //
-// The endpoint set enumerates the contract's Cursor-parameter operations whose
-// implementations parse the token (crm.yaml components.parameters.Cursor refs);
-// /approvals also declares the parameter but its implementation does not
-// paginate yet, so a garbage token there is ignored rather than parsed and has
-// nothing to misclassify.
+// The endpoint set is a SAMPLE, not a census: it carries every implementation
+// that decodes the token itself, plus several that delegate to
+// storekit.DecodeCursor. The contract declares the Cursor parameter on far more
+// operations than are listed here, and what covers those is the static gate in
+// backend/cursorrefusal_test.go — it reads every refusal in the tree, where this
+// suite reads the wire for the ones that got it wrong.
+//
+// Saying which is which matters: a list that claimed to enumerate the contract
+// would stop the next author looking when an endpoint left the list.
 
 import (
 	"net/http"
@@ -57,6 +61,7 @@ func TestMalformedCursorAnswersMalformedCursorEverywhere(t *testing.T) {
 		"/v1/search?q=probe&" + garbage,
 		"/v1/dedupe/candidates?" + garbage,
 		"/v1/data-subject-requests?" + garbage,
+		"/v1/approvals?" + garbage,
 	}
 	for _, path := range endpoints {
 		var problem cursorProblem

--- a/backend/internal/compose/integration/cursor_integration_test.go
+++ b/backend/internal/compose/integration/cursor_integration_test.go
@@ -5,14 +5,22 @@
 
 package integration
 
-// The invariant: a keyset cursor is client input, so a token that fails
-// to decode answers a 4xx problem+json, never a 500 — on EVERY
-// cursor-paginated list operation the contract exposes. The endpoint
-// set below enumerates the contract's Cursor-parameter operations whose
-// implementations parse the token (crm.yaml components.parameters.Cursor
-// refs); /approvals also declares the parameter but its implementation
-// does not paginate yet, so a garbage token there is ignored rather
-// than parsed and has nothing to misclassify.
+// The invariant: a keyset cursor is client input, so a token that fails to
+// decode answers the contract's `422 code: malformed_cursor` — on EVERY
+// cursor-paginated list operation the contract exposes.
+//
+// The CODE is the assertion, not the status class. A client acts on the code:
+// malformed_cursor means re-issue without the token. `required` tells it to
+// send a field it just sent, `invalid` names no remedy, and neither is
+// reachable from the contract, so a client written against the contract cannot
+// recognise them — yet all three are 4xx, and a test that asked only for a 4xx
+// passed over every one of them.
+//
+// The endpoint set enumerates the contract's Cursor-parameter operations whose
+// implementations parse the token (crm.yaml components.parameters.Cursor refs);
+// /approvals also declares the parameter but its implementation does not
+// paginate yet, so a garbage token there is ignored rather than parsed and has
+// nothing to misclassify.
 
 import (
 	"net/http"
@@ -21,7 +29,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
-func TestMalformedCursorAnswers4xxEverywhere(t *testing.T) {
+func TestMalformedCursorAnswersMalformedCursorEverywhere(t *testing.T) {
 	e := apptest.SetupApp(t)
 
 	apptest.BootstrapWorkspaceSession(t, e, "Cursor Probe", "admin@cursor.test", "Admin")
@@ -47,12 +55,38 @@ func TestMalformedCursorAnswers4xxEverywhere(t *testing.T) {
 		"/v1/relationships?" + garbage,
 		"/v1/lists/" + list["id"].(string) + "/members?" + garbage,
 		"/v1/search?q=probe&" + garbage,
+		"/v1/dedupe/candidates?" + garbage,
+		"/v1/data-subject-requests?" + garbage,
 	}
 	for _, path := range endpoints {
-		var problem apptest.AnyMap
+		var problem cursorProblem
 		status := e.Call(t, "GET", path, nil, nil, &problem)
-		if status < 400 || status > 499 {
-			t.Errorf("GET %s with a malformed cursor = %d %v, want a 4xx problem", path, status, problem)
+		if status != http.StatusUnprocessableEntity {
+			t.Errorf("GET %s with a malformed cursor = %d %+v, want 422", path, status, problem)
+			continue
+		}
+		if problem.Code != "validation_error" {
+			t.Errorf("GET %s problem code = %q, want validation_error", path, problem.Code)
+			continue
+		}
+		if len(problem.Details.Errors) != 1 {
+			t.Errorf("GET %s reported %+v, want exactly one field error", path, problem.Details.Errors)
+			continue
+		}
+		if got := problem.Details.Errors[0]; got.Field != "cursor" || got.Code != "malformed_cursor" {
+			t.Errorf("GET %s field error = %+v, want field=cursor code=malformed_cursor", path, got)
 		}
 	}
+}
+
+// cursorProblem is the RFC 7807 body with the field refusals a caller reads to
+// learn which input to drop.
+type cursorProblem struct {
+	Code    string `json:"code"`
+	Details struct {
+		Errors []struct {
+			Field string `json:"field"`
+			Code  string `json:"code"`
+		} `json:"errors"`
+	} `json:"details"`
 }

--- a/backend/internal/modules/collections/members.go
+++ b/backend/internal/modules/collections/members.go
@@ -106,7 +106,7 @@ func (s *Store) listStaticMembers(ctx context.Context, tx pgx.Tx, listID ids.Lis
 	if cursor != "" {
 		after, err := ids.Parse(cursor)
 		if err != nil {
-			return nil, storekit.Page{}, &BadInputError{Field: "cursor", Reason: "malformed"}
+			return nil, storekit.Page{}, &storekit.MalformedCursorError{}
 		}
 		sql += fmt.Sprintf(" AND lm.id > $%d", arg(after))
 	}
@@ -241,7 +241,7 @@ func (s *Store) evaluateSegment(ctx context.Context, listID ids.ListID, listEnti
 	if cursor != "" {
 		parsed, err := ids.Parse(cursor)
 		if err != nil {
-			return nil, storekit.Page{}, &BadInputError{Field: "cursor", Reason: "malformed"}
+			return nil, storekit.Page{}, &storekit.MalformedCursorError{}
 		}
 		after = &parsed
 	}

--- a/backend/internal/modules/consent/dsr.go
+++ b/backend/internal/modules/consent/dsr.go
@@ -123,7 +123,7 @@ func dsrListQuery(cursor, status string, bounded int) (string, []any, error) {
 	if cursor != "" {
 		after, err := ids.Parse(cursor)
 		if err != nil {
-			return "", nil, &ValidationError{Field: "cursor", Reason: "malformed"}
+			return "", nil, &storekit.MalformedCursorError{}
 		}
 		sql += storekit.SQLf(" AND id > $%d", arg(after))
 	}

--- a/backend/internal/modules/people/dedupequeue.go
+++ b/backend/internal/modules/people/dedupequeue.go
@@ -103,6 +103,13 @@ func decodeDedupeCursor(token string) (dedupeCursor, error) {
 	if err := json.Unmarshal(raw, &c); err != nil {
 		return c, &storekit.MalformedCursorError{}
 	}
+	// Valid JSON is not yet a cursor. `null` and `{}` both unmarshal without
+	// error and leave the keyset at its zero value, which reads as a real
+	// position and pages from the top of the queue instead of refusing. Every
+	// token this encodes names a row, so an absent id is the tell.
+	if c.ID == (ids.UUID{}) {
+		return dedupeCursor{}, &storekit.MalformedCursorError{}
+	}
 	return c, nil
 }
 

--- a/backend/internal/modules/people/dedupequeue.go
+++ b/backend/internal/modules/people/dedupequeue.go
@@ -80,7 +80,6 @@ const (
 	// sqlAlwaysVisible is the no-op arm of the pair-visibility predicate:
 	// the caller's scope leaves that record type unbounded.
 	sqlAlwaysVisible = "true"
-	fieldCursor      = "cursor"
 )
 
 // dedupeCursor is the queue's keyset: confidence-descending with the id

--- a/backend/internal/modules/people/dedupequeue.go
+++ b/backend/internal/modules/people/dedupequeue.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -98,10 +99,10 @@ func decodeDedupeCursor(token string) (dedupeCursor, error) {
 	var c dedupeCursor
 	raw, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
-		return c, &DedupeInputError{Field: fieldCursor, Msg: "malformed page token"}
+		return c, &storekit.MalformedCursorError{}
 	}
 	if err := json.Unmarshal(raw, &c); err != nil {
-		return c, &DedupeInputError{Field: fieldCursor, Msg: "malformed page token"}
+		return c, &storekit.MalformedCursorError{}
 	}
 	return c, nil
 }

--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -111,8 +111,19 @@ func TestDedupeQueueRefusesBadInput(t *testing.T) {
 	// so the queue answers the contract's malformed_cursor rather than its own
 	// module-shaped "invalid".
 	var badCursor *storekit.MalformedCursorError
-	if _, _, err := e.store.ListDedupeCandidates(ctx, DedupeQueueInput{Cursor: "not-base64!"}); !errors.As(err, &badCursor) {
-		t.Fatalf("malformed cursor = %v, want MalformedCursorError", err)
+	for _, token := range []string{
+		"not-base64!",
+		// Valid base64 of valid JSON that is not a cursor. `null` and `{}`
+		// unmarshal without error and leave the keyset at its zero value, which
+		// would read as a real position and page from the top of the queue
+		// instead of refusing.
+		"bnVsbA",  // null
+		"e30",     // {}
+		"WzEsMl0", // [1,2]
+	} {
+		if _, _, err := e.store.ListDedupeCandidates(ctx, DedupeQueueInput{Cursor: token}); !errors.As(err, &badCursor) {
+			t.Errorf("cursor %q = %v, want MalformedCursorError", token, err)
+		}
 	}
 }
 

--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -106,8 +107,12 @@ func TestDedupeQueueRefusesBadInput(t *testing.T) {
 	if _, err := e.store.DisposeDedupeCandidate(ctx, c.ID, "merge", &stranger); !errors.As(err, &input) {
 		t.Fatalf("winner outside the pair = %v, want DedupeInputError", err)
 	}
-	if _, _, err := e.store.ListDedupeCandidates(ctx, DedupeQueueInput{Cursor: "not-base64!"}); !errors.As(err, &input) {
-		t.Fatalf("malformed cursor = %v, want DedupeInputError", err)
+	// A malformed page token is the SAME refusal every paginated endpoint gives,
+	// so the queue answers the contract's malformed_cursor rather than its own
+	// module-shaped "invalid".
+	var badCursor *storekit.MalformedCursorError
+	if _, _, err := e.store.ListDedupeCandidates(ctx, DedupeQueueInput{Cursor: "not-base64!"}); !errors.As(err, &badCursor) {
+		t.Fatalf("malformed cursor = %v, want MalformedCursorError", err)
 	}
 }
 

--- a/backend/internal/modules/people/partner.go
+++ b/backend/internal/modules/people/partner.go
@@ -387,7 +387,7 @@ func partnerListWhere(ctx context.Context, in ListPartnersInput, arg func(any) i
 	if in.Cursor != "" {
 		after, err := ids.Parse(in.Cursor)
 		if err != nil {
-			return nil, &RequiredFieldError{Field: "cursor"}
+			return nil, &storekit.MalformedCursorError{}
 		}
 		where = append(where, storekit.SQLf("p.organization_id > $%d", arg(after)))
 	}

--- a/backend/internal/modules/people/relationship_list.go
+++ b/backend/internal/modules/people/relationship_list.go
@@ -104,7 +104,7 @@ func relationshipListWhere(ctx context.Context, in ListRelationshipsInput, arg f
 	if in.Cursor != "" {
 		after, err := ids.Parse(in.Cursor)
 		if err != nil {
-			return nil, &RequiredFieldError{Field: "cursor"}
+			return nil, &storekit.MalformedCursorError{}
 		}
 		where = append(where, storekit.SQLf("r.id > $%d", arg(after)))
 	}

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -350,22 +350,13 @@ func scanRankedPage(rows pgx.Rows, limit int) (Page, error) {
 	return page, nil
 }
 
-// cursorField names the page-token input, the third query field this error
-// answers for.
-const cursorField = "cursor"
-
 // BadQueryError maps to a 422 at the transport. Field names WHICH query input
-// was wrong: this error answers for q, types and cursor alike, and a per-field
-// taxonomy that named a constant would point two of the three at an input that
-// was fine.
+// was wrong — q or types. A malformed page token is not one of them: that answer
+// is the same on every paginated endpoint, so it is storekit's to give.
 type BadQueryError struct {
 	Field  string
 	Reason string
 }
-
-// reasonMalformedCursor is the BadQueryError reason for any un-decodable
-// keyset cursor — one spelling so the 422 body never drifts between paths.
-const reasonMalformedCursor = "malformed cursor"
 
 func (e *BadQueryError) Error() string { return "search: " + e.Reason }
 
@@ -391,19 +382,19 @@ func encodeCursor(c rankedCursor) string {
 func decodeCursor(s string) (rankedCursor, error) {
 	raw, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
-		return rankedCursor{}, &BadQueryError{Field: cursorField, Reason: reasonMalformedCursor}
+		return rankedCursor{}, &storekit.MalformedCursorError{}
 	}
 	parts := strings.SplitN(string(raw), "|", 3)
 	if len(parts) != 3 {
-		return rankedCursor{}, &BadQueryError{Field: cursorField, Reason: reasonMalformedCursor}
+		return rankedCursor{}, &storekit.MalformedCursorError{}
 	}
 	score, err := strconv.ParseFloat(parts[0], 64)
 	if err != nil {
-		return rankedCursor{}, &BadQueryError{Field: cursorField, Reason: reasonMalformedCursor}
+		return rankedCursor{}, &storekit.MalformedCursorError{}
 	}
 	id, err := ids.Parse(parts[2])
 	if err != nil {
-		return rankedCursor{}, &BadQueryError{Field: cursorField, Reason: reasonMalformedCursor}
+		return rankedCursor{}, &storekit.MalformedCursorError{}
 	}
 	return rankedCursor{Score: score, Type: parts[1], ID: id}, nil
 }


### PR DESCRIPTION
## The defect

A cursor a caller hands back is either a token this server minted or it is not. That is **one question**, and the contract gives it one answer: `422 code: malformed_cursor` — re-issue the request without the token.

**Eleven sites across six files answered it their own way.** Twenty-five others already went through `storekit.DecodeCursor`, so the rule is the tree's own, not an invention.

What a client actually received:

| endpoint | error type | code |
|---|---|---|
| `/relationships`, `/partners` | `RequiredFieldError` | **`required`** |
| `/lists/{id}/members` ×2, `/data-subject-requests`, `/dedupe/candidates` ×2 | `BadInputError` / `ValidationError` / `DedupeInputError` | **`invalid`** |
| `/search` ×4 | `BadQueryError` | **`invalid_query`** |

**None of the three is reachable from the contract**, so a client written against it cannot recognise any of them. `required` is the worst: it tells a caller to supply the field it just supplied. Acting on it means sending the same broken token again.

`search` is the instructive one. Its own comment said:

> reasonMalformedCursor is the BadQueryError reason for any un-decodable keyset cursor — one spelling so the 422 body never drifts between paths.

True *inside search*. It is also, almost certainly, the reason nobody looked outside it — a uniqueness claim scoped to one module reads like a claim about the tree.

## The fix

All eleven return `storekit.MalformedCursorError`, which `platform/httperr` already maps to the contract's code. Mapping stays the one place a wire code is decided.

## The gate, and why it has two arms

**My first sweep found five sites. The tree had eleven.** I grepped for `ids.Parse` on a cursor; `people/dedupequeue.go` decodes base64, and `search/store.go` names its field through a constant. Both were invisible, and I only found the dedupe one because a *test* named the error it expected.

So the gate reads two different things:

1. **The refusal** — nothing but storekit's type may name a cursor as the field it rejects. Resolved through package constants, so `Field: fieldCursor` reads like `Field: "cursor"`.
2. **The decode** — a function that decides whether a cursor is well-formed must be able to say so in the contract's words, *however it parses*. A refusal that names no field is invisible to arm 1.

Two connector resume tokens are ratified in arm 2 with their reason: the server mints and reads its own, no caller ever sends one, so there is no request to refuse and no code to answer with. (`offlinedemo.readCursor` returns no error at all — a stale token restarts the generator.)

Each mutant verified to **apply and compile** before its result was believed:

| planted | caught by | result |
|---|---|---|
| `&BadInputError{Field: "cursor", …}` | arm 1 | `collections/members.go: BadInputError` |
| `&DedupeInputError{Field: fieldCursor, …}` | arm 1 | `people/dedupequeue.go: DedupeInputError` — proves constant resolution |
| a decoder returning `errors.New("bad page token")` | arm 2 | `people/partner.go: partnerListWhere` |

## The test that should have caught this

`cursor_integration_test.go` already existed, already hit **every affected endpoint**, and asked only whether the status was `4xx`. All four codes are 4xx. It passed over the defect for as long as the defect existed.

It now asserts the code. Proven by A/B on the real wire — reverting one fix and re-running the lane:

```
GET /v1/partners?cursor=%21%21garbage%21%21
  field error = {Field:cursor Code:required}, want field=cursor code=malformed_cursor
--- FAIL: TestMalformedCursorAnswersMalformedCursorEverywhere
```

Two endpoints were missing from its list (`/dedupe/candidates`, `/data-subject-requests`) and are added.

## Verification

- `make check-backend` green.
- **Full integration lane green, 0 skips** (43 packages, 3171 tests) — and proven able to fail, above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes malformed page-token handling. All paginated endpoints now return 422 validation_error with a single cursor field error code malformed_cursor; previously they returned required/invalid/invalid_query, which clients could not act on.

- Replace ad‑hoc refusals with `storekit.MalformedCursorError` in `collections/members`, `consent/dsr`, `people/{partner,relationship_list,dedupequeue}`, and `search`; `platform/httperr` maps it to the contract response.
- Dedupe queue: treat “valid JSON but not a cursor” as malformed by requiring a non‑zero ID in the decoded keyset.
- Search: remove cursor-specific error constants; `decodeCursor` returns `storekit.MalformedCursorError`.
- Static gate (new test suite): enforces the one answer via two arms and now walks `internal/platform` as well. It resolves package constants, follows renamed locals, recognises common decoders (Parse/UUID, DecodeString, Unmarshal, Sscanf, Cut, Atoi, DecodeCursor), accepts %w wraps that preserve the guarded error, rejects unreadable `fmt.Errorf` formats, and only permits an unqualified `MalformedCursorError` inside `storekit`.
- Integration: assert 422 and exactly one cursor field error with code malformed_cursor; add `/dedupe/candidates`, `/data-subject-requests`, `/approvals`; include “valid JSON but not a cursor” cases.

Migration
- Clients relying on required/invalid/invalid_query must handle malformed_cursor instead; clients already following the contract need no changes.

<sup>Written for commit bb58a26f6d3246376e126fb6ee60cad06642c2bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized malformed pagination cursor handling across member lists, data-subject requests, deduplication, partner, relationship, and search endpoints.
  - Invalid cursors now consistently return HTTP 422 validation errors with the `malformed_cursor` code and a single cursor-specific error.
  - Improved handling covers invalid encoding, malformed values, invalid scores, and invalid identifiers.

- **Tests**
  - Expanded endpoint coverage and automated checks to verify consistent malformed-cursor responses.
  - Added safeguards ensuring cursor decoding failures are handled consistently across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->