### PR TITLE
fix(compose): the subject comes back byte for byte around the tag

### DIFF
--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1375,8 +1375,12 @@ function useAnchorProject(
  * a deal's project. It is adopted once, when it first arrives, so a rep who
  * then picks None is not overruled on the next render.
  *
- * The tag is written only when the CHOICE changes, never on a keystroke, so a
- * tag the rep deletes by hand stays deleted.
+ * The tag is KEPT in the subject for as long as a project is chosen, put back
+ * whenever the field stops carrying it — a subject is replaced wholesale by a
+ * draft arriving or by a rep retyping it, and a tag written once at the moment
+ * of choosing does not survive either. Removing it is done through the picker,
+ * which is what the send honours; there is no state where the text and the
+ * picker disagree.
  */
 function useProjectFiling(input: {
   activityId?: string;

--- a/frontend/src/screens/projectrecord.test.ts
+++ b/frontend/src/screens/projectrecord.test.ts
@@ -78,6 +78,30 @@ describe("the project tag a subject carries", () => {
     );
   });
 
+  it("leaves the rest of the subject byte for byte", () => {
+    // The tag is re-applied on every edit while a project is chosen, so this
+    // runs over text the rep is actively typing. Anything it tidies beyond the
+    // tag is their writing being rewritten under the cursor.
+    expect(withSubjectTag("[N2P-1] Re:  Kurzer Austausch?", "[N2P-1]")).toBe(
+      "[N2P-1] Re:  Kurzer Austausch?",
+    );
+    // Including a trailing space, which is the one they just pressed before
+    // typing the next word.
+    expect(withSubjectTag("[N2P-1] Re: ", "[N2P-1]")).toBe("[N2P-1] Re: ");
+    // And runs of spaces nowhere near a tag.
+    expect(withSubjectTag("Re:   viel   Platz", "[N2P-1]")).toBe(
+      "[N2P-1] Re:   viel   Platz",
+    );
+  });
+
+  it("closes the gap a removed tag leaves behind", () => {
+    // One separator survives when the tag sat between two things, so a subject
+    // does not read "Re:  Hallo" with a hole where the tag was.
+    expect(withSubjectTag("Re: [OTHER-9] Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] Re: Hallo",
+    );
+  });
+
   it("takes its own tag back off, and nobody else's", () => {
     expect(stripSubjectTag("[N2P-1] Re: Hallo", "[N2P-1]")).toBe("Re: Hallo");
     // A different project's tag is the rep's text, not ours to remove.

--- a/frontend/src/screens/projectrecord.ts
+++ b/frontend/src/screens/projectrecord.ts
@@ -72,11 +72,12 @@ export function subjectTag(project: Project | null): string {
 /**
  * `subject` carrying `tag` exactly once, at the front.
  *
- * Idempotent on purpose: the composer re-derives the subject whenever the
- * filing changes, and a rep may also have typed the tag themselves. Re-applying
- * must not produce `[N2P-1] [N2P-1] Re: …`. A tag the rep DELETED stays
- * deleted — that is the opt-out, and this function is only called when the
- * filing itself changes, never on every keystroke.
+ * Idempotent on purpose, and called on EVERY edit while a project is chosen:
+ * the tag is kept at the front of the subject rather than written once, so
+ * re-applying must neither stack (`[N2P-1] [N2P-1] Re: …`) nor disturb the
+ * text around it. The rest of the subject comes back byte for byte — it is
+ * what the rep is typing, and tidying it would rewrite their words under the
+ * cursor.
  */
 export function withSubjectTag(subject: string, tag: string): string {
   if (!tag) {
@@ -97,18 +98,20 @@ export function withSubjectTag(subject: string, tag: string): string {
  * Only key-SHAPED groups go. `[FYI]` is prose to the matcher and prose here.
  */
 export function stripEveryKeyTag(subject: string): string {
-  const without = subject.replace(/\[[^\]]*\]/g, (group) =>
-    keyShaped(group.slice(1, -1)) ? "" : group,
-  );
-  if (without === subject) {
-    // Nothing was cut, so nothing is tidied. This runs over a subject the rep
-    // is TYPING, and collapsing runs of spaces there would eat the space they
-    // just pressed before they can type the next word.
-    return subject;
-  }
-  // Removing a tag from mid-line leaves the spaces that surrounded it, and a
-  // subject reading "Re:  Hallo" is a tell that something was cut out of it.
-  return without.replace(/\s{2,}/g, " ");
+  // A removed tag takes ONE of the spaces that surrounded it with it, so
+  // "Re: [KEY] Hallo" becomes "Re: Hallo" rather than "Re:  Hallo". The rest of
+  // the line is returned byte for byte: this runs over a subject the rep is
+  // typing, and a global whitespace collapse would rewrite their spacing —
+  // eating the second space of "Re:  Kurzer" that they put there on purpose.
+  return subject.replace(/\s?\[[^\]]*\]\s?/g, (group) => {
+    const inner = group.trim().slice(1, -1);
+    if (!keyShaped(inner)) {
+      return group;
+    }
+    // Keep one separator when the tag sat BETWEEN two things; keep none when it
+    // sat at either end.
+    return group.startsWith(" ") && group.endsWith(" ") ? " " : "";
+  });
 }
 
 /** `subject` with a leading `tag` removed, if it carries one. */


### PR DESCRIPTION
fix(compose): the subject comes back byte for byte around the tag

The tag is re-applied on every edit while a project is chosen, so anything
`withSubjectTag` tidies beyond the tag itself is the rep's own writing being
rewritten under their cursor. Removing the tag counted as "something was cut",
which fired a whitespace collapse across the whole line: typing
`[N2P-1] Re:  Kurzer Austausch?` silently became `[N2P-1] Re: Kurzer Austausch?`.

`stripEveryKeyTag` now takes one adjoining space with the tag it removes — so a
tag cut from mid-line leaves `Re: Hallo` rather than `Re:  Hallo` — and returns
the rest of the subject untouched.

Two comments described the superseded rule, that the tag is written only when
the choice changes and that deleting it by hand is the opt-out. Both are now
what the code does: the tag is kept while a project is chosen, and the picker
is what removes it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the project tag in the subject on every edit while a project is chosen and leaves the rest of the subject byte-for-byte. Previously, removing a tag triggered a global whitespace collapse; now we remove the tag plus one adjoining space and preserve all other spacing.

- stripEveryKeyTag: remove key-shaped tags with one adjacent space; keep one separator when the tag sat between words; no global whitespace collapse.
- withSubjectTag: idempotent and invoked on every edit; must not duplicate tags or modify surrounding text. Tests cover byte-for-byte preservation, trailing spaces, and mid-line gap closure.
- Compose behavior/docs: the tag persists while a project is selected and is removed via the picker; send honors the picker so text and picker never disagree.

<sup>Written for commit 011565a08819dfcffcd03e23a24c725dd6035249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project tags now remain preserved while a project is selected, including after editing or replacing the subject.
  * Removing a project tag now cleans up surrounding spacing while preserving readable separation between words.
  * Subject formatting and whitespace are retained during edits.

* **Tests**
  * Added coverage for whitespace preservation and spacing cleanup when replacing embedded project tags.

* **Documentation**
  * Clarified project-tag behavior throughout the compose and project record experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->