### PR TITLE
fix(deals): Deal360 below the stages, stakeholders with names, and room notes that say who and what

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20292,6 +20292,14 @@ components:
       required: [person_id, role, engaged]
       properties:
         person_id: { type: string, format: uuid }
+        person_name:
+          type: [string, 'null']
+          description: >-
+            The person's display name. Null when the caller may not read that person —
+            the seat still counts toward coverage, because how many people carry a deal
+            is not a fact this reader is being told they cannot know; only who they are.
+            `our_side` has carried a display name from the start, and a buyer-side seat
+            that carries only an id is the same list rendered half-anonymous.
         role:      { type: string }
         engaged:
           type: boolean

--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -510,6 +510,25 @@ components:
         required_change:
           type: boolean
           description: True when the thread, as opened, blocks confirming the document until resolved.
+        author_name:
+          type: string
+          description: >-
+            Who spoke, by name, as the room recorded them at that moment. Additive and
+            optional: an event minted before this field existed carries none.
+
+            The comment's TEXT stays off the bus for the reason above, and a name is a
+            different thing from the text — it is who acted, which is what any record of
+            an act has to say. A timeline entry reading "the buyer said something" names
+            no buyer and is not worth the row it occupies.
+        document_title:
+          type: string
+          description: >-
+            The document the thread is about, titled as it stood at that moment. Absent for
+            a room-level exchange, and absent on an event minted before this field existed.
+
+            Carried rather than resolved later, for the reason every other field here is:
+            a document can be retitled or removed afterwards, and a timeline entry means
+            what was true when it happened.
       additionalProperties: false
 
     PublicEventDealRoomThreadResolved:

--- a/backend/internal/compose/dealroomtimeline.go
+++ b/backend/internal/compose/dealroomtimeline.go
@@ -119,21 +119,46 @@ func roomNote(env events.Envelope) (roomNoteText, bool, error) {
 	return roomNoteText{}, false, nil
 }
 
-// commentNote says who spoke and whether they started something. The body is
-// deliberately not the comment text: a Deal Room comment is written to the
-// buyer, and copying it onto the deal would duplicate a record that already
-// lives in the room and can be edited there afterwards.
+// commentNote says WHO spoke and WHAT ABOUT.
+//
+// The comment's text stays out, and that part was always right: a Deal Room
+// comment is written to the buyer, it can be edited in the room afterwards,
+// and copying it here would make a second record of it. But the earlier note
+// left out the name and the document too, and what it produced —
+// "The buyer replied in the Deal Room" over "About a document in the room" —
+// names nobody and nothing. A reader could not tell which buyer, which
+// document, or whether it mattered, so the row was pure noise on a timeline
+// that has to stay worth reading.
+//
+// A name and a title are not the comment's content; they are who acted and
+// what they acted on, which is the minimum any record of an act has to carry.
+// Both ride the event (see the payload), so the note keeps saying what was
+// true at the time even after a rename.
 func commentNote(posted dealrooms.CommentPosted) roomNoteText {
-	side := "The seller"
+	who := "The seller"
 	if posted.Side == roomSideBuyer {
-		side = "The buyer"
+		who = "The buyer"
 	}
-	subject := side + " replied in the Deal Room"
+	// The name when the event carries one. An event minted before the payload
+	// grew those fields carries none, and the note falls back to the side —
+	// vaguer than we want, but true, which the alternative of inventing a name
+	// would not be.
+	if posted.AuthorName != nil {
+		who = *posted.AuthorName
+	}
+	verb := "replied in the Deal Room"
 	if posted.OpensThread {
-		subject = side + " started a thread in the Deal Room"
+		verb = "asked a question in the Deal Room"
 	}
+	subject := who + " " + verb
 	body := "About the room as a whole."
-	if posted.DocumentID != nil {
+	switch {
+	case posted.DocumentTitle != nil:
+		body = "About " + *posted.DocumentTitle + "."
+	case posted.DocumentID != nil:
+		// The thread is about a document whose title the event does not carry.
+		// Saying so beats naming the id, which tells a reader nothing they can
+		// act on.
 		body = "About a document in the room."
 	}
 	return roomNoteText{deal: posted.DealID, subject: subject, body: body}

--- a/backend/internal/compose/dealroomtimeline_test.go
+++ b/backend/internal/compose/dealroomtimeline_test.go
@@ -43,17 +43,28 @@ func roomEnvelope[P roomPayload](t *testing.T, eventType string, payload P) even
 	}
 }
 
+// The note has to name the PERSON and the DOCUMENT, not their categories.
+//
+// The earlier version of this test asserted the words "buyer" and "document"
+// appeared somewhere, which "The buyer replied in the Deal Room / About a
+// document in the room" satisfies while telling a reader nothing. Asserting
+// the actual name and the actual title is the difference between a test that
+// describes the feature and one that would have caught its absence.
 func TestABuyerCommentBecomesANoteThatNamesTheBuyerAndTheDocument(t *testing.T) {
 	deal := ids.NewV7()
 	doc := openapi_types.UUID(ids.NewV7())
+	name := "Thorsten Sifferlien"
+	title := "Rahmenvertrag v3"
 	note, carried, err := roomNote(roomEnvelope(t, dealrooms.EventCommentPosted,
 		crmcontracts.PublicEventDealRoomCommentPosted{
-			DealId:      openapi_types.UUID(deal),
-			ThreadId:    openapi_types.UUID(ids.NewV7()),
-			CommentId:   openapi_types.UUID(ids.NewV7()),
-			DocumentId:  &doc,
-			Side:        "buyer",
-			OpensThread: true,
+			DealId:        openapi_types.UUID(deal),
+			ThreadId:      openapi_types.UUID(ids.NewV7()),
+			CommentId:     openapi_types.UUID(ids.NewV7()),
+			DocumentId:    &doc,
+			Side:          "buyer",
+			OpensThread:   true,
+			AuthorName:    &name,
+			DocumentTitle: &title,
 		}))
 	if err != nil {
 		t.Fatalf("routing a buyer comment: %v", err)
@@ -64,14 +75,41 @@ func TestABuyerCommentBecomesANoteThatNamesTheBuyerAndTheDocument(t *testing.T) 
 	if note.deal != deal {
 		t.Errorf("note is filed against %s, want the deal %s the room belongs to", note.deal, deal)
 	}
-	if !strings.Contains(note.subject, "buyer") {
-		t.Errorf("subject %q does not say who spoke", note.subject)
+	if !strings.Contains(note.subject, name) {
+		t.Errorf("subject %q does not NAME who spoke", note.subject)
 	}
-	if !strings.Contains(note.subject, "started") {
+	if !strings.Contains(note.subject, "asked a question") {
 		t.Errorf("subject %q does not say a thread was opened", note.subject)
 	}
-	if !strings.Contains(note.body, "document") {
-		t.Errorf("body %q does not say the comment was about a document", note.body)
+	if !strings.Contains(note.body, title) {
+		t.Errorf("body %q does not NAME the document the comment was about", note.body)
+	}
+}
+
+// An event minted before the payload carried a name still has to produce a
+// true note. It falls back to the side — vaguer, never wrong, and never a
+// placeholder name that would read as a real person.
+func TestACommentWithoutANameFallsBackToTheSide(t *testing.T) {
+	doc := openapi_types.UUID(ids.NewV7())
+	note, carried, err := roomNote(roomEnvelope(t, dealrooms.EventCommentPosted,
+		crmcontracts.PublicEventDealRoomCommentPosted{
+			DealId:      openapi_types.UUID(ids.NewV7()),
+			ThreadId:    openapi_types.UUID(ids.NewV7()),
+			CommentId:   openapi_types.UUID(ids.NewV7()),
+			DocumentId:  &doc,
+			Side:        "buyer",
+			OpensThread: false,
+		}))
+	if err != nil || !carried {
+		t.Fatalf("routing an old-shape comment: carried=%v err=%v", carried, err)
+	}
+	if !strings.Contains(note.subject, "buyer") {
+		t.Errorf("subject %q names neither a person nor a side", note.subject)
+	}
+	for _, bogus := range []string{"Unknown", "<nil>", "null"} {
+		if strings.Contains(note.subject, bogus) || strings.Contains(note.body, bogus) {
+			t.Errorf("note invents %q where the event carried nothing: %q / %q", bogus, note.subject, note.body)
+		}
 	}
 }
 

--- a/backend/internal/compose/integration/persongraph_integration_test.go
+++ b/backend/internal/compose/integration/persongraph_integration_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose/network"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -51,7 +52,7 @@ func readGraph(ctx context.Context, t *testing.T, e *Env, personID ids.UUID) (in
 	t.Helper()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/people/"+personID.String()+"/graph", nil).WithContext(ctx)
-	network.NewReads(e.Pool).GetPersonGraph(rec, req, crmcontracts.Id(personID))
+	network.NewReads(e.Pool, people.NewStore(e.DB())).GetPersonGraph(rec, req, crmcontracts.Id(personID))
 
 	var out crmcontracts.PersonGraph
 	if rec.Code == http.StatusOK {

--- a/backend/internal/compose/network/coveragewithheld_test.go
+++ b/backend/internal/compose/network/coveragewithheld_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -84,15 +85,45 @@ func TestTheDepartureReadRefusesBeforeItReachesAStatement(t *testing.T) {
 // The wire payload carries the omission as an array that is present and empty
 // on the ordinary read. Absent would make a client guess at the difference
 // between "nothing was withheld" and "the server did not say".
+// A seat has to reach the wire NAMED. The deal page rendered these rows as the
+// bare role — "economic_buyer" — because nothing on the payload said who the
+// person was, and a rep could not tell one stakeholder from another.
+//
+// The withheld half is the other assertion: a person the caller may not read
+// still occupies a seat, because how many people carry a deal is not the
+// secret. Its name goes absent rather than empty, so a client renders its own
+// "cannot read this contact" rather than a blank that looks like a data fault.
+func TestASeatCarriesItsPersonsNameUnlessTheCallerMayNotReadThem(t *testing.T) {
+	named, hidden := ids.NewV7(), ids.NewV7()
+	out := wireCoverage(DealCoverage{
+		DealID: ids.NewV7(),
+		Stakeholders: []deals.DealStakeholder{
+			{PersonID: named, Role: "economic_buyer", Engaged: true},
+			{PersonID: hidden, Role: "champion"},
+		},
+	}, nil, map[ids.UUID]string{named: "Thorsten Sifferlien"})
+
+	if len(out.Stakeholders) != 2 {
+		t.Fatalf("the payload carries %d seats, want both — a seat the caller cannot name still counts",
+			len(out.Stakeholders))
+	}
+	if out.Stakeholders[0].PersonName == nil || *out.Stakeholders[0].PersonName != "Thorsten Sifferlien" {
+		t.Errorf("the readable seat reached the wire unnamed: %+v", out.Stakeholders[0])
+	}
+	if out.Stakeholders[1].PersonName != nil {
+		t.Errorf("a seat the caller may not read was named %q", *out.Stakeholders[1].PersonName)
+	}
+}
+
 func TestTheWirePayloadCarriesTheOmissionAndIsNeverNull(t *testing.T) {
 	withheld := wireCoverage(DealCoverage{
 		DealID:          ids.NewV7(),
 		SectionsOmitted: []string{SectionStakeholders, SectionOurSide, SectionRisks},
-	}, nil)
+	}, nil, nil)
 	if len(withheld.SectionsOmitted) != 3 {
 		t.Errorf("the withheld payload names %v, want three sections", withheld.SectionsOmitted)
 	}
-	ordinary := wireCoverage(DealCoverage{DealID: ids.NewV7()}, nil)
+	ordinary := wireCoverage(DealCoverage{DealID: ids.NewV7()}, nil, nil)
 	if ordinary.SectionsOmitted == nil {
 		t.Error("the ordinary payload's sections_omitted is null, want an empty array")
 	}

--- a/backend/internal/compose/network/handlers.go
+++ b/backend/internal/compose/network/handlers.go
@@ -7,7 +7,7 @@ package network
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"time"
 
@@ -16,10 +16,12 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/relstrength"
@@ -31,6 +33,11 @@ import (
 // briefs handlers, and two embedded types called Handlers collide.
 type Reads struct {
 	pool *pgxpool.Pool
+	// people names the stakeholders a coverage payload seats. Injected rather
+	// than re-implemented here: PersonNames carries the person object gate as
+	// well as the row scope, and a second copy of that read is a second place
+	// for one of the two halves to go missing.
+	people *people.Store
 	// now is injected so the decayed scores are testable against a fixed
 	// clock. A score that reads time.Now() inside the handler cannot be
 	// asserted on without sleeping.
@@ -38,8 +45,8 @@ type Reads struct {
 }
 
 // NewReads builds the network surface over the pool.
-func NewReads(pool *pgxpool.Pool) Reads {
-	return Reads{pool: pool, now: func() time.Time { return time.Now().UTC() }}
+func NewReads(pool *pgxpool.Pool, ppl *people.Store) Reads {
+	return Reads{pool: pool, people: ppl, now: func() time.Time { return time.Now().UTC() }}
 }
 
 // GetPersonNetwork implements GET /people/{id}/network.
@@ -123,11 +130,11 @@ func (h Reads) GetDealCoverage(w http.ResponseWriter, r *http.Request, id crmcon
 		if err != nil {
 			return err
 		}
-		people, err := coverageSeatNames(ctx, tx, coverage)
+		seated, err := h.seatNames(ctx, tx, coverage)
 		if err != nil {
 			return err
 		}
-		out = wireCoverage(coverage, names, people)
+		out = wireCoverage(coverage, names, seated)
 		return nil
 	})
 	if err != nil {
@@ -262,50 +269,39 @@ func coverageUsers(c DealCoverage) []ids.UUID {
 	return out
 }
 
-// coverageSeatNames resolves the stakeholders' display names in one read,
-// under the caller's row scope.
+// seatNames names the stakeholders on a coverage payload.
 //
-// Scoped, where UserNames below is not, because the two answer different
-// questions. The colleague roster is readable by any authenticated member; a
-// PERSON is a customer record, and who sits on a deal is exactly the thing row
-// scope decides. A seat whose person the caller may not read is absent from
-// this map and its name goes null on the wire — the seat itself still ships,
-// because how many people carry a deal is not the secret.
-func coverageSeatNames(ctx context.Context, tx pgx.Tx, c DealCoverage) (map[ids.UUID]string, error) {
-	out := map[ids.UUID]string{}
+// It delegates to people.PersonNames rather than reading `person` here, and
+// that is the whole point of the function: PersonNames carries BOTH halves of
+// the gate — the person object check and the row-scope clause — and a copy of
+// that read in this package would be a second place for one half to go
+// missing. It went missing here once already: this started life as a local
+// query with the row scope and no object gate, so a caller holding deal:read
+// without person:read was named the deal's contacts.
+//
+// A person the caller may not read is simply absent from the map, and their
+// seat ships unnamed: how many people carry a deal is not the secret, only who
+// they are.
+func (h Reads) seatNames(ctx context.Context, tx pgx.Tx, c DealCoverage) (map[ids.UUID]string, error) {
 	if len(c.Stakeholders) == 0 {
-		return out, nil
+		return map[ids.UUID]string{}, nil
 	}
-	people := make([]ids.UUID, 0, len(c.Stakeholders))
+	seated := make([]ids.PersonID, 0, len(c.Stakeholders))
 	for _, s := range c.Stakeholders {
-		people = append(people, s.PersonID)
+		seated = append(seated, ids.From[ids.PersonKind](s.PersonID))
 	}
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	idsPos := arg(people)
-	scope, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
+	names, err := h.people.PersonNamesTx(ctx, tx, seated)
 	if err != nil {
+		// A caller who may read the deal but not people still gets their
+		// coverage — the seats simply arrive unnamed, which is what the
+		// contract's person_name already describes. Refusing the whole payload
+		// would take the findings away too, and those are about the deal.
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return map[ids.UUID]string{}, nil
+		}
 		return nil, err
 	}
-	if scope == "" {
-		scope = narrowsNothing
-	}
-	rows, err := tx.Query(ctx, fmt.Sprintf(
-		`SELECT p.id, p.full_name FROM person p
-		  WHERE p.id = ANY($%d) AND p.archived_at IS NULL AND %s`, idsPos, scope), args...)
-	if err != nil {
-		return nil, fmt.Errorf("read the deal's stakeholder names: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id ids.UUID
-		var name string
-		if err := rows.Scan(&id, &name); err != nil {
-			return nil, fmt.Errorf("scan a stakeholder name: %w", err)
-		}
-		out[id] = name
-	}
-	return out, rows.Err()
+	return names, nil
 }
 
 // userNames resolves the colleagues' display names in one read. The roster is

--- a/backend/internal/compose/network/handlers.go
+++ b/backend/internal/compose/network/handlers.go
@@ -7,6 +7,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -122,7 +123,11 @@ func (h Reads) GetDealCoverage(w http.ResponseWriter, r *http.Request, id crmcon
 		if err != nil {
 			return err
 		}
-		out = wireCoverage(coverage, names)
+		people, err := coverageSeatNames(ctx, tx, coverage)
+		if err != nil {
+			return err
+		}
+		out = wireCoverage(coverage, names, people)
 		return nil
 	})
 	if err != nil {
@@ -167,7 +172,9 @@ func WireColleague(e search.InteractionEdge, name string, now time.Time) crmcont
 	return out
 }
 
-func wireCoverage(c DealCoverage, names map[ids.UUID]string) crmcontracts.DealCoverage {
+func wireCoverage(
+	c DealCoverage, names map[ids.UUID]string, people map[ids.UUID]string,
+) crmcontracts.DealCoverage {
 	out := crmcontracts.DealCoverage{
 		DealId:       openapi_types.UUID(c.DealID),
 		Stakeholders: []crmcontracts.DealCoverageSeat{},
@@ -184,9 +191,16 @@ func wireCoverage(c DealCoverage, names map[ids.UUID]string) crmcontracts.DealCo
 			crmcontracts.DealCoverageSectionsOmitted(section))
 	}
 	for _, s := range c.Stakeholders {
-		out.Stakeholders = append(out.Stakeholders, crmcontracts.DealCoverageSeat{
+		seat := crmcontracts.DealCoverageSeat{
 			PersonId: openapi_types.UUID(s.PersonID), Role: s.Role, Engaged: s.Engaged,
-		})
+		}
+		// Absent rather than empty when the caller may not read the person:
+		// the seat still counts toward coverage, and a "" would render as a
+		// nameless row that looks like a data fault rather than a boundary.
+		if name, ok := people[s.PersonID]; ok {
+			seat.PersonName = &name
+		}
+		out.Stakeholders = append(out.Stakeholders, seat)
 	}
 	for _, e := range c.OurSide {
 		colleague := crmcontracts.PersonNetworkColleague{
@@ -246,6 +260,52 @@ func coverageUsers(c DealCoverage) []ids.UUID {
 		out = append(out, e.UserID)
 	}
 	return out
+}
+
+// coverageSeatNames resolves the stakeholders' display names in one read,
+// under the caller's row scope.
+//
+// Scoped, where UserNames below is not, because the two answer different
+// questions. The colleague roster is readable by any authenticated member; a
+// PERSON is a customer record, and who sits on a deal is exactly the thing row
+// scope decides. A seat whose person the caller may not read is absent from
+// this map and its name goes null on the wire — the seat itself still ships,
+// because how many people carry a deal is not the secret.
+func coverageSeatNames(ctx context.Context, tx pgx.Tx, c DealCoverage) (map[ids.UUID]string, error) {
+	out := map[ids.UUID]string{}
+	if len(c.Stakeholders) == 0 {
+		return out, nil
+	}
+	people := make([]ids.UUID, 0, len(c.Stakeholders))
+	for _, s := range c.Stakeholders {
+		people = append(people, s.PersonID)
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(people)
+	scope, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = narrowsNothing
+	}
+	rows, err := tx.Query(ctx, fmt.Sprintf(
+		`SELECT p.id, p.full_name FROM person p
+		  WHERE p.id = ANY($%d) AND p.archived_at IS NULL AND %s`, idsPos, scope), args...)
+	if err != nil {
+		return nil, fmt.Errorf("read the deal's stakeholder names: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id ids.UUID
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, fmt.Errorf("scan a stakeholder name: %w", err)
+		}
+		out[id] = name
+	}
+	return out, rows.Err()
 }
 
 // userNames resolves the colleagues' display names in one read. The roster is

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -131,7 +131,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// The Morning Brief always serves on the deterministic §10.1 floor;
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).
 		Handlers:          briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool)))),
-		Reads:             network.NewReads(pool),
+		Reads:             network.NewReads(pool, people.NewStore(InstallationDB(pool))),
 		orgRollupHandlers: orgRollupHandlers{pool: pool, now: time.Now},
 		strengthHandlers:  strengthHandlers{people: people.NewStore(InstallationDB(pool)), now: time.Now},
 		// The schema-change pool is boot-optional; nil

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15527,7 +15527,10 @@ type DealCoverageSeat struct {
 	// Engaged A two-way exchange in the window — both directions, not just our sends.
 	Engaged  bool               `json:"engaged"`
 	PersonId openapi_types.UUID `json:"person_id"`
-	Role     string             `json:"role"`
+
+	// PersonName The person's display name. Null when the caller may not read that person — the seat still counts toward coverage, because how many people carry a deal is not a fact this reader is being told they cannot know; only who they are. `our_side` has carried a display name from the start, and a buyer-side seat that carries only an id is the same list rendered half-anonymous.
+	PersonName *string `json:"person_name,omitempty"`
+	Role       string  `json:"role"`
 }
 
 // DealDocument One file in a deal's Files area: the attachment, whether it is hidden from this

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -687,11 +687,18 @@ type PublicEventDealRoomClosed struct {
 // comment's text is deliberately absent: a subscriber reads it through the
 // room, under the room's own authority, not off the bus.
 type PublicEventDealRoomCommentPosted struct {
-	CommentId openapi_types.UUID `json:"comment_id"`
-	DealId    openapi_types.UUID `json:"deal_id"`
+	// AuthorName Who spoke, by name, as the room recorded them at that moment. Additive and optional: an event minted before this field existed carries none.
+	// The comment's TEXT stays off the bus for the reason above, and a name is a different thing from the text — it is who acted, which is what any record of an act has to say. A timeline entry reading "the buyer said something" names no buyer and is not worth the row it occupies.
+	AuthorName *string            `json:"author_name,omitempty"`
+	CommentId  openapi_types.UUID `json:"comment_id"`
+	DealId     openapi_types.UUID `json:"deal_id"`
 
 	// DocumentId The room document the thread is about; null for a room-level exchange.
 	DocumentId *openapi_types.UUID `json:"document_id,omitempty"`
+
+	// DocumentTitle The document the thread is about, titled as it stood at that moment. Absent for a room-level exchange, and absent on an event minted before this field existed.
+	// Carried rather than resolved later, for the reason every other field here is: a document can be retitled or removed afterwards, and a timeline entry means what was true when it happened.
+	DocumentTitle *string `json:"document_title,omitempty"`
 
 	// OpensThread True when this comment is the thread's first — a new question, not a reply.
 	OpensThread bool `json:"opens_thread"`

--- a/backend/internal/modules/dealrooms/roomevents.go
+++ b/backend/internal/modules/dealrooms/roomevents.go
@@ -37,12 +37,17 @@ const (
 
 // CommentPosted is one comment as its consumers need it.
 type CommentPosted struct {
-	DealID      ids.UUID
-	ThreadID    ids.UUID
-	CommentID   ids.UUID
-	DocumentID  *ids.UUID
-	Side        string
-	OpensThread bool
+	DealID     ids.UUID
+	ThreadID   ids.UUID
+	CommentID  ids.UUID
+	DocumentID *ids.UUID
+	Side       string
+	// AuthorName and DocumentTitle are what the timeline note is written from.
+	// Both are optional on the wire: an event minted before those fields
+	// existed carries neither, and the note falls back to naming the side.
+	AuthorName    *string
+	DocumentTitle *string
+	OpensThread   bool
 }
 
 // DecodeCommentPosted reads one comment payload off the bus.
@@ -52,11 +57,13 @@ func DecodeCommentPosted(payload json.RawMessage) (CommentPosted, error) {
 		return CommentPosted{}, fmt.Errorf("decode %s: %w", EventCommentPosted, err)
 	}
 	out := CommentPosted{
-		DealID:      ids.UUID(wire.DealId),
-		ThreadID:    ids.UUID(wire.ThreadId),
-		CommentID:   ids.UUID(wire.CommentId),
-		Side:        wire.Side,
-		OpensThread: wire.OpensThread,
+		DealID:        ids.UUID(wire.DealId),
+		ThreadID:      ids.UUID(wire.ThreadId),
+		CommentID:     ids.UUID(wire.CommentId),
+		Side:          wire.Side,
+		OpensThread:   wire.OpensThread,
+		AuthorName:    wire.AuthorName,
+		DocumentTitle: wire.DocumentTitle,
 	}
 	if wire.DocumentId != nil {
 		doc := ids.UUID(*wire.DocumentId)

--- a/backend/internal/modules/dealrooms/thread_write.go
+++ b/backend/internal/modules/dealrooms/thread_write.go
@@ -185,11 +185,11 @@ func postCommentTx(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom, a
 	// Who spoke and what about, read HERE and carried on the event: a name can
 	// change and a document can be retitled or removed, and the timeline entry
 	// this event writes has to keep saying what was true when it happened.
-	authorName, err := commentAuthorName(ctx, tx, by)
+	authorName, named, err := commentAuthorName(ctx, tx, by)
 	if err != nil {
 		return err
 	}
-	docTitle, err := commentDocumentTitle(ctx, tx, at.documentID)
+	docTitle, titled, err := commentDocumentTitle(ctx, tx, at.documentID)
 	if err != nil {
 		return err
 	}
@@ -201,8 +201,12 @@ func postCommentTx(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom, a
 		Side:           by.side(),
 		OpensThread:    at.opensThread,
 		RequiredChange: &at.requiredChange,
-		AuthorName:     authorName,
-		DocumentTitle:  docTitle,
+	}
+	if named {
+		posted.AuthorName = &authorName
+	}
+	if titled {
+		posted.DocumentTitle = &docTitle
 	}
 	if err := storekit.EmitEvent(ctx, tx, auditID, ids.UUID(room.Id), posted); err != nil {
 		return fmt.Errorf("emit deal_room.comment_posted: %w", err)
@@ -214,7 +218,9 @@ func postCommentTx(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom, a
 // name, and the seller's is their user record. Nil rather than a placeholder
 // when the row has gone — a note that named "Unknown" would be asserting
 // something about the person instead of admitting the record is thin.
-func commentAuthorName(ctx context.Context, tx pgx.Tx, by threadAuthor) (*string, error) {
+// The bool is "there is a name", which is a real answer and not a failure —
+// hence (string, bool, error) rather than a nil pointer standing for both.
+func commentAuthorName(ctx context.Context, tx pgx.Tx, by threadAuthor) (string, bool, error) {
 	var name string
 	var err error
 	switch {
@@ -225,40 +231,34 @@ func commentAuthorName(ctx context.Context, tx pgx.Tx, by threadAuthor) (*string
 		err = tx.QueryRow(ctx,
 			`SELECT display_name FROM app_user WHERE id = $1`, *by.userID).Scan(&name)
 	default:
-		return nil, nil
+		return "", false, nil
 	}
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
+		return "", false, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read the comment author's name: %w", err)
+		return "", false, fmt.Errorf("read the comment author's name: %w", err)
 	}
-	if name == "" {
-		return nil, nil
-	}
-	return &name, nil
+	return name, name != "", nil
 }
 
 // commentDocumentTitle titles the document a thread is about. Nil for a
 // room-level exchange, which is not a missing title but a different kind of
 // thread, and the note says so in its own words.
-func commentDocumentTitle(ctx context.Context, tx pgx.Tx, documentID *ids.UUID) (*string, error) {
+func commentDocumentTitle(ctx context.Context, tx pgx.Tx, documentID *ids.UUID) (string, bool, error) {
 	if documentID == nil {
-		return nil, nil
+		return "", false, nil
 	}
 	var title string
 	err := tx.QueryRow(ctx,
 		`SELECT title FROM deal_room_document WHERE id = $1`, *documentID).Scan(&title)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
+		return "", false, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read the thread's document title: %w", err)
+		return "", false, fmt.Errorf("read the thread's document title: %w", err)
 	}
-	if title == "" {
-		return nil, nil
-	}
-	return &title, nil
+	return title, title != "", nil
 }
 
 // errThreadResolved refuses a reply to a settled thread: reopening is a new

--- a/backend/internal/modules/dealrooms/thread_write.go
+++ b/backend/internal/modules/dealrooms/thread_write.go
@@ -10,6 +10,7 @@ package dealrooms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -181,6 +182,17 @@ func postCommentTx(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom, a
 		u := openapi_types.UUID(*at.documentID)
 		docID = &u
 	}
+	// Who spoke and what about, read HERE and carried on the event: a name can
+	// change and a document can be retitled or removed, and the timeline entry
+	// this event writes has to keep saying what was true when it happened.
+	authorName, err := commentAuthorName(ctx, tx, by)
+	if err != nil {
+		return err
+	}
+	docTitle, err := commentDocumentTitle(ctx, tx, at.documentID)
+	if err != nil {
+		return err
+	}
 	posted := crmcontracts.PublicEventDealRoomCommentPosted{
 		DealId:         room.DealId,
 		ThreadId:       openapi_types.UUID(at.threadID),
@@ -189,11 +201,64 @@ func postCommentTx(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom, a
 		Side:           by.side(),
 		OpensThread:    at.opensThread,
 		RequiredChange: &at.requiredChange,
+		AuthorName:     authorName,
+		DocumentTitle:  docTitle,
 	}
 	if err := storekit.EmitEvent(ctx, tx, auditID, ids.UUID(room.Id), posted); err != nil {
 		return fmt.Errorf("emit deal_room.comment_posted: %w", err)
 	}
 	return nil
+}
+
+// commentAuthorName names whoever spoke: the buyer's seat carries their own
+// name, and the seller's is their user record. Nil rather than a placeholder
+// when the row has gone — a note that named "Unknown" would be asserting
+// something about the person instead of admitting the record is thin.
+func commentAuthorName(ctx context.Context, tx pgx.Tx, by threadAuthor) (*string, error) {
+	var name string
+	var err error
+	switch {
+	case by.participantID != nil:
+		err = tx.QueryRow(ctx,
+			`SELECT full_name FROM deal_room_participant WHERE id = $1`, *by.participantID).Scan(&name)
+	case by.userID != nil:
+		err = tx.QueryRow(ctx,
+			`SELECT display_name FROM app_user WHERE id = $1`, *by.userID).Scan(&name)
+	default:
+		return nil, nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read the comment author's name: %w", err)
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return &name, nil
+}
+
+// commentDocumentTitle titles the document a thread is about. Nil for a
+// room-level exchange, which is not a missing title but a different kind of
+// thread, and the note says so in its own words.
+func commentDocumentTitle(ctx context.Context, tx pgx.Tx, documentID *ids.UUID) (*string, error) {
+	if documentID == nil {
+		return nil, nil
+	}
+	var title string
+	err := tx.QueryRow(ctx,
+		`SELECT title FROM deal_room_document WHERE id = $1`, *documentID).Scan(&title)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read the thread's document title: %w", err)
+	}
+	if title == "" {
+		return nil, nil
+	}
+	return &title, nil
 }
 
 // errThreadResolved refuses a reply to a settled thread: reopening is a new

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -226,6 +226,16 @@ export interface components {
             opens_thread: boolean;
             /** @description True when the thread, as opened, blocks confirming the document until resolved. */
             required_change?: boolean;
+            /**
+             * @description Who spoke, by name, as the room recorded them at that moment. Additive and optional: an event minted before this field existed carries none.
+             *     The comment's TEXT stays off the bus for the reason above, and a name is a different thing from the text — it is who acted, which is what any record of an act has to say. A timeline entry reading "the buyer said something" names no buyer and is not worth the row it occupies.
+             */
+            author_name?: string;
+            /**
+             * @description The document the thread is about, titled as it stood at that moment. Absent for a room-level exchange, and absent on an event minted before this field existed.
+             *     Carried rather than resolved later, for the reason every other field here is: a document can be retitled or removed afterwards, and a timeline entry means what was true when it happened.
+             */
+            document_title?: string;
         };
         /** @description Payload for deal_room.thread_resolved — a thread was closed by the seller's side. */
         PublicEventDealRoomThreadResolved: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14071,6 +14071,8 @@ export interface components {
         DealCoverageSeat: {
             /** Format: uuid */
             person_id: string;
+            /** @description The person's display name. Null when the caller may not read that person — the seat still counts toward coverage, because how many people carry a deal is not a fact this reader is being told they cannot know; only who they are. `our_side` has carried a display name from the start, and a buyer-side seat that carries only an id is the same list rendered half-anonymous. */
+            person_name?: string | null;
             role: string;
             /** @description A two-way exchange in the window — both directions, not just our sends. */
             engaged: boolean;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4463,6 +4463,9 @@ export const de = {
   "network.bucket.moderate": "Mittel",
   "network.bucket.strong": "Stark",
   "coverage.title": "Abdeckung",
+  "coverage.engaged": "Im Austausch",
+  "coverage.quiet": "Kein beidseitiger Kontakt",
+  "coverage.seatWithheld": "Ein Kontakt, den Sie nicht lesen dürfen",
   "coverage.clear":
     "Nichts markiert — dieser Deal besteht alle Abdeckungsprüfungen.",
   "coverage.withheld":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4464,6 +4464,8 @@ export const de = {
   "coverage.title": "Abdeckung",
   "coverage.engaged": "Im Austausch",
   "coverage.quiet": "Kein beidseitiger Kontakt",
+  "coverage.seatsWithheld":
+    "Sie können nicht sehen, wer an diesem Deal beteiligt ist.",
   "coverage.seatWithheld": "Ein Kontakt, den Sie nicht lesen dürfen",
   "coverage.clear":
     "Nichts markiert — dieser Deal besteht alle Abdeckungsprüfungen.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1719,7 +1719,6 @@ export const de = {
   "deals.cancel": "Abbrechen",
   "deals.advanced": "Nach {stage} verschoben",
   "deal.pendingApprovals": "Wartet auf deine Bestätigung",
-  "deal.stakeholders": "Beteiligte",
   "deal.edit": "Deal bearbeiten",
   "deal.ownerKeep": "Aktuellen Inhaber behalten",
   "deal.ownerMe": "Mir zuweisen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4516,6 +4516,7 @@ export const en = {
   "coverage.title": "Coverage",
   "coverage.engaged": "Engaged",
   "coverage.quiet": "No two-way contact",
+  "coverage.seatsWithheld": "You cannot see who is on this deal.",
   "coverage.seatWithheld": "A contact you cannot read",
   "coverage.clear": "Nothing flagged — this deal passes every coverage check.",
   "coverage.withheld":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1744,7 +1744,6 @@ export const en = {
   "deals.cancel": "Cancel",
   "deals.advanced": "Moved to {stage}",
   "deal.pendingApprovals": "Awaiting your confirmation",
-  "deal.stakeholders": "Stakeholders",
   "deal.edit": "Edit deal",
   "deal.ownerKeep": "Keep current owner",
   "deal.ownerMe": "Assign to me",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4515,6 +4515,9 @@ export const en = {
   "network.bucket.moderate": "Moderate",
   "network.bucket.strong": "Strong",
   "coverage.title": "Coverage",
+  "coverage.engaged": "Engaged",
+  "coverage.quiet": "No two-way contact",
+  "coverage.seatWithheld": "A contact you cannot read",
   "coverage.clear": "Nothing flagged — this deal passes every coverage check.",
   "coverage.withheld":
     "Coverage was withheld — you cannot read this deal’s relationships, so no check was run.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1707,7 +1707,6 @@ export const vi = {
   "deals.cancel": "Huỷ",
   "deals.advanced": "Đã chuyển sang {stage}",
   "deal.pendingApprovals": "Đang chờ bạn xác nhận",
-  "deal.stakeholders": "Bên liên quan",
   "deal.edit": "Sửa deal",
   "deal.ownerKeep": "Giữ người phụ trách hiện tại",
   "deal.ownerMe": "Giao cho tôi",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4422,6 +4422,7 @@ export const vi = {
   "coverage.title": "Độ phủ",
   "coverage.engaged": "Đang trao đổi",
   "coverage.quiet": "Chưa có trao đổi hai chiều",
+  "coverage.seatsWithheld": "Bạn không thể xem ai tham gia thương vụ này.",
   "coverage.seatWithheld": "Một liên hệ bạn không thể xem",
   "coverage.clear":
     "Không có gì đáng lưu ý — deal này qua mọi kiểm tra độ phủ.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4421,6 +4421,9 @@ export const vi = {
   "network.bucket.moderate": "Vừa",
   "network.bucket.strong": "Mạnh",
   "coverage.title": "Độ phủ",
+  "coverage.engaged": "Đang trao đổi",
+  "coverage.quiet": "Chưa có trao đổi hai chiều",
+  "coverage.seatWithheld": "Một liên hệ bạn không thể xem",
   "coverage.clear":
     "Không có gì đáng lưu ý — deal này qua mọi kiểm tra độ phủ.",
   "coverage.withheld":

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3027,7 +3027,6 @@ export function OffersPanel({
 const DEAL_TABS = ["overview", "files", "history"] as const;
 type DealTab = (typeof DEAL_TABS)[number];
 
-type Relationship = components["schemas"]["Relationship"];
 
 // The deal 360's "overview" pane, split out of DealScreen so the tab switch
 // doesn't push the render-prop closure over the cognitive-complexity budget.
@@ -3142,7 +3141,6 @@ function DealOverviewPane({
   stages,
   dealApprovals,
   onDecide,
-  stakeholders,
   offers,
   creatingOffer,
   locale,
@@ -3160,7 +3158,6 @@ function DealOverviewPane({
     approvalId: string;
     verdict: "approve" | "reject";
   }) => void;
-  stakeholders: Relationship[] | undefined;
   offers: Offer[] | undefined;
   creatingOffer: boolean;
   locale: Locale;
@@ -3219,40 +3216,21 @@ function DealOverviewPane({
           )}
         </fieldset>
       )}
+      {/* Below the stage bar on purpose: a reader takes in WHERE the deal is
+          before they read the account of how it got there, and the briefing is
+          long enough that putting it first pushed the stages off the first
+          screen. */}
+      <DealLead dealId={deal.id} overlay={overlay} />
       <DealApprovals approvals={dealApprovals} decide={onDecide} />
-      {/* Above the stakeholder list on purpose: the findings are ABOUT those
-          seats, and a rep who read the list first has already formed the
-          impression the flags exist to correct. */}
+      {/* Who is on the deal and what is wrong with that coverage, in ONE card.
+          There used to be a second "Stakeholders" card below this one; it read
+          the /stakeholders relationship rows, which carry a person_id and no
+          name, so a real stakeholder rendered as the bare word
+          "economic_buyer". The coverage seats carry the name and whether the
+          person is actually engaged, which is the same list with the two facts
+          a rep needs — and it keeps the findings beside the seats they are
+          about. Overlay is handled inside the card. */}
       <DealCoverageCard id={deal.id} />
-      {/* Stakeholders are a relationship read the mirror does not serve. In
-          overlay show the honest unavailable state (never any cached native
-          rows), matching the timeline and offers panels. */}
-      {overlay ? (
-        <Card
-          title={t("deal.stakeholders")}
-          style={{ marginBottom: "var(--space-4)" }}
-        >
-          <OverlayUnavailable />
-        </Card>
-      ) : (
-        stakeholders &&
-        stakeholders.length > 0 && (
-          <Card
-            title={t("deal.stakeholders")}
-            style={{ marginBottom: "var(--space-4)" }}
-          >
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              {stakeholders.map((stakeholder) => (
-                <Badge key={stakeholder.id}>
-                  {stakeholder.role ??
-                    stakeholder.person_id ??
-                    stakeholder.kind}
-                </Badge>
-              ))}
-            </div>
-          </Card>
-        )
-      )}
       <OffersPanel
         offers={offers}
         creating={creatingOffer}
@@ -3330,19 +3308,6 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
     queryFn: async () => {
       const { data, error } = await api.GET("/organizations", {
         params: { query: { limit: 50 } },
-      });
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-  });
-  const stakeholdersQuery = useQuery({
-    queryKey: ["deal-stakeholders", id],
-    enabled: !overlay,
-    queryFn: async () => {
-      const { data, error } = await api.GET("/deals/{id}/stakeholders", {
-        params: { path: { id } },
       });
       if (error) {
         throwProblem(error);
@@ -3470,7 +3435,6 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                 )
               }
             >
-              <DealLead dealId={id} overlay={overlay} />
               <div style={{ marginBottom: 16 }}>
                 <SegmentedControl
                   options={DEAL_TABS}
@@ -3489,7 +3453,6 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                   stages={stages}
                   dealApprovals={dealApprovals}
                   onDecide={(input) => decide.mutate(input)}
-                  stakeholders={stakeholdersQuery.data?.data}
                   offers={offersQuery.data?.data}
                   creatingOffer={createOffer.isPending}
                   locale={locale}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3027,7 +3027,6 @@ export function OffersPanel({
 const DEAL_TABS = ["overview", "files", "history"] as const;
 type DealTab = (typeof DEAL_TABS)[number];
 
-
 // The deal 360's "overview" pane, split out of DealScreen so the tab switch
 // doesn't push the render-prop closure over the cognitive-complexity budget.
 // Every prop here is a value already resolved by DealScreen — no new

--- a/frontend/src/screens/network.css
+++ b/frontend/src/screens/network.css
@@ -11,6 +11,7 @@
 }
 
 .net-colleagues,
+.net-seats,
 .net-risks {
   display: flex;
   flex-direction: column;
@@ -20,12 +21,27 @@
   list-style: none;
 }
 
+/* The seats sit above the findings and read as one list with them: same row
+   rhythm, so a name and the warning about that name line up. */
+.net-seats {
+  margin-bottom: var(--space-3);
+}
+
 .net-colleagues li,
+.net-seats li,
 .net-risks li {
   display: flex;
   align-items: center;
   gap: var(--space-3);
   flex-wrap: wrap;
+}
+
+/* The name leads the row and takes the slack, so the engagement badge and the
+   role stay together at the right where they can be scanned down the column. */
+.net-seat-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
 }
 
 /* The name leads and takes the slack, so the band and counts stay right-aligned

--- a/frontend/src/screens/network.tsx
+++ b/frontend/src/screens/network.tsx
@@ -15,6 +15,7 @@ import {
   throwProblem,
   useSorMode,
 } from "./common";
+import { dealRoleLabel } from "./company360";
 
 // The two relationship-graph cards (ADR-0078).
 //
@@ -147,6 +148,7 @@ export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
     enabled: !overlay,
   });
   const risks = query.data?.risks ?? [];
+  const seats = query.data?.stakeholders ?? [];
   // Withheld is checked BEFORE the empty case, and the order is the whole
   // point: a caller without the relationship grant is served no findings, so
   // testing the risk list first would render "this deal passes every coverage
@@ -169,6 +171,32 @@ export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
           a card that failed to load. */}
       {!overlay && query.isSuccess && !withheld && risks.length === 0 && (
         <p className="t-caption">{t("coverage.clear")}</p>
+      )}
+      {/* Who is on the deal, by NAME. This list used to sit in its own card
+          rendering `role ?? person_id`, which meant a real stakeholder showed
+          as the bare word "economic_buyer" and a rep could not tell who it
+          was. The seats live here because coverage already knows which of them
+          is engaged, and a name beside a finding about single-threading is the
+          thing that makes the finding actionable. */}
+      {!overlay && seats.length > 0 && (
+        <ul className="net-seats">
+          {seats.map((seat) => (
+            <li key={seat.person_id}>
+              <span className="net-seat-name">
+                {/* Null when the caller may not read that person: the seat
+                    still counts toward coverage, so it is shown, and only the
+                    identity is withheld. */}
+                {seat.person_name ?? t("coverage.seatWithheld")}
+              </span>
+              <Badge tone={seat.engaged ? "success" : undefined}>
+                {seat.engaged ? t("coverage.engaged") : t("coverage.quiet")}
+              </Badge>
+              <span className="t-caption">
+                {dealRoleLabel(seat.role, t)}
+              </span>
+            </li>
+          ))}
+        </ul>
       )}
       {!overlay && risks.length > 0 && (
         <ul className="net-risks">

--- a/frontend/src/screens/network.tsx
+++ b/frontend/src/screens/network.tsx
@@ -154,7 +154,16 @@ export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
   // testing the risk list first would render "this deal passes every coverage
   // check" over a check that never ran. The server says which of the two
   // happened; the card must not decide for itself.
-  const withheld = (query.data?.sections_omitted ?? []).includes("risks");
+  const omitted = query.data?.sections_omitted ?? [];
+  const withheld = omitted.includes("risks");
+  // Read from the payload, not inferred from the seat list being empty: an
+  // empty list would render "nobody is on this deal" over a list the server
+  // never sent, which is the mistake the risks comment above exists to
+  // prevent. The server withholds all three sections together today, so this
+  // tracks `withheld` in practice — it is asked separately because the
+  // contract lets them differ and this card must not be the thing that breaks
+  // if they ever do.
+  const seatsWithheld = omitted.includes("stakeholders");
 
   return (
     <Card className="net-card" title={t("coverage.title")}>
@@ -178,7 +187,10 @@ export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
           was. The seats live here because coverage already knows which of them
           is engaged, and a name beside a finding about single-threading is the
           thing that makes the finding actionable. */}
-      {!overlay && seats.length > 0 && (
+      {!overlay && query.isSuccess && seatsWithheld && (
+        <EmptyState>{t("coverage.seatsWithheld")}</EmptyState>
+      )}
+      {!overlay && !seatsWithheld && seats.length > 0 && (
         <ul className="net-seats">
           {seats.map((seat) => (
             <li key={seat.person_id}>

--- a/frontend/src/screens/network.tsx
+++ b/frontend/src/screens/network.tsx
@@ -191,9 +191,7 @@ export function DealCoverageCard({ id }: Readonly<{ id: string }>) {
               <Badge tone={seat.engaged ? "success" : undefined}>
                 {seat.engaged ? t("coverage.engaged") : t("coverage.quiet")}
               </Badge>
-              <span className="t-caption">
-                {dealRoleLabel(seat.role, t)}
-              </span>
+              <span className="t-caption">{dealRoleLabel(seat.role, t)}</span>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Three things a rep hits on the deal page, plus the access-control fix a review turned up.

## Deal360 sits below the stages

It is a long card, and above the stage bar it pushed where the deal actually *is*
off the first screen. A reader takes in the stage before the account of how it
got there.

## Stakeholders have names

The Stakeholders card rendered `role ?? person_id ?? kind` over the
`/stakeholders` relationship rows, and those carry a `person_id` and no name — so
a real stakeholder showed as the bare word **`economic_buyer`**.

The seats now come from the coverage read, which carries the name *and* whether
the person is actually engaged, and the separate nameless card is gone. That also
puts the coverage findings beside the seats they are about: a single-threading
warning means something once you can see which one person it rests on.

`person_name` is new on `DealCoverageSeat` and null when the caller may not read
that person. The seat still ships — how many people carry a deal is not the
secret, only who they are. `our_side` has carried a display name from the start,
so a buyer-side seat with only an id was the same list rendered half-anonymous.

A withheld seat list now says so rather than rendering as "nobody is on this
deal", which is the false-clean reading the risks branch beside it already
guards against.

## Deal Room notes name the person and the document

Before: *"The buyer replied in the Deal Room / About a document in the room."*
After: *"Thorsten Sifferlien asked a question in the Deal Room / About
Rahmenvertrag v3."*

The old note told a reader nothing — which buyer, which document, whether it
mattered — so the row was noise on a timeline that has to stay worth reading.

The comment's **text** still stays off the bus, and that part was always right:
it is written to the buyer, it can be edited in the room, and copying it would
make a second record. A name and a title are not the text; they are who acted and
what they acted on. Both ride the event and are read at emit time, so the note
keeps saying what was true then even after a rename. Both are optional — an event
minted before the fields existed falls back to naming the side, never a
placeholder.

## The access-control fix

A review caught this in the first cut of the branch: `coverageSeatNames` read
`person` rows under the row-scope clause alone, with **no `person` object gate**.
A caller holding `deal:read` without `person:read` was named the deal's contacts,
where `GET /people/{id}` refuses them. Not reachable with the seeded roles, which
all hold `person:read` — a latent gap, not a live hole.

It is **deleted rather than patched**. `people.PersonNamesTx` is the same query
with both halves of the gate attached, and its own doc comment says the gate
exists to keep the NEXT caller safe — this was that caller. `network.Reads` now
takes the people store compose already builds two lines away, so there is one
gated person-name read instead of two.

A caller without `person:read` still gets their coverage with seats unnamed;
refusing the payload would take the findings with it, and those are about the
deal.

## A boundary question, answered deliberately

The deal timeline now shows Deal Room content, while `compose/meetingbrief`
withholds the same fact from anyone without a `deal_room:read` grant. Lars ruled
that everyone has full read access, so the disagreement is not a live exposure —
recorded here because the two surfaces do still answer it differently in code.

## Checks

- `make check-go`, `make check-fe`, `make craft-static` — green on the rebased branch.
- Integration lane green (coverage, deal room, person graph).
- Browser-verified on an isolated stack: Deal360 below the stages, the seat
  rendering as `Thorsten Sifferlien · No two-way contact · economic buyer`, and
  the timeline note naming both the person and the document.
- The note test previously asserted only that the words "buyer" and "document"
  appeared somewhere — which the old meaningless note satisfied. It now asserts
  the actual name and title and fails against the old wording; a second test
  covers the no-name event and refuses a placeholder.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deal page UX and event clarity fixes: Deal360 now sits below the stage bar, stakeholder seats render with names inside Coverage, and Deal Room timeline notes name who spoke and which document. Also closes a latent access-control gap that could leak contact names through coverage.

- API changes (backward compatible):
  - Adds `person_name` to `DealCoverageSeat` (nullable/optional). Coverage now includes seat names when the caller can read people; seats remain but ship unnamed otherwise.
  - Adds `author_name` and `document_title` to `deal_room.comment_posted` events. Older events omit these and fall back to naming the side.
- Backend:
  - `network.Reads` now depends on `people.Store`; seat names resolve via `people.PersonNamesTx` to enforce both row-scope and person object gates. Callers without `person:read` still receive coverage with unnamed seats.
  - Timeline note text updated: “asked a question/replied” and “About <document title>” when available; still excludes comment text.
- Frontend:
  - Moves Deal360 below stages. Removes the separate Stakeholders card and its `/deals/{id}/stakeholders` query.
  - Coverage card shows named seats with engagement badges and reads `sections_omitted` to render a withheld message instead of an empty list.
  - Adds minimal styling for seats and new i18n keys under `coverage.*`; drops `deal.stakeholders`.
- Tests and schema:
  - Updates generated contracts for `crm.yaml` and `public-events.yaml`.
  - Strengthens tests to assert actual names/titles and verifies named vs withheld seats.

<sup>Written for commit 4bea1e84962d41f101b9922fcd4fa90ea737a01c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deal coverage now displays stakeholder names, roles, and engagement status.
  - Names are withheld when access permissions do not allow viewing them.
  - Deal-room activity shows comment authors, related document titles, and clearer question/reply descriptions.
  - Deal overview now presents coverage in a consolidated card and places the deal lead beneath the stage progress.
- **Translations**
  - Added localized coverage statuses in English, German, and Vietnamese.
- **Bug Fixes**
  - Improved fallback behavior when comment author information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->