### PR TITLE
feat(import): a row can name the company it corrects

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16789,15 +16789,47 @@ components:
         mapping:
           type: object
           additionalProperties: { type: string }
-          description: '`{source column → target field}`, as the human settled it. Validated against the object''s live field catalog before the run is created.'
+          description: |
+            `{source column → target field}`, as the human settled it. Validated against
+            the object's live field catalog before the run is created.
+
+            One target is not a field: a column mapped to **`id`** names the record the
+            row IS, by the id this CRM gave it, and the row UPDATES that record. Nothing
+            is written to `id` itself. This is the correction workflow — read the
+            companies out with their ids, edit the file, import it back.
+
+            A row whose `id` is empty names no record and is an ordinary create, so one
+            file can carry corrections and new companies together — as long as some other
+            mapped column identifies every row (see `source_key`).
+
+            An id is the only safe way to say which record a row means. Matching by NAME
+            cannot be: the dedupe ladder exists to answer "should a human look at these
+            two?" and blurs to do it — it strips legal forms, so `Acme Inc` and
+            `Acme GmbH` are one string; it scores a trading name against a registered
+            one; and where several records tie it picks the lowest uuid. Every blur is
+            free when the answer is "show a human" and is a way to overwrite the wrong
+            company when the answer decides a write, which no `undo` reverses.
+
+            A row naming an id nothing answers to is reported as a skipped row saying so,
+            never created quietly under a new id.
         source_key:
           type: string
           description: |
-            The source column holding the row's stable id, written to the row's
-            provenance so a re-uploaded file updates rather than duplicates
-            (IEM-AC-9) and an undo can find what one run created (S-E15.4c).
-            Absent means the mapped natural key is used instead; the report
-            says which was chosen rather than leaving it to be inferred.
+            The source column holding the row's stable id. For a row this run
+            CREATES it is written to the row's provenance, so a re-uploaded file
+            updates rather than duplicates (IEM-AC-9) and an undo can find what
+            the run created (S-E15.4c). A row that names an existing record by
+            `id` records nothing: the run did not create that company, and undo
+            must not archive it.
+
+            Absent means the mapped natural key is used instead; the report says
+            which was chosen rather than leaving it to be inferred. A file whose
+            only identifying column is `id` falls back to it — a corrections
+            export can be `id,city` and nothing else — and then EVERY row needs
+            an id, because a row with no source key cannot be identified at all
+            and is reported as an unusable line. A file mixing corrections with
+            new companies therefore maps a column every row carries, and the
+            `id` column says which rows are corrections.
         on_duplicate:
           $ref: '#/components/schemas/ImportOnDuplicate'
 
@@ -16809,6 +16841,20 @@ components:
         What to do with a row naming a record the estate ALREADY holds — found
         by the same dedupe ladder every create path runs, not by this
         importer's own memory of what it once wrote.
+
+        A collision with a record the CALLER MAY NOT SEE is answered as no
+        collision: the row is not counted as a duplicate, not named in the
+        report, and CREATES. The question is asked of EVERY candidate the dedupe
+        ladder matched rather than of its winner — the winner is the highest
+        score with the lowest uuid breaking ties, so an invisible record ranking
+        first would otherwise mask a visible one behind it and decide the outcome
+        without being disclosed. Skipping it would be the intuitive choice and it
+        leaks — hiding which company was hit still says one was, and "your row
+        was not created" answers "is this company in your CRM" about a
+        colleague's owner-private capture, probed one row at a time against a
+        report readable on the `import_run` grant. The cost is a twin the dedupe
+        review queue picks up and a merge resolves; the cost of the alternative
+        is a disclosure no merge undoes.
 
         `create` is the historical behaviour and stays the default: the row
         lands and the pair goes on the dedupe review queue, exactly as a manual

--- a/backend/internal/compose/csvcollision.go
+++ b/backend/internal/compose/csvcollision.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Whether a row names a company THIS CALLER CAN SEE that the estate already
+// holds.
+//
+// One question, deliberately — an earlier shape asked two, deciding on the
+// estate and disclosing on what may be read, and every version of that leaked.
+// Filtering the preview moved the answer into the finished report, which needs
+// only the import_run grant. Making the report's wording opaque left the
+// OUTCOME saying what the words would not: "your row was not created" answers
+// "is this company in your CRM" about a colleague's owner-private capture,
+// probed one row at a time.
+//
+// So an invisible incumbent is answered as no incumbent, and the row creates.
+// The cost is a twin the dedupe review queue picks up like any other and a merge
+// resolves. The cost of the alternative is a disclosure no merge undoes.
+//
+// The ladder itself still reads every organization, by design: it is the write
+// path's collision check. What is filtered is what this caller is TOLD, never
+// what the estate knows.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// A match the caller MAY NOT SEE is answered as no match at all, so the row goes
+// on to create.
+//
+// Skipping it instead is the intuitive choice and it leaks. Hiding which company
+// was hit is not enough: the outcome still says one was, and "your row was not
+// created" answers "is this company in your CRM" — for a colleague's
+// owner-private capture, probed one CSV row at a time, against a finished report
+// readable on the import_run grant alone.
+//
+// What creating costs is a twin of a record the caller cannot see, which the
+// dedupe review queue picks up like any other and a merge resolves. What skipping
+// costs is a disclosure no merge undoes.
+//
+// Only organizations: a lead's identity is its email, which the store's own
+// unique key already refuses, so there is no silent twin to warn about.
+//
+// A read-only transaction, and NOT DedupeOrganizationForCreate — that one takes
+// a write lock to serialize concurrent creates, which a preview has no business
+// holding. The answer can go stale between the preview and the commit; the
+// create path runs the locking version itself and its answer is the one that
+// decides.
+func (w *csvWriters) collidesWithExisting(ctx context.Context, row migration.Row) (bool, error) {
+	if w.object != migration.ObjectOrganization {
+		return false, nil
+	}
+	fields := textFields(row.Fields)
+	candidate := people.OrganizationCandidate{
+		DisplayName: strings.TrimSpace(fields[fieldDisplayName]),
+		LegalName:   strings.TrimSpace(fields["legal_name"]),
+	}
+	if candidate.DisplayName == "" && candidate.LegalName == "" {
+		return false, nil
+	}
+	var visible bool
+	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		match, err := people.DedupeOrganization(ctx, tx, candidate)
+		if err != nil || match.Decision == people.DecisionNoMatch {
+			return err
+		}
+		// EVERY candidate at or above the ladder's threshold, not just its
+		// winner.
+		//
+		// The winner is chosen by confidence with the lowest uuid breaking ties,
+		// which has nothing to do with who may read it — so an invisible record
+		// ranking first MASKS a visible one behind it. Asking only about the
+		// winner then made the hidden record change what this caller is told: with
+		// it present the row created and reported no duplicate, without it the
+		// visible candidate won and the row was skipped. The hidden company was
+		// inferable from the disposition either way, which is the whole leak
+		// wearing a different hat.
+		//
+		// A collision this caller can see is a collision. One they cannot see is,
+		// as far as they are told, not there — and Ranked carries the set that
+		// question has to be asked of.
+		//
+		// The ladder itself still reads every organization, by design: it is the
+		// write path's collision check. What is filtered is what this caller is
+		// TOLD, never what the estate knows.
+		// EVERY candidate is asked, with no early exit once one answers yes.
+		//
+		// Returning on the first visible match would make the number of queries
+		// depend on where the visible candidate sits among the hidden ones — and
+		// a caller who can time the call reads that ordering back. It is a
+		// narrow channel and it is the same fact by another route: whether
+		// records they cannot see are there.
+		//
+		// The loop is bounded by the ladder's own threshold, so the cost is the
+		// candidate set and not the estate.
+		for _, candidate := range candidatesOf(match) {
+			seen, err := auth.VisibleTo(ctx, tx, "organization", candidate.UUID)
+			if err != nil {
+				return err
+			}
+			visible = visible || seen
+		}
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("import: checking %q against the companies already held: %w",
+			candidate.DisplayName, err)
+	}
+	return visible, nil
+}
+
+// candidatesOf answers every organization the ladder matched, best first.
+//
+// Held by: TestEveryMatchedCandidateIsAskedAboutNotJustTheWinner
+// (backend/internal/compose/csvcollisionvisibility_test.go)
+//
+// Ranked is the full set at or above the review threshold and is what a
+// visibility question must be asked of. It is empty for an exact (domain)
+// collision, which carries its answer in OrganizationID instead — so that one is
+// added when Ranked has nothing, and never twice.
+func candidatesOf(match people.OrganizationMatch) []ids.OrganizationID {
+	if len(match.Ranked) == 0 {
+		return []ids.OrganizationID{match.OrganizationID}
+	}
+	out := make([]ids.OrganizationID, 0, len(match.Ranked))
+	for _, scored := range match.Ranked {
+		out = append(out, scored.OrganizationID)
+	}
+	return out
+}

--- a/backend/internal/compose/csvcollisionvisibility_test.go
+++ b/backend/internal/compose/csvcollisionvisibility_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Visibility is asked of EVERY candidate the ladder matched, not of its winner.
+//
+// The winner is the highest confidence with the lowest uuid breaking ties, which
+// has nothing to do with who may read it. Asking only about the winner let an
+// invisible record MASK a visible one behind it: with the hidden company present
+// the row created and reported no duplicate, without it the visible candidate
+// won and the row was skipped. The hidden company was inferable from the
+// disposition either way — the same existence oracle in a different hat.
+//
+// candidatesOf is the seam that has to see the whole set. This is a unit gate on
+// it, because building two same-named companies with different visibility takes
+// two seats the import suite's harness does not have.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestEveryMatchedCandidateIsAskedAboutNotJustTheWinner(t *testing.T) {
+	first, second := ids.NewV7(), ids.NewV7()
+
+	// A fuzzy match ranks its candidates; every one of them is a company the row
+	// might mean, and a visibility question skipping any of them lets that one
+	// change the answer without being asked.
+	fuzzy := people.OrganizationMatch{
+		Decision:       people.DecisionFuzzyReview,
+		OrganizationID: ids.From[ids.OrganizationKind](first),
+		Ranked: []people.OrganizationCandidateScore{
+			{OrganizationID: ids.From[ids.OrganizationKind](first), Confidence: 1},
+			{OrganizationID: ids.From[ids.OrganizationKind](second), Confidence: 1},
+		},
+	}
+	got := candidatesOf(fuzzy)
+	if len(got) != 2 {
+		t.Fatalf("candidatesOf answered %d of 2 ranked candidates — one the caller CAN see, ranked "+
+			"behind one they cannot, would never be asked about and the hidden record would decide "+
+			"the outcome", len(got))
+	}
+
+	// An exact (domain) collision carries no ranked set; its answer is the id
+	// itself, and dropping it would make a real collision invisible.
+	exact := people.OrganizationMatch{
+		Decision:       people.DecisionExactCollision,
+		OrganizationID: ids.From[ids.OrganizationKind](first),
+	}
+	if got := candidatesOf(exact); len(got) != 1 || got[0] != ids.From[ids.OrganizationKind](first) {
+		t.Errorf("candidatesOf answered %v for an exact collision, want the matched id — it carries "+
+			"no ranked set, so reading only Ranked would lose the collision entirely", got)
+	}
+}

--- a/backend/internal/compose/csvdisposition_test.go
+++ b/backend/internal/compose/csvdisposition_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The four dispositions never exceed the rows read.
+//
+// A finished run's stored report carries the dry run's skips as well as the
+// commit's, because the engine folds attempts by object class and concatenates
+// their skipped lists. Usually the same rows appear in both and dedup collapses
+// them — but a row the preview skipped for a collision that then vanished
+// commits as a CREATE, and counting both reports two outcomes for one row.
+//
+// The contract says the four sum to rows_read, and `unchanged` is derived by
+// subtracting the other three: an overcount does not merely look wrong, it makes
+// `unchanged` negative and the derivation clamps it to zero, so the report
+// silently loses the surplus instead of showing it.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+)
+
+func TestAFinishedDispositionNeverExceedsTheRowsRead(t *testing.T) {
+	// One row: the preview skipped it for a collision, the commit created it
+	// because the incumbent was gone by then. Both entries survive in the stored
+	// report.
+	run := migration.Run{
+		Status: migration.StatusComplete,
+		Report: &migration.Report{Objects: []migration.ObjectReport{{
+			Object:      migration.ObjectOrganization,
+			MirrorCount: 1,
+			WillCreate:  0,
+			Created:     1,
+			Skipped: []migration.SkippedRow{{
+				ExternalID: "Kestrel Data",
+				Reason:     "a company of this name is already in the CRM",
+			}},
+		}}},
+	}
+
+	report := toContractImportReport(run)
+	got := report.Disposition.Created + report.Disposition.Updated +
+		report.Disposition.Unchanged + report.Disposition.Skipped
+	if got != report.RowsRead {
+		t.Errorf("the disposition sums to %d for %d rows read (created %d, updated %d, unchanged %d, "+
+			"skipped %d) — the commit created this row and a stale preview skip was counted beside it",
+			got, report.RowsRead, report.Disposition.Created, report.Disposition.Updated,
+			report.Disposition.Unchanged, report.Disposition.Skipped)
+	}
+	if report.Disposition.Created != 1 {
+		t.Errorf("created = %d, want 1 — the commit's own outcome is the one that happened",
+			report.Disposition.Created)
+	}
+	// The issue survives even though the count does not: a person is still owed
+	// the reason the preview gave.
+	if len(report.Issues) != 1 {
+		t.Errorf("%d issue(s), want 1 — dropping the entry hides why the preview said what it said",
+			len(report.Issues))
+	}
+}

--- a/backend/internal/compose/csvfields.go
+++ b/backend/internal/compose/csvfields.go
@@ -46,6 +46,22 @@ var csvTargets = map[string][]string{
 	migration.ObjectOrganization: append([]string{fieldDisplayName, "legal_name", fieldIndustry, "size_band", "description"}, orgAddressTargets...),
 }
 
+// csvTargetID is the column that names the record this row IS, by the id the CRM
+// gave it — the workflow behind a corrected export: read the companies out with
+// their ids, edit the file, import it back.
+//
+// It is not a field. Nothing is written to it, and a row carrying one is an
+// UPDATE of that record rather than a candidate for one. That is the whole
+// reason it exists: matching a company by NAME cannot be made safe for
+// overwriting, because the dedupe ladder is built to answer "should a human look
+// at these two" and blurs exactly the distinctions an overwrite must keep — it
+// strips legal forms, scores a trading name against a registered one, and breaks
+// ties on uuid order. Every one of those is fine for proposing a review and is a
+// way to destroy the wrong company's data when it decides a write.
+//
+// An id has none of that. It names one record or no record.
+const csvTargetID = "id"
+
 // orgAddressTargets are the address fields a CSV column may name, spelled with
 // the `address.` prefix the record-fields schema already uses for the nested
 // shape (`address: {city, country, …}`). The mapping itself stays flat — one
@@ -87,7 +103,28 @@ func importTargets(object string) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("import: %q has no mappable fields", object)
 	}
-	return append([]string(nil), core...), nil
+	targets := append([]string(nil), core...)
+	if selectsByID(object) {
+		// Accepted as a column and absent from csvTargets, because those two
+		// lists answer different questions. csvTargets is what a row WRITES, and
+		// TestEveryImportTargetRoundTripsThroughCreateAndUpdate holds it to that:
+		// a target advertised there and reaching neither input would be accepted,
+		// reported as written, and dropped.
+		//
+		// `id` writes nothing. It names the record the row IS.
+		targets = append(targets, csvTargetID)
+	}
+	return targets, nil
+}
+
+// selectsByID reports whether an object's rows may name the record they are.
+//
+// Organizations only, for now. A lead is identified by its email and the store's
+// own unique key refuses a second one, so a lead row has no ambiguity for an id
+// to resolve — and advertising a column that changes nothing would be worse than
+// not offering it.
+func selectsByID(object string) bool {
+	return object == migration.ObjectOrganization
 }
 
 // changedFields reports which mapped values differ from what the stored record
@@ -105,6 +142,13 @@ func changedFields(encoded []byte, mapped map[string]string) (map[string]string,
 
 	changed := make(map[string]string, len(mapped))
 	for field, incoming := range mapped {
+		// `id` NAMES the record; it is not a value the record holds. Comparing it
+		// would find no stored `id` field, report it as changed, and hand the
+		// update path a field the contract has no setter for. Excluded here
+		// rather than at each caller so no path can forget.
+		if field == csvTargetID {
+			continue
+		}
 		if textOf(storedValue(current, field)) != canonicalFor(field, incoming) {
 			changed[field] = incoming
 		}

--- a/backend/internal/compose/csvimport_test.go
+++ b/backend/internal/compose/csvimport_test.go
@@ -6,6 +6,7 @@ package compose
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -79,12 +80,29 @@ func TestEveryImportTargetRoundTripsThroughCreateAndUpdate(t *testing.T) {
 			}
 			created, patched := build(fields)
 			for _, target := range targets {
+				if target == csvTargetID {
+					// A SELECTOR, not a field: it names the record the row is, and
+					// writes nothing. Exempt here and asserted the other way round
+					// below — advertised, and reaching neither input on purpose.
+					continue
+				}
 				if !created[target] {
 					t.Errorf("%s: target %q is advertised but never reaches the create input", object, target)
 				}
 				if !patched[target] {
 					t.Errorf("%s: target %q is advertised but never reaches the update input", object, target)
 				}
+			}
+			if !selectsByID(object) {
+				return
+			}
+			if created[csvTargetID] || patched[csvTargetID] {
+				t.Errorf("%s: %q reached a write input — it names the record a row IS, and writing "+
+					"it would let a file move a company onto another company's id", object, csvTargetID)
+			}
+			if !slices.Contains(targets, csvTargetID) {
+				t.Errorf("%s: %q is not an accepted column, so a corrections file naming its records "+
+					"would be refused", object, csvTargetID)
 			}
 		})
 	}

--- a/backend/internal/compose/csvimportreport.go
+++ b/backend/internal/compose/csvimportreport.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the dry run TELLS a person before they approve it.
+//
+// The engine's report counts rows it would touch; this walks the file again and
+// asks the writers what each row would actually do — created, updated, unchanged,
+// refused, or already here. That second pass is the value of a preview: an
+// approval is a decision about what the report said.
+//
+// The four counts sum to rows_read and no row is counted twice among them.
+// `duplicates` sits outside that sum deliberately: it is a disclosure about rows
+// already counted elsewhere, not a fifth outcome.
+
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+)
+
+func refinePrediction(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string, report migration.Report) (migration.Report, error) {
+	p, err := predictPages(ctx, source, writers, object)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	for i := range report.Objects {
+		if report.Objects[i].Object != object {
+			continue
+		}
+		report.Objects[i].WillCreate = p.created
+		report.Objects[i].WillUpdate = p.updated
+		report.Objects[i].Unchanged = p.unchanged
+		report.Objects[i].Skipped = append(report.Objects[i].Skipped, p.skipped...)
+		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
+		report.Objects[i].Duplicates += p.duplicates
+	}
+	return report, nil
+}
+
+// predictPages walks the source and tallies what the commit would do with each
+// row, page by page, the same way the engine will walk it.
+func predictPages(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string) (p prediction, err error) {
+	for offset := 0; ; offset += importPredictPage {
+		rows, err := source.Rows(ctx, object, offset, importPredictPage)
+		if err != nil {
+			return prediction{}, err
+		}
+		for _, row := range rows {
+			outcome, refusal, err := writers.predictRow(ctx, row)
+			if err != nil {
+				return prediction{}, err
+			}
+			switch outcome {
+			case predictCreate:
+				p.created++
+			case predictUpdate:
+				p.updated++
+			case predictUnchanged:
+				p.unchanged++
+			case predictUnwritable:
+				// Disclosed as a skip rather than counted as a create: the
+				// commit will refuse this row, and the report exists to say so
+				// before a human approves it.
+				p.skipped = append(p.skipped, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     refusal,
+				})
+			case predictCollidesSkipped:
+				// The run asked to skip duplicates, so this row is a skip and
+				// the preview says so — the commit must not be the first place
+				// a person learns the row did not land.
+				p.duplicates++
+				p.skipped = append(p.skipped, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     duplicateSkipReason,
+				})
+			case predictCollides:
+				p.duplicates++
+				// Still a create — the commit lands it and files a review pair
+				// — so it is counted as one. The warning rides separately:
+				// Skipped is load-bearing arithmetic (the contract's four
+				// counts sum to rows_read, and `unchanged` is derived by
+				// subtracting them), so a row counted as BOTH created and
+				// skipped would report two outcomes for one row.
+				p.created++
+				p.collisions = append(p.collisions, migration.SkippedRow{
+					ExternalID: row.ExternalID,
+					Reason:     collisionDisclosure,
+				})
+			}
+		}
+		if len(rows) < importPredictPage {
+			return p, nil
+		}
+	}
+}
+
+// collisionDisclosure is what the report says about a row naming a company the
+// CRM already holds. It is not a refusal: the commit creates the row and files
+// the pair on the dedupe review queue, exactly as a manual create would. The
+// disclosure exists so a person reading "create 3" before approving is not
+// surprised by a duplicate afterwards.
+const collisionDisclosure = "a company of this name is already in the CRM; " +
+	"importing this row creates a second one and files the pair for review"
+
+// duplicateSkipReason is what the report says about a row the run chose to
+// leave alone, under `on_duplicate: skip`.
+const duplicateSkipReason = "a company of this name is already in the CRM, and this run was asked to skip duplicates"
+
+// prediction is what one walk of the source concluded: the three outcomes a
+// commit can have, plus the rows it will refuse outright.
+type prediction struct {
+	created   int
+	updated   int
+	unchanged int
+	skipped   []migration.SkippedRow
+	// collisions are rows that WILL land and also name a company the CRM
+	// already holds. Kept apart from skipped because each is counted in
+	// created — see the disposition arithmetic above.
+	collisions []migration.SkippedRow
+	// duplicates counts the same rows. It is reported to the human as its own
+	// number ("100 companies, 94 duplicates") and never summed with the four.
+	duplicates int
+}

--- a/backend/internal/compose/csvimportwire.go
+++ b/backend/internal/compose/csvimportwire.go
@@ -79,6 +79,19 @@ func mappingFrom(object string, req crmcontracts.CreateImportRunRequest) (migrat
 	sourceKey := csvSourceKeyDefault[object]
 	if req.SourceKey != nil && strings.TrimSpace(*req.SourceKey) != "" {
 		sourceKey = strings.TrimSpace(*req.SourceKey)
+	} else if idColumn := columnFor(fields, csvTargetID); idColumn != "" &&
+		columnFor(fields, csvSourceKeyDefault[object]) == "" {
+		// A file that names its records and carries nothing else to identify a
+		// row by falls back to the id column. That is what lets a corrections
+		// export be "id,city" — a whole legitimate file, which defaulting to
+		// display_name would refuse for not carrying a name it was never going
+		// to change.
+		//
+		// It is a FALLBACK, not a preference: every row then needs an id, since
+		// a row with no source key cannot be identified for re-import or undo.
+		// A file mixing corrections with new companies therefore keeps its own
+		// key column, and the id column says which rows are corrections.
+		sourceKey = idColumn
 	} else {
 		// The default names a TARGET field; the source must name the column
 		// mapped onto it, or no row can be identified.
@@ -207,7 +220,7 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 	// attempt keeps what the earlier one already achieved.
 	committed := run.Status == migration.StatusComplete || run.Status == migration.StatusFailed ||
 		run.Status == migration.StatusUndoing || run.Status == migration.StatusUndone
-	seen := map[int]bool{}
+	seen := map[string]bool{}
 	duplicates := 0
 	for _, o := range run.Report.Objects {
 		out.RowsRead += o.MirrorCount
@@ -222,11 +235,18 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 		for _, s := range o.Skipped {
 			// The same row skipped by the dry run and again by the commit is
 			// ONE row the human must go fix, named by its line.
-			line := lineOf(s.ExternalID)
-			if seen[line] {
+			// Keyed on the EXTERNAL ID, which is what identifies a row — not on
+			// the line lineOf derives from it, which answers 0 for every id not
+			// shaped `line N`. A file carrying its own key column has no such
+			// ids at all, so every skipped row in it collapsed onto the first:
+			// two refused rows reported as one skip and one phantom `unchanged`,
+			// and the four counts then summed to less than rows_read. That is
+			// the disposition "hiding something" its own contract warns about.
+			if seen[s.ExternalID] {
 				continue
 			}
-			seen[line] = true
+			seen[s.ExternalID] = true
+			line := lineOf(s.ExternalID)
 			out.Disposition.Skipped++
 			out.Issues = append(out.Issues, crmcontracts.ImportRowIssue{
 				Line:   line,
@@ -238,11 +258,11 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 		// row is counted in Created, and adding it here too would report two
 		// outcomes for one row and leave `unchanged` short by the difference.
 		for _, c := range o.Collisions {
-			line := lineOf(c.ExternalID)
-			if seen[line] {
+			if seen[c.ExternalID] {
 				continue
 			}
-			seen[line] = true
+			seen[c.ExternalID] = true
+			line := lineOf(c.ExternalID)
 			out.Issues = append(out.Issues, crmcontracts.ImportRowIssue{
 				Line:   line,
 				Reason: c.Reason,
@@ -254,6 +274,32 @@ func toContractImportReport(run migration.Run) crmcontracts.ImportRunReport {
 	// person is asking before they approve, and an omitted field reads as "not
 	// checked" rather than "none found".
 	out.Disposition.Duplicates = &duplicates
+
+	// A finished run's stored report can carry more outcomes than the file has
+	// rows, and there are two causes with different right answers.
+	//
+	// A row the DRY RUN skipped whose collision then vanished commits as a
+	// CREATE, and the stale skip is stored beside the real create — the engine
+	// folds attempts by object class and concatenates their skipped lists. Here
+	// the skip is the entry to drop.
+	//
+	// A RESUMED run can also double-count: ObjectReport.record runs before
+	// advanceCheckpoint, so a checkpoint that fails to persist leaves a counted
+	// row the resume walks again, and attempt reports add their counts. Here the
+	// surplus is in `created`/`updated`, and taking it out of `skipped` would
+	// erase a genuine refusal.
+	//
+	// Nothing in the stored report distinguishes them: per-row entries exist for
+	// skips alone, and everything else is an aggregate. Only the SECOND cause
+	// needs a resume to happen at all, so the attempt count is what tells them
+	// apart — a single-attempt run can only have the first.
+	if committed {
+		surplus := out.Disposition.Created + out.Disposition.Updated +
+			out.Disposition.Skipped - out.RowsRead
+		if surplus > 0 && len(run.Report.Objects) == 1 {
+			out.Disposition.Skipped = max(out.Disposition.Skipped-surplus, 0)
+		}
+	}
 
 	// Unchanged is DERIVED, never carried: it is the rows that were read and
 	// then neither created, updated nor skipped. Carrying the stored figure
@@ -379,107 +425,3 @@ func readAllUpload(file multipart.File) ([]byte, error) {
 // which the commit will not rewrite. A dry run whose whole job is to say what
 // WILL happen may not overstate it by the size of the customer's re-upload, so
 // each row is compared here exactly as the commit will compare it.
-func refinePrediction(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string, report migration.Report) (migration.Report, error) {
-	p, err := predictPages(ctx, source, writers, object)
-	if err != nil {
-		return migration.Report{}, err
-	}
-	for i := range report.Objects {
-		if report.Objects[i].Object != object {
-			continue
-		}
-		report.Objects[i].WillCreate = p.created
-		report.Objects[i].WillUpdate = p.updated
-		report.Objects[i].Unchanged = p.unchanged
-		report.Objects[i].Skipped = append(report.Objects[i].Skipped, p.skipped...)
-		report.Objects[i].Collisions = append(report.Objects[i].Collisions, p.collisions...)
-		report.Objects[i].Duplicates += p.duplicates
-	}
-	return report, nil
-}
-
-// predictPages walks the source and tallies what the commit would do with each
-// row, page by page, the same way the engine will walk it.
-func predictPages(ctx context.Context, source *migration.CSVSource, writers *csvWriters, object string) (p prediction, err error) {
-	for offset := 0; ; offset += importPredictPage {
-		rows, err := source.Rows(ctx, object, offset, importPredictPage)
-		if err != nil {
-			return prediction{}, err
-		}
-		for _, row := range rows {
-			outcome, err := writers.Predict(ctx, row)
-			if err != nil {
-				return prediction{}, err
-			}
-			switch outcome {
-			case predictCreate:
-				p.created++
-			case predictUpdate:
-				p.updated++
-			case predictUnchanged:
-				p.unchanged++
-			case predictUnwritable:
-				// Disclosed as a skip rather than counted as a create: the
-				// commit will refuse this row, and the report exists to say so
-				// before a human approves it.
-				p.skipped = append(p.skipped, migration.SkippedRow{
-					ExternalID: row.ExternalID,
-					Reason:     unwritableReason(object, textFields(row.Fields)),
-				})
-			case predictCollidesSkipped:
-				// The run asked to skip duplicates, so this row is a skip and
-				// the preview says so — the commit must not be the first place
-				// a person learns the row did not land.
-				p.duplicates++
-				p.skipped = append(p.skipped, migration.SkippedRow{
-					ExternalID: row.ExternalID,
-					Reason:     duplicateSkipReason,
-				})
-			case predictCollides:
-				p.duplicates++
-				// Still a create — the commit lands it and files a review pair
-				// — so it is counted as one. The warning rides separately:
-				// Skipped is load-bearing arithmetic (the contract's four
-				// counts sum to rows_read, and `unchanged` is derived by
-				// subtracting them), so a row counted as BOTH created and
-				// skipped would report two outcomes for one row.
-				p.created++
-				p.collisions = append(p.collisions, migration.SkippedRow{
-					ExternalID: row.ExternalID,
-					Reason:     collisionDisclosure,
-				})
-			}
-		}
-		if len(rows) < importPredictPage {
-			return p, nil
-		}
-	}
-}
-
-// collisionDisclosure is what the report says about a row naming a company the
-// CRM already holds. It is not a refusal: the commit creates the row and files
-// the pair on the dedupe review queue, exactly as a manual create would. The
-// disclosure exists so a person reading "create 3" before approving is not
-// surprised by a duplicate afterwards.
-const collisionDisclosure = "a company of this name is already in the CRM; " +
-	"importing this row creates a second one and files the pair for review"
-
-// duplicateSkipReason is what the report says about a row the run chose to
-// leave alone, under `on_duplicate: skip`.
-const duplicateSkipReason = "a company of this name is already in the CRM, and this run was asked to skip duplicates"
-
-// prediction is what one walk of the source concluded: the three outcomes a
-// commit can have, plus the rows it will refuse outright.
-type prediction struct {
-	created   int
-	updated   int
-	unchanged int
-	skipped   []migration.SkippedRow
-	// collisions are rows that WILL land and also name a company the CRM
-	// already holds. Kept apart from skipped because each is counted in
-	// created — see the disposition arithmetic above.
-	collisions []migration.SkippedRow
-	// duplicates counts the same rows. It is reported to the human as its own
-	// number ("100 companies, 94 duplicates") and never summed with the four.
-	duplicates int
-}

--- a/backend/internal/compose/csvtargetid.go
+++ b/backend/internal/compose/csvtargetid.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A row that names the record it IS.
+//
+// The correction workflow: export the companies with their ids, edit the file,
+// import it back. A row carrying an `id` column updates that record — no
+// matching, no scoring, no tie-break.
+//
+// This exists because matching by NAME cannot be made safe for overwriting. The
+// dedupe ladder answers "should a human look at these two?" and blurs to do it:
+// it strips legal forms, so `Acme Inc` and `Acme GmbH` are one string; it scores
+// a trading name against a registered one; and where several records tie it
+// picks the lowest uuid. Every blur is free when the answer is "show a human"
+// and is a way to destroy the wrong company when the answer decides a write.
+// Three attempts at fencing those off found three ways through.
+//
+// An id names one record or no record, and the refusals below are the whole of
+// what can go wrong with it.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// targetID is the record a row names, and whether it named one at all.
+type targetID struct {
+	id     ids.UUID
+	named  bool
+	reason string // why a named id cannot be used, "" when it can
+}
+
+// targetIDOf reads the `id` column and resolves it against the estate.
+//
+// Three refusals, each returned as a row-level reason rather than an error,
+// because one bad line in a spreadsheet is a thing to fix in the file and not a
+// reason to fail the run:
+//
+//   - unparseable: the column holds something that is not an id at all;
+//   - not found: a well-formed id no company in this workspace has;
+//   - not visible: a company the caller may not read.
+//
+// The last two answer the SAME sentence deliberately. Distinguishing them would
+// tell a caller that an id they cannot read nonetheless exists — an oracle over
+// a colleague's owner-private capture, one row at a time — and the honest thing
+// to say is the thing that is true from where they stand: no company you can see
+// has this id.
+func (w *csvWriters) targetIDOf(ctx context.Context, row migration.Row) targetID {
+	raw := strings.TrimSpace(textFields(row.Fields)[csvTargetID])
+	if raw == "" {
+		return targetID{}
+	}
+	if w.object != migration.ObjectOrganization {
+		return targetID{named: true, reason: fmt.Sprintf(
+			"only a company row can name an %q; a %s row is identified by its own key",
+			csvTargetID, w.object)}
+	}
+	parsed, err := ids.Parse(raw)
+	if err != nil {
+		// The parse failure is the ANSWER, not a fault to propagate: one bad cell
+		// in a spreadsheet is a thing to fix in the file, and failing the whole
+		// run over it would tell a person nothing about which line to look at.
+		return targetID{named: true, reason: fmt.Sprintf(
+			"%q is not a company id; export the companies to get theirs, or leave the column empty "+
+				"to import this row as a new company", raw)}
+	}
+	// GetOrganization runs under the caller's own row scope, so a company they
+	// may not read answers not-found here exactly as it would anywhere else.
+	// That is what makes one sentence cover both cases honestly.
+	// Likewise: a read that does not answer means no company this caller can see
+	// has that id, which is the sentence the report shows. Distinguishing "gone"
+	// from "not yours" would tell a caller that an id they cannot read exists.
+	if _, err := w.people.GetOrganization(ctx, ids.From[ids.OrganizationKind](parsed),
+		storekit.LiveOnly); err != nil {
+		return targetID{named: true, reason: fmt.Sprintf(
+			"no company you can see has the id %q; it may have been archived, merged away, or belong "+
+				"to a workspace this file did not come from", raw)}
+	}
+	return targetID{id: parsed, named: true}
+}

--- a/backend/internal/compose/csvwriters.go
+++ b/backend/internal/compose/csvwriters.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,7 +15,6 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
-	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -161,12 +159,35 @@ const (
 // discovering that only on the create branch would let the same bad value pass
 // silently on a re-import.
 func (w *csvWriters) Predict(ctx context.Context, row migration.Row) (predictedOutcome, error) {
+	outcome, _, err := w.predictRow(ctx, row)
+	return outcome, err
+}
+
+// predict answers what the commit will do AND, when it will refuse, the sentence
+// the report shows for it.
+//
+// The reason travels with the outcome rather than being recomputed by the
+// caller. It used to be recomputed — from unwritableReason, which knows about
+// the size_band vocabulary and nothing else — so a refusal from any other source
+// reached the report as a skip with an EMPTY reason, and the person reading it
+// was told a row would not land without being told why.
+func (w *csvWriters) predictRow(ctx context.Context, row migration.Row) (predictedOutcome, string, error) {
 	if reason := unwritableReason(w.object, textFields(row.Fields)); reason != "" {
-		return predictUnwritable, nil
+		return predictUnwritable, reason, nil
+	}
+	// Mirrors Ensure, in the same order: a named record first, then the identity
+	// map. The two must answer alike or an approval decides one thing and the
+	// commit does another.
+	target := w.targetIDOf(ctx, row)
+	if target.named {
+		if target.reason != "" {
+			return predictUnwritable, target.reason, nil
+		}
+		return w.reconcilePrediction(ctx, target.id, row)
 	}
 	id, found, err := w.lookup(ctx, w.object, row.ExternalID)
 	if err != nil {
-		return predictCreate, err
+		return predictCreate, "", err
 	}
 	if !found {
 		// Not a row a previous run of THIS importer landed — but the CRM may
@@ -174,94 +195,51 @@ func (w *csvWriters) Predict(ctx context.Context, row migration.Row) (predictedO
 		// seeded. The identity map cannot see any of those, so the create the
 		// engine is about to report gets the same dedupe read the create path
 		// itself performs.
-		collides, err := w.collidesWithExisting(ctx, row, w.onDuplicate != string(crmcontracts.Skip))
+		// Always disclosure-filtered: a PREVIEW reports what it found, whichever
+		// mode asked. Passing the mode through here reported invisible companies
+		// as duplicates on a `skip` run — an existence oracle over a colleague's
+		// owner-private capture, one CSV row at a time.
+		collides, err := w.collidesWithExisting(ctx, row)
 		if err != nil {
-			return predictCreate, err
+			return predictCreate, "", err
 		}
 		if collides {
 			if w.onDuplicate == string(crmcontracts.Skip) {
-				return predictCollidesSkipped, nil
+				return predictCollidesSkipped, "", nil
 			}
-			return predictCollides, nil
+			return predictCollides, "", nil
 		}
-		return predictCreate, nil
+		return predictCreate, "", nil
 	}
+	return w.reconcilePrediction(ctx, id, row)
+}
+
+// predictReconcile is what reconcile would do to this record, without writing.
+//
+// Shared by both ways a row reaches an existing record — the identity map, and
+// an `id` column naming it — so the preview cannot answer one thing for a row
+// the file identified and another for a row the importer remembered.
+func (w *csvWriters) reconcilePrediction(
+	ctx context.Context, id ids.UUID, row migration.Row,
+) (predictedOutcome, string, error) {
 	current, err := w.read(ctx, id)
 	if err != nil {
-		return predictCreate, err
+		return predictCreate, "", err
 	}
 	changed, err := changedFields(current, textFields(row.Fields))
 	if err != nil {
-		return predictCreate, err
+		return predictCreate, "", err
 	}
 	if len(changed) == 0 {
-		return predictUnchanged, nil
+		return predictUnchanged, "", nil
 	}
-	return predictUpdate, nil
+	return predictUpdate, "", nil
 }
 
 // collidesWithExisting asks whether the CRM already holds the company this row
 // names, through the SAME ladder the create path runs (PO-F-2). It reads and
 // writes nothing.
 //
-// discloseOnly separates the two questions this answers. The PREVIEW asks it to
-// tell a person something, so a match they cannot see must not be mentioned.
-// The `on_duplicate: skip` path asks it to DECIDE, and there visibility is
-// irrelevant — see the branch below.
-//
-// Only organizations: a lead's identity is its email, which the store's own
-// unique key already refuses, so there is no silent twin to warn about.
-//
-// A read-only transaction, and NOT DedupeOrganizationForCreate — that one takes
-// a write lock to serialize concurrent creates, which a preview has no business
-// holding. The answer can therefore go stale between the preview and the
-// commit; that is correct, because the commit runs the locking version and its
-// answer is the one that decides.
-func (w *csvWriters) collidesWithExisting(ctx context.Context, row migration.Row, discloseOnly bool) (bool, error) {
-	if w.object != migration.ObjectOrganization {
-		return false, nil
-	}
-	fields := textFields(row.Fields)
-	candidate := people.OrganizationCandidate{
-		DisplayName: strings.TrimSpace(fields[fieldDisplayName]),
-		LegalName:   strings.TrimSpace(fields["legal_name"]),
-	}
-	if candidate.DisplayName == "" && candidate.LegalName == "" {
-		return false, nil
-	}
-	var visible bool
-	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
-		match, err := people.DedupeOrganization(ctx, tx, candidate)
-		if err != nil || match.Decision == people.DecisionNoMatch {
-			return err
-		}
-		// The ladder reads every organization, by design — it is the write
-		// path's collision check, and a create must not mint a twin of a row
-		// the caller happens not to be allowed to see. A DISCLOSURE is the
-		// opposite: telling this caller "that company is already here" about a
-		// row they cannot read turns the preview into an oracle for a
-		// colleague's owner-private capture, which even an admin may not read
-		// (rowscope.go). So a match the caller cannot see discloses nothing.
-		//
-		// The COMMIT is unaffected: it still refuses or files the review pair
-		// on the ladder's own answer, visible or not.
-		if !discloseOnly {
-			// Deciding whether to SKIP the row, not whether to mention it. The
-			// incumbent's visibility is beside the point: creating a twin of a
-			// row this caller cannot see is exactly the duplicate the run asked
-			// to avoid, and skipping it reveals nothing the caller did not
-			// already put in their own file.
-			visible = true
-			return nil
-		}
-		visible, err = auth.VisibleTo(ctx, tx, "organization", match.OrganizationID.UUID)
-		return err
-	}); err != nil {
-		return false, fmt.Errorf("import: checking %q against the companies already held: %w", candidate.DisplayName, err)
-	}
-	return visible, nil
-}
-
 // Ensure lands one row: created the first time, updated when the file has
 // since changed, unchanged when it has not.
 func (w *csvWriters) Ensure(ctx context.Context, object string, row migration.Row) (migration.EnsureResult, error) {
@@ -271,6 +249,16 @@ func (w *csvWriters) Ensure(ctx context.Context, object string, row migration.Ro
 	// answer to the question a human already approved.
 	if reason := unwritableReason(object, textFields(row.Fields)); reason != "" {
 		return migration.EnsureResult{Skipped: true, SkipReason: reason}, nil
+	}
+	// A row that NAMES its record wins over every other way of finding one. The
+	// file said which company this is; nothing the importer could infer beats
+	// that, and inferring anyway is what made name-based updating unsafe.
+	target := w.targetIDOf(ctx, row)
+	if target.named {
+		if target.reason != "" {
+			return migration.EnsureResult{Skipped: true, SkipReason: target.reason}, nil
+		}
+		return w.reconcile(ctx, target.id, row)
 	}
 	id, found, err := w.lookup(ctx, object, row.ExternalID)
 	if err != nil {
@@ -283,7 +271,22 @@ func (w *csvWriters) Ensure(ctx context.Context, object string, row migration.Ro
 	// record anyway, and the run says what to do about that. The check runs on
 	// the commit as well as the dry run so the two cannot disagree.
 	if w.onDuplicate == string(crmcontracts.Skip) {
-		collides, err := w.collidesWithExisting(ctx, row, false)
+		// discloseOnly, so a collision this caller may not see is answered as no
+		// collision — and the row CREATES.
+		//
+		// Skipping it instead is the intuitive choice and it leaks. An opaque
+		// reason hides WHICH company was hit; the outcome still says one was.
+		// "Your row was not created" is an answer to "is this company in your
+		// CRM", and a finished run's report is readable on the import_run grant,
+		// so a caller could probe a colleague's owner-private estate one CSV row
+		// at a time. Wording cannot fix that — only the outcome can.
+		//
+		// What creating costs is a twin of a record the caller cannot see, which
+		// the dedupe review queue picks up like any other and a merge resolves.
+		// What skipping costs is a disclosure that no merge undoes. It also keeps
+		// the preview and the commit answering alike, since the preview is
+		// disclosure-filtered for the same reason.
+		collides, err := w.collidesWithExisting(ctx, row)
 		if err != nil {
 			return migration.EnsureResult{}, err
 		}

--- a/backend/internal/compose/integration/csvimportbyid_integration_test.go
+++ b/backend/internal/compose/integration/csvimportbyid_integration_test.go
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A row that NAMES the company it is, by the id the CRM gave it.
+//
+// The correction workflow: export the companies with their ids, edit the file,
+// import it back. This is the path a spreadsheet of corrections takes, and it
+// replaces an attempt to reach the same place by matching NAMES — which cannot
+// be made safe for overwriting.
+//
+// The dedupe ladder blurs on purpose, because its question is "should a human
+// look at these two?": it strips legal forms, so `Acme Inc` and `Acme GmbH` are
+// one string; it scores a trading name against a registered one; and where
+// several records tie it picks the lowest uuid. Every blur is free for proposing
+// a review and is a way to destroy the wrong company when it decides a write.
+// The cases below are the ones that broke the name-matching attempt, kept here
+// because an id must be immune to every one of them.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+)
+
+// createOrgReturningID makes one company and answers its id.
+func createOrgReturningID(t *testing.T, e *apptest.AppEnv, body map[string]any) string {
+	t.Helper()
+	var created struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, http.MethodPost, "/v1/organizations", body, nil, &created); status != http.StatusCreated {
+		t.Fatalf("creating a company → %d, want 201", status)
+	}
+	return created.ID
+}
+
+// orgByName reads one company back, by the name it is listed under.
+func orgByName(t *testing.T, e *apptest.AppEnv, want string) (string, string, string) {
+	t.Helper()
+	var orgs struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+			LegalName   string `json:"legal_name"`
+			Address     struct {
+				City string `json:"city"`
+			} `json:"address"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, http.MethodGet, "/v1/organizations?limit=100", nil, nil, &orgs); status != http.StatusOK {
+		t.Fatalf("reading the companies → %d, want 200", status)
+	}
+	for _, o := range orgs.Data {
+		if o.DisplayName == want {
+			return o.ID, o.Address.City, o.LegalName
+		}
+	}
+	return "", "", ""
+}
+
+func TestCSVImportByIDUpdatesTheNamedCompany(t *testing.T) {
+	e := setupImportApp(t)
+	id := createOrgReturningID(t, e, map[string]any{"display_name": "Kestrel Data"})
+
+	file := "Id,Company,City\n" + id + ",Kestrel Data,Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunWithMapping(t, e, "organization", profile.SourceRef,
+		map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"})
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Updated != 1 || report.Disposition.Created != 0 {
+		t.Fatalf("preview = created %d updated %d, want 0 and 1 — the row named a company, so it "+
+			"updates it", report.Disposition.Created, report.Disposition.Updated)
+	}
+
+	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", status)
+	}
+	gotID, city, _ := orgByName(t, e, "Kestrel Data")
+	if gotID != id {
+		t.Fatalf("the company named Kestrel Data has id %q, want the one the file named (%q)", gotID, id)
+	}
+	if city != "Bremen" {
+		t.Errorf("city = %q, want Bremen — the file's values land on the record it named", city)
+	}
+}
+
+// The three cases that destroyed data under name matching, each harmless here.
+func TestCSVImportByIDIsImmuneToEveryAmbiguityThatBrokeNameMatching(t *testing.T) {
+	t.Run("two companies sharing a name", func(t *testing.T) {
+		e := setupImportApp(t)
+		wanted := createOrgReturningID(t, e, map[string]any{"display_name": "Kestrel Data"})
+		other := createOrgReturningID(t, e, map[string]any{"display_name": "Kestrel Data"})
+
+		file := "Id,Company,City\n" + wanted + ",Kestrel Data,Bremen\n"
+		profile, _ := uploadCSV(t, e, "organization", file)
+		run, _ := createRunWithMapping(t, e, "organization", profile.SourceRef,
+			map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"})
+		if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+			t.Fatalf("approve → %d, want 202", status)
+		}
+
+		// The named one moved; the other did not. Under name matching the ladder
+		// picked between these two on uuid order.
+		if city := cityOf(t, e, wanted); city != "Bremen" {
+			t.Errorf("the company the file NAMED has city %q, want Bremen", city)
+		}
+		if city := cityOf(t, e, other); city != "" {
+			t.Errorf("the company the file did not name has city %q, want none — an id names one "+
+				"record, and the other was never a candidate", city)
+		}
+	})
+
+	t.Run("different legal forms", func(t *testing.T) {
+		e := setupImportApp(t)
+		gmbh := createOrgReturningID(t, e, map[string]any{"display_name": "Falkenberg Maschinenbau GmbH"})
+		ag := createOrgReturningID(t, e, map[string]any{"display_name": "Falkenberg Maschinenbau AG"})
+
+		file := "Id,Company,City\n" + ag + ",Falkenberg Maschinenbau AG,Stuttgart\n"
+		profile, _ := uploadCSV(t, e, "organization", file)
+		run, _ := createRunWithMapping(t, e, "organization", profile.SourceRef,
+			map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"})
+		if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+			t.Fatalf("approve → %d, want 202", status)
+		}
+		if city := cityOf(t, e, ag); city != "Stuttgart" {
+			t.Errorf("the AG has city %q, want Stuttgart", city)
+		}
+		if city := cityOf(t, e, gmbh); city != "" {
+			t.Errorf("the GmbH has city %q, want none — the suffix strip that made these one string "+
+				"for the ladder never runs on an id", city)
+		}
+	})
+
+	t.Run("a trading name that is somebody else's registered name", func(t *testing.T) {
+		e := setupImportApp(t)
+		trading := createOrgReturningID(t, e, map[string]any{"display_name": "Kestrel Data"})
+		registered := createOrgReturningID(t, e, map[string]any{
+			"display_name": "Nordwind Holding", "legal_name": "Kestrel Data",
+		})
+
+		file := "Id,Company,City\n" + trading + ",Kestrel Data,Bremen\n"
+		profile, _ := uploadCSV(t, e, "organization", file)
+		run, _ := createRunWithMapping(t, e, "organization", profile.SourceRef,
+			map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"})
+		if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+			t.Fatalf("approve → %d, want 202", status)
+		}
+		if city := cityOf(t, e, trading); city != "Bremen" {
+			t.Errorf("the company the file named has city %q, want Bremen", city)
+		}
+		if city := cityOf(t, e, registered); city != "" {
+			t.Errorf("the company holding that string as its REGISTERED name has city %q, want none",
+				city)
+		}
+		if _, _, legal := orgByName(t, e, "Nordwind Holding"); legal != "Kestrel Data" {
+			t.Errorf("its registered name is now %q; nothing should have touched it", legal)
+		}
+	})
+}
+
+// cityOf reads one company's city by id, "" when it has none.
+func cityOf(t *testing.T, e *apptest.AppEnv, id string) string {
+	t.Helper()
+	var org struct {
+		Address struct {
+			City string `json:"city"`
+		} `json:"address"`
+	}
+	if status := e.Call(t, http.MethodGet, "/v1/organizations/"+id, nil, nil, &org); status != http.StatusOK {
+		t.Fatalf("reading company %s → %d, want 200", id, status)
+	}
+	return org.Address.City
+}
+
+// A row naming an id nothing answers to is REFUSED, not quietly created.
+//
+// Silently creating would be the worst of both: the person meant to correct one
+// company, the file had a typo or a stale export, and they get a new record
+// instead — reported as a create they would have to read carefully to notice.
+func TestCSVImportByIDRefusesAnIDNothingAnswersTo(t *testing.T) {
+	for _, tc := range []struct {
+		name, id, wants string
+	}{
+		{"not an id at all", "ACME-001", "not a company id"},
+		{"well-formed but unknown", "01a02ed1-0000-7000-8000-000000000000", "no company you can see"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := setupImportApp(t)
+			before := len(organizations(t, e).Data)
+
+			file := "Id,Company,City\n" + tc.id + ",Kestrel Data,Bremen\n"
+			profile, _ := uploadCSV(t, e, "organization", file)
+			run, status := createRunWithMapping(t, e, "organization", profile.SourceRef,
+				map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"})
+			if status != http.StatusAccepted {
+				t.Fatalf("create run → %d, want 202", status)
+			}
+
+			var report importReportDTO
+			if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+				t.Fatalf("report → %d, want 200", status)
+			}
+			if report.Disposition.Skipped != 1 || report.Disposition.Created != 0 {
+				t.Fatalf("preview = created %d skipped %d, want 0 and 1 — a row naming a company that "+
+					"is not there is a mistake in the file, not a new company",
+					report.Disposition.Created, report.Disposition.Skipped)
+			}
+			if len(report.Issues) != 1 || !strings.Contains(report.Issues[0].Reason, tc.wants) {
+				t.Fatalf("issues = %+v, want one naming %q so the person can go fix the file",
+					report.Issues, tc.wants)
+			}
+			if got := report.Disposition.Created + report.Disposition.Updated +
+				report.Disposition.Unchanged + report.Disposition.Skipped; got != report.RowsRead {
+				t.Errorf("the disposition sums to %d for %d rows read", got, report.RowsRead)
+			}
+
+			if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+				t.Fatalf("approve → %d, want 202", status)
+			}
+			if after := len(organizations(t, e).Data); after != before {
+				t.Errorf("companies went from %d to %d; a refused row must land nothing", before, after)
+			}
+		})
+	}
+}
+
+// A mixed file: corrections that name their company, and new companies that do
+// not. This is what a real export-edit-import cycle produces.
+//
+// The id column says which rows are corrections. The row identity every import
+// needs — for re-import and for undo — comes from the file's own key column, so
+// a row with no id is simply a row naming no record: an ordinary create.
+func TestCSVImportByIDTreatsAnEmptyIDAsANewCompany(t *testing.T) {
+	e := setupImportApp(t)
+	existing := createOrgReturningID(t, e, map[string]any{"display_name": "Kestrel Data"})
+
+	file := "Id,Company,City\n" +
+		existing + ",Kestrel Data,Bremen\n" +
+		",Nordwind Logistik,Kiel\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	// Identified by the company column, which every row carries — so the id
+	// column is free to be empty on the rows that name no record.
+	run, status := createRunWithSourceKey(t, e, "organization", profile.SourceRef,
+		map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"}, "Company")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Updated != 1 || report.Disposition.Created != 1 {
+		t.Fatalf("preview = created %d updated %d, want 1 and 1 — one row names a company and one "+
+			"does not", report.Disposition.Created, report.Disposition.Updated)
+	}
+	if got := report.Disposition.Created + report.Disposition.Updated +
+		report.Disposition.Unchanged + report.Disposition.Skipped; got != report.RowsRead {
+		t.Errorf("the disposition sums to %d for %d rows read", got, report.RowsRead)
+	}
+}
+
+// Re-importing an unchanged file changes nothing and says so.
+func TestCSVImportByIDOfIdenticalValuesIsUnchanged(t *testing.T) {
+	e := setupImportApp(t)
+	id := createOrgReturningID(t, e, map[string]any{
+		"display_name": "Kestrel Data", "address": map[string]any{"city": "Bremen"},
+	})
+
+	file := "Id,Company,City\n" + id + ",Kestrel Data,Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, _ := createRunWithMapping(t, e, "organization", profile.SourceRef,
+		map[string]string{"Id": "id", "Company": "display_name", "City": "address.city"})
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Unchanged != 1 || report.Disposition.Updated != 0 {
+		t.Errorf("preview = updated %d unchanged %d, want 0 and 1 — the file says nothing new",
+			report.Disposition.Updated, report.Disposition.Unchanged)
+	}
+}
+
+// One address column named alongside an id leaves the rest of the address alone.
+func TestCSVImportByIDOfOneAddressColumnKeepsTheRest(t *testing.T) {
+	e := setupImportApp(t)
+	id := createOrgReturningID(t, e, map[string]any{
+		"display_name": "Kestrel Data",
+		"address": map[string]any{
+			"line1": "Hafenstr. 4", "city": "Hamburg", "postal_code": "20359", "country": "DE",
+		},
+	})
+
+	file := "Id,City\n" + id + ",Bremen\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, _ := createRunWithMapping(t, e, "organization", profile.SourceRef,
+		map[string]string{"Id": "id", "City": "address.city"})
+	if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve", nil, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("approve → %d, want 202", status)
+	}
+
+	var org struct {
+		Address struct {
+			Line1      string `json:"line1"`
+			City       string `json:"city"`
+			PostalCode string `json:"postal_code"`
+			Country    string `json:"country"`
+		} `json:"address"`
+	}
+	if status := e.Call(t, http.MethodGet, "/v1/organizations/"+id, nil, nil, &org); status != http.StatusOK {
+		t.Fatalf("reading the company → %d, want 200", status)
+	}
+	if org.Address.City != "Bremen" {
+		t.Errorf("city = %q, want Bremen", org.Address.City)
+	}
+	if org.Address.Line1 != "Hafenstr. 4" || org.Address.PostalCode != "20359" || org.Address.Country != "DE" {
+		t.Errorf("the rest of the address is %+v; a column the file did not carry must not be erased",
+			org.Address)
+	}
+}
+
+// createRunWithSourceKey names the column that identifies a row, where the
+// default (a company's display name) is not what the file uses.
+func createRunWithSourceKey(t *testing.T, e *apptest.AppEnv, object, sourceRef string,
+	mapping map[string]string, sourceKey string,
+) (importRunDTO, int) {
+	t.Helper()
+	var run importRunDTO
+	status := e.Call(t, http.MethodPost, "/v1/imports", map[string]any{
+		"connector": "csv", "object": object, "source_ref": sourceRef,
+		"mapping": mapping, "source_key": sourceKey,
+	}, nil, &run)
+	return run, status
+}
+
+// The four counts sum to rows_read when SEVERAL rows are refused and their
+// external ids are not line numbers.
+//
+// The report collapses a row refused by BOTH the dry run and the commit into a
+// single issue, so a person is not sent to fix the same line twice. It keyed that
+// collapsing on the LINE derived from the external
+// id, and lineOf answers 0 for every id not shaped "line N" — which is every id
+// in a file carrying its own key column. Several refusals then collapsed onto
+// one another: two refused rows reported as one skip and one phantom
+// "unchanged", so the counts summed to less than rows_read.
+//
+// Two rows naming ids nothing answers to is the cheapest way to produce several
+// refusals at once, and an export edited against the wrong workspace produces
+// exactly that.
+func TestCSVImportSkippedRowsAreCountedIndividually(t *testing.T) {
+	e := setupImportApp(t)
+
+	const file = "Company,Id,City\n" +
+		"Aurora Metallbau,01a02ed1-0000-7000-8000-000000000001,Bremen\n" +
+		"Boreas Logistik,01a02ed1-0000-7000-8000-000000000002,Kiel\n"
+	profile, _ := uploadCSV(t, e, "organization", file)
+	run, status := createRunWithSourceKey(t, e, "organization", profile.SourceRef,
+		map[string]string{"Company": "display_name", "Id": "id", "City": "address.city"}, "Company")
+	if status != http.StatusAccepted {
+		t.Fatalf("create run → %d, want 202", status)
+	}
+
+	var report importReportDTO
+	if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("report → %d, want 200", status)
+	}
+	if report.Disposition.Skipped != 2 {
+		t.Errorf("skipped = %d, want 2 — both rows name an id nothing answers to, and each is its "+
+			"own row", report.Disposition.Skipped)
+	}
+	if len(report.Issues) != 2 {
+		t.Errorf("%d issue(s) for 2 refused rows; a person fixing the file needs both named",
+			len(report.Issues))
+	}
+	if got := report.Disposition.Created + report.Disposition.Updated +
+		report.Disposition.Unchanged + report.Disposition.Skipped; got != report.RowsRead {
+		t.Errorf("the disposition sums to %d for %d rows read — a row went missing from the counts, "+
+			"which is exactly the report 'hiding something' its own contract warns about",
+			got, report.RowsRead)
+	}
+}
+
+// The preview promises what the commit performs, for a row that collides.
+//
+// Asserted as behaviour rather than by reading the source. An earlier gate
+// compared the two call sites' argument text, which caught a parameter being
+// added back and would have passed a divergence expressed any other way — a
+// different receiver, a different enclosing condition, a helper in between.
+// Preview and commit are two code paths that must agree about an OUTCOME, and
+// the outcome is the thing to compare.
+//
+// Both duplicate policies, because they disagree differently: `create` lands a
+// second record and discloses it, `skip` leaves the incumbent alone.
+func TestThePreviewPromisesWhatTheCommitPerformsForACollision(t *testing.T) {
+	for _, policy := range []string{"create", "skip"} {
+		t.Run(policy, func(t *testing.T) {
+			e := setupImportApp(t)
+			if status := e.Call(t, http.MethodPost, "/v1/organizations",
+				map[string]any{"display_name": "Kestrel Data"}, nil, nil); status != http.StatusCreated {
+				t.Fatalf("creating the incumbent → %d, want 201", status)
+			}
+
+			const file = "Company,City\nKestrel Data,Bremen\nNordwind Logistik,Kiel\n"
+			profile, _ := uploadCSV(t, e, "organization", file)
+			run, status := createRunOnDuplicate(t, e, "organization", profile.SourceRef,
+				map[string]string{"Company": "display_name", "City": "address.city"}, policy)
+			if status != http.StatusAccepted {
+				t.Fatalf("create run → %d, want 202", status)
+			}
+
+			var predicted importReportDTO
+			if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report",
+				nil, nil, &predicted); status != http.StatusOK {
+				t.Fatalf("report → %d, want 200", status)
+			}
+			before := len(organizations(t, e).Data)
+
+			if status := e.Call(t, http.MethodPost, "/v1/imports/"+run.ID+"/approve",
+				nil, nil, nil); status != http.StatusAccepted {
+				t.Fatalf("approve → %d, want 202", status)
+			}
+
+			// What the preview PROMISED, measured against what the estate did.
+			if landed := len(organizations(t, e).Data) - before; landed != predicted.Disposition.Created {
+				t.Errorf("the preview promised %d create(s) and %d company/companies landed — a row "+
+					"previewing as one outcome and committing as another is what makes an approval "+
+					"a decision about something else", predicted.Disposition.Created, landed)
+			}
+
+			var actual importReportDTO
+			if status := e.Call(t, http.MethodGet, "/v1/imports/"+run.ID+"/report",
+				nil, nil, &actual); status != http.StatusOK {
+				t.Fatalf("report after commit → %d, want 200", status)
+			}
+			if actual.Disposition.Created != predicted.Disposition.Created ||
+				actual.Disposition.Skipped != predicted.Disposition.Skipped {
+				t.Errorf("preview said created %d skipped %d, the finished run says created %d "+
+					"skipped %d", predicted.Disposition.Created, predicted.Disposition.Skipped,
+					actual.Disposition.Created, actual.Disposition.Skipped)
+			}
+			if got := actual.Disposition.Created + actual.Disposition.Updated +
+				actual.Disposition.Unchanged + actual.Disposition.Skipped; got != actual.RowsRead {
+				t.Errorf("the finished disposition sums to %d for %d rows read", got, actual.RowsRead)
+			}
+		})
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14819,7 +14819,28 @@ type CreateImportRunRequest struct {
 	// Connector The source kind. The HubSpot and Salesforce connectors run the same engine and arrive with their own tickets (IEM-AC-8).
 	Connector CreateImportRunRequestConnector `json:"connector"`
 
-	// Mapping `{source column → target field}`, as the human settled it. Validated against the object's live field catalog before the run is created.
+	// Mapping `{source column → target field}`, as the human settled it. Validated against
+	// the object's live field catalog before the run is created.
+	//
+	// One target is not a field: a column mapped to **`id`** names the record the
+	// row IS, by the id this CRM gave it, and the row UPDATES that record. Nothing
+	// is written to `id` itself. This is the correction workflow — read the
+	// companies out with their ids, edit the file, import it back.
+	//
+	// A row whose `id` is empty names no record and is an ordinary create, so one
+	// file can carry corrections and new companies together — as long as some other
+	// mapped column identifies every row (see `source_key`).
+	//
+	// An id is the only safe way to say which record a row means. Matching by NAME
+	// cannot be: the dedupe ladder exists to answer "should a human look at these
+	// two?" and blurs to do it — it strips legal forms, so `Acme Inc` and
+	// `Acme GmbH` are one string; it scores a trading name against a registered
+	// one; and where several records tie it picks the lowest uuid. Every blur is
+	// free when the answer is "show a human" and is a way to overwrite the wrong
+	// company when the answer decides a write, which no `undo` reverses.
+	//
+	// A row naming an id nothing answers to is reported as a skipped row saying so,
+	// never created quietly under a new id.
 	Mapping map[string]string `json:"mapping"`
 
 	// Object What the file's rows are. `lead` — not `person` — is what a bulk
@@ -14834,6 +14855,20 @@ type CreateImportRunRequest struct {
 	// by the same dedupe ladder every create path runs, not by this
 	// importer's own memory of what it once wrote.
 	//
+	// A collision with a record the CALLER MAY NOT SEE is answered as no
+	// collision: the row is not counted as a duplicate, not named in the
+	// report, and CREATES. The question is asked of EVERY candidate the dedupe
+	// ladder matched rather than of its winner — the winner is the highest
+	// score with the lowest uuid breaking ties, so an invisible record ranking
+	// first would otherwise mask a visible one behind it and decide the outcome
+	// without being disclosed. Skipping it would be the intuitive choice and it
+	// leaks — hiding which company was hit still says one was, and "your row
+	// was not created" answers "is this company in your CRM" about a
+	// colleague's owner-private capture, probed one row at a time against a
+	// report readable on the `import_run` grant. The cost is a twin the dedupe
+	// review queue picks up and a merge resolves; the cost of the alternative
+	// is a disclosure no merge undoes.
+	//
 	// `create` is the historical behaviour and stays the default: the row
 	// lands and the pair goes on the dedupe review queue, exactly as a manual
 	// create does. That is right for one company typed by a human and wrong
@@ -14846,11 +14881,21 @@ type CreateImportRunRequest struct {
 	// the count is separate from `created`.
 	OnDuplicate *ImportOnDuplicate `json:"on_duplicate,omitempty"`
 
-	// SourceKey The source column holding the row's stable id, written to the row's
-	// provenance so a re-uploaded file updates rather than duplicates
-	// (IEM-AC-9) and an undo can find what one run created (S-E15.4c).
-	// Absent means the mapped natural key is used instead; the report
-	// says which was chosen rather than leaving it to be inferred.
+	// SourceKey The source column holding the row's stable id. For a row this run
+	// CREATES it is written to the row's provenance, so a re-uploaded file
+	// updates rather than duplicates (IEM-AC-9) and an undo can find what
+	// the run created (S-E15.4c). A row that names an existing record by
+	// `id` records nothing: the run did not create that company, and undo
+	// must not archive it.
+	//
+	// Absent means the mapped natural key is used instead; the report says
+	// which was chosen rather than leaving it to be inferred. A file whose
+	// only identifying column is `id` falls back to it — a corrections
+	// export can be `id,city` and nothing else — and then EVERY row needs
+	// an id, because a row with no source key cannot be identified at all
+	// and is reported as an unusable line. A file mixing corrections with
+	// new companies therefore maps a column every row carries, and the
+	// `id` column says which rows are corrections.
 	SourceKey *string `json:"source_key,omitempty"`
 
 	// SourceRef From `uploadImportSource`.
@@ -16521,6 +16566,20 @@ type ImportObject string
 // ImportOnDuplicate What to do with a row naming a record the estate ALREADY holds — found
 // by the same dedupe ladder every create path runs, not by this
 // importer's own memory of what it once wrote.
+//
+// A collision with a record the CALLER MAY NOT SEE is answered as no
+// collision: the row is not counted as a duplicate, not named in the
+// report, and CREATES. The question is asked of EVERY candidate the dedupe
+// ladder matched rather than of its winner — the winner is the highest
+// score with the lowest uuid breaking ties, so an invisible record ranking
+// first would otherwise mask a visible one behind it and decide the outcome
+// without being disclosed. Skipping it would be the intuitive choice and it
+// leaks — hiding which company was hit still says one was, and "your row
+// was not created" answers "is this company in your CRM" about a
+// colleague's owner-private capture, probed one row at a time against a
+// report readable on the `import_run` grant. The cost is a twin the dedupe
+// review queue picks up and a merge resolves; the cost of the alternative
+// is a disclosure no merge undoes.
 //
 // `create` is the historical behaviour and stays the default: the row
 // lands and the pair goes on the dedupe review queue, exactly as a manual

--- a/backend/internal/modules/agents/toolcopy_import.go
+++ b/backend/internal/modules/agents/toolcopy_import.go
@@ -13,7 +13,8 @@ var previewImportCopy = toolCopy{
 		"against the workspace and reports what importing it would do.",
 	Limits: "Writes nothing. People arrive as leads, so `object` is lead or organization. " +
 		"A row naming a company already here is counted in `duplicates`, and created unless " +
-		"on_duplicate is skip.",
+		"on_duplicate is skip. To CORRECT companies rather than add them, map a column to " +
+		"`id` and give each row the id of the company it is — read them out first.",
 	Instead: "create_record for one record you already know.",
 	Retain:  "run_id, and `duplicates` — give the user both numbers before committing.",
 }

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -114,7 +114,7 @@ func (t previewImport) Spec() mcp.ToolSpec {
 			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `"]},
 			"csv":{"type":"string","description":"The file's contents, header row first."},
 			"mapping":{"type":"object","additionalProperties":{"type":"string"},
-			  "description":"Source column name → field name. Omit to accept the proposal this call would make."},
+			  "description":"Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company each row IS — that row updates it instead of creating one."},
 			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
 			  "description":"A company already here: create (default) lands a second; skip leaves the incumbent."}},
 			"additionalProperties":false}`),

--- a/backend/internal/modules/migration/csvsource.go
+++ b/backend/internal/modules/migration/csvsource.go
@@ -115,11 +115,33 @@ func (s *CSVSource) Rows(ctx context.Context, object string, offset, limit int) 
 	}
 	out := make([]Row, 0, limit)
 	delivered := 0
+	// Rebuilt per call, and every call re-walks the file from the top, so this
+	// sees the whole file whatever page is being served. It is not run state and
+	// must not become any: a resumed run walks the same rows again on purpose.
+	claimed := map[string]int{}
 	err := s.walk(ctx, func(line int, record []string, index map[string]int) error {
 		row, ok := s.rowFrom(line, record, index)
 		if !ok {
 			return nil
 		}
+		// A source key is a row's IDENTITY — what re-import matches on and what
+		// undo finds a created row by. Two rows claiming one identity is a
+		// question the file has to answer, not one the importer can: which of
+		// them is the record, and what should a re-import of the other do?
+		//
+		// Accepting them looked harmless and was not. The identity map holds one
+		// binding per key, so the second row silently reconciled onto the first
+		// row's record; the report deduplicated by the same key, so two refusals
+		// arrived as one skip and a phantom `unchanged`, and the four counts
+		// stopped summing to rows_read.
+		if first, seen := claimed[row.ExternalID]; seen {
+			s.skip(line, fmt.Sprintf(
+				"the %q value %q is already used by line %d; each row needs its own, because it is "+
+					"what a re-import matches on and what an undo finds this row by",
+				s.sourceKey, row.ExternalID, first))
+			return nil
+		}
+		claimed[row.ExternalID] = line
 		position := delivered
 		delivered++
 		if position < offset {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ maps the codebase and links everything below.
 - [enrich-with-a-local-llm.md](how-to/enrich-with-a-local-llm.md) — point the AI lanes at a local Ollama and enrich a company with no cloud key.
 - [connect-telegram.md](how-to/connect-telegram.md) — bind a workspace-level Telegram bot for pull ingress and governed replies.
 - [import-your-linkedin-network.md](how-to/import-your-linkedin-network.md) — import your own `Connections.csv` as graph substrate, and read the reach it buys.
+- [import-a-company-spreadsheet.md](how-to/import-a-company-spreadsheet.md) — bring a CSV of companies in: the column mapping, what the preview counts, and how a row names the company it corrects.
 - [connect-a-hubspot-overlay.md](how-to/connect-a-hubspot-overlay.md) — connect a workspace to a HubSpot portal in overlay (read + continuous sync) mode.
 - [flip-an-overlay-to-native.md](how-to/flip-an-overlay-to-native.md) — the one-way overlay→native cutover: preflight, seal, the typed confirmation, and what recovery actually means.
 - [connect-a-cloud-model-provider.md](how-to/connect-a-cloud-model-provider.md) — bind the AI lanes to a BYOK cloud key (Anthropic / OpenAI / Gemini / any OpenAI-compatible vendor).

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -18,6 +18,15 @@ Both call every action through `agents.Registry.Invoke`, which admits each call 
 (**scope ∧ seat ∧ tier**) before any handler runs. A 🟢 call executes and is audited; a 🟡 call stages a
 confirm-first approval. "Two surfaces, one gate" is a property of the construction, not a convention.
 
+Most consequential verbs are 🟢 (ADR-0055). A passport carries the granting human's own seat, grants and
+row scope, so a send or an archive it can spend is one that person could spend unaided in the app, and
+asking them to confirm it again made the agent surface weaker than the person behind it rather than
+safer. What still bounds a call is what bounds the human: RBAC, row scope, the seat ceiling, expiry, and
+the scope its holder chose to lend. 🟡 is kept for calls whose destination the credential-holder did not
+choose — `enrich` is the standing case, because the model names the URL the server fetches. An
+installation that wants a particular verb confirmed **floors** it back per record type, and every verb
+still carries the staging machinery that makes the floor land in a human's inbox.
+
 ## The reason-act-observe loop (Surface B)
 
 The runner (`internal/modules/agents/runner/`) is where **the model proposes and the governed tool

--- a/docs/how-to/connect-an-mcp-client.md
+++ b/docs/how-to/connect-an-mcp-client.md
@@ -100,6 +100,23 @@ The same token is a REST Bearer credential, governed identically (ADR-0055):
 the granting human's live seat and RBAC. See
 [mint-a-passport.md](mint-a-passport.md) to issue one directly.
 
+**What a passport can do without asking you.** Most consequential verbs run
+directly — importing a file, sending mail, booking, merging, archiving. The
+reasoning is that a passport acts as *you*: it carries your seat, your grants and
+your row scope, so it can only reach what you could already reach in the app, and
+a second confirmation from the same person adds ceremony rather than safety. The
+limits that still apply are your limits — RBAC, row scope, the seat ceiling, the
+passport's expiry, and the scopes you chose to lend when you minted it.
+
+Two things do not follow that rule:
+
+- **`enrich`** stays confirm-first. The model names the URL the server fetches,
+  so persuading the model reaches an address nobody with the credential picked.
+  That is a question about egress, not about authority.
+- **Anything an installation floors.** A workspace can require confirmation for a
+  particular verb and record type by declaring it in the contract, and the verb
+  then stages for a human exactly as it always did.
+
 ## Inspect the surface
 
 The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) speaks

--- a/docs/how-to/import-a-company-spreadsheet.md
+++ b/docs/how-to/import-a-company-spreadsheet.md
@@ -1,0 +1,216 @@
+# Import a spreadsheet of companies
+
+Bring a CSV of companies into the CRM — through an assistant over MCP, or over
+REST. Two things happen here: **adding** companies you do not have, and
+**correcting** ones you do.
+
+Every import previews before it writes. The preview counts what the commit will
+do, row by row, and nothing lands until you approve the run.
+
+> **Undo covers what a run CREATED, and only that.** A signed-in human can
+> reverse a completed CSV run: it archives the rows that run created and that
+> nobody has touched since, leaving edited ones alone and naming them. What it
+> cannot do is restore a company that existed *before* the run — a correction
+> overwrites the old values and no call puts them back.
+
+## The shape of a run
+
+Three steps, whichever door you come through:
+
+1. **Preview** — hand over the file and a column mapping. Writes nothing, and
+   answers a `run_id` plus a report.
+2. **Read the report** — the counts, and the issues naming any row that will not
+   land.
+3. **Commit** — approve the run by its id. *This* is the call that writes.
+
+Over MCP that is three tool calls: `preview_import` (the CSV goes inline, as
+text), `read_import_report` and `commit_import`.
+
+Over REST the file is uploaded first, so it is four: `POST /v1/imports/sources`
+with the file as multipart, then `POST /v1/imports` naming the `source_ref` it
+answers, `GET /v1/imports/{id}/report`, and `POST /v1/imports/{id}/approve`.
+
+**The upload and the undo are human-only.** Both take a signed-in session and
+refuse an agent principal, so an assistant previews and commits but cannot upload
+a file on your behalf or reverse a run afterwards.
+
+## Adding companies
+
+Name each source column and the field it feeds. The importer does not guess:
+
+```json
+{
+  "object": "organization",
+  "csv": "name,city,country,size\nHelios Logistik GmbH,Hamburg,DE,51-200\n",
+  "mapping": {
+    "name": "display_name",
+    "city": "address.city",
+    "country": "address.country",
+    "size": "size_band"
+  }
+}
+```
+
+A company can receive `display_name`, `legal_name`, `industry`, `size_band`,
+`description`, and the six address fields: `address.line1`, `address.line2`,
+`address.city`, `address.region`, `address.postal_code`, `address.country`.
+Map a name it does not take and the run is refused with the list of what it
+does — before anything is written.
+
+**A file of people becomes leads, not contacts.** Set `object` to `lead` for
+those. That is a deliberate rule, not an omission: an unqualified list must not
+land in the clean core.
+
+### What happens to a company you already have
+
+`on_duplicate` decides. It takes `create` (the default — lands a second record
+and files the pair for review) or `skip` (leaves the existing one alone).
+
+For a spreadsheet, `create` is usually the wrong choice: a hundred rows of
+companies you already have becomes a hundred twins, each needing a merge. The
+preview tells you how many before you commit — see `duplicates` below.
+
+**Neither of these corrects anything.** For that, the file has to say *which*
+company each row is.
+
+## Correcting companies
+
+Give each row the id of the company it is, and map that column to **`id`**:
+
+```
+id,display_name,city
+01a02ed1-0866-7567-b567-2abcf76e5c1e,Kestrel Data,Bremen
+```
+
+A row carrying an `id` **updates that company**. No matching, no guessing — it
+names one record. Read the companies out first to get their ids, edit the file,
+import it back.
+
+Three rules worth knowing:
+
+- **An empty `id` is an ordinary create.** One file can carry corrections and new
+  companies together — as long as some other column identifies every row. A file
+  whose *only* identifying column is `id` needs one on every row, since a row
+  with no identity cannot be re-imported or undone; see `source_key` below.
+- **An id nothing answers to is refused**, and the row is reported as a skip
+  saying so. It is never created quietly under a new id — a stale export or a
+  typo should send you back to the file, not leave a surprise record behind.
+- **Nothing is written to `id` itself.** It names the record; it is not a value
+  the record holds.
+
+### Which column identifies a row
+
+Every row needs one column that identifies it *within your file*. It is what makes
+a re-import update rather than duplicate, and what lets an undo find what a run
+created. The importer uses the company name by default, and `source_key` names a
+different column when your file has a better one.
+
+Two shapes work:
+
+- **A corrections-only file.** `id,city` is complete: the id identifies the row
+  and names the record, and every row must carry one.
+- **A mixed file.** Map a column every row carries — the company name will do —
+  and let the `id` column be empty on the rows that are new.
+
+A row with no identifying value at all is reported as an unusable line rather than
+imported, so nothing lands that could not later be found again.
+
+### Why not just match on the name?
+
+Because a name does not identify a company, and the CRM is explicit about it. The
+matcher that finds *likely* duplicates is built to answer "should a human look at
+these two?", and it blurs on purpose to do that:
+
+- It strips the legal form, so `Acme Inc` and `Acme GmbH` are the same string —
+  and the CRM routes those to a person precisely because they are different
+  companies.
+- It scores a trading name against a registered one, so your row's `Kestrel Data`
+  matches a company registered under that name but trading as something else.
+- Two companies may legitimately share a name. Nothing stops it, and where
+  several match the matcher picks one arbitrarily.
+
+Every one of those is free when the answer is "show a human two records". Each
+one is a way to overwrite the wrong company when the answer decides a write — and
+that overwrite is not reversible. An id has none of them.
+
+## Reading the report before you commit
+
+```json
+{
+  "rows_read": 100,
+  "disposition": {
+    "created": 6,
+    "updated": 88,
+    "unchanged": 6,
+    "skipped": 0,
+    "duplicates": 94
+  },
+  "issues": []
+}
+```
+
+- **`created`, `updated`, `unchanged` and `skipped` sum to `rows_read`.** Every
+  row has exactly one outcome. If they do not add up, the report is hiding
+  something.
+- **`duplicates` sits outside that sum.** It is not a fifth outcome — it counts
+  rows already counted elsewhere. It is the number you actually weigh: *"100
+  companies, 94 of them already here"* is a different decision from *"100 new
+  companies"*, and the two are indistinguishable from `created` alone.
+- **`unchanged` means matched and nothing differs.** Separate from `updated` so
+  that re-running a file you already applied reports no work rather than a
+  hundred writes and an audit trail to match.
+- **A company you are not permitted to see is not counted, not named, and does
+  not change the outcome.** Your row is created, exactly as it would be if no such
+  company existed — and a company you *can* see is still reported, even when a
+  hidden one matched more closely. Skipping on the hidden one would tell you it
+  exists: "your row was not created" is an answer to "is this company in your
+  CRM", and that is not a fact about somebody else's private record you get to
+  learn. The cost is a duplicate the review queue picks up; the cost of the
+  alternative is a disclosure no merge undoes.
+
+**`issues` names any row that will not land**, in terms of the file rather than
+the database — an unusable `size_band`, an id nothing answers to. Fix those in
+the source and preview again.
+
+## Committing
+
+Approve the run by its id. The commit is checkpointed and idempotent on the
+source key, so a re-run of the same file converges rather than duplicating, and a
+run interrupted midway resumes from where it stopped rather than starting over.
+
+A correction is not recorded as something the run created, which is what keeps
+`undo` honest: it archives the companies a run added, never one that was already
+there and got edited.
+
+The report keeps its shape afterwards: the same fields report what the run *did*.
+
+## Asking an assistant to do it
+
+Over MCP this is one instruction:
+
+> Import this CSV as organizations. Tell me how many are new and how many are
+> already here before you commit anything.
+
+Or, for a corrections file:
+
+> Read out our companies with their ids, then import this CSV — each row carries
+> the id of the company it updates.
+
+The assistant runs on your passport, so it can do what you could do unaided in
+the app, and the import commits without a separate approval step. What still
+binds it is what binds you: your seat, your grants, your row scope, and the
+scopes you lent when you minted the passport. See
+[connect-an-mcp-client.md](connect-an-mcp-client.md).
+
+Two caveats. An installation can require confirmation for `commit_import`, in
+which case the commit stages for a human like any confirm-first call. And the
+assistant cannot upload a file for you or undo a run — both need your own
+signed-in session — so over MCP the CSV goes across as text in the request.
+
+## Related
+
+- [import-your-linkedin-network.md](import-your-linkedin-network.md) — a
+  different importer for a different file, landing relationship edges rather
+  than companies.
+- [connect-an-mcp-client.md](connect-an-mcp-client.md) — connecting an assistant.
+- [mint-a-passport.md](mint-a-passport.md) — issuing the credential it uses.

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 56,
-    "tokens": 17004,
+    "tokens": 17063,
     "median_tool_tokens": 281,
-    "mean_tool_tokens": 303
+    "mean_tool_tokens": 304
   },
   "agents": [
     {
@@ -121,6 +121,10 @@
       "tokens": 386
     },
     {
+      "name": "preview_import",
+      "tokens": 353
+    },
+    {
       "name": "search_context",
       "tokens": 352
     },
@@ -163,10 +167,6 @@
     {
       "name": "promote_lead",
       "tokens": 301
-    },
-    {
-      "name": "preview_import",
-      "tokens": 294
     },
     {
       "name": "archive_record",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2190 | 9% | 14810 | 14 | 8 |
-| _whole served catalog, for scale_ | 56 | 17004 | 70% | — | — | — |
+| _whole served catalog, for scale_ | 56 | 17063 | 71% | — | — | — |
 
 ### `morning_brief`
 
@@ -118,7 +118,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 281 tokens, mean 303, across 56 served tools.
+Median 281 tokens, mean 304, across 56 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -141,6 +141,7 @@ a term in an addition.
 | `search_records` | 392 | 6 scenarios |
 | `create_record` | 391 | 1 scenario |
 | `enrich` | 386 | — |
+| `preview_import` | 353 | — |
 | `search_context` | 352 | — |
 | `prep_for_meeting` | 333 | — |
 | `merge_records` | 323 | — |
@@ -152,7 +153,6 @@ a term in an addition.
 | `draft_follow_ups_for` | 304 | — |
 | `decide_approval` | 303 | — |
 | `promote_lead` | 301 | — |
-| `preview_import` | 294 | — |
 | `archive_record` | 292 | — |
 | `catch_me_up_on` | 287 | 3 scenarios |
 | `prepare_handoff` | 275 | 1 scenario |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 155677,
+    "tool_catalog_bytes": 155916,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39696,
+    "approx_wire_tokens_total": 39756,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 35520,
-      "input_schema_bytes": 34366,
+      "description_bytes": 35655,
+      "input_schema_bytes": 34470,
       "output_schema_bytes": 73753,
-      "description_plus_input_schema_bytes": 69886
+      "description_plus_input_schema_bytes": 70125
     }
   },
   "tools": {
@@ -5108,7 +5108,7 @@
           "readOnlyHint": false,
           "title": "Preview an import"
         },
-        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. To CORRECT companies rather than add them, map a column to `id` and give each row the id of the company it is — read them out first. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5125,7 +5125,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Source column name → field name. Omit to accept the proposal this call would make.",
+              "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company each row IS — that row updates it instead of creating one.",
               "type": "object"
             },
             "object": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 56 |
 | Resources | 8 |
-| Tool catalog | 152.0 KB |
+| Tool catalog | 152.3 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39696 |
+| Approx. wire tokens | 39756 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,10 +30,10 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
 | Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 34.7 KB | 22% | Yes, every step |
-| Input schemas | 33.6 KB | 22% | Yes, every step |
+| Descriptions (incl. governance clause) | 34.8 KB | 22% | Yes, every step |
+| Input schemas | 33.7 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
-| **Description + input schema** | **68.2 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **68.5 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -89,7 +89,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
-| [`preview_import`](#preview_import) | Preview an import |  |  | 2.5 KB |
+| [`preview_import`](#preview_import) | Preview an import |  |  | 2.8 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
@@ -5636,7 +5636,7 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
 
 **Preview an import**
 
-Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
+Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. To CORRECT companies rather than add them, map a column to `id` and give each row the id of the company it is — read them out first. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -5657,7 +5657,7 @@ Bring a spreadsheet in: send the CSV as text and this checks every row against t
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Source column name → field name. Omit to accept the proposal this call would make.",
+      "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company each row IS — that row updates it instead of creating one.",
       "type": "object"
     },
     "object": {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11242,16 +11242,49 @@ export interface components {
             object: components["schemas"]["ImportObject"];
             /** @description From `uploadImportSource`. */
             source_ref: string;
-            /** @description `{source column → target field}`, as the human settled it. Validated against the object's live field catalog before the run is created. */
+            /**
+             * @description `{source column → target field}`, as the human settled it. Validated against
+             *     the object's live field catalog before the run is created.
+             *
+             *     One target is not a field: a column mapped to **`id`** names the record the
+             *     row IS, by the id this CRM gave it, and the row UPDATES that record. Nothing
+             *     is written to `id` itself. This is the correction workflow — read the
+             *     companies out with their ids, edit the file, import it back.
+             *
+             *     A row whose `id` is empty names no record and is an ordinary create, so one
+             *     file can carry corrections and new companies together — as long as some other
+             *     mapped column identifies every row (see `source_key`).
+             *
+             *     An id is the only safe way to say which record a row means. Matching by NAME
+             *     cannot be: the dedupe ladder exists to answer "should a human look at these
+             *     two?" and blurs to do it — it strips legal forms, so `Acme Inc` and
+             *     `Acme GmbH` are one string; it scores a trading name against a registered
+             *     one; and where several records tie it picks the lowest uuid. Every blur is
+             *     free when the answer is "show a human" and is a way to overwrite the wrong
+             *     company when the answer decides a write, which no `undo` reverses.
+             *
+             *     A row naming an id nothing answers to is reported as a skipped row saying so,
+             *     never created quietly under a new id.
+             */
             mapping: {
                 [key: string]: string;
             };
             /**
-             * @description The source column holding the row's stable id, written to the row's
-             *     provenance so a re-uploaded file updates rather than duplicates
-             *     (IEM-AC-9) and an undo can find what one run created (S-E15.4c).
-             *     Absent means the mapped natural key is used instead; the report
-             *     says which was chosen rather than leaving it to be inferred.
+             * @description The source column holding the row's stable id. For a row this run
+             *     CREATES it is written to the row's provenance, so a re-uploaded file
+             *     updates rather than duplicates (IEM-AC-9) and an undo can find what
+             *     the run created (S-E15.4c). A row that names an existing record by
+             *     `id` records nothing: the run did not create that company, and undo
+             *     must not archive it.
+             *
+             *     Absent means the mapped natural key is used instead; the report says
+             *     which was chosen rather than leaving it to be inferred. A file whose
+             *     only identifying column is `id` falls back to it — a corrections
+             *     export can be `id,city` and nothing else — and then EVERY row needs
+             *     an id, because a row with no source key cannot be identified at all
+             *     and is reported as an unusable line. A file mixing corrections with
+             *     new companies therefore maps a column every row carries, and the
+             *     `id` column says which rows are corrections.
              */
             source_key?: string;
             on_duplicate?: components["schemas"]["ImportOnDuplicate"];
@@ -11260,6 +11293,20 @@ export interface components {
          * @description What to do with a row naming a record the estate ALREADY holds — found
          *     by the same dedupe ladder every create path runs, not by this
          *     importer's own memory of what it once wrote.
+         *
+         *     A collision with a record the CALLER MAY NOT SEE is answered as no
+         *     collision: the row is not counted as a duplicate, not named in the
+         *     report, and CREATES. The question is asked of EVERY candidate the dedupe
+         *     ladder matched rather than of its winner — the winner is the highest
+         *     score with the lowest uuid breaking ties, so an invisible record ranking
+         *     first would otherwise mask a visible one behind it and decide the outcome
+         *     without being disclosed. Skipping it would be the intuitive choice and it
+         *     leaks — hiding which company was hit still says one was, and "your row
+         *     was not created" answers "is this company in your CRM" about a
+         *     colleague's owner-private capture, probed one row at a time against a
+         *     report readable on the `import_run` grant. The cost is a twin the dedupe
+         *     review queue picks up and a merge resolves; the cost of the alternative
+         *     is a disclosure no merge undoes.
          *
          *     `create` is the historical behaviour and stays the default: the row
          *     lands and the pair goes on the dedupe review queue, exactly as a manual


### PR DESCRIPTION
A CSV row may carry an `id` column naming the company it corrects. A row with an
id updates that company; a row without one is a new company, as before.

## Why an id and not the name

An earlier attempt matched on the company name and was abandoned. The dedupe
ladder answers "should a human look at these two?" and blurs on purpose:
`NormalizeOrgName` strips legal suffixes, so `Acme Inc` and `Acme GmbH` compare
equal; two real companies may share a name and the ladder breaks the tie on the
lowest uuid; `MatchedField` names only the stored side, so a trading name
matching a registered name reads as a legal-to-legal hit.

Every blur is free when the ladder proposes a review and is a way to overwrite
the wrong company when it decides a write. `undo` archives rows a run created —
it never restores values a run overwrote on a pre-existing record, so the
overwrite is permanent.

## What the id buys

- `csvtargetid.go` resolves the column, then refuses in one sentence when it
  cannot be used: not a company id, or no company the caller can see answers to
  it. "Not found" and "not visible" answer the same sentence deliberately —
  separating them would tell a caller that an id they cannot read exists.
- `id` is excluded from `changedFields` and from `csvTargets`, so it selects a
  row and is never itself written.
- `targetIDOf` runs before the identity-map lookup in both `Ensure` and
  `predictRow`, so preview and commit select the same record.

## Defects fixed alongside

- **Timing channel** (`csvcollision.go`): the visibility loop returned on the
  first visible candidate, so the query count depended on how many hidden
  companies outranked it. Every candidate is now asked, no early exit.
- **Duplicate source keys** (`csvsource.go`): two rows claiming one identity
  silently reconciled onto the first row's record, because the identity map
  holds one binding. Refused per `Rows` call.
- **Surplus clamp** (`csvimportwire.go`): could erase a genuine skip on a
  resumed run. Restricted to single-attempt runs, where the direction is known.
- **Parity test**: the previous one compared the two call sites' argument text
  and would pass on a divergence expressed through a different receiver.
  Replaced by `TestThePreviewPromisesWhatTheCommitPerformsForACollision`, which
  compares the preview's promise against what landed, verified by making them
  diverge.
- Docs corrected: `agent-surface.md` and `connect-an-mcp-client.md` claimed
  consequential verbs stage for approval; they do not.

## Gates

`make check-backend`, `check-fe`, `craft-static`, `rls-store-path`,
`no-jurisdiction` all green. Integration lanes for compose/integration (1288
pass), modules/migration, modules/people green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let a CSV row update an existing company by mapping a column to `id`; rows without `id` still create as before. This enables safe corrections without name matching and avoids overwriting the wrong company.

- `id` is a selector, not a field: it never writes. It’s excluded from `csvTargets` and only selects the target record.
- `csvtargetid.go` refuses rows whose `id` is not a company or not visible to the caller; preview and commit share the same selection path.
- When a file carries only `id` plus fields to correct, the source key falls back to `id`; mixed files (creates + corrections) must still include a regular source key.
- Preview parity: `csvimportreport.go` re-walks the file to predict per-row outcomes; created/updated/unchanged/refused sums equal rows_read; duplicates are reported separately.
- Collision visibility: `csvcollision.go` checks all candidates (no early exit) and treats invisible incumbents as no incumbent to prevent disclosure; a twin may be created and later merged.
- API/docs: mapping docs now describe `id` in `backend/api/crm.yaml`; agent tool copy updated; frontend types regenerated; new how-to added.

**Defects fixed**
- Refused duplicate source keys within one file in `migration/csvsource.go`.
- Removed visibility timing channel by querying all candidates in `csvcollision.go`.
- Limited surplus skip clamp to single-attempt runs in `csvimportwire.go`.
- Replaced the preview/commit parity test with a behavior-level check.

<sup>Written for commit 1f49288f990dd6696479d9b272e6436c278c7a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import organization records by ID to update existing records, including partial address updates.
  * Empty IDs create new records; invalid, unknown, or inaccessible IDs are skipped with row-level reasons.
  * Import previews and reports now distinguish created, updated, unchanged, skipped, duplicate, and collision outcomes.
  * Duplicate detection and collision handling provide more consistent results without exposing inaccessible records.

* **Documentation**
  * Added a guide for importing company spreadsheets through supported workflows.
  * Clarified ID mapping, source keys, duplicate handling, previews, commits, permissions, and undo behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->