### PR TITLE
feat(frontend): record dates read the installation's timezone, not Europe/Berlin

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -840,6 +840,24 @@ export async function mockApi(
         system_of_record: { mode: sorMode },
       });
     }
+    if (path === "/installation/settings" && method === "GET") {
+      // The authenticated shell holds its first paint on this read, because
+      // `installation.timezone` is the clock every record date is rendered in
+      // and a page painted before it arrives would renumber under the reader.
+      // The catch-all would answer it with a list envelope — a 200 carrying no
+      // timezone — so every spec would silently run on the fallback zone while
+      // appearing to exercise the configured one.
+      //
+      // Europe/Berlin because the specs assert German dates against it.
+      return json({
+        name: "Brandt Automotive",
+        timezone: "Europe/Berlin",
+        base_currency: "EUR",
+        base_language: "de",
+        base_currency_locked: false,
+        max_upload_bytes: 25_000_000,
+      });
+    }
     // The two anonymous reads the unauthenticated surface makes. Both answer
     // before a session exists, by design: the surface has to show a stranger the
     // installation's posture and its working sign-in methods.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import {
   useBuiltinCommands,
   usePaletteHotkey,
 } from "./app/palette";
+import { RecordZoneProvider, useConfiguredRecordZone } from "./app/recordzone";
 import { SPA_RELEASE } from "./app/release";
 import {
   navigate,
@@ -741,6 +742,11 @@ function AuthedApp({
   const authed = !me.isPending && !me.isError;
   const company = useCompany(authed);
   const described = company.data !== null && company.data !== undefined;
+  // The organization's clock, for every record date under this boundary. Read
+  // here rather than per screen so all of them agree, and gated on the session
+  // for the same reason the company probe is: an unauthenticated read would
+  // 401 and say nothing about the installation.
+  const recordZone = useConfiguredRecordZone(authed);
 
   // route.screen is a dependency on purpose: the gate must hold on every
   // navigation, not only on first load — otherwise the palette or a typed hash
@@ -809,7 +815,12 @@ function AuthedApp({
   // screen to show. The gate lives here rather than on the login path because
   // a live session never passes through login — a reload would otherwise walk
   // straight past onboarding into a company that does not exist.
-  if (company.isPending) {
+  // The record zone joins this gate rather than getting one of its own: both
+  // are answers the authenticated shell needs before it draws, and a second
+  // splash after the first would read as two loads of one page. Holding here
+  // is what lets every screen below take the zone as a settled value — paint
+  // first and the day headings on an open timeline renumber under the reader.
+  if (company.isPending || recordZone.pending) {
     return (
       <RaillessFrame>
         <AuthSplash />
@@ -818,7 +829,7 @@ function AuthedApp({
   }
 
   return (
-    <>
+    <RecordZoneProvider zone={recordZone.zone}>
       <AuthedShell onOpenSearch={() => setPaletteOpen(true)}>
         <ScreenView screen={route.screen} id={route.id} id2={route.id2} />
       </AuthedShell>
@@ -827,7 +838,7 @@ function AuthedApp({
         onClose={() => setPaletteOpen(false)}
         commands={commands}
       />
-    </>
+    </RecordZoneProvider>
   );
 }
 

--- a/frontend/src/app/recordzone.test.tsx
+++ b/frontend/src/app/recordzone.test.tsx
@@ -1,12 +1,16 @@
 /** @vitest-environment jsdom */
-import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatDateTime } from "../format/format";
 import { FALLBACK_RECORD_ZONE } from "../format/timezone";
 import {
   RecordZoneProvider,
   renderableRecordZone,
+  useConfiguredRecordZone,
   useRecordZone,
 } from "./recordzone";
+import { INSTALLATION_SETTINGS_KEY } from "./uploadlimit";
 
 // What the record zone must do with what the server sends it, and what a
 // screen under the provider sees.
@@ -90,3 +94,72 @@ describe("resolving the installation's configured zone", () => {
     }
   });
 });
+
+describe("an admin changing the zone while a record page is open", () => {
+  // The whole feature, end to end, at the seam where it could quietly not work:
+  // the settings screen writes the PATCH response straight into the settings
+  // cache (`setQueryData`), and nothing tells the record pages. They do not
+  // need telling — the date is computed at render time from the zone this
+  // context serves, so the write re-renders the provider and every screen under
+  // it — but that is a claim about React Query notifying an observer, which is
+  // exactly the kind of thing that is true until a library upgrade makes it
+  // false. Silently: the dates stay on the old clock and look fine.
+  //
+  // `waitFor` rather than a bare assertion after the write, because the
+  // notification is flushed asynchronously. Asserting immediately reads the DOM
+  // one tick early and reports a failure the product does not have.
+  it("re-renders an open date on the new clock", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ timezone: "Asia/Ho_Chi_Minh" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <ConfiguredRoot />
+      </QueryClientProvider>,
+    );
+
+    // 18:30 UTC is the 20th in Saigon and the 19th in Berlin — one instant, two
+    // calendar days, which is what makes this assertion able to fail.
+    await waitFor(() =>
+      expect(screen.getByTestId("when").textContent).toContain("20.08.2026"),
+    );
+
+    client.setQueryData(INSTALLATION_SETTINGS_KEY, {
+      timezone: "Europe/Berlin",
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("when").textContent).toContain("19.08.2026"),
+    );
+  });
+});
+
+// A record date, rendered the way a screen renders one: through the hook, at
+// render time, with no cache of its own.
+function WhenProbe() {
+  return (
+    <p data-testid="when">
+      {formatDateTime("2026-08-19T18:30:00Z", "de", useRecordZone())}
+    </p>
+  );
+}
+
+// The authenticated boundary's own wiring, in miniature.
+function ConfiguredRoot() {
+  const { zone } = useConfiguredRecordZone(true);
+  return (
+    <RecordZoneProvider zone={zone}>
+      <WhenProbe />
+    </RecordZoneProvider>
+  );
+}

--- a/frontend/src/app/recordzone.test.tsx
+++ b/frontend/src/app/recordzone.test.tsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FALLBACK_RECORD_ZONE } from "../format/timezone";
+import {
+  RecordZoneProvider,
+  renderableRecordZone,
+  useRecordZone,
+} from "./recordzone";
+
+// What the record zone must do with what the server sends it, and what a
+// screen under the provider sees.
+//
+// The stakes are not cosmetic. This zone reaches every date on every record
+// page, so the two failures worth proving are the ones that would be silent:
+// a zone the browser cannot render taking the application down instead of
+// falling back, and a fallback that quietly replaces a zone the installation
+// really did configure.
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function ZoneProbe() {
+  return <p data-testid="zone">{useRecordZone()}</p>;
+}
+
+describe("the zone a record's dates are read in", () => {
+  it("serves what the provider was given", () => {
+    render(
+      <RecordZoneProvider zone="Asia/Ho_Chi_Minh">
+        <ZoneProbe />
+      </RecordZoneProvider>,
+    );
+    expect(screen.getByTestId("zone").textContent).toBe("Asia/Ho_Chi_Minh");
+  });
+
+  it("falls back for a screen mounted with no provider", () => {
+    // A story or a bare test mount. It gets a renderable zone rather than an
+    // empty string, which `Intl` rejects — so the surface draws instead of
+    // throwing, and what it draws is legibly the fallback.
+    render(<ZoneProbe />);
+    expect(screen.getByTestId("zone").textContent).toBe(FALLBACK_RECORD_ZONE);
+  });
+});
+
+describe("resolving the installation's configured zone", () => {
+  it("takes a configured zone the browser can render", () => {
+    expect(renderableRecordZone("Asia/Ho_Chi_Minh")).toBe("Asia/Ho_Chi_Minh");
+  });
+
+  it("falls back while the settings read is still in flight", () => {
+    // undefined is "not yet", not "not set". The authenticated boundary holds
+    // its paint over this window, so what matters here is only that it resolves
+    // to something renderable rather than throwing.
+    expect(renderableRecordZone(undefined)).toBe(FALLBACK_RECORD_ZONE);
+  });
+
+  it("falls back and REPORTS a zone this browser cannot render", () => {
+    // Two zone databases out of step: the server validated the name against
+    // its own tzdata, this browser does not know it. Unhandled, the RangeError
+    // from Intl takes down every record page for every reader, and the admin
+    // who could fix it can no longer load the settings screen either.
+    const reported = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(renderableRecordZone("Mars/Olympus_Mons")).toBe(
+      FALLBACK_RECORD_ZONE,
+    );
+
+    // Reported, not swallowed. This state is the server and this browser
+    // disagreeing about what a zone name means; silently rendering every date
+    // on a different clock than the one the installation chose is the outcome
+    // the report exists to prevent going unnoticed.
+    expect(reported).toHaveBeenCalled();
+    expect(reported.mock.calls.flat().map(String).join(" ")).toContain(
+      "Mars/Olympus_Mons",
+    );
+  });
+
+  it("refuses a fixed offset, which freezes DST rules", () => {
+    // The trap `isRenderableZone` exists for: Intl RESOLVES these, so a
+    // hand-rolled probe would pass them and then throw inside `formatDate` one
+    // line later — in the exact place the fallback exists to protect.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    for (const offset of ["+01:00", "Etc/GMT-1", "GMT"]) {
+      expect(renderableRecordZone(offset)).toBe(FALLBACK_RECORD_ZONE);
+    }
+  });
+});

--- a/frontend/src/app/recordzone.tsx
+++ b/frontend/src/app/recordzone.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useEffect } from "react";
 import { isRenderableZone } from "../format/format";
 import { FALLBACK_RECORD_ZONE } from "../format/timezone";
 import { logUnexpectedError } from "../screens/common";
@@ -124,6 +124,25 @@ export function useConfiguredRecordZone(enabled: boolean): {
   pending: boolean;
 } {
   const query = useInstallationSettings(enabled);
+  // A settled read that carries no timezone is NOT the same state as one still
+  // in flight, though `data?.timezone` spells both `undefined`. The contract
+  // makes the field required, so a 200 without it is a server older or newer
+  // than this bundle — and treated as "not yet", it would silently render every
+  // record date on the fallback clock with nothing anywhere saying why.
+  const settledWithoutZone =
+    query.isSuccess && query.data?.timezone === undefined;
+  // In an effect rather than the render body: a render can run many times for
+  // one answer, and a console filling with the same line says less than one
+  // line does.
+  useEffect(() => {
+    if (settledWithoutZone) {
+      logUnexpectedError(
+        new Error(
+          `the installation settings carry no timezone; record dates are falling back to ${FALLBACK_RECORD_ZONE}`,
+        ),
+      );
+    }
+  }, [settledWithoutZone]);
   return {
     zone: renderableRecordZone(query.data?.timezone),
     // A DISABLED query is `isPending` forever — it is waiting for permission

--- a/frontend/src/app/recordzone.tsx
+++ b/frontend/src/app/recordzone.tsx
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { createContext, type ReactNode, useContext } from "react";
+import { isRenderableZone } from "../format/format";
+import { FALLBACK_RECORD_ZONE } from "../format/timezone";
+import { logUnexpectedError } from "../screens/common";
+import { useInstallationSettings } from "./uploadlimit";
+
+/**
+ * The organization's own clock, as the installation configured it.
+ *
+ * This is the reading half of `installation.timezone`. The admin has been able
+ * to set that value since the settings card shipped; until now nothing on a
+ * record page read it, so an installation in Ho Chi Minh City set its zone,
+ * saw the field keep the value, and still had every close date, invoice day and
+ * timeline heading rendered on a Berlin clock.
+ *
+ * Why a context rather than each screen calling the settings query itself:
+ * every screen that renders a record date has to agree on the answer. Two
+ * screens reading the same query would agree today, but the value is one
+ * decision and a second reading of it is a second place for it to be resolved
+ * differently — a fallback spelled one way here and another way there is
+ * exactly how the record zone and the viewer zone came apart before
+ * `format/timezone.ts` existed.
+ *
+ * The zone is always a string, never undefined. A `string | undefined` would
+ * push the "not yet" case into all ~150 call sites, and the honest handling
+ * there is not a per-site decision — a date rendered in a guessed zone is
+ * wrong in the same way on every one of them. So the waiting is done ONCE, at
+ * the authenticated boundary in App.tsx, which holds its first paint until the
+ * settings read lands. What reaches a screen has already arrived.
+ */
+const RecordZoneContext = createContext<string>(FALLBACK_RECORD_ZONE);
+
+/**
+ * The zone every record date on this page is read in.
+ *
+ * A record's dates belong to the record rather than to whoever is looking at
+ * it: a close date, a renewal, an invoice's issue day and a timeline's day
+ * headings must read the same for every colleague, or two people quoting the
+ * same page quote different days. That is the rule `format/timezone.ts` states,
+ * and this hook is where the organization's answer to it now comes from.
+ *
+ * For a moment the reader relates to their own clock — when a credential they
+ * are lending expires, when a slot they are booking starts — the answer is
+ * still `viewerZone()`, not this.
+ */
+export function useRecordZone(): string {
+  return useContext(RecordZoneContext);
+}
+
+/**
+ * The zone a wire value names, or the fallback when this runtime cannot render
+ * it.
+ *
+ * The server validates `installation.timezone` against its own tzdata before
+ * storing it, so a conforming server cannot send a name the browser rejects.
+ * "Cannot" is a claim about two zone databases being in step, though, and they
+ * are shipped by different vendors on different schedules — so a name Go
+ * resolves and this browser does not is a real, if unlikely, state.
+ *
+ * It must not be a thrown error. `Intl.DateTimeFormat` throws a RangeError on
+ * an unknown zone, and the record zone reaches every date on every record page:
+ * one bad name would take down not a row but the whole application, for every
+ * reader, until an admin who could no longer load the settings screen changed
+ * it back.
+ *
+ * So it falls back and reports. Reporting matters as much as the fallback: this
+ * state is the server and this browser disagreeing about what a zone name
+ * means, and swallowing it would leave every date quietly on the wrong clock
+ * with nothing anywhere saying so.
+ *
+ * Asked with `isRenderableZone` — the formatters' OWN predicate — rather than
+ * by probing Intl here. Probing Intl answers a different question: whether the
+ * name resolves, which every fixed offset does, so `Etc/GMT-1` and `+01:00`
+ * would pass a hand-rolled probe and then throw inside `formatDate` one line
+ * later. `scheduledsends.tsx` learned this on `scheduled_tz` and asks the same
+ * way for the same reason.
+ */
+export function renderableRecordZone(configured: string | undefined): string {
+  if (configured === undefined) {
+    return FALLBACK_RECORD_ZONE;
+  }
+  if (isRenderableZone(configured)) {
+    return configured;
+  }
+  logUnexpectedError(
+    new Error(
+      `installation.timezone is not a zone this browser can render: "${configured}" — record dates are falling back to ${FALLBACK_RECORD_ZONE}`,
+    ),
+  );
+  return FALLBACK_RECORD_ZONE;
+}
+
+/**
+ * The installation's zone and whether it is still on its way — the ONE reading
+ * of the settings query the record zone makes.
+ *
+ * `enabled` is the session gate. The settings read needs one, and the three
+ * public screens (`book`, `preferences`, `room`) render no record dates at all
+ * — they show a moment the reader relates to their own clock, on
+ * `viewerZone()`, which needs no installation.
+ *
+ * One hook rather than a `useRecordZone` and a separate `useRecordZonePending`,
+ * because a second reader on this key would decide `enabled` for itself:
+ * whichever mounted first would settle whether the request fires at all, and
+ * only sometimes. `uploadlimit.ts` says exactly this above its own query, and
+ * the record zone is the case that would have proved it.
+ *
+ * `pending` is what the authenticated boundary holds its splash on, which is
+ * what lets `useRecordZone` promise a screen an answer that has already
+ * arrived. Rendering through the wait instead would paint every record date on
+ * the fallback clock and then move them, so a reader watching a timeline would
+ * see the day headings renumber under a page they were reading.
+ *
+ * A FAILED read does not hold the gate: `isPending` is false once a query has
+ * settled either way. The settings request failing is not a reason to refuse
+ * the whole application — the record pages still work, on the fallback zone,
+ * which is what they did before this existed.
+ */
+export function useConfiguredRecordZone(enabled: boolean): {
+  zone: string;
+  pending: boolean;
+} {
+  const query = useInstallationSettings(enabled);
+  return {
+    zone: renderableRecordZone(query.data?.timezone),
+    // A DISABLED query is `isPending` forever — it is waiting for permission
+    // to run, not for an answer. Reported as pending, it would hold the splash
+    // up over the sign-in screen.
+    pending: enabled && query.isPending,
+  };
+}
+
+/**
+ * Serves one zone to every screen under it.
+ *
+ * The authenticated boundary mounts it with what `useConfiguredRecordZone`
+ * resolved. A test or a story mounts it with a zone it names outright, which is
+ * why the value is a prop rather than read here: a suite whose expected day
+ * moved with the machine it ran on would assert nothing, and asking a test to
+ * serve an installation-settings response to state a fact it already knows is
+ * a request about the wrong thing.
+ *
+ * The prop is not validated. The boundary's value has already been through
+ * `renderableRecordZone`, and a test naming a zone is stating the premise of
+ * its own assertion — a fallback there would quietly answer a different
+ * question than the one it asked.
+ */
+export function RecordZoneProvider({
+  zone,
+  children,
+}: Readonly<{ zone: string; children: ReactNode }>) {
+  return (
+    <RecordZoneContext.Provider value={zone}>
+      {children}
+    </RecordZoneContext.Provider>
+  );
+}

--- a/frontend/src/app/uploadlimit.ts
+++ b/frontend/src/app/uploadlimit.ts
@@ -30,9 +30,15 @@ export const INSTALLATION_SETTINGS_KEY = ["installation-settings"] as const;
  * gets undefined either way — no second request, and no second opinion about
  * what a failure means.
  */
-export function useInstallationSettings() {
+export function useInstallationSettings(enabled = true) {
   return useQuery({
     queryKey: INSTALLATION_SETTINGS_KEY,
+    // Every caller but one leaves this alone: a screen that reads a setting is
+    // already behind the session gate. The exception is the record-zone
+    // provider, which mounts AT that gate and must not fire an unauthenticated
+    // request whose 401 would report a failure for a session nobody has
+    // claimed yet.
+    enabled,
     queryFn: async () => {
       const { data, error, response } = await api.GET("/installation/settings");
       if (error || !response.ok) {

--- a/frontend/src/design-system/recordtimeline.test.tsx
+++ b/frontend/src/design-system/recordtimeline.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
-import { RECORD_ZONE } from "../format/timezone";
+import { RecordZoneProvider } from "../app/recordzone";
 import { LocaleProvider } from "../i18n";
 import { LoadMoreButton } from "../screens/common";
 import { groupChronology } from "../screens/timelinegroups";
@@ -83,6 +83,14 @@ function activityFeed(pages: Record<string, ActivityPage>) {
   };
 }
 
+// The installation's zone, stated by this suite rather than taken from a
+// default. It is deliberately NOT the fallback: a from/to filter cut on the
+// fallback clock and asserted against the fallback clock would agree with
+// itself no matter which zone the code actually read, so the one thing this
+// file has to prove — that the picked day is cut in the INSTALLATION's zone —
+// would be exactly what it could not see.
+const INSTALLATION_ZONE = "Asia/Ho_Chi_Minh";
+
 function Harness({ firstPage }: Readonly<{ firstPage?: ActivityPage }>) {
   const [filters, setFilters] = useTimelineFilters("p-1");
   const timeline = useRecordTimeline("person", "p-1", { filters, firstPage });
@@ -94,7 +102,7 @@ function Harness({ firstPage }: Readonly<{ firstPage?: ActivityPage }>) {
       <TimelineFilterBar value={filters} onChange={setFilters} />
       <GroupedTimelineList
         groups={groupChronology(entries, timeline.hasNextPage)}
-        zone={RECORD_ZONE}
+        zone={INSTALLATION_ZONE}
       />
       <LoadMoreButton query={timeline} />
     </>
@@ -108,7 +116,9 @@ function mount(firstPage?: ActivityPage) {
   render(
     <QueryClientProvider client={client}>
       <LocaleProvider initial="en">
-        <Harness firstPage={firstPage} />
+        <RecordZoneProvider zone={INSTALLATION_ZONE}>
+          <Harness firstPage={firstPage} />
+        </RecordZoneProvider>
       </LocaleProvider>
     </QueryClientProvider>,
   );
@@ -229,8 +239,12 @@ describe("a record timeline you can work in", () => {
       expect(feed.last().searchParams.get("occurred_before")).not.toBeNull(),
     );
     const params = feed.last().searchParams;
-    expect(params.get("occurred_after")).toBe(dayStartIso("2026-03-03"));
-    expect(params.get("occurred_before")).toBe(dayStartIso("2026-03-05", 1));
+    expect(params.get("occurred_after")).toBe(
+      dayStartIso("2026-03-03", INSTALLATION_ZONE),
+    );
+    expect(params.get("occurred_before")).toBe(
+      dayStartIso("2026-03-05", INSTALLATION_ZONE, 1),
+    );
   });
 
   it("folds a conversation into one row that opens, with the conversation's own verbs on it", async () => {

--- a/frontend/src/design-system/recordtimeline.ts
+++ b/frontend/src/design-system/recordtimeline.ts
@@ -6,7 +6,8 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components, operations } from "../api/schema";
 import type { EntityKind } from "../app/entity";
-import { RECORD_ZONE, startOfDayInZone } from "../format/timezone";
+import { useRecordZone } from "../app/recordzone";
+import { startOfDayInZone } from "../format/timezone";
 import { entityTimelineKeys } from "../screens/activitykeys";
 import { throwProblem, useSorMode } from "../screens/common";
 import type { ISODate } from "./dateinput";
@@ -60,14 +61,18 @@ export function hasTimelineFilters(filters: TimelineFilters): boolean {
 export const TIMELINE_PAGE_SIZE = 20;
 
 /**
- * dayStartIso turns a picked calendar day into the instant it begins — in
- * RECORD_ZONE, the clock every timeline row is rendered in, so the day the
+ * dayStartIso turns a picked calendar day into the instant it begins — in the
+ * record zone, the clock every timeline row is rendered in, so the day the
  * reader picks is the day the rows show. `daysLater` shifts by whole days,
  * which is how an EXCLUSIVE `before` is spelled from an inclusive "to" date:
  * the next day's start.
+ *
+ * The zone is a parameter because this is a plain function and the zone now
+ * comes from the installation, which only a hook can read. It is threaded from
+ * `useRecordTimeline` rather than read here.
  */
-export function dayStartIso(day: ISODate, daysLater = 0): string {
-  return startOfDayInZone(day, RECORD_ZONE, daysLater);
+export function dayStartIso(day: ISODate, zone: string, daysLater = 0): string {
+  return startOfDayInZone(day, zone, daysLater);
 }
 
 /**
@@ -80,6 +85,7 @@ export function timelineQueryParams(
   entityType: EntityKind,
   id: string,
   filters: TimelineFilters,
+  zone: string,
   cursor?: string,
 ): ListActivitiesQuery {
   const query: ListActivitiesQuery = {
@@ -90,8 +96,9 @@ export function timelineQueryParams(
   if (cursor) query.cursor = cursor;
   if (filters.kind) query.kind = filters.kind;
   if (filters.q?.trim()) query.q = filters.q.trim();
-  if (filters.after) query.occurred_after = dayStartIso(filters.after);
-  if (filters.before) query.occurred_before = dayStartIso(filters.before, 1);
+  if (filters.after) query.occurred_after = dayStartIso(filters.after, zone);
+  if (filters.before)
+    query.occurred_before = dayStartIso(filters.before, zone, 1);
   return query;
 }
 
@@ -165,17 +172,22 @@ export function useRecordTimeline(
   // refuses (422) — skip the fetch in overlay; the record page renders the
   // honest unavailable state in the timeline slot instead.
   const overlay = useSorMode() === "overlay";
+  const zone = useRecordZone();
   const seedCursor = seed?.page.next_cursor ?? undefined;
   const query = useInfiniteQuery({
-    // The key the write path invalidates, extended by the filters and the
-    // seed's edge. Spelled without the filters, a kind-narrowed page would be
-    // handed to the unfiltered view; spelled without the edge, pages continued
-    // from a seed that has since changed would start from a cursor that no
-    // longer sits at its end.
+    // The key the write path invalidates, extended by the filters, the seed's
+    // edge and the zone. Spelled without the filters, a kind-narrowed page
+    // would be handed to the unfiltered view; spelled without the edge, pages
+    // continued from a seed that has since changed would start from a cursor
+    // that no longer sits at its end; spelled without the zone, a from/to
+    // filter cached under the old record zone would keep answering after an
+    // admin moved it, and the rows it returns are cut at day boundaries that
+    // have moved with it.
     queryKey: [
       ...entityTimelineKeys(entityType, id)[0],
       filters,
       { continuesFrom: seedCursor ?? null },
+      { zone },
     ],
     // With a seed the first page is already on screen: nothing is fetched
     // until the reader asks, and `fetchNextPage` fetches regardless of this.
@@ -186,7 +198,7 @@ export function useRecordTimeline(
     queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET("/activities", {
         params: {
-          query: timelineQueryParams(entityType, id, filters, pageParam),
+          query: timelineQueryParams(entityType, id, filters, zone, pageParam),
         },
       });
       if (error) {

--- a/frontend/src/format/calendarday.ts
+++ b/frontend/src/format/calendarday.ts
@@ -93,7 +93,7 @@ export function localDateTimeValue(utcIso: string): string {
 
 // The instant that is NOON of a picked calendar day in a named zone — for a
 // backdated entry whose screens render dates in that zone (the record pages'
-// RECORD_ZONE): filing it at the zone's own midday is what keeps it on the
+// own record zone): filing it at the zone's own midday is what keeps it on the
 // picked day both there and in the wall clock of any writer within twelve
 // hours of that zone.
 //

--- a/frontend/src/format/timezone.test.ts
+++ b/frontend/src/format/timezone.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { formatDate } from "./format";
-import { RECORD_ZONE, startOfDayInZone, viewerZone } from "./timezone";
+import { FALLBACK_RECORD_ZONE, startOfDayInZone, viewerZone } from "./timezone";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -45,21 +45,33 @@ describe("viewerZone", () => {
   });
 });
 
-describe("RECORD_ZONE", () => {
+describe("FALLBACK_RECORD_ZONE", () => {
   it("is a zone the formatters accept", () => {
     // format.ts refuses a fixed offset ("+01:00", "Etc/GMT-1") because those
-    // freeze the DST rules. The record zone has to pass that door.
+    // freeze the DST rules. The fallback has to pass that door — it is what
+    // renders when the installation's own zone cannot, so a fallback that
+    // itself threw would turn a recoverable disagreement between two zone
+    // databases into a blank page.
     expect(() =>
-      formatDate("2026-07-02T00:30:00Z", "en", RECORD_ZONE),
+      formatDate("2026-07-02T00:30:00Z", "en", FALLBACK_RECORD_ZONE),
     ).not.toThrow();
   });
+});
 
-  it("reads an instant on its own calendar, not the reader's", () => {
-    // 00:30 UTC is already 2 July in the record zone and still 1 July on the
-    // US west coast — the boundary the two purposes disagree across.
+describe("a record's clock against the reader's", () => {
+  it("reads an instant on the record's calendar, not the reader's", () => {
+    // The distinction the whole module exists for, asserted against a zone
+    // this test NAMES rather than against whatever the installation or the
+    // fallback happens to hold. Berlin is a stand-in for any configured
+    // record zone here; the claim is about the two purposes disagreeing, and
+    // pinning it to a constant would make the test restate that constant
+    // instead of the rule.
+    //
+    // 00:30 UTC is already 2 July in a zone east of UTC and still 1 July on
+    // the US west coast — the boundary the two purposes disagree across.
     pretendReportedZone("America/Los_Angeles");
     const instant = "2026-07-02T00:30:00Z";
-    expect(formatDate(instant, "en", RECORD_ZONE)).toBe("02/07/2026");
+    expect(formatDate(instant, "en", "Europe/Berlin")).toBe("02/07/2026");
     expect(formatDate(instant, "en", viewerZone())).toBe("01/07/2026");
   });
 });

--- a/frontend/src/format/timezone.test.ts
+++ b/frontend/src/format/timezone.test.ts
@@ -91,4 +91,40 @@ describe("startOfDayInZone", () => {
       "2026-08-01T04:00:00.000Z",
     );
   });
+
+  // A day whose midnight does not exist. Santiago springs forward AT midnight
+  // on 2026-09-06: its clock reads 23:00 on the 5th and then 01:00 on the 6th,
+  // so `2026-09-06T00:00` is a wall-clock time that never happens there.
+  //
+  // Resolving it by offset arithmetic alone lands one hour before the jump —
+  // an instant that still reads as the FIFTH. A "from 6 September" timeline
+  // filter built on that pulls in an hour of the fifth, and the exclusive end
+  // of a "to 5 September" range drops that same hour. Both are silent: the
+  // rows are plausible, just off by an hour at one edge, once a year, in a
+  // zone whoever wrote the filter probably does not live in.
+  //
+  // Reachable because the record zone is now the INSTALLATION's, not a
+  // hardcoded Europe/Berlin — Berlin transitions at 02:00 and never removes
+  // its own midnight.
+  it("returns the day's first REAL instant when its midnight does not exist", () => {
+    // 04:00Z is the transition itself — Santiago's clock jumps from 23:00 on
+    // the 5th to 01:00 on the 6th at that instant, so it is the first moment
+    // the zone reads as the 6th at all. 03:00Z, what offset arithmetic alone
+    // resolves to, is still 23:00 on the 5th there.
+    expect(startOfDayInZone("2026-09-06", "America/Santiago")).toBe(
+      "2026-09-06T04:00:00.000Z",
+    );
+  });
+
+  // The other side of the same zone's year, and what keeps the correction from
+  // firing where it is not wanted: on a day whose midnight exists normally, the
+  // resolved instant already reads as that day, so nothing is stepped forward.
+  // Santiago is back on UTC-4 here, four hours from the spring-forward case
+  // above, so a correction that ran unconditionally would show up as an offset
+  // that is wrong by the transition's width rather than as a missing hour.
+  it("leaves a day alone when its midnight exists", () => {
+    expect(startOfDayInZone("2026-04-04", "America/Santiago")).toBe(
+      "2026-04-04T03:00:00.000Z",
+    );
+  });
 });

--- a/frontend/src/format/timezone.ts
+++ b/frontend/src/format/timezone.ts
@@ -10,14 +10,20 @@
 // The two purposes are NOT interchangeable, and each has its own way of being
 // wrong:
 //
-//   RECORD_ZONE — the organization's own clock. Its dates belong to the
-//   record, not to whoever is looking at it. Following the reader here
-//   MISSTATES the record: a close date, a renewal, an invoice's issue day and
-//   a timeline's day headings have to read the same for every colleague, or two
-//   people quoting the same page quote different days. It is also the only
-//   correct answer for a date-only wire value (OpenAPI `format: date`): there
-//   is no instant in `2026-08-21` to localize, and reading it in a zone behind
-//   UTC prints the day before.
+//   useRecordZone() — the organization's own clock, as the installation
+//   configured it (`installation.timezone`, served by app/recordzone.tsx). Its
+//   dates belong to the record, not to whoever is looking at it. Following the
+//   reader here MISSTATES the record: a close date, a renewal, an invoice's
+//   issue day and a timeline's day headings have to read the same for every
+//   colleague, or two people quoting the same page quote different days. It is
+//   also the only correct answer for a date-only wire value (OpenAPI
+//   `format: date`): there is no instant in `2026-08-21` to localize, and
+//   reading it in a zone behind UTC prints the day before.
+//
+//   It is a HOOK rather than a constant because the answer belongs to the
+//   installation and arrives over the wire. A plain helper that needs it takes
+//   it as a parameter from the component that read it — never by importing the
+//   fallback below, which is a different value that only happens to agree.
 //
 //   viewerZone() — the reader's own clock, for a moment they relate to
 //   themselves: when a credential they are lending expires, when a paused job
@@ -33,19 +39,28 @@
 // "Genuinely both" means both readings are defensible, and that is a claim about
 // the STORED value, not about the screen. An activity's `due_at` is minted by
 // `dueInstant` as the end of the picked day in the BROWSER's zone, so the wire
-// value already carries the picker's clock; RECORD_ZONE does not read the
+// value already carries the picker's clock; the record zone does not read the
 // organization's day out of it, it reads a day the picker never chose, off by
 // one for every reader outside that zone. A value with no record reading has
 // nothing for the page to win against, so `due_at` takes viewerZone() wherever
 // it is shown — the tasks queue, the record's next steps, the task detail —
-// while the activity's `occurred_at` beside it stays on RECORD_ZONE, because
-// when something happened IS a fact about the record.
+// while the activity's `occurred_at` beside it stays on the record zone,
+// because when something happened IS a fact about the record.
 
-// The organization's zone. A constant, and deliberately not read from the
-// installation's configured timezone yet: every screen that renders a record
-// date has to agree, and a per-request value that arrives late would render the
-// first paint in one zone and the second in another.
-export const RECORD_ZONE = "Europe/Berlin";
+// The zone a record's dates are read in when the installation's own answer is
+// not on hand. It is the LAST resort, not the value: `useRecordZone` in
+// app/recordzone.tsx serves `installation.timezone`, and the authenticated
+// shell holds its first paint until that read lands, so no signed-in surface
+// renders a record date against this constant.
+//
+// It stays a real zone rather than UTC because the surfaces that can still
+// reach it are the ones outside the settings read — a story, a test that mounts
+// a screen bare — and those are easier to read against a zone with an offset
+// and a DST rule than against one with neither.
+//
+// Do not import it into a screen. The gate in zone-by-purpose.test.ts refuses
+// that, and names this comment when it does.
+export const FALLBACK_RECORD_ZONE = "Europe/Berlin";
 
 /**
  * The zone the reader's own browser is in, or `UTC` when it will not say.

--- a/frontend/src/format/timezone.ts
+++ b/frontend/src/format/timezone.ts
@@ -134,6 +134,64 @@ function instantInZone(
   return utcMs;
 }
 
+// The calendar day `zone`'s wall clock reads at `utcMs`, as `yyyy-mm-dd`.
+// Derived through Intl rather than by arithmetic on the offset, because the
+// offset is what is in question at the moments this is asked about.
+function dayInZone(utcMs: number, zone: string): string {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+      .formatToParts(new Date(utcMs))
+      .map((part) => [part.type, part.value]),
+  );
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+/**
+ * The first instant of `dateOnly` in `zone` — the day's true beginning, even
+ * when its midnight does not exist.
+ *
+ * A spring-forward transition can REMOVE a wall-clock hour, and some zones put
+ * that transition at midnight: Santiago goes from 23:00 on 5 September 2026
+ * straight to 01:00 on the 6th, so `2026-09-06T00:00` is a time that never
+ * happens there. Asked for it, `instantInZone` converges on the instant one
+ * hour before the jump, whose local reading is still 23:00 on the FIFTH — a
+ * "from 6 September" filter then pulls in an hour of the fifth, and an
+ * exclusive "to the fifth" end drops that hour instead.
+ *
+ * So the resolved instant is checked against the day it was supposed to land
+ * on. When it falls short, the day's first instant is the transition itself,
+ * found by stepping forward a minute at a time — a removed span is a whole
+ * number of minutes in every zone tzdata describes, and the largest is
+ * Lord Howe's 30, so the walk is bounded and short. Stepping BACK is never
+ * needed: the resolved instant is never later than the day's start, because a
+ * removed hour only ever moves the clock forward.
+ */
+function startOfDayInstant(dateOnly: string, zone: string): number {
+  const resolved = instantInZone(dateOnly, zone, 0, 0, 0);
+  if (dayInZone(resolved, zone) === dateOnly) {
+    return resolved;
+  }
+  const minute = 60_000;
+  // Two hours covers every transition tzdata records; the loop exits at the
+  // first minute that reads as the wanted day.
+  for (let step = 1; step <= 120; step += 1) {
+    const candidate = resolved + step * minute;
+    if (dayInZone(candidate, zone) === dateOnly) {
+      return candidate;
+    }
+  }
+  // No minute in two hours reads as the wanted day. That is not a zone rule
+  // this code knows how to interpret, and guessing would silently file records
+  // under a day nobody picked — so the honest answer is the unadjusted one,
+  // which is what every caller got before this correction existed.
+  return resolved;
+}
+
 /**
  * A calendar day, picked as a date-only string, read as a day in `zone`.
  * Minting it as `new Date(dateOnly).toISOString()` reads the string as UTC
@@ -141,10 +199,11 @@ function instantInZone(
  * forward for evening messages east of it: the picker and the rendered row
  * would then disagree about which day was meant.
  *
- * `startOfDayInZone` is the day's first instant; `daysLater` shifts by whole
- * calendar days, which is how an EXCLUSIVE range end is spelled from an
- * inclusive "to" day — the next day's start — without an arithmetic step
- * across a DST change.
+ * `startOfDayInZone` is the day's first instant — which is not always its
+ * midnight, since a spring-forward transition can remove one (see
+ * `startOfDayInstant`). `daysLater` shifts by whole calendar days, which is how
+ * an EXCLUSIVE range end is spelled from an inclusive "to" day — the next day's
+ * start — without an arithmetic step across a DST change.
  */
 export function startOfDayInZone(
   dateOnly: string,
@@ -155,7 +214,7 @@ export function startOfDayInZone(
   const shifted = new Date(Date.UTC(year, month - 1, day + daysLater))
     .toISOString()
     .slice(0, 10);
-  return new Date(instantInZone(shifted, zone, 0, 0, 0)).toISOString();
+  return new Date(startOfDayInstant(shifted, zone)).toISOString();
 }
 
 /** The day's last instant, 23:59:59.999 on `zone`'s wall clock. */

--- a/frontend/src/format/zone-by-purpose.test.ts
+++ b/frontend/src/format/zone-by-purpose.test.ts
@@ -6,7 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { RECORD_ZONE } from "./timezone";
+import { FALLBACK_RECORD_ZONE } from "./timezone";
 
 // A screen that names a zone has decided something, and the decision is the
 // part that has to be reviewable: whose calendar does this date belong to, the
@@ -18,11 +18,19 @@ import { RECORD_ZONE } from "./timezone";
 // (right for nobody, since two colleagues then quote different days for the
 // same fact).
 //
-// So the rule is that a zone is NAMED in one file. `RECORD_ZONE` and
+// So the rule is that a zone is NAMED in one file. `useRecordZone()` and
 // `viewerZone()` carry the purposes; a call site picks one and reads as the
 // judgement it is. This gate holds the negative half: nothing outside that
 // module spells ANY zone out again — not the record zone, and not a second one
 // chosen because it looked harmless.
+//
+// Since the record zone became the INSTALLATION's answer rather than a
+// constant, there is a second way to pin it silently, and this gate holds that
+// half too: importing `FALLBACK_RECORD_ZONE`. It is a real zone name that a
+// screen could use and that would look right on the machine of whoever wrote
+// it, while every installation that configured something else got Berlin — the
+// exact defect the hook exists to end. Only the record-zone module itself may
+// name it.
 //
 // Every half is derived from the tree — each `.ts`/`.tsx` under `src/`, read
 // through the parser, matched against the IANA zone shape and the two spellings
@@ -139,6 +147,18 @@ function code(path: string, source: string): string {
 // the one thing `viewerZone()` cannot stand in for: a suite whose expected
 // output moved with the machine it ran on would assert nothing.
 const pinnedZones: { file: string; why: string }[] = [
+  {
+    file: "app/recordzone.test.tsx",
+    why: "Proves what the record zone does with what the server sends it, which needs a configured zone to hand it and an unrenderable one to refuse — neither is a zone this code picks, both are the input under test.",
+  },
+  {
+    file: "design-system/recordtimeline.test.tsx",
+    why: "The timeline's from/to filter cuts a picked day at the INSTALLATION's boundaries; asserting that against the fallback would agree with itself whichever zone the code read, so the suite names a zone that is not the fallback.",
+  },
+  {
+    file: "screens/recordlist.test.tsx",
+    why: "createdColumn now takes the zone it renders dates in; this suite asserts what the column SORTS on, so it hands over a named zone to satisfy the signature and the zone itself carries none of the claim.",
+  },
   {
     file: "app/mefixture.ts",
     why: "The offline `me` fixture stands in for a real installation's stored settings, and its organization timezone is one of those settings — a value on the wire, not a zone this code picks.",
@@ -339,17 +359,47 @@ describe("a zone is named in one module", () => {
 
   it("sees the record zone it exists to protect", () => {
     // The pattern is derived from the IANA shape, not copied from the value of
-    // RECORD_ZONE — and the two must not drift, because the way that drift ends
-    // is silent. Retune the record zone to something the pattern cannot see and
-    // every arm below still passes, over a tree the sweep no longer reads.
-    expect(`"${RECORD_ZONE}"`.match(ZONE_LITERAL)).toEqual([
-      `"${RECORD_ZONE}"`,
+    // the fallback — and the two must not drift, because the way that drift
+    // ends is silent. Retune the fallback to something the pattern cannot see
+    // and every arm below still passes, over a tree the sweep no longer reads.
+    expect(`"${FALLBACK_RECORD_ZONE}"`.match(ZONE_LITERAL)).toEqual([
+      `"${FALLBACK_RECORD_ZONE}"`,
     ]);
     // And it has to be a zone Intl accepts, or the shape matched a name that
-    // formats nothing.
+    // formats nothing. This is load-bearing for the fallback specifically: it
+    // is what a screen renders against when the installation's own zone cannot
+    // be rendered, so a fallback that itself threw would turn a recoverable
+    // disagreement between two zone databases into a blank application.
     expect(
-      () => new Intl.DateTimeFormat("en", { timeZone: RECORD_ZONE }),
+      () => new Intl.DateTimeFormat("en", { timeZone: FALLBACK_RECORD_ZONE }),
     ).not.toThrow();
+  });
+
+  it("leaves the fallback zone importable by nothing but its own reader", () => {
+    // The record zone is the installation's, served by a hook. The fallback is
+    // what stands in when that answer cannot be rendered, and it is a REAL zone
+    // name — so a screen that imported it would look correct to whoever wrote
+    // it and would quietly show Berlin to every installation that configured
+    // something else. That is the defect the hook exists to end, reintroduced
+    // through the back door, and no zone LITERAL appears in such a file for the
+    // sweep above to catch.
+    //
+    // Three permitted files, all of them ABOUT the fallback rather than users
+    // of it: `app/recordzone.tsx` decides when it applies, its own suite proves
+    // that decision, and `format/timezone.test.ts` asserts the one property the
+    // fallback must never lose — that the formatters accept it, since it is
+    // what renders when the installation's own zone cannot. A test forbidden
+    // from naming the value it asserts on could only check it against itself.
+    const allowed = new Set([
+      "app/recordzone.tsx",
+      "app/recordzone.test.tsx",
+      "format/timezone.test.ts",
+    ]);
+    const importers = sourceFiles(srcRoot)
+      .filter((path) => /FALLBACK_RECORD_ZONE/.test(readFileSync(path, "utf8")))
+      .map((path) => relative(srcRoot, path).split("\\").join("/"))
+      .filter((file) => !allowed.has(file));
+    expect(importers.sort()).toEqual([]);
   });
 
   it("sees a zone that is not the record zone", () => {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5292,7 +5292,7 @@ export const de = {
     "Wird überall dort angezeigt, wo das Produkt Ihre Organisation benennt.",
   "installationSettings.timezone": "Zeitzone für Auswertungen",
   "installationSettings.timezoneHint":
-    "IANA-Zonenname (zum Beispiel Europe/Berlin). Periodengrenzen aller Auswertungen werden darin berechnet, unabhängig von Ihrer eigenen Anzeigezeitzone.",
+    "IANA-Zonenname (zum Beispiel Europe/Berlin). Die Uhr Ihrer Organisation: Periodengrenzen aller Auswertungen werden darin berechnet, und jedes Datum eines Datensatzes — Abschlusstermine, Rechnungstage, Verlaufsüberschriften — wird darin angezeigt, damit ein Datum für das ganze Team gleich lautet. Unabhängig von Ihrer eigenen Anzeigezeitzone.",
   "installationSettings.baseCurrency": "Basiswährung",
   "installationSettings.baseCurrencyHint":
     "ISO-4217-Code, in den alle Beträge für Auswertungen umgerechnet werden. Änderbar, bis der erste Betrag dagegen umgerechnet wurde.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5326,7 +5326,7 @@ export const en = {
     "Shown wherever the product names your organization.",
   "installationSettings.timezone": "Reporting timezone",
   "installationSettings.timezoneHint":
-    "IANA zone name (for example Europe/Berlin). Period boundaries in every report are computed in it, separate from your own display timezone.",
+    "IANA zone name (for example Europe/Berlin). Your organization's own clock: report period boundaries are computed in it, and every record date — close dates, invoice days, timeline headings — is shown in it, so a date reads the same for the whole team. Separate from your own display timezone.",
   "installationSettings.baseCurrency": "Base currency",
   "installationSettings.baseCurrencyHint":
     "ISO-4217 code every amount converts to for roll-ups. Changeable until the first amount converts against it.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5240,7 +5240,7 @@ export const vi = {
     "Hiển thị ở mọi nơi sản phẩm gọi tên tổ chức của bạn.",
   "installationSettings.timezone": "Múi giờ báo cáo",
   "installationSettings.timezoneHint":
-    "Tên múi giờ IANA (ví dụ Europe/Berlin). Ranh giới kỳ của mọi báo cáo được tính theo múi giờ này, tách biệt với múi giờ hiển thị của riêng bạn.",
+    "Tên múi giờ IANA (ví dụ Europe/Berlin). Đồng hồ riêng của tổ chức bạn: ranh giới kỳ của mọi báo cáo được tính theo múi giờ này, và mọi ngày tháng của bản ghi — ngày chốt, ngày hoá đơn, tiêu đề dòng thời gian — đều hiển thị theo nó, để một ngày đọc giống nhau với cả nhóm. Tách biệt với múi giờ hiển thị của riêng bạn.",
   "installationSettings.baseCurrency": "Đơn vị tiền tệ cơ sở",
   "installationSettings.baseCurrencyHint":
     "Mã ISO-4217 mà mọi số tiền được quy đổi về khi tổng hợp. Có thể thay đổi cho đến khi số tiền đầu tiên được quy đổi theo nó.",

--- a/frontend/src/screens/audit.tsx
+++ b/frontend/src/screens/audit.tsx
@@ -7,9 +7,9 @@ import {
   UserRoundCheck,
 } from "lucide-react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge } from "../design-system/atoms";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import "./audit.css";
@@ -211,6 +211,7 @@ export function AuditEntryLine({
   meUserId,
 }: Readonly<{ entry: AuditLogEntry; meUserId?: string }>) {
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   return (
     <div className="audit-line">
       <ActorTag entry={entry} meUserId={meUserId} />
@@ -224,7 +225,7 @@ export function AuditEntryLine({
           record clock exists to prevent. `dateTime` carries the unambiguous
           instant for anyone who has to convert. */}
       <time className="audit-when" dateTime={entry.occurred_at}>
-        {formatDateTime(entry.occurred_at, locale, RECORD_ZONE)}
+        {formatDateTime(entry.occurred_at, locale, recordZone)}
       </time>
     </div>
   );

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useEffect, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { navigate, routeHash } from "../app/router";
 import {
   Avatar,
@@ -42,7 +43,7 @@ import {
   formatMoneyCompact,
   formatMoneyOrAbsent,
 } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -1156,6 +1157,7 @@ export function CommercialPanel({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const deals = view?.deals;
   const state = sectionState(
     view,
@@ -1221,7 +1223,7 @@ export function CommercialPanel({
                       when: formatDate(
                         deal.expected_close_date,
                         locale,
-                        RECORD_ZONE,
+                        recordZone,
                       ),
                     })}
                   </span>
@@ -1280,10 +1282,14 @@ const RECENT_ACTIVITY_LIMIT = 5;
 // day is never revisited later in the same page.
 type ActivityDay = { key: string; entries: TimelineEntry[] };
 
-function groupByDay(entries: readonly TimelineEntry[], locale: Locale) {
+function groupByDay(
+  entries: readonly TimelineEntry[],
+  locale: Locale,
+  recordZone: string,
+) {
   const days: ActivityDay[] = [];
   for (const entry of entries) {
-    const key = formatDate(entry.atIso, locale, RECORD_ZONE);
+    const key = formatDate(entry.atIso, locale, recordZone);
     const last = days.at(-1);
     if (last?.key === key) {
       last.entries.push(entry);
@@ -1318,6 +1324,7 @@ export function RecentActivityPanel({
   const t = useT();
   const { locale } = useLocale();
   const viewerId = useViewerId();
+  const recordZone = useRecordZone();
   // Every logged activity, not only the ones with a subject: a call or a note
   // often has none, and filtering them out here would under-report the
   // chronology and — because the count feeds sectionState — draw "nothing
@@ -1333,6 +1340,7 @@ export function RecentActivityPanel({
   const days = groupByDay(
     activityTimeline(logged.slice(0, RECENT_ACTIVITY_LIMIT), viewerId),
     locale,
+    recordZone,
   );
   return (
     <Panel
@@ -1351,7 +1359,7 @@ export function RecentActivityPanel({
             <h3 className="co-timeline-day-heading t-eyebrow">{day.key}</h3>
             <ul className="timeline">
               {day.entries.map((entry) => (
-                <TimelineRow key={entry.id} entry={entry} zone={RECORD_ZONE} />
+                <TimelineRow key={entry.id} entry={entry} zone={recordZone} />
               ))}
             </ul>
           </div>
@@ -1458,7 +1466,7 @@ export function NextSteps({
                       // calendar day than the one the picker chose, for every
                       // reader outside that zone — there is no organization
                       // reading of it to prefer. The timeline below still reads
-                      // in RECORD_ZONE, because an activity's occurrence IS a
+                      // in the record zone, because an activity's occurrence IS a
                       // fact about the record.
                       when: formatDate(step.due_at, locale, viewerZone()),
                     })}
@@ -1861,6 +1869,7 @@ export function AccountBrief({
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();
+  const recordZone = useRecordZone();
   // The project the brief is about. Part of the query key, so a scoped brief
   // and the whole account's are two cached readings rather than one
   // overwriting the other on screen.
@@ -1933,7 +1942,7 @@ export function AccountBrief({
   const titleAction = readable && (
     <span className="t-small">
       {t("co.brief.generatedAt", {
-        when: formatDateTime(readable.generated_at, locale, RECORD_ZONE),
+        when: formatDateTime(readable.generated_at, locale, recordZone),
       })}
     </span>
   );
@@ -2068,6 +2077,7 @@ export function AskSection({
   const t = useT();
   const { locale } = useLocale();
   const [projectId, setProjectId] = useState("");
+  const recordZone = useRecordZone();
   const live = liveProjects(projects);
   useSoleProjectDefault(live, projectId, setProjectId);
   useClearVanishedChoice(live, projectId, setProjectId);
@@ -2160,7 +2170,7 @@ export function AskSection({
             <WrittenBy by={readable.generated_by} />
             <span>
               {t("co.brief.generatedAt", {
-                when: formatDate(readable.generated_at, locale, RECORD_ZONE),
+                when: formatDate(readable.generated_at, locale, recordZone),
               })}
             </span>
           </p>
@@ -2304,6 +2314,7 @@ export function StateStrip({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const strip = view?.state_strip;
   if (!strip) {
     // Absent for two different reasons, and only `sections_omitted` tells
@@ -2360,7 +2371,12 @@ export function StateStrip({
           // reading with nothing to add.
           detail={relationships === lifecycle ? undefined : relationships}
         />
-        <PipelineCard commercial={strip.commercial} locale={locale} t={t} />
+        <PipelineCard
+          commercial={strip.commercial}
+          locale={locale}
+          recordZone={recordZone}
+          t={t}
+        />
         {/* Expected close is a prospect's question — how soon a deal not yet
             won might land — and stays out of a customer's row, where a money
             reading already answers what is coming from them. The two are
@@ -2369,7 +2385,12 @@ export function StateStrip({
             sometimes drew a sixth would fold at a different width from one
             click away. */}
         {!customer && (
-          <CloseDateStat commercial={strip.commercial} locale={locale} t={t} />
+          <CloseDateStat
+            commercial={strip.commercial}
+            locale={locale}
+            recordZone={recordZone}
+            t={t}
+          />
         )}
         <HealthStat health={view?.health} withheld={healthWithheld} t={t} />
         {/* Whose move it is and the worst open signal both moved to the daily
@@ -2611,10 +2632,12 @@ type StripCommercial = NonNullable<
 function PipelineCard({
   commercial,
   locale,
+  recordZone,
   t,
 }: Readonly<{
   commercial?: StripCommercial | null;
   locale: Locale;
+  recordZone: string;
   t: ReturnType<typeof useT>;
 }>) {
   if (!commercial) {
@@ -2667,7 +2690,7 @@ function PipelineCard({
     commercial.converted_count > 0 && commercial.fx_as_of
       ? t("co.strip.convertedAsOf", {
           count: commercial.converted_count,
-          date: formatDate(commercial.fx_as_of, locale, RECORD_ZONE),
+          date: formatDate(commercial.fx_as_of, locale, recordZone),
         })
       : undefined;
   return (
@@ -2701,10 +2724,12 @@ function join(...parts: (string | undefined)[]): string {
 function CloseDateStat({
   commercial,
   locale,
+  recordZone,
   t,
 }: Readonly<{
   commercial?: StripCommercial | null;
   locale: Locale;
+  recordZone: string;
   t: ReturnType<typeof useT>;
 }>) {
   // Three readings, not one blank. Withheld deals are the reader's boundary;
@@ -2729,7 +2754,7 @@ function CloseDateStat({
   return (
     <StatCard
       label={t("co.strip.expectedClose")}
-      value={formatDate(commercial.next_close_on, locale, RECORD_ZONE)}
+      value={formatDate(commercial.next_close_on, locale, recordZone)}
     />
   );
 }
@@ -2966,6 +2991,7 @@ export function useSuggestionsBody({
 } {
   const { locale } = useLocale();
   const t = useT();
+  const recordZone = useRecordZone();
   const client = useQueryClient();
   const dismiss = useMutation({
     mutationFn: async (fingerprint: string) => {
@@ -3044,7 +3070,7 @@ export function useSuggestionsBody({
                 shows none. */}
             {suggestion.due_at && (
               <span className="co-row-meta">
-                {formatDate(suggestion.due_at, locale, RECORD_ZONE)}
+                {formatDate(suggestion.due_at, locale, recordZone)}
               </span>
             )}
           </span>

--- a/frontend/src/screens/companycommercial.tsx
+++ b/frontend/src/screens/companycommercial.tsx
@@ -2,11 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge } from "../design-system/atoms";
 import { PanelBody } from "../design-system/panel";
 import { formatDate, formatMoney } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 
@@ -46,6 +46,7 @@ export function CompanyLastOffer({
 }: Readonly<{ view?: Organization360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const deals = view?.deals?.data ?? [];
   const truncated = view?.deals?.page?.has_more === true;
   // Offers are their own RBAC object: a reader who may see deals may not see
@@ -94,7 +95,7 @@ export function CompanyLastOffer({
         {offer.valid_until && (
           <span>
             {t("commercial.validUntil", {
-              when: formatDate(offer.valid_until, locale, RECORD_ZONE),
+              when: formatDate(offer.valid_until, locale, recordZone),
             })}
           </span>
         )}
@@ -183,6 +184,7 @@ export function CompanyContractState({
 }: Readonly<{ view?: Organization360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const contracts = view?.state_strip?.contracts;
 
   // Absent means the reader has no contract grant — a different fact from an
@@ -226,7 +228,7 @@ export function CompanyContractState({
                 when: formatDate(
                   contracts.cancellation_effective_on,
                   locale,
-                  RECORD_ZONE,
+                  recordZone,
                 ),
               })}
             </Badge>
@@ -237,7 +239,7 @@ export function CompanyContractState({
               when: formatDate(
                 contracts.nearest_renewal_on,
                 locale,
-                RECORD_ZONE,
+                recordZone,
               ),
             })}
           </span>

--- a/frontend/src/screens/companycontracts.tsx
+++ b/frontend/src/screens/companycontracts.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan, useCanWrite } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import {
   Badge,
   Button,
@@ -14,7 +15,6 @@ import { FileChip } from "../design-system/filechip";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatBytes, formatDate, formatMoney } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
@@ -417,6 +417,7 @@ function ContractPaper({
 function ContractTermState({ contract }: Readonly<{ contract: Contract }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
 
   // Its dates have run out and nobody has moved the status. Saying only
   // "active" here would present an approval queue as a live agreement.
@@ -432,7 +433,7 @@ function ContractTermState({ contract }: Readonly<{ contract: Contract }>) {
           when: formatDate(
             contract.cancellation_effective_on,
             locale,
-            RECORD_ZONE,
+            recordZone,
           ),
         })}
       </Badge>
@@ -442,7 +443,7 @@ function ContractTermState({ contract }: Readonly<{ contract: Contract }>) {
     return (
       <span className="t-caption">
         {t("contracts.renewsOn", {
-          when: formatDate(contract.renewal_on, locale, RECORD_ZONE),
+          when: formatDate(contract.renewal_on, locale, recordZone),
         })}
       </span>
     );
@@ -481,7 +482,8 @@ export function basisLabel(contract: Contract): MessageKey | "" {
 function ContractTerm({ contract }: Readonly<{ contract: Contract }>) {
   const t = useT();
   const { locale } = useLocale();
-  const on = (date: string) => formatDate(date, locale, RECORD_ZONE);
+  const recordZone = useRecordZone();
+  const on = (date: string) => formatDate(date, locale, recordZone);
   if (!contract.starts_on && !contract.ends_on) {
     return <span className="t-caption">{t("contracts.noTerm")}</span>;
   }

--- a/frontend/src/screens/companydocuments.tsx
+++ b/frontend/src/screens/companydocuments.tsx
@@ -3,11 +3,11 @@ import { Fragment, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { AddDocumentDialog } from "./adddocument";
@@ -306,6 +306,7 @@ function DocumentRow({
 }: Readonly<{ doc: Attachment; canWriteDeals: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // The staged reading is OPENED, never mounted by the list. Each panel asks
   // the server for its own document's reading on mount, so a list that opened
   // them all fired one request per deal file and stacked a wall of panels over
@@ -352,7 +353,7 @@ function DocumentRow({
               <span>{doc.filename}</span>
             )}
             <span>{doc.source}</span>
-            <span>{formatDateTime(doc.created_at, locale, RECORD_ZONE)}</span>
+            <span>{formatDateTime(doc.created_at, locale, recordZone)}</span>
           </span>
         </div>
         <div className="rec-end">

--- a/frontend/src/screens/companydossier.tsx
+++ b/frontend/src/screens/companydossier.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState, Skeleton } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
@@ -48,6 +48,7 @@ export function DossierPanel({
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();
+  const recordZone = useRecordZone();
   const dossier = useQuery({
     queryKey: ["org-dossier", orgId],
     enabled,
@@ -110,7 +111,7 @@ export function DossierPanel({
       )}
       <span className="t-small">
         {t("co.brief.generatedAt", {
-          when: formatDateTime(readable.generated_at, locale, RECORD_ZONE),
+          when: formatDateTime(readable.generated_at, locale, recordZone),
         })}
       </span>
       <Button

--- a/frontend/src/screens/companyevidence.tsx
+++ b/frontend/src/screens/companyevidence.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import {
   Badge,
   Button,
@@ -9,7 +10,6 @@ import {
   Skeleton,
 } from "../design-system/atoms";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
@@ -259,19 +259,20 @@ function EvidenceTimes({
   locale: "en" | "de" | "vi";
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   return (
     <>
       {retrievedAt && (
         <p className="co-evidence-line">
           {t("co.evidence.retrievedAt", {
-            when: formatDateTime(retrievedAt, locale, RECORD_ZONE),
+            when: formatDateTime(retrievedAt, locale, recordZone),
           })}
         </p>
       )}
       {lastVerifiedAt && (
         <p className="co-evidence-line">
           {t("co.evidence.verifiedAt", {
-            when: formatDateTime(lastVerifiedAt, locale, RECORD_ZONE),
+            when: formatDateTime(lastVerifiedAt, locale, recordZone),
           })}
         </p>
       )}

--- a/frontend/src/screens/companyfinance.tsx
+++ b/frontend/src/screens/companyfinance.tsx
@@ -1,13 +1,13 @@
 import { Landmark } from "lucide-react";
 import type { ReactNode } from "react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, TableScroll } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Meter, Sparkline } from "../design-system/readings";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatDate, formatMoney } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemCodeOf, useFinanceSummary } from "./common";
@@ -80,6 +80,7 @@ export function CompanyFinanceCard({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const query = useFinanceSummary(orgId);
 
   if (lifecycle && NEVER_INVOICED.has(lifecycle)) {
@@ -143,7 +144,7 @@ export function CompanyFinanceCard({
           detail={{
             onRetry: () => void query.refetch(),
             staleAsOf: summary.last_synced_at
-              ? formatDate(summary.last_synced_at, locale, RECORD_ZONE)
+              ? formatDate(summary.last_synced_at, locale, recordZone)
               : undefined,
           }}
         >
@@ -428,6 +429,7 @@ function InvoiceRow({
   locale: ReturnType<typeof useLocale>["locale"];
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const late = invoice.days_late != null && invoice.days_late > 0;
   return (
     // A row the customer still owes past its due date carries the tint, so the
@@ -439,8 +441,8 @@ function InvoiceRow({
         {invoice.number ?? t("finance.unnumbered")}
       </td>
       <td className="fin-cell-dates">
-        {formatDate(invoice.issued_at, locale, RECORD_ZONE)} →{" "}
-        {invoice.due_at ? formatDate(invoice.due_at, locale, RECORD_ZONE) : "—"}
+        {formatDate(invoice.issued_at, locale, recordZone)} →{" "}
+        {invoice.due_at ? formatDate(invoice.due_at, locale, recordZone) : "—"}
         {/* When it was actually settled, appended rather than given a column
             of its own: an unpaid invoice has no date to put there, and a
             column of dashes states nothing the status does not. */}
@@ -448,7 +450,7 @@ function InvoiceRow({
           <span className="fin-cell-paid">
             {" · "}
             {t("finance.paidOn", {
-              when: formatDate(invoice.paid_at, locale, RECORD_ZONE),
+              when: formatDate(invoice.paid_at, locale, recordZone),
             })}
           </span>
         )}
@@ -526,6 +528,7 @@ const STATUS_TONE: Record<
 function FinanceProvenance({ summary }: Readonly<{ summary: FinanceSummary }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   if (!summary.provider) {
     return null;
   }
@@ -535,7 +538,7 @@ function FinanceProvenance({ summary }: Readonly<{ summary: FinanceSummary }>) {
       {summary.last_synced_at
         ? t("finance.syncedFrom", {
             provider: summary.provider,
-            when: formatDate(summary.last_synced_at, locale, RECORD_ZONE),
+            when: formatDate(summary.last_synced_at, locale, recordZone),
           })
         : t("finance.fromNeverSynced", { provider: summary.provider })}
     </p>

--- a/frontend/src/screens/companygrowthfit.tsx
+++ b/frontend/src/screens/companygrowthfit.tsx
@@ -2,12 +2,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState, PendingBody } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
@@ -68,6 +68,7 @@ export function GrowthFitPanel({
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();
+  const recordZone = useRecordZone();
   const fit = useQuery({
     queryKey: ["org-growth-fit", orgId],
     enabled,
@@ -132,7 +133,7 @@ export function GrowthFitPanel({
         readable && (
           <span className="t-small">
             {t("co.brief.generatedAt", {
-              when: formatDateTime(readable.generated_at, locale, RECORD_ZONE),
+              when: formatDateTime(readable.generated_at, locale, recordZone),
             })}
           </span>
         )

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -4,12 +4,12 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { useCanWrite } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge, Button, OverflowMenu } from "../design-system/atoms";
 import { InlineChoice } from "../design-system/inlinechoice";
 import { ProvenanceTag } from "../design-system/trust";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { ArchiveAction } from "./archive";
 import { provenanceOf, throwProblem, useSorMode, useViewerId } from "./common";
@@ -805,6 +805,7 @@ export function CompanyIdentityLine({
   const t = useT();
   const { locale } = useLocale();
   const viewerId = useViewerId();
+  const recordZone = useRecordZone();
   // WHO wrote this record, by name. The roster is the page's existing one —
   // CompanyOwnerControl on the line above already reads it, and both share
   // react-query's `["users"]` entry, so this adds no request.
@@ -822,7 +823,7 @@ export function CompanyIdentityLine({
   // Withheld or still in flight, the line says nothing about it: naming no way
   // in on an account that has one is worse than saying nothing.
   const wayIn = loading ? undefined : view?.strength;
-  const when = (at: string) => formatDateAbbrev(at, locale, RECORD_ZONE);
+  const when = (at: string) => formatDateAbbrev(at, locale, recordZone);
   // Withheld, absent, or still in flight, the line says nothing about it at
   // all: "never contacted" read off data the page could not answer is a
   // business conclusion it has no basis for, and it is the one a rep would

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { routeHash } from "../app/router";
 import { Avatar, Badge, Disclosure } from "../design-system/atoms";
 import { AvatarStack } from "../design-system/avatarstack";
@@ -14,7 +15,6 @@ import {
 } from "../design-system/surfacestate";
 import { useTruncationTooltip } from "../design-system/tooltip";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemCodeOf, throwProblem } from "./common";
 import { signalKindLabel, worstOf } from "./company360";
@@ -401,6 +401,7 @@ function signalDotTone(severity: string): "warn" | "danger" | undefined {
 function SignalsSection({ orgId }: Readonly<{ orgId: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const query = useQuery({
     queryKey: ["signals", "organization", orgId],
     queryFn: async () => {
@@ -465,7 +466,7 @@ function SignalsSection({ orgId }: Readonly<{ orgId: string }>) {
               )}
             </span>
             <span className="co-row-meta">
-              {formatDate(signal.detected_at, locale, RECORD_ZONE)}
+              {formatDate(signal.detected_at, locale, recordZone)}
             </span>
           </PanelRow>
         ))

--- a/frontend/src/screens/companytoday.tsx
+++ b/frontend/src/screens/companytoday.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState, Skeleton } from "../design-system/atoms";
 import { Panel, PanelBody, PanelPlate, PanelRow } from "../design-system/panel";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -128,6 +128,7 @@ export function TodayOnThisAccount({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // Called unconditionally regardless of the loading/failed branches below,
   // same as every other hook here — React requires it, and the hook itself
   // already answers "nothing to show" by returning `ready: false`.
@@ -160,7 +161,7 @@ export function TodayOnThisAccount({
   const ctx: TodayContext = {
     view,
     t,
-    when: (at: string) => formatDateTime(at, locale, RECORD_ZONE),
+    when: (at: string) => formatDateTime(at, locale, recordZone),
   };
   const lead = whoseMove(ctx);
   const items = todayContextItems(ctx);

--- a/frontend/src/screens/connected-agents.tsx
+++ b/frontend/src/screens/connected-agents.tsx
@@ -5,13 +5,14 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Disclosure, EmptyState } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
 import { ScopeChips } from "../design-system/passportselect";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
@@ -301,14 +302,15 @@ function ConnectionFacts({
 }: Readonly<{ passport: Connection; state: ConnectionState }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // A credential's lifetime is a personal deadline, so it reads on the
   // viewer's own calendar (format.ts zone-by-purpose, the same split
-  // oauthconsent.tsx makes). connected_at is a record date and keeps the fixed
-  // zone: it says when a consent was given, not when the reader must act.
+  // oauthconsent.tsx makes). connected_at is a record date and keeps the
+  // record zone: it says when a consent was given, not when the reader must act.
   const connected = formatDate(
     passport.connection.connected_at,
     locale,
-    RECORD_ZONE,
+    recordZone,
   );
   // Two of the three states say something about this date; the third must not.
   // A LIVE row shows when the agent must next hold a fresh credential, and a

--- a/frontend/src/screens/dealfiles.tsx
+++ b/frontend/src/screens/dealfiles.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, OverflowMenu } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { AddDocumentDialog } from "./adddocument";
@@ -128,6 +128,7 @@ function FileRow({
 }: Readonly<{ dealId: string; doc: DealDocument; mayWrite: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const file = doc.attachment;
   const [confirming, setConfirming] = useState<"delete" | "hide" | null>(null);
   const verbs = useFileVerbs(dealId, file.id);
@@ -150,11 +151,11 @@ function FileRow({
                 when: formatDateAbbrev(
                   doc.origin.occurred_at,
                   locale,
-                  RECORD_ZONE,
+                  recordZone,
                 ),
               })
             : t("files.uploaded", {
-                when: formatDateAbbrev(file.created_at, locale, RECORD_ZONE),
+                when: formatDateAbbrev(file.created_at, locale, recordZone),
               })}
         </p>
       </div>

--- a/frontend/src/screens/dealroomaccess.tsx
+++ b/frontend/src/screens/dealroomaccess.tsx
@@ -3,6 +3,7 @@ import { Copy, Link2, UserX } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import {
   Badge,
   Button,
@@ -15,7 +16,6 @@ import { ChoiceList } from "../design-system/choicelist";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
@@ -155,6 +155,7 @@ function ParticipantRow({
 }: Readonly<{ room: DealRoom; participant: Participant; mayManage: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const [confirming, setConfirming] = useState<
     "revoke" | "reissue" | "capability" | null
   >(null);
@@ -181,7 +182,7 @@ function ParticipantRow({
               ? t("access.state.active")
               : t("access.state.invited")}
           {participant.last_seen_at
-            ? ` · ${t("access.lastSeen", { when: formatDateAbbrev(participant.last_seen_at, locale, RECORD_ZONE) })}`
+            ? ` · ${t("access.lastSeen", { when: formatDateAbbrev(participant.last_seen_at, locale, recordZone) })}`
             : ""}
         </p>
         <ReadingSoFar participant={participant} />
@@ -192,7 +193,7 @@ function ParticipantRow({
               when: formatDateAbbrev(
                 participant.link_requested_at,
                 locale,
-                RECORD_ZONE,
+                recordZone,
               ),
             })}
           </p>
@@ -473,6 +474,7 @@ function RevokeDialog({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const queryClient = useQueryClient();
   const revoke = useMutation({
     mutationFn: async () => {
@@ -505,7 +507,7 @@ function RevokeDialog({
       <p>
         {participant.email}
         {participant.last_seen_at
-          ? ` · ${t("access.lastSeen", { when: formatDateAbbrev(participant.last_seen_at, locale, RECORD_ZONE) })}`
+          ? ` · ${t("access.lastSeen", { when: formatDateAbbrev(participant.last_seen_at, locale, recordZone) })}`
           : ` · ${t("access.neverSignedIn")}`}
       </p>
       <p className="t-small">{t("access.revokeBody")}</p>

--- a/frontend/src/screens/dealroompage.tsx
+++ b/frontend/src/screens/dealroompage.tsx
@@ -5,6 +5,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { useCanWrite } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import {
   Badge,
@@ -18,7 +19,6 @@ import { Callout } from "../design-system/callout";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Panel, PanelBody } from "../design-system/panel";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryStates, throwProblem } from "./common";
 import {
@@ -147,6 +147,7 @@ function ViewAsBuyerButton({ room }: Readonly<{ room: DealRoom }>) {
 function StateBanner({ room }: Readonly<{ room: DealRoom }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   switch (room.state) {
     case "paused":
       return <Callout tone="warn">{t("roompage.banner.paused")}</Callout>;
@@ -160,7 +161,7 @@ function StateBanner({ room }: Readonly<{ room: DealRoom }>) {
       return room.expires_at ? (
         <Callout tone="info">
           {t("roompage.banner.liveUntil", {
-            when: formatDateAbbrev(room.expires_at, locale, RECORD_ZONE),
+            when: formatDateAbbrev(room.expires_at, locale, recordZone),
           })}
         </Callout>
       ) : null;

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -19,6 +19,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { approvalDotTier, useAgentTierMap, verbTier } from "../app/autonomy";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { useInstallationSettings } from "../app/uploadlimit";
 import { activityTimeline } from "../design-system/activitytimeline";
@@ -57,7 +58,6 @@ import {
   formatMoneyOrAbsent,
 } from "../format/format";
 import { toMajorUnits, toMinorUnits } from "../format/minorunits";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { dealRecordKeys, dealWinKeys } from "./activitykeys";
@@ -1197,6 +1197,7 @@ function AmountCell({
 function dealColumns(
   t: ReturnType<typeof useT>,
   locale: Locale,
+  recordZone: string,
   stageName: Map<string, string>,
 ): ListColumn<Deal>[] {
   return [
@@ -1255,7 +1256,7 @@ function dealColumns(
       sort: "expected_close_date",
       cell: (deal) =>
         deal.expected_close_date
-          ? formatDate(deal.expected_close_date, locale, RECORD_ZONE)
+          ? formatDate(deal.expected_close_date, locale, recordZone)
           : null,
     },
     {
@@ -1625,6 +1626,7 @@ export function DealsScreen({
 }: Readonly<{ startCreating?: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const cf = useObjectCustomFields("deal");
   const overlay = useSorMode() === "overlay";
   const pipelinesQuery = usePipelines(!overlay);
@@ -2052,7 +2054,7 @@ export function DealsScreen({
         <ListTable
           state={dealsListState}
           unit="deals.unit"
-          columns={dealColumns(t, locale, stageName)}
+          columns={dealColumns(t, locale, recordZone, stageName)}
           rowKey={(deal) => deal.id}
           rowRoute={(deal) => ({ screen: "deals", id: deal.id })}
           searchable={false}
@@ -2390,6 +2392,7 @@ function DealTable({
 }: Readonly<{ deals: Deal[]; stages: Stage[]; sortable?: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const [sortKey, setSortKey] = useState<"name" | "amount" | "close">("name");
   const [descending, setDescending] = useState(false);
   const stageName = useMemo(
@@ -2486,7 +2489,7 @@ function DealTable({
             header: t("deals.close"),
             render: (deal: Deal) =>
               deal.expected_close_date
-                ? formatDate(deal.expected_close_date, locale, RECORD_ZONE)
+                ? formatDate(deal.expected_close_date, locale, recordZone)
                 : null,
           },
           {
@@ -2528,6 +2531,7 @@ export function FxLine({
   locale: Locale;
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   // A deal carrying a rate but no amount converts to nothing, not to zero.
   const baseMinor =
     amountMinor == null ? null : Math.round(amountMinor * Number(fxRateToBase));
@@ -2536,7 +2540,7 @@ export function FxLine({
       {t("deal.fxBase", {
         value: formatMoneyOrAbsent(baseMinor, baseCurrency, locale),
         rate: fxRateToBase,
-        date: fxRateDate ? formatDate(fxRateDate, locale, RECORD_ZONE) : "—",
+        date: fxRateDate ? formatDate(fxRateDate, locale, recordZone) : "—",
       })}
     </p>
   );
@@ -3268,6 +3272,7 @@ function archivedDealBand(
 export function DealScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const queryClient = useQueryClient();
   // Minted here because the band that carries the sentence and the verbs that
   // point at it are two different slots of the same header.
@@ -3396,7 +3401,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
             <RecordView
               name={deal.name}
               subtitle={<DealSubtitle deal={deal} locale={locale} />}
-              zone={RECORD_ZONE}
+              zone={recordZone}
               badges={
                 <DealBadges
                   deal={deal}

--- a/frontend/src/screens/evidenceverdict.tsx
+++ b/frontend/src/screens/evidenceverdict.tsx
@@ -2,9 +2,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Button, TextInput } from "../design-system/atoms";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 
@@ -119,6 +119,7 @@ export function EvidenceVerdict({
 }: Readonly<{ orgId: string; claim: EvidenceClaim; canEdit: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const queryClient = useQueryClient();
   const [correcting, setCorrecting] = useState(false);
   const [draft, setDraft] = useState(claim.value);
@@ -161,7 +162,7 @@ export function EvidenceVerdict({
       <span className="evidence-verdict t-muted">
         {claim.verifiedAt
           ? t("evidence.confirmedAt", {
-              when: formatDateTime(claim.verifiedAt, locale, RECORD_ZONE),
+              when: formatDateTime(claim.verifiedAt, locale, recordZone),
             })
           : t("evidence.humanSet")}
       </span>

--- a/frontend/src/screens/history.tsx
+++ b/frontend/src/screens/history.tsx
@@ -7,6 +7,7 @@ import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
 import type { EntityKind } from "../app/entity";
+import { useRecordZone } from "../app/recordzone";
 import {
   Button,
   Card,
@@ -23,7 +24,6 @@ import {
   toEvidence,
 } from "../design-system/trust";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import {
   LoadMoreButton,
@@ -148,6 +148,7 @@ function HistoryEntryRow({
   locale: ReturnType<typeof useLocale>["locale"];
 }>) {
   const viewerId = useViewerId();
+  const recordZone = useRecordZone();
   return (
     <li>
       <span className="tl-body">
@@ -157,7 +158,7 @@ function HistoryEntryRow({
             sentence would now say the same person twice. */}
         <span className="tl-title">{entry.summary}</span>
         <span className="tl-meta">
-          <span>{formatDateTime(entry.occurred_at, locale, RECORD_ZONE)}</span>
+          <span>{formatDateTime(entry.occurred_at, locale, recordZone)}</span>
           <ProvenanceTag
             provenance={provenanceOfEntry(entry, viewerId)}
             // The design system has no record lookups, so the resolved name
@@ -291,6 +292,7 @@ function ChangeGrounding({ change }: Readonly<{ change: FieldHistoryEntry }>) {
 
 function FieldGroupSection({ group }: Readonly<{ group: FieldGroup }>) {
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   return (
     <div className="fgroup">
       <div className="fgroup-head">{group.field}</div>
@@ -302,7 +304,7 @@ function FieldGroupSection({ group }: Readonly<{ group: FieldGroup }>) {
               newValue={change.new_value ?? null}
             />
             <span className="tl-meta">
-              {formatDateTime(change.changed_at, locale, RECORD_ZONE)}
+              {formatDateTime(change.changed_at, locale, recordZone)}
             </span>
             <ChangeWho change={change} />
           </li>

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -7,6 +7,7 @@ import {
 import { ArrowRight, Check, RefreshCw, X } from "lucide-react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import {
   Badge,
@@ -21,7 +22,7 @@ import {
   formatDateTime,
   formatMoneyOrAbsent,
 } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
@@ -204,6 +205,7 @@ function DigestProjectsSection({
 function DigestSection() {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const digestQuery = useMorningDigest();
   return (
     <QueryGate query={digestQuery}>
@@ -222,7 +224,7 @@ function DigestSection() {
                 <span className="digest-title">{t("home.digest")}</span>
                 <span className="t-caption">
                   {t("home.digestFor", {
-                    date: formatDate(digest.date, locale, RECORD_ZONE),
+                    date: formatDate(digest.date, locale, recordZone),
                   })}
                 </span>
               </div>

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, SegmentedControl } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { ToastRegion, useToast } from "../design-system/toast";
@@ -204,6 +205,7 @@ function LeadsWorkbench({
   const roster = useRoster("user", true);
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const overlay = useSorMode() === "overlay";
   const leadSettings = useLeadSettings();
   const slaOn = leadSettings.data?.first_response_enabled === true;
@@ -418,7 +420,7 @@ function LeadsWorkbench({
               </span>
             ),
           },
-          lastActivityColumn<Lead>(t, locale),
+          lastActivityColumn<Lead>(t, locale, recordZone),
           {
             key: "source",
             header: t("lead.source"),

--- a/frontend/src/screens/licenseholder.tsx
+++ b/frontend/src/screens/licenseholder.tsx
@@ -1,10 +1,10 @@
 import { CalendarClock, TriangleAlert } from "lucide-react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import "./licenseholder.css";
 
@@ -28,9 +28,10 @@ export function LicenseHolderCard({
 }: Readonly<{ holder: LicenseHolder }>) {
   const t = useT();
   const { locale } = useLocale();
-  // RECORD_ZONE is the one zone this product renders dates in, so an expiry and
-  // an activity beside it can never be read in two different zones.
-  const expiry = formatDateAbbrev(holder.expiry, locale, RECORD_ZONE);
+  const recordZone = useRecordZone();
+  // The record zone is the one zone this product renders dates in, so an
+  // expiry and an activity beside it can never be read in two different zones.
+  const expiry = formatDateAbbrev(holder.expiry, locale, recordZone);
 
   return (
     <Panel title={t("license.holder.title")}>

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -10,9 +10,9 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { RecordZoneProvider } from "../app/recordzone";
 import { pickOption } from "../design-system/select-testing";
 import { calendarDay } from "../format/calendarday";
-import { RECORD_ZONE } from "../format/timezone";
 import { LocaleProvider } from "../i18n";
 import { LogActivity } from "./logactivity";
 import { PersonScreen } from "./people";
@@ -51,13 +51,22 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
+// The installation's zone this suite asserts against. Named rather than taken
+// from the fallback: what these tests prove is that a logged entry's stored
+// instant is cut on the INSTALLATION's clock, and a test that minted and read
+// back on the same default would agree with itself whichever zone the code
+// actually used.
+const INSTALLATION_ZONE = "Asia/Ho_Chi_Minh";
+
 function render(ui: ReactNode) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return rtlRender(
     <QueryClientProvider client={client}>
-      <LocaleProvider initial="en">{ui}</LocaleProvider>
+      <LocaleProvider initial="en">
+        <RecordZoneProvider zone={INSTALLATION_ZONE}>{ui}</RecordZoneProvider>
+      </LocaleProvider>
     </QueryClientProvider>,
   );
 }
@@ -262,11 +271,11 @@ describe("log activity from a 360", () => {
     stubApi({ "POST /activities": createdActivity });
     // Read the clock on both sides of the render: a run that straddles
     // midnight would otherwise fail on which "today" the prefill caught. The
-    // zone is RECORD_ZONE because a note's day is the timeline heading it will
+    // zone is the installation's record zone because a note's day is the timeline heading it will
     // file under, and the timeline groups there.
-    const dayBeforeRender = calendarDay(new Date(), RECORD_ZONE);
+    const dayBeforeRender = calendarDay(new Date(), INSTALLATION_ZONE);
     render(<LogActivity entityType="organization" entityId="o1" />);
-    const dayAfterRender = calendarDay(new Date(), RECORD_ZONE);
+    const dayAfterRender = calendarDay(new Date(), INSTALLATION_ZONE);
     // A note's date is the day it happened, live from the start and showing
     // the today that would otherwise be assumed invisibly at submit.
     const noteDay = screen.getByLabelText<HTMLInputElement>("Date", {
@@ -301,11 +310,11 @@ describe("log activity from a 360", () => {
     const post = captured.find((entry) => entry.key === "POST /activities");
     if (!post) throw new Error("expected a POST /activities to be captured");
     // The instant lands on the day the writer picked in BOTH zones that
-    // matter: the record pages render timelines in RECORD_ZONE, and the
+    // matter: the record pages render timelines in the record zone, and the
     // writer reads their own wall clock — and a note never carries a due
     // date, backdated or not.
     const occurred = new Date(postedOccurredAt(post.body));
-    expect(calendarDay(occurred, RECORD_ZONE)).toBe(PICKED_DAY);
+    expect(calendarDay(occurred, INSTALLATION_ZONE)).toBe(PICKED_DAY);
     expect(calendarDay(occurred, READER_ZONE)).toBe(PICKED_DAY);
     expect(post.body).not.toHaveProperty("due_at");
   });
@@ -316,7 +325,7 @@ describe("log activity from a 360", () => {
     //
     // 23:00Z on 21 August is 16:00 the same afternoon in Los Angeles and 01:00
     // the NEXT day in Berlin. Offered the writer's own today, the composer
-    // named 21 August and the record timeline — which groups in RECORD_ZONE —
+    // named 21 August and the record timeline — which groups in that zone —
     // then filed the entry under 22 August: the composer promised a day it did
     // not deliver.
     // `toFake: ["Date"]` and not the default set: the default ALSO replaces
@@ -348,7 +357,7 @@ describe("log activity from a 360", () => {
     if (!post) throw new Error("expected a POST /activities to be captured");
     const occurred = new Date(postedOccurredAt(post.body));
     // The day the composer offered IS the day the timeline files it under.
-    expect(calendarDay(occurred, RECORD_ZONE)).toBe(noteDay.value);
+    expect(calendarDay(occurred, INSTALLATION_ZONE)).toBe(noteDay.value);
   });
 
   it("files a note on the day the writer overrode to, when the record's clock already calls it yesterday", async () => {
@@ -378,7 +387,7 @@ describe("log activity from a 360", () => {
     const post = captured.find((entry) => entry.key === "POST /activities");
     if (!post) throw new Error("expected a POST /activities to be captured");
     const occurred = new Date(postedOccurredAt(post.body));
-    expect(calendarDay(occurred, RECORD_ZONE)).toBe(writersOwnToday);
+    expect(calendarDay(occurred, INSTALLATION_ZONE)).toBe(writersOwnToday);
   });
 
   it("refuses a future day for a note but not for a task's due date", async () => {

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { EntityKind } from "../app/entity";
+import { useRecordZone } from "../app/recordzone";
 import {
   Button,
   Card,
@@ -13,7 +14,7 @@ import {
 } from "../design-system/atoms";
 import { Select } from "../design-system/select";
 import { calendarDay, dueInstant, middayInstant } from "../format/calendarday";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys, taskWriteKeys } from "./activitykeys";
@@ -62,35 +63,38 @@ const ACCEPTED_TRANSCRIPT_EXTENSION = ".txt";
 //
 // Which zone that is follows what the day MEANS, the same split the draft's
 // `day` field carries. A note or meeting files under a heading on the record's
-// timeline, grouped in RECORD_ZONE, so the day it can be offered is the record's
+// timeline, grouped in the record zone, so the day it can be offered is the record's
 // today; a task's day is a personal due date, minted by `dueInstant` in the
 // browser's zone and rendered there, so its today is the writer's own. Offer a
 // day from the other zone and the composer names a day the entry does not land
 // on: an afternoon in Los Angeles is already tomorrow on a Berlin clock, so a
 // writer offered their own today, accepting it, watched the entry file under the
 // day after.
-function todayDay(kind: ActivityDraft["kind"]): string {
-  return calendarDay(new Date(), kind === "task" ? viewerZone() : RECORD_ZONE);
+function todayDay(kind: ActivityDraft["kind"], recordZone: string): string {
+  return calendarDay(new Date(), kind === "task" ? viewerZone() : recordZone);
 }
 
-function freshDraft(kind: ActivityDraft["kind"] = "note"): ActivityDraft {
-  return { ...EMPTY_DRAFT, kind, day: todayDay(kind) };
+function freshDraft(
+  recordZone: string,
+  kind: ActivityDraft["kind"] = "note",
+): ActivityDraft {
+  return { ...EMPTY_DRAFT, kind, day: todayDay(kind, recordZone) };
 }
 
 // The instant a logged activity carries. The picked day left on today — or, for
 // a note, pushed into the future, which nothing can have occurred in — means the
 // actual moment of logging, so entries logged in sequence keep their timeline
-// order. A backdated day becomes that day's noon in RECORD_ZONE. Either way the
+// order. A backdated day becomes that day's noon in the record zone. Either way the
 // entry files under the day the writer picked, because both branches and the
 // timeline's day headings read the same clock. A task's picked day is its DUE
 // date instead — the task itself occurred now.
-function occurredInstant(input: ActivityDraft): string {
+function occurredInstant(input: ActivityDraft, recordZone: string): string {
   const now = new Date();
-  const today = calendarDay(now, RECORD_ZONE);
+  const today = calendarDay(now, recordZone);
   if (input.kind === "task" || input.day === "" || input.day >= today) {
     return now.toISOString();
   }
-  return middayInstant(input.day, RECORD_ZONE);
+  return middayInstant(input.day, recordZone);
 }
 
 // The wire body one drafted entry becomes.
@@ -98,6 +102,7 @@ function activityRequestBody(
   input: ActivityDraft,
   entityType: EntityKind,
   entityId: string,
+  recordZone: string,
 ) {
   // source_system: transcript is what routes the body through the
   // server's ADR-0058 normalizer and what the activity/transcript
@@ -119,7 +124,7 @@ function activityRequestBody(
     kind: input.kind,
     subject: input.subject.trim(),
     body: outgoingBody || null,
-    occurred_at: occurredInstant(input),
+    occurred_at: occurredInstant(input, recordZone),
     // A due date becomes the instant that day ENDS in the writer's
     // own zone (format/calendarday). Handing the bare `yyyy-mm-dd` to
     // `new Date` reads it as UTC midnight instead, which is neither the
@@ -158,8 +163,9 @@ export function LogActivityForm({
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
+  const recordZone = useRecordZone();
   const [draft, setDraft] = useState<ActivityDraft>(() =>
-    freshDraft(initialKind),
+    freshDraft(recordZone, initialKind),
   );
   const [fileError, setFileError] = useState<string | null>(null);
 
@@ -168,9 +174,19 @@ export function LogActivityForm({
     // activity's own id: the reader wants the name of what the activity is
     // ABOUT, and the record on screen is always already named in the cache.
     mutationKey: ["activity-log", entityId],
-    mutationFn: async (input: ActivityDraft) => {
+    // The zone travels as a VARIABLE rather than being read from the closure.
+    // A mutationFn closing over render state runs against whatever the last
+    // committed render held, and what this one decides with the zone is the
+    // instant the entry is STORED at — so a stale read would not misdraw a
+    // page, it would file the activity on the wrong day, permanently.
+    mutationFn: async (input: { draft: ActivityDraft; zone: string }) => {
       const { data, error } = await api.POST("/activities", {
-        body: activityRequestBody(input, entityType, entityId),
+        body: activityRequestBody(
+          input.draft,
+          entityType,
+          entityId,
+          input.zone,
+        ),
       });
       if (error) {
         throwProblem(error, t);
@@ -179,13 +195,13 @@ export function LogActivityForm({
     },
     onSuccess: (_data, input) => {
       const keys =
-        input.kind === "task"
+        input.draft.kind === "task"
           ? taskWriteKeys(entityType, entityId)
           : entityTimelineKeys(entityType, entityId);
       for (const queryKey of keys) {
         queryClient.invalidateQueries({ queryKey });
       }
-      setDraft(freshDraft());
+      setDraft(freshDraft(input.zone));
       onLogged?.();
     },
   });
@@ -198,7 +214,7 @@ export function LogActivityForm({
       className="form-stack"
       onSubmit={(event) => {
         event.preventDefault();
-        log.mutate(draft);
+        log.mutate({ draft, zone: recordZone });
       }}
     >
       <div className="form-row">
@@ -236,7 +252,11 @@ export function LogActivityForm({
               // occurredInstant clamps a typed-in future day the same way, and
               // against the same clock, so the box refuses exactly the days the
               // submit would have moved.
-              max={draft.kind === "task" ? undefined : todayDay(draft.kind)}
+              max={
+                draft.kind === "task"
+                  ? undefined
+                  : todayDay(draft.kind, recordZone)
+              }
               onChange={(event) => setField({ day: event.target.value })}
               // A native date input opens its calendar only from the tiny
               // icon; a click on the value just places a caret. Opening on

--- a/frontend/src/screens/network.tsx
+++ b/frontend/src/screens/network.tsx
@@ -4,9 +4,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Card, EmptyState, Skeleton } from "../design-system/atoms";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import "./network.css";
 import {
@@ -86,6 +86,7 @@ async function fetchDealCoverage(id: string): Promise<DealCoverage> {
 export function PersonNetworkCard({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // The projection is folded from natively captured participants, which the
   // incumbent mirror does not hold. Show the honest unavailable state rather
   // than a doomed fetch that renders as "nobody knows them".
@@ -127,7 +128,7 @@ export function PersonNetworkCard({ id }: Readonly<{ id: string }>) {
               )}
               <span className="t-caption">
                 {colleague.last_at
-                  ? formatDateTime(colleague.last_at, locale, RECORD_ZONE)
+                  ? formatDateTime(colleague.last_at, locale, recordZone)
                   : t("network.neverSpoken")}
               </span>
             </li>

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -4,6 +4,7 @@ import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan, useCanWriteRecord } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import {
   Avatar,
@@ -40,7 +41,7 @@ import {
   EvidenceChip,
 } from "../design-system/trust";
 import { formatDateTime, formatMoney } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { taskWriteKeys } from "./activitykeys";
@@ -553,6 +554,7 @@ async function createCompany(
 export function CompaniesScreen() {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const cf = useObjectCustomFields("organization");
   const state = useListQuery<Organization>({
     key: "organizations",
@@ -701,8 +703,8 @@ export function CompaniesScreen() {
               ) : null,
           },
           ownerColumn<Organization>(t),
-          lastActivityColumn<Organization>(t, locale),
-          createdColumn<Organization>(t, locale),
+          lastActivityColumn<Organization>(t, locale, recordZone),
+          createdColumn<Organization>(t, locale, recordZone),
         ]}
         tools={<SaveViewAction resource="organizations" query={state.query} />}
         rowKey={(org) => org.id}
@@ -1190,6 +1192,7 @@ async function fetchHierarchyRollup(
 function HierarchyRollupCard({ orgId }: Readonly<{ orgId: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const rollupQuery = useQuery({
     queryKey: ["rollup", orgId],
     queryFn: () => fetchHierarchyRollup(orgId),
@@ -1244,7 +1247,7 @@ function HierarchyRollupCard({ orgId }: Readonly<{ orgId: string }>) {
       )}
       <p className="t-caption" style={{ marginTop: 10 }}>
         {t("rollup.computedAt", {
-          when: formatDateTime(rollup.computed_at, locale, RECORD_ZONE),
+          when: formatDateTime(rollup.computed_at, locale, recordZone),
         })}
       </p>
     </Card>
@@ -1272,6 +1275,7 @@ function derivedSource(
     updated_at?: string;
   }>,
   locale: Locale,
+  recordZone: string,
 ): EvidenceMarkSource | undefined {
   const provenance = provenanceOf(row.captured_by);
   if (provenance.kind === "human") {
@@ -1283,7 +1287,7 @@ function derivedSource(
     snippet: row.evidence_snippet,
     sourceUrl: row.source_url,
     at: row.updated_at
-      ? formatDateTime(row.updated_at, locale, RECORD_ZONE)
+      ? formatDateTime(row.updated_at, locale, recordZone)
       : undefined,
   };
 }
@@ -1331,6 +1335,7 @@ function ProfileFieldRow({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const canEdit = useCan("organization", "update");
   return (
     <div className="co-field">
@@ -1338,7 +1343,7 @@ function ProfileFieldRow({
       <div>
         <EvidenceMark
           value={field.value}
-          source={derivedSource(field, locale)}
+          source={derivedSource(field, locale, recordZone)}
           onOpenHistory={onOpenHistory}
         />
         {/* The verdict beside the value, not inside the mark: the mark says
@@ -1449,6 +1454,7 @@ function FactRow({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const canEdit = useCan("organization", "update");
   return (
     <div className="co-field">
@@ -1456,7 +1462,7 @@ function FactRow({
       <div>
         <EvidenceMark
           value={fact.value}
-          source={derivedSource(fact, locale)}
+          source={derivedSource(fact, locale, recordZone)}
           onOpenHistory={onOpenHistory}
         />
         {/* The value contradicts its own field — a phone number filed as a
@@ -2019,6 +2025,7 @@ function CompanyPage({
   onTab: (next: CompanyTab) => void;
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const archivedReasonId = useId();
   // ONE composer, opened two ways. Anchored on a timeline message it answers
   // that message; anchored on a person it starts a new one and grounds on the
@@ -2095,7 +2102,7 @@ function CompanyPage({
       // facts (mockup's target header), alongside the ones that already had
       // no chip (owner).
       subtitle={<CompanyDescription org={org} />}
-      zone={RECORD_ZONE}
+      zone={recordZone}
       pulse={<CompanyIdentityLine org={org} view={view} loading={loading} />}
       // The composer opens from a button rather than standing open above the
       // page: a whole form in the header's action strip pushed the account's

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -3,6 +3,7 @@ import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { activityTimeline } from "../design-system/activitytimeline";
 import { Badge, SegmentedControl } from "../design-system/atoms";
@@ -13,7 +14,6 @@ import {
 } from "../design-system/recordtimeline";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
 import { ProvenanceTag } from "../design-system/trust";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
@@ -325,6 +325,7 @@ function PersonAside({
 export function ContactsScreen() {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // Offered only once /me has answered: a chip whose value is still "" reads
   // as "clear this filter", so a half-built owner dial narrows nothing.
   const viewerId = useViewerId();
@@ -384,8 +385,8 @@ export function ContactsScreen() {
             ),
           },
           ownerColumn<Person>(t),
-          lastActivityColumn<Person>(t, locale),
-          createdColumn<Person>(t, locale),
+          lastActivityColumn<Person>(t, locale, recordZone),
+          createdColumn<Person>(t, locale, recordZone),
         ]}
         tools={<SaveViewAction resource="people" query={state.query} />}
         rowKey={(person) => person.id}
@@ -406,6 +407,7 @@ type PersonTab = (typeof PERSON_TABS)[number];
 
 export function PersonScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const cf = useObjectCustomFields("person");
   // ONE sentence about this contact being archived, minted here and pointed at
   // by every verb the archive refuses. Said once for the page rather than
@@ -456,7 +458,7 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
           <RecordView
             name={person.full_name}
             subtitle={person.title ?? undefined}
-            zone={RECORD_ZONE}
+            zone={recordZone}
             badges={
               <>
                 <ProvenanceTag

--- a/frontend/src/screens/person360.tsx
+++ b/frontend/src/screens/person360.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import {
   Badge,
   Button,
@@ -13,7 +14,6 @@ import { EvidenceMark } from "../design-system/evidencemark";
 import { FactList } from "../design-system/factlist";
 import type { ConfidenceLevel } from "../design-system/trust";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import { provenanceOf, throwProblem } from "./common";
 import { dealRoleLabel } from "./company360";
@@ -145,6 +145,7 @@ export function ThinState({
 export function RelationshipPulse({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const s = view.strength;
   const warmest = view.network?.colleagues[0];
 
@@ -168,14 +169,14 @@ export function RelationshipPulse({ view }: Readonly<{ view: Person360 }>) {
               // is a fact about the record, and two colleagues comparing the
               // same relationship have to name the same day for it.
               value: view.last_inbound_at
-                ? formatDate(view.last_inbound_at, locale, RECORD_ZONE)
+                ? formatDate(view.last_inbound_at, locale, recordZone)
                 : t("person.pulse.neverInbound"),
             },
             {
               key: "last-outbound",
               term: t("person.pulse.lastOutbound"),
               value: view.last_outbound_at
-                ? formatDate(view.last_outbound_at, locale, RECORD_ZONE)
+                ? formatDate(view.last_outbound_at, locale, recordZone)
                 : t("person.pulse.neverOutbound"),
             },
           ]}
@@ -436,6 +437,7 @@ function confidenceBand(score?: number | null): ConfidenceLevel | undefined {
 export function WhoKnowsThem({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const colleagues = view.network?.colleagues ?? [];
   if (colleagues.length === 0) {
     return null;
@@ -449,7 +451,7 @@ export function WhoKnowsThem({ view }: Readonly<{ view: Person360 }>) {
             <li key={c.user_id} style={{ padding: "8px 0" }}>
               <strong>{c.display_name}</strong>
               <div style={{ fontSize: 12, opacity: 0.75 }}>
-                {proofLine(c, t, locale)}
+                {proofLine(c, t, locale, recordZone)}
               </div>
             </li>
           ))}
@@ -468,6 +470,7 @@ function proofLine(
   c: Colleague,
   t: ReturnType<typeof useT>,
   locale: Locale,
+  recordZone: string,
 ): string {
   const twoWay = (c.inbound_90d ?? 0) > 0 && (c.outbound_90d ?? 0) > 0;
   const parts = [
@@ -478,7 +481,7 @@ function proofLine(
   if (c.last_inbound_at) {
     parts.push(
       t("person.network.replied", {
-        when: formatDate(c.last_inbound_at, locale, RECORD_ZONE),
+        when: formatDate(c.last_inbound_at, locale, recordZone),
       }),
     );
   }

--- a/frontend/src/screens/personcards.tsx
+++ b/frontend/src/screens/personcards.tsx
@@ -1,11 +1,11 @@
 import { ExternalLink, FileText } from "lucide-react";
 import type { ReactNode } from "react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Avatar, Badge, Button, Checkbox } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { formatDayMonth, formatMoneyCompact } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { interactionIcon, useInteractionLabel } from "./interactionchrome";
@@ -263,6 +263,7 @@ function Absent(): ReactNode {
 export function PersonCommercialCard({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const commercial = view.commercial;
   if (!commercial) {
     // The section was withheld. "You may not see deals" and "there is no deal"
@@ -307,11 +308,7 @@ export function PersonCommercialCard({ view }: Readonly<{ view: Person360 }>) {
                       // wire value with no instant to localize, and a reader
                       // west of UTC rendering it in their own would quote the
                       // day before to a colleague quoting the right one.
-                      date: formatDayMonth(
-                        deal.close_date,
-                        locale,
-                        RECORD_ZONE,
-                      ),
+                      date: formatDayMonth(deal.close_date, locale, recordZone),
                     })
                   : null,
               ]

--- a/frontend/src/screens/personcorrections.tsx
+++ b/frontend/src/screens/personcorrections.tsx
@@ -4,9 +4,9 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCanWrite } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Card, SectionHeader } from "../design-system/atoms";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 
@@ -84,6 +84,7 @@ function EnrichedField({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(field.value);
   const queryClient = useQueryClient();
@@ -157,7 +158,7 @@ function EnrichedField({
           source: field.source,
           // The record's zone: when the machine read this is a fact about the
           // record, and the correction beside it is judged against that day.
-          when: formatDate(field.captured_at, locale, RECORD_ZONE),
+          when: formatDate(field.captured_at, locale, recordZone),
         })}{" "}
         — “{field.evidence_snippet}”
       </p>

--- a/frontend/src/screens/personfiles.tsx
+++ b/frontend/src/screens/personfiles.tsx
@@ -2,11 +2,11 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button } from "../design-system/atoms";
 import { Panel, PanelRow } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { AddDocumentDialog } from "./adddocument";
@@ -43,6 +43,7 @@ const CATEGORY_LABELS: Record<Category, MessageKey> = {
 export function PersonFilesTab({ personId }: Readonly<{ personId: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const [adding, setAdding] = useState(false);
 
   const query = useInfiniteQuery({
@@ -141,7 +142,7 @@ export function PersonFilesTab({ personId }: Readonly<{ personId: string }>) {
               name is what a reader looks for, and the filename is what the
               saved file is called. */}
             <span className="pe-row-label">
-              {formatDateAbbrev(file.created_at, locale, RECORD_ZONE)}
+              {formatDateAbbrev(file.created_at, locale, recordZone)}
             </span>
             <span className="pe-row-value">
               <a

--- a/frontend/src/screens/persongraph.tsx
+++ b/frontend/src/screens/persongraph.tsx
@@ -3,9 +3,9 @@ import { useState } from "react";
 
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Card, SectionHeader } from "../design-system/atoms";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 
@@ -304,6 +304,7 @@ function EdgeFacts({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // Whom this edge joins the SELECTED node to. Both ends have to be read,
   // because an account-arm edge need not touch the anchor at all: reading `to`
   // alone named the selected node as its own counterpart whenever the edge
@@ -361,7 +362,7 @@ function EdgeFacts({
               {r.subject ?? t("person.graph.untitledMessage")} ·{" "}
               {/* The record's zone: a receipt is evidence of when a message
                   happened, so every reader of this edge names the same day. */}
-              {formatDate(r.occurred_at, locale, RECORD_ZONE)}
+              {formatDate(r.occurred_at, locale, recordZone)}
             </li>
           ))}
         </ul>

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, SegmentedControl } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { emailSummaryText } from "../format/emailtext";
 import { formatDayMonth, formatTimeOfDay } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import { ChannelReplyAction } from "./compose";
 import { interactionIcon, useInteractionLabel } from "./interactionchrome";
@@ -36,6 +36,7 @@ type Filter = (typeof FILTERS)[number];
 export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const [filter, setFilter] = useState<Filter>("all");
   const interactionLabel = useInteractionLabel();
   const entries = view.conversation_memory ?? [];
@@ -45,8 +46,10 @@ export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
   // beside it is withholding.
   const rows =
     entries.length > 0
-      ? entries.map((entry) => fromEntry(entry, t, interactionLabel, locale))
-      : foldActivities(view, t, interactionLabel, locale);
+      ? entries.map((entry) =>
+          fromEntry(entry, t, interactionLabel, locale, recordZone),
+        )
+      : foldActivities(view, t, interactionLabel, locale, recordZone);
   const shown = rows.filter((row) => matches(row, filter));
 
   return (
@@ -159,6 +162,8 @@ function channelKeyOf(
 
 // interactionLabel is useInteractionLabel's resolver, threaded in rather than
 // called here: a Row is built outside the component, and a hook may not be.
+// recordZone rides in the same way, for the same reason — useRecordZone is a
+// hook, so the zone is read once in PersonMemory and passed down.
 type InteractionLabel = ReturnType<typeof useInteractionLabel>;
 
 function fromEntry(
@@ -166,12 +171,13 @@ function fromEntry(
   t: ReturnType<typeof useT>,
   interactionLabel: InteractionLabel,
   locale: Locale,
+  recordZone: string,
 ): Row {
   const status = entry.status ?? null;
   return {
     key: entry.key,
-    date: formatDayMonth(entry.occurred_at, locale, RECORD_ZONE),
-    time: formatTimeOfDay(entry.occurred_at, locale, RECORD_ZONE),
+    date: formatDayMonth(entry.occurred_at, locale, recordZone),
+    time: formatTimeOfDay(entry.occurred_at, locale, recordZone),
     // first_activity_id is what "expand to original" opens, and it is the right
     // anchor for a reply too: the send resolves the conversation from the
     // anchor's own links and thread key, so the first message of a thread names
@@ -201,6 +207,7 @@ function foldActivities(
   t: ReturnType<typeof useT>,
   interactionLabel: InteractionLabel,
   locale: Locale,
+  recordZone: string,
 ): Row[] {
   const rows = view.activities?.data ?? [];
   return rows
@@ -209,8 +216,8 @@ function foldActivities(
       const status = statusOf(row, view);
       return {
         key: row.id,
-        date: formatDayMonth(row.occurred_at, locale, RECORD_ZONE),
-        time: formatTimeOfDay(row.occurred_at, locale, RECORD_ZONE),
+        date: formatDayMonth(row.occurred_at, locale, recordZone),
+        time: formatTimeOfDay(row.occurred_at, locale, recordZone),
         activityId: row.id,
         kind: row.kind,
         channelProvider: row.channel_provider ?? null,

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -13,11 +13,11 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Button, SegmentedControl } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import { liveProjects } from "../design-system/projectpicker";
-import { RECORD_ZONE } from "../format/timezone";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
@@ -146,6 +146,7 @@ export function PersonPageV2({
   tab,
 }: Readonly<{ id: string; tab: PersonTab }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const view = useQuery({
     queryKey: ["person360", id],
     queryFn: async () => {
@@ -304,7 +305,7 @@ export function PersonPageV2({
           />
         }
         actionsInline
-        zone={RECORD_ZONE}
+        zone={recordZone}
         // The readings ride the band, above the columns and across the full
         // width: they describe the RELATIONSHIP, not one view of it, and a
         // strip that vanished on the Deals tab would move the tab bar and

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -6,6 +6,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { useCan } from "../app/capability";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import {
   Avatar,
@@ -31,7 +32,6 @@ import {
   SurfaceState,
 } from "../design-system/surfacestate";
 import { formatDayMonth } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import { useProviderLabel } from "./channelproviders";
 import {
@@ -676,7 +676,8 @@ function EmploymentRow({
 }>) {
   const t = useT();
   const { locale } = useLocale();
-  const detail = employmentDetail(employment, t, locale);
+  const recordZone = useRecordZone();
+  const detail = employmentDetail(employment, t, locale, recordZone);
   const ending =
     actions.end.isPending &&
     actions.end.variables?.relationship_id === employment.relationship_id;
@@ -940,6 +941,7 @@ function employmentDetail(
   employment: Employment,
   t: ReturnType<typeof useT>,
   locale: Locale,
+  recordZone: string,
 ): string {
   // The record's zone. These arrive as instants (`format: date-time`), but they
   // are WRITTEN from a date picker, so what is stored is midnight on the day a
@@ -948,10 +950,10 @@ function employmentDetail(
   // colleagues would quote different start dates for one employment. The
   // record's zone is never behind UTC, so it renders the day that was picked.
   const start = employment.started_at
-    ? formatDayMonth(employment.started_at, locale, RECORD_ZONE)
+    ? formatDayMonth(employment.started_at, locale, recordZone)
     : undefined;
   const end = employment.ended_at
-    ? formatDayMonth(employment.ended_at, locale, RECORD_ZONE)
+    ? formatDayMonth(employment.ended_at, locale, recordZone)
     : undefined;
   if (start && end) {
     return `${start} – ${end}`;

--- a/frontend/src/screens/personresearch.tsx
+++ b/frontend/src/screens/personresearch.tsx
@@ -1,10 +1,10 @@
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { EvidenceMark } from "../design-system/evidencemark";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { SurfaceState, sectionState } from "../design-system/surfacestate";
 import { ProvenanceTag } from "../design-system/trust";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { provenanceOf } from "./common";
 import { confidenceLevel } from "./inbox";
@@ -107,6 +107,7 @@ export function PersonResearchTab({
 function ProfileFieldRow({ field }: Readonly<{ field: ProfileField }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const provenance = provenanceOf(field.captured_by);
   return (
     <PanelRow className="pe-row">
@@ -120,7 +121,7 @@ function ProfileFieldRow({ field }: Readonly<{ field: ProfileField }>) {
             provenance,
             confidence: confidenceLevel(field.confidence) ?? undefined,
             snippet: field.evidence_snippet,
-            at: formatDateAbbrev(field.captured_at, locale, RECORD_ZONE),
+            at: formatDateAbbrev(field.captured_at, locale, recordZone),
           }}
         />
       </span>

--- a/frontend/src/screens/personstrip.tsx
+++ b/frontend/src/screens/personstrip.tsx
@@ -1,8 +1,8 @@
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
 import { formatDayMonth, formatMoneyCompact } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 
 // The relationship state strip (concept §5.3): six facts that change how a
@@ -28,6 +28,7 @@ export function PersonStrip({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const omitted = new Set(view.sections_omitted ?? []);
   // A withheld slot says so. Rendering it empty would read as "there is none",
   // which is a claim about the record rather than about the reader's grants —
@@ -63,7 +64,7 @@ export function PersonStrip({
       <StatCard
         label={t("person.strip.nextMeeting")}
         value={reading(
-          nextMeeting(view, t, locale),
+          nextMeeting(view, t, locale, recordZone),
           omitted.has("next_meeting"),
         )}
       />
@@ -137,6 +138,7 @@ function nextMeeting(
   view: Person360,
   t: ReturnType<typeof useT>,
   locale: Locale,
+  recordZone: string,
 ): string {
   const meeting = view.next_meeting;
   if (!meeting) {
@@ -145,7 +147,7 @@ function nextMeeting(
   // The record's zone, which is what persontabs.tsx renders the same field in.
   // Rendered in the reader's own instead, the strip and the tab beside it name
   // different days for one meeting whenever the reader is not in that zone.
-  return formatDayMonth(meeting.starts_at, locale, RECORD_ZONE);
+  return formatDayMonth(meeting.starts_at, locale, recordZone);
 }
 
 // The verdict word and its tone are read from the SERVER's verdict key, never

--- a/frontend/src/screens/persontabs.tsx
+++ b/frontend/src/screens/persontabs.tsx
@@ -1,4 +1,5 @@
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { activityTimeline } from "../design-system/activitytimeline";
 import { Avatar, Button } from "../design-system/atoms";
@@ -18,7 +19,6 @@ import {
 } from "../design-system/surfacestate";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { useViewerId } from "./common";
 import { TimelineActions } from "./compose";
@@ -73,6 +73,7 @@ export function PersonTimelineTab({
   onBriefMeeting?: (activityId: string) => void;
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const [filter, setFilter] = useChronologyFilter(personId);
   const [filters, setFilters] = useTimelineFilters(personId);
   // The 360's own page seeds the list; older pages and every narrowed read
@@ -136,7 +137,7 @@ export function PersonTimelineTab({
         >
           <GroupedTimelineList
             groups={groupChronology(chronology.entries, timeline.hasNextPage)}
-            zone={RECORD_ZONE}
+            zone={recordZone}
           />
         </SurfaceState>
       </PanelBody>
@@ -305,6 +306,7 @@ export function PersonMeetingsTab({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const viewerId = useViewerId();
   // The booked meeting is drawn above, from the server's own next-meeting
   // read. It is also an activity, so an unfiltered list draws it a second time
@@ -345,7 +347,7 @@ export function PersonMeetingsTab({
                   {next.subject ?? t("person.meetings.untitled")}
                 </p>
                 <p className="pe-brief-line">
-                  {formatDateTime(next.starts_at, locale, RECORD_ZONE)}
+                  {formatDateTime(next.starts_at, locale, recordZone)}
                 </p>
                 {/* next_meeting carries no content_state because the 360
                     withholds the whole section rather than a redacted row, so
@@ -396,7 +398,7 @@ export function PersonMeetingsTab({
                 )),
                 hasMore,
               )}
-              zone={RECORD_ZONE}
+              zone={recordZone}
             />
           </SurfaceState>
         </PanelBody>

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type ReactNode, useId, useState } from "react";
 import { api } from "../api/client";
 import { ifMatch, requireVersion } from "../api/version";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { RecordView } from "../design-system/composed";
 import {
@@ -15,7 +16,6 @@ import {
 import { SurfaceState, sectionState } from "../design-system/surfacestate";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { ArchiveAction } from "./archive";
 import { QueryGate, throwProblem, useMe, useSorMode } from "./common";
@@ -91,6 +91,7 @@ export function ProjectScreen({ id }: Readonly<{ id: string }>) {
 
 function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const project = view.project;
   const archivedReasonId = useId();
   const [moveTo, setMoveTo] = useState<ProjectPhase | null>(null);
@@ -101,7 +102,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
     <RecordView
       name={project.name}
       subtitle={<ProjectSubtitle view={view} />}
-      zone={RECORD_ZONE}
+      zone={recordZone}
       badges={
         <>
           <PhaseBadge phase={project.phase} />
@@ -180,6 +181,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
 function ProjectSubtitle({ view }: Readonly<{ view: Project360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const project = view.project;
   const company = view.organization;
   const companyState = sectionState(
@@ -210,7 +212,7 @@ function ProjectSubtitle({ view }: Readonly<{ view: Project360 }>) {
           <span aria-hidden="true">·</span>
           <span>
             {t("project.targetEndShort", {
-              date: formatDate(project.target_end_date, locale, RECORD_ZONE),
+              date: formatDate(project.target_end_date, locale, recordZone),
             })}
           </span>
         </>

--- a/frontend/src/screens/projectreadings.tsx
+++ b/frontend/src/screens/projectreadings.tsx
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useRecordZone } from "../app/recordzone";
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
 import { SurfaceState } from "../design-system/surfacestate";
 import { formatDateAbbrev, formatMoneyOrAbsent } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { type Project360, stateOf } from "./projectsections";
 
@@ -23,6 +23,7 @@ import { type Project360, stateOf } from "./projectsections";
 export function RollupsStrip({ view }: Readonly<{ view: Project360 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const rollups = view.rollups;
   const state = stateOf(view, "rollups", Boolean(rollups), rollups ? 1 : 0);
   if (state !== "ready" || !rollups) {
@@ -61,7 +62,7 @@ export function RollupsStrip({ view }: Readonly<{ view: Project360 }>) {
         label={t("project.rollups.lastActivity")}
         value={
           rollups.last_activity_at
-            ? formatDateAbbrev(rollups.last_activity_at, locale, RECORD_ZONE)
+            ? formatDateAbbrev(rollups.last_activity_at, locale, recordZone)
             : t("project.rollups.never")
         }
       />

--- a/frontend/src/screens/projects.tsx
+++ b/frontend/src/screens/projects.tsx
@@ -4,6 +4,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Hash } from "lucide-react";
 import { api } from "../api/client";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, EmptyState } from "../design-system/atoms";
 import { Chip } from "../design-system/readings";
 import { useLocale, useT } from "../i18n";
@@ -165,6 +166,7 @@ const PHASE_CHIP_OPTIONS: { value: ProjectPhase; label: MessageKey }[] =
 export function ProjectsScreen() {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const me = useMe();
   const overlay = useSorMode() === "overlay";
   const companies = useCompanyOptions();
@@ -251,7 +253,7 @@ export function ProjectsScreen() {
             cell: (project: Project) => <PhaseBadge phase={project.phase} />,
           },
           ownerColumn<Project>(t),
-          lastActivityColumn<Project>(t, locale),
+          lastActivityColumn<Project>(t, locale, recordZone),
         ]}
         tools={<SaveViewAction resource="projects" query={state.query} />}
         rowKey={(project) => project.id}

--- a/frontend/src/screens/projectsections.tsx
+++ b/frontend/src/screens/projectsections.tsx
@@ -3,6 +3,7 @@
 
 import type { ReactNode } from "react";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
@@ -18,7 +19,7 @@ import {
   formatDuration,
   formatMoneyOrAbsent,
 } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { dealRoleLabel } from "./company360";
@@ -167,6 +168,7 @@ function TransitionRow({
 }: Readonly<{ transition: PhaseTransition }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   return (
     <PanelRow className="project-row">
       <span>
@@ -180,9 +182,7 @@ function TransitionRow({
             })}
       </span>
       <span className="project-row-meta">
-        <span>
-          {formatDateTime(transition.changed_at, locale, RECORD_ZONE)}
-        </span>
+        <span>{formatDateTime(transition.changed_at, locale, recordZone)}</span>
         <span>
           {transition.changed_by.display_name ?? t("project.history.bySystem")}
         </span>
@@ -317,6 +317,7 @@ function ContractRow({
   contract: Contract;
   locale: ReturnType<typeof useLocale>["locale"];
 }>) {
+  const recordZone = useRecordZone();
   return (
     <PanelRow className="project-row">
       <span>{contract.title}</span>
@@ -326,7 +327,7 @@ function ContractRow({
           {formatMoneyOrAbsent(contract.value_minor, contract.currency, locale)}
         </span>
         {contract.ends_on && (
-          <span>{formatDateAbbrev(contract.ends_on, locale, RECORD_ZONE)}</span>
+          <span>{formatDateAbbrev(contract.ends_on, locale, recordZone)}</span>
         )}
       </span>
     </PanelRow>
@@ -366,6 +367,7 @@ function DocumentRow({
   doc: Attachment;
   locale: ReturnType<typeof useLocale>["locale"];
 }>) {
+  const recordZone = useRecordZone();
   return (
     <PanelRow className="project-row">
       {/* The name is the download, as on the company page: one thing to find
@@ -381,7 +383,7 @@ function DocumentRow({
         {doc.byte_size != null && (
           <span className="t-mono">{formatBytes(doc.byte_size, locale)}</span>
         )}
-        <span>{formatDateAbbrev(doc.created_at, locale, RECORD_ZONE)}</span>
+        <span>{formatDateAbbrev(doc.created_at, locale, recordZone)}</span>
       </span>
     </PanelRow>
   );

--- a/frontend/src/screens/recordlist.test.tsx
+++ b/frontend/src/screens/recordlist.test.tsx
@@ -35,7 +35,10 @@ describe("one record list, three record types", () => {
   it("the standard views are All, and Mine only for a signed-in reader", () => {
     const t = ((key: string) => key) as Parameters<typeof ownerColumn>[0];
     expect(ownerColumn(t).sort).toBe("owner_id");
-    expect(createdColumn(t, "en").sort).toBe("created_at");
+    // The zone is what the column RENDERS its dates in; this line asserts what
+    // it SORTS on, which the zone cannot change. Any zone the column would
+    // accept states the same claim.
+    expect(createdColumn(t, "en", "Europe/Berlin").sort).toBe("created_at");
     expect(standardViews(undefined).map((v) => v.label)).toEqual([
       "list.viewAll",
     ]);

--- a/frontend/src/screens/recordlist.tsx
+++ b/frontend/src/screens/recordlist.tsx
@@ -1,6 +1,5 @@
 import type { ListColumn } from "../design-system/listtable";
 import { formatDateAbbrev } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import type { useLocale, useT } from "../i18n";
 import { OwnerName } from "./entityref";
 import type { ViewSpec } from "./listquery";
@@ -44,6 +43,7 @@ export function ownerColumn<Row extends OwnedRecord>(
 export function createdColumn<Row extends OwnedRecord>(
   t: Translate,
   locale: Locale,
+  recordZone: string,
 ): ListColumn<Row> {
   return {
     key: "created",
@@ -51,7 +51,7 @@ export function createdColumn<Row extends OwnedRecord>(
     cell: (row) => (
       <span className="t-caption">
         {row.created_at
-          ? formatDateAbbrev(row.created_at, locale, RECORD_ZONE)
+          ? formatDateAbbrev(row.created_at, locale, recordZone)
           : ""}
       </span>
     ),
@@ -66,6 +66,7 @@ export function createdColumn<Row extends OwnedRecord>(
 export function lastActivityColumn<Row extends OwnedRecord>(
   t: Translate,
   locale: Locale,
+  recordZone: string,
 ): ListColumn<Row> {
   return {
     key: "lastActivity",
@@ -73,7 +74,7 @@ export function lastActivityColumn<Row extends OwnedRecord>(
     cell: (row) => (
       <span className="t-caption">
         {row.last_activity_at
-          ? formatDateAbbrev(row.last_activity_at, locale, RECORD_ZONE)
+          ? formatDateAbbrev(row.last_activity_at, locale, recordZone)
           : ""}
       </span>
     ),

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -42,6 +42,7 @@ import {
 import { isEntityKind } from "../app/entity";
 import { unitsForSecretScope } from "../app/extensions";
 import type { NavLevelEntry, NavLevelGroup, NavSection } from "../app/nav";
+import { useRecordZone } from "../app/recordzone";
 import { ResumeConnectBanner } from "../app/resumeconnectbanner";
 import { navigateReplacing, type Route } from "../app/router";
 import { useUnsavedGuard } from "../app/unsaved";
@@ -74,7 +75,7 @@ import {
   toEvidence,
 } from "../design-system/trust";
 import { formatDate, formatDateTime } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { AiRoutingCard } from "./ai-routing";
@@ -1589,6 +1590,7 @@ function PassportRow({
   onRevoke: (row: HTMLElement | null) => void;
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   const revoked = passport.revoked_at != null;
   return (
     <div data-passport={passport.id} tabIndex={-1}>
@@ -1606,7 +1608,7 @@ function PassportRow({
           <span className="settings-run">
             <span>
               {t("settings.created", {
-                date: formatDate(passport.created_at, locale, RECORD_ZONE),
+                date: formatDate(passport.created_at, locale, recordZone),
               })}
             </span>
             {/* A credential's lifetime is a personal deadline, so it reads on
@@ -2685,6 +2687,7 @@ function AuditLogRow({
 }: Readonly<{ entry: AuditLogEntry; meUserId?: string }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const [expanded, setExpanded] = useState(false);
   const keys = diffKeys(entry.before, entry.after);
   const evidence = toEvidence(entry.evidence);
@@ -2701,7 +2704,7 @@ function AuditLogRow({
             and 22 August to one in Ho Chi Minh City — two operators quoting the
             same line quote different days. */}
         <span className="t-small">
-          {formatDateTime(entry.occurred_at, locale, RECORD_ZONE)}
+          {formatDateTime(entry.occurred_at, locale, recordZone)}
         </span>
         <ActorTag entry={entry} meUserId={meUserId} />
         <Badge tone="accent">{entry.action}</Badge>

--- a/frontend/src/screens/strength.tsx
+++ b/frontend/src/screens/strength.tsx
@@ -4,10 +4,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Card, EmptyState, Skeleton } from "../design-system/atoms";
 import { Meter } from "../design-system/readings";
 import { formatDateTime } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import {
   OverlayUnavailable,
@@ -109,6 +109,7 @@ function StrengthBody({
   locale: ReturnType<typeof useLocale>["locale"];
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   // The contract guarantees factors/bucket/score, but a single data-driven
   // card must never crash the whole 360 if a response arrives malformed —
   // degrade to the honest zero/dormant reading instead (craft T7).
@@ -177,7 +178,7 @@ function StrengthBody({
               when: formatDateTime(
                 strength.last_interaction,
                 locale,
-                RECORD_ZONE,
+                recordZone,
               ),
             })
           : t("strength.none")}

--- a/frontend/src/screens/taskactions.tsx
+++ b/frontend/src/screens/taskactions.tsx
@@ -7,9 +7,10 @@ import {
 import { useId } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Modal, Skeleton } from "../design-system/atoms";
 import { formatDate, formatDateTime } from "../format/format";
-import { RECORD_ZONE, viewerZone } from "../format/timezone";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { EntityRef } from "./entityref";
@@ -180,6 +181,7 @@ export function TaskDetailModal({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const titleId = useId();
   const query = useQuery({
     queryKey: ["activity", activityId],
@@ -227,7 +229,7 @@ export function TaskDetailModal({
             )}
             <span>
               {t("tasks.logged")}{" "}
-              {formatDateTime(task.occurred_at, locale, RECORD_ZONE)}
+              {formatDateTime(task.occurred_at, locale, recordZone)}
             </span>
             {task.is_done && <Badge tone="success">{t("tasks.isDone")}</Badge>}
             {task.assignee_id && (

--- a/frontend/src/screens/voice-versions.tsx
+++ b/frontend/src/screens/voice-versions.tsx
@@ -3,9 +3,9 @@ import { RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Card } from "../design-system/atoms";
 import { formatDate } from "../format/format";
-import { RECORD_ZONE } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { parseVoiceInsights, VoiceInsights } from "./voice-insights";
@@ -361,6 +361,7 @@ function VersionRow({
     onError: (e: Error) => setError(problemMessageOf(e, t)),
   });
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   return (
     <li className="vdna-row">
       <span>
@@ -374,7 +375,7 @@ function VersionRow({
             product prints 21/08/2026. The regioned tag comes from format/, and
             the record's zone with it: a profile version is stamped by the
             record, not by where its reader sits. */}
-        {formatDate(version.created_at, locale, RECORD_ZONE)}
+        {formatDate(version.created_at, locale, recordZone)}
       </span>
       {canEdit && version.status === "superseded" && (
         <button


### PR DESCRIPTION
An admin has been able to set `installation.timezone` since the settings card shipped, and nothing on a record page read it. A deployment in Ho Chi Minh City set its zone, watched the field keep the value, and still had every close date, invoice day and timeline heading rendered on a Berlin clock.

Verified in a browser against a live stack — same activity, two settings:

| `installation.timezone` | renders as |
|---|---|
| `Europe/Berlin` | `19.08.2026, 20:30` |
| `Asia/Ho_Chi_Minh` | `20.08.2026, 01:30` |

One instant, two zones, two correct readings.

## How

`RECORD_ZONE` is replaced by `useRecordZone()`, served from a context mounted at the authenticated boundary and fed by the existing installation-settings read. The boundary already held its splash on the company probe; the settings read joins the same condition, so no screen paints a record date against a guessed zone and then moves it. The alternative was pushing a "not yet" case into ~150 call sites, where the honest handling is identical at every one.

Thirteen plain helpers cannot call a hook and take the zone as a parameter instead, threaded from the component that read it. Two of them decide more than a rendering:

- `dayStartIso` cuts the timeline filter's day boundaries, so the zone joins that query key — without it, a filter cached under the old zone keeps answering after an admin moves it, over rows cut at boundaries that moved with it.
- `occurredInstant` in `logactivity.tsx` mints the instant an entry is **stored** at, so it travels as a mutation variable rather than through a closure. A stale read there files the activity on the wrong day permanently.

## Two defects found and fixed

**A day whose midnight does not exist.** Santiago springs forward AT midnight on 6 September 2026 — its clock reads 23:00 on the 5th and then 01:00 on the 6th — so `2026-09-06T00:00` never happens there. `startOfDayInZone` converged on the instant one hour before the jump, whose local reading is still the 5th. A "from 6 September" filter then pulls in an hour of the fifth; an exclusive "to the fifth" end drops that same hour. Silent, once a year, in a zone whoever wrote the filter probably does not live in.

The bug predates this branch and was unreachable while the record zone was a hardcoded Berlin, which transitions at 02:00 and never removes its own midnight. Reading the installation's zone is what makes it reachable, so it is fixed here rather than left for whoever first deploys in Chile. Confirmed by execution before fixing, and the test mutation-checked.

**A settled read carrying no timezone was indistinguishable from one still in flight** — `data?.timezone` spells both `undefined`. The contract makes the field required, so a 200 without it is version skew, and treating it as "not yet" put every record date on the fallback clock with nothing saying why. It now reports.

## The gate

`zone-by-purpose.test.ts` gains the half this change creates. `FALLBACK_RECORD_ZONE` is a real zone name, so a screen importing it would look right to whoever wrote it and show Berlin to every installation that configured something else — with no zone literal for the existing sweep to catch. Only the record-zone module and its own suite may name it. Mutation-checked by planting the import in a screen.

## Copy

The settings hint said the zone governed report period boundaries. It now governs every record date, and says so in en/de/vi.

## Filed rather than fixed here

- **#2518** — the authenticated shell can hold its splash forever if a gating request never answers. Neither gating query carries a timeout. The `company` half has had this property since the onboarding gate shipped, so patching only the newer half would leave the failure reachable through the other branch.
- **#2517** — Deal 360 in overlay mode renders 4 unavailable panels where the spec expects 5. Pre-existing; reproduced on `origin/main` with a clean tree.

## Gates

`make check-backend`, `make check-fe` (4435 tests), `make craft-static` (0 findings) all green. `make frontend-e2e` is 93/94, the one failure being #2517 above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render all record dates in the installation’s timezone instead of Europe/Berlin. Previously, record pages always used Europe/Berlin; now they read `installation.timezone`, so close dates, invoice days, and timeline headings are consistent for the whole team. Pages hold their first paint until the timezone loads to avoid rendering and then shifting dates.

- Replace the `RECORD_ZONE` constant with `useRecordZone()` from a provider mounted at the authenticated boundary; the provider reads `/installation/settings` (gated) and re-renders on changes.
- Introduce `FALLBACK_RECORD_ZONE` and `renderableRecordZone()` to report unrenderable zones and fall back safely instead of throwing.
- Thread the zone into helpers that cannot use hooks; `dayStartIso` now keys timeline queries by zone to avoid stale caches, and `occurredInstant` sends the zone with mutations so stored entries land on the correct day.
- Fix `startOfDayInZone` for zones that skip midnight at DST transitions; add coverage. A settled settings read missing `timezone` now reports instead of silently using the fallback.
- Update screens to read the zone via `useRecordZone()`; extend tests and gates to enforce zone-by-purpose usage; seed `/installation/settings` in e2e; clarify the settings hint in `en/de/vi`.

<sup>Written for commit 560402f64271b8ce98a6ab22f49b574e3174e731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Record dates, timestamps, report boundaries, invoice dates, close dates, and timeline headings now use the configured installation timezone.
  * Personal display timezone behavior remains unchanged for viewer-specific dates, such as task due dates.
  * The app waits for installation settings before displaying authenticated content and safely falls back when a timezone is unavailable or invalid.
* **Bug Fixes**
  * Improved date handling for daylight-saving transitions where local midnight does not exist.
* **Documentation**
  * Updated timezone guidance in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->