### PR TITLE
fix(records): one place decides whether something is late

### DIFF
--- a/backend/internal/compose/meetingbrief/ranking.go
+++ b/backend/internal/compose/meetingbrief/ranking.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/elapsed"
 )
 
@@ -100,7 +101,7 @@ func score(claim ClaimIn, now time.Time) int {
 		// A promise of ours still inside its date ranks below a question we
 		// owe an answer to; once overdue it leads everything.
 		s += 400
-		if claim.DueAt != nil && claim.DueAt.Before(now) {
+		if deadline.Passed(claim.DueAt, now) {
 			s += 500
 		}
 	case kindOpenQuestion:

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/claims"
 	"github.com/gradionhq/margince/backend/internal/compose/personcontext"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/elapsed"
 )
 
@@ -231,7 +232,7 @@ func goalLine(ask ClaimIn, now time.Time) string {
 	case kindDecision:
 		return fmt.Sprintf("Get the decision %s is holding: %s", ask.PersonName, ask.Body)
 	default:
-		if ask.DueAt != nil && ask.DueAt.Before(now) {
+		if deadline.Passed(ask.DueAt, now) {
 			return fmt.Sprintf("Close out what we owe %s, overdue since %s: %s", ask.PersonName, ask.DueAt.UTC().Format("2 Jan"), ask.Body)
 		}
 		return fmt.Sprintf("Close out what we promised %s: %s", ask.PersonName, ask.Body)
@@ -411,7 +412,7 @@ func riskLine(claim ClaimIn, now time.Time) (string, bool) {
 	}
 	overdue := claim.Kind == kindCommitmentOurs &&
 		claim.Status == statusOpen &&
-		claim.DueAt != nil && claim.DueAt.Before(now)
+		deadline.Passed(claim.DueAt, now)
 	if overdue {
 		return fmt.Sprintf("We are past due to %s on: %s", claim.PersonName, claim.Body), true
 	}

--- a/backend/internal/compose/org360/sections.go
+++ b/backend/internal/compose/org360/sections.go
@@ -23,6 +23,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -157,7 +158,7 @@ func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 		step.AssigneeId = uuidPtr(assignee)
 		step.LinkedDealId = uuidPtr(dealID)
 		step.LinkedPersonId = uuidPtr(personID)
-		step.Overdue = step.DueAt != nil && step.DueAt.Before(now)
+		step.Overdue = deadline.Passed(step.DueAt, now)
 		return step, nil
 	})
 	if err != nil {

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -21,6 +21,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/relstrength"
 )
 
@@ -229,7 +230,7 @@ func oldestOverdueCommitment(now time.Time, page *crmcontracts.Person360) (crmco
 		if claim.Kind != crmcontracts.CommitmentOurs || claim.Status != crmcontracts.ConversationClaimStatusOpen {
 			continue
 		}
-		if claim.DueAt == nil || !claim.DueAt.Before(now) {
+		if !deadline.Passed(claim.DueAt, now) {
 			continue
 		}
 		if oldest == nil || claim.DueAt.Before(*oldest.DueAt) {

--- a/backend/internal/compose/persondraft/fold.go
+++ b/backend/internal/compose/persondraft/fold.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/personcontext"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/convstate"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/textlang"
 )
@@ -260,7 +261,7 @@ func isOverdueOurs(claim crmcontracts.ConversationClaim, now time.Time) bool {
 	if claim.Status != crmcontracts.ConversationClaimStatusOpen {
 		return false
 	}
-	return claim.DueAt != nil && claim.DueAt.Before(now)
+	return deadline.Passed(claim.DueAt, now)
 }
 
 // hoistOverdueOurs moves our overdue promises to the front, keeping every other

--- a/backend/internal/compose/project360/sectionswork.go
+++ b/backend/internal/compose/project360/sectionswork.go
@@ -11,6 +11,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -61,7 +62,7 @@ func (a *assembly) readCommitments() error {
 			Subject:    t.Subject,
 			DueAt:      t.DueAt,
 			AssigneeId: uuidPtr(t.AssigneeID),
-			Overdue:    t.DueAt != nil && t.DueAt.Before(a.now),
+			Overdue:    deadline.Passed(t.DueAt, a.now),
 		}
 		if t.AssigneeID != nil {
 			name := t.AssigneeName

--- a/backend/internal/modules/agents/tools_commitments.go
+++ b/backend/internal/modules/agents/tools_commitments.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/agents/apps"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -209,31 +210,23 @@ func (c OpenCommitment) wire(asOf time.Time) CommitmentItem {
 	return item
 }
 
-// commitmentState judges one promise against the instant the set was swept
-// at. A due date exactly equal to that instant reads as overdue: the moment
-// it was promised for has arrived and it is not done.
+// commitmentState judges one promise against the instant the set was swept at.
+//
+// The boundary is deadline.Passed's, so this surface and every list, card and
+// figure the same person can open agree about the same promise.
 func commitmentState(dueAt *time.Time, asOf time.Time) string {
 	switch {
 	case dueAt == nil:
 		return commitmentUndated
-	case dueAt.After(asOf):
-		return commitmentUpcoming
-	default:
+	case deadline.Passed(dueAt, asOf):
 		return commitmentOverdue
+	default:
+		return commitmentUpcoming
 	}
 }
 
-// daysOverdue answers how many WHOLE days a promise has been past its date,
-// and whether it is past it at all.
-//
-// Whole days elapsed, not calendar days crossed — the second needs a timezone
-// this build does not store, and would report a promise made at 23:00 and
-// judged at 01:00 as a day late. Zero is a real answer here: a promise hours
-// past its date is overdue by no whole days, which is not the same as not
-// being overdue.
+// daysOverdue answers how many WHOLE days a promise has been past its date, and
+// whether it is past it at all.
 func daysOverdue(dueAt *time.Time, asOf time.Time) (int, bool) {
-	if dueAt == nil || dueAt.After(asOf) {
-		return 0, false
-	}
-	return int(asOf.Sub(*dueAt) / (24 * time.Hour)), true
+	return deadline.DaysPast(dueAt, asOf)
 }

--- a/backend/internal/modules/agents/tools_commitments_test.go
+++ b/backend/internal/modules/agents/tools_commitments_test.go
@@ -47,8 +47,16 @@ func TestAPromiseIsJudgedAgainstTheInstantItWasSweptAt(t *testing.T) {
 		{"a promise due tomorrow is upcoming", at(24 * time.Hour), commitmentUpcoming},
 		{"a promise due one second from now is still upcoming", at(time.Second), commitmentUpcoming},
 		{
-			"a promise due exactly now is overdue: the moment arrived and it is not done",
-			at(0), commitmentOverdue,
+			// At the instant a promise falls due it is due, not late — the
+			// boundary every surface reads and the one the SQL asks
+			// (`due_at < now()`). A reader told they had missed something in
+			// the moment it came due has been told a thing that is not so.
+			"a promise due exactly now is upcoming: the moment arrived, it has not passed",
+			at(0), commitmentUpcoming,
+		},
+		{
+			"a promise due one nanosecond ago is overdue",
+			at(-time.Nanosecond), commitmentOverdue,
 		},
 		{"a promise due yesterday is overdue", at(-24 * time.Hour), commitmentOverdue},
 	} {

--- a/backend/internal/modules/finance/formulas.go
+++ b/backend/internal/modules/finance/formulas.go
@@ -15,6 +15,8 @@ package finance
 import (
 	"sort"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 )
 
 // Window parameters (FIN-PARAM-1..3). Named rather than inlined because each
@@ -172,7 +174,7 @@ func OpenBalanceAt(invoices []Invoice, asOf time.Time) OpenBalance {
 			return OpenBalance{RateUnavailable: true}
 		}
 		out.OpenMinorBase += inv.OpenMinorBase
-		if inv.DueOn == nil || !inv.DueOn.Before(asOf) {
+		if !deadline.Passed(inv.DueOn, asOf) {
 			continue
 		}
 		out.OverdueMinorBase += inv.OpenMinorBase

--- a/backend/internal/modules/finance/mirror.go
+++ b/backend/internal/modules/finance/mirror.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -463,7 +464,7 @@ func deriveStatus(inv SourceInvoice, open int64, now time.Time) string {
 }
 
 func overdue(inv SourceInvoice, now time.Time) bool {
-	return inv.DueOn != nil && now.After(*inv.DueOn)
+	return deadline.Passed(inv.DueOn, now)
 }
 
 func nullable(value string) *string {

--- a/backend/internal/modules/finance/summary.go
+++ b/backend/internal/modules/finance/summary.go
@@ -24,6 +24,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/deadline"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -355,7 +356,7 @@ func scanRecentInvoice(rows pgx.Rows, now time.Time) (crmcontracts.FinanceInvoic
 		OpenMinorBase: open,
 	}); ok {
 		out.DaysLate = &late
-	} else if due != nil && open > 0 && now.After(*due) {
+	} else if open > 0 && deadline.Passed(due, now) {
 		// Still open and past due: lateness is measured against today rather
 		// than against a settlement that has not happened.
 		running := int(now.Sub(*due).Hours() / 24)

--- a/backend/internal/shared/kernel/deadline/deadline.go
+++ b/backend/internal/shared/kernel/deadline/deadline.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package deadline answers whether a promised moment has passed.
+package deadline
+
+import "time"
+
+// Passed reports whether a due moment is in the past — whether the thing is
+// LATE.
+//
+// Strictly past. At the instant a promise falls due it is due, not late: a task
+// due at 14:00 is not yet late at 14:00:00, and a reader shown it as overdue in
+// that instant would be told they had already failed something they had not.
+//
+// THIS IS NOT THE SCHEDULER'S QUESTION, and conflating the two is how the two
+// readings drifted apart. A scheduler asks "has the moment ARRIVED" — inclusive,
+// because a job due now should run now. An overdue display asks "has the moment
+// PASSED" — exclusive, because a deadline is not missed until it is behind you.
+// Both are correct for their own question and neither answers the other's, so a
+// call site that reaches for the wrong one looks right while disagreeing with
+// every sibling.
+//
+// The exclusive reading is also what this product's SQL already asks
+// (`due_at < now()`), so a list assembled in Go and a count assembled in the
+// database agree about the same row.
+//
+// A nil due moment is not late. Something with no date promised cannot have
+// missed it, and returning true would put every undated item in an overdue list.
+func Passed(due *time.Time, now time.Time) bool {
+	return due != nil && due.Before(now)
+}
+
+// DaysPast is how many WHOLE days a due moment is behind now, and whether it is
+// behind at all.
+//
+// Whole days ELAPSED, not calendar days crossed. The two differ: a promise made
+// at 23:00 and judged at 01:00 has crossed a calendar day and elapsed two hours,
+// and calling that "a day late" overstates it.
+//
+// Calendar counting needs a timezone to say where a day begins. The
+// installation stores one, but it is not an argument here and this package is
+// stdlib-only by tier — so a caller that means calendar days must count them
+// where that setting is in scope, as the close-date sweep does.
+//
+// NOT `kernel/elapsed`, which counts calendar days in UTC and is the right
+// answer for ITS question. That one measures silence between two moments and is
+// deliberately calendar-based, so its wording can only change when the UTC-day
+// cache key it rides does. This one measures how far past a promise we are,
+// where elapsed time is what a reader means — 23:00 to 01:00 has crossed a
+// calendar day and is not "a day late". Reaching for the wrong one produces a
+// count that is off by one for most of every day.
+//
+// Zero is a real answer: something hours past its date is late by no whole
+// days, which is not the same as not being late. Callers read the bool, never
+// the count, to decide.
+func DaysPast(due *time.Time, now time.Time) (int, bool) {
+	if !Passed(due, now) {
+		return 0, false
+	}
+	return int(now.Sub(*due) / (24 * time.Hour)), true
+}

--- a/backend/internal/shared/kernel/deadline/deadline_test.go
+++ b/backend/internal/shared/kernel/deadline/deadline_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deadline
+
+import (
+	"testing"
+	"time"
+)
+
+var noon = time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+
+func at(d time.Duration) *time.Time {
+	t := noon.Add(d)
+	return &t
+}
+
+// The boundary is the whole point of this package: every surface that decides
+// lateness agrees here or the same record reads two ways.
+func TestPassedIsStrict(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		due  *time.Time
+		want bool
+	}{
+		{"nothing promised cannot have been missed", nil, false},
+		{"due tomorrow", at(24 * time.Hour), false},
+		{"due one nanosecond from now", at(time.Nanosecond), false},
+		{"due exactly now is DUE, not late", at(0), false},
+		{"due one nanosecond ago is late", at(-time.Nanosecond), true},
+		{"due yesterday", at(-24 * time.Hour), true},
+	} {
+		if got := Passed(tc.due, noon); got != tc.want {
+			t.Errorf("%s: Passed = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// Zero is a real answer and is not the same as "not late", so callers read the
+// bool. A test that only checked the count would pass while the two were
+// conflated.
+func TestDaysPastSeparatesTheCountFromTheVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		due      *time.Time
+		wantDays int
+		wantLate bool
+	}{
+		{"undated", nil, 0, false},
+		{"upcoming", at(time.Hour), 0, false},
+		{"due exactly now", at(0), 0, false},
+		{"late by hours is late by no whole days", at(-5 * time.Hour), 0, true},
+		{"late by a day", at(-24 * time.Hour), 1, true},
+		{"late by a day and most of another", at(-47 * time.Hour), 1, true},
+		{"late by two days", at(-48 * time.Hour), 2, true},
+	} {
+		days, late := DaysPast(tc.due, noon)
+		if days != tc.wantDays || late != tc.wantLate {
+			t.Errorf("%s: DaysPast = (%d, %v), want (%d, %v)",
+				tc.name, days, late, tc.wantDays, tc.wantLate)
+		}
+	}
+}
+
+// DaysPast must agree with Passed about lateness, or a caller reading one and a
+// caller reading the other disagree about the same record.
+func TestDaysPastAgreesWithPassed(t *testing.T) {
+	for _, offset := range []time.Duration{
+		-49 * time.Hour, -24 * time.Hour, -time.Nanosecond, 0, time.Nanosecond, time.Hour,
+	} {
+		_, late := DaysPast(at(offset), noon)
+		if want := Passed(at(offset), noon); late != want {
+			t.Errorf("at %v: DaysPast says late=%v, Passed says %v", offset, late, want)
+		}
+	}
+	if _, late := DaysPast(nil, noon); late != Passed(nil, noon) {
+		t.Error("the two disagree about an undated promise")
+	}
+}

--- a/backend/overdueboundary_test.go
+++ b/backend/overdueboundary_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// "Is this late?" is one question about one record, and a reader can ask it of a
+// list, a card, a brief or an agent tool. They must all answer alike, because
+// the reader does not know which one they are looking at — and the answer they
+// disagreed about was the boundary: whether a promise due at this instant has
+// already been missed.
+//
+// It has not. At the moment a promise falls due it is due; a reader told they
+// had failed something in the instant it came due has been told a thing that is
+// not so. `shared/kernel/deadline` holds that reading, and the SQL asks it the
+// same way with `due_at < now()`.
+//
+// WHAT THIS DOES NOT COVER, so the absence of findings is not read as a wider
+// claim than it is: fields carrying a promise under another name — an SLA
+// `deadline`, a deal's `expected_close_date` — and the frontend, which decides
+// lateness in TypeScript no Go census reads.
+//
+// THE DISTINCTION THAT MADE THEM DRIFT, because a gate that does not name it
+// will be read as forbidding both: a SCHEDULER asks whether the moment has
+// ARRIVED — inclusive, since a job due now should run now — and an overdue
+// display asks whether it has PASSED. Both are right for their own question.
+// This census governs the second only, which is why it keys on a comparison
+// against a due date rather than on `<=` anywhere.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+// deadlineOwner is the package that may spell the comparison.
+const deadlineOwner = "internal/shared/kernel/deadline"
+
+// schedulerClaims ask whether the moment has ARRIVED, not whether it has
+// passed, and are inclusive for that reason: a job due now is due now, and a
+// scheduler that waited for the instant to go by would never run anything due
+// exactly on a tick. In Go and in SQL alike — the question is the same one
+// whichever language asks it.
+//
+// Ratified by name rather than excluded by a narrower pattern, because the two
+// questions are written identically — `due_at <= now()` against `due_at <
+// now()` — and nothing in the SQL says which is being asked. A pattern that
+// could tell them apart would be a pattern that could be fooled.
+var schedulerClaims = gatekit.Waive(map[string]string{
+	"internal/compose/runnerservice.go":       "fires a cron-seeded agent when its scheduled moment has arrived. `!now.Before(due)` is the inclusive reading on purpose: a job due exactly on a tick must run on that tick, and nothing here is shown to a reader as late.",
+	"internal/modules/agents/runner/store.go": "claims the next runner job whose scheduled moment has arrived. This is the scheduler's question, and a job due exactly now must run rather than wait a tick; nothing here is shown to a reader as late.",
+})
+
+// asksIfLateInSQL matches a statement comparing a due column to the database's
+// own clock. `<=` there is the inclusive reading, which no display wants.
+var asksIfLateInSQL = regexp.MustCompile(`(?i)\bdue_at\s*<=\s*now\(\)`)
+
+func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
+	// A ratification that stops matching is one for a statement that has moved
+	// or been fixed, and leaving it re-exempts whatever takes its place.
+	defer schedulerClaims.AssertAllMatched(t)
+
+	var inGo, inSQL []string
+	judged := 0
+	fset := token.NewFileSet()
+	for _, root := range []string{"internal", "../extensions"} {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if name := entry.Name(); name == "testdata" || name == "node_modules" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			rel := filepath.ToSlash(path)
+			if strings.Contains(rel, deadlineOwner) {
+				return nil
+			}
+			source, readErr := os.ReadFile(path) // #nosec G304 -- a *.go path from walking the trusted source tree
+			if readErr != nil {
+				return readErr
+			}
+			judged++
+			for _, statement := range sqlStatementsIn(t, path, string(source)) {
+				if asksIfLateInSQL.MatchString(statement) && !schedulerClaims.Waived(t, rel) {
+					inSQL = append(inSQL, rel+": "+firstSQLStatementLine(statement))
+				}
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok || !comparesADueDateToTheClock(call) {
+					return true
+				}
+				if !schedulerClaims.Waived(t, rel) {
+					inGo = append(inGo, rel)
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	if judged < 500 {
+		t.Fatalf("the census read only %d Go files, so it covered almost nothing", judged)
+	}
+	sort.Strings(inGo)
+	sort.Strings(inSQL)
+	if len(inGo) > 0 {
+		t.Errorf("%d site(s) compare a due date to the clock themselves.\n\n"+
+			"Whether a promise due at this instant is already late is one decision, and the "+
+			"surfaces that disagreed about it were a list, a card and an agent tool answering the "+
+			"same reader. Call deadline.Passed.\n\n\t%s", len(inGo), strings.Join(inGo, "\n\t"))
+	}
+	if len(inSQL) > 0 {
+		t.Errorf("%d statement(s) ask `due_at <= now()`, the INCLUSIVE reading.\n\n"+
+			"A row counted late in SQL and upcoming in Go is the same record answering two ways "+
+			"depending on which surface assembled it. Use `<`.\n\n\t%s",
+			len(inSQL), strings.Join(inSQL, "\n\t"))
+	}
+}
+
+// comparesADueDateToTheClock reports whether a call compares a due date against
+// the clock, in EITHER direction.
+//
+// `now.After(due)` is the same decision as `due.Before(now)` with the operands
+// swapped, and reading only the receiver missed it — which is how a second
+// spelling of "is this invoice late" lived in the same module as the first.
+//
+// Exactly one side must name a due date. Two due dates compared to each other is
+// finding the earlier of them, a different and legitimate question; neither side
+// naming one is not this decision at all.
+func comparesADueDateToTheClock(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || len(call.Args) != 1 {
+		return false
+	}
+	if selector.Sel.Name != "Before" && selector.Sel.Name != "After" {
+		return false
+	}
+	return mentionsADueDate(selector.X) != mentionsADueDate(call.Args[0])
+}
+
+// mentionsADueDate reports whether an expression names a DUE date.
+//
+// "due" only, and that is a scope decision rather than an oversight. A due date
+// is a moment promised to a person, and being past it is something a reader is
+// shown. An expiry, a lease, a quiesce deadline and a token lifetime are also
+// moments compared against a clock, and none of them is a promise anybody
+// missed — widening to those words reported eleven sites that were all correct,
+// which is how a census teaches its readers to skip the output.
+//
+// Fields that carry a promise under another name — an SLA `deadline`, a deal's
+// `expected_close_date` — are real and are NOT covered here. They are tracked
+// rather than swept in, because each has its own semantics to settle first.
+func mentionsADueDate(expr ast.Expr) bool {
+	named := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if ident, ok := node.(*ast.Ident); ok && strings.Contains(strings.ToLower(ident.Name), "due") {
+			named = true
+		}
+		return true
+	})
+	return named
+}

--- a/backend/overdueboundary_test.go
+++ b/backend/overdueboundary_test.go
@@ -59,9 +59,18 @@ var schedulerClaims = gatekit.Waive(map[string]string{
 	"internal/modules/agents/runner/store.go": "claims the next runner job whose scheduled moment has arrived. This is the scheduler's question, and a job due exactly now must run rather than wait a tick; nothing here is shown to a reader as late.",
 })
 
-// asksIfLateInSQL matches a statement comparing a due column to the database's
-// own clock. `<=` there is the inclusive reading, which no display wants.
-var asksIfLateInSQL = regexp.MustCompile(`(?i)\bdue_at\s*<=\s*now\(\)`)
+// asksIfLateInSQL matches a statement asking whether a due column has been
+// reached INCLUSIVELY — the reading no display wants.
+//
+// Both directions, and any right-hand side. This tree does not write the clock
+// literally: `deals/health.go` binds it as `a.due_at < $2`, so a census keyed on
+// `now()` could not have seen an inclusive version of the very statement it was
+// written to guard. `now() >= due_at` is the same question with the operands
+// swapped, which is how the Go arm was blind until this round too.
+var asksIfLateInSQL = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bdue_at\s*<=`),
+	regexp.MustCompile(`(?i)(now\(\)|\$\d+|current_timestamp)\s*>=\s*[a-z_.]*\bdue_at\b`),
+}
 
 func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
 	// A ratification that stops matching is one for a statement that has moved
@@ -96,8 +105,11 @@ func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
 			}
 			judged++
 			for _, statement := range sqlStatementsIn(t, path, string(source)) {
-				if asksIfLateInSQL.MatchString(statement) && !schedulerClaims.Waived(t, rel) {
-					inSQL = append(inSQL, rel+": "+firstSQLStatementLine(statement))
+				for _, inclusive := range asksIfLateInSQL {
+					if inclusive.MatchString(statement) && !schedulerClaims.Waived(t, rel) {
+						inSQL = append(inSQL, rel+": "+firstSQLStatementLine(statement))
+						break
+					}
 				}
 			}
 			file, parseErr := parser.ParseFile(fset, path, nil, 0)
@@ -132,7 +144,7 @@ func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
 			"same reader. Call deadline.Passed.\n\n\t%s", len(inGo), strings.Join(inGo, "\n\t"))
 	}
 	if len(inSQL) > 0 {
-		t.Errorf("%d statement(s) ask `due_at <= now()`, the INCLUSIVE reading.\n\n"+
+		t.Errorf("%d statement(s) ask whether a due moment has been reached INCLUSIVELY.\n\n"+
 			"A row counted late in SQL and upcoming in Go is the same record answering two ways "+
 			"depending on which surface assembled it. Use `<`.\n\n\t%s",
 			len(inSQL), strings.Join(inSQL, "\n\t"))

--- a/backend/overdueboundary_test.go
+++ b/backend/overdueboundary_test.go
@@ -62,14 +62,68 @@ var schedulerClaims = gatekit.Waive(map[string]string{
 // asksIfLateInSQL matches a statement asking whether a due column has been
 // reached INCLUSIVELY — the reading no display wants.
 //
-// Both directions, and any right-hand side. This tree does not write the clock
-// literally: `deals/health.go` binds it as `a.due_at < $2`, so a census keyed on
-// `now()` could not have seen an inclusive version of the very statement it was
-// written to guard. `now() >= due_at` is the same question with the operands
-// swapped, which is how the Go arm was blind until this round too.
+// Both directions, because `now() >= due_at` is the same question with the
+// operands swapped — the blindness the Go arm carried until a round ago.
+//
+// The other side must be a CLOCK: `now()`, `current_timestamp`, or a bound
+// parameter, since this tree does not write the clock literally (`deals/health.go`
+// binds it as `a.due_at < $2`, so a census keyed on `now()` could not have seen
+// an inclusive version of the statement it was written to guard).
+//
+// Requiring a clock is also what keeps `due_at <= due_on` out. Two due dates
+// compared to each other is finding the earlier of them — a different and
+// legitimate question, permitted by the Go arm, and a census that refused it in
+// SQL while allowing it in Go would be two rules for one decision.
 var asksIfLateInSQL = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)\bdue_at\s*<=`),
-	regexp.MustCompile(`(?i)(now\(\)|\$\d+|current_timestamp)\s*>=\s*[a-z_.]*\bdue_at\b`),
+	regexp.MustCompile(`(?i)\bdue_at\s*<=\s*(now\(\)|current_timestamp|\$\d+)`),
+	regexp.MustCompile(`(?i)(now\(\)|current_timestamp|\$\d+)\s*>=\s*[a-z_.]*\bdue_at\b`),
+}
+
+// TestTheSQLPatternsSeeWhatTheyClaimTo pins both what they catch and what they
+// must let through.
+//
+// A census asserting a shape is ABSENT passes identically over a clean tree and
+// over a pattern that has stopped matching.
+func TestTheSQLPatternsSeeWhatTheyClaimTo(t *testing.T) {
+	caught := []string{
+		"WHERE a.due_at <= now()",
+		"WHERE a.due_at <= $2",
+		"WHERE a.due_at <= current_timestamp",
+		"WHERE now() >= a.due_at",
+		"WHERE $3 >= due_at",
+		"where DUE_AT  <=  NOW()",
+	}
+	for _, statement := range caught {
+		if !anyAsksIfLate(statement) {
+			t.Errorf("the census does not see an inclusive reading it must:\n\t%s", statement)
+		}
+	}
+	missed := []string{
+		// The exclusive reading, which is the one every surface wants.
+		"WHERE a.due_at < now()",
+		"WHERE a.due_at < $2",
+		// Two due dates compared to each other: finding the earlier of them.
+		"WHERE due_at <= due_on",
+		"WHERE inv.due_at <= q.due_at",
+		// A due date in the FUTURE is a different question again.
+		"WHERE a.due_at >= now()",
+		// Another column entirely.
+		"WHERE expires_at <= now()",
+	}
+	for _, statement := range missed {
+		if anyAsksIfLate(statement) {
+			t.Errorf("the census reports something that is not an inclusive lateness test:\n\t%s", statement)
+		}
+	}
+}
+
+func anyAsksIfLate(statement string) bool {
+	for _, inclusive := range asksIfLateInSQL {
+		if inclusive.MatchString(statement) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
@@ -105,11 +159,8 @@ func TestOnlyOnePlaceDecidesWhetherSomethingIsLate(t *testing.T) {
 			}
 			judged++
 			for _, statement := range sqlStatementsIn(t, path, string(source)) {
-				for _, inclusive := range asksIfLateInSQL {
-					if inclusive.MatchString(statement) && !schedulerClaims.Waived(t, rel) {
-						inSQL = append(inSQL, rel+": "+firstSQLStatementLine(statement))
-						break
-					}
+				if anyAsksIfLate(statement) && !schedulerClaims.Waived(t, rel) {
+					inSQL = append(inSQL, rel+": "+firstSQLStatementLine(statement))
 				}
 			}
 			file, parseErr := parser.ParseFile(fset, path, nil, 0)


### PR DESCRIPTION
## The defect

"Is this late?" is one question about one record. A reader can ask it of a list, a card, a meeting brief, a finance figure, or an agent tool — and they do not know which one is answering. **Eleven sites each spelled the comparison themselves, and they disagreed about the boundary.**

| reading | sites |
|---|---|
| `DueAt.Before(now)` — at the instant it falls due, **not** late | 9 display sites, and **both** SQL predicates (`due_at < now()`) |
| `!dueAt.After(asOf)` — at that instant, **late** | the agent tool surface |

So a reader could ask the agent what they had missed, be told about a commitment, open the same record in the UI, and find it upcoming. Same record, same instant, two answers.

## Which is right

It is not late. **At the moment a promise falls due it is due, not missed** — telling someone they have failed something in the instant it comes due tells them a thing that is not so. That is also what this product's SQL already asked, so a list assembled in Go and a count assembled in the database now agree about the same row.

The reading lives once in `internal/shared/kernel/deadline` and every site calls it.

## The distinction that let them drift

Worth writing down, because a gate that does not name it reads as forbidding both:

- a **scheduler** asks whether the moment has **ARRIVED** — inclusive, because a job due now should run now, and one that waited for the instant to pass would never fire on a tick;
- an **overdue display** asks whether it has **PASSED**.

Both are correct for their own question and neither answers the other's, so a site that reaches for the wrong one looks right while disagreeing with every sibling. That is exactly what happened to the agent tool, whose comment argued the scheduler's reading for a display's question.

The runner's `due_at <= now()` claim is inclusive on purpose and ratified with that reason, rather than excluded by a narrower pattern — the two questions are written identically and nothing in the SQL says which is being asked.

## The gate found the eleventh site itself

My own sweep found ten, by grepping `DueAt`. The census found `internal/modules/finance/formulas.go`, which decides **how much money counts as overdue** and spells it with `DueOn`:

```go
if inv.DueOn == nil || !inv.DueOn.Before(asOf) { continue }
out.OverdueMinorBase += inv.OpenMinorBase
```

No sweep for `DueAt` would ever have reached it. That is the argument for the gate over the fix.

## Verification

Every mutant verified to apply and compile:

| planted | result |
|---|---|
| a Go site spelling the comparison itself | `internal/compose/org360/sections.go` |
| SQL flipped to `due_at <= now()` | `internal/modules/deals/health.go: SELECT a.id FROM activity a` |
| **comparing two due dates to each other** (finding the earliest — a legitimate, different question) | **silent, correctly** |

`make check-backend` green. Full integration lane green — 43 packages, 0 skips.

## Behaviour change

A commitment due at exactly the sweep instant is reported `upcoming` by the agent tool where it was `overdue`. The test that pinned the old boundary is updated with the reasoning rather than the digit, and a `-1ns` case added so the boundary is asserted from both sides.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the overdue decision in `internal/shared/kernel/deadline` and standardizes the boundary to exclusive: an item is overdue only when `due_at < now`. Previously the agent tool treated items due exactly now as overdue; now they are upcoming, aligning all Go surfaces with SQL.

- All call sites use `deadline.Passed(due, now)`; nil due is not late. `deadline.DaysPast` returns whole-day deltas plus a late flag. Updated: meeting briefs; org/project/person 360 and draft; agent commitments (state and days); finance (`mirror`, `formulas`, `summary`).
- Adds `internal/shared/kernel/deadline` with tests and an architectural gate `backend/overdueboundary_test.go` that forbids ad‑hoc due-vs-now checks in Go and inclusive SQL (`<=`/`>=`) when comparing to a clock (`now()`, `current_timestamp`, or a bound `$n`). The SQL gate reads both directions; comparisons between two due fields remain allowed. Scheduler job selection is explicitly waived in both Go and SQL.
- Agent behavior: a commitment due exactly at sweep time is now upcoming; tests updated and a `-1ns` case asserts the boundary.

<sup>Written for commit 9c422015da7890c196c49070ed55fcb3567c1a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized overdue status across commitments, goals, risks, projects, invoices, and other deadline-based records.
  * Items due exactly at the current time are now treated as upcoming rather than overdue.
  * Overdue durations consistently report elapsed whole days.
  * Improved handling of missing due dates and consistent deadline behavior across features.
  * Refined overdue detection to avoid incorrectly classifying unrelated date comparisons.

* **Tests**
  * Added coverage for deadline boundaries, missing due dates, whole-day calculations, and overdue detection patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->