### PR TITLE
fix(deals): the deal card's verdict survives the shape the model actually sends

### DIFF
--- a/backend/internal/compose/dealstatus/model.go
+++ b/backend/internal/compose/dealstatus/model.go
@@ -61,7 +61,7 @@ Each of "story", "blocker", "buyer" and "verdict.because" is a list of {"text":"
 "story" — what happened and where it leaves things, in the order it happened. Two to four sentences. Start with the thing a reader who has forgotten this deal most needs to know. Name people, dates and what was actually said.
 "blocker" — what is HOLDING THE DEAL UP, named as something somebody can act on: an unsent mail, a question nobody answered, a person who never replied, a decision nobody has asked for. One or two sentences. Return an empty list when nothing is holding it up. "Time has passed" is not a blocker; "she asked for times on 2 June and nobody sent them" is.
 "buyer" — what the buyer wants, read from what they have actually said: what they are optimising for, what they asked for, what they have NOT objected to. One or two sentences. Return an empty list when they have said too little to read honestly. Never guess at a motive the summary does not support.
-"verdict" — your honest call. "standing" is exactly one of: live (moving, with a next step both sides expect), drifting (nothing wrong, nothing happening, it dies of neglect if nobody acts), blocked (something specific is in the way, and you named it in "blocker"), cold (a long silence after real engagement — treat as lost unless something changes). "because" is one or two sentences saying what the call rests on. Be willing to say a deal is cold. A briefing that never delivers bad news is not read twice.
+"verdict" — your honest call. "standing" is exactly one of: live (moving, with a next step both sides expect), drifting (nothing wrong, nothing happening, it dies of neglect if nobody acts), blocked (something specific is in the way, and you named it in "blocker"), cold (a long silence after real engagement — treat as lost unless something changes). "because" is a LIST of one or two {"text","evidence"} objects saying what the call rests on — the same shape as "story", never a bare string. Be willing to say a deal is cold. A briefing that never delivers bad news is not read twice.
 "move_reason" — one sentence on why the recommended move is the right one now. The move itself is decided elsewhere and given to you in "recommended_move": explain it, never replace it.
 
 Every sentence in "story", "blocker", "buyer" and "verdict.because" lists the ids it rests on in its own "evidence", from the summary's "id" fields. Ids belong in "evidence" only — never in any "text", in "move_reason" or in "opening".
@@ -290,8 +290,8 @@ type replyShape struct {
 	Blocker []replyLine `json:"blocker"`
 	Buyer   []replyLine `json:"buyer"`
 	Verdict struct {
-		Standing string      `json:"standing"`
-		Because  []replyLine `json:"because"`
+		Standing string     `json:"standing"`
+		Because  replyLines `json:"because"`
 	} `json:"verdict"`
 	MoveReason string `json:"move_reason"`
 }
@@ -350,6 +350,42 @@ func keepFreeText(out *WrittenStatus, parsed replyShape, known map[string]bool) 
 type replyLine struct {
 	Text     string   `json:"text"`
 	Evidence []string `json:"evidence"`
+}
+
+// replyLines is a list of cited sentences that also accepts a BARE STRING.
+//
+// It has to, and the reason is worth stating because the card spent its whole
+// life without a verdict on account of it. The prompt describes this field
+// twice — once in the shape line as a list, once in prose as "one or two
+// sentences" — and the model followed the prose, returning a string. The
+// decoder refused it, the verdict was dropped, and the card fell back to the
+// deterministic writer EVERY TIME, logging a warning nobody was reading. A
+// reader saw a card with no call and no way to tell that one had been written.
+//
+// The prompt is fixed too, but a prompt is a request and this is the parse. A
+// model can always answer the older shape — a different provider, a cheaper
+// lane, a retry — and losing the whole verdict over a JSON shape is the wrong
+// trade when the sentence itself is right there. A bare string becomes one
+// uncited line: the grounding filter then treats it as any other uncited
+// sentence, so nothing skips the check that matters.
+type replyLines []replyLine
+
+func (r *replyLines) UnmarshalJSON(raw []byte) error {
+	var lines []replyLine
+	if err := json.Unmarshal(raw, &lines); err == nil {
+		*r = lines
+		return nil
+	}
+	var bare string
+	if err := json.Unmarshal(raw, &bare); err != nil {
+		return fmt.Errorf("verdict.because is neither a list of sentences nor a string: %w", err)
+	}
+	if strings.TrimSpace(bare) == "" {
+		*r = nil
+		return nil
+	}
+	*r = replyLines{{Text: bare}}
+	return nil
 }
 
 // keepGrounded drops a sentence whose citations do not resolve, and refuses

--- a/backend/internal/compose/dealstatus/model_test.go
+++ b/backend/internal/compose/dealstatus/model_test.go
@@ -271,3 +271,49 @@ func TestTheRequestFencesTheSummaryItCarries(t *testing.T) {
 		t.Fatal("the fence marker carries no nonce")
 	}
 }
+
+// The verdict survives a model that answers the older shape.
+//
+// This is not a hypothetical tolerance. The prompt described `verdict.because`
+// twice — as a list in the shape line, as "one or two sentences" in prose —
+// and the model followed the prose. The decoder refused the string, the whole
+// reply failed to parse, and the card fell back to the deterministic writer on
+// EVERY call, logging a warning nobody read. Deal360 shipped a verdict head
+// that no reader ever saw.
+func TestTheVerdictSurvivesABareStringReason(t *testing.T) {
+	var got replyShape
+	raw := []byte(`{"story":[{"text":"They wrote.","evidence":[]}],` +
+		`"verdict":{"standing":"blocked","because":"Nobody sent the times."},` +
+		`"move_reason":"Answer them."}`)
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("a bare-string reason must parse, not sink the whole reply: %v", err)
+	}
+	if len(got.Verdict.Because) != 1 {
+		t.Fatalf("a bare string is one line, got %d", len(got.Verdict.Because))
+	}
+	if got.Verdict.Because[0].Text != "Nobody sent the times." {
+		t.Errorf("the sentence is kept verbatim, got %q", got.Verdict.Because[0].Text)
+	}
+	if got.Verdict.Standing != "blocked" {
+		t.Errorf("the standing rides along, got %q", got.Verdict.Standing)
+	}
+}
+
+// And the shape the prompt actually asks for still parses, with its citations.
+// Without this the tolerance above could be satisfied by a decoder that threw
+// the list form away.
+func TestTheVerdictKeepsCitationsWhenTheModelSendsTheList(t *testing.T) {
+	var got replyShape
+	raw := []byte(`{"story":[],"verdict":{"standing":"cold","because":` +
+		`[{"text":"Silence since May.","evidence":["a1"]},{"text":"No reply.","evidence":[]}]},` +
+		`"move_reason":"Close it."}`)
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("the list shape must still parse: %v", err)
+	}
+	if len(got.Verdict.Because) != 2 {
+		t.Fatalf("both sentences are kept, got %d", len(got.Verdict.Because))
+	}
+	if len(got.Verdict.Because[0].Evidence) != 1 || got.Verdict.Because[0].Evidence[0] != "a1" {
+		t.Errorf("the citations ride along, got %v", got.Verdict.Because[0].Evidence)
+	}
+}


### PR DESCRIPTION
Deal360's verdict has **never once rendered from the model**. Every call fell back to the deterministic writer, and the reason was in the log the whole time:

```
cannot unmarshal string into Go struct field .verdict.because
of type dealstatus.replyLine
```

## Why

The prompt described that field twice and the two disagreed.

The shape line said `"verdict":{"standing":"...","because":[...]}`. The prose two lines below said *"because is one or two sentences saying what the call rests on"*. The model followed the prose and sent a string. The decoder refused it, the **whole reply** failed to parse, and the card silently served the deterministic version — which writes no verdict at all.

So a reader saw a card with no call on it, and nothing to say that one had been written and thrown away. The warning went to the log, where nobody reads it on a card that renders fine.

## The fix, both halves

**The prompt** now says the field is a list of `{"text","evidence"}` objects "never a bare string", in the same sentence that used to imply otherwise.

**The parse** accepts either shape. A bare string becomes one uncited line, which the grounding filter then treats like any other uncited sentence — nothing skips the check that matters.

The tolerance is not belt-and-braces for its own sake. A prompt is a request; this is the parse. A different provider, a cheaper lane or a retry can always answer the older shape, and losing the entire verdict over a JSON shape is the wrong trade when the sentence itself is sitting right there.

## How it was found

By opening the page after merging #2553, not by a test. Every unit test passed throughout, because they all feed the parser the shape the prompt asks for.

`TestTheVerdictSurvivesABareStringReason` reproduces the production error against the old decoder — reverting the fix makes it fail with that exact message. Its sibling holds the list shape *with its citations*, so the tolerance cannot be satisfied by a decoder that quietly discards them.

## Verified on a running stack

Before: `generated_by: deterministic`, no verdict, on all three real deals checked.

After, on the same deal:

```
generated_by: model
standing:     drifting
because:      We haven't spoken to the buyer in six days and
              there is no agreed-upon next action.
```

The card renders **DRIFTING** in the warn tone with its citation, above the coverage chips. The voice is right too — contraction, first person, leading with the fact.

`make check-backend` green (exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Deal360 renders the model’s verdict instead of silently falling back to the deterministic writer. Previously, a string-valued `verdict.because` caused the reply to fail parsing and the card to show no verdict; now the parser accepts both shapes.

- Parser: introduce `replyLines` so `verdict.because` accepts a list of `{"text","evidence"}` or a bare string. A string becomes one uncited line and still goes through grounding.
- Prompt: clarify the requested shape is a list (never a bare string) to align request and parse.
- Tests: add cases for both shapes to preserve citations and prevent regressions.
- Rollout: no API or data changes; providers returning the older string shape continue to work.

<sup>Written for commit 84f03015e7a5881a096c39ac52762b62db82092c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved status response handling to support structured, evidence-backed explanations.
  * Maintained compatibility with existing text-based explanations.
  * Preserved cited text and evidence during response processing.

* **Bug Fixes**
  * Improved validation of verdict reasoning to ensure explanations remain properly grounded in supporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->