### PR TITLE
feat(platform): one dev stack per worktree, claimed not hashed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,14 +92,14 @@ Commands and flags: [docs/reference/make-targets.md](docs/reference/make-targets
 Config and endpoints: [docs/reference/configuration.md](docs/reference/configuration.md).
 CI: [infra/ci-pipeline.md](infra/ci-pipeline.md).
 
-## Exactly one dev stack at a time
+## One dev stack per worktree
 
-`make dev` sweeps first: it kills every margince api, worker and Vite on the
-machine, evicts `:8080`, and force-drops stray `margince_dev_*` databases before
-booting one stack. So you never stop the old one by hand — but it is **not**
-harmless: it reaches other worktrees and other sessions, and drops a `DEV_SLUG`
-stack's data with it. `make dev-stop` is the mirror; `DEV_SLUG=x` gives an
-isolated stack, spared until the next bare `make dev`.
+`make dev` starts a stack for THIS worktree and touches nobody else's: a linked
+worktree claims its own database, Redis logical database, port pair and object
+bucket, with no flag to remember. The primary worktree keeps `:8080` and the
+shared `margince` database, which is what `make migrate` and `make seed-dev`
+target. `make dev-stop` stops this worktree's; `make dev-sweep` clears every
+stack on the machine and is the only thing that does.
 
 **The API does not hot-reload.** Vite does, so the frontend is live as you type;
 the API is a compiled binary and every backend change needs `make dev` again. A

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SEED_DSN ?= postgres://margince_owner:dev@localhost:15432/margince
 # every company renders as a placeholder initial.
 MINIO_PORT ?= 29000
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -147,6 +147,14 @@ dev-fresh:
 ## just that one. DROP=1 also drops the per-slug databases (never `margince`).
 dev-stop:
 	@bash scripts/dev.sh stop "$(DEV_SLUG)" $(if $(filter 1,$(DROP)),--drop,)
+
+## dev-sweep — clear EVERY margince dev stack on this machine: kill every
+## api/worker/vite (recorded, orphaned, or belonging to another worktree) and
+## forget their claims. `DROP=1` also drops every per-slug margince_dev_*
+## database. This is the old bare-`make dev` behaviour, now explicit: `make dev`
+## starts your worktree's stack and leaves everyone else's alone.
+dev-sweep:
+	@bash scripts/dev.sh sweep "" $(if $(filter 1,$(DROP)),--drop,)
 
 ## dev-logs — follow the dev stack's log, coloured per process (api/worker/fe)
 ## and per severity, with the job-queue heartbeat hidden. ROLE=<api|worker|fe|boot>

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SEED_DSN ?= postgres://margince_owner:dev@localhost:15432/margince
 # every company renders as a placeholder initial.
 MINIO_PORT ?= 29000
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile perfdoc e2e-company fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -74,7 +74,7 @@ ai-routing-local:
 ## #1639 is about: a backend-only author never runs the lane that would
 ## otherwise catch a stranded frontend schema. On a pull request CI covers the
 ## same ground from the other side, through fe-quality's fe-drift.
-check-backend: check-craft-doc craft-test test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze
+check-backend: check-craft-doc craft-test test-dev-isolation test-golangci-guard test-scheduled-report test-ci-verdict test-laneorder check-image-pins check-host-ports ci-doc-parity make-target-parity contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -601,6 +601,14 @@ test-api-entrypoint:
 ## keeps a query string like ?sslmode=require, and never echoes a DSN.
 test-dev-dsn:
 	@./scripts/test-dev-dsn.sh
+
+## test-dev-isolation — prove two worktrees get two stacks: the slug comes from
+## the worktree, the Redis database and the port pair are CLAIMED from one
+## machine-global registry rather than hashed, and the object bucket is
+## per-stack. The failure it replaces was silent — two stacks sharing one Redis
+## consumer group, each acking events the other never saw.
+test-dev-isolation:
+	@./scripts/test-dev-isolation.sh
 
 ## test-scheduled-report — prove the scheduled lane still files ONE issue per
 ## failing check: stub the tracker, and require the reporter to find an already

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -17,7 +17,7 @@ DB_NAME   ?= margince
 # for, and defaulting to the shared database there would point a linked worktree's
 # psql at the primary's data — silently, which is the failure this exists to
 # prevent. An empty name makes psql fail loudly instead.
-DEV_DB_NAME ?= $(shell bash -c '. "$(CURDIR)/../scripts/lib-devstate.sh" && dev_database_name')
+DEV_DB_NAME ?= $(shell bash -c '. "$$1" && dev_database_name' -- '$(CURDIR)/../scripts/lib-devstate.sh')
 # An ambient MARGINCE_OWNER_DSN redirects every migrate target here, because it is
 # the same variable cmd/migrate reads when no --dsn is given — the two can never
 # name different databases. That also means a staging or production owner DSN
@@ -620,7 +620,7 @@ run: composition ## Run the api on :8080 (no db-up/migrate) — go run ./cmd/api
 	$(GOWORK_COMPOSED) $(GO) run ./cmd/api --dsn "$(APP_DSN)"
 
 psql: ## Open a psql shell on the dev database (owner role)
-	$(COMPOSE) exec postgres psql -U margince_owner -d $(DB_NAME)
+	$(COMPOSE) exec postgres psql -U margince_owner -d $(DEV_DB_NAME)
 
 redis-cli: ## Open a redis-cli shell on the dev Redis
 	$(COMPOSE) exec redis redis-cli

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,7 +3,13 @@
 GO        ?= go
 PG_PORT   ?= 15432
 REDIS_PORT?= 16379
-DB_NAME   ?= margince
+# The database THIS worktree's stack runs against, resolved by the same code
+# scripts/dev.sh uses. It was the literal `margince`, which is still the answer in
+# the primary worktree and in CI; from a linked worktree it is margince_dev_<slug>,
+# and the SQL half of a seed used to land in a different database from the API
+# half. Lazy (`?=` makes a recursively expanded variable), so the git calls only
+# happen for a target that actually reads it.
+DB_NAME   ?= $(shell bash -c '. "$(CURDIR)/../scripts/lib-devstate.sh" && dev_database_name' 2>/dev/null || echo margince)
 # An ambient MARGINCE_OWNER_DSN redirects every migrate target here, because it is
 # the same variable cmd/migrate reads when no --dsn is given — the two can never
 # name different databases. That also means a staging or production owner DSN

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,7 +24,11 @@ DB_NAME   ?= margince
 # variable, and the $(shell …) here would answer for the worktree instead — seeding
 # a different stack's database than the one just named on the command line.
 # Empty expands to no argument, which leaves the script to derive it.
-DEV_DB_NAME ?= $(shell bash ../scripts/dev-database-name.sh $(DEV_SLUG))
+# QUOTED. Unquoted, make's shell parses whatever DEV_SLUG contains before the
+# resolver validates it — a metacharacter would run, and a value with whitespace
+# would split into arguments and select a different database. Quoted, the worst a
+# hostile value does is break the shell parse loudly.
+DEV_DB_NAME ?= $(shell bash ../scripts/dev-database-name.sh '$(DEV_SLUG)')
 # An ambient MARGINCE_OWNER_DSN redirects every migrate target here, because it is
 # the same variable cmd/migrate reads when no --dsn is given — the two can never
 # name different databases. That also means a staging or production owner DSN

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -19,7 +19,12 @@ DB_NAME   ?= margince
 # for, and defaulting to the shared database there would point a linked worktree's
 # psql at the primary's data — silently, which is the failure this exists to
 # prevent. An empty name makes psql fail loudly instead.
-DEV_DB_NAME ?= $(shell bash ../scripts/dev-database-name.sh)
+# $(DEV_SLUG) is passed as an ARGUMENT, because a make-level override does not
+# otherwise reach the resolver: `make seed-dev DEV_SLUG=alpha` sets a make
+# variable, and the $(shell …) here would answer for the worktree instead — seeding
+# a different stack's database than the one just named on the command line.
+# Empty expands to no argument, which leaves the script to derive it.
+DEV_DB_NAME ?= $(shell bash ../scripts/dev-database-name.sh $(DEV_SLUG))
 # An ambient MARGINCE_OWNER_DSN redirects every migrate target here, because it is
 # the same variable cmd/migrate reads when no --dsn is given — the two can never
 # name different databases. That also means a staging or production owner DSN

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -12,12 +12,14 @@ DB_NAME   ?= margince
 # made `make dev` fail at db-init with "database does not exist".
 #
 # Lazy (`?=` makes a recursively expanded variable), so the git calls only happen
-# for a target that reads it. NO fallback to margince on failure: a failed
+# for a target that reads it. Through a script reached by a RELATIVE path, because
+# make hands a `$(shell …)` string to /bin/sh and an absolute checkout path
+# containing an apostrophe breaks that quoting before the shell reaches anything. NO fallback to margince on failure: a failed
 # resolution means an invalid DEV_SLUG or a worktree identity git could not answer
 # for, and defaulting to the shared database there would point a linked worktree's
 # psql at the primary's data — silently, which is the failure this exists to
 # prevent. An empty name makes psql fail loudly instead.
-DEV_DB_NAME ?= $(shell bash -c '. "$$1" && dev_database_name' -- '$(CURDIR)/../scripts/lib-devstate.sh')
+DEV_DB_NAME ?= $(shell bash ../scripts/dev-database-name.sh)
 # An ambient MARGINCE_OWNER_DSN redirects every migrate target here, because it is
 # the same variable cmd/migrate reads when no --dsn is given — the two can never
 # name different databases. That also means a staging or production owner DSN

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,13 +3,21 @@
 GO        ?= go
 PG_PORT   ?= 15432
 REDIS_PORT?= 16379
+DB_NAME   ?= margince
+
 # The database THIS worktree's stack runs against, resolved by the same code
-# scripts/dev.sh uses. It was the literal `margince`, which is still the answer in
-# the primary worktree and in CI; from a linked worktree it is margince_dev_<slug>,
-# and the SQL half of a seed used to land in a different database from the API
-# half. Lazy (`?=` makes a recursively expanded variable), so the git calls only
-# happen for a target that actually reads it.
-DB_NAME   ?= $(shell bash -c '. "$(CURDIR)/../scripts/lib-devstate.sh" && dev_database_name' 2>/dev/null || echo margince)
+# scripts/dev.sh uses. SEPARATE from DB_NAME on purpose: DB_NAME also feeds
+# db-init and db-wait, which run before dev.sh has created the per-stack database
+# and must target one that already exists — pointing them at margince_dev_<slug>
+# made `make dev` fail at db-init with "database does not exist".
+#
+# Lazy (`?=` makes a recursively expanded variable), so the git calls only happen
+# for a target that reads it. NO fallback to margince on failure: a failed
+# resolution means an invalid DEV_SLUG or a worktree identity git could not answer
+# for, and defaulting to the shared database there would point a linked worktree's
+# psql at the primary's data — silently, which is the failure this exists to
+# prevent. An empty name makes psql fail loudly instead.
+DEV_DB_NAME ?= $(shell bash -c '. "$(CURDIR)/../scripts/lib-devstate.sh" && dev_database_name')
 # An ambient MARGINCE_OWNER_DSN redirects every migrate target here, because it is
 # the same variable cmd/migrate reads when no --dsn is given — the two can never
 # name different databases. That also means a staging or production owner DSN
@@ -556,10 +564,10 @@ db-init: ## (Re)apply scripts/db-init.sql to the running Postgres
 	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/db-init.sql
 
 seed-reset: ## Wipe the demo workspace (scripts/seed-reset.sql); make seed-dev rebuilds it
-	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/seed-reset.sql
+	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DEV_DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/seed-reset.sql
 
 seed-dev-db: ## Apply the dev DB seed for API-less demo data (scripts/seed-dev.sql); run after seed-dev
-	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/seed-dev.sql
+	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DEV_DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/seed-dev.sql
 
 # MARGINCE_SEED_DSN is not optional in practice, and the root target always
 # supplies it: without a DSN the seeder silently skips teams, seats, finance

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -12,10 +12,11 @@ enforces — so a command copied out of here works from either directory.
 |---|---|
 | `help` | List targets (the default goal) |
 | `install` | One-shot fresh-worktree setup (frontend deps + Go gate binaries + git hooks). The factory's `worktree-init` runs this by name |
-| `dev` | Full local stack: db-up + migrate + `cmd/api` + `cmd/worker` (always on: the outbox relay + Surface-B runner) + the app on `http://localhost:8080` (the api behind it on `:18080`, proxied through). **Sweeps first** (bare invocation): kills every margince api/worker/vite on the machine — recorded, orphaned, or from another checkout — evicts anything holding `:8080`, and drops stray `margince_dev_*` databases, so one stack runs and the app is always on `:8080`. Boots **cold** — the organization + admin bootstrapped from `config/margince.yaml` and nothing else, so onboarding and empty states are the default; `make seed-dev` adds the demo records on top. Returns when ready; the servers run in the background. `DEV_SLUG=<slug>` gives an isolated `margince_dev_<slug>` on slug-derived ports (two worktrees at once). Activates real AI routing only when every cloud provider bound in `config/ai-routing.yaml` has its BYOK key in the environment / `.env.local` (else the offline fake) |
+| `dev` | Full local stack: db-up + migrate + `cmd/api` + `cmd/worker` (always on: the outbox relay + Surface-B runner) + the app on `http://localhost:8080` (the api behind it on `:18080`, proxied through). Starts **this worktree's** stack only and touches no other (`make dev-sweep` is the machine-wide clear). A linked worktree claims its own database, Redis logical database, port pair and object bucket automatically; the primary worktree keeps the shared `margince` on `:8080`. Boots **cold** — the organization + admin bootstrapped from `config/margince.yaml` and nothing else, so onboarding and empty states are the default; `make seed-dev` adds the demo records on top. Returns when ready; the servers run in the background. `DEV_SLUG=<slug>` overrides the derived slug when you want a second stack inside one worktree. Activates real AI routing only when every cloud provider bound in `config/ai-routing.yaml` has its BYOK key in the environment / `.env.local` (else the offline fake) |
 | `dev-fresh` | `make dev-fresh [DEV_SLUG=<slug>]` — `dev` onto a **rebuilt** database: drops it, re-migrates, and boots the installation a first customer gets. Plain `dev` keeps whatever data is there, so a restart for a backend change never costs you a half-finished record |
-| `dev-stop` | `make dev-stop [DEV_SLUG=<slug>] [DROP=1]` — bare, it stops **every** dev stack on the machine and frees the ports (the mirror of what `dev` sweeps); with `DEV_SLUG` just that one. `DROP=1` also drops the per-slug `margince_dev_*` databases — never the shared `margince` |
-| `dev-logs` | `make dev-logs [DEV_SLUG=<slug>] [ROLE=api\|worker\|fe\|boot] [LEVEL=debug\|info\|warn\|error] [ALL=1] [FOLLOW=0 N=<n>]` — follow `.tmp/dev/<slug>/dev.log` coloured by process and severity. api, worker and Vite all append to that one file, so `make dev` tags each line with the process that wrote it. At `MARGINCE_LOG_LEVEL=debug` the writer also colours the tag and severity **in the file**, so a plain `tail -f` is readable on its own; at info level the file stays plain text so `grep` and editors see clean lines. This view strips whatever colour is there and repaints, so its filters work either way. The job-queue (River) heartbeat is hidden by default because at `MARGINCE_LOG_LEVEL=debug` it repeats every few seconds and pushes real lines off the screen; `ALL=1` restores it. `LEVEL` is a floor, so `LEVEL=warn` shows warnings **and** errors. A dev view only: the servers' own output is unchanged plain text for a log collector |
+| `dev-stop` | `make dev-stop [DEV_SLUG=<slug>] [DROP=1]` — stops **this worktree's** stack and frees its ports. `DROP=1` also drops its per-slug `margince_dev_*` database — never the shared `margince` |
+| `dev-sweep` | `make dev-sweep [DROP=1]` — clears **every** margince dev stack on the machine: every api/worker/vite, recorded, orphaned, or from another worktree, and their claims. `DROP=1` also drops every per-slug `margince_dev_*` database. This is the old bare-`make dev` behaviour, now explicit |
+| `dev-logs` | `make dev-logs [DEV_SLUG=<slug>] [ROLE=api\|worker\|fe\|boot] [LEVEL=debug\|info\|warn\|error] [ALL=1] [FOLLOW=0 N=<n>]` — follow the stack's `dev.log` (under `$XDG_STATE_HOME/margince/dev/<slug>/`) coloured by process and severity. api, worker and Vite all append to that one file, so `make dev` tags each line with the process that wrote it. At `MARGINCE_LOG_LEVEL=debug` the writer also colours the tag and severity **in the file**, so a plain `tail -f` is readable on its own; at info level the file stays plain text so `grep` and editors see clean lines. This view strips whatever colour is there and repaints, so its filters work either way. The job-queue (River) heartbeat is hidden by default because at `MARGINCE_LOG_LEVEL=debug` it repeats every few seconds and pushes real lines off the screen; `ALL=1` restores it. `LEVEL` is a floor, so `LEVEL=warn` shows warnings **and** errors. A dev view only: the servers' own output is unchanged plain text for a log collector |
 | `db-up` / `infra-up` | Start the dev Postgres 16 (pgvector, port 15432) and Redis 7 (port 16379) containers, create the app role (`infra-up` is an alias) |
 | `db-init` | (Re)apply `scripts/db-init.sql` to the running Postgres |
 | `migrate` | Apply core + custom migrations with the owner DSN |
@@ -177,22 +178,55 @@ in `lastactivity_integration_test.go`.
 | `storybook` | The component workbench on `:6006` — the design-system catalog and the story surface `fe-uat` renders. Stories live beside their component as `<name>.stories.tsx` |
 | `fe-uat` | Change-scoped Storybook render+capture UAT for frontend-only diffs: renders THIS branch's changed component's stories in headless Chromium and screenshots them (no live stack, no DB). Fails on an unclean render, an unregistered story, or a changed component with no story. Artifact: `.tmp/fe-uat/manifest.json`. Deliberately **not** in `make check` — the fe-only UAT lane a coordinator runs instead of the full stack. `ARGS="--allow-missing"` |
 
-A `DEV_SLUG` stack is spared while it starts — a slugged `make dev` sweeps
-nothing, so it can come up beside the base stack. It is NOT spared afterwards:
-the next **bare** `make dev` stops it like any other and drops its per-slug
-database, because exclusivity is what that sweep is for. Tear yours down
-explicitly when you are done with it:
+## One stack per worktree
 
-```sh
-DEV_SLUG=x make dev-stop DROP=1
-```
+`make dev` runs a full stack that will not collide with another worktree's: the
+ONE shared infra (Postgres/Redis/MinIO on `15432`/`16379`/`29000`), but a private
+database, a private **Redis logical database**, a private object bucket, and its
+own api/FE port pair.
 
-Re-running `make dev DEV_SLUG=x` while that stack is already up does not restart
-it: slugged startup sweeps nothing, so it stops at the port guard with `port
-:… already in use`. Stop it first.
+Nothing has to be passed for that. A **linked worktree** derives its slug from
+its own directory name, so `.claude/worktrees/cfg-retire` gets
+`margince_dev_cfg-retire`. The **primary worktree** keeps the shared `margince`
+database, Redis db 0 and the app on the base `:8080`, because `make migrate`,
+`make seed-dev` and `make verify-boot` all target that database by name.
+`DEV_SLUG=<slug>` overrides the derived name when you want a second stack inside
+one worktree.
 
-`DROP=1` removes the per-slug databases; without it the stack stops and its data
-stays.
+Logs, pids and claims live under `$XDG_STATE_HOME/margince/dev/<slug>/`
+(`~/.local/state/...` by default) — **one directory per machine, not per
+worktree**. That is load-bearing rather than tidy: the registry below is only a
+registry if every worktree reads the same one.
+
+**The Redis index is isolation, not tidiness.** The stream names and consumer
+groups are constants (`gw:events:crm:*`, `cg:*`), so two stacks on one index
+share one consumer group: whichever worker reads an entry first consumes it,
+resolves it against its OWN Postgres, finds nothing, and acks. The other
+stack's event is gone, and a projection or accrual that never runs looks
+exactly like a broken feature — it cost a day and a wrongly-filed critical bug
+once.
+
+The instance serves 80 databases in three blocks: **0** is the primary
+worktree's stack, **1–63** the parallel integration lane (one per package, which
+`FLUSHDB`s), and **64–79** per-worktree stacks. A stack takes the lowest free
+index in its block, claimed under a lock and recorded in the machine-global
+registry, so restarting reclaims its own index and two stacks never share one. A
+17th concurrent stack is refused rather than doubled up.
+
+**Ports are claimed the same way, from 8081–8179 (api at +10000).** They used to
+be derived from `8080 + cksum(slug) % 1000`, and two hashes differing by a
+multiple of the block size took different ports and the SAME Redis database — a
+collision the port check could not see. A claim also skips a port some unrelated
+process is listening on, which a hash cannot.
+
+`make dev-stop [DEV_SLUG=<slug>] [DROP=1]` stops **this worktree's** stack;
+`DROP=1` also drops its per-slug database, never the shared `margince`.
+
+`make dev-sweep [DROP=1]` clears **every** stack on the machine — every
+api/worker/vite, recorded, orphaned, or belonging to another worktree — and is
+the only thing that does. It used to be what a bare `make dev` did on the way up,
+which made the routine command the destructive one: it killed every parallel
+session's stack and dropped databases another agent was mid-test against.
 
 ## The API is a compiled binary, and Vite is not
 
@@ -207,51 +241,17 @@ answering perfectly happily, so the SPA calls endpoints it has never heard of an
 the app breaks in ways that look exactly like a bug in the code you just wrote. An
 old server is indistinguishable from a broken feature.
 
-The same shape catches you across branches, and this working tree is often shared
-with parallel agent sessions that switch branches underneath you. So before you
-trust **any** manual test, confirm both:
+The same shape catches you across branches, and this tree is often worked in
+several worktrees at once. So before you trust **any** manual test, confirm both:
 
 - `git branch --show-current` is the branch you think it is, and
 - the **API** process was started *after* your last backend change. That is the
-  one on `:18080` (or the slug's API port) — `:8080` is Vite, which hot-reloads,
-  so its start time tells you nothing about the binary that does not.
+  one behind the app port — `:18080` for the primary worktree, a claimed port for
+  a linked one, both printed by the startup banner. The app port itself is Vite,
+  which hot-reloads, so its start time tells you nothing about the binary that
+  does not.
 
 Neither costs anything to check, and skipping them costs a debugging session.
-
-## Isolated stack per worktree
-
-`make dev DEV_SLUG=<slug>` runs a full stack that won't collide with another
-worktree's: the ONE shared infra (Postgres/Redis on `15432`/`16379`), but a
-private database `margince_dev_<slug>`, a private **Redis logical database**,
-and api/FE ports derived deterministically from the slug (the FE's `/v1` proxy
-follows the api via `BACKEND_PORT`). Logs + stop handle live under
-`.tmp/dev/<slug>/`. Bare `make dev` uses the shared `margince` database, Redis
-db 0, and the app on the base `:8080`. Stop either with
-`make dev-stop [DEV_SLUG=<slug>] [DROP=1]`.
-
-**The Redis index is isolation, not tidiness.** The stream names and consumer
-groups are constants (`gw:events:crm:*`, `cg:*`), so two stacks on one index
-share one consumer group: whichever worker reads an entry first consumes it,
-resolves it against its OWN Postgres, finds nothing, and acks. The other
-stack's event is gone, and a projection or accrual that never runs looks
-exactly like a broken feature — it cost a day and a wrongly-filed critical bug
-once.
-
-The instance serves 80 databases in three blocks: **0** is bare `make dev`,
-**1–63** the parallel integration lane (one per package, which `FLUSHDB`s), and
-**64–79** slugged stacks. A slug takes the lowest free index in its block,
-claimed under a lock and recorded in `.tmp/dev/<slug>/env`, so restarting a
-slug reclaims its own and two slugs never share one. Deliberately not the port
-hash: two hashes differing by a multiple of the block size would take different
-ports and the SAME database, a collision the port check cannot see. The startup
-banner prints the index. A 17th concurrent slugged stack is refused rather than
-doubled up.
-
-A slugged stack is the one thing `make dev`'s sweep does not perform — it
-sweeps nothing itself, so it can start alongside the base stack. But the next
-**bare** `make dev` takes it down and drops its database: exclusivity is the
-whole point of the sweep, and an isolated env is a deliberate, temporary
-exception to it.
 
 ## Root-only (craftsmanship gate)
 
@@ -263,6 +263,7 @@ exception to it.
 | `secret-scan` | No hardcoded credential reaches `main`: gitleaks over a clean `git archive HEAD` export, policy in `.gitleaks.toml`. Scans the committed tree, not the working tree — gitleaks ignores `.gitignore`, so an in-place scan would read a sibling worktree or your real `.env.local` and differ per machine. Installs nothing on your machine and needs no account: `scripts/gitleaks-pin.sh` fetches the version- and checksum-pinned scanner into `.tmp/` on first use, so the binary — and therefore the verdict — is the one CI's `secret-scan` job runs on every non-draft change |
 | `test-api-entrypoint` | Prove `scripts/deploy/api-entrypoint.sh` writes the bootstrap admin credential **only** onto an unprovisioned installation, retires one a previous boot left, and refuses to start when its probe cannot answer. Stubs `margince-migrate`/`margince-api` on `PATH`, so it needs no container and no database. Every failure on that path is silent — a credential written to a live installation looks exactly like one that was not — and the entrypoint runs where nobody is watching. CI runs it beside the secret gate |
 | `test-dev-dsn` | Prove `scripts/dev.sh` resolves its DSNs through the same names the binaries read (`MARGINCE_OWNER_DSN` / `MARGINCE_DSN`) after an explicit `OWNER_DSN`/`APP_DSN` argument, still names the database itself so a `DEV_SLUG` stack cannot land on the base one, carries a query string like `?sslmode=require` across the swap, and never echoes a DSN. Pure shell — no Docker, no database |
+| `test-dev-isolation` | Prove two worktrees get two stacks: the slug is derived from the worktree, the Redis logical database and the port pair are CLAIMED from one machine-global registry rather than hashed, a port with a foreign listener is skipped, an exhausted block is refused rather than doubled up, and the integration lane's template is per worktree. Pure shell — no Docker, no database |
 | `test-secret-scan` | Prove `secret-scan` still catches: plant a credential-shaped token in each file `.gitleaks.toml` exempts, and require the scan to fail anyway. An over-broad allowlist reports "no leaks found" exactly like a clean tree — this is the only thing that tells them apart. CI runs it right after the scan |
 | `check-craft-doc` | Assert AGENTS.md still carries its `## Craftsmanship` section — a cheap doc floor so the gate's rules cannot be silently unpinned from the rulebook. A `check-backend` prerequisite |
 
@@ -335,7 +336,7 @@ outranks the environment, so a value set in `.env.local` was inert for the whole
 dev stack before this.
 
 Two things the stack keeps for itself whatever DSN it is handed. It **names the
-database**, so `DEV_SLUG=x` reaches `margince_dev_x` on slug-derived ports and
+database**, so `DEV_SLUG=x` reaches `margince_dev_x` on its claimed ports and
 never the base database a supplied DSN happened to name. And `--fresh` still
 refuses when the effective owner DSN is not the compose Postgres, because it
 drops through the compose container while migrations follow the DSN. A query

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -16,7 +16,7 @@ enforces — so a command copied out of here works from either directory.
 | `dev-fresh` | `make dev-fresh [DEV_SLUG=<slug>]` — `dev` onto a **rebuilt** database: drops it, re-migrates, and boots the installation a first customer gets. Plain `dev` keeps whatever data is there, so a restart for a backend change never costs you a half-finished record |
 | `dev-stop` | `make dev-stop [DEV_SLUG=<slug>] [DROP=1]` — stops **this worktree's** stack and frees its ports. `DROP=1` also drops its per-slug `margince_dev_*` database — never the shared `margince` |
 | `dev-sweep` | `make dev-sweep [DROP=1]` — clears **every** margince dev stack on the machine: every api/worker/vite, recorded, orphaned, or from another worktree, and their claims. `DROP=1` also drops every per-slug `margince_dev_*` database. This is the old bare-`make dev` behaviour, now explicit |
-| `dev-logs` | `make dev-logs [DEV_SLUG=<slug>] [ROLE=api\|worker\|fe\|boot] [LEVEL=debug\|info\|warn\|error] [ALL=1] [FOLLOW=0 N=<n>]` — follow the stack's `dev.log` (under `$XDG_STATE_HOME/margince/dev/<slug>/`) coloured by process and severity. api, worker and Vite all append to that one file, so `make dev` tags each line with the process that wrote it. At `MARGINCE_LOG_LEVEL=debug` the writer also colours the tag and severity **in the file**, so a plain `tail -f` is readable on its own; at info level the file stays plain text so `grep` and editors see clean lines. This view strips whatever colour is there and repaints, so its filters work either way. The job-queue (River) heartbeat is hidden by default because at `MARGINCE_LOG_LEVEL=debug` it repeats every few seconds and pushes real lines off the screen; `ALL=1` restores it. `LEVEL` is a floor, so `LEVEL=warn` shows warnings **and** errors. A dev view only: the servers' own output is unchanged plain text for a log collector |
+| `dev-logs` | `make dev-logs [DEV_SLUG=<slug>] [ROLE=api\|worker\|fe\|boot] [LEVEL=debug\|info\|warn\|error] [ALL=1] [FOLLOW=0 N=<n>]` — follow this worktree's `dev.log` (under `$XDG_STATE_HOME/margince/dev/<slug>/`, or `_base/` for the primary worktree) coloured by process and severity. api, worker and Vite all append to that one file, so `make dev` tags each line with the process that wrote it. At `MARGINCE_LOG_LEVEL=debug` the writer also colours the tag and severity **in the file**, so a plain `tail -f` is readable on its own; at info level the file stays plain text so `grep` and editors see clean lines. This view strips whatever colour is there and repaints, so its filters work either way. The job-queue (River) heartbeat is hidden by default because at `MARGINCE_LOG_LEVEL=debug` it repeats every few seconds and pushes real lines off the screen; `ALL=1` restores it. `LEVEL` is a floor, so `LEVEL=warn` shows warnings **and** errors. A dev view only: the servers' own output is unchanged plain text for a log collector |
 | `db-up` / `infra-up` | Start the dev Postgres 16 (pgvector, port 15432) and Redis 7 (port 16379) containers, create the app role (`infra-up` is an alias) |
 | `db-init` | (Re)apply `scripts/db-init.sql` to the running Postgres |
 | `migrate` | Apply core + custom migrations with the owner DSN |
@@ -194,9 +194,16 @@ database, Redis db 0 and the app on the base `:8080`, because `make migrate`,
 one worktree.
 
 Logs, pids and claims live under `$XDG_STATE_HOME/margince/dev/<slug>/`
-(`~/.local/state/...` by default) — **one directory per machine, not per
-worktree**. That is load-bearing rather than tidy: the registry below is only a
-registry if every worktree reads the same one.
+(`~/.local/state/...` by default), and the primary worktree's stack — which has
+no slug — uses `_base/` there. **One directory per machine, not per worktree**:
+that is load-bearing rather than tidy, because the registry below is only a
+registry if every worktree reads the same one. `DEV_SLUG=_base` is refused for
+the same reason, since it would land a second stack on the primary's own state.
+
+Every script that needs those paths gets them from `scripts/lib-devstate.sh`
+rather than composing them — `make dev-logs` spent one revision of this change
+looking for a file `make dev` no longer wrote, and reporting it as "is the stack
+up?".
 
 **The Redis index is isolation, not tidiness.** The stream names and consumer
 groups are constants (`gw:events:crm:*`, `cg:*`), so two stacks on one index

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -17,13 +17,19 @@
 # out of reach; do not renumber back upward. `make check-host-ports` enforces
 # the floor, because the constraint is invisible in the number itself.
 #
-# The second constraint the floor does not cover: scripts/dev.sh gives each
-# `make dev DEV_SLUG=<slug>` stack a hash-derived port, `8080 + (hash % 1000)`
-# for the app and `18080 + …` for the api — so 8080–9079 and 18080–19079 are
-# BOTH spoken for, by one slug out of a thousand rather than reliably. That is
-# why MinIO is 29000/29001 and not the 19000/19001 the prefix pattern would
-# suggest: 19000 is inside the api's span, and the collision would surface only
-# for whichever engineer's slug happened to hash to 920.
+# The second constraint the floor does not cover: scripts/dev.sh spends two
+# spans of its own. The primary worktree's stack is fixed at 8080/18080, and
+# every other worktree CLAIMS a pair from 8081–8179 and 18081–18179 — so
+# 8080–8179 and 18080–18179 are both spoken for, reliably rather than
+# probabilistically. That is why MinIO is 29000/29001 rather than the
+# 19000/19001 the prefix pattern would suggest.
+#
+# The spans used to be 8080–9079 and 18080–19079, because a stack derived its
+# port from `8080 + (cksum(slug) % 1000)`. Claiming replaced hashing — a hash
+# gave two stacks different ports and the same Redis database whenever the two
+# hashes differed by a multiple of the block size, which no port check could
+# see — and the claimed range is narrower, so this is more headroom below
+# 29000 than before, never less.
 #
 # Images are digest-pinned to the multi-arch INDEX digest (works on both
 # arm64 dev machines and amd64 CI — CI's integration lane runs this same
@@ -165,7 +171,7 @@ services:
     #   1..63    the parallel integration lane, one per package
     #            (REDIS_DBS in scripts/test-integration-parallel.sh,
     #             testdb.RedisDBs — the two must agree)
-    #   64..79   DEV_SLUG stacks, one per slug (scripts/dev.sh)
+    #   64..79   per-worktree dev stacks, one per slug (scripts/dev.sh)
     # A slug sharing a db with a test package would have its streams FLUSHDB'd
     # mid-run, and the test would read a dev stack's events as its own.
     command: ["redis-server", "--databases", "80"]

--- a/scripts/dev-database-name.sh
+++ b/scripts/dev-database-name.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Print the Postgres database THIS worktree's dev stack runs against.
+#
+# A one-line wrapper so a Makefile can ask for the name without embedding an
+# absolute path in a `$(shell …)` string: make hands that string to /bin/sh, and a
+# checkout path containing an apostrophe or a space breaks the quoting before the
+# shell ever reaches the library. Invoked by a path relative to the Makefile, this
+# has nothing to quote.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=scripts/lib-devstate.sh
+. ./lib-devstate.sh
+dev_database_name

--- a/scripts/dev-database-name.sh
+++ b/scripts/dev-database-name.sh
@@ -13,4 +13,13 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # An explicit slug wins, whether it arrives as an argument (a make-level
 # `DEV_SLUG=x` override, which does not reach this script's environment) or in the
 # environment. Empty means: derive it from the worktree.
-DEV_SLUG="${1:-${DEV_SLUG:-}}" dev_database_name
+# $# rather than ${1:-…}: make passes `$(DEV_SLUG)`, which expands to NO argument
+# when unset and to an empty one when set to empty. Those mean different things —
+# "derive it" versus "the caller said nothing" — and collapsing them lets an
+# exported DEV_SLUG from some parent shell decide a database the command did not
+# name.
+if [[ $# -gt 0 ]]; then
+  DEV_SLUG="$1" dev_database_name
+else
+  dev_database_name
+fi

--- a/scripts/dev-database-name.sh
+++ b/scripts/dev-database-name.sh
@@ -10,4 +10,7 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 # shellcheck source=scripts/lib-devstate.sh
 . ./lib-devstate.sh
-dev_database_name
+# An explicit slug wins, whether it arrives as an argument (a make-level
+# `DEV_SLUG=x` override, which does not reach this script's environment) or in the
+# environment. Empty means: derive it from the worktree.
+DEV_SLUG="${1:-${DEV_SLUG:-}}" dev_database_name

--- a/scripts/dev-logs.sh
+++ b/scripts/dev-logs.sh
@@ -17,7 +17,15 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-log=".tmp/dev/${DEV_SLUG:-_base}/dev.log"
+# The same slug and the same state root `make dev` used, resolved by the same
+# code. This script composed the path itself until the state root moved out of
+# the worktree, and then looked for a file `make dev` no longer wrote — with a
+# "is the stack up?" message that named the wrong reason.
+# shellcheck source=scripts/lib-devstate.sh
+. "$PWD/scripts/lib-devstate.sh"
+
+slug="$(dev_resolve_slug "${DEV_SLUG:-}")" || exit 1
+log="$(dev_state_dir "$slug")/dev.log"
 role="${ROLE:-}"
 level="${LEVEL:-}"
 all="${ALL:-0}"
@@ -25,7 +33,7 @@ follow="${FOLLOW:-1}"
 lines="${N:-200}"
 
 if [[ ! -f "$log" ]]; then
-  echo "No dev log at ${log} — is the stack up? Start it with 'make dev'${DEV_SLUG:+ DEV_SLUG=$DEV_SLUG}." >&2
+  echo "No dev log at ${log} — is this worktree's stack up? Start it with 'make dev'${DEV_SLUG:+ DEV_SLUG=$DEV_SLUG}." >&2
   exit 1
 fi
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -77,113 +77,227 @@ REDIS_PORT="${REDIS_PORT:-16379}"
 # production secret.
 MINIO_PORT="${MINIO_PORT:-29000}"
 
-# Bare `make dev` runs the shared `margince` database on the base ports, so it
-# stays coherent with `make migrate` / `seed-dev` / `verify-boot`. A DEV_SLUG
-# gives an isolated database on deterministically derived ports (same slug →
-# same db + ports, so a resume reuses whatever that database already holds).
+# A slug reaches three places that each refuse different characters: a
+# filesystem path, a CREATE DATABASE identifier, and (via bucket_for_slug) an S3
+# bucket name. Fold to the narrowest of the three rather than validating in
+# three places — a branch or directory name is the usual source, and
+# `feat/ai-keys` is an ordinary one.
+sanitize_slug() { # name → a slug matching ^[a-z0-9_-]+$
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9_-]/-/g; s/--*/-/g; s/^-//; s/-*$//'
+}
+
+# The bucket holding attachment and transcript bytes. It was one name for every
+# stack, so two worktrees wrote each other's object bytes into one place — the
+# same class of defect as a shared Redis database, and invisible for the same
+# reason.
+#
+# S3 bucket names admit no underscore and the slug charset does, so the two
+# names are not interchangeable. blobstore.New creates a missing bucket, so a
+# new name needs no infra change.
+bucket_for_slug() { # slug → an S3-legal bucket name
+  local slug="$1"
+  if [[ -z "$slug" ]]; then
+    printf 'margince-dev'
+    return 0
+  fi
+  printf 'margince-dev-%s' "$(printf '%s' "$slug" | tr '_' '-')"
+}
+
+# The PRIMARY worktree keeps the shared stack — database `margince` on :8080,
+# Redis db 0 — because `make migrate`, `make seed-dev` and `make verify-boot`
+# all target that database by name, and an auto-slug here would silently
+# decouple them from the stack the developer is looking at.
+#
+# A LINKED worktree gets its own everything, named after itself, with no flag to
+# remember. That is the point: an engineer runs several agent sessions, one
+# worktree each, and none of them should have to know DEV_SLUG exists.
+#
+# The primary/linked test is the git directory, not the path: in a linked
+# worktree --absolute-git-dir is <common>/worktrees/<name> and differs from
+# --git-common-dir. The latter can print a relative path, so it is resolved
+# before the comparison.
+derive_slug() { # → "" in the primary worktree, this worktree's name in a linked one
+  local gitdir commondir
+  gitdir=$(git rev-parse --absolute-git-dir)
+  commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+  [[ "$gitdir" == "$commondir" ]] && return 0
+  sanitize_slug "$(basename "$(git rev-parse --show-toplevel)")"
+}
+
+# An explicit DEV_SLUG always wins; otherwise the worktree decides. A supplied
+# slug is validated rather than sanitised: silently rewriting what somebody
+# typed would point them at a database they did not name.
+if [[ -z "$slug" ]]; then
+  slug="$(derive_slug)"
+elif ! [[ "$slug" =~ ^[a-z0-9_-]+$ ]]; then
+  echo "FAIL: DEV_SLUG must match ^[a-z0-9_-]+$ (got '$slug')" >&2
+  exit 1
+fi
 if [[ -z "$slug" ]]; then
   label="dev"
   db="margince"
-  hash=0
 else
-  # The slug flows into a filesystem path and a CREATE DATABASE identifier —
-  # keep it to a safe charset so it can neither traverse paths nor break SQL.
-  if ! [[ "$slug" =~ ^[a-z0-9_-]+$ ]]; then
-    echo "FAIL: DEV_SLUG must match ^[a-z0-9_-]+$ (got '$slug')" >&2
-    exit 1
-  fi
   label="dev '$slug'"
   db="margince_dev_${slug}"
-  hash=$(printf '%s' "$slug" | cksum | awk '{print $1 % 1000}')
 fi
-# :8080 is THE port — the app, the thing a human opens, always and only.
-# The api sits behind it on 18080 and the app's dev server proxies /v1 and
-# the probes through, so `curl localhost:8080/v1/...` still answers and
-# nobody has to remember which of two ports serves what. The two ranges
-# (8080.. and 18080..) cannot collide however the slug hashes.
-fe_port=$(( 8080 + hash ))
-api_port=$(( 18080 + hash ))
+blob_bucket="$(bucket_for_slug "$slug")"
+# :8080 is THE port — the app, the thing a human opens, always and only. The api
+# sits behind it at fe+10000 and the app's dev server proxies /v1 and the probes
+# through, so `curl localhost:8080/v1/...` still answers and nobody has to
+# remember which of two ports serves what.
+#
+# The primary worktree's stack is FIXED at 8080/18080 rather than claimed, and
+# the claim range starts above it, so :8080 always means the same thing.
+DEV_FE_PORT_MIN=8081
+DEV_FE_PORT_MAX=8179
+DEV_API_PORT_OFFSET=10000
 
-# The Redis LOGICAL DATABASE this stack uses.
+# port_listeners names only the processes SERVING a port. Plain
+# `lsof -ti tcp:8080` also lists everything CONNECTED to it — the
+# developer's browser among them — and this sweep kills what it is given.
+port_listeners() { # port
+  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null || true
+}
+
+# Where a stack's claim is recorded. ONE directory per machine, deliberately
+# outside the repository.
 #
-# One Redis serves every stack on the machine, and the stream names and
-# consumer groups are constants (`gw:events:crm:*`, `cg:*`). Two stacks on the
-# same index therefore share ONE consumer group: whichever worker reads an
-# entry first consumes it, resolves it against its OWN Postgres database, finds
-# nothing, and acks. The other stack's event is gone, and the symptom — a
-# projection or an accrual that never runs — is indistinguishable from a broken
-# feature. That cost a day and a wrongly-filed critical bug once.
+# It used to be <worktree>/.tmp/dev/, and that is the defect this whole file is
+# being changed for: a second worktree read an EMPTY registry and claimed Redis
+# database 64 for the second time. The guarantee the old comment made — "a
+# running stack's db is never handed out twice" — held only within one checkout,
+# which is the one case that never needed it. Two stacks then shared one
+# consumer group: whichever worker read an entry first resolved it against its
+# own database, found nothing, and acked it, so the other stack's event was
+# simply gone.
 #
-# The instance serves 80 databases in three blocks that must not overlap
-# (infra/docker-compose.dev.yml says the same): db 0 is bare `make dev`, 1..63
-# belong to the parallel integration lane one per package, and 64..79 are
-# these slugged stacks. A slug landing in the test range would have its streams
-# FLUSHDB'd mid-run by a suite that believes it owns the db.
-#
-# The index is NOT the port hash. Two hashes differing by a multiple of the
-# block size would take different ports and the same db — a collision the port
-# check cannot see, which is the failure this whole change is about. It is
-# instead the lowest free index, claimed under a lock and recorded beside the
-# stack's other state, so a running stack's db is never handed out twice and a
-# resumed slug reclaims its own.
+# MARGINCE_DEV_STATE_DIR exists so the tests can point this somewhere
+# disposable. Nothing else should set it.
+dev_state_root() {
+  printf '%s' "${MARGINCE_DEV_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/margince/dev}"
+}
+
+# The Redis instance serves 80 logical databases in three blocks that must not
+# overlap (infra/docker-compose.dev.yml says the same): 0 is the primary
+# worktree's stack, 1..63 belong to the parallel integration lane one per
+# package, and 64..79 are these per-worktree stacks. A stack landing in the test
+# range would have its streams FLUSHDB'd mid-run by a suite that believes it
+# owns the database.
 DEV_REDIS_DB_MIN=64
 DEV_REDIS_DB_MAX=79
 
-# claim_redis_db SLUG — the logical database this slug owns, on stdout.
+# read_registry SLUG — what every OTHER recorded stack holds, and what this slug
+# already holds itself. Sets TAKEN_DBS / TAKEN_PORTS (space-separated) and
+# MINE_DB / MINE_PORT.
 #
-# Same slug wins the same index back, so restarting a stack keeps whatever its
-# streams already hold. A NEW slug takes the lowest index no other recorded
-# stack is using; two starting at once are serialised by a lock directory, so
-# they cannot both read "64 is free" and both take it.
+# Globals rather than stdout because there are four answers, and a caller that
+# had to parse one string is the place the four would drift apart.
+read_registry() { # slug
+  local want="$1" root state_file other REDIS_DB FE_PORT
+  root="$(dev_state_root)"
+  TAKEN_DBS=''; TAKEN_PORTS=''; MINE_DB=''; MINE_PORT=''
+  for state_file in "$root"/*/env; do
+    [[ -f "$state_file" ]] || continue
+    other="$(basename "$(dirname "$state_file")")"
+    REDIS_DB=''; FE_PORT=''
+    # shellcheck disable=SC1090
+    . "$state_file"
+    if [[ "$other" == "$want" ]]; then
+      MINE_DB="$REDIS_DB"; MINE_PORT="$FE_PORT"
+      continue
+    fi
+    [[ -n "$REDIS_DB" ]] && TAKEN_DBS="${TAKEN_DBS}${TAKEN_DBS:+ }${REDIS_DB}"
+    [[ -n "$FE_PORT" ]] && TAKEN_PORTS="${TAKEN_PORTS}${TAKEN_PORTS:+ }${FE_PORT}"
+  done
+  return 0
+}
+
+# The lowest Redis database no recorded stack holds. Refuses rather than
+# wrapping: a 17th concurrent stack is a situation to notice, not to paper over,
+# and doubling up is the silent failure this mechanism exists to prevent.
+pick_free_db() { # → a free Redis logical database, or non-zero
+  local db t used
+  for (( db = DEV_REDIS_DB_MIN; db <= DEV_REDIS_DB_MAX; db++ )); do
+    used=0
+    for t in $TAKEN_DBS; do [[ "$t" == "$db" ]] && { used=1; break; }; done
+    (( used )) || { printf '%s' "$db"; return 0; }
+  done
+  return 1
+}
+
+# A port is free when no recorded stack claims it AND nothing is listening on
+# either half of the pair. The listener check is not redundant: the registry
+# knows only about OUR stacks, so a foreign process on a port would otherwise be
+# handed out, bind would fail, and wait_ready would then poll that foreign
+# server and report this stack ready.
+pick_free_port() { # → a free frontend port, or non-zero
+  local port t used
+  for (( port = DEV_FE_PORT_MIN; port <= DEV_FE_PORT_MAX; port++ )); do
+    used=0
+    for t in $TAKEN_PORTS; do [[ "$t" == "$port" ]] && { used=1; break; }; done
+    (( used )) && continue
+    [[ -n "$(port_listeners "$port")" ]] && continue
+    [[ -n "$(port_listeners "$(( port + DEV_API_PORT_OFFSET ))")" ]] && continue
+    printf '%s' "$port"
+    return 0
+  done
+  return 1
+}
+
+# claim_stack SLUG — reserve this slug's Redis database and port pair, and
+# RECORD the reservation before anything binds.
 #
-# Reading the recorded stacks rather than hashing is what makes the guarantee
-# real: a hash gives distinct ports and a shared db whenever two hashes differ
-# by a multiple of the block size, which the port check cannot see and which is
-# exactly the collision this change exists to remove.
-claim_redis_db() { # slug
-  local want="$1" lock=".tmp/dev/.redis-db.lock" taken=() db
-  mkdir -p .tmp/dev
-  # A stale lock from a killed run would wedge every later start, so it is
-  # cleared on exit AND bounded: mkdir is the atomic primitive here.
-  local waited=0
+# Recording inside the lock is the load-bearing part. The old code wrote its
+# state file only once the servers were up, so two `make dev` runs a second
+# apart both read "nothing is taken" and both picked the same database. A claim
+# that is invisible until the stack is running is not a claim.
+claim_stack() { # slug → "<redis_db> <fe_port>"
+  local want="$1" root lock waited=0 db port
+  root="$(dev_state_root)"
+  lock="${root}/.claim.lock"
+  mkdir -p "$root"
+  # mkdir is the atomic primitive here. A stale lock from a killed run would
+  # wedge every later start, so the wait is bounded and then breaks it.
   until mkdir "$lock" 2>/dev/null; do
     (( waited++ >= 50 )) && { rm -rf "$lock"; continue; }
     sleep 0.1
   done
   trap 'rm -rf "'"$lock"'"' RETURN
 
-  local state_file other_slug REDIS_DB
-  for state_file in .tmp/dev/*/env; do
-    [[ -f "$state_file" ]] || continue
-    other_slug="$(basename "$(dirname "$state_file")")"
-    REDIS_DB=''
-    # shellcheck disable=SC1090
-    . "$state_file"
-    [[ -z "$REDIS_DB" ]] && continue
-    # This slug's own recorded index is the one it reclaims.
-    if [[ "$other_slug" == "$want" ]]; then
-      printf '%s' "$REDIS_DB"
-      return 0
-    fi
-    taken+=("$REDIS_DB")
-  done
-
-  for (( db = DEV_REDIS_DB_MIN; db <= DEV_REDIS_DB_MAX; db++ )); do
-    local used=0 t
-    for t in "${taken[@]:-}"; do [[ "$t" == "$db" ]] && { used=1; break; }; done
-    (( used )) || { printf '%s' "$db"; return 0; }
-  done
-
-  # Every index in the block is spoken for. Refuse rather than double up: a
-  # shared bus is the silent failure this whole mechanism prevents, and a
-  # 17th concurrent stack is a situation to notice, not to paper over.
-  echo "FAIL: all ${DEV_REDIS_DB_MIN}..${DEV_REDIS_DB_MAX} Redis databases are claimed by other dev stacks." >&2
-  echo "  Stop one (make dev-stop DEV_SLUG=<slug>), or a bare 'make dev' to sweep them all." >&2
-  exit 1
+  read_registry "$want"
+  db="$MINE_DB"; port="$MINE_PORT"
+  if [[ -z "$db" ]]; then
+    db="$(pick_free_db)" || {
+      echo "FAIL: every Redis database ${DEV_REDIS_DB_MIN}..${DEV_REDIS_DB_MAX} is claimed by another dev stack." >&2
+      echo "  Stop one (make dev-stop DEV_SLUG=<slug>), or clear them all with 'make dev-sweep'." >&2
+      return 1
+    }
+  fi
+  if [[ -z "$port" ]]; then
+    port="$(pick_free_port)" || {
+      echo "FAIL: no free port pair in ${DEV_FE_PORT_MIN}..${DEV_FE_PORT_MAX}." >&2
+      echo "  Stop a stack (make dev-stop DEV_SLUG=<slug>), or clear them all with 'make dev-sweep'." >&2
+      return 1
+    }
+  fi
+  mkdir -p "${root}/${want}"
+  printf 'SLUG=%s\nFE_PORT=%s\nAPI_PORT=%s\nREDIS_DB=%s\n' \
+    "$want" "$port" "$(( port + DEV_API_PORT_OFFSET ))" "$db" \
+    >"${root}/${want}/env"
+  printf '%s %s' "$db" "$port"
 }
-redis_db=0
-if [[ -n "$slug" ]]; then
-  redis_db=$(claim_redis_db "$slug")
+
+if [[ -z "$slug" ]]; then
+  # Fixed, not claimed: :8080 and Redis db 0 belong to the primary worktree by
+  # construction, and both claim ranges start above them.
+  fe_port=8080
+  api_port=18080
+  redis_db=0
+else
+  read -r redis_db fe_port <<<"$(claim_stack "$slug")"
+  api_port=$(( fe_port + DEV_API_PORT_OFFSET ))
 fi
 REDIS_ADDR="localhost:${REDIS_PORT}/${redis_db}"
 
@@ -345,13 +459,6 @@ vite_pids() {
     cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
     [[ "$cmd" == *"$repo_root"* ]] && echo "$pid"
   done
-}
-
-# port_listeners names only the processes SERVING a port. Plain
-# `lsof -ti tcp:8080` also lists everything CONNECTED to it — the
-# developer's browser among them — and this sweep kills what it is given.
-port_listeners() { # port
-  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null || true
 }
 
 # still_ours answers whether a pid recorded in an old state file is still a
@@ -693,7 +800,7 @@ up)
     MARGINCE_BLOBSTORE_ENDPOINT="localhost:${MINIO_PORT}" \
     MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin \
     MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
-    MARGINCE_BLOBSTORE_BUCKET=margince-dev \
+    MARGINCE_BLOBSTORE_BUCKET="$blob_bucket" \
     MARGINCE_BLOBSTORE_REGION=us-east-1 \
     ./bin/api --addr ":${api_port}" --dsn "$dev_app_url" --config "$deploy_cfg" \
     --redis "${REDIS_ADDR}" \
@@ -747,7 +854,7 @@ up)
     MARGINCE_BLOBSTORE_ENDPOINT="localhost:${MINIO_PORT}" \
     MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin \
     MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
-    MARGINCE_BLOBSTORE_BUCKET=margince-dev \
+    MARGINCE_BLOBSTORE_BUCKET="$blob_bucket" \
     MARGINCE_BLOBSTORE_REGION=us-east-1 \
     ./bin/worker --dsn "$dev_app_url" --redis "${REDIS_ADDR}" \
     --config "$deploy_cfg" \

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -116,6 +116,16 @@ still_ours() { # pid
   [[ -n "$cmd" ]] || return 1
   [[ "$cmd" == *margince* || "$cmd" == *"$repo_root"* ]]
 }
+# is_dev_launcher reports whether a pid is a live run of THIS script. The starter
+# recorded in a reservation is a shell running dev.sh, so that is what to look for
+# — checking liveness alone confuses a recycled pid for a peer.
+is_dev_launcher() { # pid
+  local cmd
+  cmd=$(ps -o command= -p "$1" 2>/dev/null || true)
+  [[ -n "$cmd" ]] || return 1
+  [[ "$cmd" == *dev.sh* ]]
+}
+
 # release_unconfirmed_stack — give back this run's claim, and take down whatever
 # it started. Called from the EXIT trap while stack_recorded is 0, which is every
 # path that does not reach a stack answering its own readiness probe.
@@ -305,10 +315,13 @@ claim_stack() { # slug → "<redis_db> <fe_port>"
       printf '%s' "${STARTER_PID:-}"
     )
   fi
-  # still_ours, not `kill -0`: a pid is recycled, and a bare liveness check reads
-  # an unrelated process as another starter — which would refuse every later
-  # `make dev` for this slug, permanently, with no way to tell why.
-  if [[ -n "$holder" && "$holder" != "$STACK_STARTER_PID" ]] && still_ours "$holder"; then
+  # A live process that is actually one of THESE. still_ours identifies a running
+  # SERVER, by the margince connection string on its command line, and a starter
+  # is a shell running this script — it carries neither, so still_ours rejected
+  # the very launcher this guard exists to notice. A bare `kill -0` is the other
+  # wrong answer: pids are recycled, and it would refuse every later `make dev`
+  # for this slug once an unrelated process inherited the number.
+  if [[ -n "$holder" && "$holder" != "$STACK_STARTER_PID" ]] && is_dev_launcher "$holder"; then
     echo "FAIL: another 'make dev' (pid ${holder}) is already starting the '${want}' stack. Wait for it, or stop it with 'make dev-stop'." >&2
     return 1
   fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -305,7 +305,10 @@ claim_stack() { # slug → "<redis_db> <fe_port>"
       printf '%s' "${STARTER_PID:-}"
     )
   fi
-  if [[ -n "$holder" && "$holder" != "$STACK_STARTER_PID" ]] && kill -0 "$holder" 2>/dev/null; then
+  # still_ours, not `kill -0`: a pid is recycled, and a bare liveness check reads
+  # an unrelated process as another starter — which would refuse every later
+  # `make dev` for this slug, permanently, with no way to tell why.
+  if [[ -n "$holder" && "$holder" != "$STACK_STARTER_PID" ]] && still_ours "$holder"; then
     echo "FAIL: another 'make dev' (pid ${holder}) is already starting the '${want}' stack. Wait for it, or stop it with 'make dev-stop'." >&2
     return 1
   fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -81,64 +81,13 @@ REDIS_PORT="${REDIS_PORT:-16379}"
 # production secret.
 MINIO_PORT="${MINIO_PORT:-29000}"
 
-# A slug reaches three places that each refuse different characters: a
-# filesystem path, a CREATE DATABASE identifier, and (via bucket_for_slug) an S3
-# bucket name. Fold to the narrowest of the three rather than validating in
-# three places — a branch or directory name is the usual source, and
-# `feat/ai-keys` is an ordinary one.
-sanitize_slug() { # name → a slug matching ^[a-z0-9_-]+$
-  printf '%s' "$1" \
-    | tr '[:upper:]' '[:lower:]' \
-    | sed 's/[^a-z0-9_-]/-/g; s/--*/-/g; s/^-//; s/-*$//'
-}
+# Slug, state root and bucket come from the shared helper — three scripts need
+# the same answers and dev.sh knowing them alone is how `make dev-logs` came to
+# look for a file `make dev` no longer wrote.
+# shellcheck source=scripts/lib-devstate.sh
+. "${repo_root}/scripts/lib-devstate.sh"
 
-# The bucket holding attachment and transcript bytes. It was one name for every
-# stack, so two worktrees wrote each other's object bytes into one place — the
-# same class of defect as a shared Redis database, and invisible for the same
-# reason.
-#
-# S3 bucket names admit no underscore and the slug charset does, so the two
-# names are not interchangeable. blobstore.New creates a missing bucket, so a
-# new name needs no infra change.
-bucket_for_slug() { # slug → an S3-legal bucket name
-  local slug="$1"
-  if [[ -z "$slug" ]]; then
-    printf 'margince-dev'
-    return 0
-  fi
-  printf 'margince-dev-%s' "$(printf '%s' "$slug" | tr '_' '-')"
-}
-
-# The PRIMARY worktree keeps the shared stack — database `margince` on :8080,
-# Redis db 0 — because `make migrate`, `make seed-dev` and `make verify-boot`
-# all target that database by name, and an auto-slug here would silently
-# decouple them from the stack the developer is looking at.
-#
-# A LINKED worktree gets its own everything, named after itself, with no flag to
-# remember. That is the point: an engineer runs several agent sessions, one
-# worktree each, and none of them should have to know DEV_SLUG exists.
-#
-# The primary/linked test is the git directory, not the path: in a linked
-# worktree --absolute-git-dir is <common>/worktrees/<name> and differs from
-# --git-common-dir. The latter can print a relative path, so it is resolved
-# before the comparison.
-derive_slug() { # → "" in the primary worktree, this worktree's name in a linked one
-  local gitdir commondir
-  gitdir=$(git rev-parse --absolute-git-dir)
-  commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
-  [[ "$gitdir" == "$commondir" ]] && return 0
-  sanitize_slug "$(basename "$(git rev-parse --show-toplevel)")"
-}
-
-# An explicit DEV_SLUG always wins; otherwise the worktree decides. A supplied
-# slug is validated rather than sanitised: silently rewriting what somebody
-# typed would point them at a database they did not name.
-if [[ -z "$slug" ]]; then
-  slug="$(derive_slug)"
-elif ! [[ "$slug" =~ ^[a-z0-9_-]+$ ]]; then
-  echo "FAIL: DEV_SLUG must match ^[a-z0-9_-]+$ (got '$slug')" >&2
-  exit 1
-fi
+slug="$(dev_resolve_slug "$slug")" || exit 1
 if [[ -z "$slug" ]]; then
   label="dev"
   db="margince"
@@ -146,7 +95,7 @@ else
   label="dev '$slug'"
   db="margince_dev_${slug}"
 fi
-blob_bucket="$(bucket_for_slug "$slug")"
+blob_bucket="$(dev_bucket_for_slug "$slug")"
 # :8080 is THE port — the app, the thing a human opens, always and only. The api
 # sits behind it at fe+10000 and the app's dev server proxies /v1 and the probes
 # through, so `curl localhost:8080/v1/...` still answers and nobody has to
@@ -163,24 +112,6 @@ DEV_API_PORT_OFFSET=10000
 # developer's browser among them — and this sweep kills what it is given.
 port_listeners() { # port
   lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null || true
-}
-
-# Where a stack's claim is recorded. ONE directory per machine, deliberately
-# outside the repository.
-#
-# It used to be <worktree>/.tmp/dev/, and that is the defect this whole file is
-# being changed for: a second worktree read an EMPTY registry and claimed Redis
-# database 64 for the second time. The guarantee the old comment made — "a
-# running stack's db is never handed out twice" — held only within one checkout,
-# which is the one case that never needed it. Two stacks then shared one
-# consumer group: whichever worker read an entry first resolved it against its
-# own database, found nothing, and acked it, so the other stack's event was
-# simply gone.
-#
-# MARGINCE_DEV_STATE_DIR exists so the tests can point this somewhere
-# disposable. Nothing else should set it.
-dev_state_root() {
-  printf '%s' "${MARGINCE_DEV_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/margince/dev}"
 }
 
 # The Redis instance serves 80 logical databases in three blocks that must not
@@ -299,9 +230,28 @@ if [[ -z "$slug" ]]; then
   fe_port=8080
   api_port=18080
   redis_db=0
-else
-  read -r redis_db fe_port <<<"$(claim_stack "$slug")"
+elif [[ "$cmd" == "up" ]]; then
+  # Assign first, THEN read: `read … <<<"$(claim_stack)"` reports read's status,
+  # not the claim's, so a refused claim printed its FAIL and the stack carried on
+  # with an empty port and an api listening on :10000.
+  claimed="$(claim_stack "$slug")" || exit 1
+  read -r redis_db fe_port <<<"$claimed"
   api_port=$(( fe_port + DEV_API_PORT_OFFSET ))
+  # A reservation that outlives a failed boot holds its port and Redis database
+  # against every later stack until somebody sweeps by hand, and nothing says so
+  # — the next `make dev` in a fresh worktree just gets a higher number, and the
+  # block runs out sixteen stacks early. Released on any exit before the final
+  # state write, which is the point the stack is actually running.
+  stack_recorded=0
+  trap 'if [[ "$stack_recorded" == "0" ]]; then rm -rf "$(dev_state_dir "$slug")"; fi' EXIT
+else
+  # stop and sweep READ; only `up` claims. Claiming here would mint a reservation
+  # for a stack nobody asked to start, and then the caller would tear it down
+  # again — a write on the path whose whole job is to clean up.
+  read_registry "$slug"
+  redis_db="${MINE_DB:-0}"
+  fe_port="${MINE_PORT:-0}"
+  api_port=$(( fe_port == 0 ? 0 : fe_port + DEV_API_PORT_OFFSET ))
 fi
 REDIS_ADDR="localhost:${REDIS_PORT}/${redis_db}"
 
@@ -366,7 +316,7 @@ psql_owner() { # db [psql args…] — SQL via args or stdin
 # reserved, so a sweep from any worktree can see this stack; while these were two
 # different files the reservation carried ports and no pids, and the sweep read a
 # directory only this worktree could see.
-rundir="$(dev_state_root)/${slug:-_base}"
+rundir="$(dev_state_dir "$slug")"
 log="${rundir}/dev.log"
 state="${rundir}/env"
 
@@ -462,11 +412,17 @@ margince_server_pids() {
 # the worktree path — that is what distinguishes our dev server from any other
 # Vite project the developer happens to be running.
 vite_pids() {
-  local pid cmd
+  local pid cmd common
+  # The git COMMON directory, not this worktree's root: every worktree of this
+  # repository resolves vite out of its own node_modules, so matching on
+  # $repo_root found only our own. `make dev-sweep` promises to clear the
+  # machine, and an orphaned vite from a sibling worktree — the exact process
+  # this whole change makes more likely — survived it.
+  common=$(cd "$(git rev-parse --git-common-dir)" && cd .. && pwd -P)
   for pid in $(pgrep -f 'vite' 2>/dev/null || true); do
     [[ "$pid" == "$$" ]] && continue
     cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
-    [[ "$cmd" == *"$repo_root"* ]] && echo "$pid"
+    [[ "$cmd" == *"$common"* ]] && echo "$pid"
   done
 }
 
@@ -875,6 +831,7 @@ up)
   # index is spoken for.
   printf 'SLUG=%s\nAPI_PORT=%s\nFE_PORT=%s\nDB=%s\nREDIS_DB=%s\nBACKEND_PID=%s\nFE_PID=%s\nWORKER_PID=%s\nLOG=%s\n' \
     "$slug" "$api_port" "$fe_port" "$db" "$redis_db" "$be_pid" "$fe_pid" "$worker_pid" "$log" >"$state"
+  stack_recorded=1
 
   if wait_ready "http://localhost:${fe_port}/" 90; then
     echo "$label ready"
@@ -922,11 +879,10 @@ stop)
     rm -rf "$rundir"
     echo "stopped $label (freed :${API_PORT:-?} :${FE_PORT:-?})"
   else
-    for p in "$api_port" "$fe_port"; do
-      pids=$(lsof -ti "tcp:${p}" 2>/dev/null || true)
-      [[ -n "$pids" ]] && kill $pids 2>/dev/null || true
-    done
-    echo "no recorded env for $label (freed derived ports :$api_port :$fe_port if bound)"
+    # Ports are CLAIMED now, not derived from the slug, so there is nothing to
+    # guess at for a stack that was never recorded: naming a port here would
+    # print `:0`. Say what is true instead.
+    echo "no recorded stack for $label — nothing to stop"
   fi
   if [[ "$drop" == "1" ]]; then
     if [[ -z "$slug" ]]; then

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -87,6 +87,69 @@ MINIO_PORT="${MINIO_PORT:-29000}"
 # shellcheck source=scripts/lib-devstate.sh
 . "${repo_root}/scripts/lib-devstate.sh"
 
+# Process helpers, defined HERE rather than beside the sweep that used to be their
+# only caller: the EXIT trap below names release_unconfirmed_stack, and a trap
+# installed above the definition calls a function that does not exist yet. Any
+# exit between the two — a DSN that will not resolve, for instance — printed
+# `command not found` and left the claim behind.
+
+kill_pids() { # pid… — TERM, then KILL whatever is still standing
+  local pids=("$@") alive=()
+  [[ ${#pids[@]} -gt 0 ]] || return 0
+  kill "${pids[@]}" 2>/dev/null || true
+  for _ in $(seq 1 10); do
+    alive=()
+    for p in "${pids[@]}"; do kill -0 "$p" 2>/dev/null && alive+=("$p"); done
+    [[ ${#alive[@]} -eq 0 ]] && return 0
+    sleep 0.5
+  done
+  kill -9 "${alive[@]}" 2>/dev/null || true
+}
+# still_ours answers whether a pid recorded in an old state file is still a
+# process of ours. PIDs are recycled: a stack killed by a crash or a machine
+# sleep leaves its file behind, and by the time the next `make dev` reads it
+# that number can belong to anything. The pgrep paths already re-check the
+# live command line before killing — a recorded pid gets the same proof.
+still_ours() { # pid
+  local cmd
+  cmd=$(ps -o command= -p "$1" 2>/dev/null || true)
+  [[ -n "$cmd" ]] || return 1
+  [[ "$cmd" == *margince* || "$cmd" == *"$repo_root"* ]]
+}
+# release_unconfirmed_stack — give back this run's claim, and take down whatever
+# it started. Called from the EXIT trap while stack_recorded is 0, which is every
+# path that does not reach a stack answering its own readiness probe.
+release_unconfirmed_stack() {
+  [[ "${stack_recorded:-1}" == "0" ]] || return 0
+  # Never release a claim this run did not create: it belongs to a stack that was
+  # already up, and taking its record away would leave it running with nothing
+  # able to stop it.
+  [[ "${STACK_CLAIM_PREEXISTING:-0}" == "1" ]] && return 0
+  # Nor one another `make dev` is mid-way through starting. Two runs for the same
+  # slug both see a pid-less reservation, and without this the one that loses the
+  # port race deletes the claim the winner is still booting against.
+  local owner=''
+  # shellcheck disable=SC1090
+  [[ -f "$(dev_state_dir "$slug")/env" ]] && owner=$(
+    STARTER_PID=''
+    . "$(dev_state_dir "$slug")/env"
+    printf '%s' "${STARTER_PID:-}"
+  )
+  [[ -n "$owner" && "$owner" != "$$" ]] && return 0
+  # TERM then KILL, through the helper the sweep uses: a bare TERM can leave a
+  # server standing after its claim is gone, which is the orphan this is for.
+  local pids=()
+  local p
+  for p in "${be_pid:-}" "${fe_pid:-}" "${worker_pid:-}"; do
+    [[ -n "$p" ]] && pids+=("$p")
+  done
+  [[ ${#pids[@]} -gt 0 ]] && kill_pids "${pids[@]}"
+  # The CLAIM goes; the LOG stays. Removing the directory took the log with it,
+  # so a failed boot deleted the one file that said why it failed — which cost a
+  # debugging cycle here before it could cost anyone else one.
+  rm -f "$(dev_state_dir "$slug")/env"
+}
+
 slug="$(dev_resolve_slug "$slug")" || exit 1
 if [[ -z "$slug" ]]; then
   label="dev"
@@ -231,8 +294,11 @@ claim_stack() { # slug → "<redis_db> <fe_port>"
   fi
 
   mkdir -p "${root}/${want}"
-  printf 'SLUG=%s\nFE_PORT=%s\nAPI_PORT=%s\nREDIS_DB=%s\n' \
-    "$want" "$port" "$(( port + DEV_API_PORT_OFFSET ))" "$db" \
+  # STARTER_PID is who is booting this stack. release_unconfirmed_stack reads it
+  # so a run that loses the port race cannot delete a claim another run is still
+  # starting against. It is overwritten by the final state write.
+  printf 'SLUG=%s\nFE_PORT=%s\nAPI_PORT=%s\nREDIS_DB=%s\nSTARTER_PID=%s\n' \
+    "$want" "$port" "$(( port + DEV_API_PORT_OFFSET ))" "$db" "$STACK_STARTER_PID" \
     >"${root}/${want}/env"
   printf '%s %s' "$db" "$port"
 }
@@ -253,9 +319,19 @@ elif [[ "$cmd" == "up" ]]; then
   # stack that was still running. Same subshell trap as the swallowed claim status
   # above, one line apart.
   STACK_CLAIM_PREEXISTING=0
-  if grep -q '^BACKEND_PID=[0-9]' "$(dev_state_dir "$slug")/env" 2>/dev/null; then
+  recorded_be=$(
+    BACKEND_PID=''
+    # shellcheck disable=SC1090
+    [[ -f "$(dev_state_dir "$slug")/env" ]] && . "$(dev_state_dir "$slug")/env"
+    printf '%s' "${BACKEND_PID:-}"
+  )
+  # ALIVE, not merely recorded. A crashed stack leaves its pids in the file, and
+  # treating that as a live claim would disable the release for every later failed
+  # boot — the stale reservation then holds a port and a Redis database forever.
+  if [[ -n "$recorded_be" ]] && still_ours "$recorded_be"; then
     STACK_CLAIM_PREEXISTING=1
   fi
+  export STACK_STARTER_PID=$$
   claimed="$(claim_stack "$slug")" || exit 1
   read -r redis_db fe_port <<<"$claimed"
   api_port=$(( fe_port + DEV_API_PORT_OFFSET ))
@@ -408,18 +484,6 @@ wait_ready() { # url timeout_s — only a 2xx counts as ready (a 401/500/503 is 
 # :8080 against `margince`. `DEV_SLUG` keeps its escape hatch (it sweeps
 # nothing, so an isolated env survives until the next bare `make dev`).
 
-kill_pids() { # pid… — TERM, then KILL whatever is still standing
-  local pids=("$@") alive=()
-  [[ ${#pids[@]} -gt 0 ]] || return 0
-  kill "${pids[@]}" 2>/dev/null || true
-  for _ in $(seq 1 10); do
-    alive=()
-    for p in "${pids[@]}"; do kill -0 "$p" 2>/dev/null && alive+=("$p"); done
-    [[ ${#alive[@]} -eq 0 ]] && return 0
-    sleep 0.5
-  done
-  kill -9 "${alive[@]}" 2>/dev/null || true
-}
 
 # Margince server processes anywhere on this machine, not just this checkout: a
 # second worktree's api on :8081 owns a different database and is exactly the
@@ -451,7 +515,9 @@ vite_pids() {
     [[ "$pid" == "$$" ]] && continue
     cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
     for root in "${roots[@]}"; do
-      if [[ "$cmd" == *"$root"* ]]; then
+      # "$root/" — with the separator. A bare substring match sweeps an unrelated
+      # project living at <root>-scratch, whose path merely starts with ours.
+      if [[ "$cmd" == *"$root/"* ]]; then
         echo "$pid"
         break
       fi
@@ -459,36 +525,7 @@ vite_pids() {
   done
 }
 
-# still_ours answers whether a pid recorded in an old state file is still a
-# process of ours. PIDs are recycled: a stack killed by a crash or a machine
-# sleep leaves its file behind, and by the time the next `make dev` reads it
-# that number can belong to anything. The pgrep paths already re-check the
-# live command line before killing — a recorded pid gets the same proof.
-still_ours() { # pid
-  local cmd
-  cmd=$(ps -o command= -p "$1" 2>/dev/null || true)
-  [[ -n "$cmd" ]] || return 1
-  [[ "$cmd" == *margince* || "$cmd" == *"$repo_root"* ]]
-}
 
-# release_unconfirmed_stack — give back this run's claim, and take down whatever
-# it started. Called from the EXIT trap while stack_recorded is 0, which is every
-# path that does not reach a stack answering its own readiness probe.
-release_unconfirmed_stack() {
-  [[ "${stack_recorded:-1}" == "0" ]] || return 0
-  # Never release a claim this run did not create: it belongs to a stack that was
-  # already up, and taking its record away would leave it running with nothing
-  # able to stop it.
-  [[ "${STACK_CLAIM_PREEXISTING:-0}" == "1" ]] && return 0
-  local p
-  for p in "${be_pid:-}" "${fe_pid:-}" "${worker_pid:-}"; do
-    [[ -n "$p" ]] && kill "$p" 2>/dev/null || true
-  done
-  # The CLAIM goes; the LOG stays. Removing the directory took the log with it,
-  # so a failed boot deleted the one file that said why it failed — which cost a
-  # debugging cycle here before it could cost anyone else one.
-  rm -f "$(dev_state_dir "$slug")/env"
-}
 
 sweep_stacks() { # kill every margince dev stack: recorded, orphaned, or foreign
   local victims=() pids p port state_file

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -361,7 +361,12 @@ psql_owner() { # db [psql args…] — SQL via args or stdin
     psql -U margince_owner -d "$db" "$@"
 }
 
-rundir=".tmp/dev/${slug:-_base}"
+# Under the machine-global root, not the worktree's own .tmp/ — the same reason
+# the claim registry moved there. The pids land in the SAME file claim_stack
+# reserved, so a sweep from any worktree can see this stack; while these were two
+# different files the reservation carried ports and no pids, and the sweep read a
+# directory only this worktree could see.
+rundir="$(dev_state_root)/${slug:-_base}"
 log="${rundir}/dev.log"
 state="${rundir}/env"
 
@@ -483,7 +488,7 @@ sweep_stacks() { # kill every margince dev stack: recorded, orphaned, or foreign
   # 1. Every stack this script ever recorded — its own pids and its own ports.
   #    The locals above shadow what the state file sets, so sourcing one cannot
   #    leak a stale pid into the rest of the run.
-  for state_file in .tmp/dev/*/env; do
+  for state_file in "$(dev_state_root)"/*/env; do
     [[ -f "$state_file" ]] || continue
     BACKEND_PID=''; FE_PID=''; WORKER_PID=''; API_PORT=''; FE_PORT=''
     # shellcheck disable=SC1090
@@ -511,7 +516,7 @@ sweep_stacks() { # kill every margince dev stack: recorded, orphaned, or foreign
     kill_pids $pids
     echo "dev: swept $(printf '%s\n' $pids | wc -l | tr -d ' ') stray process(es) from earlier stacks"
   fi
-  rm -rf .tmp/dev/*
+  rm -rf "$(dev_state_root)"/*
 }
 
 drop_stray_dev_dbs() { # every margince_dev_<slug> database an isolated env left behind

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -292,6 +292,23 @@ claim_stack() { # slug → "<redis_db> <fe_port>"
     printf '%s %s' "$db" "$port"
     return 0
   fi
+  # Nor one another `make dev` is still starting. Two runs that overlap before
+  # either writes its pids would otherwise both rewrite this file, and whichever
+  # wrote last would own it — so the one that then failed its port check released
+  # the claim the other was booting against.
+  local holder=''
+  if [[ -f "${root}/${want}/env" ]]; then
+    holder=$(
+      STARTER_PID=''
+      # shellcheck disable=SC1090
+      . "${root}/${want}/env"
+      printf '%s' "${STARTER_PID:-}"
+    )
+  fi
+  if [[ -n "$holder" && "$holder" != "$STACK_STARTER_PID" ]] && kill -0 "$holder" 2>/dev/null; then
+    echo "FAIL: another 'make dev' (pid ${holder}) is already starting the '${want}' stack. Wait for it, or stop it with 'make dev-stop'." >&2
+    return 1
+  fi
 
   mkdir -p "${root}/${want}"
   # STARTER_PID is who is booting this stack. release_unconfirmed_stack reads it

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -217,6 +217,19 @@ claim_stack() { # slug → "<redis_db> <fe_port>"
       return 1
     }
   fi
+  # Whether this slug ALREADY had a started stack recorded. `make dev` run again
+  # in a worktree whose stack is up reaches here, reclaims its own numbers, and
+  # then fails the port check further down — at which point the release must not
+  # delete the entry, because those pids are a live stack that dev-stop still has
+  # to find. Reclaiming must also not overwrite the record with a pid-less one.
+  # An entry that already describes a started stack is returned as-is: rewriting
+  # it would replace live pids with a pid-less reservation, and dev-stop would
+  # then have nothing to kill.
+  if grep -q '^BACKEND_PID=[0-9]' "${root}/${want}/env" 2>/dev/null; then
+    printf '%s %s' "$db" "$port"
+    return 0
+  fi
+
   mkdir -p "${root}/${want}"
   printf 'SLUG=%s\nFE_PORT=%s\nAPI_PORT=%s\nREDIS_DB=%s\n' \
     "$want" "$port" "$(( port + DEV_API_PORT_OFFSET ))" "$db" \
@@ -234,6 +247,15 @@ elif [[ "$cmd" == "up" ]]; then
   # Assign first, THEN read: `read … <<<"$(claim_stack)"` reports read's status,
   # not the claim's, so a refused claim printed its FAIL and the stack carried on
   # with an empty port and an api listening on :10000.
+  # Computed HERE, not inside claim_stack: that runs in a command substitution,
+  # which is a subshell, so a variable it sets never reaches this shell. The first
+  # version set it in there and the trap read the default — deleting the pids of a
+  # stack that was still running. Same subshell trap as the swallowed claim status
+  # above, one line apart.
+  STACK_CLAIM_PREEXISTING=0
+  if grep -q '^BACKEND_PID=[0-9]' "$(dev_state_dir "$slug")/env" 2>/dev/null; then
+    STACK_CLAIM_PREEXISTING=1
+  fi
   claimed="$(claim_stack "$slug")" || exit 1
   read -r redis_db fe_port <<<"$claimed"
   api_port=$(( fe_port + DEV_API_PORT_OFFSET ))
@@ -242,8 +264,12 @@ elif [[ "$cmd" == "up" ]]; then
   # — the next `make dev` in a fresh worktree just gets a higher number, and the
   # block runs out sixteen stacks early. Released on any exit before the final
   # state write, which is the point the stack is actually running.
+  # Released on any exit before the stack is CONFIRMED up, and the release kills
+  # whatever this run started. Deleting the claim alone would leave an api or a
+  # vite running that nothing records any more — an orphan holding the port the
+  # claim just gave back, which is worse than the leak it was fixing.
   stack_recorded=0
-  trap 'if [[ "$stack_recorded" == "0" ]]; then rm -rf "$(dev_state_dir "$slug")"; fi' EXIT
+  trap 'release_unconfirmed_stack' EXIT
 else
   # stop and sweep READ; only `up` claims. Claiming here would mint a reservation
   # for a stack nobody asked to start, and then the caller would tear it down
@@ -412,17 +438,24 @@ margince_server_pids() {
 # the worktree path — that is what distinguishes our dev server from any other
 # Vite project the developer happens to be running.
 vite_pids() {
-  local pid cmd common
-  # The git COMMON directory, not this worktree's root: every worktree of this
-  # repository resolves vite out of its own node_modules, so matching on
-  # $repo_root found only our own. `make dev-sweep` promises to clear the
-  # machine, and an orphaned vite from a sibling worktree — the exact process
-  # this whole change makes more likely — survived it.
-  common=$(cd "$(git rev-parse --git-common-dir)" && cd .. && pwd -P)
+  local pid cmd root roots=()
+  # EVERY worktree of this repository, enumerated. Each resolves vite out of its
+  # own node_modules, so its command line carries its own path — matching on this
+  # checkout's root found only our own, and `make dev-sweep` promises to clear the
+  # machine. Deriving a parent directory from the git common dir was no better: a
+  # linked worktree can live anywhere, not only beside its siblings.
+  while IFS= read -r root; do
+    [[ -n "$root" ]] && roots+=("$root")
+  done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}')
   for pid in $(pgrep -f 'vite' 2>/dev/null || true); do
     [[ "$pid" == "$$" ]] && continue
     cmd=$(ps -o command= -p "$pid" 2>/dev/null || true)
-    [[ "$cmd" == *"$common"* ]] && echo "$pid"
+    for root in "${roots[@]}"; do
+      if [[ "$cmd" == *"$root"* ]]; then
+        echo "$pid"
+        break
+      fi
+    done
   done
 }
 
@@ -436,6 +469,25 @@ still_ours() { # pid
   cmd=$(ps -o command= -p "$1" 2>/dev/null || true)
   [[ -n "$cmd" ]] || return 1
   [[ "$cmd" == *margince* || "$cmd" == *"$repo_root"* ]]
+}
+
+# release_unconfirmed_stack — give back this run's claim, and take down whatever
+# it started. Called from the EXIT trap while stack_recorded is 0, which is every
+# path that does not reach a stack answering its own readiness probe.
+release_unconfirmed_stack() {
+  [[ "${stack_recorded:-1}" == "0" ]] || return 0
+  # Never release a claim this run did not create: it belongs to a stack that was
+  # already up, and taking its record away would leave it running with nothing
+  # able to stop it.
+  [[ "${STACK_CLAIM_PREEXISTING:-0}" == "1" ]] && return 0
+  local p
+  for p in "${be_pid:-}" "${fe_pid:-}" "${worker_pid:-}"; do
+    [[ -n "$p" ]] && kill "$p" 2>/dev/null || true
+  done
+  # The CLAIM goes; the LOG stays. Removing the directory took the log with it,
+  # so a failed boot deleted the one file that said why it failed — which cost a
+  # debugging cycle here before it could cost anyone else one.
+  rm -f "$(dev_state_dir "$slug")/env"
 }
 
 sweep_stacks() { # kill every margince dev stack: recorded, orphaned, or foreign
@@ -831,9 +883,12 @@ up)
   # index is spoken for.
   printf 'SLUG=%s\nAPI_PORT=%s\nFE_PORT=%s\nDB=%s\nREDIS_DB=%s\nBACKEND_PID=%s\nFE_PID=%s\nWORKER_PID=%s\nLOG=%s\n' \
     "$slug" "$api_port" "$fe_port" "$db" "$redis_db" "$be_pid" "$fe_pid" "$worker_pid" "$log" >"$state"
-  stack_recorded=1
-
   if wait_ready "http://localhost:${fe_port}/" 90; then
+    # CONFIRMED up, and only here. This used to be set at the state write above,
+    # which is before this probe — so an FE that never came ready left a claim
+    # behind holding a port and a Redis database, while the script killed the
+    # processes and exited 1.
+    stack_recorded=1
     echo "$label ready"
     echo ""
     echo "  OPEN     http://localhost:${fe_port}"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,10 +2,12 @@
 # One-command local dev stack on the ONE shared infra: Postgres + Redis, the api
 # (cmd/api), the background worker (cmd/worker — outbox relay + Surface-B runner),
 # and the Vite dev server — so the SPA runs in a real browser against a live api.
-# Bare `make dev` serves the app on :8080 (the api behind it on :18080);
-# `make dev DEV_SLUG=<slug>` gives an isolated `margince_dev_<slug>` database on
-# slug-derived ports, so two worktrees can run concurrently without colliding on
-# the database or the host ports.
+# One stack per WORKTREE, so several agent sessions can run at once. The primary
+# worktree serves the app on :8080 (the api behind it on :18080) against the
+# shared `margince` database; every linked worktree derives its own slug from
+# its directory name and claims its own database, Redis logical database, port
+# pair and object bucket — no flag to remember. `DEV_SLUG=<slug>` overrides the
+# derived name.
 #
 # MARGINCE_ENV=dev relaxes the production-only postures (an unlicensed install
 # warns rather than refuses, the data reset is reachable). It does NOT switch on
@@ -26,10 +28,12 @@
 # no secret literal beyond the shared dev defaults, and there is one set of names
 # rather than two.
 #
-#   scripts/dev.sh up   [slug] [--fresh]  # spin infra + db + api + FE
-#   scripts/dev.sh stop [slug] [--drop]   # stop servers; --drop also drops the db
+#   scripts/dev.sh up    [slug] [--fresh]  # spin infra + db + api + FE
+#   scripts/dev.sh stop  [slug] [--drop]   # stop THIS stack; --drop also drops its db
+#   scripts/dev.sh sweep       [--drop]    # stop EVERY stack on the machine
 set -euo pipefail
-# Runtime state under .tmp/dev/ (logs, pids) — keep everything this script
+# Runtime state (logs, pids, claims) lives under dev_state_root below, one
+# directory per machine rather than per worktree — keep everything this script
 # writes owner-only.
 umask 077
 
@@ -530,19 +534,20 @@ drop_stray_dev_dbs() { # every margince_dev_<slug> database an isolated env left
 
 case "$cmd" in
 up)
-  if [[ -z "$slug" ]]; then
-    # Bare `make dev` is the exclusive stack: clear the machine first, so the
-    # ports below are free by construction and the browser can only be talking
-    # to the api this command starts.
-    sweep_stacks
-  fi
-  # Belt and braces after the sweep, and the only guard a slugged env gets: a
-  # bound port must stop the boot, because binding would fail silently and
+  # `make dev` starts THIS worktree's stack and touches nobody else's. It used
+  # to sweep the machine first — every margince process, every recorded stack,
+  # every per-slug database — which made one engineer's routine command destroy
+  # every parallel session's stack, including the one another agent was
+  # mid-test against. The sweep is now `dev-sweep`, asked for by name.
+  #
+  # A bound port must still stop the boot: binding would fail silently and
   # wait_ready would then read "ready" off the OLD server. (Vite without
   # --strictPort would not even fail — it would walk to a port we never poll.)
   for _p in "$api_port" "$fe_port"; do
     if [[ -n "$(port_listeners "$_p")" ]]; then
-      echo "FAIL: port :${_p} already in use — is $label already running? (make dev-stop${slug:+ DEV_SLUG=$slug})" >&2
+      echo "FAIL: port :${_p} already in use — is $label already running?" >&2
+      echo "  Stop it:                      make dev-stop${slug:+ DEV_SLUG=$slug}" >&2
+      echo "  Or clear every stack here:    make dev-sweep" >&2
       exit 1
     fi
   done
@@ -557,13 +562,6 @@ up)
   {
     echo "=== infra + db ==="
     make db-up
-    # The stray-database sweep runs HERE, not with the process sweep above:
-    # every statement it issues goes through the compose Postgres, so running
-    # it before db-up on a stopped stack would connect to nothing, fail
-    # silently, and leave the databases to reappear the moment infra starts.
-    if [[ -z "$slug" ]]; then
-      drop_stray_dev_dbs
-    fi
     # --fresh means "the install a first customer gets": drop the database
     # and let the migrations and the bootstrap rebuild it. Deliberately not
     # the default — a restart to pick up a backend change must not cost the
@@ -905,18 +903,7 @@ up)
   ;;
 
 stop)
-  if [[ -z "$slug" ]]; then
-    # The mirror of `up`: bare dev-stop clears the machine, so `make dev-stop`
-    # is a promise you can trust before starting anything else. Stray databases
-    # are left alone unless DROP=1 asks for them — stopping is not deleting.
-    sweep_stacks
-    echo "stopped every dev stack (freed :$api_port :$fe_port)"
-    if [[ "$drop" == "1" ]]; then
-      drop_stray_dev_dbs
-      echo "note: the shared 'margince' database is kept — DROP=1 only removes the per-slug ones" >&2
-    fi
-    exit 0
-  fi
+  # This worktree's stack, and only it. `dev-sweep` is what clears the machine.
   if [[ -f "$state" ]]; then
     # shellcheck disable=SC1090
     . "$state"
@@ -948,8 +935,24 @@ stop)
   fi
   ;;
 
+sweep)
+  # The machine-wide clear, now something you ask for by name. This used to be
+  # what a bare `make dev` did on the way up, so the routine command was also
+  # the destructive one.
+  sweep_stacks
+  echo "swept every dev stack on this machine"
+  if [[ "$drop" == "1" ]]; then
+    # db-up first: drop_stray_dev_dbs issues every statement through the compose
+    # Postgres, so on a stopped stack it would connect to nothing, fail
+    # silently, and leave the databases to reappear the moment infra started.
+    make db-up >/dev/null
+    drop_stray_dev_dbs
+    echo "note: the shared 'margince' database is kept — DROP=1 removes only the per-slug ones" >&2
+  fi
+  ;;
+
 *)
-  echo "usage: dev.sh {up|stop} [slug] [--drop]" >&2
+  echo "usage: dev.sh {up|stop|sweep} [slug] [--drop]" >&2
   exit 2
   ;;
 esac

--- a/scripts/lib-devstate.sh
+++ b/scripts/lib-devstate.sh
@@ -72,39 +72,40 @@ dev_bucket_for_slug() { # slug → an S3-legal bucket name
 # --git-common-dir. The latter can print a relative path, so it is resolved
 # before the comparison.
 dev_derive_slug() { # → "" in the primary worktree, this worktree's name in a linked one
-  local gitdir commondir top name digest twin
+  local gitdir commondir top name digest
   gitdir=$(git rev-parse --absolute-git-dir) || return 1
   commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P) || return 1
   [[ "$gitdir" == "$commondir" ]] && return 0
 
   top="$(git rev-parse --show-toplevel)"
   name="$(dev_sanitize_slug "$(basename "$top")")"
-  # A digest of the FULL PATH, because the basename does not identify a worktree:
-  # two of them can both be called `feature`, and giving both the same slug hands
-  # them one database, one Redis logical database and one bucket — the collision
-  # this whole mechanism exists to remove, arrived at from the other end.
+
+  # The digest is of the FULL PATH and is ALWAYS appended. Two things force that,
+  # and the second is the one that matters:
+  #
+  #   - a basename does not identify a worktree. Two can both be called `feature`,
+  #     and one slug between them is one database, one Redis logical database and
+  #     one bucket shared by two stacks.
+  #   - a slug must be STABLE for as long as a stack runs. An earlier version
+  #     appended the digest only when a twin existed, so creating a second
+  #     `feature` worktree renamed a RUNNING stack from `feature` to
+  #     `feature-<digest>` — after which dev-stop resolved a slug with no record
+  #     and could not stop it.
+  #
+  # So the name is noisier than it could be, and reliably its own.
   digest="$(printf '%s' "$top" | shasum -a 256 | cut -c1-8)"
 
-  # An empty answer means the PRIMARY worktree, so a name that sanitises away to
-  # nothing (a directory of pure punctuation) must not produce one: it would put a
-  # linked worktree on the shared `margince` database and :8080.
+  # Bounded so the names built from it fit their own limits: this slug becomes
+  # `margince_dev_<slug>` (Postgres caps an identifier at 63 bytes) and
+  # `margince-dev-<slug>` (S3 caps a bucket name at 63). 24 + 1 + 8 = 33 leaves
+  # both prefixes room. A name that sanitises away to nothing — a directory of
+  # pure punctuation — must not yield the empty answer that means PRIMARY, so it
+  # gets the digest alone.
   if [[ -z "$name" ]]; then
     printf 'wt-%s' "$digest"
     return 0
   fi
-
-  # Disambiguate only when another worktree really shares this basename, so the
-  # common case stays a name a human recognises.
-  twin=0
-  while IFS= read -r other; do
-    [[ -z "$other" || "$other" == "$top" ]] && continue
-    [[ "$(dev_sanitize_slug "$(basename "$other")")" == "$name" ]] && twin=1
-  done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}')
-  if (( twin )); then
-    printf '%s-%s' "$name" "$digest"
-    return 0
-  fi
-  printf '%s' "$name"
+  printf '%s-%s' "${name:0:24}" "$digest"
 }
 
 # dev_resolve_slug [supplied] — the slug this invocation runs under.

--- a/scripts/lib-devstate.sh
+++ b/scripts/lib-devstate.sh
@@ -72,35 +72,32 @@ dev_bucket_for_slug() { # slug → an S3-legal bucket name
 # --git-common-dir. The latter can print a relative path, so it is resolved
 # before the comparison.
 dev_derive_slug() { # → "" in the primary worktree, this worktree's name in a linked one
-  local gitdir commondir top name digest
+  local gitdir commondir name digest
   gitdir=$(git rev-parse --absolute-git-dir) || return 1
   commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P) || return 1
   [[ "$gitdir" == "$commondir" ]] && return 0
 
-  top="$(git rev-parse --show-toplevel)"
-  name="$(dev_sanitize_slug "$(basename "$top")")"
-
-  # The digest is of the FULL PATH and is ALWAYS appended. Two things force that,
-  # and the second is the one that matters:
+  # The worktree's ADMIN name — the directory git keeps for it under
+  # <common>/worktrees/ — not its checkout path.
   #
-  #   - a basename does not identify a worktree. Two can both be called `feature`,
-  #     and one slug between them is one database, one Redis logical database and
-  #     one bucket shared by two stacks.
-  #   - a slug must be STABLE for as long as a stack runs. An earlier version
-  #     appended the digest only when a twin existed, so creating a second
-  #     `feature` worktree renamed a RUNNING stack from `feature` to
-  #     `feature-<digest>` — after which dev-stop resolved a slug with no record
-  #     and could not stop it.
-  #
-  # So the name is noisier than it could be, and reliably its own.
-  digest="$(printf '%s' "$top" | shasum -a 256 | cut -c1-8)"
+  # Two properties the path does not have. It is assigned at creation and git
+  # keeps it across `git worktree move`, so moving a checkout does not rename a
+  # RUNNING stack out from under dev-stop. And git guarantees it is unique among
+  # this repository's worktrees, so two checkouts cannot derive one slug however
+  # they are named on disk.
+  name="$(dev_sanitize_slug "$(basename "$gitdir")")"
 
-  # Bounded so the names built from it fit their own limits: this slug becomes
-  # `margince_dev_<slug>` (Postgres caps an identifier at 63 bytes) and
-  # `margince-dev-<slug>` (S3 caps a bucket name at 63). 24 + 1 + 8 = 33 leaves
-  # both prefixes room. A name that sanitises away to nothing — a directory of
-  # pure punctuation — must not yield the empty answer that means PRIMARY, so it
-  # gets the digest alone.
+  # The digest identifies the REPOSITORY, so two clones on one machine — the
+  # registry is machine-global — cannot collide on a shared admin name like
+  # `feature`. It is of the common dir, which is stable for as long as the clone
+  # stays put.
+  digest="$(printf '%s' "$commondir" | shasum -a 256 | cut -c1-8)"
+
+  # Bounded so the names built from it fit their own limits: `margince_dev_<slug>`
+  # (Postgres caps an identifier at 63 bytes) and `margince-dev-<slug>` (S3 caps a
+  # bucket name at 63). 24 + 1 + 8 = 33 leaves both prefixes room. A name that
+  # sanitises away to nothing must not yield the empty answer that means PRIMARY,
+  # so it gets the digest alone.
   if [[ -z "$name" ]]; then
     printf 'wt-%s' "$digest"
     return 0

--- a/scripts/lib-devstate.sh
+++ b/scripts/lib-devstate.sh
@@ -72,11 +72,39 @@ dev_bucket_for_slug() { # slug → an S3-legal bucket name
 # --git-common-dir. The latter can print a relative path, so it is resolved
 # before the comparison.
 dev_derive_slug() { # → "" in the primary worktree, this worktree's name in a linked one
-  local gitdir commondir
+  local gitdir commondir top name digest twin
   gitdir=$(git rev-parse --absolute-git-dir) || return 1
   commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P) || return 1
   [[ "$gitdir" == "$commondir" ]] && return 0
-  dev_sanitize_slug "$(basename "$(git rev-parse --show-toplevel)")"
+
+  top="$(git rev-parse --show-toplevel)"
+  name="$(dev_sanitize_slug "$(basename "$top")")"
+  # A digest of the FULL PATH, because the basename does not identify a worktree:
+  # two of them can both be called `feature`, and giving both the same slug hands
+  # them one database, one Redis logical database and one bucket — the collision
+  # this whole mechanism exists to remove, arrived at from the other end.
+  digest="$(printf '%s' "$top" | shasum -a 256 | cut -c1-8)"
+
+  # An empty answer means the PRIMARY worktree, so a name that sanitises away to
+  # nothing (a directory of pure punctuation) must not produce one: it would put a
+  # linked worktree on the shared `margince` database and :8080.
+  if [[ -z "$name" ]]; then
+    printf 'wt-%s' "$digest"
+    return 0
+  fi
+
+  # Disambiguate only when another worktree really shares this basename, so the
+  # common case stays a name a human recognises.
+  twin=0
+  while IFS= read -r other; do
+    [[ -z "$other" || "$other" == "$top" ]] && continue
+    [[ "$(dev_sanitize_slug "$(basename "$other")")" == "$name" ]] && twin=1
+  done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}')
+  if (( twin )); then
+    printf '%s-%s' "$name" "$digest"
+    return 0
+  fi
+  printf '%s' "$name"
 }
 
 # dev_resolve_slug [supplied] — the slug this invocation runs under.
@@ -117,18 +145,30 @@ dev_state_dir() { # slug
 # Falls back to :8080 when this worktree has no recorded stack, which keeps the
 # primary worktree and CI on the URL they already use.
 dev_app_base_url() {
-  local slug port FE_PORT
+  local slug env_file FE_PORT
   slug="$(dev_resolve_slug "${DEV_SLUG:-}")" || return 1
-  port=8080
-  local env_file
   env_file="$(dev_state_dir "$slug")/env"
   if [[ -f "$env_file" ]]; then
     FE_PORT=''
     # shellcheck disable=SC1090
     . "$env_file"
-    [[ -n "$FE_PORT" ]] && port="$FE_PORT"
+    if [[ -n "$FE_PORT" ]]; then
+      printf 'http://localhost:%s' "$FE_PORT"
+      return 0
+    fi
   fi
-  printf 'http://localhost:%s' "$port"
+  # No recorded stack. For the PRIMARY worktree :8080 is still the answer — that
+  # stack is the shared one and its port is fixed. For a LINKED worktree there is
+  # no answer to fall back to: :8080 belongs to a different stack, and returning
+  # it would send the API half of a seed there while dev_database_name sends the
+  # SQL half to margince_dev_<slug>. That split is the defect this pair exists to
+  # close, so refuse instead of half-answering.
+  if [[ -z "$slug" ]]; then
+    printf 'http://localhost:8080'
+    return 0
+  fi
+  echo "FAIL: no dev stack recorded for this worktree (slug '${slug}') — start it with 'make dev' first, or set API_BASE explicitly. Falling back to :8080 would seed a different worktree's stack." >&2
+  return 1
 }
 
 # dev_database_name — the Postgres database THIS worktree's stack runs against.

--- a/scripts/lib-devstate.sh
+++ b/scripts/lib-devstate.sh
@@ -87,11 +87,17 @@ dev_derive_slug() { # → "" in the primary worktree, this worktree's name in a 
   # they are named on disk.
   name="$(dev_sanitize_slug "$(basename "$gitdir")")"
 
-  # The digest identifies the REPOSITORY, so two clones on one machine — the
-  # registry is machine-global — cannot collide on a shared admin name like
-  # `feature`. It is of the common dir, which is stable for as long as the clone
-  # stays put.
-  digest="$(printf '%s' "$commondir" | shasum -a 256 | cut -c1-8)"
+  # The digest identifies this WORKTREE OF THIS CLONE: the common dir separates
+  # two clones on one machine (the registry is machine-global), and the admin name
+  # separates two worktrees of one clone. Both are needed.
+  #
+  # Hashing the common dir alone was a regression: every worktree of a clone
+  # shares it, so once the display name is truncated to 24 characters two long
+  # siblings folded onto one slug — one database, one Redis logical database and
+  # one bucket between two stacks, which is the collision this file exists to
+  # remove. The digest is over the FULL admin name, so truncating the readable
+  # half cannot cost uniqueness.
+  digest="$(printf '%s\0%s' "$commondir" "$(basename "$gitdir")" | shasum -a 256 | cut -c1-8)"
 
   # Bounded so the names built from it fit their own limits: `margince_dev_<slug>`
   # (Postgres caps an identifier at 63 bytes) and `margince-dev-<slug>` (S3 caps a

--- a/scripts/lib-devstate.sh
+++ b/scripts/lib-devstate.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Where a dev stack's identity comes from, spelled once for every script that
+# needs it. Source this; don't execute it.
+#
+# There are three writers of this invariant — dev.sh starts a stack, dev-logs.sh
+# reads its log, and the test suite checks both — and the first version of the
+# per-worktree change had dev.sh alone knowing the answer. dev-logs.sh kept
+# composing the old path, so `make dev-logs` looked for a file `make dev` no
+# longer wrote. That is the failure this file exists to make impossible: one
+# spelling, sourced, rather than three that happen to agree.
+
+# The registry and log root. ONE directory per machine, deliberately outside the
+# repository: it used to be <worktree>/.tmp/dev/, so a second worktree read an
+# empty registry and claimed a Redis logical database that was already in use.
+# Two stacks then shared one consumer group and quietly ate each other's events.
+#
+# MARGINCE_DEV_STATE_DIR exists so the tests can point this somewhere
+# disposable. Nothing else should set it.
+dev_state_root() {
+  printf '%s' "${MARGINCE_DEV_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/margince/dev}"
+}
+
+# The primary worktree's stack has no slug, so its state directory needs a name
+# anyway. It is reserved: DEV_SLUG may not take it, or two stacks would share one
+# directory and each stop would remove the other's pids and claim.
+DEV_BASE_SLUG_DIR=_base
+
+# A slug reaches four places that each refuse different characters: a filesystem
+# path, a CREATE DATABASE identifier, an S3 bucket name, and a Redis key prefix.
+# Fold to the narrowest of them rather than validating in four places — a branch
+# or directory name is the usual source, and `feat/ai-keys` is an ordinary one.
+#
+# Underscore folds to a hyphen rather than surviving, and that is not cosmetic:
+# the bucket name has to be derived from the slug INJECTIVELY. While `_` was
+# legal in a slug and illegal in a bucket, `a_b` and `a-b` were two worktrees
+# sharing one bucket — the same defect as a shared Redis database, in the store
+# that holds attachment bytes. With `_` gone from the slug alphabet the mapping
+# is the prefix and nothing else, so it cannot collide.
+dev_sanitize_slug() { # name → a slug matching ^[a-z0-9-]+$
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-*$//'
+}
+
+# The bucket holding attachment and transcript bytes, one per stack. It was a
+# single name for every stack, so two worktrees wrote each other's object bytes
+# into one place. blobstore.New creates a missing bucket, so a new name needs no
+# infra change.
+#
+# The slug alphabet is already S3-legal (see dev_sanitize_slug), so this is a
+# prefix and nothing more — an injective mapping by construction rather than by
+# a substitution that could fold two slugs together.
+dev_bucket_for_slug() { # slug → an S3-legal bucket name
+  local slug="$1"
+  if [[ -z "$slug" ]]; then
+    printf 'margince-dev'
+    return 0
+  fi
+  printf 'margince-dev-%s' "$slug"
+}
+
+# The PRIMARY worktree keeps the shared stack — database `margince` on :8080,
+# Redis db 0 — because `make migrate`, `make seed-dev` and `make verify-boot`
+# target that database by name.
+#
+# A LINKED worktree gets its own everything, named after itself, with no flag to
+# remember: an engineer runs several agent sessions, one worktree each, and none
+# of them should have to know DEV_SLUG exists.
+#
+# The primary/linked test is the git directory, not the path: in a linked
+# worktree --absolute-git-dir is <common>/worktrees/<name> and differs from
+# --git-common-dir. The latter can print a relative path, so it is resolved
+# before the comparison.
+dev_derive_slug() { # → "" in the primary worktree, this worktree's name in a linked one
+  local gitdir commondir
+  gitdir=$(git rev-parse --absolute-git-dir) || return 1
+  commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P) || return 1
+  [[ "$gitdir" == "$commondir" ]] && return 0
+  dev_sanitize_slug "$(basename "$(git rev-parse --show-toplevel)")"
+}
+
+# dev_resolve_slug [supplied] — the slug this invocation runs under.
+#
+# An explicit value always wins and is VALIDATED rather than sanitised: silently
+# rewriting what somebody typed would point them at a database they did not name.
+# `_base` is refused because it is the primary stack's own directory.
+dev_resolve_slug() { # [supplied] → slug on stdout
+  local supplied="${1:-}"
+  if [[ -z "$supplied" ]]; then
+    dev_derive_slug
+    return
+  fi
+  if ! [[ "$supplied" =~ ^[a-z0-9-]+$ ]]; then
+    echo "FAIL: DEV_SLUG must match ^[a-z0-9-]+$ (got '$supplied'). Use a hyphen where you would write an underscore — the slug also names an S3 bucket, which admits no underscore." >&2
+    return 1
+  fi
+  if [[ "$supplied" == "$DEV_BASE_SLUG_DIR" ]]; then
+    echo "FAIL: DEV_SLUG=${DEV_BASE_SLUG_DIR} is reserved for the primary worktree's own stack — pick another name, or drop DEV_SLUG to use that stack." >&2
+    return 1
+  fi
+  printf '%s' "$supplied"
+}
+
+# dev_state_dir SLUG — where this stack's log, pids and claim live.
+dev_state_dir() { # slug
+  printf '%s/%s' "$(dev_state_root)" "${1:-$DEV_BASE_SLUG_DIR}"
+}
+
+# dev_app_base_url — the URL this worktree's stack actually serves the app on.
+#
+# `make seed-dev` and `make verify-boot` both defaulted to :8080, which was the
+# only answer while there was one stack. From a linked worktree it is the wrong
+# one: `make dev` there serves a claimed port against `margince_dev_<slug>`, so
+# seeding :8080 either seeds the PRIMARY worktree's stack — silently, with the
+# records landing in a database nobody was looking at — or fails against nothing.
+#
+# Falls back to :8080 when this worktree has no recorded stack, which keeps the
+# primary worktree and CI on the URL they already use.
+dev_app_base_url() {
+  local slug port FE_PORT
+  slug="$(dev_resolve_slug "${DEV_SLUG:-}")" || return 1
+  port=8080
+  local env_file
+  env_file="$(dev_state_dir "$slug")/env"
+  if [[ -f "$env_file" ]]; then
+    FE_PORT=''
+    # shellcheck disable=SC1090
+    . "$env_file"
+    [[ -n "$FE_PORT" ]] && port="$FE_PORT"
+  fi
+  printf 'http://localhost:%s' "$port"
+}
+
+# dev_database_name — the Postgres database THIS worktree's stack runs against.
+#
+# The SQL half of `make seed-dev` (seed-dev.sql, seed-reset.sql) goes through
+# psql with an explicit -d, and that was `margince` for everyone. Once `make dev`
+# in a linked worktree started using margince_dev_<slug>, the two halves of one
+# seed landed in two different databases: the API records in the worktree's, the
+# fixture rows in the primary's. It surfaced as a NOT NULL violation on
+# app_user.workspace_id — the fixture ran against a database whose demo workspace
+# the API half had never created.
+dev_database_name() {
+  local slug
+  slug="$(dev_resolve_slug "${DEV_SLUG:-}")" || return 1
+  if [[ -z "$slug" ]]; then
+    printf 'margince'
+    return 0
+  fi
+  printf 'margince_dev_%s' "$slug"
+}

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -169,6 +169,10 @@ declare_lane_budget() {
 # would. That is a different constraint from dev.sh's bucket_for_slug, which
 # folds the other way for S3 — so the two expressions stay separate rather than
 # being unified into one helper that would be wrong for both.
+# An answer of "" means the shared `margince_test`, which is also the right
+# answer when the question cannot be asked: a tree with no git (a source tarball,
+# a container that copied the files in) has no worktrees to collide over, so
+# falling back to the shared name is correct rather than merely quiet.
 _testdb_worktree_slug() {
   local gitdir commondir
   gitdir=$(git rev-parse --absolute-git-dir 2>/dev/null) || return 0

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -192,8 +192,12 @@ _testdb_worktree_slug() {
   # a directory of pure punctuation does — the answer carries a digest of the full
   # PATH instead of the name alone. Truncating without one would map every name
   # sharing its first 49 characters onto a single template.
+  # sha256, not shasum's default sha1. This digest only disambiguates two
+  # directory names, so the strength is irrelevant to what it does — but a weak
+  # hash in the tree is a security finding whatever it is used for, and arguing
+  # the exception costs more than the flag.
   local digest
-  digest="$(printf '%s' "$raw" | shasum | cut -c1-8)"
+  digest="$(printf '%s' "$raw" | shasum -a 256 | cut -c1-8)"
   if (( ${#name} == 0 )); then
     printf 'wt_%s' "$digest"
     return 0

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -174,13 +174,35 @@ declare_lane_budget() {
 # a container that copied the files in) has no worktrees to collide over, so
 # falling back to the shared name is correct rather than merely quiet.
 _testdb_worktree_slug() {
-  local gitdir commondir
+  local gitdir commondir raw name
   gitdir=$(git rev-parse --absolute-git-dir 2>/dev/null) || return 0
   commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P) || return 0
   [[ "$gitdir" == "$commondir" ]] && return 0
-  basename "$(git rev-parse --show-toplevel)" \
+
+  # The full path, not the basename, is what identifies a worktree: two
+  # checkouts can both hold `.../worktrees/feature`, and a basename would give
+  # them one template to rebuild under each other.
+  raw="$(git rev-parse --show-toplevel)"
+  name="$(basename "$raw" \
     | tr '[:upper:]' '[:lower:]' \
-    | sed 's/[^a-z0-9_]/_/g; s/__*/_/g; s/^_//; s/_*$//'
+    | sed 's/[^a-z0-9_]/_/g; s/__*/_/g; s/^_//; s/_*$//')"
+
+  # `margince_test_` + this must fit Postgres's 63-byte identifier limit, so the
+  # budget here is 49. Over it — or when the name sanitises away to nothing, which
+  # a directory of pure punctuation does — the answer carries a digest of the full
+  # PATH instead of the name alone. Truncating without one would map every name
+  # sharing its first 49 characters onto a single template.
+  local digest
+  digest="$(printf '%s' "$raw" | shasum | cut -c1-8)"
+  if (( ${#name} == 0 )); then
+    printf 'wt_%s' "$digest"
+    return 0
+  fi
+  if (( ${#name} > 49 )); then
+    printf '%s_%s' "${name:0:40}" "$digest"
+    return 0
+  fi
+  printf '%s' "$name"
 }
 _testdb_slug="$(_testdb_worktree_slug)"
 export TEMPLATE_NAME="${TEMPLATE_NAME:-margince_test${_testdb_slug:+_${_testdb_slug}}}"

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -39,7 +39,6 @@ parse_test_dsn() {
   local o_tail="${o_body#*/}"                 # db?query  (or db)
   local o_db="${o_tail%%\?*}"
   O_QUERY=""; [[ "$o_tail" != "$o_db" ]] && O_QUERY="${o_tail#*\?}"
-  TEMPLATE_DB="$o_db"
 
   # App: same peel; the app credentials/host are preserved, only the db swaps.
   local a_body="${app#*://}"
@@ -47,7 +46,7 @@ parse_test_dsn() {
   local a_tail="${a_body#*/}"
   A_QUERY=""; local a_db="${a_tail%%\?*}"; [[ "$a_tail" != "$a_db" ]] && A_QUERY="${a_tail#*\?}"
 
-  export O_PREFIX O_QUERY A_PREFIX A_QUERY TEMPLATE_DB
+  export O_PREFIX O_QUERY A_PREFIX A_QUERY
 }
 
 # db_admin verb [flags…] — create/drop/probe databases through cmd/migrate's

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -148,7 +148,39 @@ declare_lane_budget() {
 
 # The migrated template every per-package clone is copied from. Exported so the
 # xargs -P worker subshells (fresh bash processes) see it — make_clone reads it.
-export TEMPLATE_NAME="${TEMPLATE_NAME:-margince_test}"
+#
+# ONE template per machine was a cross-session collision, not a saving. This
+# tree is worked in several git worktrees at once by design, and build_template
+# recreates the template from scratch: a parallel session on another branch
+# rebuilds it underneath you, and your lane then fails wholesale with
+# schema-shaped errors that read as your own migration being broken. A linked
+# worktree therefore gets its own template, named after itself.
+#
+# The PRIMARY worktree — and CI, which has no linked worktree — keeps
+# `margince_test` unchanged, so nothing about the existing lane moves.
+#
+# Per WORKTREE rather than per migration-set hash on purpose: migrate_template
+# migrates an EXISTING template up incrementally, which is what keeps the
+# migration-authoring inner loop fast. A content-addressed name would throw that
+# away, since every migration edit would name a database that does not exist yet
+# and rebuild the whole schema from scratch.
+#
+# Underscores, not hyphens: this name is only ever a Postgres identifier, and
+# `margince_test_cfg_retire` needs no quoting where `margince_test_cfg-retire`
+# would. That is a different constraint from dev.sh's bucket_for_slug, which
+# folds the other way for S3 — so the two expressions stay separate rather than
+# being unified into one helper that would be wrong for both.
+_testdb_worktree_slug() {
+  local gitdir commondir
+  gitdir=$(git rev-parse --absolute-git-dir 2>/dev/null) || return 0
+  commondir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P) || return 0
+  [[ "$gitdir" == "$commondir" ]] && return 0
+  basename "$(git rev-parse --show-toplevel)" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9_]/_/g; s/__*/_/g; s/^_//; s/_*$//'
+}
+_testdb_slug="$(_testdb_worktree_slug)"
+export TEMPLATE_NAME="${TEMPLATE_NAME:-margince_test${_testdb_slug:+_${_testdb_slug}}}"
 
 owner_clone_dsn() { local db="$1"; echo "${O_PREFIX}/${db}${O_QUERY:+?$O_QUERY}"; }
 app_clone_dsn()   { local db="$1"; echo "${A_PREFIX}/${db}${A_QUERY:+?$A_QUERY}"; }

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -19,7 +19,12 @@
 
 set -euo pipefail
 
-API_BASE="${API_BASE:-http://localhost:8080}"
+# The stack THIS worktree runs, not whatever holds :8080 — from a linked
+# worktree those are different, and seeding the wrong one puts the records in a
+# database nobody is looking at. An explicit API_BASE still wins.
+# shellcheck source=scripts/lib-devstate.sh
+. "$(git rev-parse --show-toplevel)/scripts/lib-devstate.sh"
+API_BASE="${API_BASE:-$(dev_app_base_url)}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@demo.test}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
 # What the operator put in margince.yaml. Only ever used for the one login that

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -105,6 +105,28 @@ port_listeners() { # port
 
 echo "dev.sh: the registry is machine-global, so a second worktree sees the first"
 
+# The DEFAULT location, checked before anything overrides it. Every assertion
+# below points the root at a temp directory, so without this one the whole file
+# would keep passing after somebody moved the default back under the worktree —
+# and a per-worktree default is the entire defect. What matters is not the exact
+# path but that it is not INSIDE this checkout, because a path inside it is
+# per-worktree by construction however it is spelled.
+default_root="$(dev_state_root)"
+default_verdict=shared
+case "$default_root" in
+    # Inside the checkout: per-worktree by construction.
+    "$root"/*) default_verdict="inside the checkout ($default_root)" ;;
+    # RELATIVE: dev.sh cds to the worktree top before using it, so a relative
+    # path is per-worktree too — and it is the spelling the old code used
+    # (`.tmp/dev`). Checking only for "not under $root" would call that clean,
+    # which is how this very assertion first passed over the defect it exists
+    # to catch.
+    /*) default_verdict=shared ;;
+    *) default_verdict="relative, so resolved per worktree ($default_root)" ;;
+esac
+check "shared" "$default_verdict" \
+      "the default registry is one absolute path per machine, not one per worktree"
+
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "$tmp_root"' EXIT
 export MARGINCE_DEV_STATE_DIR="$tmp_root"

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# test-dev-isolation.sh — prove two worktrees get two stacks.
+#
+# The defect this exists for: the registry that hands out Redis logical
+# databases used to live under the WORKTREE's own .tmp/dev/, so a second
+# worktree read an empty registry and claimed database 64 as well. Two stacks
+# then shared one consumer group, and whichever worker read an event first
+# resolved it against its own database, found nothing, and acked it. The other
+# stack's event was gone — and a projection that never runs is indistinguishable
+# from a broken feature.
+#
+# Every function under test is LIFTED from scripts/dev.sh rather than
+# reimplemented here, the way test-dev-dsn.sh does it: a copy would prove
+# nothing about production.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+dev="$root/scripts/dev.sh"
+failures=0
+
+check() { # want got description
+    if [ "$1" = "$2" ]; then
+        printf '  ok   %s\n' "$3"
+    else
+        printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# lift NAME — eval one function out of dev.sh, so every check below exercises
+# production rather than a copy of it.
+#
+# awk rather than the `sed -n '/^name() {/,/^}$/p'` idiom test-dev-dsn.sh uses:
+# that idiom needs the function name written as a literal inside single quotes,
+# and this one takes it as an argument. Interpolating it means double quotes,
+# and macOS ships bash 3.2, which brace-expands the `{/,/^}` in that pattern
+# even when it is double-quoted — sed then receives two mangled programs, prints
+# nothing, and every lifted function is silently missing. A test whose subject
+# failed to load still runs, which is the part that makes it worth avoiding.
+lift() { # function name
+    eval "$(awk -v fn="$1" '
+        index($0, fn "() ") == 1 { inside = 1 }
+        inside                   { print }
+        inside && $0 == "}"      { exit }
+    ' "$dev")"
+}
+
+lift sanitize_slug
+
+echo "dev.sh: a slug is safe for a path and for CREATE DATABASE"
+
+check "cfg-retire" "$(sanitize_slug "cfg-retire")" \
+      "an already-legal name is unchanged"
+check "feat-ai-keys" "$(sanitize_slug "feat/ai-keys")" \
+      "a slash becomes a hyphen — a slug reaches the filesystem"
+check "abc" "$(sanitize_slug "ABC")" \
+      "uppercase is folded — Postgres would fold it anyway"
+check "a-b" "$(sanitize_slug "a...b")" \
+      "a run of illegal characters collapses to one hyphen"
+check "ab" "$(sanitize_slug "-ab-")" \
+      "no leading or trailing hyphen"
+
+# lift_const NAME — eval one top-level assignment out of dev.sh.
+#
+# The block bounds are READ from production rather than restated here. A test
+# that carried its own copy of "64..79" would keep passing unchanged after
+# somebody widened the block in dev.sh, and would then be asserting a range that
+# no longer exists — a gate that fails short reports PASS over a smaller subject
+# and there is nothing to notice.
+lift_const() { # name
+    eval "$(grep -m1 "^$1=" "$dev")"
+}
+
+lift bucket_for_slug
+
+echo "dev.sh: attachment bytes are not shared between stacks"
+
+check "margince-dev" "$(bucket_for_slug "")" \
+      "the primary worktree keeps the bucket it already has"
+check "margince-dev-cfg-retire" "$(bucket_for_slug "cfg-retire")" \
+      "a linked worktree gets its own"
+check "margince-dev-a-b" "$(bucket_for_slug "a_b")" \
+      "an underscore becomes a hyphen — S3 bucket names admit no underscore, slugs do"
+
+lift dev_state_root
+lift read_registry
+lift pick_free_db
+lift pick_free_port
+lift_const DEV_REDIS_DB_MIN
+lift_const DEV_REDIS_DB_MAX
+lift_const DEV_FE_PORT_MIN
+lift_const DEV_FE_PORT_MAX
+lift_const DEV_API_PORT_OFFSET
+
+# port_listeners asks the OS what is bound. It is stubbed here — the one true
+# boundary in this file — so the claim logic is checked against a KNOWN machine
+# rather than against whatever happens to hold :8082 on the developer's laptop.
+# A test that consults the real port table would pass or fail by coincidence,
+# and the specific coincidence (someone else's dev server) is common.
+listener_on=''
+port_listeners() { # port
+    [[ "$1" == "$listener_on" ]] && echo 4242
+    return 0
+}
+
+echo "dev.sh: the registry is machine-global, so a second worktree sees the first"
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+export MARGINCE_DEV_STATE_DIR="$tmp_root"
+
+check "$tmp_root" "$(dev_state_root)" \
+      "MARGINCE_DEV_STATE_DIR overrides the root — without it nothing here is testable"
+
+# One worktree's stack, recorded the way dev.sh records it.
+mkdir -p "$tmp_root/first"
+printf 'SLUG=first\nFE_PORT=8081\nAPI_PORT=18081\nREDIS_DB=64\n' >"$tmp_root/first/env"
+
+read_registry second
+check "64" "$TAKEN_DBS" "the registry reports the other stack's Redis database"
+check "8081" "$TAKEN_PORTS" "and its frontend port"
+check "65" "$(pick_free_db)" \
+      "a second stack takes the next free Redis database, never 64 again"
+check "8082" "$(pick_free_port)" \
+      "and the next free port"
+
+# The same slug reclaims its own, so a restart keeps its URL and its streams.
+read_registry first
+check "64" "$MINE_DB" "the slug's own recorded Redis database is reclaimed"
+check "8081" "$MINE_PORT" "and its own port"
+
+# The registry only knows about OUR stacks. A foreign listener must still take a
+# port out of play, or bind fails and wait_ready polls somebody else's server.
+listener_on=8082
+read_registry second
+check "8083" "$(pick_free_port)" \
+      "a port with a foreign listener is skipped even though no stack claims it"
+listener_on=''
+
+# The blocks are finite. Running out must refuse rather than double up: a shared
+# bus is the silent failure this whole mechanism exists to prevent.
+rm -rf "$tmp_root"/*
+for i in $(seq "$DEV_REDIS_DB_MIN" "$DEV_REDIS_DB_MAX"); do
+    mkdir -p "$tmp_root/s$i"
+    printf 'SLUG=s%s\nFE_PORT=%s\nREDIS_DB=%s\n' "$i" "$((8000 + i))" "$i" >"$tmp_root/s$i/env"
+done
+read_registry newcomer
+check "" "$(pick_free_db || true)" \
+      "every Redis database claimed → pick_free_db yields nothing rather than reusing one"
+check "1" "$(pick_free_db >/dev/null 2>&1; echo $?)" \
+      "and it reports failure rather than returning success with an empty answer"
+
+if [ "$failures" -gt 0 ]; then
+    printf 'FAIL: %d check(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'OK: dev isolation checks passed\n'

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -116,11 +116,25 @@ echo "lib-devstate.sh: every half of a seed resolves the SAME stack"
 # violation on app_user.workspace_id, which reads as a broken fixture rather than
 # as two halves pointing at two databases.
 probe_state="$(mktemp -d)"
-MARGINCE_DEV_STATE_DIR="$probe_state" DEV_SLUG=alpha \
-    bash -c '. "'"$root"'/scripts/lib-devstate.sh"; printf "%s %s" "$(dev_app_base_url)" "$(dev_database_name)"' \
-    > "$probe_state/answer"
-check "http://localhost:8080 margince_dev_alpha" "$(cat "$probe_state/answer")" \
-      "with no recorded stack the URL falls back to :8080 but the database is still the slug's own"
+
+# No recorded stack, and a slug: there is no URL to fall back to. :8080 belongs to
+# a DIFFERENT stack, so answering it would send the API half of a seed there while
+# the database half goes to margince_dev_<slug> — the split this pair exists to
+# close. Refusing is the only honest answer.
+check "1" "$(MARGINCE_DEV_STATE_DIR="$probe_state" DEV_SLUG=alpha \
+    bash -c '. "'"$root"'/scripts/lib-devstate.sh"; dev_app_base_url' >/dev/null 2>&1; echo $?)" \
+      "with no recorded stack a linked worktree gets a refusal, not :8080"
+
+# The PRIMARY worktree is the exception, and not by special-casing: its stack is
+# the shared one and its port is fixed, so :8080 is the answer rather than a guess.
+# Checked from a real primary repository — DEV_SLUG='' cannot fake it, because an
+# empty value is exactly what makes dev_resolve_slug ask the worktree.
+primary_probe="$(mktemp -d)"
+git init -q "$primary_probe/repo"
+check "http://localhost:8080" "$(cd "$primary_probe/repo" && \
+    MARGINCE_DEV_STATE_DIR="$probe_state" bash -c '. "'"$root"'/scripts/lib-devstate.sh"; dev_app_base_url')" \
+      "the primary worktree still answers :8080 with nothing recorded"
+rm -rf "$primary_probe"
 
 mkdir -p "$probe_state/alpha"
 printf 'SLUG=alpha\nFE_PORT=8093\nAPI_PORT=18093\nREDIS_DB=70\n' >"$probe_state/alpha/env"
@@ -296,6 +310,25 @@ check "" "$(cd "$probe/primary" && _testdb_worktree_slug)" \
       "a primary worktree yields no slug, so CI and the main checkout keep margince_test"
 check "linked" "$(cd "$probe/linked" && _testdb_worktree_slug)" \
       "a linked worktree yields its own name, so a parallel branch cannot rebuild your template"
+
+# dev_derive_slug, in the same throwaway repositories. An empty answer means THE
+# PRIMARY worktree, so a linked worktree must never produce one: a name that
+# sanitises away to nothing would put it on the shared margince database and
+# :8080 — the collision this mechanism removes, arrived at from the other end.
+# `_` is such a name: the underscore folds to a hyphen and the hyphen is trimmed.
+git -C "$probe/primary" worktree add -q "$probe/_" --detach
+check "" "$(dev_sanitize_slug "_")" \
+      "the sanitiser really does reduce this name to nothing, which is what makes the next check the real case"
+check "1" "$([ -n "$(cd "$probe/_" && dev_derive_slug)" ] && echo 1 || echo 0)" \
+      "a name that sanitises to nothing still yields a slug, never the empty answer that means primary"
+
+# Two worktrees whose basenames are identical must not share one slug: that would
+# be one database, one Redis logical database and one bucket between two stacks.
+mkdir -p "$probe/a" "$probe/b"
+git -C "$probe/primary" worktree add -q "$probe/a/dup" --detach
+git -C "$probe/primary" worktree add -q "$probe/b/dup" --detach
+check "1" "$([ "$(cd "$probe/a/dup" && dev_derive_slug)" != "$(cd "$probe/b/dup" && dev_derive_slug)" ] && echo 1 || echo 0)" \
+      "two worktrees with the SAME basename get different slugs, so they cannot share a database"
 
 long_one="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && _testdb_worktree_slug)"
 long_two="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-two" && _testdb_worktree_slug)"

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -172,6 +172,33 @@ check "" "$(pick_free_db || true)" \
 check "1" "$(pick_free_db >/dev/null 2>&1; echo $?)" \
       "and it reports failure rather than returning success with an empty answer"
 
+echo "lib-testdb.sh: the integration lane's template is per worktree"
+
+# Lifted from lib-testdb.sh for the same reason everything above is lifted from
+# dev.sh. Exercised inside a THROWAWAY repository rather than this one, because
+# the answer depends on whether the caller sits in a primary worktree or a
+# linked one, and this checkout can only ever be one of the two.
+testdb="$root/scripts/lib-testdb.sh"
+eval "$(awk '
+    index($0, "_testdb_worktree_slug() ") == 1 { inside = 1 }
+    inside                                     { print }
+    inside && $0 == "}"                        { exit }
+' "$testdb")"
+
+probe="$(mktemp -d)"
+git init -q "$probe/primary"
+(
+    cd "$probe/primary"
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    git worktree add -q "$probe/linked" --detach
+)
+
+check "" "$(cd "$probe/primary" && _testdb_worktree_slug)" \
+      "a primary worktree yields no slug, so CI and the main checkout keep margince_test"
+check "linked" "$(cd "$probe/linked" && _testdb_worktree_slug)" \
+      "a linked worktree yields its own name, so a parallel branch cannot rebuild your template"
+rm -rf "$probe"
+
 if [ "$failures" -gt 0 ]; then
     printf 'FAIL: %d check(s) failed\n' "$failures" >&2
     exit 1

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -313,9 +313,9 @@ git init -q "$probe/primary"
     git worktree add -q "$probe/$(printf 'w%.0s' $(seq 1 60))-two" --detach
 )
 
-check "" "$(cd "$probe/primary" && _testdb_worktree_slug)" \
+check "" "$(cd "$probe/primary" || exit 1; _testdb_worktree_slug)" \
       "a primary worktree yields no slug, so CI and the main checkout keep margince_test"
-check "linked" "$(cd "$probe/linked" && _testdb_worktree_slug)" \
+check "linked" "$(cd "$probe/linked" || exit 1; _testdb_worktree_slug)" \
       "a linked worktree yields its own name, so a parallel branch cannot rebuild your template"
 
 # dev_derive_slug, in the same throwaway repositories. An empty answer means THE
@@ -326,7 +326,7 @@ check "linked" "$(cd "$probe/linked" && _testdb_worktree_slug)" \
 git -C "$probe/primary" worktree add -q "$probe/_" --detach
 check "" "$(dev_sanitize_slug "_")" \
       "the sanitiser really does reduce this name to nothing, which is what makes the next check the real case"
-check "1" "$([ -n "$(cd "$probe/_" && dev_derive_slug)" ] && echo 1 || echo 0)" \
+check "1" "$([ -n "$(cd "$probe/_" || exit 1; dev_derive_slug)" ] && echo 1 || echo 0)" \
       "a name that sanitises to nothing still yields a slug, never the empty answer that means primary"
 
 # Two worktrees whose basenames are identical must not share one slug: that would
@@ -334,26 +334,38 @@ check "1" "$([ -n "$(cd "$probe/_" && dev_derive_slug)" ] && echo 1 || echo 0)" 
 mkdir -p "$probe/a" "$probe/b"
 git -C "$probe/primary" worktree add -q "$probe/a/dup" --detach
 git -C "$probe/primary" worktree add -q "$probe/b/dup" --detach
-check "1" "$([ "$(cd "$probe/a/dup" && dev_derive_slug)" != "$(cd "$probe/b/dup" && dev_derive_slug)" ] && echo 1 || echo 0)" \
+check "1" "$([ "$(cd "$probe/a/dup" || exit 1; dev_derive_slug)" != "$(cd "$probe/b/dup" || exit 1; dev_derive_slug)" ] && echo 1 || echo 0)" \
       "two worktrees with the SAME basename get different slugs, so they cannot share a database"
 
 # A slug must be STABLE for as long as a stack runs. An earlier version appended
 # the digest only when a twin existed, so creating a second worktree of the same
 # name RENAMED a running stack — and dev-stop then resolved a slug with no record
 # and could not stop it. The slug must not depend on what else exists.
-slug_before="$(cd "$probe/linked" && dev_derive_slug)"
+slug_before="$(cd "$probe/linked" || exit 1; dev_derive_slug)"
 git -C "$probe/primary" worktree add -q "$probe/c/linked" --detach
-check "$slug_before" "$(cd "$probe/linked" && dev_derive_slug)" \
+check "$slug_before" "$(cd "$probe/linked" || exit 1; dev_derive_slug)" \
       "adding a same-named worktree does NOT rename an existing one — a running stack stays stoppable"
+
+# And moving the checkout does not rename it either. The slug comes from the
+# worktree's ADMIN name under <common>/worktrees/, which git keeps across
+# `git worktree move` — a path-derived slug changed here, so relocating a checkout
+# renamed a running stack and dev-stop then missed its claim.
+git -C "$probe/primary" worktree move "$probe/linked" "$probe/linked-moved"
+check "$slug_before" "$(cd "$probe/linked-moved" || exit 1; dev_derive_slug)" \
+      "moving a worktree does NOT rename it, so a running stack survives the move"
 
 # The slug becomes margince_dev_<slug> (Postgres caps an identifier at 63 bytes)
 # and margince-dev-<slug> (S3 caps a bucket name at 63), so it has to leave room
 # for both prefixes however long the directory name is.
-long_slug="$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && dev_derive_slug)"
+long_slug="$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" || exit 1; dev_derive_slug)"
 check "1" "$([ "${#long_slug}" -le 40 ] && echo 1 || echo 0)" \
       "a long directory name still yields a slug short enough for the database and bucket names built from it"
-check "1" "$([ "${#long_slug}" -gt 8 ] && echo 1 || echo 0)" \
-      "and it keeps enough of the name to be recognisable, not just the digest"
+case "$long_slug" in
+    www*) recognisable=1 ;;
+    *)    recognisable="digest only ($long_slug)" ;;
+esac
+check "1" "$recognisable" \
+      "and it still opens with the worktree's own name — a digest-only slug would pass a length check and tell a reader nothing"
 
 long_one="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && _testdb_worktree_slug)"
 long_two="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-two" && _testdb_worktree_slug)"

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -172,6 +172,26 @@ check "" "$(pick_free_db || true)" \
 check "1" "$(pick_free_db >/dev/null 2>&1; echo $?)" \
       "and it reports failure rather than returning success with an empty answer"
 
+echo "dev.sh: the state home is spelled once"
+
+# Every path under the state home must be composed from dev_state_root. This is
+# here because the lifted-function checks above structurally cannot see it: they
+# exercise pure functions, and the run directory is assigned at the top level.
+#
+# The defect it catches is not hypothetical — it is what shipped in the first
+# draft of this change. claim_stack wrote its reservation to the machine-global
+# registry while `rundir` still pointed at the worktree's own .tmp/dev/, so the
+# two were different files: the reservation carried ports and never the pids, and
+# the sweep read a directory only its own worktree could see. Both halves looked
+# right in isolation and the whole was worktree-blind, which is the defect this
+# change exists to remove.
+#
+# Comment lines are stripped first: the file explains the old location on
+# purpose, and that prose must stay.
+stray_state_paths=$(grep -vE '^[[:space:]]*#' "$dev" | grep -c '\.tmp/dev' || true)
+check "0" "$stray_state_paths" \
+      "no code line in dev.sh names .tmp/dev — the state home comes from dev_state_root"
+
 echo "lib-testdb.sh: the integration lane's template is per worktree"
 
 # Lifted from lib-testdb.sh for the same reason everything above is lifted from

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -9,9 +9,8 @@
 # stack's event was gone — and a projection that never runs is indistinguishable
 # from a broken feature.
 #
-# Every function under test is LIFTED from scripts/dev.sh rather than
-# reimplemented here, the way test-dev-dsn.sh does it: a copy would prove
-# nothing about production.
+# Every function under test is LIFTED from the scripts, or sourced from them,
+# rather than reimplemented here: a copy would prove nothing about production.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -45,21 +44,6 @@ lift() { # function name
     ' "$dev")"
 }
 
-lift sanitize_slug
-
-echo "dev.sh: a slug is safe for a path and for CREATE DATABASE"
-
-check "cfg-retire" "$(sanitize_slug "cfg-retire")" \
-      "an already-legal name is unchanged"
-check "feat-ai-keys" "$(sanitize_slug "feat/ai-keys")" \
-      "a slash becomes a hyphen — a slug reaches the filesystem"
-check "abc" "$(sanitize_slug "ABC")" \
-      "uppercase is folded — Postgres would fold it anyway"
-check "a-b" "$(sanitize_slug "a...b")" \
-      "a run of illegal characters collapses to one hyphen"
-check "ab" "$(sanitize_slug "-ab-")" \
-      "no leading or trailing hyphen"
-
 # lift_const NAME — eval one top-level assignment out of dev.sh.
 #
 # The block bounds are READ from production rather than restated here. A test
@@ -71,21 +55,87 @@ lift_const() { # name
     eval "$(grep -m1 "^$1=" "$dev")"
 }
 
-lift bucket_for_slug
+# The identity helper is SOURCED, not lifted: it is a library, and sourcing it is
+# what production does.
+# shellcheck source=scripts/lib-devstate.sh
+. "$root/scripts/lib-devstate.sh"
 
-echo "dev.sh: attachment bytes are not shared between stacks"
+echo "lib-devstate.sh: a slug is safe for a path, a database, and a bucket"
 
-check "margince-dev" "$(bucket_for_slug "")" \
+check "cfg-retire" "$(dev_sanitize_slug "cfg-retire")" \
+      "an already-legal name is unchanged"
+check "feat-ai-keys" "$(dev_sanitize_slug "feat/ai-keys")" \
+      "a slash becomes a hyphen — a slug reaches the filesystem"
+check "abc" "$(dev_sanitize_slug "ABC")" \
+      "uppercase is folded — Postgres would fold it anyway"
+check "a-b" "$(dev_sanitize_slug "a...b")" \
+      "a run of illegal characters collapses to one hyphen"
+check "ab" "$(dev_sanitize_slug "-ab-")" \
+      "no leading or trailing hyphen"
+check "a-b" "$(dev_sanitize_slug "a_b")" \
+      "an underscore folds to a hyphen, so the slug alphabet is already S3-legal"
+
+echo "lib-devstate.sh: attachment bytes are not shared between stacks"
+
+check "margince-dev" "$(dev_bucket_for_slug "")" \
       "the primary worktree keeps the bucket it already has"
-check "margince-dev-cfg-retire" "$(bucket_for_slug "cfg-retire")" \
+check "margince-dev-cfg-retire" "$(dev_bucket_for_slug "cfg-retire")" \
       "a linked worktree gets its own"
-check "margince-dev-a-b" "$(bucket_for_slug "a_b")" \
-      "an underscore becomes a hyphen — S3 bucket names admit no underscore, slugs do"
 
-lift dev_state_root
+# Injectivity is the property, not the spelling. While `_` was legal in a slug
+# and illegal in a bucket, `a_b` and `a-b` were two worktrees sharing one bucket
+# — the shared-Redis defect again, in the store holding attachment bytes.
+same=0
+for a in a-b a_b; do
+    for b in a-b a_b; do
+        [[ "$a" == "$b" ]] && continue
+        [[ "$(dev_bucket_for_slug "$(dev_sanitize_slug "$a")")" \
+           == "$(dev_bucket_for_slug "$(dev_sanitize_slug "$b")")" ]] && same=1
+    done
+done
+check "1" "$same" \
+      "two directory names differing only by _ vs - fold to ONE slug, so they cannot take two buckets that collide"
+
+echo "lib-devstate.sh: the primary stack's directory is reserved"
+
+check "1" "$(dev_resolve_slug "$DEV_BASE_SLUG_DIR" >/dev/null 2>&1; echo $?)" \
+      "DEV_SLUG=_base is refused — it is the primary worktree's own state directory"
+check "1" "$(dev_resolve_slug "Not A Slug" >/dev/null 2>&1; echo $?)" \
+      "an illegal DEV_SLUG is refused rather than silently rewritten"
+check "1" "$(dev_resolve_slug "has_underscore" >/dev/null 2>&1; echo $?)" \
+      "an underscore in an explicit DEV_SLUG is refused — the same name has to work as a bucket"
+check "mine" "$(dev_resolve_slug "mine")" \
+      "a legal DEV_SLUG is returned unchanged"
+
+echo "lib-devstate.sh: every half of a seed resolves the SAME stack"
+
+# `make seed-dev` has two halves — API calls against a base URL, and psql against
+# a database name — and they were resolved independently. Once a linked worktree
+# stopped using :8080 and `margince`, the API records went to the worktree's
+# database and the SQL fixture to the primary's. It surfaced as a NOT NULL
+# violation on app_user.workspace_id, which reads as a broken fixture rather than
+# as two halves pointing at two databases.
+probe_state="$(mktemp -d)"
+MARGINCE_DEV_STATE_DIR="$probe_state" DEV_SLUG=alpha \
+    bash -c '. "'"$root"'/scripts/lib-devstate.sh"; printf "%s %s" "$(dev_app_base_url)" "$(dev_database_name)"' \
+    > "$probe_state/answer"
+check "http://localhost:8080 margince_dev_alpha" "$(cat "$probe_state/answer")" \
+      "with no recorded stack the URL falls back to :8080 but the database is still the slug's own"
+
+mkdir -p "$probe_state/alpha"
+printf 'SLUG=alpha\nFE_PORT=8093\nAPI_PORT=18093\nREDIS_DB=70\n' >"$probe_state/alpha/env"
+MARGINCE_DEV_STATE_DIR="$probe_state" DEV_SLUG=alpha \
+    bash -c '. "'"$root"'/scripts/lib-devstate.sh"; printf "%s %s" "$(dev_app_base_url)" "$(dev_database_name)"' \
+    > "$probe_state/answer2"
+check "http://localhost:8093 margince_dev_alpha" "$(cat "$probe_state/answer2")" \
+      "once the stack is recorded both halves name it — the API base takes the claimed port"
+rm -rf "$probe_state"
+
+lift port_listeners
 lift read_registry
 lift pick_free_db
 lift pick_free_port
+lift claim_stack
 lift_const DEV_REDIS_DB_MIN
 lift_const DEV_REDIS_DB_MAX
 lift_const DEV_FE_PORT_MIN
@@ -109,14 +159,13 @@ echo "dev.sh: the registry is machine-global, so a second worktree sees the firs
 # below points the root at a temp directory, so without this one the whole file
 # would keep passing after somebody moved the default back under the worktree —
 # and a per-worktree default is the entire defect. What matters is not the exact
-# path but that it is not INSIDE this checkout, because a path inside it is
-# per-worktree by construction however it is spelled.
+# path but that it is one absolute path per machine.
 default_root="$(dev_state_root)"
 default_verdict=shared
 case "$default_root" in
     # Inside the checkout: per-worktree by construction.
     "$root"/*) default_verdict="inside the checkout ($default_root)" ;;
-    # RELATIVE: dev.sh cds to the worktree top before using it, so a relative
+    # RELATIVE: the scripts cd to the worktree top before using it, so a relative
     # path is per-worktree too — and it is the spelling the old code used
     # (`.tmp/dev`). Checking only for "not under $root" would call that clean,
     # which is how this very assertion first passed over the defect it exists
@@ -159,8 +208,34 @@ check "8083" "$(pick_free_port)" \
       "a port with a foreign listener is skipped even though no stack claims it"
 listener_on=''
 
+echo "dev.sh: claim_stack reserves before anything binds, and refuses rather than doubling up"
+
+# The whole allocation path, not its parts. The unit checks above can all pass
+# while the function that calls them is wired wrong — which is what happened: the
+# reservation went to the machine-global registry while the run directory still
+# pointed inside the worktree, so the two were different files.
+rm -rf "$tmp_root"/*
+claimed="$(claim_stack "alpha")"
+read -r alpha_db alpha_port <<<"$claimed"
+check "64" "$alpha_db" "the first stack claims the bottom of the Redis block"
+check "8081" "$alpha_port" "and the bottom of the port range"
+check "1" "$([ -f "$tmp_root/alpha/env" ] && echo 1 || echo 0)" \
+      "the reservation is on disk BEFORE anything binds — a claim visible only once the stack is up is not a claim"
+
+claimed="$(claim_stack "beta")"
+read -r beta_db beta_port <<<"$claimed"
+check "65" "$beta_db" "a second slug cannot be handed the first slug's Redis database"
+check "8082" "$beta_port" "nor its port"
+
+claimed="$(claim_stack "alpha")"
+read -r again_db again_port <<<"$claimed"
+check "$alpha_db $alpha_port" "$again_db $again_port" \
+      "the same slug reclaims exactly what it had, so a restart keeps its URL and its streams"
+
 # The blocks are finite. Running out must refuse rather than double up: a shared
-# bus is the silent failure this whole mechanism exists to prevent.
+# bus is the silent failure this whole mechanism exists to prevent. And the
+# refusal must be a non-zero STATUS, because dev.sh's caller acts on that — a
+# printed FAIL with a zero status let the stack start with no port at all.
 rm -rf "$tmp_root"/*
 for i in $(seq "$DEV_REDIS_DB_MIN" "$DEV_REDIS_DB_MAX"); do
     mkdir -p "$tmp_root/s$i"
@@ -171,33 +246,33 @@ check "" "$(pick_free_db || true)" \
       "every Redis database claimed → pick_free_db yields nothing rather than reusing one"
 check "1" "$(pick_free_db >/dev/null 2>&1; echo $?)" \
       "and it reports failure rather than returning success with an empty answer"
+check "1" "$(claim_stack newcomer >/dev/null 2>&1; echo $?)" \
+      "claim_stack propagates that refusal as a non-zero status, which is what stops the boot"
 
-echo "dev.sh: the state home is spelled once"
+unset MARGINCE_DEV_STATE_DIR
 
-# Every path under the state home must be composed from dev_state_root. This is
-# here because the lifted-function checks above structurally cannot see it: they
-# exercise pure functions, and the run directory is assigned at the top level.
+echo "the state home is spelled once, across every script that composes it"
+
+# Every script that needs the state home must get it from lib-devstate.sh. This
+# is here because the lifted checks above structurally cannot see it, and because
+# a one-file version of this check already missed the real defect: it greppped
+# dev.sh alone, so dev-logs.sh kept composing `.tmp/dev/<slug>/dev.log` and
+# `make dev-logs` looked for a file `make dev` no longer wrote — with a message
+# that named the wrong reason ("is the stack up?").
 #
-# The defect it catches is not hypothetical — it is what shipped in the first
-# draft of this change. claim_stack wrote its reservation to the machine-global
-# registry while `rundir` still pointed at the worktree's own .tmp/dev/, so the
-# two were different files: the reservation carried ports and never the pids, and
-# the sweep read a directory only its own worktree could see. Both halves looked
-# right in isolation and the whole was worktree-blind, which is the defect this
-# change exists to remove.
-#
-# Comment lines are stripped first: the file explains the old location on
-# purpose, and that prose must stay.
-stray_state_paths=$(grep -vE '^[[:space:]]*#' "$dev" | grep -c '\.tmp/dev' || true)
-check "0" "$stray_state_paths" \
-      "no code line in dev.sh names .tmp/dev — the state home comes from dev_state_root"
+# The corpus is every script in the tree, derived rather than listed, for the
+# reason the rulebook gives: a list of two paths stops describing the tree the
+# first time a third script needs the state home.
+stray=$(grep -rlE '^[^#]*\.tmp/dev' "$root/scripts" 2>/dev/null \
+        | grep -v 'test-dev-isolation.sh' | sort || true)
+check "" "$stray" \
+      "no script composes .tmp/dev itself — the state home comes from lib-devstate.sh"
 
 echo "lib-testdb.sh: the integration lane's template is per worktree"
 
-# Lifted from lib-testdb.sh for the same reason everything above is lifted from
-# dev.sh. Exercised inside a THROWAWAY repository rather than this one, because
-# the answer depends on whether the caller sits in a primary worktree or a
-# linked one, and this checkout can only ever be one of the two.
+# Lifted from lib-testdb.sh and exercised inside THROWAWAY repositories, because
+# the answer depends on whether the caller sits in a primary worktree or a linked
+# one, and this checkout can only ever be one of the two.
 testdb="$root/scripts/lib-testdb.sh"
 eval "$(awk '
     index($0, "_testdb_worktree_slug() ") == 1 { inside = 1 }
@@ -211,12 +286,23 @@ git init -q "$probe/primary"
     cd "$probe/primary"
     git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
     git worktree add -q "$probe/linked" --detach
+    # A name long enough that margince_test_<slug> would cross Postgres's 63-byte
+    # identifier limit, and a second one sharing its first 49 characters.
+    git worktree add -q "$probe/$(printf 'w%.0s' $(seq 1 60))-one" --detach
+    git worktree add -q "$probe/$(printf 'w%.0s' $(seq 1 60))-two" --detach
 )
 
 check "" "$(cd "$probe/primary" && _testdb_worktree_slug)" \
       "a primary worktree yields no slug, so CI and the main checkout keep margince_test"
 check "linked" "$(cd "$probe/linked" && _testdb_worktree_slug)" \
       "a linked worktree yields its own name, so a parallel branch cannot rebuild your template"
+
+long_one="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && _testdb_worktree_slug)"
+long_two="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-two" && _testdb_worktree_slug)"
+check "1" "$([ "${#long_one}" -le 63 ] && echo 1 || echo 0)" \
+      "a long worktree name still yields a template name inside Postgres's 63-byte identifier limit"
+check "1" "$([ "$long_one" != "$long_two" ] && echo 1 || echo 0)" \
+      "two long names sharing a prefix still get different templates, so neither rebuilds the other's schema"
 rm -rf "$probe"
 
 if [ "$failures" -gt 0 ]; then

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -337,6 +337,20 @@ git -C "$probe/primary" worktree add -q "$probe/b/dup" --detach
 check "1" "$([ "$(cd "$probe/a/dup" || exit 1; dev_derive_slug)" != "$(cd "$probe/b/dup" || exit 1; dev_derive_slug)" ] && echo 1 || echo 0)" \
       "two worktrees with the SAME basename get different slugs, so they cannot share a database"
 
+# And two whose names share only their FIRST 24 CHARACTERS. The readable half of a
+# slug is truncated to fit the database and bucket names built from it, so
+# uniqueness cannot depend on it — it has to come from the digest. Hashing the
+# clone alone was a regression exactly here: every worktree of one clone shares
+# that, so two long siblings folded onto one slug.
+git -C "$probe/primary" worktree add -q "$probe/$(printf 'p%.0s' $(seq 1 30))-alpha" --detach
+git -C "$probe/primary" worktree add -q "$probe/$(printf 'p%.0s' $(seq 1 30))-beta" --detach
+long_a="$(cd "$probe/$(printf 'p%.0s' $(seq 1 30))-alpha" || exit 1; dev_derive_slug)"
+long_b="$(cd "$probe/$(printf 'p%.0s' $(seq 1 30))-beta" || exit 1; dev_derive_slug)"
+check "1" "$([ "${long_a:0:24}" = "${long_b:0:24}" ] && echo 1 || echo 0)" \
+      "the two names really do share their first 24 characters, which is what makes the next check the real case"
+check "1" "$([ "$long_a" != "$long_b" ] && echo 1 || echo 0)" \
+      "and they still get different slugs — uniqueness lives in the digest, not the truncated name"
+
 # A slug must be STABLE for as long as a stack runs. An earlier version appended
 # the digest only when a twin existed, so creating a second worktree of the same
 # name RENAMED a running stack — and dev-stop then resolved a slug with no record

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -132,7 +132,8 @@ check "1" "$(MARGINCE_DEV_STATE_DIR="$probe_state" DEV_SLUG=alpha \
 primary_probe="$(mktemp -d)"
 git init -q "$primary_probe/repo"
 check "http://localhost:8080" "$(cd "$primary_probe/repo" && \
-    MARGINCE_DEV_STATE_DIR="$probe_state" bash -c '. "'"$root"'/scripts/lib-devstate.sh"; dev_app_base_url')" \
+    MARGINCE_DEV_STATE_DIR="$probe_state" DEV_SLUG='' \
+    bash -c '. "'"$root"'/scripts/lib-devstate.sh"; dev_app_base_url')" \
       "the primary worktree still answers :8080 with nothing recorded"
 rm -rf "$primary_probe"
 
@@ -229,12 +230,18 @@ echo "dev.sh: claim_stack reserves before anything binds, and refuses rather tha
 # reservation went to the machine-global registry while the run directory still
 # pointed inside the worktree, so the two were different files.
 rm -rf "$tmp_root"/*
+# dev.sh sets this in the shell that calls claim_stack — the reservation records
+# who is starting the stack, so a run that loses the port race cannot delete a
+# claim another run is still booting against.
+export STACK_STARTER_PID=$$
 claimed="$(claim_stack "alpha")"
 read -r alpha_db alpha_port <<<"$claimed"
 check "64" "$alpha_db" "the first stack claims the bottom of the Redis block"
 check "8081" "$alpha_port" "and the bottom of the port range"
 check "1" "$([ -f "$tmp_root/alpha/env" ] && echo 1 || echo 0)" \
       "the reservation is on disk BEFORE anything binds — a claim visible only once the stack is up is not a claim"
+check "1" "$(grep -c "^STARTER_PID=$$\$" "$tmp_root/alpha/env")" \
+      "and it records who is starting it, which is what stops a losing run deleting a winner's claim"
 
 claimed="$(claim_stack "beta")"
 read -r beta_db beta_port <<<"$claimed"
@@ -329,6 +336,24 @@ git -C "$probe/primary" worktree add -q "$probe/a/dup" --detach
 git -C "$probe/primary" worktree add -q "$probe/b/dup" --detach
 check "1" "$([ "$(cd "$probe/a/dup" && dev_derive_slug)" != "$(cd "$probe/b/dup" && dev_derive_slug)" ] && echo 1 || echo 0)" \
       "two worktrees with the SAME basename get different slugs, so they cannot share a database"
+
+# A slug must be STABLE for as long as a stack runs. An earlier version appended
+# the digest only when a twin existed, so creating a second worktree of the same
+# name RENAMED a running stack — and dev-stop then resolved a slug with no record
+# and could not stop it. The slug must not depend on what else exists.
+slug_before="$(cd "$probe/linked" && dev_derive_slug)"
+git -C "$probe/primary" worktree add -q "$probe/c/linked" --detach
+check "$slug_before" "$(cd "$probe/linked" && dev_derive_slug)" \
+      "adding a same-named worktree does NOT rename an existing one — a running stack stays stoppable"
+
+# The slug becomes margince_dev_<slug> (Postgres caps an identifier at 63 bytes)
+# and margince-dev-<slug> (S3 caps a bucket name at 63), so it has to leave room
+# for both prefixes however long the directory name is.
+long_slug="$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && dev_derive_slug)"
+check "1" "$([ "${#long_slug}" -le 40 ] && echo 1 || echo 0)" \
+      "a long directory name still yields a slug short enough for the database and bucket names built from it"
+check "1" "$([ "${#long_slug}" -gt 8 ] && echo 1 || echo 0)" \
+      "and it keeps enough of the name to be recognisable, not just the digest"
 
 long_one="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && _testdb_worktree_slug)"
 long_two="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-two" && _testdb_worktree_slug)"

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -403,9 +403,9 @@ fi
 # thinner run must never read as a passing one.
 echo "test-integration-parallel: $NTESTS tagged tests in $NPKGS_DISCOVERED packages; skipped $NUNTAGGED untagged (they run in \`make check\`)"
 if (( SHARD_TOTAL > 0 )); then
-  echo "test-integration-parallel: shard ${SHARD_IDX}/${SHARD_TOTAL} — $(wc -l < "$ASSIGNED" | tr -d ' ') of $NTESTS tests across $NPKGS packages, up to $JOBS concurrent (template db=$TEMPLATE_DB)"
+  echo "test-integration-parallel: shard ${SHARD_IDX}/${SHARD_TOTAL} — $(wc -l < "$ASSIGNED" | tr -d ' ') of $NTESTS tests across $NPKGS packages, up to $JOBS concurrent (template db=$TEMPLATE_NAME)"
 else
-  echo "test-integration-parallel: $NPKGS packages, up to $JOBS concurrent (template db=$TEMPLATE_DB)"
+  echo "test-integration-parallel: $NPKGS packages, up to $JOBS concurrent (template db=$TEMPLATE_NAME)"
 fi
 
 # One job = clone an empty db + own a private MinIO bucket, run that package

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -20,7 +20,12 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-API_BASE="${API_BASE:-http://localhost:8080}"
+# The stack THIS worktree runs, not whatever holds :8080 — from a linked
+# worktree those are different, and seeding the wrong one puts the records in a
+# database nobody is looking at. An explicit API_BASE still wins.
+# shellcheck source=scripts/lib-devstate.sh
+. "$(git rev-parse --show-toplevel)/scripts/lib-devstate.sh"
+API_BASE="${API_BASE:-$(dev_app_base_url)}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@demo.test}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
 


### PR DESCRIPTION
## Purpose

One dev stack per worktree, so several agent sessions can run at once — and
`make dev` stops destroying the other ones.

Isolation is by NAME, not by container: api/worker/vite stay host processes and
Postgres/Redis/MinIO stay one shared compose stack. A slug derived from the
worktree selects the database, the Redis logical database, the port pair, the
object bucket and the test template.

## Five defects, all of them silent

| Defect | Where it was |
|---|---|
| The registry handing out Redis logical databases lived under the **worktree's own** `.tmp/dev/`, so a second worktree read an empty registry and claimed database 64 again. Two stacks then shared one consumer group: whichever worker read an entry first resolved it against its own database, found nothing, and acked it. | `scripts/dev.sh` |
| Ports were **hashed** (`8080 + cksum(slug) % 1000`), not claimed. Two slugs whose hashes differed by a multiple of the block size took different ports and the SAME Redis database — a collision no port check can see. Redis got a claim registry; ports never did. | `scripts/dev.sh` |
| `MARGINCE_BLOBSTORE_BUCKET=margince-dev` was hardcoded at both call sites, so every stack wrote attachment bytes into one bucket. | `scripts/dev.sh` |
| A bare `make dev` **swept the machine** on the way up — every margince process, every recorded stack, every `margince_dev_*` database. The routine command was also the destructive one. | `scripts/dev.sh` |
| The integration lane shared one `margince_test` template per machine. `build_template` recreates it from scratch, so a parallel session on another branch rebuilt it underneath you and your lane failed wholesale with schema-shaped errors that read as your own migration being broken. | `scripts/lib-testdb.sh` |

The first one is the expensive one. `scripts/dev.sh` promised "a running stack's
db is never handed out twice"; across worktrees it did exactly that, and the
comment beside it records that the resulting silent event loss once cost a day
and a wrongly-filed critical bug.

## What changed

- **The registry is machine-global** — `$XDG_STATE_HOME/margince/dev/` — which is
  what makes the existing claim-under-lock logic mean anything across worktrees.
- **The slug comes from the worktree.** A linked worktree derives it from its own
  directory name; the primary worktree keeps `:8080` and the shared `margince`
  database, because `make migrate`, `make seed-dev` and `make verify-boot` target
  that database by name. `DEV_SLUG=` still overrides.
- **Ports are claimed, not hashed**, from 8081–8179 (api at +10000), under the
  same lock and recorded before anything binds — a claim only visible once the
  stack is up is not a claim. A port with a foreign listener is skipped, which a
  hash cannot do.
- **Per-stack object bucket.** `blobstore.New` creates a missing bucket, so no
  infra change.
- **`make dev` touches nobody else's stack**; `make dev-stop` stops this
  worktree's; the machine-wide clear is now `make dev-sweep`, asked for by name.
- **The test template is per worktree.** Named per worktree rather than per
  migration-set hash on purpose: `migrate_template` migrates an EXISTING template
  up incrementally, and content-addressing would rebuild the whole schema on every
  migration edit. The primary worktree and CI keep `margince_test` unchanged.

## Evidence

**Three stacks at once, on this machine, with another session's stack among them.**
`:8080` was a stack from a different session — the kind the old code killed. It
was still answering afterwards:

```
dev-isolation    FE_PORT=8081 REDIS_DB=64
probe-second     FE_PORT=8082 REDIS_DB=65

:8080 /readyz -> 200      (another session — survived my `make dev`)
:8081 /readyz -> 200
:8082 /readyz -> 200
```

Before this change both worktrees would have taken Redis database 64.
`make dev-stop` in one worktree then stopped only that stack and dropped only its
database, leaving the other two running.

**`make test-integration`** — `OK: integration passed with 0 skips (43 packages,
parallel)`, against `margince_test_dev_isolation`.

**`make check-backend`** — exit 0.

**Every new assertion was watched failing.** Five mutations, each red, each green
on restore: a relative state root, an absolute-but-inside-the-checkout state root,
dropping the same-slug reclaim, dropping the foreign-listener check, and
`pick_free_db` always answering the block floor.

Two of those mutations exist because the gate was blind first:

- The registry assertions all point the root at a temp directory through the
  override, so **none of them could see the default move back under the
  worktree** — which is the entire defect. The first version of the added check
  tested only for a path under the checkout, which calls a relative `.tmp/dev`
  clean: that is the spelling the old code actually used, so the assertion passed
  over the one case it existed to catch.
- `rundir` was **left pointing at `.tmp/dev/` in the first draft**, so the
  reservation carried ports and never the pids and the sweep read a directory
  only its own worktree could see. Both halves looked right in isolation and the
  whole was still worktree-blind. The lifted-function checks structurally cannot
  see that — they exercise pure functions and the run directory is assigned at
  the top level — so a gate that greps for a second spelling of the state home
  stands in for what they cannot reach. It was caught by running two stacks, not
  by the unit checks.

## Also fixed, same invariant

`scripts/test-integration-parallel.sh` printed `TEMPLATE_DB` — the database
segment of `MARGINCE_TEST_DSN` — while cloning from `TEMPLATE_NAME`. Identical
strings until the template became per-worktree, and then the banner reported one
template while the run used another. `TEMPLATE_DB` had no other caller, so it is
gone rather than kept in step.

## Known gap, deliberate

Nothing reaps a stale `margince_test_<slug>` template after its worktree is
deleted. `make dev-sweep DROP=1` drops `margince_dev_*` but not `margince_test_*`,
and widening it into the test namespace risks deleting the template a parallel
lane is actively cloning from. Left out rather than half-built.

## Migration note

A stack recorded under the old `<worktree>/.tmp/dev/` is invisible to the new
registry. Its processes are still caught by `sweep_stacks`'s pgrep arms, which
match on the binary name and a margince connection string rather than on a state
file, so `make dev-sweep` still stops it. Run it once after taking this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Development environments now use isolated ports, databases, Redis resources, and object storage for each worktree.
  - Added `make dev-sweep` to clean up all local development stacks.
  - Added `make dev-stop` to stop only the current worktree’s stack.
  - Added optional custom development slugs and worktree-specific service URLs, logs, and test databases.
  - Development startup now preserves other active worktree sessions.

- **Documentation**
  - Updated development workflow and command reference documentation.

- **Tests**
  - Added coverage for isolation, allocation, conflicts, and capacity limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->