### PR TITLE
fix(frontend): the overlay AC counts the panels that exist

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1007,9 +1007,14 @@ test.describe("B-EP09.23: overlay mode", () => {
     await expect(page.getByTestId("person-strip")).toBeVisible();
     await expect(page.getByText(errorBox)).toHaveCount(0);
 
-    // Deal 360: timeline, coverage, stakeholders, offers, and the context
-    // panel. Coverage joins the interaction projection too, so it is
-    // unavailable for the same reason rather than reporting a clean deal.
+    // Deal 360: timeline, coverage, offers, and the context panel. Coverage
+    // joins the interaction projection too, so it is unavailable for the same
+    // reason rather than reporting a clean deal.
+    //
+    // FOUR, not five: stakeholders is no longer a panel of its own. The seats
+    // and the findings about them are one card now, and that card states the
+    // overlay case itself — so the stakeholder fact is still refused honestly,
+    // it is refused by the coverage card rather than beside it.
     await page.goto("/#/deals/d-fleet");
     // `exact`, and this is the case that shows why: another test in this file
     // renames the same deal to "Fleet retrofit — expanded scope", and a
@@ -1021,7 +1026,7 @@ test.describe("B-EP09.23: overlay mode", () => {
         exact: true,
       }),
     ).toBeVisible();
-    await expect(page.getByText(unavailable)).toHaveCount(5);
+    await expect(page.getByText(unavailable)).toHaveCount(4);
     await expect(page.getByText(errorBox)).toHaveCount(0);
 
     // Tasks (nav.tasks): a defining `kind=task` filter the mirror can't honor.


### PR DESCRIPTION
## The uat lane has been red on main since 01:22

Nothing reported it, because `uat` is not a required check and `main-health` cannot see that lane (#2325). I found it by checking a merged PR's own checks.

```
1) e2e/ac.spec.ts:980:3 › AC-overlay-7: every 360 panel renders its unavailable state, never an error box
   Locator: getByText('In der HubSpot-Ansicht nicht verfügbar')
   Expected: 5
   Received: 4
```

**#2507** merged with this failing at 01:22, and **#2515** inherited it at 02:24 — the identical failure, which is how I know #2515 did not cause it. Reproduced locally on clean `origin/main` before changing anything.

## The test is stale, not the code

#2507 removed the standalone Stakeholders card on purpose and folded it into `DealCoverageCard`. Its own comment says why:

> There used to be a second "Stakeholders" card below this one; it read the /stakeholders relationship rows, which carry a person_id and no name, so a real stakeholder rendered as the bare word `economic_buyer`. The coverage seats carry the name and whether the person is actually engaged.

So Deal 360 has four unavailable panels, not five. **The count follows the product, not the other way round.** The stakeholder fact is still refused honestly in overlay — refused *by* the coverage card rather than beside it, and that card states the overlay case itself.

## What changed

The expectation, and the comment above it. The comment previously enumerated "timeline, coverage, stakeholders, offers, and the context panel"; it now names the four that exist and says why stakeholders is not among them — so the next reader who merges two cards changes a sentence rather than only a digit.

## Evidence

Reproduced on `origin/main` (`9a868d3`), fixed, then the whole lane run locally, not just the one test:

```
AC-overlay grep:  8 passed (3.4s)
full playwright:  94 passed, 14 skipped (21.6s)
```

`make check-fe` exits 0.

## Worth noting separately

This is the second time today the `uat` lane sat red and unobserved — the first ran two days (#2469 → #2470). Both times it was found by a person looking, not by a gate. #2325 covers main-health's blindness to the lane; #2504 covers merges landing before their checks report. This PR fixes the break, not either of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AC overlay e2e by updating Deal 360’s unavailable panel count from 5 to 4, reflecting #2507 merging the Stakeholders card into the Coverage card. This is a test-only change that aligns expectations with the UI and should clear the red uat lane.

- Clarifies the inline comment to list the four panels and explain that stakeholders are now part of coverage.

<sup>Written for commit 490ca8000b878171123c91eed6710ca428de1328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the deal 360 end-to-end test to reflect stakeholder information now appearing within the coverage card.
  * Adjusted the expected unavailable-panel count from five to four.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->