### PR TITLE
fix(agents): the import copy says an empty id means a new company

### DIFF
--- a/backend/internal/modules/agents/toolcopy_import.go
+++ b/backend/internal/modules/agents/toolcopy_import.go
@@ -14,7 +14,7 @@ var previewImportCopy = toolCopy{
 	Limits: "Writes nothing. People arrive as leads, so `object` is lead or organization. " +
 		"A row naming a company already here is counted in `duplicates`, and created unless " +
 		"on_duplicate is skip. To CORRECT companies rather than add them, map a column to " +
-		"`id` and give each row the id of the company it is — read them out first.",
+		"`id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add.",
 	Instead: "create_record for one record you already know.",
 	Retain:  "run_id, and `duplicates` — give the user both numbers before committing.",
 }

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -114,7 +114,7 @@ func (t previewImport) Spec() mcp.ToolSpec {
 			"object":{"type":"string","enum":["` + importObjectOrganization + `","` + importObjectLead + `"]},
 			"csv":{"type":"string","description":"The file's contents, header row first."},
 			"mapping":{"type":"object","additionalProperties":{"type":"string"},
-			  "description":"Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company each row IS — that row updates it instead of creating one."},
+			  "description":"Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add."},
 			"on_duplicate":{"type":"string","enum":["` + importOnDuplicateCreate + `","` + importOnDuplicateSkip + `"],
 			  "description":"A company already here: create (default) lands a second; skip leaves the incumbent."}},
 			"additionalProperties":false}`),

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 56,
-    "tokens": 17063,
+    "tokens": 17106,
     "median_tool_tokens": 281,
-    "mean_tool_tokens": 304
+    "mean_tool_tokens": 305
   },
   "agents": [
     {
@@ -109,6 +109,10 @@
       "tokens": 402
     },
     {
+      "name": "preview_import",
+      "tokens": 396
+    },
+    {
       "name": "search_records",
       "tokens": 392
     },
@@ -119,10 +123,6 @@
     {
       "name": "enrich",
       "tokens": 386
-    },
-    {
-      "name": "preview_import",
-      "tokens": 353
     },
     {
       "name": "search_context",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2190 | 9% | 14810 | 14 | 8 |
-| _whole served catalog, for scale_ | 56 | 17063 | 71% | — | — | — |
+| _whole served catalog, for scale_ | 56 | 17106 | 71% | — | — | — |
 
 ### `morning_brief`
 
@@ -118,7 +118,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 281 tokens, mean 304, across 56 served tools.
+Median 281 tokens, mean 305, across 56 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -138,10 +138,10 @@ a term in an addition.
 | `progress_deal` | 435 | 3 scenarios |
 | `book_meeting` | 431 | — |
 | `query_workspace` | 402 | 3 scenarios |
+| `preview_import` | 396 | — |
 | `search_records` | 392 | 6 scenarios |
 | `create_record` | 391 | 1 scenario |
 | `enrich` | 386 | — |
-| `preview_import` | 353 | — |
 | `search_context` | 352 | — |
 | `prep_for_meeting` | 333 | — |
 | `merge_records` | 323 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 155916,
+    "tool_catalog_bytes": 156087,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39756,
+    "approx_wire_tokens_total": 39798,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 35655,
-      "input_schema_bytes": 34470,
+      "description_bytes": 35742,
+      "input_schema_bytes": 34554,
       "output_schema_bytes": 73753,
-      "description_plus_input_schema_bytes": 70125
+      "description_plus_input_schema_bytes": 70296
     }
   },
   "tools": {
@@ -5108,7 +5108,7 @@
           "readOnlyHint": false,
           "title": "Preview an import"
         },
-        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. To CORRECT companies rather than add them, map a column to `id` and give each row the id of the company it is — read them out first. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. To CORRECT companies rather than add them, map a column to `id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5125,7 +5125,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company each row IS — that row updates it instead of creating one.",
+              "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add.",
               "type": "object"
             },
             "object": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 56 |
 | Resources | 8 |
-| Tool catalog | 152.3 KB |
+| Tool catalog | 152.4 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39756 |
+| Approx. wire tokens | 39798 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,10 +30,10 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
 | Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 34.8 KB | 22% | Yes, every step |
+| Descriptions (incl. governance clause) | 34.9 KB | 22% | Yes, every step |
 | Input schemas | 33.7 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
-| **Description + input schema** | **68.5 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **68.6 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -89,7 +89,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
-| [`preview_import`](#preview_import) | Preview an import |  |  | 2.8 KB |
+| [`preview_import`](#preview_import) | Preview an import |  |  | 2.9 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
@@ -5636,7 +5636,7 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
 
 **Preview an import**
 
-Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. To CORRECT companies rather than add them, map a column to `id` and give each row the id of the company it is — read them out first. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
+Bring a spreadsheet in: send the CSV as text and this checks every row against the workspace and reports what importing it would do. Writes nothing. People arrive as leads, so `object` is lead or organization. A row naming a company already here is counted in `duplicates`, and created unless on_duplicate is skip. To CORRECT companies rather than add them, map a column to `id`, then give a row the id of the company it corrects — read them out first. A row whose `id` is EMPTY is a new company, so one file may both correct and add. create_record for one record you already know. run_id, and `duplicates` — give the user both numbers before committing. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -5657,7 +5657,7 @@ Bring a spreadsheet in: send the CSV as text and this checks every row against t
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company each row IS — that row updates it instead of creating one.",
+      "description": "Source column name → field name. Omit to accept the proposal this call would make. Map a column to \"id\" to name the company a row corrects: that row updates it instead of creating one. A row whose \"id\" is empty is a new company, so one file may both correct and add.",
       "type": "object"
     },
     "object": {


### PR DESCRIPTION
## What went wrong

`preview_import` told a caller to *"give each row the id of the company it is"*.
That reads as every row needing an id, and nothing anywhere said an empty one is
allowed.

Connected through claude.ai on 2026-08-24 against main, the model read it
literally and **split a four-row file into two runs** — one for the rows with
ids, one for the row without — because it believed a file carrying an `id`
column would skip the new company rather than create it.

It does not. An empty id is an ordinary create, and the mixed file was already
covered by `TestCSVImportByIDTreatsAnEmptyIDAsANewCompany` and verified
hands-on: `created 1, updated 1, skipped 1` over 3 rows read.

The code was right and the sentence was wrong, so the model worked around a
limit that does not exist. It reached the correct result by a route no caller
should need.

## The change

Copy only — no behaviour changes.

- `toolcopy_import.go`: "give a row the id of the company it corrects … A row
  whose `id` is EMPTY is a new company, so one file may both correct and add."
- `tools_import.go`: the same fact on the `mapping` field description, which is
  where a caller looks when deciding what to map.
- Regenerated `docs/reference/mcp-info.*` and `agent-tool-budget.*`.

`docs/how-to/import-a-company-spreadsheet.md` already stated this correctly.
Only the copy an agent actually reads was missing it.

## Gates

`make check-backend` (drift included), `craft-static`, `rls-store-path`,
`no-jurisdiction` all green.

## Found in the same session

Issue #2513 — import auto-mapping proposes only the `id` column and silently
drops every data column, producing an import that validates clean and writes
nothing. Separate subsystem, not fixed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `preview_import` copy to state that an empty id creates a new company and a single file may both update existing companies and add new ones. The old copy implied every row needed an id; behavior remains unchanged.

- Review notes: Only copy changed in `backend/internal/modules/agents/toolcopy_import.go` and `backend/internal/modules/agents/tools_import.go`. API shape is unchanged; descriptions now say “A row whose id is empty is a new company.” Reference docs (`docs/reference/mcp-info.*`, `docs/reference/agent-tool-budget.*`) were regenerated; expect token/size diffs only.

<sup>Written for commit 947408b115e0303798ec71cb3978a7f7d052832e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import previews now clearly support mixed operations: populated IDs update existing companies, while blank IDs create new companies.

- **Documentation**
  - Updated import guidance and mapping descriptions to explain the new behavior.
  - Refreshed tool catalog metrics and preview documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->