### PR TITLE
test(frontend): the inline picker's Tab rule is read off the control, not the emulator

### DIFF
--- a/frontend/src/design-system/inlinechoice.test.tsx
+++ b/frontend/src/design-system/inlinechoice.test.tsx
@@ -1,5 +1,11 @@
 /** @vitest-environment jsdom */
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -176,7 +182,16 @@ describe("editing a value where it is read", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Change Account lifecycle" }),
     );
-    await userEvent.tab();
+    // The keydown alone, deliberately, rather than `userEvent.tab()`: moving
+    // focus is the BROWSER's half of a Tab press, and it is the half no DOM
+    // emulation models. A browser remembers the place a removed focused
+    // element held — the sequential focus navigation starting point — and
+    // carries the reader on from there. jsdom keeps no such place, so once
+    // this picker unmounts the emulation restarts from the top of the
+    // document and lands on the resting trigger of its own accord, which
+    // would read here as the control having reached for focus. Dispatching
+    // the press by itself leaves exactly the half this control owns.
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Tab" });
     // Tab already moved the reader on — reclaiming focus here would fight
     // the very key that just moved it, the opposite of what Escape does.
     const trigger = screen.getByRole("button", {

--- a/frontend/src/design-system/inlinechoice.test.tsx
+++ b/frontend/src/design-system/inlinechoice.test.tsx
@@ -177,7 +177,7 @@ describe("editing a value where it is read", () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  it("does not pull focus back to the trigger when Tab moves it forward", async () => {
+  it("does not reach for the trigger when Tab leaves the open list", async () => {
     const { onSave } = renderChoice();
     await userEvent.click(
       screen.getByRole("button", { name: "Change Account lifecycle" }),
@@ -190,7 +190,11 @@ describe("editing a value where it is read", () => {
     // this picker unmounts the emulation restarts from the top of the
     // document and lands on the resting trigger of its own accord, which
     // would read here as the control having reached for focus. Dispatching
-    // the press by itself leaves exactly the half this control owns.
+    // the press by itself leaves exactly the half this control owns, which is
+    // the half the name of this test claims and no more. The browser's half —
+    // a Tab press carrying the reader to the next field — is checked in
+    // select.test.tsx, where the trigger survives the press and so jsdom can
+    // still model where focus goes.
     fireEvent.keyDown(screen.getByRole("combobox"), { key: "Tab" });
     // Tab already moved the reader on — reclaiming focus here would fight
     // the very key that just moved it, the opposite of what Escape does.


### PR DESCRIPTION
Unblocks the lock-file maintenance PR https://github.com/margince/margince/pull/2081, whose only real failure is this one test. Landing it here rather than on the Renovate branch keeps the lockfile refresh a lockfile refresh, and Renovate is free to rebase over it.

## What went red

`fe-unit` on https://github.com/margince/margince/pull/2081:

```
FAIL  src/design-system/inlinechoice.test.tsx > editing a value where it is read
      > does not pull focus back to the trigger when Tab moves it forward
AssertionError: expected <button …> not to be <button …> // Object.is equality
```

The lockfile moves `@testing-library/user-event` 14.6.4 → 14.6.5. That release changes exactly one file — the `Tab` keydown behaviour — to compute the destination from the **live** active element instead of the stale keydown target:

```diff
-const dest = getTabDestination(target, shift)
+// target would be stale … focus may have been moved to another element
+const dest = getTabDestination(getActiveElementOrBody(document), shift)
```

That is the more faithful emulation. It is also what exposes the test's instrument.

## Why the test read it as a regression

`userEvent.tab()` does two things: it dispatches the press, and it then moves focus the way a browser would. The rule under test is only ever about the first — whether `InlineChoice` reaches for focus once Tab has left an open picker — but it was observed through the second.

`InlineChoice` unmounts the focused combobox inside that keydown (`onLeave` closes the editing view), so by the time the destination is computed the focused element is gone and jsdom reports `document.body`. A real browser remembers where the removed element sat — the [sequential focus navigation starting point](https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point) — and carries the reader on from there. jsdom keeps no such place, so the emulation restarts from the top of the document and lands on the only focusable element there: the resting trigger. The assertion read that as the control having pulled focus back.

Probing it directly, with the control correct and untouched:

```
BEFORE TAB  activeElement = <button role="combobox" aria-expanded="true">
AFTER  TAB  activeElement = <button aria-label="Change Account lifecycle">
```

The control never called `focus()`. The emulation chose that element on its own.

## The change

Dispatch the keydown by itself, which leaves exactly the half this control owns. Where the browser then puts focus is the browser's business, and it is the half no DOM emulation models.

## The rule is still gated

Not merely green — it still fails when broken. Swapping `onLeave={close}` for `onLeave={revert}` in `inlinechoice.tsx` (the one-line way to make the control reclaim focus on Tab) fails this test under **both** versions:

| user-event | control as written | `onLeave={revert}` |
|---|---|---|
| 14.6.4 (main) | 20 passed | 1 failed \| 19 passed |
| 14.6.5 (https://github.com/margince/margince/pull/2081) | 18 passed | 1 failed \| 17 passed |

So the `onLeave`/`onCancel` distinction — the reason `onLeave` exists at all — stays held.

## Verification

- `pnpm vitest run src/design-system/inlinechoice.test.tsx` — green on main's lockfile (14.6.4) and on https://github.com/margince/margince/pull/2081's (14.6.5).
- `make check-fe` — biome (1058 files) and both `tsc` configs clean. `fe-unit` reports 4 failures on this machine that are **pre-existing on untouched `origin/main`**: three in `personstrip.test.tsx` and one in `buyerroom.test.tsx`, from local Node v22.17.0 formatting compact currency as `-€95K` where CI's newer ICU gives `-€95k`. Unrelated to this diff, and CI is the authority on them.
- No Go touched, so `craft static` reports no changed Go files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated inline-choice keyboard interaction tests to reliably verify Tab key handling.
  * Reduced dependence on simulated focus-navigation behavior in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->