### PR TITLE
fix(compose): a space the rep typed beside the tag is theirs, and stays

### DIFF
--- a/frontend/src/screens/projectrecord.test.ts
+++ b/frontend/src/screens/projectrecord.test.ts
@@ -94,6 +94,23 @@ describe("the project tag a subject carries", () => {
     );
   });
 
+  it("keeps a second space the rep typed right after the tag", () => {
+    // The space beside the tag is the easiest one to lose and the least
+    // visible when it goes: what this module manages is the tag plus ONE
+    // separator, and anything past that is the rep's own spacing.
+    expect(withSubjectTag("[N2P-1]  Re: Hallo", "[N2P-1]")).toBe(
+      "[N2P-1]  Re: Hallo",
+    );
+    expect(withSubjectTag("[N2P-1]   Re: Hallo", "[N2P-1]")).toBe(
+      "[N2P-1]   Re: Hallo",
+    );
+    // And the ordinary single-separator case is untouched, so re-applying is
+    // still idempotent rather than growing a space each pass.
+    expect(withSubjectTag("[N2P-1] Re: Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] Re: Hallo",
+    );
+  });
+
   it("closes the gap a removed tag leaves behind", () => {
     // One separator survives when the tag sat between two things, so a subject
     // does not read "Re:  Hallo" with a hole where the tag was.
@@ -104,6 +121,8 @@ describe("the project tag a subject carries", () => {
 
   it("takes its own tag back off, and nobody else's", () => {
     expect(stripSubjectTag("[N2P-1] Re: Hallo", "[N2P-1]")).toBe("Re: Hallo");
+    // One separator comes off with the tag, not every space behind it.
+    expect(stripSubjectTag("[N2P-1]  Re: Hallo", "[N2P-1]")).toBe(" Re: Hallo");
     // A different project's tag is the rep's text, not ours to remove.
     expect(stripSubjectTag("[OTHER-9] Re: Hallo", "[N2P-1]")).toBe(
       "[OTHER-9] Re: Hallo",

--- a/frontend/src/screens/projectrecord.ts
+++ b/frontend/src/screens/projectrecord.ts
@@ -103,7 +103,9 @@ export function stripEveryKeyTag(subject: string): string {
   // the line is returned byte for byte: this runs over a subject the rep is
   // typing, and a global whitespace collapse would rewrite their spacing —
   // eating the second space of "Re:  Kurzer" that they put there on purpose.
-  return subject.replace(/\s?\[[^\]]*\]\s?/g, (group) => {
+  // Exactly ONE space on each side is eligible to go with the tag — the
+  // separator this module writes. A second space is the rep's own and stays.
+  return subject.replace(/ ?\[[^\]]*\] ?/g, (group) => {
     const inner = group.trim().slice(1, -1);
     if (!keyShaped(inner)) {
       return group;
@@ -114,24 +116,31 @@ export function stripEveryKeyTag(subject: string): string {
   });
 }
 
-/** `subject` with a leading `tag` removed, if it carries one. */
+/**
+ * `subject` with a leading `tag` removed, if it carries one — along with the
+ * ONE space this module puts after it, and no more.
+ *
+ * What Margince manages is the tag plus a single separator. Everything after
+ * that is the rep's, including a second space they typed themselves: stripping
+ * every leading space would take `[KEY]  Re:` down to `Re:` and quietly change
+ * what they wrote.
+ */
 export function stripSubjectTag(subject: string, tag: string): string {
-  if (!tag) {
+  if (!tag || !subject.startsWith(tag)) {
     return subject;
   }
-  const trimmed = subject.trimStart();
-  return trimmed.startsWith(tag)
-    ? trimmed.slice(tag.length).trimStart()
-    : subject;
+  const rest = subject.slice(tag.length);
+  return rest.startsWith(" ") ? rest.slice(1) : rest;
 }
 
-/** `body` behind `tag`, with one space and no leading blank. */
+/**
+ * `body` behind `tag`, with the one separator this module owns.
+ *
+ * `body` arrives already stripped of the tag and its separator, so it is used
+ * verbatim — leading spaces included, because those are the rep's.
+ */
 function prefixed(body: string, tag: string): string {
-  // Only the LEADING space is dropped, and only to avoid "[KEY]  Re:". A
-  // trailing one is the space the rep just typed before the next word, and
-  // trimming it here takes it back out from under their cursor.
-  const rest = body.replace(/^\s+/, "");
-  return rest ? `${tag} ${rest}` : tag;
+  return body === "" ? tag : `${tag} ${body}`;
 }
 
 /**


### PR DESCRIPTION
fix(compose): a space the rep typed beside the tag is theirs, and stays

`withSubjectTag("[N2P-1]  Re: Hallo", "[N2P-1]")` returned
`"[N2P-1] Re: Hallo"` — the second space, typed deliberately, was eaten on the
next edit. The previous round's regression tests covered repeated spaces
further into the subject and missed the one place the rewrite actually reaches:
right beside the tag.

What this module manages is the tag plus ONE separator. `stripSubjectTag` and
`prefixed` were removing every leading space instead of that one, so anything
the rep put after the separator was silently collapsed. Both now take exactly
one space and hand back the rest verbatim.

The adjacent-space case is pinned, and mutation-checked against the real fix:
restoring either helper's `trimStart`/`replace(/^\s+/)` fails the new test.

One comment claimed the pattern matched a single space "rather than `\s+`",
which was wrong twice over — it had been `\s?`, and `\s?` matches one character
just as ` ?` does. The regex was never the defect; the claim is gone rather
than restated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves a user-typed extra space immediately after the subject tag. Previously we collapsed all leading spaces after the tag; now we remove exactly one separator space and keep the rest.

- stripEveryKeyTag: remove tags with at most one space on each side; do not collapse additional spaces.
- stripSubjectTag: remove the tag and one following space if present; leave any further spaces intact.
- prefixed: stop trimming the body; add exactly one separator between tag and body.
- Tests: add coverage for the adjacent-space case and idempotency.

<sup>Written for commit 445a84a4d41c40202be76bcc732606d1bb8a03ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project tag handling to preserve user-entered spacing.
  - Prevented extra whitespace from being removed when tags are stripped.
  - Ensured subject text remains unchanged except for the tag and its single separator.
  - Improved handling of empty tags and consistent spacing when adding tags.

- **Tests**
  - Added coverage for multiple spaces, single separators, and tag removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->