### PR TITLE
fix(contract-api): `neq` keeps the rows whose column was never set

### DIFF
--- a/backend/filtervocabularyparity_test.go
+++ b/backend/filtervocabularyparity_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Two surfaces answer a filtered question: the list/segment compiler in
+// `platform/database/storekit`, and the query compiler in `modules/search`.
+// A reader does not know which one served them, so `status neq lost` has to
+// mean the same thing on both.
+//
+// TWO WAYS IT CAN STOP MEANING THE SAME THING, and this file holds both.
+//
+// The SQL. `<>` and `IS DISTINCT FROM` are different row sets, not different
+// spellings: a record whose status is UNSET is dropped by the first and kept by
+// the second. A caller reading "everything that is not lost" means to be shown
+// it. Nothing about the operator's name says which reading applies, so the
+// choice has to be made once and held.
+//
+// The VOCABULARY. One surface offering an operator the other refuses is a
+// reader who can ask a question in search and not in a segment. That may be
+// right — the two surfaces do not index the same things — but it is a decision,
+// and an undeclared difference is indistinguishable from an oversight.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	storekitMatrix = "internal/platform/database/storekit/predicate.go"
+	searchMatrix   = "internal/modules/search/queryvocab.go"
+)
+
+// correspondingTypes pairs a storekit field type with the search kind that
+// answers the same question about the same data.
+//
+// Declared rather than derived: the two vocabularies were named independently
+// and neither is a renaming of the other. A pair left out of this map is not
+// compared, so the map is also the statement of what this gate does NOT cover.
+// gatekit:fixture the declared pairing between the two vocabularies' type names
+var correspondingTypes = map[string]string{
+	"FieldText":     "KindText",
+	"FieldID":       "KindID",
+	"FieldNumber":   "KindNumber",
+	"FieldDate":     "KindDate",
+	"FieldBoolean":  "KindBoolean",
+	"FieldPicklist": "KindText",
+	"FieldCurrency": "KindNumber",
+}
+
+// declaredDifferences ratifies each operator one surface offers and the other
+// does not. A difference without an entry is a finding; an entry that stops
+// matching is one for a difference that has been resolved, and leaving it
+// re-exempts whatever takes its place.
+var declaredDifferences = gatekit.Waive(map[string]string{
+	"FieldText/exists":     "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldID/exists":       "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldNumber/exists":   "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldDate/exists":     "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldBoolean/exists":  "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldPicklist/exists": "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldCurrency/exists": "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldText/contains":   "search declares no `contains` operator. Its structured `where` answers exact and ordering comparisons; approximate text is the free-text half of the same request, not a structured operator. storekit has no free-text half, so `contains` is the only way to ask there. The split is real, but nothing states it as a decision — it is how the two surfaces were built.",
+	"FieldBoolean/neq":     "search offers `eq` alone on a boolean, its vocabulary saying `neq true` is `eq false`. THAT REASONING NO LONGER HOLDS: with neq NULL-safe, `neq true` selects false AND unset, which `eq false` does not. storekit's boolean neq now answers a question search cannot express. Waived because closing it is a product decision about search's vocabulary, not a repair.",
+	"FieldDate/in":         "search admits `in` on a date and storekit does not. A gap rather than a decision — but not a one-bit fix: flipping the matrix routes dates through the string `in` branch, which binds a text array against a date column and fails at query time. It needs a date branch.",
+})
+
+// operatorSets reads a matrix declaration and returns, per type, its operators.
+func operatorSets(t *testing.T, path, declName string) map[string][]string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	sets := map[string][]string{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		spec, ok := node.(*ast.ValueSpec)
+		if !ok || len(spec.Names) == 0 || spec.Names[0].Name != declName || len(spec.Values) == 0 {
+			return true
+		}
+		matrix, ok := spec.Values[0].(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		for _, element := range matrix.Elts {
+			pair, ok := element.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := pair.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			sets[key.Name] = operatorNames(pair.Value)
+		}
+		return true
+	})
+	if len(sets) == 0 {
+		t.Fatalf("%s declares no %s this census can read", path, declName)
+	}
+	return sets
+}
+
+// operatorNames reads a type's operators from either shape the two matrices
+// use: a set (`map[string]bool`) or a list (`[]string`).
+//
+// A set entry's VALUE decides admission — storekit refuses an operator whose
+// entry is `false` — so reading the key alone would count a refused operator as
+// offered, and the census would report parity across a real divergence.
+func operatorNames(value ast.Expr) []string {
+	lit, ok := value.(*ast.CompositeLit)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, element := range lit.Elts {
+		switch entry := element.(type) {
+		case *ast.KeyValueExpr:
+			key, isIdent := entry.Key.(*ast.Ident)
+			if isIdent && admits(entry.Value) {
+				names = append(names, operatorConstant(key.Name))
+			}
+		case *ast.Ident:
+			names = append(names, operatorConstant(entry.Name))
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// admits reads a set entry's value. Anything that is not the literal `true` is
+// treated as a refusal: a value this cannot read is not one it has cleared.
+func admits(value ast.Expr) bool {
+	ident, ok := value.(*ast.Ident)
+	return ok && ident.Name == "true"
+}
+
+// operatorConstant reduces `OpNeq` to `neq`, so the two packages' constants
+// compare by what they mean rather than by how each spells them.
+func operatorConstant(name string) string {
+	return strings.ToLower(strings.TrimPrefix(name, "Op"))
+}
+
+func TestBothFilterSurfacesOfferTheSameOperators(t *testing.T) {
+	// A ratification that stops matching is one for a difference already closed.
+	defer declaredDifferences.AssertAllMatched(t)
+
+	storekitOps := operatorSets(t, storekitMatrix, "operatorsByType")
+	searchOps := operatorSets(t, searchMatrix, "operatorsByKind")
+
+	var findings []string
+	compared := 0
+	for fieldType, kind := range correspondingTypes {
+		mine, known := storekitOps[fieldType]
+		theirs, paired := searchOps[kind]
+		if !known || !paired {
+			findings = append(findings, fieldType+"/"+kind+": one side no longer declares this type")
+			continue
+		}
+		compared++
+		for _, op := range symmetricDifference(mine, theirs) {
+			if declaredDifferences.Waived(t, fieldType+"/"+op) {
+				continue
+			}
+			findings = append(findings, fieldType+"/"+op+" — offered by one surface, refused by the other")
+		}
+	}
+	if compared < 5 {
+		t.Fatalf("the census compared only %d type pairs, so it is judging almost nothing", compared)
+	}
+	sort.Strings(findings)
+	if len(findings) > 0 {
+		t.Errorf("%d operator difference(s) between the two filter surfaces are undeclared.\n\n"+
+			"A reader does not know which surface answered them, so a question they can ask in "+
+			"search and not in a segment is a decision somebody has to have made. Offer it on both, "+
+			"or ratify it in declaredDifferences with the reason.\n\n\t%s",
+			len(findings), strings.Join(findings, "\n\t"))
+	}
+}
+
+// nullDroppingInequality are the spellings Postgres treats as the same
+// NULL-dropping comparison. `!=` is documented as a synonym for `<>`, and it is
+// the one a hand typing it reaches for first, so a census that read only `<>`
+// would refuse the spelling nobody uses and admit the one they do.
+//
+// `NOT (col = $1)` drops unset rows too and is NOT matched here: it is also the
+// shape of the linked-field path's legitimate NOT EXISTS, and a pattern wide
+// enough to catch one catches the other.
+var nullDroppingInequality = []string{"<>", "!="}
+
+// filterCompilers are the files that turn a caller's operator into SQL. Both
+// answer the same vocabulary, so both have to answer it the same way.
+var filterCompilers = []string{
+	"internal/platform/database/storekit/predicate.go",
+	"internal/platform/database/storekit/predicateoperand.go",
+	"internal/modules/search/querysql.go",
+}
+
+func TestNeitherFilterCompilerDropsAnUnsetRowFromNeq(t *testing.T) {
+	nullSafe := 0
+	var findings []string
+	for _, path := range filterCompilers {
+		source, err := os.ReadFile(path) // #nosec G304 -- a fixed path in the tracked source tree
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		for _, statement := range sqlStatementsIn(t, path, string(source)) {
+			for _, spelling := range nullDroppingInequality {
+				if strings.Contains(statement, spelling) {
+					findings = append(findings, path+": "+statement)
+					break
+				}
+			}
+			if strings.Contains(strings.ToUpper(statement), "IS DISTINCT FROM") {
+				nullSafe++
+			}
+		}
+	}
+	// Zero `<>` is what a clean tree and a blind census both look like. The
+	// null-safe rendering has to be visible for the absence to mean anything.
+	if nullSafe == 0 {
+		t.Fatal("no filter compiler renders IS DISTINCT FROM, so this census is vouching for nothing")
+	}
+	if len(findings) > 0 {
+		sort.Strings(findings)
+		t.Errorf("%d comparison(s) in a filter compiler drop unset rows.\n\n"+
+			"`<>` and IS DISTINCT FROM are different ROW SETS, not different spellings: a record "+
+			"whose column is unset is dropped by the first and kept by the second, and a caller "+
+			"reading \"everything that is not X\" means to be shown it. The other compiler, and this "+
+			"package's own linked-field path, both keep it.\n\n\t%s",
+			len(findings), strings.Join(findings, "\n\t"))
+	}
+}
+
+func symmetricDifference(left, right []string) []string {
+	in := func(list []string, want string) bool {
+		for _, item := range list {
+			if item == want {
+				return true
+			}
+		}
+		return false
+	}
+	var only []string
+	for _, op := range left {
+		if !in(right, op) {
+			only = append(only, op)
+		}
+	}
+	for _, op := range right {
+		if !in(left, op) {
+			only = append(only, op)
+		}
+	}
+	sort.Strings(only)
+	return only
+}

--- a/backend/filtervocabularyparity_test.go
+++ b/backend/filtervocabularyparity_test.go
@@ -44,6 +44,21 @@ const (
 // Declared rather than derived: the two vocabularies were named independently
 // and neither is a renaming of the other. A pair left out of this map is not
 // compared, so the map is also the statement of what this gate does NOT cover.
+// exists is why neither surface's `exists` difference is a defect. It is one
+// fact about one operator, so it has one home: seven copies would be seven
+// things to keep in step, and whichever drifted would misstate why its
+// difference is ratified while still reading like a reason.
+const exists = "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about."
+
+// unpairedKinds are types one surface declares that the other has no counterpart
+// for, so `correspondingTypes` cannot name them. Ratified rather than skipped:
+// an unpaired type is uncompared, and the gate must say which ones those are or
+// a new type on either surface joins them silently.
+var unpairedKinds = gatekit.Waive(map[string]string{
+	"KindTimestamp": "search separates a timestamp from a date; storekit's FieldDate covers both, so there is no distinct storekit type to compare this against. The operators it carries are identical to KindDate's, which FieldDate is already compared with.",
+	"KindGeo":       "a geo field admits only within_radius, an operator storekit has no compiler for at all. There is nothing to compare: the difference is the whole type, not an operator within it.",
+})
+
 // gatekit:fixture the declared pairing between the two vocabularies' type names
 var correspondingTypes = map[string]string{
 	"FieldText":     "KindText",
@@ -60,13 +75,13 @@ var correspondingTypes = map[string]string{
 // matching is one for a difference that has been resolved, and leaving it
 // re-exempts whatever takes its place.
 var declaredDifferences = gatekit.Waive(map[string]string{
-	"FieldText/exists":     "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
-	"FieldID/exists":       "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
-	"FieldNumber/exists":   "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
-	"FieldDate/exists":     "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
-	"FieldBoolean/exists":  "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
-	"FieldPicklist/exists": "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
-	"FieldCurrency/exists": "search declares no `exists` operator at all — its vocabulary is eq, neq, in, lt, lte, gt, gte, within_radius and nothing else. It compiles against the record's OWN TABLE (querysql builds `FROM <table> t`, columns derived from information_schema), so an unset field is a NULL column exactly as it is for storekit and `IS NULL` would answer it. There is no capability reason; this is a vocabulary gap nobody has decided about.",
+	"FieldText/exists":     exists,
+	"FieldID/exists":       exists,
+	"FieldNumber/exists":   exists,
+	"FieldDate/exists":     exists,
+	"FieldBoolean/exists":  exists,
+	"FieldPicklist/exists": exists,
+	"FieldCurrency/exists": exists,
 	"FieldText/contains":   "search declares no `contains` operator. Its structured `where` answers exact and ordering comparisons; approximate text is the free-text half of the same request, not a structured operator. storekit has no free-text half, so `contains` is the only way to ask there. The split is real, but nothing states it as a decision — it is how the two surfaces were built.",
 	"FieldBoolean/neq":     "search offers `eq` alone on a boolean, its vocabulary saying `neq true` is `eq false`. THAT REASONING NO LONGER HOLDS: with neq NULL-safe, `neq true` selects false AND unset, which `eq false` does not. storekit's boolean neq now answers a question search cannot express. Waived because closing it is a product decision about search's vocabulary, not a repair.",
 	"FieldDate/in":         "search admits `in` on a date and storekit does not. A gap rather than a decision — but not a one-bit fix: flipping the matrix routes dates through the string `in` branch, which binds a text array against a date column and fails at query time. It needs a date branch.",
@@ -170,6 +185,25 @@ func TestBothFilterSurfacesOfferTheSameOperators(t *testing.T) {
 				continue
 			}
 			findings = append(findings, fieldType+"/"+op+" — offered by one surface, refused by the other")
+		}
+	}
+	// Nothing either surface declares may go uncompared without being named. A
+	// type added to one matrix and not to correspondingTypes would otherwise
+	// escape the parity check entirely — the census would keep passing while
+	// covering less of the tree than it did yesterday.
+	defer unpairedKinds.AssertAllMatched(t)
+	paired := map[string]bool{}
+	for fieldType, kind := range correspondingTypes {
+		paired[fieldType], paired[kind] = true, true
+	}
+	for declared := range storekitOps {
+		if !paired[declared] && !unpairedKinds.Waived(t, declared) {
+			findings = append(findings, declared+" is declared by storekit and compared with nothing")
+		}
+	}
+	for declared := range searchOps {
+		if !paired[declared] && !unpairedKinds.Waived(t, declared) {
+			findings = append(findings, declared+" is declared by search and compared with nothing")
 		}
 	}
 	if compared < 5 {

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 22
+	wantFixtureAnnotations = 23
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/integration/predicate_integration_test.go
+++ b/backend/internal/compose/integration/predicate_integration_test.go
@@ -141,3 +141,76 @@ func TestPredicateEngineFiltersRealRowsWithinRowScope(t *testing.T) {
 		t.Errorf("team-scoped count on a foreign owner = %d, want 0 — a count must not confirm rows the caller cannot read", n)
 	}
 }
+
+// `neq` answers "everything that is not X", and a record whose column was never
+// set is not X. The engine compiles IS DISTINCT FROM so those rows are in the
+// answer; `<>` would have dropped every one of them under three-valued logic,
+// silently, on a filter a reader wrote to be exhaustive.
+//
+// The same reading already governed a linked field, where `neq` compiles to
+// NOT EXISTS and is true for a record with no linked row at all. This proves
+// the scalar column agrees with it against real rows rather than against a
+// golden string.
+func TestNeqReturnsTheRowsWhoseColumnWasNeverSet(t *testing.T) {
+	e := Setup(t)
+	// Seeded through the real writer, then the column is nulled: CreatePerson
+	// stamps the calling seat as owner when the body names none, so "seed with
+	// no owner" does NOT produce an unset column. A fixture that models the
+	// state by its name rather than its value proves nothing about it.
+	unowned := e.SeedPerson(t, "Nadia Nobody", nil)
+	mine := e.SeedPerson(t, "Owen Owner", &e.Rep1)
+	theirs := e.SeedPerson(t, "Tessa Theirs", &e.Rep3)
+
+	engine := storekit.Query{
+		Table:     "person",
+		Fields:    personFilterFields,
+		BaseWhere: "t.archived_at IS NULL",
+	}
+	admin := e.As(e.Rep3, []ids.UUID{e.Team1, e.Team2}, AdminPerms)
+	if err := database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
+		_, execErr := tx.Exec(admin, `UPDATE person SET owner_id = NULL WHERE id = $1`, unowned)
+		return execErr
+	}); err != nil {
+		t.Fatalf("nulling the owner: %v", err)
+	}
+	// The column really is unset. Without this the test would go on passing if
+	// the writer ever started filling it again, and would be asserting nothing.
+	var stillSet bool
+	if err := database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(admin, `SELECT owner_id IS NOT NULL FROM person WHERE id = $1`, unowned).Scan(&stillSet)
+	}); err != nil {
+		t.Fatalf("reading back the owner: %v", err)
+	}
+	if stillSet {
+		t.Fatal("the fixture row still carries an owner, so this test cannot see what neq does to an unset column")
+	}
+	selectIDs := func(p storekit.Predicate) map[ids.UUID]bool {
+		t.Helper()
+		got := map[ids.UUID]bool{}
+		err := database.WithWorkspaceTx(admin, e.Pool, func(tx pgx.Tx) error {
+			matched, err := engine.SelectIDs(admin, tx, p, 100)
+			for _, id := range matched {
+				got[id] = true
+			}
+			return err
+		})
+		if err != nil {
+			t.Fatalf("predicate select: %v", err)
+		}
+		return got
+	}
+
+	// The control: this seat sees all three rows and the field narrows on them.
+	// Without it, an empty `neq` answer would read as "unset rows excluded" when
+	// the real cause was a scope clause hiding everything.
+	if got := selectIDs(storekit.Predicate{Field: "owner_id", Op: storekit.OpEq, Value: e.Rep1.String()}); !got[mine] || got[unowned] || got[theirs] {
+		t.Fatalf("control eq(rep1) = %v, want exactly the row owned by rep1", got)
+	}
+
+	got := selectIDs(storekit.Predicate{Field: "owner_id", Op: storekit.OpNeq, Value: e.Rep3.String()})
+	for id, want := range map[ids.UUID]bool{unowned: true, mine: true, theirs: false} {
+		if got[id] != want {
+			t.Errorf("neq(rep3) selected %s = %v, want %v", id, got[id], want)
+		}
+	}
+}

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -406,6 +406,18 @@ func compileLeaf(p Predicate, fields map[string]Field, arg func(any) int, leaves
 		if err != nil {
 			return "", err
 		}
+		if p.Op == OpNeq {
+			// IS DISTINCT FROM rather than <>: a column that is UNSET is
+			// distinct from every value, and three-valued logic would otherwise
+			// drop those rows from an answer the caller reads as "everything
+			// that is not X".
+			//
+			// It is also what the rest of this package answers. A `neq` on a
+			// LINKED field compiles to NOT EXISTS(... = ...), which is true for a
+			// record with no linked row at all; `<>` here would make one operator
+			// mean two things depending on where the field lives.
+			return fmt.Sprintf("%s IS DISTINCT FROM $%d", field.Expr, arg(value)), nil
+		}
 		return fmt.Sprintf("%s %s $%d", field.Expr, comparisonSQL[p.Op], arg(value)), nil
 	}
 }

--- a/backend/internal/platform/database/storekit/predicate_test.go
+++ b/backend/internal/platform/database/storekit/predicate_test.go
@@ -82,7 +82,9 @@ func TestCompileGoldenSQLPerOperator(t *testing.T) {
 		wantArgs []any
 	}{
 		{"eq id", leaf("owner_id", OpEq, ownerUUID), "t.owner_id = $1", []any{ownerUUID}},
-		{"neq picklist", leaf("status", OpNeq, "lost"), "t.status <> $1", []any{"lost"}},
+		// IS DISTINCT FROM, not <>: a record whose status is unset is not "lost",
+		// and a caller reading "everything that is not lost" gets it.
+		{"neq picklist", leaf("status", OpNeq, "lost"), "t.status IS DISTINCT FROM $1", []any{"lost"}},
 		{"gt currency", leaf("amount_minor", OpGt, 5000.0), "t.amount_minor > $1", []any{int64(5000)}},
 		{"gte number int accepted", leaf("probability", OpGte, 40), "t.probability >= $1", []any{40.0}},
 		{"lt date", leaf("expected_close_date", OpLt, "2026-09-01"), "t.expected_close_date < $1", []any{"2026-09-01"}},

--- a/backend/internal/platform/database/storekit/predicateoperand.go
+++ b/backend/internal/platform/database/storekit/predicateoperand.go
@@ -19,8 +19,12 @@ import (
 
 // comparisonSQL is closed over the operator constants above; compileLeaf
 // only reaches it after the operator passed the typed matrix.
+//
+// `neq` is deliberately absent. It compiles to IS DISTINCT FROM, which is not a
+// comparison operator this table can hold, and leaving a `<>` here would offer
+// the next author the spelling that drops unset rows.
 var comparisonSQL = map[string]string{
-	OpEq: "=", OpNeq: "<>", OpGt: ">", OpGte: ">=", OpLt: "<", OpLte: "<=",
+	OpEq: "=", OpGt: ">", OpGte: ">=", OpLt: "<", OpLte: "<=",
 }
 
 // existsOperand validates the operand of an exists operator: must be


### PR DESCRIPTION
## The defect

Two surfaces answer a filtered question — the list/segment compiler in `storekit` and the query compiler in `search` — and a reader does not know which one served them. `owner_id neq <someone>` has to mean the same thing on both.

It did not:

| where | compiles to | a row whose column is unset |
|---|---|---|
| `search` | `col IS DISTINCT FROM $1` | **kept** |
| `storekit` **linked** field | `NOT EXISTS(... = ...)` | **kept** |
| `storekit` **scalar** field | `col <> $1` | **dropped** |

These are different **row sets**, not different spellings. Under three-valued logic `NULL <> 'x'` is NULL, so the row falls out of an answer the caller wrote to be exhaustive.

**storekit already disagreed with itself.** Its linked-field path reasons about exactly this and chooses to include absence — its docblock says so at length. So one operator meant two things inside one package depending on where the field lived.

**Nothing failed, because each side had a golden test asserting its own string and nothing compared the two.**

## The fix

storekit's scalar path compiles `IS DISTINCT FROM`. `OpNeq` is removed from the `comparisonSQL` table rather than left pointing at `<>`, so the spelling that drops unset rows is not sitting there for the next author.

## Blast radius — stored filters change membership, and that is the point

No Go code constructs a `neq` predicate. Every affected filter is **user-authored** and **persisted**: saved views, dynamic lists (re-evaluated from stored JSON on each read), filtered export, and preview counts. On deploy, a stored filter with `neq` on a **nullable** column gains the previously-excluded rows.

Worth being precise about which those are, because my own first framing was wrong: core `status`/`phase` picklists are `NOT NULL`, so `status neq lost` is exactly the case that does **not** change. The real carriers are **custom fields** (every `cf_` column is nullable) and nullable references — `person.owner_id`, `deal.organization_id`, `partner_org_id`.

A user who wants the old reading composes `neq X and exists:true`, which is now expressible and was not distinguishable before.

## The gates

**Vocabulary parity.** The two operator matrices are compared both ways, and every difference must be ratified with its reason. One surface offering an operator the other refuses may be right — but an undeclared difference is indistinguishable from an oversight.

**No NULL-dropping inequality in a filter compiler.** `<>` and `!=` both.

## Verification

`make check-backend` green. Full integration lane green — 43 packages, 3171 tests, **0 skips**.

The behavioural test runs against real rows and **its first version proved nothing**: seeding a person with no owner does not leave `owner_id` NULL, because the writer stamps the calling seat when the body names none. It passed against the defect. The column is nulled explicitly now and the test asserts the null *before* it asserts anything about the answer:

```
with <>                 neq(rep3) selected <unowned> = false, want true
with IS DISTINCT FROM   PASS
```

Every gate mutant was verified to apply and compile before its result was believed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `neq` NULL-safe across both filter compilers so rows with unset columns are kept. Previously, scalar `neq` in `storekit` used `<>` and dropped NULLs; now it compiles to `IS DISTINCT FROM`, matching `search` and linked-field behavior.

- Review notes
  - `storekit` scalar `neq` compiles to IS DISTINCT FROM; removed `OpNeq` from `comparisonSQL` to avoid `<>`.
  - Added a parity census that reads both vocabularies from code and flags undeclared differences; ratifies unpaired kinds (`KindTimestamp`, `KindGeo`), centralizes the `exists` rationale, and documents the boolean `neq` gap in `search`.
  - Gate forbids null-dropping inequality (`<>`/`!=`) in filter compilers and asserts at least one IS DISTINCT FROM rendering exists.
  - Integration test nulls `person.owner_id` and asserts the NULL before verifying results.

- Rollout impact
  - Stored user filters using `neq` on nullable columns (`cf_*`, `person.owner_id`, `deal.organization_id`, `partner_org_id`) will now include previously excluded rows; NOT NULL fields like `status`/`phase` are unchanged. To emulate the old read, use `neq X and exists:true`. This affects saved views, dynamic lists, exports, and preview counts.

<sup>Written for commit ed130d109929c6cd0159d919592f9581a07959bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated “not equal” filters to include records where the field is unset, while continuing to exclude records matching the specified value.
  * Improved consistency for “not equal” filtering across supported field types.

* **Tests**
  * Added coverage for unset fields, filter behavior, and consistency between filtering options.
  * Added validation to ensure documented filter capabilities remain aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->