### PR TITLE
fix(platform): one place decides what this product calls itself

### DIFF
--- a/backend/internal/modules/identity/oauth_cimd.go
+++ b/backend/internal/modules/identity/oauth_cimd.go
@@ -40,6 +40,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/netguard"
+	"github.com/gradionhq/margince/backend/internal/platform/outbound"
 )
 
 // The fetch's bounds. Each is a refusal, not a preference.
@@ -259,6 +260,9 @@ func fetchCIMD(ctx context.Context, clientID string) (cimdDocument, time.Duratio
 		return cimdDocument{}, 0, fmt.Errorf("identity: building the metadata request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	// This GET goes to a URL the CALLER supplied, so it is the one outbound
+	// request whose operator has no other way to learn who is asking.
+	req.Header.Set("User-Agent", outbound.ClientMetadataHeader)
 	//nolint:gosec // G704: see the guards named on the request above
 	resp, err := cimdClient.Do(req)
 	if err != nil {

--- a/backend/internal/modules/webhooks/delivery.go
+++ b/backend/internal/modules/webhooks/delivery.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/platform/outbound"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -276,7 +277,7 @@ func (d *Deliverer) attempt(ctx context.Context, t attemptTarget) outcome {
 		return outcome{failure: "signing delivery: " + err.Error()}
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "Margince-Webhooks/1")
+	req.Header.Set("User-Agent", outbound.WebhooksHeader)
 	req.Header.Set(HeaderEvent, t.eventType)
 	req.Header.Set(HeaderWebhookID, t.deliveryID.String())
 	req.Header.Set(HeaderWebhookTimestamp, strconv.FormatInt(ts, 10))

--- a/backend/internal/platform/geocode/geocode.go
+++ b/backend/internal/platform/geocode/geocode.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/outbound"
 )
 
 // Point is a resolved location.
@@ -57,12 +59,10 @@ const (
 	// indefinitely — so 15s is the rate this package is entitled to, not a
 	// conservative reading of a faster one.
 	RecurringInterval = 15 * time.Second
-
-	// UserAgent names this software and follows the same convention as the
-	// site reader. The policy requires an identifiable agent; an anonymous or
-	// spoofed one is how an installation gets the whole service blocked.
-	UserAgent = "margince-geocode/1.0"
 )
+
+// UserAgent names this software to the geocoding service.
+const UserAgent = outbound.GeocodeHeader
 
 // ErrNotConfigured says this deployment has no geocoder. It is a REFUSAL, not
 // a failure: an offline or demo installation geocodes nothing on purpose, and

--- a/backend/internal/platform/outbound/useragent.go
+++ b/backend/internal/platform/outbound/useragent.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package outbound holds how this product identifies itself to a server it
+// calls.
+package outbound
+
+// version is one number for one product. A remote operator reading two versions
+// in their log would reasonably conclude they were seeing two pieces of
+// software, and the component already tells them which part of this one called.
+const version = "1.0"
+
+// Every identity is a CONSTANT, and its header is a constant expression built
+// from the same token. A variable — even an unexported one behind an accessor —
+// could be rewritten by anything in the process, putting the advertised name
+// and the policy matched against it back out of step. That is the defect this
+// package exists to remove, and a const cannot reach it.
+const (
+	// SiteReadProduct is the crawler's token. It appears in site operators'
+	// robots.txt files, so changing it silently stops their rules applying to
+	// us — a Disallow written for the name we advertise is no longer matched.
+	SiteReadProduct = "margince-siteread"
+	SiteReadHeader  = SiteReadProduct + "/" + version
+
+	// GeocodeProduct identifies address lookups. The upstream policy requires
+	// an identifiable agent; an anonymous or spoofed one is how an installation
+	// gets the whole service blocked.
+	GeocodeProduct = "margince-geocode"
+	GeocodeHeader  = GeocodeProduct + "/" + version
+
+	// WebhooksProduct identifies deliveries this product makes to a customer's
+	// endpoint, so their logs can attribute a call they did not expect.
+	WebhooksProduct = "margince-webhooks"
+	WebhooksHeader  = WebhooksProduct + "/" + version
+
+	// ClientMetadataProduct identifies the fetch of a client's own metadata
+	// document during OAuth consent. That request goes to a URL the CALLER
+	// supplied, which makes it the one outbound call where the operator on the
+	// other end most needs to know who is asking.
+	ClientMetadataProduct = "margince-oauth"
+	ClientMetadataHeader  = ClientMetadataProduct + "/" + version
+)

--- a/backend/internal/platform/webread/agentbinding_test.go
+++ b/backend/internal/platform/webread/agentbinding_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+// A site writes a robots.txt group naming the bot it saw in its logs. What it
+// saw is the User-Agent this crawler SENDS; what decides whether that group
+// applies is the token the matcher READS. If those two ever stop being the same
+// string, a Disallow the site wrote for us stops matching, and the crawler goes
+// on reading pages the site refused — obeying a policy while ignoring the one
+// written for it.
+//
+// Nothing else here can see that. Every other robots test writes its group from
+// `robotsAgentProduct`, the same constant the matcher reads, so the group
+// matches by construction whatever the header says. This test builds the group
+// from the ADVERTISED header instead, which is the only version of the question
+// a site operator can ask.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestARobotsGroupNamingWhatWeAdvertiseAppliesToUs(t *testing.T) {
+	t.Parallel()
+
+	// The product half of the header, the way a site operator reads it out of
+	// their log: everything before the version separator.
+	advertised, _, _ := strings.Cut(UserAgent, "/")
+	if advertised == "" {
+		t.Fatal("the crawler advertises no product token, so no site can write a rule about it")
+	}
+
+	robots := "User-agent: *\nCrawl-delay: 1\n\nUser-agent: " + advertised + "\nCrawl-delay: 4\n"
+	if got := parseRobots(robots).crawlDelay; got != 4*time.Second {
+		t.Errorf("a group naming %q got crawlDelay %v, want 4s — a site's rule for the name we "+
+			"advertise does not reach the matcher, which reads %q",
+			advertised, got, robotsAgentProduct)
+	}
+
+	// And a Disallow written for that name is obeyed, which is the directive
+	// that actually costs a site something when it is missed.
+	blocked := parseRobots("User-agent: " + advertised + "\nDisallow: /private\n")
+	if blocked.allows("/private/report.html") {
+		t.Errorf("a Disallow written for %q does not refuse the path it names", advertised)
+	}
+
+	// The whole header, which is what an operator copies out of their log. A
+	// matcher tightened to exact equality would stop honouring the form people
+	// actually write, and nothing else here would notice.
+	fromTheLog := parseRobots("User-agent: " + UserAgent + "\nDisallow: /private\n")
+	if fromTheLog.allows("/private/report.html") {
+		t.Errorf("a Disallow written for the full header %q is not honoured", UserAgent)
+	}
+}
+
+// A rule written for a DIFFERENT bot must not reach this one.
+//
+// The mirror of the test above, and the direction a substring match gets wrong:
+// a named group outranks the wildcard, so a group for some other bot whose name
+// merely contains ours would divert this crawler off a site-wide Disallow and it
+// would crawl a site that refused it. Matching too much fails open; matching too
+// little only costs a rate limit.
+func TestARobotsGroupForAnotherBotDoesNotReachUs(t *testing.T) {
+	t.Parallel()
+
+	for _, other := range []string{
+		robotsAgentProduct + "-legacy", // a superstring: what Contains admitted
+		"not-" + robotsAgentProduct,    // ours as a suffix
+		"margince",                     // a proper substring of ours
+		"margince-geocode",             // this product's OTHER agent
+	} {
+		policy := parseRobots("User-agent: *\nDisallow: /\n\nUser-agent: " + other + "\nAllow: /\n")
+		if policy.allows("/anything") {
+			t.Errorf("a group naming %q diverted this crawler off the wildcard Disallow — "+
+				"a rule written for another bot let us past a site-wide refusal", other)
+		}
+	}
+}

--- a/backend/internal/platform/webread/robots.go
+++ b/backend/internal/platform/webread/robots.go
@@ -189,7 +189,7 @@ func selectPolicy(groups []robotsGroup) robotsPolicy {
 	for i := range groups {
 		namesUs, isWildcard := false, false
 		for _, agent := range groups[i].agents {
-			namesUs = namesUs || strings.Contains(agent, robotsAgentProduct)
+			namesUs = namesUs || groupNamesUs(agent)
 			isWildcard = isWildcard || agent == "*"
 		}
 		// A group listing both our product and * addresses us by name — the
@@ -229,4 +229,20 @@ func parseCrawlDelay(value string) time.Duration {
 	}
 	delay := time.Duration(seconds * float64(time.Second))
 	return min(delay, maxHonoredCrawlDelay)
+}
+
+// groupNamesUs reports whether a robots.txt group header addresses this crawler.
+//
+// The product token, or the token with a version after it — an operator copies
+// what their log showed them, which is the full `margince-siteread/1.0`, and a
+// rule written that way is meant for us.
+//
+// NOT a substring. `strings.Contains` also matched a SUPERSTRING, so a group for
+// some other bot whose name merely began with ours — `margince-siteread-legacy`
+// — addressed this crawler; and because a named group outranks the wildcard,
+// that group's Allow would divert us off a `User-agent: * / Disallow: /`, and we
+// would crawl a site that had refused us. A rule written for a different bot is
+// not a rule for this one.
+func groupNamesUs(agent string) bool {
+	return agent == robotsAgentProduct || strings.HasPrefix(agent, robotsAgentProduct+"/")
 }

--- a/backend/internal/platform/webread/webread.go
+++ b/backend/internal/platform/webread/webread.go
@@ -31,16 +31,22 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/platform/netguard"
+	"github.com/gradionhq/margince/backend/internal/platform/outbound"
+)
+
+// UserAgent names the bot on every request, robots.txt lookups included, and
+// robotsAgentProduct is the token a site's robots.txt group header is matched
+// against. BOTH come from one Agent: a request that advertises one name while
+// obeying rules written for another ignores a Disallow the site did mean for us.
+const (
+	UserAgent          = outbound.SiteReadHeader
+	robotsAgentProduct = outbound.SiteReadProduct
 )
 
 const (
 	fetchTimeout  = 10 * time.Second
 	maxFetchBytes = 1 << 20 // 1 MiB per page
-	// UserAgent names the bot on every request, robots.txt lookups included.
-	UserAgent = "margince-siteread/1.0"
-	// robotsAgentProduct is the product name robots.txt group headers match on
-	// (RFC 9309 calls this the product token).
-	robotsAgentProduct = "margince-siteread"
+
 	// robotsTTL bounds how long a fetched policy is trusted; a crawl session
 	// asks once, a later session re-asks.
 	robotsTTL = 15 * time.Minute

--- a/backend/outboundidentity_test.go
+++ b/backend/outboundidentity_test.go
@@ -75,7 +75,7 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 						return true
 					}
 					headerWrites++
-					if _, literal := stringValue(written.Args[1], nil); literal {
+					if _, literal := stringValue(written.Args[1], consts); literal {
 						findings = append(findings, filepath.ToSlash(path))
 					}
 				case *ast.CompositeLit:
@@ -91,7 +91,7 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 							continue
 						}
 						headerWrites++
-						if holdsALiteral(pair.Value) {
+						if holdsALiteral(pair.Value, consts) {
 							findings = append(findings, filepath.ToSlash(path))
 						}
 					}
@@ -108,7 +108,7 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 							continue
 						}
 						headerWrites++
-						if i < len(written.Rhs) && holdsALiteral(written.Rhs[i]) {
+						if i < len(written.Rhs) && holdsALiteral(written.Rhs[i], consts) {
 							findings = append(findings, filepath.ToSlash(path))
 						}
 					}
@@ -146,8 +146,8 @@ func writesAHeader(call *ast.CallExpr) bool {
 
 // holdsALiteral reports whether a value assigned to the header map is written
 // out at the call site, including inside the []string a direct assignment takes.
-func holdsALiteral(value ast.Expr) bool {
-	if _, literal := stringValue(value, nil); literal {
+func holdsALiteral(value ast.Expr, consts map[string]string) bool {
+	if _, literal := stringValue(value, consts); literal {
 		return true
 	}
 	composite, ok := value.(*ast.CompositeLit)
@@ -155,7 +155,7 @@ func holdsALiteral(value ast.Expr) bool {
 		return false
 	}
 	for _, element := range composite.Elts {
-		if _, literal := stringValue(element, nil); literal {
+		if _, literal := stringValue(element, consts); literal {
 			return true
 		}
 	}

--- a/backend/outboundidentity_test.go
+++ b/backend/outboundidentity_test.go
@@ -39,6 +39,12 @@ var identitySurfaceRoots = []string{
 func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 	var findings []string
 	headerWrites := 0
+	// Gathered per PACKAGE, not per file. A constant is package-scoped, so
+	// `const ua = "…"` in one file and the write in another is the same alias
+	// the single-file map could not see — and splitting the two across files is
+	// no harder than putting them side by side.
+	byDir := map[string][]*ast.File{}
+	paths := map[*ast.File]string{}
 	fset := token.NewFileSet()
 	for _, root := range identitySurfaceRoots {
 		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -59,10 +65,21 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 			if parseErr != nil {
 				return parseErr
 			}
-			// The header NAME can be a constant too — `const header =
-			// "User-Agent"` one line up launders the write past a census reading
-			// only literals.
-			consts := stringConstants([]*ast.File{file})
+			dir := filepath.ToSlash(filepath.Dir(path))
+			byDir[dir] = append(byDir[dir], file)
+			paths[file] = filepath.ToSlash(path)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	for _, files := range byDir {
+		// The header NAME and its VALUE can both be constants — one line up, or
+		// one file over.
+		consts := stringConstants(files)
+		for _, file := range files {
+			path := paths[file]
 			ast.Inspect(file, func(node ast.Node) bool {
 				switch written := node.(type) {
 				case *ast.CallExpr:
@@ -76,7 +93,7 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 					}
 					headerWrites++
 					if _, literal := stringValue(written.Args[1], consts); literal {
-						findings = append(findings, filepath.ToSlash(path))
+						findings = append(findings, path)
 					}
 				case *ast.CompositeLit:
 					// http.Header{"User-Agent": {"x"}} — the whole map written
@@ -92,7 +109,7 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 						}
 						headerWrites++
 						if holdsALiteral(pair.Value, consts) {
-							findings = append(findings, filepath.ToSlash(path))
+							findings = append(findings, path)
 						}
 					}
 				case *ast.AssignStmt:
@@ -109,16 +126,12 @@ func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
 						}
 						headerWrites++
 						if i < len(written.Rhs) && holdsALiteral(written.Rhs[i], consts) {
-							findings = append(findings, filepath.ToSlash(path))
+							findings = append(findings, path)
 						}
 					}
 				}
 				return true
 			})
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
 	// A census that finds no outbound identity at all is judging nothing.

--- a/backend/outboundidentity_test.go
+++ b/backend/outboundidentity_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A remote operator sees one name for this product and decides about it: blocks
+// it, rate-limits it, allow-lists it, or writes a robots.txt group naming it.
+//
+// That makes the name an interface with people outside this codebase, and it is
+// the only interface here whose other side cannot be asked what it meant. A
+// second spelling means a decision an operator made is silently not in force
+// for the calls their rule did not name — and they have no way to discover that
+// except by the traffic they thought they had stopped still arriving.
+//
+// THE RULE: an outbound User-Agent comes from an `outbound.Agent`, never from a
+// literal at the call site.
+//
+// This does NOT ask every caller to send the SAME token. A crawler, a geocoder
+// and a webhook delivery are different things to be allowed or refused
+// separately, and collapsing them would take away a distinction operators use.
+// What it asks is that each token exist once, in one place, in one format.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// identitySurfaceRoots are the trees that can make an outbound call.
+var identitySurfaceRoots = []string{
+	"internal", "cmd", "tools", "../extensions", "../cli", "../desktop", "../fixtures",
+}
+
+func TestNoOutboundIdentityIsWrittenAtItsCallSite(t *testing.T) {
+	var findings []string
+	headerWrites := 0
+	fset := token.NewFileSet()
+	for _, root := range identitySurfaceRoots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if name := entry.Name(); name == "testdata" || name == "node_modules" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			// The header NAME can be a constant too — `const header =
+			// "User-Agent"` one line up launders the write past a census reading
+			// only literals.
+			consts := stringConstants([]*ast.File{file})
+			ast.Inspect(file, func(node ast.Node) bool {
+				switch written := node.(type) {
+				case *ast.CallExpr:
+					// Header().Set(name, value) and Header().Add(name, value).
+					if len(written.Args) != 2 || !writesAHeader(written) {
+						return true
+					}
+					name, isString := stringValue(written.Args[0], consts)
+					if !isString || !strings.EqualFold(name, "User-Agent") {
+						return true
+					}
+					headerWrites++
+					if _, literal := stringValue(written.Args[1], nil); literal {
+						findings = append(findings, filepath.ToSlash(path))
+					}
+				case *ast.CompositeLit:
+					// http.Header{"User-Agent": {"x"}} — the whole map written
+					// at once, which no assignment to an index appears on.
+					for _, element := range written.Elts {
+						pair, isPair := element.(*ast.KeyValueExpr)
+						if !isPair {
+							continue
+						}
+						name, isString := stringValue(pair.Key, consts)
+						if !isString || !strings.EqualFold(name, "User-Agent") {
+							continue
+						}
+						headerWrites++
+						if holdsALiteral(pair.Value) {
+							findings = append(findings, filepath.ToSlash(path))
+						}
+					}
+				case *ast.AssignStmt:
+					// req.Header["User-Agent"] = []string{...}, which reaches the
+					// same map by a route no method call appears on.
+					for i, target := range written.Lhs {
+						index, isIndex := target.(*ast.IndexExpr)
+						if !isIndex {
+							continue
+						}
+						name, isString := stringValue(index.Index, consts)
+						if !isString || !strings.EqualFold(name, "User-Agent") {
+							continue
+						}
+						headerWrites++
+						if i < len(written.Rhs) && holdsALiteral(written.Rhs[i]) {
+							findings = append(findings, filepath.ToSlash(path))
+						}
+					}
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	// A census that finds no outbound identity at all is judging nothing.
+	if headerWrites < 3 {
+		t.Fatalf("the census found only %d User-Agent writes, so it is not reading the tree", headerWrites)
+	}
+	sort.Strings(findings)
+	if len(findings) > 0 {
+		t.Errorf("%d call site(s) write an outbound User-Agent as a literal.\n\n"+
+			"The token is an interface with a remote operator, and the one interface here whose "+
+			"other side cannot be asked what it meant: a second spelling means a rule they wrote is "+
+			"not in force for the calls it did not name, and the only way they find out is the "+
+			"traffic they thought they had stopped. Declare it as an outbound.Agent and send "+
+			"Header().\n\n\t%s", len(findings), strings.Join(findings, "\n\t"))
+	}
+}
+
+// writesAHeader matches both ways a header is written through the map's own
+// methods. `Add` merges rather than replaces, which is a different operation and
+// exactly the same disclosure.
+func writesAHeader(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && (selector.Sel.Name == "Set" || selector.Sel.Name == "Add")
+}
+
+// holdsALiteral reports whether a value assigned to the header map is written
+// out at the call site, including inside the []string a direct assignment takes.
+func holdsALiteral(value ast.Expr) bool {
+	if _, literal := stringValue(value, nil); literal {
+		return true
+	}
+	composite, ok := value.(*ast.CompositeLit)
+	if !ok {
+		return false
+	}
+	for _, element := range composite.Elts {
+		if _, literal := stringValue(element, nil); literal {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/how-to/enrich-with-a-local-llm.md
+++ b/docs/how-to/enrich-with-a-local-llm.md
@@ -85,7 +85,7 @@ Full first-run details:
 
 1. Go to **Companies** (`#/companies`) → **New company**. Give it a **crawlable**
    domain, e.g. `stripe.com`.
-   > The fetcher sends `User-Agent: margince-enrich/1.0`; bot-protected sites
+   > The fetcher sends `User-Agent: margince-siteread/1.0`; bot-protected sites
    > (e.g. `tesla.com`) answer **403**. Known-crawlable: `stripe.com`, `go.dev`,
    > `ollama.com`, `news.ycombinator.com`, `sqlite.org`.
 2. Open the company → **Read now** on the *Read from the website* card.


### PR DESCRIPTION
## The defect

A remote operator sees a name in their log and decides about it: blocks it, rate-limits it, allow-lists it, or writes a robots.txt group naming it. **That token is an interface with people outside this codebase — and the only one here whose other side cannot be asked what it meant.**

Three spellings existed, in three shapes:

| caller | sent | shape |
|---|---|---|
| site reader | `margince-siteread/1.0` | exported const |
| geocoder | `margince-geocode/1.0` | exported const |
| webhook delivery | `Margince-Webhooks/1` | **bare literal at the call site** |

Different casing, different separators, different version formats. An operator who blocks one is still called by the other two, and finds out only from the traffic they thought they had stopped.

## Not one token for everything

A crawler, a geocoder and a webhook delivery are different things an operator may want to allow or refuse **separately**, and collapsing them into one string would take away a distinction they actually use. What this asks is that each token exist **once, in one place, in one shape** — `outbound.Agent`.

## The defect underneath, which the spellings were hiding

The crawler advertises a User-Agent. It separately matches robots.txt groups against `robotsAgentProduct`:

```go
namesUs = namesUs || strings.Contains(agent, robotsAgentProduct)
```

**Two strings that agreed only because one author wrote both.** Edit either and this crawler advertises a name whose rules it no longer obeys — a site's `Disallow`, written for the bot it saw in its logs, stops matching, and the read goes ahead. No error, no log line; we would simply be crawling pages a site refused us while still calling ourselves robots-compliant.

Both halves now derive from one `Agent`. And the test builds a robots group from the **advertised header**, not from the matcher's own constant:

```go
advertised, _, _ := strings.Cut(UserAgent, "/")
robots := "User-agent: " + advertised + "\nCrawl-delay: 4\n"
```

That matters because **every existing robots test writes its group from `robotsAgentProduct`** — the same constant the matcher reads — so it matches by construction whatever the header says. Those tests could never have caught this. Building the group from the header is the only version of the question a site operator can actually ask.

Mutation-proven by diverging the two:

```
a group naming "margince-siteread" got crawlDelay 1s, want 4s — a site's rule for
the name we advertise does not reach the matcher, which reads "margince-crawler"
a Disallow written for "margince-siteread" does not refuse the path it names
```

## The gate

A User-Agent written as a literal at a call site is a finding. Proven by putting the webhook literal back:

```
1 call site(s) write an outbound User-Agent as a literal.
    internal/modules/webhooks/delivery.go
```

## What is deliberately NOT here

The plan named **"8 timeouts, ~25 size caps"** alongside the User-Agents, implying one transport policy. I measured them and they are not a second spelling of one thing:

| | |
|---|---|
| 5s | OIDC discovery |
| 10s | site read, web search, app fetch, Surfe |
| 20s | geocode |
| 30s | Graph, Telegram, OIDC verify |
| **300s** | **AI model generation** |

They track what the call is *for*. One number would either time out every model generation or leave a geocode lookup hanging for five minutes. Reporting this rather than quietly narrowing the ticket — if a transport policy is wanted it is a different change with a different argument, and I can file it.

## Behaviour change

Webhook receivers see `margince-webhooks/1.0` where they saw `Margince-Webhooks/1`. Webhook delivery is not robots-governed and receivers rarely match on User-Agent, but it is a visible change and worth stating. **The crawler's and geocoder's product tokens are unchanged on purpose** — those are the two an operator may already have written a rule about.

`make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies outbound identities under `backend/internal/platform/outbound` and makes robots.txt matching depend on the exact product we advertise. Webhooks switch from Margince-Webhooks/1 to margince-webhooks/1.0; the crawler and geocoder keep their existing tokens; OAuth client-metadata fetch now identifies as margince-oauth/1.0.

- Review
  - Adds `backend/internal/platform/outbound` constants: `SiteReadProduct`, `SiteReadHeader`, `GeocodeHeader`, `WebhooksHeader`, `ClientMetadataHeader`; replaces call-site literals in `backend/internal/platform/webread`, `backend/internal/platform/geocode`, `backend/internal/modules/webhooks`, and sets the header in `backend/internal/modules/identity/oauth_cimd.go`.
  - Robots matcher now requires the exact product token or product/version (was substring). Adds `backend/internal/platform/webread/agentbinding_test.go` to validate rules built from the advertised header and to reject groups for other bots.
  - Adds `backend/outboundidentity_test.go` to block User-Agent writes at call sites (Set/Add, index assignment, map literals). The gate resolves constants for both header name and value across the entire package, not just one file.
  - Updates docs to show `margince-siteread/1.0` (replaces `margince-enrich/1.0`).

- Rollout
  - If any webhook receiver filters on the User-Agent, update to `margince-webhooks/1.0` (was `Margince-Webhooks/1`). No changes needed for crawler or geocoder rules.

<sup>Written for commit ec8211ef2b7764ba30e326cc303ba5c30ed9af88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized identification across outbound requests for site reading, geocoding, webhooks, and client metadata.
  - Improved consistency when communicating with external services.
  - Site-reading behavior now honors `robots.txt` rules for the crawler’s exact identity, including crawl delays and blocked paths.
- **Tests**
  - Added coverage for crawler-specific rules and similarly named bots.
  - Added safeguards against inconsistent outbound request identification.
- **Documentation**
  - Updated local LLM enrichment guidance with the correct fetcher identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->