### PR TITLE
fix(records): correcting a legal name is not naming the company

### DIFF
--- a/backend/internal/modules/people/organization_evidence_write_integration_test.go
+++ b/backend/internal/modules/people/organization_evidence_write_integration_test.go
@@ -406,3 +406,69 @@ func TestCorrectingTheDisplayNameIsTreatedAsAHumanRename(t *testing.T) {
 		t.Errorf("name_source = %q, want human — an unstamped correction is overwritten by the next enrichment run", got)
 	}
 }
+
+// Correcting the LEGAL name is not authoring the DISPLAY name, and the two do
+// not share a provenance stamp. name_source records where display_name came
+// from: stamping it 'human' for a legal-name correction claims a human named
+// the company, and PromoteOrgNameTx — which promotes only while it still reads
+// 'domain' — then refuses that company its own name for good, with nothing
+// reporting it.
+//
+// The scenario is the one renamerecheck.go's header narrates: a company sits
+// under a provisional name derived from its mail domain while somebody
+// corrects the legal name the site states.
+func TestCorrectingTheLegalNameLeavesTheDisplayNamePromotable(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	orgID := evidenceOrg(ctx, t, e)
+
+	// The state a captured company sits in before its real name arrives: a
+	// provisional display name, and a legal-name receipt to correct.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			`UPDATE organization SET name_source = 'domain' WHERE id = $1`, orgID); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO organization_profile_field (organization_id, field, value, evidence_snippet, source_url, confidence, source, captured_by, retrieved_at)
+			VALUES ($1,'legal_name','Voltaq Systems','"Voltaq Systems"','https://voltaq.test/impressum',0.8,'site_read','agent:deepread',now())`,
+			orgID)
+		return err
+	}); err != nil {
+		t.Fatalf("seed the provisional name and its legal-name receipt: %v", err)
+	}
+
+	corrected := "Voltaq Systems GmbH"
+	if _, err := e.store.UpdateOrganizationProfileField(ctx, orgID, "legal_name",
+		ProfileFieldWriteInput{Value: &corrected}); err != nil {
+		t.Fatalf("correct legal_name: %v", err)
+	}
+	if got := orgColumn(ctx, t, e, orgID, "legal_name"); got != corrected {
+		t.Errorf("legal_name = %q, want %q — the correction still owes the column its value", got, corrected)
+	}
+	// Errorf, not Fatalf: the stamp is the cause and the refused promotion below
+	// is the harm, and a regression should report both rather than stopping at
+	// the column and leaving the consequence to be inferred.
+	if got := orgColumn(ctx, t, e, orgID, "name_source"); got != "domain" {
+		t.Errorf("name_source = %q, want domain — correcting the legal name stamped provenance "+
+			"on a display name nobody touched", got)
+	}
+
+	// The consequence, asserted as the behaviour rather than the column: the
+	// signature sweep can still give the company the name its own people sign
+	// with.
+	var promoted bool
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		promoted, err = e.store.PromoteOrgNameTx(ctx, tx, orgID, "Voltaq Energietechnik GmbH", "two employees")
+		return err
+	}); err != nil {
+		t.Fatalf("promote org name: %v", err)
+	}
+	if !promoted {
+		t.Fatal("the name promotion was refused — correcting a legal name froze the display name for good")
+	}
+	if got := orgColumn(ctx, t, e, orgID, "display_name"); got != "Voltaq Energietechnik GmbH" {
+		t.Errorf("display_name = %q, want the promoted name", got)
+	}
+}

--- a/backend/internal/modules/people/organization_profile_field_write.go
+++ b/backend/internal/modules/people/organization_profile_field_write.go
@@ -181,9 +181,10 @@ func (s *Store) writeProfileField(
 //     provenance and nothing else, so a legal-name correction must not stamp
 //     it: that would claim a human authored a display name nobody touched, and
 //     PromoteOrgNameTx (which promotes only while it still reads 'domain')
-//     would refuse that company its real name forever. 'human' means a
-//     display-name authoring here exactly as it does in UpdateOrganization and
-//     in the cold-start create.
+//     would refuse that company its real name forever. The rule is not local
+//     to this writer: UpdateOrganization stamps 'human' only when display_name
+//     actually moved, and the cold-start create declines the value outright,
+//     reserving it in its own comment for a human's naming.
 //   - THE RENAME RECHECK RUNS. A new name can collide with an existing company,
 //     and the duplicate queue only learns about it if this asks. Either name
 //     can collide, so either name pays for it.

--- a/backend/internal/modules/people/organization_profile_field_write.go
+++ b/backend/internal/modules/people/organization_profile_field_write.go
@@ -174,16 +174,30 @@ func (s *Store) writeProfileField(
 //   - THE VERSION MOVES, so another editor holding the organization's If-Match
 //     is told the row changed under them. trg_organization_updated does that
 //     for any UPDATE on the row, which is why nothing here sets it.
-//   - name_source = 'human'. A human naming the company is the top of the
-//     provenance lattice (ADR-0072/A118). Left unstamped, the next enrichment
-//     run overwrites the correction as though no one had made it.
+//   - name_source = 'human', FOR A DISPLAY-NAME CORRECTION ONLY. A human naming
+//     the company is the top of the provenance lattice (ADR-0072/A118), and
+//     left unstamped the next enrichment run overwrites the correction as
+//     though no one had made it. The column describes display_name's
+//     provenance and nothing else, so a legal-name correction must not stamp
+//     it: that would claim a human authored a display name nobody touched, and
+//     PromoteOrgNameTx (which promotes only while it still reads 'domain')
+//     would refuse that company its real name forever. 'human' means a
+//     display-name authoring here exactly as it does in UpdateOrganization and
+//     in the cold-start create.
 //   - THE RENAME RECHECK RUNS. A new name can collide with an existing company,
-//     and the duplicate queue only learns about it if this asks.
+//     and the duplicate queue only learns about it if this asks. Either name
+//     can collide, so either name pays for it.
 func writeCanonicalOrgColumn(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, column, value string,
 ) error {
-	renamed := column == fieldDisplayName || column == fieldLegalName
-	if renamed {
+	// Two questions, and they are not one: which corrections write a NAME (both
+	// of them, and each owes the lock and the re-check), and which correction
+	// authors the name whose provenance name_source records (display_name
+	// alone). One flag cannot answer both without stamping a provenance onto a
+	// display name nobody touched.
+	nameWrite := column == fieldDisplayName || column == fieldLegalName
+	authoredDisplayName := column == fieldDisplayName
+	if nameWrite {
 		// Workspace-wide, and taken before the row write for the ordering rule
 		// on lockOrgNameWrites. Only a rename pays for it.
 		if err := lockOrgNameWrites(ctx, tx); err != nil {
@@ -195,7 +209,7 @@ func writeCanonicalOrgColumn(
 	// name_source rides the same statement rather than a second UPDATE: one
 	// write, so the value and its provenance cannot land apart.
 	nameSource := ""
-	if renamed {
+	if authoredDisplayName {
 		nameSource = ", name_source = 'human'"
 	}
 	tag, err := tx.Exec(ctx,
@@ -207,7 +221,7 @@ func writeCanonicalOrgColumn(
 	if tag.RowsAffected() == 0 {
 		return apperrors.ErrNotFound
 	}
-	if !renamed {
+	if !nameWrite {
 		return nil
 	}
 	editor, err := storekit.CapturedBy(ctx)


### PR DESCRIPTION
Closes #2203. First item on #2145's programme.

## What was wrong

`writeCanonicalOrgColumn` read one flag for two questions. `renamed` was true for a `display_name` **or** a `legal_name` correction, and it decided three things: take the workspace name lock, stamp `name_source = 'human'`, and run the rename re-check.

Two of those are owed by either name — each can collide with an existing company. The third is not: `name_source` records where **`display_name`** came from and nothing else.

So correcting a company's legal name claimed a human had authored its display name. `PromoteOrgNameTx` promotes only while it still reads `'domain'`, so a company captured from its mail domain — sitting under a provisional name derived from that domain — was frozen under that name **for good** the moment somebody corrected the legal name its site states. Nothing reported it.

The tree already had the rule right in two other places, which is what makes this a slip rather than a design choice:

- `UpdateOrganization` (`organization.go:292`) stamps `'human'` only when `display_name` actually moved.
- The cold-start create says it outright: *"'human' is reserved for UpdateOrganization"*.

## The fix

One flag becomes two: `nameWrite` for the lock and the re-check, which both names owe, and `authoredDisplayName` for the stamp, which only the display name does. The docblock's four-obligation list is corrected to say which obligation belongs to which column, rather than being re-commented around the conflation (README engineering rule 5).

## The test asserts the harm, not the column

`TestCorrectingTheLegalNameLeavesTheDisplayNamePromotable` puts a company in the state capture leaves it in — a provisional domain-derived name plus a legal-name receipt — corrects the legal name, and then asserts **the signature sweep can still promote the company's real name**. The `name_source` assertion is deliberately `Errorf` rather than `Fatalf` so a regression reports the cause *and* the consequence in one run.

Verified it fails on the old code, with the promotion refused:

```
organization_evidence_write_integration_test.go:450: name_source = "human", want domain —
  correcting the legal name stamped provenance on a display name nobody touched
```

## Gates

`make check-backend` green, `craft static --strict` over `backend/` green (0 blocker, 0 major, 0 minor), and the whole `people` integration package green on a throwaway clone.

## The damage check — run, and it does NOT produce a repair migration here

#2203 requires this before the fix, because existing damage would need an additive repair shipping *with* it. My conclusion is that **the repair cannot be a `.sql` migration and should not be attempted blind** — reasoning, so the next person does not re-derive it:

1. **The stamp is unaudited on the organization row.** `writeEvidence` audits the *sidecar* (`organization_profile_field`, keyed by the sidecar row id); `writeCanonicalOrgColumn` writes the org row and its `name_source` with a raw `Exec` and no audit row of its own. So there is no direct record of which orgs were stamped this way.
2. **A blind reset to `'domain'` can do harm.** Only rows that were at `'domain'` lost anything — `PromoteOrgNameTx` refuses every other value anyway, so a `'dossier'` or `'signature'` row was never promotable. Resetting those to `'domain'` would *demote* a name a stronger source had legitimately set.
3. **The safe predicate needs Go, not SQL.** The one signal that proves a display name was never human-authored is that it still equals `DisplayNameFromDomain(primary domain)` — and that is `freemail.DisplayName`, a public-suffix-list walk with IDN/punycode handling. A `.sql` migration cannot express it.

What a detection query *can* see precisely is the domain-triage capture path, which is the main population at risk, because it is the one create path that records `name_source` in its audit image (`domaintriageresolve.go:248`):

```sql
SELECT o.id, o.display_name, o.name_source
  FROM organization o
  JOIN audit_log a
    ON a.entity_type = 'organization' AND a.entity_id = o.id AND a.action = 'create'
 WHERE o.name_source = 'human'
   AND a.after->>'name_source' = 'domain'
   AND NOT EXISTS (
         SELECT 1 FROM audit_log d
          WHERE d.entity_type = 'organization' AND d.entity_id = o.id
            AND d.action = 'update' AND d.after ? 'display_name');
```

An organization created provisionally, now marked human-named, with no audited display-name edit anywhere — that is the damaged set. Cold-start-created organizations are **not** covered, because that path's create audit does not carry `name_source`.

This installation has no data to check against (the dev database holds zero organizations), so I could not run it for a verdict. If it returns rows on a real installation, the repair is its own change with its own review — a one-time Go routine, not a migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when organization display names are marked as manually authored during edits.
  * Documented that initial organization creation does not automatically mark display names as manually authored.

* **Tests**
  * Added coverage confirming legal-name corrections preserve eligibility for automatic display-name promotion when the current name came from the organization’s domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->