### PR TITLE
fix(compose): the project tag stays in the subject line

### DIFF
--- a/docs/how-to/run-a-project.md
+++ b/docs/how-to/run-a-project.md
@@ -136,8 +136,13 @@ of.
 
 **Choosing a project puts `[KEY]` at the front of the Subject.** Choosing **No
 project** takes it out. Switching to another project swaps the tag. There is no
-explanation printed beside it, because the Subject field shows the tag: edit or
-delete it like any other text, and it stays as you left it.
+explanation printed beside it, because the Subject field shows the tag — you
+can see exactly what will go out.
+
+The rest of the subject is yours; the tag is the picker's. While a project is
+chosen the tag stays at the front, so deleting it out of the text does not
+unset the project — the picker still names one, and that is what the send
+honours. To send without a tag, choose **No project**.
 
 **What it starts on.** The picker suggests, in this order:
 

--- a/docs/tutorials/run-your-first-project.md
+++ b/docs/tutorials/run-your-first-project.md
@@ -275,8 +275,12 @@ ones it is the customer of.
 - **Switching projects** swaps the tag.
 
 Nothing explains this on screen, and nothing needs to: the tag is right there
-in the Subject field. Edit it, delete it, type your own — it is ordinary text
-and Margince leaves your version alone.
+in the Subject field, so you can see exactly what will go out.
+
+Write the rest of the subject however you like — the tag stays at the front
+while a project is chosen. Deleting it out of the text does not unset the
+project, because the picker still names one and the picker is what the send
+follows. To send without a tag, choose **No project**.
 
 ### What it starts on
 

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -2083,7 +2083,7 @@ describe("ComposeModal started from an account", () => {
     expect(subject().value).toBe("");
   });
 
-  it("leaves a tag the rep deleted by hand deleted", async () => {
+  it("keeps the tag when the rep types a subject over it", async () => {
     const user = userEvent.setup();
     replyBackend(
       [{ entity_type: "deal", entity_id: "d-1" }],
@@ -2092,11 +2092,37 @@ describe("ComposeModal started from an account", () => {
     const subject = await openReply();
     await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
 
+    // The ordinary thing a rep does next: type the subject. The field is
+    // replaced wholesale, and the tag has to survive that — writing it once
+    // when the picker moved is what lost it.
+    await user.clear(subject());
+    await user.type(subject(), "Re: Kurzer Austausch?");
+
+    await waitFor(() =>
+      expect(subject().value).toBe("[N2P-1] Re: Kurzer Austausch?"),
+    );
+  });
+
+  it("puts the tag back when the subject loses it, while a project is chosen", async () => {
+    const user = userEvent.setup();
+    replyBackend(
+      [{ entity_type: "deal", entity_id: "d-1" }],
+      [{ project_id: "pr-9", name: "Netcare 2 project", key: "N2P-1" }],
+    );
+    const subject = await openReply();
+    await waitFor(() => expect(subject().value).toBe("[N2P-1]"));
+
+    // Deleting the tag out of the text is not how a project is unset — the
+    // picker is, and it still names one. Leaving the text without it would put
+    // the field and the picker in two different states, and the send would
+    // honour the picker.
     await user.clear(subject());
     await user.type(subject(), "Re: ohne Tag");
 
+    await waitFor(() => expect(subject().value).toBe("[N2P-1] Re: ohne Tag"));
+
+    // The way to have no tag is to choose No project.
+    await pickOption(user, screen.getByLabelText("Project"), "No project");
     await waitFor(() => expect(subject().value).toBe("Re: ohne Tag"));
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(subject().value).toBe("Re: ohne Tag");
   });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1420,24 +1420,27 @@ function useProjectFiling(input: {
   const projectId = offered ? chosen : "";
   const { project } = useProjectRecord(projectId || undefined);
   const tag = subjectTag(project);
-  const applied = useRef<string>("");
-  const subjectRef = useRef(input.subject);
-  subjectRef.current = input.subject;
+  // Keeping the tag in the subject is a rule about the FIELD, not an action
+  // taken once when the picker moves. A subject is replaced wholesale — by a
+  // draft arriving, or by a rep selecting all and retyping — and a tag written
+  // only at the moment of choosing is gone the first time either happens.
+  //
+  // So the tag is kept at the front of the subject for as long as a project is
+  // chosen. Taking it off is done through the picker (choose No project), which
+  // is the control that means it; there is no way to half-choose a project by
+  // editing the text, because that state is not one the send could honour.
   const setSubject = input.setSubject;
-  // In an effect, not during render: setting the subject inline would be a
-  // state write inside another component's render pass, the shape that drives
-  // React into an update loop.
+  const subject = input.subject;
+  const previousTag = useRef("");
   useEffect(() => {
-    if (applied.current === tag) {
-      return;
+    const priorTag = previousTag.current;
+    previousTag.current = tag;
+    const withoutOld = priorTag ? stripSubjectTag(subject, priorTag) : subject;
+    const wanted = tag ? withSubjectTag(withoutOld, tag) : withoutOld;
+    if (wanted !== subject) {
+      setSubject(wanted);
     }
-    const previous = applied.current;
-    applied.current = tag;
-    const bare = previous
-      ? stripSubjectTag(subjectRef.current, previous)
-      : subjectRef.current;
-    setSubject(tag ? withSubjectTag(bare, tag) : bare);
-  }, [tag, setSubject]);
+  }, [tag, subject, setSubject]);
   return { projectId, setProjectId: setPicked };
 }
 

--- a/frontend/src/screens/projectrecord.ts
+++ b/frontend/src/screens/projectrecord.ts
@@ -97,15 +97,18 @@ export function withSubjectTag(subject: string, tag: string): string {
  * Only key-SHAPED groups go. `[FYI]` is prose to the matcher and prose here.
  */
 export function stripEveryKeyTag(subject: string): string {
-  return (
-    subject
-      .replace(/\[[^\]]*\]/g, (group) =>
-        keyShaped(group.slice(1, -1)) ? "" : group,
-      )
-      // Removing a tag from mid-line leaves the spaces that surrounded it, and a
-      // subject reading "Re:  Hallo" is a tell that something was cut out of it.
-      .replace(/\s{2,}/g, " ")
+  const without = subject.replace(/\[[^\]]*\]/g, (group) =>
+    keyShaped(group.slice(1, -1)) ? "" : group,
   );
+  if (without === subject) {
+    // Nothing was cut, so nothing is tidied. This runs over a subject the rep
+    // is TYPING, and collapsing runs of spaces there would eat the space they
+    // just pressed before they can type the next word.
+    return subject;
+  }
+  // Removing a tag from mid-line leaves the spaces that surrounded it, and a
+  // subject reading "Re:  Hallo" is a tell that something was cut out of it.
+  return without.replace(/\s{2,}/g, " ");
 }
 
 /** `subject` with a leading `tag` removed, if it carries one. */
@@ -121,7 +124,10 @@ export function stripSubjectTag(subject: string, tag: string): string {
 
 /** `body` behind `tag`, with one space and no leading blank. */
 function prefixed(body: string, tag: string): string {
-  const rest = body.trim();
+  // Only the LEADING space is dropped, and only to avoid "[KEY]  Re:". A
+  // trailing one is the space the rep just typed before the next word, and
+  // trimming it here takes it back out from under their cursor.
+  const rest = body.replace(/^\s+/, "");
   return rest ? `${tag} ${rest}` : tag;
 }
 


### PR DESCRIPTION
fix(compose): the project tag stays in the subject line

Typing a subject removed the tag and nothing put it back. The tag was written
once, at the moment the project choice changed, so the first thing a rep does
after opening a reply — type the subject — replaced the field wholesale and
took the tag with it. A draft arriving did the same. The tag was only ever
visible until it was used.

Keeping it is a rule about the FIELD, not an action taken once: while a project
is chosen, its tag belongs at the front of the subject, and it is put back
whenever the subject stops carrying it. Removing it is done through the picker,
which is the control that means it — there is no half-chosen state where the
text says one thing and the picker another, because the send honours the
picker.

Two helpers were eating the space the rep had just typed. `stripEveryKeyTag`
collapsed runs of whitespace even when it had cut nothing, and `prefixed`
trimmed both ends of the subject rather than only its leading space. Both now
tidy only what they actually changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the project tag at the front of the Subject while a project is chosen, and restores it if the Subject loses it. Previously the tag was written once on picker change; typing or a draft overwrite removed it and could desync the Subject from the picker.

- Enforces the rule in useProjectFiling and updates docs: recompute from the current subject and tag; keep the tag while a project is chosen; remove it only by choosing "No project."
- Fixes spacing: stripEveryKeyTag only collapses spaces when it actually removed a key-shaped tag; prefixed trims only leading space to avoid eating a just-typed space.
- Tests cover typing over the tag, automatic restoration while a project is selected, and proper removal when choosing "No project."

<sup>Written for commit 70a28250281939eb711e958d4e832345ce1d7bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project tags now remain synchronized at the start of email subjects while a project is selected.
  * To send an email without a project tag, select **No project**.

* **Bug Fixes**
  * Editing or replacing a subject no longer unintentionally removes the selected project tag.
  * Subject spacing, including trailing spaces while typing, is preserved more accurately.

* **Documentation**
  * Updated project and email composition guidance to reflect the new project-tag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->