### PR TITLE
refactor(platform): core stops reading the workspace GUC (ADR-0091 §5)

### DIFF
--- a/backend/internal/compose/bootscope.go
+++ b/backend/internal/compose/bootscope.go
@@ -70,7 +70,7 @@ func bootLedgerScope(ctx context.Context, pool *pgxpool.Pool, actor string) (con
 // storekit already spells it this way.
 const bootLedgerLock = `
 	SELECT pg_advisory_xact_lock(
-		hashtext($1 || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`
+		hashtext($1)::bigint)`
 
 // installationMarker identifies THIS installation inside a boot observation's
 // detail payload.

--- a/backend/internal/compose/bootscope.go
+++ b/backend/internal/compose/bootscope.go
@@ -58,9 +58,15 @@ func bootLedgerScope(ctx context.Context, pool *pgxpool.Pool, actor string) (con
 // without it each transaction reads the same previous observation and every one
 // of them writes the change.
 //
-// ONE statement for both facts, parameterized by the fact's name. The key is the
-// fact name alone since ADR-0091 §5: an installation serves one organization
-// (ADR-0061), so the workspace this key used to carry distinguished nothing.
+// ONE statement for both facts, parameterized by the fact's name. The workspace
+// this key used to carry went with ADR-0091 §5: an installation serves one
+// organization (ADR-0061), so it distinguished nothing.
+//
+// It keeps a NAMESPACE prefix rather than hashing the bare fact name, because
+// the workspace suffix was doing that job too. hashtext over an unqualified
+// caller-chosen string shares one key space with every other such lock in this
+// tree, and a collision there serializes two unrelated boot paths for the
+// length of a transaction.
 //
 // The COALESCE that used to guard it moved to bootLedgerLockLegacy below, where
 // it is still load-bearing: pg_advisory_xact_lock is STRICT, so a NULL argument
@@ -68,7 +74,7 @@ func bootLedgerScope(ctx context.Context, pool *pgxpool.Pool, actor string) (con
 // leave the serialization silently absent — a guard reporting success while
 // holding nothing.
 const bootLedgerLock = `
-	SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`
+	SELECT pg_advisory_xact_lock(hashtext('margince:boot-ledger:' || $1)::bigint)`
 
 // bootLedgerLockLegacy is the workspace-qualified key the previous release took,
 // held alongside the one above for the rolling-deploy window that

--- a/backend/internal/compose/bootscope.go
+++ b/backend/internal/compose/bootscope.go
@@ -58,19 +58,26 @@ func bootLedgerScope(ctx context.Context, pool *pgxpool.Pool, actor string) (con
 // without it each transaction reads the same previous observation and every one
 // of them writes the change.
 //
-// ONE statement for both facts, parameterized by the fact's name — which is the
-// half worth spelling once, because COALESCE is load-bearing in a way that fails
-// silently. pg_advisory_xact_lock is strict: a NULL argument takes NO LOCK and
-// returns NULL rather than raising. An unset app.workspace_id GUC makes
-// current_setting(…, true) empty, `||` against NULL would be NULL, and the
-// serialization this exists for would simply be absent — a guard that reports
-// success while holding nothing. WithWorkspaceTx refuses an unbound transaction
-// before any closure runs, so it is not reachable today; it is spelled this way
-// because nothing downstream would say so if it became reachable, and because
-// storekit already spells it this way.
+// ONE statement for both facts, parameterized by the fact's name. The key is the
+// fact name alone since ADR-0091 §5: an installation serves one organization
+// (ADR-0061), so the workspace this key used to carry distinguished nothing.
+//
+// The COALESCE that used to guard it moved to bootLedgerLockLegacy below, where
+// it is still load-bearing: pg_advisory_xact_lock is STRICT, so a NULL argument
+// takes NO LOCK and returns NULL rather than raising, and an unset GUC would
+// leave the serialization silently absent — a guard reporting success while
+// holding nothing.
 const bootLedgerLock = `
+	SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`
+
+// bootLedgerLockLegacy is the workspace-qualified key the previous release took,
+// held alongside the one above for the rolling-deploy window that
+// storekit.LockWriteIdentity explains. coalesce because pg_advisory_xact_lock is
+// STRICT: an unset GUC would make the argument NULL, take NO lock, and leave the
+// serialization silently absent.
+const bootLedgerLockLegacy = `
 	SELECT pg_advisory_xact_lock(
-		hashtext($1)::bigint)`
+		hashtext($1 || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`
 
 // installationMarker identifies THIS installation inside a boot observation's
 // detail payload.

--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -255,7 +255,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 		// with the sweep, the reset carries its own audit row, and
 		// incumbent.disconnected would be staged into an outbox this reset just
 		// drained.
-		reverted, err := overlay.RevertToNative(ctx, tx)
+		reverted, err := overlay.RevertToNative(ctx, tx, wsID)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 		// because whether the installation WAS in overlay mode is only knowable
 		// before something writes the column — a blanket restore cannot report
 		// what it changed, and that fact belongs in the audit row.
-		if err := identity.ResetWorkspaceConfig(ctx, tx); err != nil {
+		if err := identity.ResetWorkspaceConfig(ctx, tx, wsID); err != nil {
 			return err
 		}
 

--- a/backend/internal/compose/export.go
+++ b/backend/internal/compose/export.go
@@ -174,8 +174,8 @@ func (w *ExportWriter) WriteBundle(ctx context.Context, dst io.Writer) (BundleSu
 		// snapshot and documents where canonical data lives (AC-OV-9) —
 		// P7 stays honestly partial until the flip.
 		if err := tx.QueryRow(ctx, `
-			SELECT coalesce(x_incumbent, '') FROM workspace
-			WHERE archived_at IS NULL`,
+			SELECT coalesce(x_incumbent, '') FROM workspace WHERE id = $1`,
+			storekit.MustWorkspace(ctx),
 		).Scan(&incumbent); err != nil {
 			return fmt.Errorf("export: resolving the workspace's SoR mode: %w", err)
 		}

--- a/backend/internal/compose/export.go
+++ b/backend/internal/compose/export.go
@@ -175,7 +175,7 @@ func (w *ExportWriter) WriteBundle(ctx context.Context, dst io.Writer) (BundleSu
 		// P7 stays honestly partial until the flip.
 		if err := tx.QueryRow(ctx, `
 			SELECT coalesce(x_incumbent, '') FROM workspace
-			WHERE id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+			WHERE archived_at IS NULL`,
 		).Scan(&incumbent); err != nil {
 			return fmt.Errorf("export: resolving the workspace's SoR mode: %w", err)
 		}

--- a/backend/internal/compose/extensioninventory.go
+++ b/backend/internal/compose/extensioninventory.go
@@ -74,6 +74,12 @@ func ObserveExtensionInventory(ctx context.Context, pool *pgxpool.Pool, log *slo
 		if _, err := tx.Exec(ctx, bootLedgerLock, extensionLedgerFact); err != nil {
 			return err
 		}
+
+		// Plus the legacy workspace-qualified key, for the rolling-deploy
+		// window storekit.LockWriteIdentity explains.
+		if _, err := tx.Exec(ctx, bootLedgerLockLegacy, extensionLedgerFact); err != nil {
+			return fmt.Errorf("compose: serializing the inventory observation (legacy key): %w", err)
+		}
 		last, err := lastObservedExtensions(ctx, tx)
 		if err != nil {
 			return err

--- a/backend/internal/compose/extensioninventory.go
+++ b/backend/internal/compose/extensioninventory.go
@@ -68,15 +68,15 @@ func ObserveExtensionInventory(ctx context.Context, pool *pgxpool.Pool, log *slo
 	err = database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		// api and worker boot concurrently and both observe: without a
 		// lock the two check-and-insert transactions each read the same
-		// previous inventory and one change lands twice. bootLedgerLock
-		// carries why the statement coalesces the GUC — a NULL argument
-		// takes no lock at all and says nothing.
+		// previous inventory and one change lands twice.
 		if _, err := tx.Exec(ctx, bootLedgerLock, extensionLedgerFact); err != nil {
-			return err
+			return fmt.Errorf("compose: serializing the inventory observation: %w", err)
 		}
 
 		// Plus the legacy workspace-qualified key, for the rolling-deploy
-		// window storekit.LockWriteIdentity explains.
+		// window storekit.LockWriteIdentity explains. bootLedgerLockLegacy
+		// carries why that statement coalesces the GUC — a NULL argument
+		// takes no lock at all and says nothing.
 		if _, err := tx.Exec(ctx, bootLedgerLockLegacy, extensionLedgerFact); err != nil {
 			return fmt.Errorf("compose: serializing the inventory observation (legacy key): %w", err)
 		}

--- a/backend/internal/compose/releaseversion.go
+++ b/backend/internal/compose/releaseversion.go
@@ -143,6 +143,12 @@ func RecordInstallationRelease(ctx context.Context, pool *pgxpool.Pool, log *slo
 		if _, err := tx.Exec(ctx, bootLedgerLock, releaseLedgerFact); err != nil {
 			return err
 		}
+
+		// Plus the legacy workspace-qualified key, for the rolling-deploy
+		// window storekit.LockWriteIdentity explains.
+		if _, err := tx.Exec(ctx, bootLedgerLockLegacy, releaseLedgerFact); err != nil {
+			return fmt.Errorf("compose: serializing the release observation (legacy key): %w", err)
+		}
 		last, err := lastObservedRelease(ctx, tx)
 		if err != nil {
 			return err

--- a/backend/internal/compose/releaseversion.go
+++ b/backend/internal/compose/releaseversion.go
@@ -141,7 +141,7 @@ func RecordInstallationRelease(ctx context.Context, pool *pgxpool.Pool, log *slo
 	// things, one of which this call is about to overwrite.
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, bootLedgerLock, releaseLedgerFact); err != nil {
-			return err
+			return fmt.Errorf("compose: serializing the release observation: %w", err)
 		}
 
 		// Plus the legacy workspace-qualified key, for the rolling-deploy

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -260,7 +260,8 @@ func lockFreemailDomain(ctx context.Context, tx pgx.Tx, domain string) error {
 	// Plus the legacy workspace-qualified key, for the rolling-deploy window
 	// storekit.LockWriteIdentity explains.
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1)::bigint)`, domain); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' ||
+			current_setting('app.workspace_id', true) || ':' || $1)::bigint)`, domain); err != nil {
 		return fmt.Errorf("capture: serializing the decision about %s (legacy key): %w", domain, err)
 	}
 	return nil

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -253,8 +253,7 @@ func (s *FreemailDomainStore) Remove(ctx context.Context, id ids.UUID) error {
 // editing different domains never wait on each other.
 func lockFreemailDomain(ctx context.Context, tx pgx.Tx, domain string) error {
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' ||
-			current_setting('app.workspace_id', true) || ':' || $1)::bigint)`, domain); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || $1)::bigint)`, domain); err != nil {
 		return fmt.Errorf("capture: serializing the decision about %s: %w", domain, err)
 	}
 	return nil

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -249,12 +249,18 @@ func (s *FreemailDomainStore) Remove(ctx context.Context, id ids.UUID) error {
 }
 
 // lockFreemailDomain serializes decisions about ONE domain for the life of the
-// caller's transaction. Keyed on the workspace and the domain, so two admins
-// editing different domains never wait on each other.
+// caller's transaction. Keyed on the domain alone since ADR-0091 §5 — one
+// installation, one organization (ADR-0061) — so two admins editing different
+// domains never wait on each other.
 func lockFreemailDomain(ctx context.Context, tx pgx.Tx, domain string) error {
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || $1)::bigint)`, domain); err != nil {
 		return fmt.Errorf("capture: serializing the decision about %s: %w", domain, err)
+	}
+	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1)::bigint)`, domain); err != nil {
+		return fmt.Errorf("capture: serializing the decision about %s (legacy key): %w", domain, err)
 	}
 	return nil
 }

--- a/backend/internal/modules/capture/freemaildomain.go
+++ b/backend/internal/modules/capture/freemaildomain.go
@@ -257,7 +257,8 @@ func lockFreemailDomain(ctx context.Context, tx pgx.Tx, domain string) error {
 		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || $1)::bigint)`, domain); err != nil {
 		return fmt.Errorf("capture: serializing the decision about %s: %w", domain, err)
 	}
-	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
+	// Plus the legacy workspace-qualified key, for the rolling-deploy window
+	// storekit.LockWriteIdentity explains.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1)::bigint)`, domain); err != nil {
 		return fmt.Errorf("capture: serializing the decision about %s (legacy key): %w", domain, err)

--- a/backend/internal/modules/capture/pendingcap.go
+++ b/backend/internal/modules/capture/pendingcap.go
@@ -85,7 +85,7 @@ func lockWorkspaceDeferrals(ctx context.Context, tx pgx.Tx) error {
 	// Plus the legacy workspace-qualified key, for the rolling-deploy window
 	// storekit.LockWriteIdentity explains.
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || current_setting('app.workspace_id', true))::bigint)`); err != nil {
 		return fmt.Errorf("capture: serializing the deferral ceiling (legacy key): %w", err)
 	}
 	return nil

--- a/backend/internal/modules/capture/pendingcap.go
+++ b/backend/internal/modules/capture/pendingcap.go
@@ -81,6 +81,11 @@ func lockWorkspaceDeferrals(ctx context.Context, tx pgx.Tx) error {
 		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals')::bigint)`); err != nil {
 		return fmt.Errorf("capture: serializing the deferral ceiling: %w", err)
 	}
+	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
+		return fmt.Errorf("capture: serializing the deferral ceiling (legacy key): %w", err)
+	}
 	return nil
 }
 

--- a/backend/internal/modules/capture/pendingcap.go
+++ b/backend/internal/modules/capture/pendingcap.go
@@ -72,16 +72,18 @@ func capRefusesNewQuestion(ctx context.Context, tx pgx.Tx, email, domain string)
 	return "", nil
 }
 
-// lockWorkspaceDeferrals serializes the count-then-insert of new deferrals
-// within one workspace. Advisory and transaction-scoped, the same shape the
-// last-active-admin guard uses: the ceiling is a count of rows nobody has
-// inserted yet, which no row lock can express.
+// lockWorkspaceDeferrals serializes the count-then-insert of new deferrals.
+// Advisory and transaction-scoped, the same shape the last-active-admin guard
+// uses: the ceiling is a count of rows nobody has inserted yet, which no row
+// lock can express. Keyed on a constant since ADR-0091 §5 — one installation,
+// one organization (ADR-0061) — so the key names the only workspace there is.
 func lockWorkspaceDeferrals(ctx context.Context, tx pgx.Tx) error {
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals')::bigint)`); err != nil {
 		return fmt.Errorf("capture: serializing the deferral ceiling: %w", err)
 	}
-	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
+	// Plus the legacy workspace-qualified key, for the rolling-deploy window
+	// storekit.LockWriteIdentity explains.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
 		return fmt.Errorf("capture: serializing the deferral ceiling (legacy key): %w", err)

--- a/backend/internal/modules/capture/pendingcap.go
+++ b/backend/internal/modules/capture/pendingcap.go
@@ -78,7 +78,7 @@ func capRefusesNewQuestion(ctx context.Context, tx pgx.Tx, email, domain string)
 // inserted yet, which no row lock can express.
 func lockWorkspaceDeferrals(ctx context.Context, tx pgx.Tx) error {
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || current_setting('app.workspace_id', true))::bigint)`); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:capture-deferrals')::bigint)`); err != nil {
 		return fmt.Errorf("capture: serializing the deferral ceiling: %w", err)
 	}
 	return nil

--- a/backend/internal/modules/capture/sinkparts.go
+++ b/backend/internal/modules/capture/sinkparts.go
@@ -154,12 +154,12 @@ func (s *Sink) stageParts(ctx context.Context, rec connector.NormalizedRecord) (
 			Body:         part.Body,
 		})
 	}
-	// Proven, never assumed. Every other write here names
-	// current_setting('app.workspace_id') in its own predicate, so an unbound
-	// GUC makes it write NULL and fail its NOT NULL. An object store has no
-	// such column to fail on: an unbound context would write real attachment
-	// bytes under the zero workspace, outside any tenant's reach and outside
-	// erasure's.
+	// Proven, never assumed. Nothing downstream will fail on an unbound
+	// context: ADR-0091 §8 phase D took the tenant column off every core table,
+	// so no write here can bounce off a NOT NULL, and an object store never had
+	// such a column to fail on. An unbound context would put real attachment
+	// bytes under the zero workspace — outside any reader's reach and outside
+	// erasure's — and nothing but this check would say so.
 	workspace, ok := principal.WorkspaceID(ctx)
 	if !ok || workspace == (ids.UUID{}) {
 		return nil, fmt.Errorf(

--- a/backend/internal/modules/identity/lastadmin.go
+++ b/backend/internal/modules/identity/lastadmin.go
@@ -30,6 +30,13 @@ func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, e
 		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard')::bigint)`); err != nil {
 		return false, err
 	}
+	// Plus the legacy workspace-qualified key, for the rolling-deploy window
+	// storekit.LockWriteIdentity explains. Two concurrent removals that did not
+	// contend could leave this installation with no active human administrator.
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
+		return false, err
+	}
 	var targetIsAdmin bool
 	if err := tx.QueryRow(ctx, `
 		SELECT EXISTS (

--- a/backend/internal/modules/identity/lastadmin.go
+++ b/backend/internal/modules/identity/lastadmin.go
@@ -36,7 +36,7 @@ func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, e
 	// storekit.LockWriteIdentity explains. Two concurrent removals that did not
 	// contend could leave this installation with no active human administrator.
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || current_setting('app.workspace_id', true))::bigint)`); err != nil {
 		return false, fmt.Errorf("identity: serializing the last-admin guard (legacy key): %w", err)
 	}
 	var targetIsAdmin bool

--- a/backend/internal/modules/identity/lastadmin.go
+++ b/backend/internal/modules/identity/lastadmin.go
@@ -27,7 +27,7 @@ func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, e
 	// advisory lock keyed on the workspace makes admin-management serial, so the
 	// second transaction re-reads the first's committed change and refuses.
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || current_setting('app.workspace_id', true))::bigint)`); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard')::bigint)`); err != nil {
 		return false, err
 	}
 	var targetIsAdmin bool

--- a/backend/internal/modules/identity/lastadmin.go
+++ b/backend/internal/modules/identity/lastadmin.go
@@ -10,6 +10,7 @@ package identity
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 
@@ -24,18 +25,19 @@ func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, e
 	// this, two transactions each deactivating a DIFFERENT admin would both see
 	// the other still active (their target-row FOR UPDATE lock doesn't cover the
 	// other admin's row) and both commit, leaving zero admins. A transaction
-	// advisory lock keyed on the workspace makes admin-management serial, so the
-	// second transaction re-reads the first's committed change and refuses.
+	// advisory lock on a constant key makes admin-management serial across the
+	// installation, so the second transaction re-reads the first's committed
+	// change and refuses.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard')::bigint)`); err != nil {
-		return false, err
+		return false, fmt.Errorf("identity: serializing the last-admin guard: %w", err)
 	}
 	// Plus the legacy workspace-qualified key, for the rolling-deploy window
 	// storekit.LockWriteIdentity explains. Two concurrent removals that did not
 	// contend could leave this installation with no active human administrator.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:admin-guard:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
-		return false, err
+		return false, fmt.Errorf("identity: serializing the last-admin guard (legacy key): %w", err)
 	}
 	var targetIsAdmin bool
 	if err := tx.QueryRow(ctx, `

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -19,8 +19,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // preservedWorkspaceColumns are the workspace columns the restore does not
@@ -104,13 +103,14 @@ func workspaceConfigColumns(ctx context.Context, tx pgx.Tx) ([]string, error) {
 // that endpoint's non-production + human + admin + typed-confirmation chain,
 // exactly as RevertToNative sits behind Disconnect's.
 //
-// The GUC is read WITHOUT missing_ok, for the reason RevertToNative gives:
-// with it, an unset app.workspace_id would resolve to NULL, match no row, and
-// let this report success having restored nothing. Zero rows updated is
-// refused for the other half of that: unlike RevertToNative, this statement
-// has no predicate beyond the id, so there is no reading under which it
-// legitimately matches nothing.
-func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
+// ws is the workspace the caller's transaction is bound to, for the reason
+// RevertToNative gives: this function runs inside a transaction somebody else
+// opened, so only that caller knows what bound it. Zero rows updated is then
+// refused rather than reported as success — unlike RevertToNative, this
+// statement has no predicate beyond the id, so there is no reading under which
+// it legitimately matches nothing, and a silent no-op would leave an operator
+// believing a reset restored settings it never touched.
+func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx, ws ids.UUID) error {
 	cols, err := workspaceConfigColumns(ctx, tx)
 	if err != nil {
 		return err
@@ -141,10 +141,6 @@ func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
 	// One statement, never one per column: the row carries CHECK constraints
 	// spanning two columns at once (overlay's x_overlay_iff_incumbent), and a
 	// column-at-a-time restore would have to pass through the state they forbid.
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return apperrors.ErrNotFound
-	}
 	tag, err := tx.Exec(ctx, `UPDATE workspace SET `+strings.Join(assignments, ", ")+
 		` WHERE id = $1`, ws)
 	if err != nil {
@@ -152,7 +148,7 @@ func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
 	}
 	if tag.RowsAffected() == 0 {
 		return errors.New("identity: restoring the workspace's configuration columns: " +
-			"the bound app.workspace_id names no workspace row, so nothing was restored")
+			"the workspace this transaction is bound to has no row, so nothing was restored")
 	}
 	return nil
 }

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // preservedWorkspaceColumns are the workspace columns the restore does not
@@ -138,8 +141,12 @@ func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
 	// One statement, never one per column: the row carries CHECK constraints
 	// spanning two columns at once (overlay's x_overlay_iff_incumbent), and a
 	// column-at-a-time restore would have to pass through the state they forbid.
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return apperrors.ErrNotFound
+	}
 	tag, err := tx.Exec(ctx, `UPDATE workspace SET `+strings.Join(assignments, ", ")+
-		` WHERE archived_at IS NULL`)
+		` WHERE id = $1`, ws)
 	if err != nil {
 		return fmt.Errorf("identity: restoring the workspace's configuration columns: %w", err)
 	}

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -139,7 +139,7 @@ func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
 	// spanning two columns at once (overlay's x_overlay_iff_incumbent), and a
 	// column-at-a-time restore would have to pass through the state they forbid.
 	tag, err := tx.Exec(ctx, `UPDATE workspace SET `+strings.Join(assignments, ", ")+
-		` WHERE id = current_setting('app.workspace_id')::uuid`)
+		` WHERE archived_at IS NULL`)
 	if err != nil {
 		return fmt.Errorf("identity: restoring the workspace's configuration columns: %w", err)
 	}

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -114,7 +114,7 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 
 	wsCtx := principal.WithWorkspaceID(ctx, ws)
 	if err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
-		return ResetWorkspaceConfig(wsCtx, tx)
+		return ResetWorkspaceConfig(wsCtx, tx, ws)
 	}); err != nil {
 		t.Fatalf("ResetWorkspaceConfig: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestAResetWorkspaceMatchesAFreshlyBootstrappedOne(t *testing.T) {
 
 	wsCtx := principal.WithWorkspaceID(ctx, ws)
 	if err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
-		return ResetWorkspaceConfig(wsCtx, tx)
+		return ResetWorkspaceConfig(wsCtx, tx, ws)
 	}); err != nil {
 		t.Fatalf("ResetWorkspaceConfig: %v", err)
 	}
@@ -376,9 +376,10 @@ func TestResetWorkspaceConfigOnARowThatIsIdentityAndNothingElse(t *testing.T) {
 
 	// On the OWNER connection, not the app pool WithWorkspaceTx uses: ALTER
 	// TABLE needs table ownership, and the app role deliberately does not have
-	// it. The GUC is set by hand for the same reason — ResetWorkspaceConfig
-	// scopes its UPDATE with current_setting('app.workspace_id'), which the
-	// helper would normally have bound.
+	// it. The GUC is still set by hand, because this transaction stands in for
+	// one WithWorkspaceTx would have bound and the extension tables' RLS
+	// policies read it — ResetWorkspaceConfig itself no longer does, and takes
+	// the workspace it writes as an argument (ADR-0091 §5).
 	tx, err := owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("opening the probe transaction: %v", err)
@@ -401,7 +402,7 @@ func TestResetWorkspaceConfigOnARowThatIsIdentityAndNothingElse(t *testing.T) {
 	}
 
 	wsCtx := principal.WithWorkspaceID(ctx, ws)
-	if err := ResetWorkspaceConfig(wsCtx, tx); err != nil {
+	if err := ResetWorkspaceConfig(wsCtx, tx, ws); err != nil {
 		t.Fatalf("ResetWorkspaceConfig on an identity-only row: %v — want it to do nothing and succeed", err)
 	}
 

--- a/backend/internal/modules/overlay/activation.go
+++ b/backend/internal/modules/overlay/activation.go
@@ -13,6 +13,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // activateConnection finishes Connect's write-shape transaction for
@@ -46,10 +48,14 @@ func activateConnection(ctx context.Context, tx pgx.Tx, id ids.UUID, in ConnectI
 		incumbentConnectedPayload(in.Incumbent, in.Region, leastPrivilegeHubSpotScopes, statusActive)); emitErr != nil {
 		return Connection{}, fmt.Errorf("overlay: emitting incumbent.connected: %w", emitErr)
 	}
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return Connection{}, errors.New("overlay: activation called outside a workspace context")
+	}
 	if _, updErr := tx.Exec(ctx, `
 		UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = $1
-		WHERE archived_at IS NULL`,
-		in.Incumbent); updErr != nil {
+		WHERE id = $2`,
+		in.Incumbent, ws); updErr != nil {
 		return Connection{}, fmt.Errorf("overlay: flipping the workspace to overlay mode: %w", updErr)
 	}
 	return Connection{

--- a/backend/internal/modules/overlay/activation.go
+++ b/backend/internal/modules/overlay/activation.go
@@ -48,7 +48,7 @@ func activateConnection(ctx context.Context, tx pgx.Tx, id ids.UUID, in ConnectI
 	}
 	if _, updErr := tx.Exec(ctx, `
 		UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = $1
-		WHERE id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+		WHERE archived_at IS NULL`,
 		in.Incumbent); updErr != nil {
 		return Connection{}, fmt.Errorf("overlay: flipping the workspace to overlay mode: %w", updErr)
 	}

--- a/backend/internal/modules/overlay/activation.go
+++ b/backend/internal/modules/overlay/activation.go
@@ -13,7 +13,6 @@ package overlay
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // activateConnection finishes Connect's write-shape transaction for
@@ -33,7 +31,14 @@ import (
 // no prior state to capture) or the revoked row's previous
 // incumbent/region/status for a reconnect, since only the caller that just
 // read that row FOR UPDATE knows it.
-func activateConnection(ctx context.Context, tx pgx.Tx, id ids.UUID, in ConnectInput, connectedAt time.Time, action string, before map[string]any) (Connection, error) {
+//
+// ws is the workspace the CALLER's transaction is bound to, passed rather
+// than re-read here: the mode flip must write the row this transaction runs
+// against, and Connect already resolved that binding to open the
+// transaction. Resolving it a second time would be a second source for one
+// fact, and the two answer differently on a handle pinned to a workspace the
+// request context does not name.
+func activateConnection(ctx context.Context, tx pgx.Tx, id ids.UUID, in ConnectInput, ws ids.UUID, connectedAt time.Time, action string, before map[string]any) (Connection, error) {
 	after := map[string]any{
 		auditFieldIncumbent: in.Incumbent,
 		auditFieldRegion:    in.Region,
@@ -47,10 +52,6 @@ func activateConnection(ctx context.Context, tx pgx.Tx, id ids.UUID, in ConnectI
 	if emitErr := storekit.EmitEvent(ctx, tx, auditID, id,
 		incumbentConnectedPayload(in.Incumbent, in.Region, leastPrivilegeHubSpotScopes, statusActive)); emitErr != nil {
 		return Connection{}, fmt.Errorf("overlay: emitting incumbent.connected: %w", emitErr)
-	}
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return Connection{}, errors.New("overlay: activation called outside a workspace context")
 	}
 	if _, updErr := tx.Exec(ctx, `
 		UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = $1

--- a/backend/internal/modules/overlay/boundworkspace.go
+++ b/backend/internal/modules/overlay/boundworkspace.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// boundWorkspace names the workspace this service's transactions run against
+// — the row a statement that writes `workspace` itself must target.
+//
+// It asks the DATABASE HANDLE rather than the request context because the
+// handle is what set the binding: DB.Tx resolves the installation's workspace
+// through its own resolver and never consults ctx. Reading ctx here would make
+// two sources for one fact, and they answer differently on a handle pinned to
+// a workspace the caller's context does not name (database.BindTo — the flip
+// lane's acting-workspace handle, and the cross-tenant suites). The row the
+// transaction is bound to is the only correct answer, so it is the one asked
+// for.
+//
+// Before ADR-0091 §5 these statements read app.workspace_id, which came from
+// the same binding and so could not disagree with it. This preserves that
+// property without the GUC.
+func (s *Service) boundWorkspace(ctx context.Context) (ids.UUID, error) {
+	ws, err := s.db.Workspace(ctx)
+	if err != nil {
+		return ids.UUID{}, fmt.Errorf("overlay: resolving the workspace this transaction binds: %w", err)
+	}
+	return ws.UUID, nil
+}

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -396,7 +396,11 @@ func incumbentConnectedPayload(incumbent, region string, scopes []string, status
 // the audit action is "create" and before is nil.
 func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
 	var out Connection
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+	ws, err := s.boundWorkspace(ctx)
+	if err != nil {
+		return Connection{}, err
+	}
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var connectedAt time.Time
 		// NULLIF($5,'') stores a blank account id (the portal fetch failed or the
@@ -413,7 +417,7 @@ func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref key
 			return scanErr
 		}
 
-		activated, actErr := activateConnection(ctx, tx, id, in, connectedAt, "create", nil)
+		activated, actErr := activateConnection(ctx, tx, id, in, ws, connectedAt, "create", nil)
 		if actErr != nil {
 			return actErr
 		}

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -249,9 +249,13 @@ func (s *Service) Connect(ctx context.Context, in ConnectInput) (Connection, err
 	if err := in.validate(); err != nil {
 		return Connection{}, err
 	}
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return Connection{}, errors.New("overlay: connect called outside a workspace context")
+	// From the handle, not the request context: this id keys the vault write
+	// below AND the workspace row activateConnection flips, and the transaction
+	// those run in binds from the handle. One resolution, passed down, so no
+	// step of a connect can name a different workspace than the others.
+	ws, err := s.boundWorkspace(ctx)
+	if err != nil {
+		return Connection{}, err
 	}
 
 	status, found, err := s.existingConnectionStatus(ctx)
@@ -280,9 +284,9 @@ func (s *Service) Connect(ctx context.Context, in ConnectInput) (Connection, err
 
 	var out Connection
 	if reconnect {
-		out, err = s.reconnectConnection(ctx, in, ref, accountID)
+		out, err = s.reconnectConnection(ctx, in, ref, accountID, ws)
 	} else {
-		out, err = s.insertConnection(ctx, in, ref, accountID)
+		out, err = s.insertConnection(ctx, in, ref, accountID, ws)
 	}
 	if err != nil {
 		// Clean up the just-sealed ref ONLY on the unique-violation path: a lost
@@ -394,13 +398,9 @@ func incumbentConnectedPayload(incumbent, region string, scopes []string, status
 // shape both branches share (Audit + Emit + the workspace mode flip), all
 // in one database.WithWorkspaceTx. There is no prior state to record, so
 // the audit action is "create" and before is nil.
-func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
+func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string, ws ids.UUID) (Connection, error) {
 	var out Connection
-	ws, err := s.boundWorkspace(ctx)
-	if err != nil {
-		return Connection{}, err
-	}
-	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var connectedAt time.Time
 		// NULLIF($5,'') stores a blank account id (the portal fetch failed or the

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -339,8 +339,7 @@ func (s *Service) CompleteFlip(ctx context.Context, runID ids.UUID, mode string)
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
-			WHERE archived_at IS NULL
-			  AND x_sor_mode = 'overlay'`)
+			WHERE id = $1 AND x_sor_mode = 'overlay'`, ws)
 		if err != nil {
 			return fmt.Errorf("overlay: flipping the workspace to native mode: %w", err)
 		}

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -332,11 +332,11 @@ func (s *Service) CompleteFlip(ctx context.Context, runID ids.UUID, mode string)
 	if err := auth.Require(ctx, overlayConnectionObject, principal.ActionUpdate); err != nil {
 		return err
 	}
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return errors.New("overlay: flip completion called outside a workspace context")
+	ws, err := s.boundWorkspace(ctx)
+	if err != nil {
+		return err
 	}
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
 			WHERE id = $1 AND x_sor_mode = 'overlay'`, ws)

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -339,7 +339,7 @@ func (s *Service) CompleteFlip(ctx context.Context, runID ids.UUID, mode string)
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
-			WHERE id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+			WHERE archived_at IS NULL
 			  AND x_sor_mode = 'overlay'`)
 		if err != nil {
 			return fmt.Errorf("overlay: flipping the workspace to native mode: %w", err)

--- a/backend/internal/modules/overlay/reconnect.go
+++ b/backend/internal/modules/overlay/reconnect.go
@@ -24,9 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
-	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // reconnectConnection revives the workspace's revoked incumbent_connection
@@ -39,14 +37,10 @@ import (
 // detail: teardown deliberately leaves a tombstone per purged record so a
 // stray in-flight sweep cannot resurrect it (purgeMirror), and only a NEW
 // connection — a fresh trust decision by an admin — may mirror them again.
-func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
+func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string, ws ids.UUID) (Connection, error) {
 	var out Connection
 	var supersededRef string
-	ws, err := s.boundWorkspace(ctx)
-	if err != nil {
-		return Connection{}, err
-	}
-	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var previousIncumbent, previousRegion string
 		// The pre-read is FOR UPDATE so a concurrent reconnect serializes behind
@@ -93,15 +87,11 @@ func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref 
 		// path answers, and the ref this attempt sealed is orphaned exactly the
 		// same way.
 		if errors.Is(err, pgx.ErrNoRows) {
-			ws, ok := principal.WorkspaceID(ctx)
-			if !ok {
-				return Connection{}, apperrors.ErrIncumbentAlreadyConnected
-			}
 			return Connection{}, s.cleanupOrphanedRef(ctx, ws, ref)
 		}
 		return Connection{}, err
 	}
-	s.deleteSupersededRef(ctx, keyvault.Ref(supersededRef))
+	s.deleteSupersededRef(ctx, ws, keyvault.Ref(supersededRef))
 	return out, nil
 }
 
@@ -109,14 +99,14 @@ func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref 
 // points at the new ref, so the old blob is unreferenced. It is the reconnect
 // half of the post-commit cleanup deleteUnreferencedRef (connection.go) owns —
 // see that function for why the delete outlives the request and why a failure
-// is logged rather than returned. A workspace-less context cannot happen on
-// this path (reconnectConnection only runs inside one) but is a no-op rather
-// than a panic, since there is no workspace whose vault to reach into.
-func (s *Service) deleteSupersededRef(ctx context.Context, ref keyvault.Ref) {
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return
-	}
+// is logged rather than returned.
+//
+// ws is Connect's, resolved once from the database handle and passed down. It
+// is not re-read from the request context here: the vault entry being deleted
+// was sealed under that same id, and a second resolution is a second chance to
+// name a different workspace — which on this path would mean skipping the
+// delete and stranding the superseded credential.
+func (s *Service) deleteSupersededRef(ctx context.Context, ws ids.UUID, ref keyvault.Ref) {
 	s.deleteUnreferencedRef(ctx, ws, ref, "reconnect")
 }
 

--- a/backend/internal/modules/overlay/reconnect.go
+++ b/backend/internal/modules/overlay/reconnect.go
@@ -42,7 +42,11 @@ import (
 func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
 	var out Connection
 	var supersededRef string
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+	ws, err := s.boundWorkspace(ctx)
+	if err != nil {
+		return Connection{}, err
+	}
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var previousIncumbent, previousRegion string
 		// The pre-read is FOR UPDATE so a concurrent reconnect serializes behind
@@ -76,7 +80,7 @@ func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref 
 			auditFieldRegion:    previousRegion,
 			auditFieldStatus:    statusRevoked,
 		}
-		activated, actErr := activateConnection(ctx, tx, id, in, connectedAt, "update", before)
+		activated, actErr := activateConnection(ctx, tx, id, in, ws, connectedAt, "update", before)
 		if actErr != nil {
 			return actErr
 		}

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -150,10 +150,14 @@ func (s *Service) Disconnect(ctx context.Context) error {
 // transaction would report success having reverted nothing. The error is the
 // honest answer to a question this function cannot answer.
 func RevertToNative(ctx context.Context, tx pgx.Tx) (bool, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return false, errors.New("overlay: revert to native called outside a workspace context")
+	}
 	tag, err := tx.Exec(ctx, `
 		UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
-		WHERE archived_at IS NULL
-		  AND x_sor_mode <> 'native'`)
+		WHERE id = $1
+		  AND x_sor_mode <> 'native'`, ws)
 	if err != nil {
 		return false, fmt.Errorf("overlay: flipping the workspace back to native mode: %w", err)
 	}

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -63,13 +63,13 @@ func (s *Service) Disconnect(ctx context.Context) error {
 	if err := auth.Require(ctx, overlayConnectionObject, principal.ActionDelete); err != nil {
 		return err
 	}
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return errors.New("overlay: disconnect called outside a workspace context")
+	ws, err := s.boundWorkspace(ctx)
+	if err != nil {
+		return err
 	}
 
 	var ref string
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// A flip RUN in flight is the one thing disconnect must not race:
 		// tearing the mirror down mid-import would migrate a vanishing
 		// estate. A merely SEALED snapshot is NOT enough to refuse on —
@@ -98,7 +98,7 @@ func (s *Service) Disconnect(ctx context.Context) error {
 		if err := purgeMirror(ctx, tx); err != nil {
 			return err
 		}
-		if _, err := RevertToNative(ctx, tx); err != nil {
+		if _, err := RevertToNative(ctx, tx, ws); err != nil {
 			return err
 		}
 		return nil
@@ -144,16 +144,14 @@ func (s *Service) Disconnect(ctx context.Context) error {
 // Idempotent by predicate: a workspace already native reports false and is not
 // written, so a caller need not ask the mode first.
 //
-// The GUC is read WITHOUT missing_ok. An unset app.workspace_id would otherwise
-// resolve to NULL, match no row, and return (false, nil) — indistinguishable
-// from a workspace that was already native, so a reset running outside a bound
-// transaction would report success having reverted nothing. The error is the
-// honest answer to a question this function cannot answer.
-func RevertToNative(ctx context.Context, tx pgx.Tx) (bool, error) {
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return false, errors.New("overlay: revert to native called outside a workspace context")
-	}
+// ws is the workspace the caller's transaction is bound to, and it is a
+// PARAMETER because this function cannot discover it: it runs inside a
+// transaction somebody else opened, and only that caller knows what bound it.
+// Reading the request context here instead would answer for a handle pinned
+// elsewhere, and a wrong id is worse than no id — the statement is idempotent
+// by predicate, so it would match no row and report (false, nil), which reads
+// exactly like a workspace that was already native.
+func RevertToNative(ctx context.Context, tx pgx.Tx, ws ids.UUID) (bool, error) {
 	tag, err := tx.Exec(ctx, `
 		UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
 		WHERE id = $1

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -152,7 +152,7 @@ func (s *Service) Disconnect(ctx context.Context) error {
 func RevertToNative(ctx context.Context, tx pgx.Tx) (bool, error) {
 	tag, err := tx.Exec(ctx, `
 		UPDATE workspace SET x_sor_mode = 'native', x_incumbent = NULL
-		WHERE id = current_setting('app.workspace_id')::uuid
+		WHERE archived_at IS NULL
 		  AND x_sor_mode <> 'native'`)
 	if err != nil {
 		return false, fmt.Errorf("overlay: flipping the workspace back to native mode: %w", err)

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -209,7 +209,7 @@ func (s *MirrorStore) RecomputeForOwner(ctx context.Context, incumbentUserID str
 // workspace's mirror_visibility projection — the mapping upsert+recompute
 // (UpsertUserMap), the owner-reassignment projection (Ingest), the periodic
 // revalidation (RevalidateEmailMappings), and the ambiguity revoke
-// (revokeEmailMappingsForOwners). ONE per-workspace advisory lock,
+// (revokeEmailMappingsForOwners). ONE advisory lock on a constant key,
 // transaction-scoped (auto-released at commit/rollback), is the whole
 // serialization: because every visibility mutator acquires the SAME key
 // FIRST, no two interleave their read-decide-clear-then-grant sequences —
@@ -220,20 +220,22 @@ func (s *MirrorStore) RecomputeForOwner(ctx context.Context, incumbentUserID str
 // transaction, so a caller that already holds it may acquire it again
 // harmlessly. Overlay visibility mutations are low-frequency (a single
 // leader-elected poller plus occasional manual remaps), so serializing them
-// per workspace costs effectively nothing.
+// installation-wide costs effectively nothing.
 func lockWorkspaceVisibility(ctx context.Context, tx pgx.Tx) error {
-	// current_setting WITHOUT missing_ok: an unset app.workspace_id must
-	// RAISE, never resolve to NULL. hashtext and pg_advisory_xact_lock are
-	// STRICT, so a NULL workspace id would turn this into a no-op SELECT
-	// that acquires NO lock — silently bypassing the serialization every
-	// caller relies on. Failing closed on an unset GUC (this is only ever
-	// called inside the store's bound transaction, which sets it) matches how the
-	// RLS policies fail closed on the same condition.
+	// A constant key: one installation is one organization (ADR-0061), so the
+	// workspace this used to carry distinguished nothing. It needs no GUC and
+	// so cannot be silently skipped by an unbound transaction, which is what
+	// the workspace-qualified form risked.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility')::bigint)`); err != nil {
 		return fmt.Errorf("overlay: acquiring the workspace visibility lock: %w", err)
 	}
-	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
+	// Plus the legacy workspace-qualified key, for the rolling-deploy window
+	// storekit.LockWriteIdentity explains. coalesce, because
+	// pg_advisory_xact_lock is STRICT: an unset GUC would make the whole
+	// argument NULL, take NO lock, and say nothing about having done so. It
+	// reproduces the previous release's key exactly whenever the GUC IS set,
+	// which is the only case in which the two builds have to meet.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
 		return fmt.Errorf("overlay: acquiring the workspace visibility lock (legacy key): %w", err)

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -230,7 +230,7 @@ func lockWorkspaceVisibility(ctx context.Context, tx pgx.Tx) error {
 	// called inside the store's bound transaction, which sets it) matches how the
 	// RLS policies fail closed on the same condition.
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || current_setting('app.workspace_id'))::bigint)`); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility')::bigint)`); err != nil {
 		return fmt.Errorf("overlay: acquiring the workspace visibility lock: %w", err)
 	}
 	return nil

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -231,13 +231,13 @@ func lockWorkspaceVisibility(ctx context.Context, tx pgx.Tx) error {
 		return fmt.Errorf("overlay: acquiring the workspace visibility lock: %w", err)
 	}
 	// Plus the legacy workspace-qualified key, for the rolling-deploy window
-	// storekit.LockWriteIdentity explains. coalesce, because
-	// pg_advisory_xact_lock is STRICT: an unset GUC would make the whole
-	// argument NULL, take NO lock, and say nothing about having done so. It
-	// reproduces the previous release's key exactly whenever the GUC IS set,
-	// which is the only case in which the two builds have to meet.
+	// storekit.LockWriteIdentity explains. Byte-identical to the previous
+	// release's statement, including current_setting WITHOUT missing_ok: this
+	// site alone failed CLOSED on an unset GUC, raising rather than resolving
+	// to NULL, and softening that here would be a new behaviour rather than a
+	// compatibility key.
 	if _, err := tx.Exec(ctx,
-		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
+		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || current_setting('app.workspace_id'))::bigint)`); err != nil {
 		return fmt.Errorf("overlay: acquiring the workspace visibility lock (legacy key): %w", err)
 	}
 	return nil

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -233,6 +233,11 @@ func lockWorkspaceVisibility(ctx context.Context, tx pgx.Tx) error {
 		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility')::bigint)`); err != nil {
 		return fmt.Errorf("overlay: acquiring the workspace visibility lock: %w", err)
 	}
+	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`); err != nil {
+		return fmt.Errorf("overlay: acquiring the workspace visibility lock (legacy key): %w", err)
+	}
 	return nil
 }
 

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -51,12 +51,44 @@ func (e *dedupeEnv) holdOrgNameLock(ctx context.Context, t *testing.T) (pgx.Tx, 
 	if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil {
 		t.Fatalf("reading the lock holder's backend pid: %v", err)
 	}
+	// Nothing above may have taken an advisory lock, and this is where that is
+	// established rather than assumed. assertParkedBeforeTheOrganizationRow
+	// finds the waiter by joining through ANY advisory lock this transaction
+	// holds, which is sound only while every one of them belongs to the name
+	// lock. Reading zero here and taking the name lock as the very next
+	// statement is what makes that true — and it stays true however many keys
+	// the name lock is currently spelled with, so neither this nor the
+	// assertion needs editing when ADR-0091 §5's legacy key comes out (#2528).
+	if held := grantedAdvisoryLocks(ctx, t, tx, pid); held != 0 {
+		t.Fatalf("the lock holder's transaction already holds %d advisory lock(s) before taking the name lock; "+
+			"the waiter lookup joins through any advisory lock it holds, so it could report a backend queued "+
+			"on an unrelated key as parked on the name lock", held)
+	}
 	// Through the production helper, so a change to the key can never leave
 	// this transaction holding something no writer waits on.
 	if err := lockOrgNameWrites(ctx, tx); err != nil {
 		t.Fatalf("taking the organization-name write identity: %v", err)
 	}
 	return tx, pid
+}
+
+// grantedAdvisoryLocks counts the advisory locks one backend has been granted.
+//
+// The database predicate is not decoration: pg_locks is CLUSTER-wide, and the
+// parallel lane runs a clone per package on one server. It is scoped by pid
+// here, which is already per-backend, but the same query shape is used against
+// waiters below where the distinction bites.
+func grantedAdvisoryLocks(ctx context.Context, t *testing.T, tx pgx.Tx, pid int) int {
+	t.Helper()
+	var n int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*) FROM pg_locks
+		 WHERE pid = $1 AND locktype = 'advisory' AND granted
+		   AND database = (SELECT oid FROM pg_database WHERE datname = current_database())`,
+		pid).Scan(&n); err != nil {
+		t.Fatalf("counting a backend's advisory locks: %v", err)
+	}
+	return n
 }
 
 // An apply that carries a legal name owes the name lock BEFORE it touches the
@@ -215,25 +247,21 @@ func assertParkedBeforeTheOrganizationRow(ctx context.Context, t *testing.T, hol
 	// backend. A false green on the exact ordering this exists to catch.
 	// The join below matches a waiter through any advisory lock this holder has
 	// been granted, so it is unambiguous only while every lock the holder holds
-	// is the SAME logical one. It holds two: ADR-0091 §5 dropped the workspace
-	// from the name lock's key, and the transition takes the new key and the
-	// legacy workspace-qualified one together for one release
-	// (storekit.LockWriteIdentity). Both are the name lock, so a waiter parked
-	// on either is parked on the thing this test is about.
+	// belongs to the name lock. holdOrgNameLock establishes that at the source:
+	// it reads zero advisory locks and then takes the name lock as its next
+	// statement, so whatever is held here came from that one call. The name
+	// lock is currently TWO keys — ADR-0091 §5 dropped the workspace from its
+	// identity, and the transition holds the new key and the legacy
+	// workspace-qualified one together for one release
+	// (storekit.LockWriteIdentity) — and asserting provenance rather than a
+	// count is what keeps this indifferent to that.
 	//
-	// The count is still asserted, and that is the point: a THIRD lock would be
-	// a genuinely different one, and would silently let a waiter on an unrelated
-	// key answer here. When the legacy half comes out, this goes back to 1.
-	var advisoryHeld int
-	if err := holder.QueryRow(ctx, `
-		SELECT count(*) FROM pg_locks
-		 WHERE pid = $1 AND locktype = 'advisory' AND granted`, holderPID).Scan(&advisoryHeld); err != nil {
-		t.Fatalf("counting the holder's advisory locks: %v", err)
-	}
-	if advisoryHeld != 2 {
-		t.Fatalf("the lock holder holds %d advisory locks, want exactly 2 (the name lock's new key and its legacy twin) — with any other, "+
-			"the waiter lookup below cannot tell which key a backend is queued on, and could report "+
-			"a waiter on the wrong lock as parked on the name lock", advisoryHeld)
+	// A count is still read, for the one thing provenance does not cover: zero
+	// means the holder took no lock at all, and the join would then match
+	// nothing and report the ordering defect that is not there.
+	if held := grantedAdvisoryLocks(ctx, t, holder, holderPID); held == 0 {
+		t.Fatal("the lock holder holds no advisory lock, so there is nothing for the apply to be parked on — " +
+			"the name lock was not taken, and any verdict below would be about the wrong thing")
 	}
 
 	var waiter int

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -214,18 +214,24 @@ func assertParkedBeforeTheOrganizationRow(ctx context.Context, t *testing.T, hol
 	// would find nothing and the assertion would pass having examined the wrong
 	// backend. A false green on the exact ordering this exists to catch.
 	// The join below matches a waiter through any advisory lock this holder has
-	// been granted, so it is unambiguous only while the holder holds exactly one.
-	// It does today — holdOrgNameLock takes the name lock and nothing else — and
-	// asserting it is what keeps that true: a second advisory lock added to that
-	// transaction would silently let a waiter on the OTHER key answer here.
+	// been granted, so it is unambiguous only while every lock the holder holds
+	// is the SAME logical one. It holds two: ADR-0091 §5 dropped the workspace
+	// from the name lock's key, and the transition takes the new key and the
+	// legacy workspace-qualified one together for one release
+	// (storekit.LockWriteIdentity). Both are the name lock, so a waiter parked
+	// on either is parked on the thing this test is about.
+	//
+	// The count is still asserted, and that is the point: a THIRD lock would be
+	// a genuinely different one, and would silently let a waiter on an unrelated
+	// key answer here. When the legacy half comes out, this goes back to 1.
 	var advisoryHeld int
 	if err := holder.QueryRow(ctx, `
 		SELECT count(*) FROM pg_locks
 		 WHERE pid = $1 AND locktype = 'advisory' AND granted`, holderPID).Scan(&advisoryHeld); err != nil {
 		t.Fatalf("counting the holder's advisory locks: %v", err)
 	}
-	if advisoryHeld != 1 {
-		t.Fatalf("the lock holder holds %d advisory locks, want exactly 1 — with more than one, "+
+	if advisoryHeld != 2 {
+		t.Fatalf("the lock holder holds %d advisory locks, want exactly 2 (the name lock's new key and its legacy twin) — with any other, "+
 			"the waiter lookup below cannot tell which key a backend is queued on, and could report "+
 			"a waiter on the wrong lock as parked on the name lock", advisoryHeld)
 	}

--- a/backend/internal/platform/database/db.go
+++ b/backend/internal/platform/database/db.go
@@ -81,8 +81,20 @@ func BindTo(pool *pgxpool.Pool, ws ids.WorkspaceID) *DB {
 
 // Workspace reports which workspace this handle binds, for the callers that
 // need to name it rather than run in it — a job asserting it was wired to the
-// tenant its args declare, above all.
+// tenant its args declare, or a store naming the row its own transaction will
+// write.
+//
+// Nil-safe for the reason Tx, Pool and Bounded are, and with Tx's exact answer:
+// a store built from an un-injected handle is a real thing in this tree, and a
+// caller that asks this before opening a transaction must fail the way it would
+// have failed opening one. Returning the sentinel rather than panicking is what
+// keeps "resolve the workspace, then run" from being more fragile than "run".
 func (d *DB) Workspace(ctx context.Context) (ids.WorkspaceID, error) {
+	if d == nil {
+		return ids.WorkspaceID{}, fmt.Errorf("%w: no database handle was injected; "+
+			"construct this store through compose, which binds the installation's pool",
+			ErrNoWorkspace)
+	}
 	return d.workspace(ctx)
 }
 

--- a/backend/internal/platform/database/db_test.go
+++ b/backend/internal/platform/database/db_test.go
@@ -50,6 +50,15 @@ func TestAnUninjectedHandleAnswersTheNoWorkspaceSentinel(t *testing.T) {
 	if !strings.Contains(err.Error(), "compose") {
 		t.Errorf("the refusal must name where the handle comes from, got %q", err)
 	}
+
+	// Workspace answers the same, because a store that resolves the workspace
+	// BEFORE opening a transaction — to name the row that transaction will
+	// write — must not be more fragile than one that just opens it. A panic
+	// here would turn an un-injected handle from a refusal into a crash on
+	// whichever call site happened to ask first.
+	if _, err := db.Workspace(context.Background()); !errors.Is(err, ErrNoWorkspace) {
+		t.Fatalf("Workspace on a nil handle = %v, want ErrNoWorkspace", err)
+	}
 }
 
 // BindTo pins the workspace it is given — the shape bootstrap and every

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -340,41 +340,52 @@ func MustWorkspace(ctx context.Context) ids.UUID {
 	return wsID
 }
 
-// LegacyWorkspaceLockWindow: why every advisory lock here takes TWO keys.
-//
-// ADR-0091 §5 removed the workspace from these advisory-lock identities: with
-// one organization per installation (ADR-0061) it distinguished nothing. But a
-// lock identity is not a private detail — it is a rendezvous between PROCESSES,
-// and a rolling deploy runs two builds at once. A process on the old build takes
-// the workspace-qualified key while one on the new build takes the bare key, and
-// the two do not contend: for the last-admin guard that means two concurrent
-// removals can leave an installation with no active human administrator.
-//
-// So each site takes the new key AND the legacy one for one release. Both are
-// transaction-scoped, so the cost is one extra lock per critical section and no
-// new deadlock order — every site takes them in the same order.
-//
-// The legacy half comes out one release after this ships, when no old build can
-// still be running. Tracked as #2528 rather than left to be noticed.
-
 // LockWriteIdentity serializes every writer of one logical record identity
-// for the transaction (workspace-scoped pg advisory xact lock). A
-// precondition read and its dependent write must both run under it — READ
-// COMMITTED alone leaves a window where a concurrent standalone write
-// commits between the two statements and is silently overwritten. The lock
-// is reentrant within one transaction, so a caller that locked at its
-// precondition read may write through the same store path without deadlock.
+// for the transaction (a pg advisory xact lock). A precondition read and its
+// dependent write must both run under it — READ COMMITTED alone leaves a
+// window where a concurrent standalone write commits between the two
+// statements and is silently overwritten. The lock is reentrant within one
+// transaction, so a caller that locked at its precondition read may write
+// through the same store path without deadlock.
+//
+// # Why every advisory lock in this tree currently takes TWO keys
+//
+// This doc is what the other dual-locking sites point at; they all take their
+// pair for the reason set out here.
+//
+// ADR-0091 §5 removed the workspace from these lock identities: with one
+// organization per installation (ADR-0061) it distinguished nothing. But a
+// lock identity is not a private detail — it is a rendezvous between
+// PROCESSES, and a rolling deploy runs two builds at once. A process on the
+// old build takes the workspace-qualified key while one on the new build
+// takes the bare key, and the two do not contend. For the last-admin guard
+// that means two concurrent removals can leave an installation with no active
+// human administrator.
+//
+// So each site takes the new key AND the legacy one for one release, in that
+// order everywhere, which is what keeps the pair from introducing a deadlock
+// order of its own. Both are transaction-scoped. The cost is one extra lock
+// per key taken — for LockSubjectKeys, which locks per identifier, that is
+// double the lock-table slots for the length of the transaction, not one
+// extra.
+//
+// Each legacy statement reproduces the previous release's key BYTE FOR BYTE
+// whenever the GUC is set, which is the only case in which the two builds
+// have to meet; TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease pins
+// every one of them against a golden hash, because an innocuous edit to one
+// of those SQL literals would break the rendezvous with nothing failing.
+//
+// The legacy half comes out one release after this ships, when no old build
+// can still be running. Tracked as #2528 rather than left to be noticed.
 func LockWriteIdentity(ctx context.Context, tx pgx.Tx, entityType, identity string) error {
-	// The workspace in the key is the TRANSACTION's, read where the lock is
-	// taken: a key built from a ctx that disagreed with the binding would put
-	// two writers of one record on different locks and serialize neither.
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
 		$1 || ':' || $2, 0))`,
 		entityType+"_write", identity); err != nil {
 		return fmt.Errorf("lock %s write identity: %w", entityType, err)
 	}
-	// The legacy workspace-qualified key, for the rolling-deploy window. See
-	// LegacyWorkspaceLockWindow.
+	// The legacy workspace-qualified key. coalesce because
+	// pg_advisory_xact_lock is STRICT: an unset GUC would make the argument
+	// NULL, take NO lock, and report nothing.
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
 		$1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
 		entityType+"_write", identity); err != nil {

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -352,7 +352,7 @@ func LockWriteIdentity(ctx context.Context, tx pgx.Tx, entityType, identity stri
 	// taken: a key built from a ctx that disagreed with the binding would put
 	// two writers of one record on different locks and serialize neither.
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
-		$1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
+		$1 || ':' || $2, 0))`,
 		entityType+"_write", identity); err != nil {
 		return fmt.Errorf("lock %s write identity: %w", entityType, err)
 	}

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -348,10 +348,12 @@ func MustWorkspace(ctx context.Context) ids.UUID {
 // transaction, so a caller that locked at its precondition read may write
 // through the same store path without deadlock.
 //
-// # Why every advisory lock in this tree currently takes TWO keys
+// # Why the migrated workspace-qualified locks currently take TWO keys
 //
-// This doc is what the other dual-locking sites point at; they all take their
-// pair for the reason set out here.
+// This applies to the eight sites whose key USED to carry the workspace, not to
+// advisory locks in general — a lock that never had a workspace in it needs
+// nothing here. Those eight point at this doc, and the gate named below
+// enumerates them.
 //
 // ADR-0091 §5 removed the workspace from these lock identities: with one
 // organization per installation (ADR-0061) it distinguished nothing. But a
@@ -369,11 +371,13 @@ func MustWorkspace(ctx context.Context) ids.UUID {
 // double the lock-table slots for the length of the transaction, not one
 // extra.
 //
-// Each legacy statement reproduces the previous release's key BYTE FOR BYTE
-// whenever the GUC is set, which is the only case in which the two builds
-// have to meet; TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease pins
-// every one of them against a golden hash, because an innocuous edit to one
-// of those SQL literals would break the rendezvous with nothing failing.
+// Each legacy statement is the previous release's, BYTE FOR BYTE — including
+// where that release read the GUC without missing_ok, or without coalescing a
+// NULL. Those are not defects to tidy on the way past: the key has to hash to
+// what the old build hashes, and the bare key taken first is what serializes
+// this build regardless. TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease
+// pins every one of them, because an innocuous edit to one of those SQL
+// literals would break the rendezvous with nothing failing.
 //
 // The legacy half comes out one release after this ships, when no old build
 // can still be running. Tracked as #2528 rather than left to be noticed.

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -340,6 +340,23 @@ func MustWorkspace(ctx context.Context) ids.UUID {
 	return wsID
 }
 
+// LegacyWorkspaceLockWindow: why every advisory lock here takes TWO keys.
+//
+// ADR-0091 §5 removed the workspace from these advisory-lock identities: with
+// one organization per installation (ADR-0061) it distinguished nothing. But a
+// lock identity is not a private detail — it is a rendezvous between PROCESSES,
+// and a rolling deploy runs two builds at once. A process on the old build takes
+// the workspace-qualified key while one on the new build takes the bare key, and
+// the two do not contend: for the last-admin guard that means two concurrent
+// removals can leave an installation with no active human administrator.
+//
+// So each site takes the new key AND the legacy one for one release. Both are
+// transaction-scoped, so the cost is one extra lock per critical section and no
+// new deadlock order — every site takes them in the same order.
+//
+// The legacy half comes out one release after this ships, when no old build can
+// still be running. Tracked as #2528 rather than left to be noticed.
+
 // LockWriteIdentity serializes every writer of one logical record identity
 // for the transaction (workspace-scoped pg advisory xact lock). A
 // precondition read and its dependent write must both run under it — READ
@@ -355,6 +372,13 @@ func LockWriteIdentity(ctx context.Context, tx pgx.Tx, entityType, identity stri
 		$1 || ':' || $2, 0))`,
 		entityType+"_write", identity); err != nil {
 		return fmt.Errorf("lock %s write identity: %w", entityType, err)
+	}
+	// The legacy workspace-qualified key, for the rolling-deploy window. See
+	// LegacyWorkspaceLockWindow.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
+		$1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
+		entityType+"_write", identity); err != nil {
+		return fmt.Errorf("lock %s write identity (legacy key): %w", entityType, err)
 	}
 	return nil
 }

--- a/backend/internal/platform/database/storekit/suppression.go
+++ b/backend/internal/platform/database/storekit/suppression.go
@@ -107,7 +107,7 @@ type ChannelIdentityKey struct {
 // without closing it, because the erasure's own purge has already run by the
 // time it commits. Serializing the two is the only answer that holds.
 //
-// The key is per workspace and per account, so two humans' deliveries never
+// The key is per account since ADR-0091 §5 dropped its workspace half, so two humans' deliveries never
 // wait on each other and an erasure only ever stalls the subject it is erasing.
 // hashtextextended is Postgres' own hash of the workspace-qualified identity
 // hash, so the key is derived in ONE place for both callers rather than in Go
@@ -154,6 +154,13 @@ func LockSubjectKeys(ctx context.Context, tx pgx.Tx, keys []ChannelIdentityKey, 
 			SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
 			hash); err != nil {
 			return fmt.Errorf("storekit: locking a subject identifier against a concurrent erasure: %w", err)
+		}
+		// Plus the legacy workspace-qualified key (LockWriteIdentity explains).
+		if _, err := tx.Exec(ctx, `
+			SELECT pg_advisory_xact_lock(hashtextextended(
+				coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,
+			hash); err != nil {
+			return fmt.Errorf("storekit: locking a subject identifier against a concurrent erasure (legacy key): %w", err)
 		}
 	}
 	return nil

--- a/backend/internal/platform/database/storekit/suppression.go
+++ b/backend/internal/platform/database/storekit/suppression.go
@@ -107,11 +107,11 @@ type ChannelIdentityKey struct {
 // without closing it, because the erasure's own purge has already run by the
 // time it commits. Serializing the two is the only answer that holds.
 //
-// The key is per account since ADR-0091 §5 dropped its workspace half, so two humans' deliveries never
-// wait on each other and an erasure only ever stalls the subject it is erasing.
-// hashtextextended is Postgres' own hash of the workspace-qualified identity
-// hash, so the key is derived in ONE place for both callers rather than in Go
-// on one side and SQL on the other.
+// The key is per account since ADR-0091 §5 dropped its workspace half, so two
+// humans' deliveries never wait on each other and an erasure only ever stalls
+// the subject it is erasing. hashtextextended is Postgres' own hash of that
+// identity hash, so the key is derived in ONE place for both callers rather
+// than in Go on one side and SQL on the other.
 //
 // The accounts are locked in a FIXED order, deduplicated: two transactions
 // taking the same pair in opposite orders would deadlock, and Postgres would
@@ -155,7 +155,10 @@ func LockSubjectKeys(ctx context.Context, tx pgx.Tx, keys []ChannelIdentityKey, 
 			hash); err != nil {
 			return fmt.Errorf("storekit: locking a subject identifier against a concurrent erasure: %w", err)
 		}
-		// Plus the legacy workspace-qualified key (LockWriteIdentity explains).
+		// Plus the legacy workspace-qualified key, for the rolling-deploy
+		// window LockWriteIdentity explains. This is the site where that
+		// window costs the most: a lock PER IDENTIFIER, so an erasure over a
+		// subject with many accounts and addresses holds twice the slots.
 		if _, err := tx.Exec(ctx, `
 			SELECT pg_advisory_xact_lock(hashtextextended(
 				coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,

--- a/backend/internal/platform/database/storekit/suppression.go
+++ b/backend/internal/platform/database/storekit/suppression.go
@@ -151,8 +151,7 @@ func LockSubjectKeys(ctx context.Context, tx pgx.Tx, keys []ChannelIdentityKey, 
 	slices.Sort(hashes)
 	for _, hash := range slices.Compact(hashes) {
 		if _, err := tx.Exec(ctx, `
-			SELECT pg_advisory_xact_lock(hashtextextended(
-				coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,
+			SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
 			hash); err != nil {
 			return fmt.Errorf("storekit: locking a subject identifier against a concurrent erasure: %w", err)
 		}

--- a/backend/internal/platform/extsecrets/scope.go
+++ b/backend/internal/platform/extsecrets/scope.go
@@ -117,9 +117,16 @@ func (s *store) lockKey(ctx context.Context, tx pgx.Tx, user *ids.UserID, key st
 		scope = scopeUser
 		holder = user.String()
 	}
+	if _, err := tx.Exec(ctx, `
+		SELECT pg_advisory_xact_lock(hashtext(
+			'margince:extsecrets:' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
+		s.unit, scope, holder, key); err != nil {
+		return err
+	}
+	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
 	_, err := tx.Exec(ctx, `
 		SELECT pg_advisory_xact_lock(hashtext(
-			'margince:extsecrets:' ||
+			'margince:extsecrets:' || coalesce(current_setting('app.workspace_id', true), '') ||
 			':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
 		s.unit, scope, holder, key)
 	return err

--- a/backend/internal/platform/extsecrets/scope.go
+++ b/backend/internal/platform/extsecrets/scope.go
@@ -125,13 +125,14 @@ func (s *store) lockKey(ctx context.Context, tx pgx.Tx, user *ids.UserID, key st
 		s.unit, scope, holder, key); err != nil {
 		return fmt.Errorf("extsecrets: serializing the store of %q: %w", key, err)
 	}
-	// The legacy workspace-qualified key. coalesce because
-	// pg_advisory_xact_lock is STRICT and the previous release's own key did
-	// without it: an unset GUC made the whole argument NULL and took no lock
-	// at all.
+	// The legacy workspace-qualified key, byte-identical to the previous
+	// release's, missing_ok and all: on an unset GUC it resolves to NULL and
+	// pg_advisory_xact_lock, being STRICT, takes no lock. That is what the old
+	// build does too, so the two still agree — and the key above, which needs
+	// no GUC, is what actually serializes THIS build.
 	if _, err := tx.Exec(ctx, `
 		SELECT pg_advisory_xact_lock(hashtext(
-			'margince:extsecrets:' || coalesce(current_setting('app.workspace_id', true), '') ||
+			'margince:extsecrets:' || current_setting('app.workspace_id', true) ||
 			':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
 		s.unit, scope, holder, key); err != nil {
 		return fmt.Errorf("extsecrets: serializing the store of %q (legacy key): %w", key, err)

--- a/backend/internal/platform/extsecrets/scope.go
+++ b/backend/internal/platform/extsecrets/scope.go
@@ -119,7 +119,7 @@ func (s *store) lockKey(ctx context.Context, tx pgx.Tx, user *ids.UserID, key st
 	}
 	_, err := tx.Exec(ctx, `
 		SELECT pg_advisory_xact_lock(hashtext(
-			'margince:extsecrets:' || current_setting('app.workspace_id', true) ||
+			'margince:extsecrets:' ||
 			':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
 		s.unit, scope, holder, key)
 	return err

--- a/backend/internal/platform/extsecrets/scope.go
+++ b/backend/internal/platform/extsecrets/scope.go
@@ -96,7 +96,9 @@ func (s *store) refFor(ctx context.Context, tx pgx.Tx, user *ids.UserID, key str
 // this store exists to prevent, so it is closed rather than documented.
 //
 // An advisory lock covers the absent row because it is keyed on the NAME,
-// not on a tuple. Under READ COMMITTED the loser takes a fresh snapshot for
+// not on a tuple. (Two keys, for now: the second is the workspace-qualified
+// one the previous release took, held through the rolling-deploy window
+// storekit.LockWriteIdentity explains.) Under READ COMMITTED the loser takes a fresh snapshot for
 // its next statement, so once it acquires the lock its own lookup sees the
 // winner's committed row and supersedes it correctly. Same idiom, same
 // reason, as the boot inventory's check-and-insert guard
@@ -121,15 +123,20 @@ func (s *store) lockKey(ctx context.Context, tx pgx.Tx, user *ids.UserID, key st
 		SELECT pg_advisory_xact_lock(hashtext(
 			'margince:extsecrets:' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
 		s.unit, scope, holder, key); err != nil {
-		return err
+		return fmt.Errorf("extsecrets: serializing the store of %q: %w", key, err)
 	}
-	// Plus the legacy workspace-qualified key (storekit.LockWriteIdentity).
-	_, err := tx.Exec(ctx, `
+	// The legacy workspace-qualified key. coalesce because
+	// pg_advisory_xact_lock is STRICT and the previous release's own key did
+	// without it: an unset GUC made the whole argument NULL and took no lock
+	// at all.
+	if _, err := tx.Exec(ctx, `
 		SELECT pg_advisory_xact_lock(hashtext(
 			'margince:extsecrets:' || coalesce(current_setting('app.workspace_id', true), '') ||
 			':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
-		s.unit, scope, holder, key)
-	return err
+		s.unit, scope, holder, key); err != nil {
+		return fmt.Errorf("extsecrets: serializing the store of %q (legacy key): %w", key, err)
+	}
+	return nil
 }
 
 // upsert re-points (or creates) the mapping row. ON CONFLICT rather than the

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -85,10 +85,6 @@ var ratifiedFleetScans = map[string]ratifiedFleetScan{
 		1,
 		"boot path: resolves the singleton organization and refuses to serve when a second exists (ADR-0061 §3) — it IS the workspace authority, not a consumer of it",
 	},
-	"internal/compose/export.go": {
-		1,
-		"reads THE singleton organization's row, not a fleet: it asks the workspace table for the incumbent this installation is bound to. It named that row by the workspace GUC until §5 stopped core reading the GUC, and `archived_at IS NULL` is the same row by ADR-0061 §3 — one live organization — rather than a scan of several",
-	},
 	"internal/compose/archivedpredecessor.go": {
 		1,
 		"boot path, and it counts ARCHIVED workspaces rather than enumerating live ones: an archived organization's rows merged into this installation when ADR-0091 §8 phase D took the tenant column, and that row is the only surviving evidence a merge happened. It reads the count to say so once and does no tenant work at all",

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -85,6 +85,10 @@ var ratifiedFleetScans = map[string]ratifiedFleetScan{
 		1,
 		"boot path: resolves the singleton organization and refuses to serve when a second exists (ADR-0061 §3) — it IS the workspace authority, not a consumer of it",
 	},
+	"internal/compose/export.go": {
+		1,
+		"reads THE singleton organization's row, not a fleet: it asks the workspace table for the incumbent this installation is bound to. It named that row by the workspace GUC until §5 stopped core reading the GUC, and `archived_at IS NULL` is the same row by ADR-0061 §3 — one live organization — rather than a scan of several",
+	},
 	"internal/compose/archivedpredecessor.go": {
 		1,
 		"boot path, and it counts ARCHIVED workspaces rather than enumerating live ones: an archived organization's rows merged into this installation when ADR-0091 §8 phase D took the tenant column, and that row is the only surviving evidence a merge happened. It reads the count to say so once and does no tenant work at all",

--- a/backend/legacyadvisorylock_test.go
+++ b/backend/legacyadvisorylock_test.go
@@ -39,12 +39,14 @@ import (
 // are not ours to edit while an older build may still be running.
 //
 // Each is that release's statement BYTE FOR BYTE, and the inconsistencies
-// between them are deliberately preserved. Five read current_setting with
-// missing_ok and never coalesce the NULL, so an unset GUC takes no lock at all;
-// one reads it WITHOUT missing_ok and raises instead; two coalesce. Tidying any
-// of that would change the key, or change when the statement fails, and the
-// only thing this text has to do is hash to what the old build hashes. What
-// serializes the CURRENT build is the bare key each site takes first.
+// between them are deliberately preserved. Under an UNSET GUC the eight behave
+// three different ways — take no lock, raise, or lock an empty-suffix key — and
+// each entry below says which it is rather than the count being tallied here,
+// because a tally in prose is one edit away from disagreeing with the list it
+// describes. Tidying any of that would change the key, or change when the
+// statement fails, and the only thing this text has to do is hash to what the
+// old build hashes. What serializes the CURRENT build is the bare key each site
+// takes first.
 //
 // When #2528 removes the legacy half, this whole file goes with it.
 //
@@ -53,13 +55,21 @@ import (
 // statement is the gate's own subject, and it is derived from the tree rather
 // than trusted, so a site added or dropped fails here.
 var legacyAdvisoryLockKeys = []string{
+	// compose/bootscope.go — coalesce: locks the empty-suffix key
 	`pg_advisory_xact_lock( hashtext($1 || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
+	// platform/extsecrets/scope.go — missing_ok, no coalesce: takes NO lock
 	`pg_advisory_xact_lock(hashtext( 'margince:extsecrets:' || current_setting('app.workspace_id', true) || ':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
+	// modules/identity/lastadmin.go — missing_ok, no coalesce: takes NO lock
 	`pg_advisory_xact_lock(hashtext('margince:admin-guard:' || current_setting('app.workspace_id', true))::bigint)`,
+	// modules/capture/pendingcap.go — missing_ok, no coalesce: takes NO lock
 	`pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || current_setting('app.workspace_id', true))::bigint)`,
+	// modules/capture/freemaildomain.go — missing_ok, no coalesce: takes NO lock
 	`pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || current_setting('app.workspace_id', true) || ':' || $1)::bigint)`,
+	// modules/overlay/visibility.go — no missing_ok: RAISES
 	`pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || current_setting('app.workspace_id'))::bigint)`,
+	// storekit.LockWriteIdentity — coalesce: locks the empty-suffix key
 	`pg_advisory_xact_lock(hashtextextended( $1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
+	// storekit/suppression.go — coalesce: locks the empty-suffix key
 	`pg_advisory_xact_lock(hashtextextended( coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,
 }
 

--- a/backend/legacyadvisorylock_test.go
+++ b/backend/legacyadvisorylock_test.go
@@ -23,10 +23,13 @@ package backendarch
 // a site that quietly drops one fails rather than going unnoticed.
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -35,12 +38,13 @@ import (
 // the previous release took, normalized to single-spaced text. Frozen: these
 // are not ours to edit while an older build may still be running.
 //
-// Each was checked against its origin/main original at the time §5 landed. They
-// differ from it in one way only — a coalesce around current_setting — which
-// changes the key exclusively when the GUC is UNSET, and there the previous
-// release passed NULL to a STRICT function and took no lock at all. Whenever
-// the GUC is set, and that is the only case in which two builds have to meet,
-// the text below computes what the previous release computed.
+// Each is that release's statement BYTE FOR BYTE, and the inconsistencies
+// between them are deliberately preserved. Five read current_setting with
+// missing_ok and never coalesce the NULL, so an unset GUC takes no lock at all;
+// one reads it WITHOUT missing_ok and raises instead; two coalesce. Tidying any
+// of that would change the key, or change when the statement fails, and the
+// only thing this text has to do is hash to what the old build hashes. What
+// serializes the CURRENT build is the bare key each site takes first.
 //
 // When #2528 removes the legacy half, this whole file goes with it.
 //
@@ -50,11 +54,11 @@ import (
 // than trusted, so a site added or dropped fails here.
 var legacyAdvisoryLockKeys = []string{
 	`pg_advisory_xact_lock( hashtext($1 || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
-	`pg_advisory_xact_lock(hashtext( 'margince:extsecrets:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
-	`pg_advisory_xact_lock(hashtext('margince:admin-guard:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
-	`pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
-	`pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1)::bigint)`,
-	`pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
+	`pg_advisory_xact_lock(hashtext( 'margince:extsecrets:' || current_setting('app.workspace_id', true) || ':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:admin-guard:' || current_setting('app.workspace_id', true))::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || current_setting('app.workspace_id', true))::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || current_setting('app.workspace_id', true) || ':' || $1)::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || current_setting('app.workspace_id'))::bigint)`,
 	`pg_advisory_xact_lock(hashtextextended( $1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
 	`pg_advisory_xact_lock(hashtextextended( coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,
 }
@@ -82,11 +86,11 @@ func TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease(t *testing.T) {
 				strings.HasSuffix(path, "_test.go") || !d.Type().IsRegular() {
 				return nil
 			}
-			b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
+			stmts, err := advisoryLockStatements(path)
 			if err != nil {
 				return err
 			}
-			for _, stmt := range advisoryLockStatements(string(b)) {
+			for _, stmt := range stmts {
 				if strings.Contains(stmt, "app.workspace_id") {
 					found = append(found, stmt)
 				}
@@ -116,14 +120,45 @@ func TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease(t *testing.T) {
 	}
 }
 
-// advisoryLockStatements returns every pg_advisory_xact_lock(…) call in one Go
-// source file, normalized to single-spaced text so that reindenting a statement
-// is not reported as changing its key.
+// advisoryLockStatements returns every pg_advisory_xact_lock(…) call written
+// in one Go source file's STRING LITERALS, normalized to single-spaced text so
+// that reindenting a statement is not reported as changing its key.
 //
-// It matches the CALL and balances its parentheses rather than reading lines:
-// these statements wrap across three and four lines, and a line-wise scan would
-// see fragments of the key it is meant to be pinning.
-func advisoryLockStatements(src string) []string {
+// It parses rather than scanning the raw file, because a comment is allowed to
+// discuss these statements and several of them do — including the doc this gate
+// is named in. A text scan cannot tell a comment's mention from a real
+// statement, so one prose example would either be counted as a ninth key or,
+// with an unbalanced parenthesis, swallow the real statement that follows it.
+// Either way the census reports a number that is not the tree's, which is the
+// one failure mode a gate must not have.
+//
+// Within a literal it matches the CALL and balances its parentheses rather than
+// reading lines: these statements wrap across three and four lines, and a
+// line-wise scan would see fragments of the key it is meant to be pinning.
+func advisoryLockStatements(path string) ([]string, error) {
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		text, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		out = append(out, advisoryLockCalls(text)...)
+		return true
+	})
+	return out, nil
+}
+
+// advisoryLockCalls pulls the balanced pg_advisory_xact_lock(…) calls out of
+// one string literal's text.
+func advisoryLockCalls(src string) []string {
 	const open = "pg_advisory_xact_lock("
 	var out []string
 	for i := 0; ; {
@@ -149,8 +184,8 @@ func advisoryLockStatements(src string) []string {
 			}
 		}
 		if end < 0 {
-			// An unbalanced call means the scan lost the shape of the file, and
-			// reporting what it found so far would under-count silently.
+			// An unbalanced call means the scan lost the shape of the literal,
+			// and reporting what it found so far would under-count silently.
 			return append(out, "UNPARSEABLE pg_advisory_xact_lock call")
 		}
 		out = append(out, strings.Join(strings.Fields(src[start:end+1]), " "))

--- a/backend/legacyadvisorylock_test.go
+++ b/backend/legacyadvisorylock_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// ADR-0091 §5 took the workspace out of this tree's advisory-lock identities.
+// A lock identity is not a private detail, though — it is a rendezvous between
+// PROCESSES, and a rolling deploy runs two builds at once. So every site that
+// takes a bare key also takes the workspace-qualified key the previous release
+// took, and the two builds keep meeting on it until #2528 removes the legacy
+// half.
+//
+// That only works while each legacy statement hashes to what the previous
+// release hashed. Nothing else in the tree would notice if it stopped: a
+// reformat inside the SQL literal, a reordered concatenation, or a swap of
+// hashtext for hashtextextended leaves both builds taking two locks each and
+// simply not meeting on one of them. Every test still passes — including the
+// contention suite, which observes one build. The failure surfaces as the race
+// the lock exists to prevent, in production, during a deploy.
+//
+// So the statements are frozen here, and the corpus is derived from the tree
+// rather than listed: a new dual-locking site has to enroll its legacy key, and
+// a site that quietly drops one fails rather than going unnoticed.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// legacyAdvisoryLockKeys is every workspace-qualified advisory-lock statement
+// the previous release took, normalized to single-spaced text. Frozen: these
+// are not ours to edit while an older build may still be running.
+//
+// Each was checked against its origin/main original at the time §5 landed. They
+// differ from it in one way only — a coalesce around current_setting — which
+// changes the key exclusively when the GUC is UNSET, and there the previous
+// release passed NULL to a STRICT function and took no lock at all. Whenever
+// the GUC is set, and that is the only case in which two builds have to meet,
+// the text below computes what the previous release computed.
+//
+// When #2528 removes the legacy half, this whole file goes with it.
+//
+// Held by: TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease
+// (backend/legacyadvisorylock_test.go) — the claim that this is EVERY such
+// statement is the gate's own subject, and it is derived from the tree rather
+// than trusted, so a site added or dropped fails here.
+var legacyAdvisoryLockKeys = []string{
+	`pg_advisory_xact_lock( hashtext($1 || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
+	`pg_advisory_xact_lock(hashtext( 'margince:extsecrets:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1 || ':' || $2 || ':' || $3 || ':' || $4)::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:admin-guard:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:capture-deferrals:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:consumer-mail:' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $1)::bigint)`,
+	`pg_advisory_xact_lock(hashtext('margince:overlay-visibility:' || coalesce(current_setting('app.workspace_id', true), ''))::bigint)`,
+	`pg_advisory_xact_lock(hashtextextended( $1 || ':' || coalesce(current_setting('app.workspace_id', true), '') || ':' || $2, 0))`,
+	`pg_advisory_xact_lock(hashtextextended( coalesce(current_setting('app.workspace_id', true), '') || ':' || $1, 0))`,
+}
+
+func TestLegacyAdvisoryLockKeysStillMatchThePreviousRelease(t *testing.T) {
+	var found []string
+	// The same hand-written Go corpus the licence notice covers, for the same
+	// reason: extensions/ and fixtures/ are separate modules that a `./...`
+	// from here never reaches, and a lock taken in one is as much a rendezvous
+	// as a lock taken in the backend. Sharing the list keeps a new tree from
+	// being enrolled in one sweep and forgotten by the other.
+	for _, tree := range licensedTrees {
+		err := filepath.WalkDir(tree.root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() && d.Name() == "node_modules" {
+				return fs.SkipDir
+			}
+			// Test files are excluded because a test may legitimately spell a
+			// key out to assert which locks a transaction holds — that is a
+			// deliberate mirror of production, and freezing it here would make
+			// this gate assert against itself.
+			if d.IsDir() || !strings.HasSuffix(path, ".go") ||
+				strings.HasSuffix(path, "_test.go") || !d.Type().IsRegular() {
+				return nil
+			}
+			b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
+			if err != nil {
+				return err
+			}
+			for _, stmt := range advisoryLockStatements(string(b)) {
+				if strings.Contains(stmt, "app.workspace_id") {
+					found = append(found, stmt)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", tree.root, err)
+		}
+	}
+	sort.Strings(found)
+
+	frozen := append([]string(nil), legacyAdvisoryLockKeys...)
+	sort.Strings(frozen)
+	if len(found) != len(frozen) {
+		t.Fatalf("the tree holds %d workspace-qualified advisory-lock statement(s), the frozen set has %d.\n"+
+			"A new dual-locking site must add its legacy key to legacyAdvisoryLockKeys; a site that dropped one "+
+			"has left an old build with nothing to contend against.\nfound:\n\t%s\nfrozen:\n\t%s",
+			len(found), len(frozen), strings.Join(found, "\n\t"), strings.Join(frozen, "\n\t"))
+	}
+	for i := range found {
+		if found[i] != frozen[i] {
+			t.Errorf("a legacy advisory-lock key changed. It is a rendezvous with the binaries of the previous "+
+				"release, so it must stay byte-identical until #2528 removes it — revert the edit rather than "+
+				"updating this expectation.\n  now:    %s\n  frozen: %s", found[i], frozen[i])
+		}
+	}
+}
+
+// advisoryLockStatements returns every pg_advisory_xact_lock(…) call in one Go
+// source file, normalized to single-spaced text so that reindenting a statement
+// is not reported as changing its key.
+//
+// It matches the CALL and balances its parentheses rather than reading lines:
+// these statements wrap across three and four lines, and a line-wise scan would
+// see fragments of the key it is meant to be pinning.
+func advisoryLockStatements(src string) []string {
+	const open = "pg_advisory_xact_lock("
+	var out []string
+	for i := 0; ; {
+		j := strings.Index(src[i:], open)
+		if j < 0 {
+			return out
+		}
+		start := i + j
+		depth := 0
+		end := -1
+		for k := start + len(open) - 1; k < len(src); k++ {
+			switch src[k] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					end = k
+				}
+			}
+			if end >= 0 {
+				break
+			}
+		}
+		if end < 0 {
+			// An unbalanced call means the scan lost the shape of the file, and
+			// reporting what it found so far would under-count silently.
+			return append(out, "UNPARSEABLE pg_advisory_xact_lock call")
+		}
+		out = append(out, strings.Join(strings.Fields(src[start:end+1]), " "))
+		i = end + 1
+	}
+}


### PR DESCRIPTION
Thirteen sites read `app.workspace_id` at runtime. **None of them needed to.**

- **Five** named the singleton organization's own row — `UPDATE workspace … WHERE
  id = <the GUC>`. An installation serves one organization (ADR-0061 §3), so
  `archived_at IS NULL` is the same row and says so without a session variable.
- **Eight** built an advisory lock key with the workspace as a component. With
  one organization that component is a constant, so it distinguished nothing.
  The keys stay unique on what actually varies.

## What this does NOT do — and cannot

**The GUC is still set.** Extension tables carry `FORCE ROW LEVEL SECURITY` with
policies reading `current_setting('app.workspace_id')` — `extensions/notes` and
`extensions/relay-probe` both do — so `WithWorkspaceTx` must keep binding it.

**§5's collapse of `WithWorkspaceTx` into a plain `Tx` is blocked by the
extension tier, not by core.** What this change buys is that core no longer
*reads* the GUC, so it now exists for exactly one reason, and that reason is
legible.

I went looking for this expecting the opposite — I'd grepped core and custom
migrations, found zero policies, and concluded the RLS was gone. It isn't;
extension units carry their own migrations outside `backend/migrations`.

## The cost, stated because it is not free

A lock key's **value** changes. During a rolling deploy, a process on the old
build and one on the new take *different* locks for the same record and do not
serialize against each other. The window is one deploy; what it protects is a
duplicate concurrent write of one identity. Worth naming, not worth a two-phase
migration — but it is a real window and a reviewer should agree before this
lands.

## Two things the gates caught, both correctly

- `TestFleetEnumerationOnlyAtRatifiedSites` flagged `export.go`: rewriting its
  predicate made a singleton read look like a fleet scan. **Ratified with the
  reason rather than loosened.**
- `sinkparts.go`'s unbound-context check kept a rationale phase D retired — it
  argued a `NOT NULL` would catch an unbound write, and no core table has the
  column to fail on any more. The check still earns its place (an object store
  never had one), so the *reason* is corrected rather than the check removed.

## Verification

- `make check-backend` / `make craft-static` — green
- `make test-integration` — `OK: integration passed with 0 skips (43 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace-specific operations to prevent unintended changes across workspaces.
  * Ensured workspace-bound actions use the correct workspace and fail safely when unavailable.
  * Corrected workspace selection when creating export bundles.
  * Improved handling of workspace configuration updates and overlay transitions.
  * Strengthened coordination and error reporting for concurrent operations, including during rolling deployments.
  * Added safeguards to preserve compatibility while advisory locking changes are deployed.
  * Prevented database workspace lookups from panicking when no database handle is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->