### PR TITLE
fix(deals): the offer-draft fixture holds the pool the drafter now reads

### DIFF
--- a/backend/internal/compose/offerdraft_integration_test.go
+++ b/backend/internal/compose/offerdraft_integration_test.go
@@ -59,6 +59,11 @@ func newOfferDrafterFixture(t *testing.T, e *integration.Env, brain *ai.FakeClie
 		deals:    e.Deals,
 		rateCard: e.Deals,
 		context:  search.NewRetriever(search.NewStore(e.DB()), nil),
+		// The real pool, because the drafter reads the installation's base
+		// language through it. A fixture that left this nil panicked inside the
+		// call rather than failing an assertion, which read as a nil RESULT and
+		// sent the report looking at the wrong line entirely.
+		pool: e.Pool,
 	}
 }
 


### PR DESCRIPTION
## main is red, and it is mine

Every test in `offerdraft_integration_test.go` panics with a nil-pointer dereference. From #2490.

That change gave `offerDrafter` a `pool` so it can read the installation's base language for the drafted line descriptions. Production wires it in `WithOfferDraft`. The integration fixture builds the struct **literally** and was never updated, so the pool was nil and the read dereferenced it.

## Why the report looked like something else

The panic is attributed to the line *after* the call, so #2509 read it as `DraftOfferLines` returning a nil result with a nil error, and diagnosed a missing return in the honest-empty path.

`DraftResult` is a **value type** and cannot be nil. The panic is inside the call, on a field the fixture never set. Worth stating because the issue's proposed remedy would have added a guard to a path that was never broken.

## The general shape

A fixture that constructs a production type field by field goes stale **silently** every time that type gains a dependency. The compiler is happy — a missing field is its zero value — and only a test that exercises the new field says so.

## Verification

All eight tests in the file pass against a real database:

```
--- PASS: TestDraftOfferLinesDropsUngroundedCandidateAsHonestEmpty
--- PASS: TestDraftOfferLinesStagesGroundedLinesAndDiscloses
--- PASS: TestDraftOfferLinesGroundsPriceOnTheRateCardWhenNoConversationPrice
--- PASS: TestDraftOfferLinesNeverGroundsARateCardPriceInAMismatchedCurrency
--- PASS: TestDraftOfferLinesNeverGuessesAnUngroundedPrice
--- PASS: TestDraftOfferLinesDropsStoreInvalidQuantityWithoutErroringTheBatch
--- PASS: TestDraftOfferLinesStripsSecretsBeforeTheModelCall
```

Closes #2509.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nil-pointer panics in `offerdraft_integration_test.go` by wiring the real `pool` into the `offerDrafter` fixture. Previously the fixture built the drafter without a pool; the drafter reads the installation’s base language from the pool, so tests crashed. Now the fixture uses `e.Pool`, matching production wiring via `WithOfferDraft`.

- Change is limited to the test fixture: add `pool: e.Pool`; no production behavior change.
- All offer draft integration tests should pass; no migration or configuration changes.

<sup>Written for commit b7faf904091fdd4d16cd53efb1175ba1a50f6cad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offer drafting integration tests now use the configured database environment, ensuring installation-level language settings are respected during drafting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->