### PR TITLE
fix(frontend): a project's company link opens the company

### DIFF
--- a/frontend/src/screens/projectcompanies.test.tsx
+++ b/frontend/src/screens/projectcompanies.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { parseHash } from "../app/router";
+import { LocaleProvider } from "../i18n";
+import { ProjectCompanies } from "./projectcompanies";
+
+// Every OTHER link in this tree spells a company `#/companies/<id>`; this
+// section is the one place that builds the href itself rather than taking
+// ProjectLinks' `#/projects/<id>` default, which is how it once spelled a
+// prefix the router does not answer. The oracle is parseHash — the router's own
+// entry point — so the assertion cannot drift from the route table the way a
+// hard-coded list of prefixes would.
+function renderSection(companies: readonly unknown[]) {
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider>
+        <ProjectCompanies
+          projectId="01a02e25-a5ac-7099-8099-581cbf001a99"
+          companies={
+            companies as Parameters<typeof ProjectCompanies>[0]["companies"]
+          }
+          readOnly
+        />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("the companies on a project", () => {
+  const netcare = {
+    organization_id: "01a02be9-2293-75d2-9dd2-3027d9b63dc2",
+    display_name: "netcare",
+    role: "customer",
+  };
+
+  it("links a company to an address the router answers", () => {
+    renderSection([netcare]);
+
+    // EVERY link the section draws for this company, not the first one: a
+    // section that renders two must not pass on the half that happens to work.
+    const links = screen.getAllByRole("link", { name: /netcare/ });
+    expect(links.length).toBeGreaterThan(0);
+
+    // The defect this holds: `#/organizations/<id>` parses to not-found, so the
+    // row rendered fine and the click landed on an empty page.
+    for (const link of links) {
+      const route = parseHash(link.getAttribute("href") ?? "");
+      expect(route.screen).not.toBe("not-found");
+      expect(route.id).toBe(netcare.organization_id);
+    }
+  });
+});

--- a/frontend/src/screens/projectcompanies.tsx
+++ b/frontend/src/screens/projectcompanies.tsx
@@ -85,7 +85,7 @@ export function ProjectCompanies({
       project_id: company.organization_id,
       name: company.display_name,
       phase: <Badge>{company.role}</Badge>,
-      href: `#/organizations/${company.organization_id}`,
+      href: `#/companies/${company.organization_id}`,
     })),
     readOnly,
     allowsMany: true,


### PR DESCRIPTION
Re-lands the fix whose contents #2514 lost.

## What was wrong

Clicking a company in the **Companies** section of a project page landed on "Not found".

The section built its own href as `#/organizations/<id>`. No route answers that first segment, so `parseHash` returns `not-found` and the router renders the empty page. Every other link to a company in this tree spells it `#/companies/<id>` — `blocked-domains.tsx`, `entityref`, `partners`, the palette.

Found by clicking it on a live stack, not by a gate.

## Why only here

`projectlinks.tsx:205` defaults to `#/projects/<id>`. `projectcompanies.tsx` is the only caller that overrides `href`, because it is the only one pointing at a company rather than a project. A tree-wide grep confirms it was the only occurrence.

Nothing caught it because the section had no test file at all.

## The test

`projectcompanies.test.tsx` asserts through `parseHash` — the router's own entry point — rather than a hard-coded list of valid prefixes, which would be a second copy of the route table and would go stale the first time somebody added a screen.

It checks **every** link the section renders rather than the first, so a section that grows a second link cannot pass on the half that happens to work.

Mutation-checked: reverting the one-line fix fails the test on exactly the intended assertion (`expected 'not-found' not to be 'not-found'`).

## Why #2514 did not carry this

#2514 merged with this commit message but six unrelated files — the agents/import work that a parallel session committed in the shared checkout while this branch was mid-flow. Neither of the two files below was in it. Verified before opening this PR that the pushed branch holds the corrected href and the test.

## Gates

`make check-fe` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the company links in a project’s Companies section so they open the company page. Previously the link used `#/organizations/<id>` and landed on Not found; it now uses `#/companies/<id>`.

- Changes a single href in `frontend/src/screens/projectcompanies.tsx`; other company links were already correct.
- Adds `frontend/src/screens/projectcompanies.test.tsx` to assert via `parseHash` that every rendered link resolves and carries the company id.
- No routing changes. No migrations or config updates required.

<sup>Written for commit 1efa5d7c4d36707825131f11ca5f92ac4812e4a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected project company links so they open the corresponding company profile instead of an invalid organization page.

- **Tests**
  - Added coverage to verify company links resolve correctly and preserve the associated company ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->