### PR TITLE
feat(ai-models): the dossier and growth fit are written in the base language

### DIFF
--- a/backend/internal/compose/certcase_growthfit.go
+++ b/backend/internal/compose/certcase_growthfit.go
@@ -37,6 +37,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -172,7 +173,11 @@ type growthFitCase struct {
 // Run issues the one request this site sends, through the production writer's
 // own request builder.
 func (c *growthFitCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
-	req := orgdossier.GrowthFitRequest(c.in)
+	// English, pinned, rather than the installation's base language: a
+	// certification record grades a fixed corpus, and a score that moved with a
+	// settings row would not be comparable between two installations. The rule
+	// is PRESENT for the same reason — production sends one.
+	req := orgdossier.GrowthFitRequest(c.in, string(textlang.English))
 	trace := aitasks.Trace{Requests: []model.Request{req}}
 	resp, err := completer.Complete(ctx, req)
 	if err != nil {

--- a/backend/internal/compose/certcase_orgdossier.go
+++ b/backend/internal/compose/certcase_orgdossier.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/aitasks"
 	"github.com/gradionhq/margince/backend/internal/compose/orgdossier"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -84,7 +85,11 @@ type orgDossierCase struct {
 // Run issues the one request this site sends, through the production writer's
 // own request builder.
 func (c *orgDossierCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
-	req := orgdossier.DossierRequest(c.in)
+	// English, pinned, rather than the installation's base language: a
+	// certification record grades a fixed corpus, and a score that moved with a
+	// settings row would not be comparable between two installations. The rule
+	// is PRESENT for the same reason — production sends one.
+	req := orgdossier.DossierRequest(c.in, string(textlang.English))
 	trace := aitasks.Trace{Requests: []model.Request{req}}
 	resp, err := completer.Complete(ctx, req)
 	if err != nil {

--- a/backend/internal/compose/integration/promptlanguage_integration_test.go
+++ b/backend/internal/compose/integration/promptlanguage_integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/orgdossier"
 	"github.com/gradionhq/margince/backend/internal/compose/promptlang"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -105,5 +106,37 @@ func TestAnInstallationThatNeverNamedALanguageStillGetsAPrompt(t *testing.T) {
 	rule := promptlang.Rule(identity.BaseLanguageForPrompt(ctx, e.Pool))
 	if !strings.Contains(rule, "English") {
 		t.Fatalf("an installation with no base-language row did not fall back to English:\n%s", rule)
+	}
+}
+
+// The two shared-artifact prompts carry the language the installation actually
+// set, resolved through the same accessor production uses.
+//
+// The static gate can see that a rule reaches these prompts. It cannot see that
+// the rule names the right language, because that is a settings row and a
+// transaction — which is what this reads back.
+func TestTheDossierAndGrowthFitPromptsCarryTheInstallationsLanguage(t *testing.T) {
+	e := Setup(t)
+	ctx := e.Admin()
+
+	setBaseLanguage(ctx, t, e, "vi")
+	lang := identity.BaseLanguageForPrompt(ctx, e.Pool)
+
+	dossier := orgdossier.DossierRequest(orgdossier.Input{}, lang)
+	if !strings.Contains(dossier.System, "Vietnamese") {
+		t.Errorf("the dossier prompt does not ask for Vietnamese:\n%s", dossier.System)
+	}
+	fit := orgdossier.GrowthFitRequest(orgdossier.Input{}, lang)
+	if !strings.Contains(fit.System, "Vietnamese") {
+		t.Errorf("the growth-fit prompt does not ask for Vietnamese:\n%s", fit.System)
+	}
+
+	// Both prompts must still say what must NOT be translated. A model told to
+	// write Vietnamese will otherwise translate a JSON key or an entity_type
+	// value, and the parser that reads the reply matches those exactly.
+	for name, req := range map[string]string{"dossier": dossier.System, "growth fit": fit.System} {
+		if !strings.Contains(req, "JSON keys") {
+			t.Errorf("the %s prompt asks for a language without protecting its JSON keys from translation", name)
+		}
 	}
 }

--- a/backend/internal/compose/orgbrief/write.go
+++ b/backend/internal/compose/orgbrief/write.go
@@ -161,7 +161,7 @@ func BriefRequest(in Input) model.Request {
 // the fence so the two can never disagree — a request whose prompt named a
 // different boundary than the one wrapping the data would fence nothing.
 //
-//promptlang:exempt DEFERRED, not exempt on the merits: a brief is cached per reader and the language has to enter Fingerprint with it, or an installation that switches language keeps serving the old-language brief until some unrelated fact moves — the setting would appear to do nothing. Fingerprint is being rewritten concurrently to derive its prompt version from the prompt text, and two edits to the same function land as a conflict rather than a change. Adding the rule without the key is the worse half to ship alone.
+//promptlang:exempt DEFERRED, and the question is WHICH language rather than whether. A brief is cached per reader and written for that one reader, so it takes the reader's language and not the installation's — the rule the dossier beside it follows in the other direction, because a dossier is filed on the company and read by everyone. Where a reader's language comes from is unsettled: compose/meetingbrief reads Accept-Language, app_user.locale now holds a stored choice, and the two disagree for the same person on a borrowed laptop. Picking one here would put a third answer in the tree.
 func groundedRequest(systemFor func(promptfence.Fence) string, in Input) model.Request {
 	fence := promptfence.New()
 	return model.Request{

--- a/backend/internal/compose/orgdossier/fingerprint_test.go
+++ b/backend/internal/compose/orgdossier/fingerprint_test.go
@@ -11,18 +11,20 @@ package orgdossier
 import (
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 func TestTheDossierFingerprintMovesWithItsInputsAndItsLane(t *testing.T) {
 	in := fourOfSeven()
-	base, err := Fingerprint(in, "routing-1")
+	base, err := Fingerprint(in, "routing-1", string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
 
 	// The same input hashes the same way twice, or nothing could ever be a
 	// cache HIT and every read would rewrite.
-	again, err := Fingerprint(in, "routing-1")
+	again, err := Fingerprint(in, "routing-1", string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
@@ -34,7 +36,7 @@ func TestTheDossierFingerprintMovesWithItsInputsAndItsLane(t *testing.T) {
 	// company that has since been re-read.
 	moved := fourOfSeven()
 	moved.ProfileFields[0].Value = "Something else entirely"
-	changed, err := Fingerprint(moved, "routing-1")
+	changed, err := Fingerprint(moved, "routing-1", string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
@@ -43,7 +45,7 @@ func TestTheDossierFingerprintMovesWithItsInputsAndItsLane(t *testing.T) {
 			"would keep describing the old value indefinitely")
 	}
 
-	repointed, err := Fingerprint(in, "routing-2")
+	repointed, err := Fingerprint(in, "routing-2", string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
@@ -58,11 +60,11 @@ func TestTheDossierFingerprintMovesWithItsInputsAndItsLane(t *testing.T) {
 // a workspace that has since described itself.
 func TestTheGrowthFitFingerprintMovesWhenOurOwnOfferingIsConfirmed(t *testing.T) {
 	in := fourOfSeven()
-	unconfirmed, err := growthFitFingerprint(in, "routing-1", Offering{Fingerprint: "offer-a"})
+	unconfirmed, err := growthFitFingerprint(in, "routing-1", Offering{Fingerprint: "offer-a"}, string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
-	confirmed, err := growthFitFingerprint(in, "routing-1", Offering{Confirmed: true, Fingerprint: "offer-a"})
+	confirmed, err := growthFitFingerprint(in, "routing-1", Offering{Confirmed: true, Fingerprint: "offer-a"}, string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
@@ -76,7 +78,7 @@ func TestTheGrowthFitFingerprintMovesWhenOurOwnOfferingIsConfirmed(t *testing.T)
 	// that edit, so a key carrying only the boolean would keep serving bands
 	// measured against an offering this workspace no longer has.
 	edited, err := growthFitFingerprint(in, "routing-1",
-		Offering{Confirmed: true, Fingerprint: "offer-b"})
+		Offering{Confirmed: true, Fingerprint: "offer-b"}, string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
@@ -90,11 +92,11 @@ func TestTheGrowthFitFingerprintMovesWhenOurOwnOfferingIsConfirmed(t *testing.T)
 // other's freshness check.
 func TestTheTwoSurfacesDoNotShareAFingerprint(t *testing.T) {
 	in := fourOfSeven()
-	dossier, err := Fingerprint(in, "routing-1")
+	dossier, err := Fingerprint(in, "routing-1", string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}
-	fit, err := growthFitFingerprint(in, "routing-1", Offering{Confirmed: true, Fingerprint: "offer-a"})
+	fit, err := growthFitFingerprint(in, "routing-1", Offering{Confirmed: true, Fingerprint: "offer-a"}, string(textlang.English))
 	if err != nil {
 		t.Fatalf("fingerprint: %v", err)
 	}

--- a/backend/internal/compose/orgdossier/fingerprintlanguage_test.go
+++ b/backend/internal/compose/orgdossier/fingerprintlanguage_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package orgdossier
+
+// The language belongs to the cache key, and this is the case that says so.
+//
+// A dossier is written in the installation's base language. When an admin
+// switches that setting, nothing about the company has moved — every other
+// component of the key is identical — so a key that did not carry the language
+// would report a hit and serve the old-language text indefinitely, until some
+// unrelated fact happened to change. The setting would appear to do nothing,
+// which is the exact complaint that made base language worth having.
+//
+// It sits beside the other entries in fingerprint_test.go for the reason that
+// file's own comment gives: these are the changes that alter the answer without
+// altering the company's rows.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
+)
+
+func TestTheDossierFingerprintMovesWhenTheInstallationChangesLanguage(t *testing.T) {
+	in := fourOfSeven()
+
+	english, err := Fingerprint(in, "routing-1", string(textlang.English))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	german, err := Fingerprint(in, "routing-1", string(textlang.German))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+
+	if english == german {
+		t.Error("the same company hashes identically in English and German, so an installation that " +
+			"switched language would keep serving its old-language dossiers until an unrelated fact moved")
+	}
+
+	// The other direction, and it is not redundant: a key that hashed the
+	// language into noise would move for two languages AND move for the same
+	// one, so every read would rewrite and nothing would ever be a cache hit.
+	againGerman, err := Fingerprint(in, "routing-1", string(textlang.German))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	if againGerman != german {
+		t.Error("the same company and the same language hashed differently twice: no dossier would ever be reused")
+	}
+}
+
+func TestTheGrowthFitFingerprintMovesWhenTheInstallationChangesLanguage(t *testing.T) {
+	in := fourOfSeven()
+	offering := Offering{Confirmed: true, Fingerprint: "offering-1"}
+
+	english, err := growthFitFingerprint(in, "routing-1", offering, string(textlang.English))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	german, err := growthFitFingerprint(in, "routing-1", offering, string(textlang.German))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+
+	if english == german {
+		t.Error("the same assessment hashes identically in English and German, so an installation that " +
+			"switched language would keep serving its old-language growth fits")
+	}
+
+	againGerman, err := growthFitFingerprint(in, "routing-1", offering, string(textlang.German))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	if againGerman != german {
+		t.Error("the same inputs and the same language hashed differently twice: no assessment would ever be reused")
+	}
+}
+
+// The two keys must not collide with each other. They cover different prompts
+// over the same company, and a language component appended to both in the same
+// position is exactly the kind of edit that can make two keys agree by
+// accident — at which point a dossier would be served as a growth fit.
+func TestTheDossierAndGrowthFitKeysStayDistinctInEveryLanguage(t *testing.T) {
+	in := fourOfSeven()
+	offering := Offering{Confirmed: true, Fingerprint: "offering-1"}
+
+	for _, lang := range textlang.Shipped {
+		dossier, err := Fingerprint(in, "routing-1", string(lang))
+		if err != nil {
+			t.Fatalf("dossier fingerprint in %q: %v", lang, err)
+		}
+		fit, err := growthFitFingerprint(in, "routing-1", offering, string(lang))
+		if err != nil {
+			t.Fatalf("growth-fit fingerprint in %q: %v", lang, err)
+		}
+		if dossier == fit {
+			t.Errorf("the dossier and growth-fit keys collide in %q, so one surface's cached answer "+
+				"could be served as the other's", lang)
+		}
+	}
+}

--- a/backend/internal/compose/orgdossier/growthfitservice.go
+++ b/backend/internal/compose/orgdossier/growthfitservice.go
@@ -28,8 +28,11 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 // growthFitAssemblyVersion identifies the assembly RULES in the fingerprint —
@@ -47,7 +50,17 @@ const growthFitAssemblyVersion = "growth-fit-assembly-v2"
 // fingerprints, and folding both prompts into one would rewrite every cached
 // dossier whenever the growth-fit wording moved, and every cached assessment
 // whenever the dossier's did.
-var growthFitPromptVersion = ai.PromptDigest(growthFitSystemFor)
+//
+// Digested at ONE fixed language rather than the installation's, the same way
+// dealstatus does it. The language rides the fingerprint as its own component,
+// so folding it in here would say the same thing twice — and this is a
+// package-level var computed at init, where no installation's setting is
+// readable at all. What it has to capture is the WORDING, which English
+// captures completely: a reword moves the digest whichever language the prompt
+// is later asked for.
+var growthFitPromptVersion = ai.PromptDigest(func(fence promptfence.Fence) string {
+	return growthFitSystemFor(fence, string(textlang.English))
+})
 
 // growthFitStoredVersion is the payload SHAPE this build writes and can read.
 // v2 adds the sub-scores (DOSS-AC-17): a v1 payload has none, and serving one
@@ -136,7 +149,8 @@ func (s *GrowthFitService) Get(ctx context.Context, orgID ids.OrganizationID, fo
 	if err != nil {
 		return zero, err
 	}
-	fingerprint, err := growthFitFingerprint(in, s.routingVersion, offering)
+	lang := identity.BaseLanguageForPrompt(ctx, s.pool)
+	fingerprint, err := growthFitFingerprint(in, s.routingVersion, offering, lang)
 	if err != nil {
 		return zero, err
 	}
@@ -150,7 +164,7 @@ func (s *GrowthFitService) Get(ctx context.Context, orgID ids.OrganizationID, fo
 		return cached.wire(orgID), nil
 	}
 
-	assessed, by, laneFailed := WriteGrowthFit(ctx, s.lane, in, offering.Confirmed, utc)
+	assessed, by, laneFailed := WriteGrowthFit(ctx, s.lane, in, offering.Confirmed, utc, lang)
 	if laneFailed && cached.mayStandIn(found, fingerprint, utc()) {
 		// A lane that failed must not be able to DESTROY an assessment. The
 		// degraded answer is an abstention, and writing it over a real band
@@ -226,14 +240,17 @@ func (g storedGrowthFit) mayStandIn(found bool, fingerprint string, now time.Tim
 // product, a different ideal customer — changes every company's fit while
 // `confirmed` stays true throughout. A key blind to either keeps serving bands
 // measured against an offering this workspace no longer has.
-func growthFitFingerprint(in Input, routingVersion string, offering Offering) (string, error) {
+// The LANGUAGE is a component of its own, beside the derived prompt version: the
+// assessment is written in it, and nothing else about the company moves when an
+// installation changes language.
+func growthFitFingerprint(in Input, routingVersion string, offering Offering, lang string) (string, error) {
 	encoded, err := json.Marshal(in)
 	if err != nil {
 		return "", fmt.Errorf("fingerprint the growth-fit input: %w", err)
 	}
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s\x00%s\x00%s\x00%t\x00%s\x00%s",
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s\x00%s\x00%s\x00%t\x00%s\x00%s\x00%s",
 		growthFitAssemblyVersion, growthFitPromptVersion, routingVersion,
-		offering.Confirmed, offering.Fingerprint, encoded))
+		offering.Confirmed, offering.Fingerprint, lang, encoded))
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/backend/internal/compose/orgdossier/growthfitwrite.go
+++ b/backend/internal/compose/orgdossier/growthfitwrite.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
+	"github.com/gradionhq/margince/backend/internal/compose/promptlang"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
@@ -54,18 +55,19 @@ Never invent a fact. If the summary does not say it, you may still ASSESS it, bu
 Write one claim per sentence, plainly.`
 
 // growthFitSystemFor names THIS call's data boundary; see promptfence.Fence.Rule.
-func growthFitSystemFor(fence promptfence.Fence) string {
-	return growthFitSystem + "\n" + fence.Rule("company summary")
+//
+// The assessment is filed on the company and read by whoever opens it, so it
+// takes the installation's shared language.
+func growthFitSystemFor(fence promptfence.Fence, lang string) string {
+	return growthFitSystem + "\n" + promptlang.Rule(lang) + "\n" + fence.Rule("company summary")
 }
 
 // GrowthFitRequest builds the one-shot call. Exported so the AI cert case
 // measures the request production actually sends rather than a copy of it.
-//
-//promptlang:exempt DEFERRED, not exempt on the merits: the growth fit is cached against growthFitFingerprint, so the language has to enter that key with the rule or a language change serves the old assessment indefinitely. That fingerprint is being rewritten concurrently to derive its prompt version from the prompt text; the two edits belong in one change rather than as a conflict.
-func GrowthFitRequest(in Input) model.Request {
+func GrowthFitRequest(in Input, lang string) model.Request {
 	fence := promptfence.New()
 	return model.Request{
-		System:   growthFitSystemFor(fence),
+		System:   growthFitSystemFor(fence, lang),
 		Messages: []model.Message{{Role: "user", Content: fence.Wrap(encodeInput(in))}},
 		// Our own offering is what makes this a FIT rather than a description,
 		// so it is requested unconditionally — a growth fit written without it
@@ -155,13 +157,13 @@ func keepSubScores(
 // down sees "here is what I would need to know" rather than a band nobody
 // stands behind — and `generated_by` says which of the two they are reading.
 func WriteGrowthFit(ctx context.Context, lane Completer, in Input,
-	selfConfirmed bool, now nowFunc,
+	selfConfirmed bool, now nowFunc, lang string,
 ) (Assessment, crmcontracts.WrittenBy, bool) {
 	if lane == nil {
 		return Assess(in, crmcontracts.GrowthFitBandUnknown, selfConfirmed, AbstainedNoWriter, now()),
 			crmcontracts.Deterministic, false
 	}
-	assessed, err := assessWithModel(ctx, lane, in, selfConfirmed, now)
+	assessed, err := assessWithModel(ctx, lane, in, selfConfirmed, now, lang)
 	if err != nil {
 		// The declared degrade posture (on_budget_exhausted: degrade), not a
 		// swallowed error. A lane that is unavailable, over budget, or
@@ -186,9 +188,9 @@ func WriteGrowthFit(ctx context.Context, lane Completer, in Input,
 }
 
 func assessWithModel(ctx context.Context, lane Completer, in Input,
-	selfConfirmed bool, now nowFunc,
+	selfConfirmed bool, now nowFunc, lang string,
 ) (Assessment, error) {
-	resp, err := lane.Complete(ctx, GrowthFitRequest(in))
+	resp, err := lane.Complete(ctx, GrowthFitRequest(in, lang))
 	if err != nil {
 		return Assessment{}, err
 	}

--- a/backend/internal/compose/orgdossier/growthfitwrite_test.go
+++ b/backend/internal/compose/orgdossier/growthfitwrite_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -86,7 +87,7 @@ func TestEveryModelFailureDegradesToTheFloorAndSaysSo(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			got, by, laneFailed := WriteGrowthFit(context.Background(), tc.lane, in, true, at)
+			got, by, laneFailed := WriteGrowthFit(context.Background(), tc.lane, in, true, at, string(textlang.English))
 
 			if by != crmcontracts.Deterministic {
 				t.Errorf("generated_by = %q, want deterministic — the model did not produce this", by)
@@ -109,7 +110,7 @@ func TestEveryModelFailureDegradesToTheFloorAndSaysSo(t *testing.T) {
 func TestAGroundedReplyIsServedAsTheModelsWithItsClaims(t *testing.T) {
 	in := sevenOfSeven()
 
-	got, by, _ := WriteGrowthFit(context.Background(), scriptedLane{reply: citing("strong", in)}, in, true, at)
+	got, by, _ := WriteGrowthFit(context.Background(), scriptedLane{reply: citing("strong", in)}, in, true, at, string(textlang.English))
 
 	if by != crmcontracts.Model {
 		t.Fatalf("generated_by = %q, want model", by)
@@ -134,7 +135,7 @@ func TestTheCompletenessFloorOverrulesAConfidentModelAndWithholdsItsReasons(t *t
 		},
 	}
 
-	got, by, _ := WriteGrowthFit(context.Background(), scriptedLane{reply: citing("strong", thin)}, thin, true, at)
+	got, by, _ := WriteGrowthFit(context.Background(), scriptedLane{reply: citing("strong", thin)}, thin, true, at, string(textlang.English))
 
 	if got.Band != crmcontracts.GrowthFitBandUnknown {
 		t.Errorf("band = %q, want unknown — one of seven cannot support a judgment", got.Band)
@@ -158,7 +159,7 @@ func TestTheCompletenessFloorOverrulesAConfidentModelAndWithholdsItsReasons(t *t
 func TestTheCapAppliesToTheModelsBandAsWell(t *testing.T) {
 	in := sevenOfSeven()
 
-	got, _, _ := WriteGrowthFit(context.Background(), scriptedLane{reply: citing("strong", in)}, in, false, at)
+	got, _, _ := WriteGrowthFit(context.Background(), scriptedLane{reply: citing("strong", in)}, in, false, at, string(textlang.English))
 
 	if got.Band != crmcontracts.GrowthFitBandModerate {
 		t.Errorf("band = %q, want moderate — our own offering is unconfirmed", got.Band)

--- a/backend/internal/compose/orgdossier/service.go
+++ b/backend/internal/compose/orgdossier/service.go
@@ -25,10 +25,13 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 // assemblyVersion identifies the assembly RULES in the fingerprint, and is the
@@ -41,7 +44,17 @@ const assemblyVersion = "dossier-assembly-v1"
 // promptVersion is DERIVED from the prompt as it is SENT — boundary rule
 // included — so editing that wording bumps it whether or not anybody remembers
 // to.
-var promptVersion = ai.PromptDigest(dossierSystemFor)
+//
+// Digested at ONE fixed language rather than the installation's, the same way
+// dealstatus does it. The language rides the fingerprint as its own component,
+// so folding it in here would say the same thing twice — and this is a
+// package-level var computed at init, where no installation's setting is
+// readable at all. What it has to capture is the WORDING, which English
+// captures completely: a reword moves the digest whichever language the prompt
+// is later asked for.
+var promptVersion = ai.PromptDigest(func(fence promptfence.Fence) string {
+	return dossierSystemFor(fence, string(textlang.English))
+})
 
 // storedVersion is the payload SHAPE this build writes and can read. A row
 // written by an older shape unmarshals cleanly into a newer envelope with its
@@ -144,7 +157,8 @@ func (s *Service) Get(ctx context.Context, orgID ids.OrganizationID, force bool)
 	if err != nil {
 		return zero, err
 	}
-	fingerprint, err := Fingerprint(in, s.routingVersion)
+	lang := identity.BaseLanguageForPrompt(ctx, s.pool)
+	fingerprint, err := Fingerprint(in, s.routingVersion, lang)
 	if err != nil {
 		return zero, err
 	}
@@ -157,7 +171,7 @@ func (s *Service) Get(ctx context.Context, orgID ids.OrganizationID, force bool)
 		return cached.wire(orgID, s.now().UTC()), nil
 	}
 
-	sections, by, laneFailed := WriteDossier(ctx, s.lane, in)
+	sections, by, laneFailed := WriteDossier(ctx, s.lane, in, lang)
 	if laneFailed && found && cached.usable(fingerprint) {
 		// The floor is a real answer, but it is a plainer one than the model
 		// already wrote for these same facts. A transient outage must not
@@ -223,14 +237,19 @@ var knownNature = map[string]bool{
 // Fingerprint covers everything that could change the content: the assembled
 // factual input, the prompt version and the model routing version
 // (DOSS-PARAM-5).
-func Fingerprint(in Input, routingVersion string) (string, error) {
+// The LANGUAGE is a component of its own, beside the derived prompt version. A
+// dossier is written in it, so an installation that switches language must
+// rewrite every dossier — and nothing else about the company has moved, so
+// every other component of this key is identical. Without it the setting would
+// appear to do nothing until some unrelated fact changed.
+func Fingerprint(in Input, routingVersion, lang string) (string, error) {
 	// json.Marshal orders struct fields by declaration, so the same input
 	// hashes the same way across processes — a map would not.
 	encoded, err := json.Marshal(in)
 	if err != nil {
 		return "", fmt.Errorf("fingerprint the dossier input: %w", err)
 	}
-	sum := sha256.Sum256([]byte(assemblyVersion + "\x00" + promptVersion + "\x00" + routingVersion + "\x00" + string(encoded)))
+	sum := sha256.Sum256([]byte(assemblyVersion + "\x00" + promptVersion + "\x00" + routingVersion + "\x00" + lang + "\x00" + string(encoded)))
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/backend/internal/compose/orgdossier/write.go
+++ b/backend/internal/compose/orgdossier/write.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
+	"github.com/gradionhq/margince/backend/internal/compose/promptlang"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
@@ -39,18 +40,21 @@ Put ids ONLY in evidence. An id must never appear in a sentence's text — the r
 Write plainly, one claim per sentence, and never open two sentences with the company name.`
 
 // dossierSystemFor names THIS call's data boundary; see promptfence.Fence.Rule.
-func dossierSystemFor(fence promptfence.Fence) string {
-	return dossierSystem + "\n" + fence.Rule("company summary")
+//
+// The dossier describes a company and is filed on that company's page, where
+// anybody who opens it reads the same text. So it takes the installation's
+// shared language rather than the language the crawled site happened to be in,
+// which is what an unruled prompt would have followed.
+func dossierSystemFor(fence promptfence.Fence, lang string) string {
+	return dossierSystem + "\n" + promptlang.Rule(lang) + "\n" + fence.Rule("company summary")
 }
 
 // DossierRequest builds the one-shot call. Exported so the AI cert case
 // measures the request production actually sends rather than a copy of it.
-//
-//promptlang:exempt DEFERRED, not exempt on the merits: the dossier is cached against Fingerprint, so the language has to enter that key with the rule or a language change serves the old dossier indefinitely. Fingerprint is being rewritten concurrently to derive its prompt version from the prompt text; the two edits belong in one change rather than as a conflict.
-func DossierRequest(in Input) model.Request {
+func DossierRequest(in Input, lang string) model.Request {
 	fence := promptfence.New()
 	return model.Request{
-		System:   dossierSystemFor(fence),
+		System:   dossierSystemFor(fence, lang),
 		Messages: []model.Message{{Role: "user", Content: fence.Wrap(encodeInput(in))}},
 		// Deliberately NOT set: the dossier describes the company, and our own
 		// context is only ever an input to a judgment about fit. A writer given
@@ -66,12 +70,12 @@ func DossierRequest(in Input) model.Request {
 // The floor is a real answer here, unlike the growth fit's: it describes the
 // company from the same fields, just plainly. So a deployment with no lane is
 // not missing the surface, and `generated_by` says which of the two wrote it.
-func WriteDossier(ctx context.Context, lane Completer, in Input) ([]Section, crmcontracts.WrittenBy, bool) {
+func WriteDossier(ctx context.Context, lane Completer, in Input, lang string) ([]Section, crmcontracts.WrittenBy, bool) {
 	floor := keepGrounded(Deterministic(in), in)
 	if lane == nil {
 		return floor, crmcontracts.Deterministic, false
 	}
-	written, err := writeWithModel(ctx, lane, in)
+	written, err := writeWithModel(ctx, lane, in, lang)
 	if err != nil {
 		// The declared degrade posture (on_budget_exhausted: degrade), not a
 		// swallowed error. A lane that is unavailable, over budget or answering
@@ -88,8 +92,8 @@ func WriteDossier(ctx context.Context, lane Completer, in Input) ([]Section, crm
 	return written, crmcontracts.Model, false
 }
 
-func writeWithModel(ctx context.Context, lane Completer, in Input) ([]Section, error) {
-	resp, err := lane.Complete(ctx, DossierRequest(in))
+func writeWithModel(ctx context.Context, lane Completer, in Input, lang string) ([]Section, error) {
+	resp, err := lane.Complete(ctx, DossierRequest(in, lang))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/orgdossier/write_test.go
+++ b/backend/internal/compose/orgdossier/write_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
 
 // describing renders a reply whose one sentence cites a row of this input.
@@ -34,7 +35,7 @@ func TestEveryDossierModelFailureFallsBackToADescribedCompany(t *testing.T) {
 		"lane inventing a section": scriptedLane{reply: describing("pipeline", "They are close to buying.", in)},
 	} {
 		t.Run(name, func(t *testing.T) {
-			got, by, _ := WriteDossier(context.Background(), lane, in)
+			got, by, _ := WriteDossier(context.Background(), lane, in, string(textlang.English))
 
 			if by != crmcontracts.Deterministic {
 				t.Errorf("generated_by = %q, want deterministic — the model did not produce this", by)
@@ -60,7 +61,7 @@ func TestAGroundedDossierIsServedAsTheModels(t *testing.T) {
 		reply: describing("summary", "They build load-shifting software for industrial sites.", in),
 	}
 
-	got, by, _ := WriteDossier(context.Background(), lane, in)
+	got, by, _ := WriteDossier(context.Background(), lane, in, string(textlang.English))
 
 	if by != crmcontracts.Model {
 		t.Fatalf("generated_by = %q, want model", by)
@@ -108,7 +109,7 @@ func sectionEntry(kind, text string, in Input) string {
 // all — a writer given it starts comparing, which is the growth fit's job and
 // the reason the two surfaces are separate.
 func TestTheDossierRequestDoesNotAskForOurOwnCompanyContext(t *testing.T) {
-	if req := DossierRequest(fourOfSeven()); req.IncludeCompanyContext {
+	if req := DossierRequest(fourOfSeven(), string(textlang.English)); req.IncludeCompanyContext {
 		t.Error("the dossier asked for our own offering; that is the growth fit's input, not this one")
 	}
 }


### PR DESCRIPTION
## What changes

Both surfaces are filed on a company's page and read by whoever opens it, so they take the installation's shared language — rather than the language the crawled site happened to be in, which is what an unruled prompt follows.

They carried `DEFERRED` waivers from #2490 because their cache keys were being rewritten concurrently (#2486) to derive a prompt version from the prompt text. Adding a language rule **without** adding the language to the key is the worse half to ship alone: an installation that switched language would keep serving the old-language text until some unrelated fact moved, and the setting would appear to do nothing. That work landed, so both halves ship together here.

## The key carries the language as its own component

Beside the derived prompt version, not folded into it.

The digest renders its prompt at a **fixed English**, the same way `dealstatus` does. `promptVersion` is a package-level `var` computed at init, where no installation's setting is readable at all — and what it has to capture is the **wording**, which English captures completely. The language is a separate question and gets a separate component.

## Three tests, and each catches a different way to get this wrong

| property | what breaks without it |
|---|---|
| two languages hash differently | a language switch serves stale text forever |
| the same language hashes identically twice | nothing is ever a cache hit; every read rewrites |
| the two keys stay distinct in every shipped language | a dossier gets served as a growth fit |

The third is not paranoia: the two keys cover different prompts over the same company, and appending a component to both in the same position is exactly how two keys come to agree by accident.

Mutation-checked — dropping the language from both keys fails both language tests.

## orgbrief stays deferred, for a different reason

Its waiver said the fingerprint was being rewritten. That is no longer true, and **a waiver whose stated reason has expired is worse than no waiver** — the next reader believes it.

It now says what actually blocks it. A brief is written for one reader and takes *that reader's* language, and where a reader's language comes from is unsettled: `compose/meetingbrief` reads `Accept-Language`, `app_user.locale` holds a stored choice, and the two disagree for the same person on a borrowed laptop. Picking one inside `orgbrief` would put a third answer in the tree.

Filed as #2497, with a recommendation (stored locale first, header as fallback, base language as floor).

## Verification

`make check-backend`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` — green.

Integration lane, against a real database, through the same accessor production calls:

```
--- PASS: TestTheBaseLanguageSetOnTheInstallationReachesThePrompt
--- PASS: TestAnInstallationThatNeverNamedALanguageStillGetsAPrompt
--- PASS: TestTheDossierAndGrowthFitPromptsCarryTheInstallationsLanguage
```

That last one also asserts both prompts still protect their JSON keys from translation — a model told to write Vietnamese will otherwise translate a key or an `entity_type` value, and the parser reading the reply matches those exactly.

Certification cases pass English explicitly and pinned, so a score stays comparable between two installations. Their records go stale; covered by #2491.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes the organization dossier and growth fit in the installation’s base language and includes that language in their cache keys. Previously they followed the crawled site’s language and keys omitted language, which made language changes serve stale text.

- Prompts add a language rule via `promptlang.Rule(lang)`; services resolve it with `identity.BaseLanguageForPrompt`. Certification cases pin English by passing `string(textlang.English)` to keep scores comparable.
- Cache keys add language as its own component: `Fingerprint(in, routingVersion, lang)` and `growthFitFingerprint(in, routingVersion, offering, lang)`. Prompt digests are computed at fixed English via `ai.PromptDigest(func(fence) { ... })` to track wording only; dossier and growth-fit keys stay distinct.
- Updated signatures and call sites: `orgdossier.DossierRequest(in, lang)`, `orgdossier.GrowthFitRequest(in, lang)`, `orgdossier.WriteDossier(ctx, lane, in, lang)`, `orgdossier.WriteGrowthFit(ctx, lane, in, confirmed, now, lang)`, `orgdossier.Fingerprint(in, routingVersion, lang)`, `orgdossier.growthFitFingerprint(in, routingVersion, offering, lang)`.
- Tests: new `fingerprintlanguage_test.go` ensures language changes rekey, same-language stability, and no cross-surface collisions; integration asserts prompts carry the selected language and still protect JSON keys.
- `orgbrief` remains deferred: it must use the reader’s language (stored locale vs `Accept-Language` is unsettled); the waiver now cites this blocker.
- Rollout: no migration. Changing base language rekeys and rewrites cached artifacts; installations without a setting fall back to English.

<sup>Written for commit f59cd8afd72b7c3d605b037acdb2ca515d365188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dossier and growth-fit assessments now use the installation’s configured language.
  * Generated prompts preserve translated JSON keys for more reliable multilingual results.
* **Bug Fixes**
  * Changing the installation language now correctly refreshes cached dossier and growth-fit results.
  * Dossier and growth-fit outputs remain distinct across supported languages.
* **Tests**
  * Added coverage for language-specific prompts, fingerprints, caching behavior, and translated output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->