### PR TITLE
feat(reports): the installation's business year need not start in January

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15511,7 +15511,7 @@ components:
       description: |
         The installation's identity and reporting basis (ADR-0090/A135). Read by every role,
         changed only by admin/ops.
-      required: [name, timezone, base_currency, base_language, base_currency_locked, max_upload_bytes]
+      required: [name, timezone, base_currency, base_language, fiscal_year_start_month, base_currency_locked, max_upload_bytes]
       properties:
         name:
           type: string
@@ -15535,6 +15535,24 @@ components:
             It does not govern everything a model writes: correspondence keeps the language of
             the correspondence, so a German thread still gets a German reply, and a brief cached
             for one reader keeps that reader's language.
+        fiscal_year_start_month:
+          type: integer
+          minimum: 1
+          maximum: 12
+          description: |
+            The month the installation's business year begins, 1..12. January (1) is the
+            default, which is the calendar year every installation reported by before this
+            setting existed.
+
+            It buckets period reports on READ and stores nothing, so changing it re-labels
+            every report immediately and re-means no stored row. What it DOES re-mean is a
+            saved report view: a period bucket's text travels out in a derivation handle and
+            binds back as an equality filter, so a view saved under one fiscal start asks for
+            a span of months nobody chose after it moves.
+
+            The label spells both calendar years a non-January year spans — `FY2026/27` — so
+            a reader can tell which twelve months a bucket covers without knowing the
+            convention. A January year is not a span and keeps the plain `2026`.
         base_currency_locked:
           type: boolean
           description: |
@@ -15575,6 +15593,17 @@ components:
           description: |
             The language shared AI writing is written in. Never frozen: changing it re-means
             nothing already written, so artifacts stay in the language they were written in.
+        fiscal_year_start_month:
+          type: integer
+          minimum: 1
+          maximum: 12
+          description: |
+            The month the installation's business year begins, 1..12. Never frozen: it cuts
+            reports on read and stores nothing.
+
+            Moving it re-labels every period report at once, and re-points any saved report
+            view whose filter names a period bucket — the report still runs and still looks
+            right, over a different twelve months.
 
     CaptureActivityResponse:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15545,10 +15545,7 @@ components:
             setting existed.
 
             It buckets period reports on READ and stores nothing, so changing it re-labels
-            every report immediately and re-means no stored row. What it DOES re-mean is a
-            saved report view: a period bucket's text travels out in a derivation handle and
-            binds back as an equality filter, so a view saved under one fiscal start asks for
-            a span of months nobody chose after it moves.
+            every report immediately and re-means no stored row.
 
             The label spells both calendar years a non-January year spans — `FY2026/27` — so
             a reader can tell which twelve months a bucket covers without knowing the
@@ -15599,11 +15596,8 @@ components:
           maximum: 12
           description: |
             The month the installation's business year begins, 1..12. Never frozen: it cuts
-            reports on read and stores nothing.
-
-            Moving it re-labels every period report at once, and re-points any saved report
-            view whose filter names a period bucket — the report still runs and still looks
-            right, over a different twelve months.
+            reports on read and stores nothing, so moving it re-labels every period report at
+            once and re-means no stored row.
 
     CaptureActivityResponse:
       type: object

--- a/backend/frontendfiscalyear_test.go
+++ b/backend/frontendfiscalyear_test.go
@@ -29,8 +29,20 @@ package backendarch
 //
 // What it cannot see: an off-by-one in the SQL's month shift, or a to_char
 // pattern that renders the right shape from the wrong instant. Those are
-// arithmetic rather than shape, and TestQuarterBounds plus the report
-// integration tests are what hold them.
+// arithmetic rather than shape, and they are held by TestQuarterBounds and by
+// TestWinLossPeriodBucketsFollowTheInstallationFiscalYear /
+// TestTheFiscalMonthShiftIsExactAtTheYearsFirstDay in
+// internal/compose/report_winloss_integration_test.go, which execute the real
+// statement against Postgres. The second of those exists BECAUSE this gate
+// could not see the shift: dropping the `- 1` left every assertion here green
+// while an April-start installation labelled its year one year early.
+//
+// It also matches SOURCE FRAGMENTS, which is a real limitation in the other
+// direction: an innocuous refactor that extracts `'FY'` to a constant or
+// reorders the concatenation fails it, even though the behaviour is unchanged.
+// That is the trade a shape gate makes, and the failure is loud and obvious
+// rather than silent — fix the fragments here, and let the integration tests
+// above say whether the behaviour actually moved.
 
 import (
 	"os"
@@ -44,13 +56,110 @@ const (
 	backendFiscalYear  = "internal/compose/reportperiod.go"
 )
 
+// readFiscalSource reads a file with its COMMENTS REMOVED.
+//
+// Load-bearing, not tidiness. Every fragment this gate matches is prose-shaped
+// enough to survive being quoted in a comment, so a plain read would let the
+// gate be satisfied by its own subject's obituary: rewrite the January branch
+// to `= 99` and leave `// was: ... " = 1"` above it, and the gate stays green
+// over code that no longer does what it checks. Verified by doing exactly that
+// before this existed.
+//
+// Blanked rather than deleted, keeping the newlines, so a finding's line number
+// still points at the code rather than at whatever the collapse shifted into
+// its place.
 func readFiscalSource(t *testing.T, path string) string {
 	t.Helper()
 	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)
 	}
-	return string(body)
+	return blankComments(string(body))
+}
+
+// blankComments replaces every // and /* */ comment with spaces, preserving
+// newlines and the length of the file.
+//
+// A scanner rather than a regexp, because a comment opener is not something a
+// pattern can settle: `//` sits inside every URL, and both openers sit inside
+// ordinary string literals — this very file contains `"'FY' || to_char("`. A
+// pattern that paired an opener with the next terminator would blank real code
+// and report success over lines it never read, which is worse than a false
+// finding: a finding gets looked at, a blind spot reports PASS. The frontend's
+// zone-by-purpose gate reaches for the TypeScript parser for the same reason.
+func blankComments(source string) string {
+	out := []rune(source)
+	const (
+		code = iota
+		lineComment
+		blockComment
+		stringLit
+		rawStringLit
+		runeLit
+	)
+	state := code
+	blank := func(i int) {
+		if out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+	for i := 0; i < len(out); i++ {
+		c := out[i]
+		next := rune(0)
+		if i+1 < len(out) {
+			next = out[i+1]
+		}
+		switch state {
+		case code:
+			switch {
+			case c == '/' && next == '/':
+				state = lineComment
+				blank(i)
+			case c == '/' && next == '*':
+				state = blockComment
+				blank(i)
+			case c == '"':
+				state = stringLit
+			case c == '`':
+				state = rawStringLit
+			case c == '\'':
+				state = runeLit
+			}
+		case lineComment:
+			if c == '\n' {
+				state = code
+			} else {
+				blank(i)
+			}
+		case blockComment:
+			blank(i)
+			if c == '*' && next == '/' {
+				blank(i + 1)
+				i++
+				state = code
+			}
+		case stringLit:
+			switch c {
+			// An escaped quote does not close the literal.
+			case '\\':
+				i++
+			case '"':
+				state = code
+			}
+		case rawStringLit:
+			if c == '`' {
+				state = code
+			}
+		case runeLit:
+			switch c {
+			case '\\':
+				i++
+			case '\'':
+				state = code
+			}
+		}
+	}
+	return string(out)
 }
 
 // TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire holds the mirror.
@@ -100,4 +209,38 @@ func TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire(t *testing.T) {
 			t.Error("the SQL quarter no longer extends the fiscal year label")
 		}
 	})
+}
+
+// TestTheGateReadsCodeRatherThanComments is the gate's own acceptance test.
+//
+// blankComments is what stops a fragment migrating into a comment from
+// satisfying an assertion about code, and a stripper that quietly stopped
+// stripping would take the gate with it — silently, since every assertion
+// would keep passing. So the two directions are both planted here: a fragment
+// in a comment must NOT be seen, and the same fragment in code must be.
+func TestTheGateReadsCodeRatherThanComments(t *testing.T) {
+	source := "package p\n" +
+		"// was: reportFiscalStartMonthToken + \" = 1\"\n" +
+		"/* also: reportFiscalStartMonthToken + \" = 1\" */\n" +
+		"const url = \"https://example.test/a//b\"\n" +
+		"const live = reportFiscalStartMonthToken + \" = 99\"\n"
+
+	stripped := blankComments(source)
+
+	if strings.Contains(stripped, `" = 1"`) {
+		t.Error("a fragment inside a comment survived the strip, so the gate can be satisfied by prose")
+	}
+	if !strings.Contains(stripped, `" = 99"`) {
+		t.Error("the strip ate real code")
+	}
+	// The URL's `//` is inside a string literal and opens no comment; a
+	// pattern-based stripper blanks the rest of that line and every line under
+	// it, which is how a gate goes blind while reporting PASS.
+	if !strings.Contains(stripped, "https://example.test/a//b") {
+		t.Error("a URL inside a string literal was treated as a comment opener")
+	}
+	// Line numbers must survive, or a finding points at innocent code.
+	if strings.Count(stripped, "\n") != strings.Count(source, "\n") {
+		t.Error("the strip changed the line count")
+	}
 }

--- a/backend/frontendfiscalyear_test.go
+++ b/backend/frontendfiscalyear_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A fiscal year's label is spelled twice: the server builds it in SQL
+// (internal/compose/reportperiod.go) because that is what a report is actually
+// cut by, and the browser builds it in TypeScript
+// (frontend/src/format/fiscalyear.ts) to show an admin what the setting they
+// are about to save will produce.
+//
+// Two spellings of one rule drift, and this one drifts SILENTLY: the settings
+// screen would promise "FY2026/27" while every report said something else, and
+// nothing on either side would fail. An admin would discover it by disbelieving
+// a report.
+//
+// WHAT THIS GATE CAN AND CANNOT DO, stated plainly because the limit is the
+// interesting part. The server's label is a SQL string assembled from tokens
+// and bound at query time; proving the two produce identical text would mean
+// executing it against Postgres, and this package has no database — the
+// integration lane does. So this gate holds the two DECISIONS that can be read
+// off the source, and they are the two that carry the whole rule:
+//
+//  1. January is spelled as a bare calendar year on both sides, and every other
+//     month is spelled as a two-year span. That branch is the entire product
+//     decision, and getting it wrong is the failure that reaches a reader.
+//  2. The span names the starting year in full and the ending year in two
+//     digits, in that order, separated by "/", behind an "FY" prefix.
+//
+// What it cannot see: an off-by-one in the SQL's month shift, or a to_char
+// pattern that renders the right shape from the wrong instant. Those are
+// arithmetic rather than shape, and TestQuarterBounds plus the report
+// integration tests are what hold them.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	frontendFiscalYear = "../frontend/src/format/fiscalyear.ts"
+	backendFiscalYear  = "internal/compose/reportperiod.go"
+)
+
+func readFiscalSource(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(body)
+}
+
+// TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire holds the mirror.
+func TestFiscalYearLabelIsSpelledTheSameOnBothSidesOfTheWire(t *testing.T) {
+	frontend := readFiscalSource(t, frontendFiscalYear)
+	backend := readFiscalSource(t, backendFiscalYear)
+
+	t.Run("both branch on January", func(t *testing.T) {
+		// The server compares the bound month against 1; the browser compares
+		// its argument against 1. Either side losing this branch is the
+		// regression that matters most, because it changes what every EXISTING
+		// installation sees — all of them run on the January default.
+		if !strings.Contains(backend, `reportFiscalStartMonthToken + " = 1"`) {
+			t.Error("the SQL no longer branches on a January start; every calendar-year installation would be relabelled")
+		}
+		if !regexp.MustCompile(`startMonth === 1`).MatchString(frontend) {
+			t.Error("the TypeScript no longer branches on a January start")
+		}
+	})
+
+	t.Run("both spell the span FY<full>/<two>", func(t *testing.T) {
+		// The server concatenates 'FY', a YYYY, '/', and a YY.
+		wantBackend := []string{`"'FY' || to_char("`, `" || '/' || to_char("`, `'YY'`}
+		for _, fragment := range wantBackend {
+			if !strings.Contains(backend, fragment) {
+				t.Errorf("the SQL no longer builds the FY<full>/<two> span: missing %s", fragment)
+			}
+		}
+		// The browser builds the same shape as a template literal.
+		if !strings.Contains(frontend, "`FY${startYear}/${ends}`") {
+			t.Error("the TypeScript no longer builds the FY<full>/<two> span")
+		}
+		// And derives the second half by ADDING a year rather than slicing the
+		// first, which is what makes 2099 roll to 00 rather than to 100.
+		if !strings.Contains(frontend, "(startYear + 1) % 100") {
+			t.Error("the TypeScript no longer derives the ending year by addition; the century would not roll over")
+		}
+		if !strings.Contains(backend, `+ interval '1 year'`) {
+			t.Error("the SQL no longer derives the ending year by addition")
+		}
+	})
+
+	t.Run("the quarter hangs off the year label", func(t *testing.T) {
+		// A quarter is the year's own label plus "-Qn", so the two can never
+		// disagree about the year part.
+		if !strings.Contains(backend, `" || '-Q' || to_char("`) {
+			t.Error("the SQL quarter no longer extends the fiscal year label")
+		}
+	})
+}

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -77,21 +77,14 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 		lang := string(*req.BaseLanguage)
 		patch.BaseLanguage = &lang
 	}
-	if req.FiscalYearStartMonth != nil {
-		// Checked here as well as on the entry, for the same reason the
-		// language is: the contract states the range and the setting states it
-		// too, and neither defers to the other. The generated decoder does NOT
-		// enforce `minimum`/`maximum` — those are documentation to it — so
-		// without this line a 0 or a 13 reaches the entry and comes back as a
-		// generic settings refusal that names no field.
-		if *req.FiscalYearStartMonth < 1 || *req.FiscalYearStartMonth > 12 {
-			httperr.Write(w, r, httperr.Validation(
-				"fiscal_year_start_month", "invalid",
-				"a fiscal year starts in month 1..12"))
-			return
-		}
-		patch.FiscalYearStartMonth = req.FiscalYearStartMonth
-	}
+	// No range check here, unlike BaseLanguage above. That one exists because
+	// the generated enum type carries a Valid() method worth calling; this
+	// field has no such type, and the entry's own refusal is already the better
+	// answer — settings.InvalidValue implements apperrors.FieldFault, so an
+	// out-of-range month comes back as a 422 naming the setting and carrying
+	// identity's own sentence, which quotes the value that was refused. A
+	// second check here would name a different field and say less.
+	patch.FiscalYearStartMonth = req.FiscalYearStartMonth
 	s, err := h.store.UpdateInstallation(r.Context(), patch)
 	if err != nil {
 		httperr.Write(w, r, err)

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -77,6 +77,21 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 		lang := string(*req.BaseLanguage)
 		patch.BaseLanguage = &lang
 	}
+	if req.FiscalYearStartMonth != nil {
+		// Checked here as well as on the entry, for the same reason the
+		// language is: the contract states the range and the setting states it
+		// too, and neither defers to the other. The generated decoder does NOT
+		// enforce `minimum`/`maximum` — those are documentation to it — so
+		// without this line a 0 or a 13 reaches the entry and comes back as a
+		// generic settings refusal that names no field.
+		if *req.FiscalYearStartMonth < 1 || *req.FiscalYearStartMonth > 12 {
+			httperr.Write(w, r, httperr.Validation(
+				"fiscal_year_start_month", "invalid",
+				"a fiscal year starts in month 1..12"))
+			return
+		}
+		patch.FiscalYearStartMonth = req.FiscalYearStartMonth
+	}
 	s, err := h.store.UpdateInstallation(r.Context(), patch)
 	if err != nil {
 		httperr.Write(w, r, err)
@@ -94,12 +109,13 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 // changeable: an empty string would render as a reason that says nothing.
 func (h installationSettingsHandlers) toContract(s identity.InstallationSettings) crmcontracts.InstallationSettings {
 	out := crmcontracts.InstallationSettings{
-		Name:               s.Name,
-		Timezone:           s.Timezone,
-		BaseCurrency:       s.BaseCurrency,
-		BaseLanguage:       crmcontracts.InstallationSettingsBaseLanguage(s.BaseLanguage),
-		BaseCurrencyLocked: s.BaseCurrencyLocked,
-		MaxUploadBytes:     h.maxUploadBytes,
+		Name:                 s.Name,
+		Timezone:             s.Timezone,
+		BaseCurrency:         s.BaseCurrency,
+		BaseLanguage:         crmcontracts.InstallationSettingsBaseLanguage(s.BaseLanguage),
+		FiscalYearStartMonth: s.FiscalYearStartMonth,
+		BaseCurrencyLocked:   s.BaseCurrencyLocked,
+		MaxUploadBytes:       h.maxUploadBytes,
 	}
 	if s.BaseCurrencyLockedReason != "" {
 		reason := s.BaseCurrencyLockedReason

--- a/backend/internal/compose/integration/installation_settings_integration_test.go
+++ b/backend/internal/compose/integration/installation_settings_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -165,6 +166,83 @@ func TestInstallationSettingsRefuseValuesTheOwningModuleRejects(t *testing.T) {
 	}
 	if !strings.Contains(message, "ISO-4217") {
 		t.Errorf("refusal message %q does not say what a base currency is", message)
+	}
+
+	// The fiscal start is the one field of this patch that is not a string, so
+	// it is the one whose encoding could be wrong in a way the others cannot
+	// show. A month outside 1..12 must be refused by the entry, not stored.
+	thirteen := 13
+	_, err = store.UpdateInstallation(admin, identity.InstallationPatch{FiscalYearStartMonth: &thirteen})
+	if err == nil {
+		t.Fatal("a thirteenth month was accepted as a fiscal year start")
+	}
+	if !errors.As(err, &fault) {
+		t.Fatalf("the fiscal-start refusal does not classify as a field fault: %v", err)
+	}
+	field, _, message = fault.FieldFault()
+	if field != "installation.fiscal_year_start_month" {
+		t.Errorf("the fiscal-start refusal names field %q, want the setting key", field)
+	}
+	// The value that was refused, quoted back. Without it the caller is told a
+	// range and left to work out which of their fields was out of it.
+	if !strings.Contains(message, "13") {
+		t.Errorf("the fiscal-start refusal %q does not quote the month it refused", message)
+	}
+}
+
+// The fiscal start travels the REAL write path — patch, encode, validate,
+// store, read back.
+//
+// It earns its own test because every other test of this setting writes the
+// `setting` row with raw SQL, so `UpdateInstallation` could be broken for this
+// field alone and the report tests would stay green: they would be asserting
+// against a row they had written themselves. It is also the only non-string
+// field on the patch, so it is the one that proves the encoding is per-type
+// rather than accidentally string-shaped.
+func TestInstallationSettingsRoundTripTheFiscalYearStart(t *testing.T) {
+	e := SetupSearch(t)
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
+	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
+
+	before, err := store.GetInstallation(admin)
+	if err != nil {
+		t.Fatalf("reading the installation settings: %v", err)
+	}
+	if before.FiscalYearStartMonth != int(time.January) {
+		t.Fatalf("a fresh installation starts its year in month %d, want January — "+
+			"every installation predating this setting reports by the calendar year",
+			before.FiscalYearStartMonth)
+	}
+
+	april := int(time.April)
+	written, err := store.UpdateInstallation(admin, identity.InstallationPatch{FiscalYearStartMonth: &april})
+	if err != nil {
+		t.Fatalf("setting the fiscal year start to April: %v", err)
+	}
+	if written.FiscalYearStartMonth != april {
+		t.Errorf("the write returned month %d, want %d", written.FiscalYearStartMonth, april)
+	}
+
+	reread, err := store.GetInstallation(admin)
+	if err != nil {
+		t.Fatalf("re-reading the installation settings: %v", err)
+	}
+	if reread.FiscalYearStartMonth != april {
+		t.Errorf("re-read month %d, want %d — the write did not reach the row", reread.FiscalYearStartMonth, april)
+	}
+
+	// A patch that names OTHER fields leaves this one alone. The sparse write
+	// is the whole contract of this endpoint, and an encoding that treated an
+	// absent field as a zero would set the month to 0 here rather than fail
+	// loudly — 0 is not a month, but nothing on the read path would say so.
+	renamed := "Renamed, fiscal untouched"
+	after, err := store.UpdateInstallation(admin, identity.InstallationPatch{Name: &renamed})
+	if err != nil {
+		t.Fatalf("renaming the organization: %v", err)
+	}
+	if after.FiscalYearStartMonth != april {
+		t.Errorf("a patch naming only the name moved the fiscal start to %d, want %d",
+			after.FiscalYearStartMonth, april)
 	}
 }
 

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -83,14 +83,35 @@ func pruneUnreadable(rootID ids.UUID, nodes []orgTreeNode, readable func(ids.UUI
 	return included, restricted, true
 }
 
-// currentQuarterBounds returns the calendar quarter [start, end) that
-// now falls in, evaluated in loc — the workspace timezone, not UTC, so
-// a moment shortly after midnight UTC can still belong to the prior
-// quarter (and year) for a workspace west of Greenwich.
-func currentQuarterBounds(now time.Time, loc *time.Location) (start, end time.Time) {
+// currentQuarterBounds returns the quarter [start, end) that now falls in,
+// evaluated in loc — the workspace timezone, not UTC, so a moment shortly
+// after midnight UTC can still belong to the prior quarter (and year) for a
+// workspace west of Greenwich.
+//
+// fiscalStartMonth is the month the installation's business year begins, 1..12.
+// The quarters are cut FROM it rather than from January, so an installation
+// whose year starts in April reads April–June as its first quarter — the same
+// cut the period reports make, and the figure on the company page has to agree
+// with the report a reader checks it against.
+//
+// January (the default, and every installation that predates the setting)
+// leaves the offset at zero and reproduces the calendar quarters exactly.
+func currentQuarterBounds(now time.Time, loc *time.Location, fiscalStartMonth int) (start, end time.Time) {
 	local := now.In(loc)
-	quarterStartMonth := time.Month(((int(local.Month())-1)/3)*3 + 1)
-	start = time.Date(local.Year(), quarterStartMonth, 1, 0, 0, 0, 0, loc)
+	// Months since the fiscal year began, 0..11. The +12 keeps the modulo
+	// positive for a month earlier in the calendar than the fiscal start —
+	// February under an April start is 10 months in, not -2.
+	monthsIn := (int(local.Month()) - fiscalStartMonth + 12) % 12
+	quarterOffset := (monthsIn / 3) * 3
+	// Anchored on the fiscal start month IN local's own calendar year, then
+	// walked forward by whole quarters. That anchor can land in the future —
+	// February under an April start sits in the fiscal year that began the
+	// PREVIOUS April — so a start after `local` is pulled back a year.
+	start = time.Date(local.Year(), time.Month(fiscalStartMonth), 1, 0, 0, 0, 0, loc).
+		AddDate(0, quarterOffset, 0)
+	if start.After(local) {
+		start = start.AddDate(-1, 0, 0)
+	}
 	end = start.AddDate(0, 3, 0)
 	return start, end
 }

--- a/backend/internal/compose/orgrollup_test.go
+++ b/backend/internal/compose/orgrollup_test.go
@@ -21,52 +21,128 @@ func TestQuarterBounds(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		now       time.Time
-		loc       *time.Location
-		wantStart time.Time
-		wantEnd   time.Time
+		name string
+		now  time.Time
+		loc  *time.Location
+		// The month the installation's business year begins. Every case below
+		// that names January is asserting the CALENDAR behaviour, which the
+		// fiscal cut must reproduce exactly for the default nobody changes.
+		fiscalStart int
+		wantStart   time.Time
+		wantEnd     time.Time
 	}{
 		{
-			name:      "mid-quarter",
-			now:       time.Date(2026, time.May, 15, 10, 30, 0, 0, time.UTC),
-			loc:       time.UTC,
-			wantStart: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
-			wantEnd:   time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			name:        "mid-quarter",
+			now:         time.Date(2026, time.May, 15, 10, 30, 0, 0, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.January),
+			wantStart:   time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			// The instant exactly on a quarter boundary belongs to the
 			// quarter it opens, never the one it closes.
-			name:      "quarter boundary instant",
-			now:       time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
-			loc:       time.UTC,
-			wantStart: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
-			wantEnd:   time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC),
+			name:        "quarter boundary instant",
+			now:         time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.January),
+			wantStart:   time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			// One nanosecond before the boundary must still resolve to
 			// the closing quarter, proving the end bound is exclusive.
-			name:      "instant before quarter boundary stays in prior quarter",
-			now:       time.Date(2026, time.June, 30, 23, 59, 59, 999999999, time.UTC),
-			loc:       time.UTC,
-			wantStart: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
-			wantEnd:   time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			name:        "instant before quarter boundary stays in prior quarter",
+			now:         time.Date(2026, time.June, 30, 23, 59, 59, 999999999, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.January),
+			wantStart:   time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			// UTC instant lands early morning Jan 1, but Los Angeles is
 			// still Dec 31 the prior year — the workspace timezone must
 			// shift which quarter (and year) this resolves to, not UTC.
-			name:      "timezone shifts the calendar date across a year boundary",
-			now:       time.Date(2026, time.January, 1, 4, 0, 0, 0, time.UTC),
-			loc:       losAngeles,
-			wantStart: time.Date(2025, time.October, 1, 0, 0, 0, 0, losAngeles),
-			wantEnd:   time.Date(2026, time.January, 1, 0, 0, 0, 0, losAngeles),
+			name:        "timezone shifts the calendar date across a year boundary",
+			now:         time.Date(2026, time.January, 1, 4, 0, 0, 0, time.UTC),
+			loc:         losAngeles,
+			fiscalStart: int(time.January),
+			wantStart:   time.Date(2025, time.October, 1, 0, 0, 0, 0, losAngeles),
+			wantEnd:     time.Date(2026, time.January, 1, 0, 0, 0, 0, losAngeles),
+		},
+		// The fiscal cases below all use a start month that is NOT itself a
+		// calendar-quarter boundary, and that is deliberate.
+		//
+		// April, July and October are the obvious fiscal starts to reach for,
+		// and every one of them is useless as a test: April–June is the second
+		// calendar quarter as well as the first fiscal one, so a cut that
+		// ignored the setting entirely returns the same bounds and the case
+		// passes. Four such cases were written here first and the whole set
+		// still passed with the fiscal arithmetic deleted.
+		//
+		// A February start shares no boundary with the calendar in any month of
+		// the year, so each case below fails the moment the setting stops being
+		// read.
+		{
+			// February–April is the FIRST quarter of a February-starting year.
+			// A calendar cut puts March in the quarter beginning in January.
+			name:        "february fiscal year, first quarter",
+			now:         time.Date(2026, time.March, 15, 10, 30, 0, 0, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.February),
+			wantStart:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// The quarter that begins BEFORE the calendar year it ends in.
+			// January 2026 sits in the fourth quarter of the year that began in
+			// February 2025, so the bounds run back into the previous year —
+			// the case that proves the anchor is pulled back rather than
+			// clamped to `local.Year()`.
+			name:        "february fiscal year, the quarter that reaches back a year",
+			now:         time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.February),
+			wantStart:   time.Date(2025, time.November, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// The last instant of a February-starting fiscal year: it belongs
+			// to the quarter ENDING on 1 February, not the one starting there.
+			// The half-open boundary, on a fiscal cut.
+			name:        "february fiscal year, its final instant",
+			now:         time.Date(2026, time.January, 31, 23, 59, 59, 999999999, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.February),
+			wantStart:   time.Date(2025, time.November, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// And its first instant, which must open the new year's Q1 rather
+			// than close the old year's Q4.
+			name:        "february fiscal year, its first instant",
+			now:         time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.February),
+			wantStart:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// A late start month, so the quarter runs forward across the
+			// calendar boundary instead of back: November–January under a
+			// November start.
+			name:        "november fiscal year, quarter crossing into the next year",
+			now:         time.Date(2026, time.December, 20, 12, 0, 0, 0, time.UTC),
+			loc:         time.UTC,
+			fiscalStart: int(time.November),
+			wantStart:   time.Date(2026, time.November, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:     time.Date(2027, time.February, 1, 0, 0, 0, 0, time.UTC),
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			start, end := currentQuarterBounds(tc.now, tc.loc)
+			start, end := currentQuarterBounds(tc.now, tc.loc, tc.fiscalStart)
 			if !start.Equal(tc.wantStart) {
 				t.Errorf("start = %v, want %v", start, tc.wantStart)
 			}

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -97,7 +97,7 @@ func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID
 		if err := auth.EnsureVisible(ctx, tx, "organization", rootID); err != nil {
 			return err
 		}
-		baseCurrency, loc, err := rollupInstallationMeta(ctx, tx)
+		baseCurrency, loc, fiscalStart, err := rollupInstallationMeta(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID
 		if result.WeightedPipelineMinor, err = weightedPipelineMinor(ctx, tx, included, fx); err != nil {
 			return err
 		}
-		if result.ClosedWonMinor, err = closedWonMinorThisQuarter(ctx, tx, included, asOf, loc); err != nil {
+		if result.ClosedWonMinor, err = closedWonMinorThisQuarter(ctx, tx, included, asOf, loc, fiscalStart); err != nil {
 			return err
 		}
 		if result.ActivityCount30d, err = orgActivityCount30d(ctx, tx, included, asOf); err != nil {
@@ -136,25 +136,35 @@ func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID
 	return result, nil
 }
 
-// rollupInstallationMeta reads the installation's base currency and reporting
-// timezone. A stored zone the host cannot resolve degrades the quarter
-// window to UTC rather than failing the read — the zone was validated
-// at write time, so this only fires when the host lost its tzdata, and
-// an aggregate read is the wrong place to surface that deployment fault.
-func rollupInstallationMeta(ctx context.Context, tx pgx.Tx) (string, *time.Location, error) {
+// rollupInstallationMeta reads the installation's base currency, reporting
+// timezone and the month its business year begins — the basis every figure in
+// this rollup is expressed in. A stored zone the host cannot resolve degrades
+// the quarter window to UTC rather than failing the read — the zone was
+// validated at write time, so this only fires when the host lost its tzdata,
+// and an aggregate read is the wrong place to surface that deployment fault.
+//
+// All three read here rather than where each is used, so one rollup takes one
+// settings read per value. The fiscal month in particular is used by a leaf
+// function that runs once per read, and resolving it there would have been a
+// second answer to a question this function already asks.
+func rollupInstallationMeta(ctx context.Context, tx pgx.Tx) (string, *time.Location, int, error) {
 	baseCurrency, err := identity.BaseCurrencyOf(ctx, tx)
 	if err != nil {
-		return "", nil, err
+		return "", nil, 0, err
 	}
 	tzName, err := identity.TimezoneOf(ctx, tx)
 	if err != nil {
-		return "", nil, err
+		return "", nil, 0, err
 	}
 	loc, err := time.LoadLocation(tzName)
 	if err != nil {
 		loc = time.UTC
 	}
-	return baseCurrency, loc, nil
+	fiscalStart, err := identity.FiscalYearStartMonthOf(ctx, tx)
+	if err != nil {
+		return "", nil, 0, err
+	}
+	return baseCurrency, loc, fiscalStart, nil
 }
 
 // orgRollupMaxDepth caps the recursive tree walk. The DB trigger already
@@ -381,18 +391,14 @@ func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, 
 // here: the deal_closed_fx CHECK guarantees fx_rate_to_base for every
 // closed deal that has an amount, and an amountless won deal's NULL
 // amount_minor_base is skipped by SUM — an honest 0, not an invented rate.
-func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time, loc *time.Location) (int64, error) {
-	// The quarter is the installation's FISCAL one. A reader who checks this
-	// figure against the win-loss report by quarter is comparing two answers to
-	// one question, and they have to be cut the same way or the company page
-	// and the report disagree in front of them.
-	fiscalStart, err := identity.FiscalYearStartMonthOf(ctx, tx)
-	if err != nil {
-		return 0, err
-	}
+// The quarter is the installation's FISCAL one, threaded in alongside the zone
+// it is cut in. A reader who checks this figure against the win-loss report by
+// quarter is comparing two answers to one question, and they have to be cut the
+// same way or the company page and the report disagree in front of them.
+func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time, loc *time.Location, fiscalStart int) (int64, error) {
 	start, end := currentQuarterBounds(asOf, loc, fiscalStart)
 	var total int64
-	err = tx.QueryRow(ctx, `
+	err := tx.QueryRow(ctx, `
 		SELECT COALESCE(SUM(d.amount_minor_base), 0)::bigint
 		FROM deal d
 		WHERE d.organization_id = ANY($1) AND d.status = 'won' AND d.archived_at IS NULL

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -382,9 +382,17 @@ func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, 
 // closed deal that has an amount, and an amountless won deal's NULL
 // amount_minor_base is skipped by SUM — an honest 0, not an invented rate.
 func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time, loc *time.Location) (int64, error) {
-	start, end := currentQuarterBounds(asOf, loc)
+	// The quarter is the installation's FISCAL one. A reader who checks this
+	// figure against the win-loss report by quarter is comparing two answers to
+	// one question, and they have to be cut the same way or the company page
+	// and the report disagree in front of them.
+	fiscalStart, err := identity.FiscalYearStartMonthOf(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+	start, end := currentQuarterBounds(asOf, loc, fiscalStart)
 	var total int64
-	err := tx.QueryRow(ctx, `
+	err = tx.QueryRow(ctx, `
 		SELECT COALESCE(SUM(d.amount_minor_base), 0)::bigint
 		FROM deal d
 		WHERE d.organization_id = ANY($1) AND d.status = 'won' AND d.archived_at IS NULL

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -85,7 +85,11 @@ func setupForecast(t *testing.T) *forecastEnv {
 	if _, err := owner.Exec(ctx, `INSERT INTO setting (key, value) VALUES
 			('installation.name', '"Forecast"'::jsonb),
 			('installation.base_currency', '"EUR"'::jsonb),
-			('installation.timezone', '"UTC"'::jsonb)
+			('installation.timezone', '"UTC"'::jsonb),
+			-- January, seeded explicitly rather than left absent: the period
+			-- buckets read it, and a fixture that relied on the registered
+			-- default would assert against a row nothing wrote.
+			('installation.fiscal_year_start_month', '1'::jsonb)
 		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
 		t.Fatalf("seeding the installation settings: %v", err)
 	}

--- a/backend/internal/compose/report_winloss_integration_test.go
+++ b/backend/internal/compose/report_winloss_integration_test.go
@@ -62,6 +62,24 @@ func (e *forecastEnv) setInstallationZone(t *testing.T, zone string) {
 	}
 }
 
+// setFiscalYearStart moves the month the installation's business year begins.
+//
+// An upsert rather than the plain UPDATE its zone sibling uses. This harness
+// seeds no installation settings at all, so there is no row to update: an
+// UPDATE matches nothing, succeeds, and leaves the test asserting against the
+// January default while believing it had set something. That is the shape of
+// failure a setting-driven test must not have — it passes for the wrong
+// reason, and only in the direction that hides a real defect.
+func (e *forecastEnv) setFiscalYearStart(t *testing.T, month int) {
+	t.Helper()
+	if _, err := e.owner.Exec(t.Context(),
+		`INSERT INTO setting (key, value)
+		 VALUES ('installation.fiscal_year_start_month', to_jsonb($1::int))
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`, month); err != nil {
+		t.Fatalf("setting the fiscal year start: %v", err)
+	}
+}
+
 // bucketRow finds the one aggregate row whose group keys all match, so a test
 // naming two dimensions cannot silently assert against the wrong group.
 func bucketRow(t *testing.T, result reportResultWire, keys map[string]string) map[string]any {
@@ -168,6 +186,103 @@ func TestWinLossPeriodBucketsFollowTheInstallationZone(t *testing.T) {
 		`{"group_by":["period_year"],"aggregates":[{"fn":"count","as":"deals"}]}`)
 	if got := local.Rows[0]["period_year"]; got != "2025" {
 		t.Errorf("under America/New_York the bucket is %v, want 2025 — the bucket ignored the installation zone", got)
+	}
+}
+
+// A bucket's YEAR is the installation's business year, not the calendar's.
+//
+// This test is the one that holds the fiscal arithmetic, and it is here rather
+// than in the deterministic lane because no deterministic test can do it. The
+// mirror gate in backend/frontendfiscalyear_test.go reads both spellings of the
+// label out of source and checks their SHAPE; it cannot execute SQL assembled
+// from bound tokens, so deleting the `- 1` from the month shift leaves every
+// assertion there green while an April-start installation labels its year one
+// year early.
+//
+// The instant is chosen so all three starts below disagree about it. 15 March
+// 2026 is:
+//
+//	January start  → 2026        (the calendar year, unchanged)
+//	April start    → FY2025/26   (the last month of the year that began in April 2025)
+//	February start → FY2026/27   (the first quarter of the year that began weeks ago)
+//
+// A February start is deliberate. April, July and October are the fiscal starts
+// one reaches for first, and every one of them is ALSO a calendar-quarter
+// boundary — so a cut that ignored the setting entirely returns the same
+// quarter and the case passes. The sibling unit test's first four cases were
+// written that way and all four passed with the fiscal arithmetic deleted.
+func TestWinLossPeriodBucketsFollowTheInstallationFiscalYear(t *testing.T) {
+	e := setupForecast(t)
+	e.seedClosedDeal(t, "Mid-March", "won", "2026-03-15T12:00:00Z", 10000)
+
+	bucket := func(t *testing.T, dimension string) any {
+		t.Helper()
+		result := e.runReport(e.Admin(), t, "win-loss",
+			`{"group_by":["`+dimension+`"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+		if len(result.Rows) != 1 {
+			t.Fatalf("%s: %d rows, want the 1 seeded deal: %+v", dimension, len(result.Rows), result.Rows)
+		}
+		return result.Rows[0][dimension]
+	}
+
+	// The default first, and the fixture's own discriminator: if January did
+	// not produce the plain calendar year, the cases below would prove nothing
+	// about the fiscal branch.
+	if got := bucket(t, "period_year"); got != "2026" {
+		t.Fatalf("on the January default the year is %v, want the plain 2026", got)
+	}
+	if got := bucket(t, "period_quarter"); got != "2026-Q1" {
+		t.Fatalf("on the January default the quarter is %v, want the plain 2026-Q1", got)
+	}
+
+	e.setFiscalYearStart(t, 4)
+	if got := bucket(t, "period_year"); got != "FY2025/26" {
+		t.Errorf("under an April start the year is %v, want FY2025/26 — March belongs to the year that began the previous April", got)
+	}
+	if got := bucket(t, "period_quarter"); got != "FY2025/26-Q4" {
+		t.Errorf("under an April start the quarter is %v, want FY2025/26-Q4", got)
+	}
+
+	e.setFiscalYearStart(t, 2)
+	if got := bucket(t, "period_year"); got != "FY2026/27" {
+		t.Errorf("under a February start the year is %v, want FY2026/27", got)
+	}
+	if got := bucket(t, "period_quarter"); got != "FY2026/27-Q1" {
+		t.Errorf("under a February start the quarter is %v, want FY2026/27-Q1 — February to April is its FIRST quarter", got)
+	}
+
+	// The month grain is not fiscal: a month is the same month under every
+	// start, so the setting that just moved the other two must leave it alone.
+	if got := bucket(t, "period_month"); got != "2026-03" {
+		t.Errorf("the month grain is %v, want 2026-03 — it moved with the fiscal start", got)
+	}
+}
+
+// The month SHIFT itself, on the one instant that can see it.
+//
+// Separate from the test above because the instants differ and the difference
+// is the whole point. 15 March sits four months from an April boundary, so a
+// shift that is off by one month still lands in the same fiscal year and the
+// assertion passes over a broken expression — which it did: the reviewer's
+// counter-example (dropping the `- 1`) survived the test above untouched.
+//
+// 1 April is the FIRST day of an April-start year, so being one month out puts
+// it in the previous year's last quarter instead of this year's first. Correct
+// gives FY2026/27-Q1; a shift of `months => 4` rather than `4 - 1` gives
+// FY2025/26-Q4. Nothing else in the tree distinguishes those.
+func TestTheFiscalMonthShiftIsExactAtTheYearsFirstDay(t *testing.T) {
+	e := setupForecast(t)
+	e.seedClosedDeal(t, "First day of the fiscal year", "won", "2026-04-01T12:00:00Z", 10000)
+	e.setFiscalYearStart(t, 4)
+
+	result := e.runReport(e.Admin(), t, "win-loss",
+		`{"group_by":["period_quarter"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	if len(result.Rows) != 1 {
+		t.Fatalf("%d rows, want the 1 seeded deal: %+v", len(result.Rows), result.Rows)
+	}
+	if got := result.Rows[0]["period_quarter"]; got != "FY2026/27-Q1" {
+		t.Errorf("the quarter is %v, want FY2026/27-Q1 — 1 April OPENS an April-start year, "+
+			"and FY2025/26-Q4 means the month shift is one out", got)
 	}
 }
 

--- a/backend/internal/compose/report_winloss_integration_test.go
+++ b/backend/internal/compose/report_winloss_integration_test.go
@@ -64,19 +64,22 @@ func (e *forecastEnv) setInstallationZone(t *testing.T, zone string) {
 
 // setFiscalYearStart moves the month the installation's business year begins.
 //
-// An upsert rather than the plain UPDATE its zone sibling uses. This harness
-// seeds no installation settings at all, so there is no row to update: an
-// UPDATE matches nothing, succeeds, and leaves the test asserting against the
-// January default while believing it had set something. That is the shape of
-// failure a setting-driven test must not have — it passes for the wrong
-// reason, and only in the direction that hides a real defect.
+// Seeded as January by setupForecast, the same way the zone is seeded as UTC —
+// so this is a plain UPDATE like its sibling, and a statement that matched
+// nothing would be a fixture that had stopped seeding the row.
 func (e *forecastEnv) setFiscalYearStart(t *testing.T, month int) {
 	t.Helper()
-	if _, err := e.owner.Exec(t.Context(),
-		`INSERT INTO setting (key, value)
-		 VALUES ('installation.fiscal_year_start_month', to_jsonb($1::int))
-		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`, month); err != nil {
+	tag, err := e.owner.Exec(t.Context(),
+		`UPDATE setting SET value = to_jsonb($1::int)
+		 WHERE key = 'installation.fiscal_year_start_month'`, month)
+	if err != nil {
 		t.Fatalf("setting the fiscal year start: %v", err)
+	}
+	// An UPDATE that matches nothing SUCCEEDS, and the test would then assert
+	// against the January default while believing it had set something —
+	// passing for the wrong reason, in the direction that hides a defect.
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("the fiscal-year-start row is not seeded: UPDATE touched %d rows", tag.RowsAffected())
 	}
 }
 

--- a/backend/internal/compose/reportperiod.go
+++ b/backend/internal/compose/reportperiod.go
@@ -42,25 +42,11 @@ const (
 	patternQuarter = `YYYY"-Q"Q`
 	patternMonth   = "YYYY-MM"
 
-	// The fiscal spellings of the year and quarter, for an installation whose
-	// business year does not start in January. A month keeps its calendar
-	// spelling under every fiscal start — March is March — so there is no
-	// fiscal patternMonth.
-	//
-	// Both name BOTH calendar years the fiscal year spans: "FY2026/27" rather
-	// than "FY2026" or "FY2027". Those two shorter forms are each a real
-	// convention somewhere — the UK names a fiscal year for the year it starts
-	// in, Australia and Japan for the year it ends — so either alone is read
-	// wrong by half the readers, and this product is deployed in Europe and
-	// Vietnam at once. The label is also effectively permanent (see
-	// periodBucketExpr on the derivation round trip), which is what makes five
-	// extra characters the cheaper side of the trade.
-	//
-	// They still sort as text, which is the property the calendar patterns
-	// above are chosen for and the one a longer label could have broken. The
-	// leading four-digit year carries the ordering and the "/YY" is decorative,
-	// so 'FY2099/00-Q1' sorts after 'FY2026/27-Q4' rather than before it.
-	patternFiscalYear    = "YYYY"
+	// A fiscal year renders through patternYear above — the SHIFT is what makes
+	// it fiscal, not the pattern — and a month keeps its calendar spelling under
+	// every fiscal start, since March is March. Only the quarter needs a
+	// spelling of its own: bare Q, because the year half is built separately
+	// and the two are concatenated.
 	patternFiscalQuarter = "Q"
 )
 
@@ -120,7 +106,8 @@ func fiscalAnchor(anchor string) string {
 // and no saved view starts asking for a span nobody chose. Spelling a calendar
 // year 'FY2026/27' would also just be false: it does not span 2027.
 //
-// The spanning form names BOTH years for the reason patternFiscalYear records.
+// The spanning form is spanningYearLabel below, which records why it names
+// both years.
 // Its second half is read off the shifted anchor plus a year rather than by
 // adding one to the first, so Postgres does the arithmetic and the century
 // rolls over on its own — 'FY2099/00' comes out right with nobody having
@@ -135,9 +122,22 @@ func fiscalYearLabel(anchor string) string {
 // spanningYearLabel is the 'FY2025/26' half, without the calendar branch — so
 // the quarter label can build on it rather than nesting one CASE inside
 // another's ELSE.
+//
+// It names BOTH calendar years the fiscal year spans rather than one. "FY2026"
+// alone is a real convention in two incompatible directions — the UK names a
+// fiscal year for the year it starts in, Australia and Japan for the year it
+// ends — so either short form reads as the other twelve months to half the
+// readers, and this product is deployed in Europe and Vietnam at once. The
+// label is also effectively permanent (see periodBucketExpr on the derivation
+// round trip), which makes five extra characters the cheaper side of the trade.
+//
+// It still sorts as text, which is the property the calendar patterns are
+// chosen for and the one a longer label could have broken silently. The leading
+// four-digit year carries the ordering and the "/YY" is decorative, so
+// 'FY2099/00-Q1' sorts after 'FY2026/27-Q4' rather than before it.
 func spanningYearLabel(anchor string) string {
 	shifted := fiscalAnchor(anchor)
-	return "'FY' || to_char(" + shifted + ", '" + patternFiscalYear + "')" +
+	return "'FY' || to_char(" + shifted + ", '" + patternYear + "')" +
 		" || '/' || to_char(" + shifted + " + interval '1 year', 'YY')"
 }
 

--- a/backend/internal/compose/reportperiod.go
+++ b/backend/internal/compose/reportperiod.go
@@ -41,6 +41,27 @@ const (
 	patternYear    = "YYYY"
 	patternQuarter = `YYYY"-Q"Q`
 	patternMonth   = "YYYY-MM"
+
+	// The fiscal spellings of the year and quarter, for an installation whose
+	// business year does not start in January. A month keeps its calendar
+	// spelling under every fiscal start — March is March — so there is no
+	// fiscal patternMonth.
+	//
+	// Both name BOTH calendar years the fiscal year spans: "FY2026/27" rather
+	// than "FY2026" or "FY2027". Those two shorter forms are each a real
+	// convention somewhere — the UK names a fiscal year for the year it starts
+	// in, Australia and Japan for the year it ends — so either alone is read
+	// wrong by half the readers, and this product is deployed in Europe and
+	// Vietnam at once. The label is also effectively permanent (see
+	// periodBucketExpr on the derivation round trip), which is what makes five
+	// extra characters the cheaper side of the trade.
+	//
+	// They still sort as text, which is the property the calendar patterns
+	// above are chosen for and the one a longer label could have broken. The
+	// leading four-digit year carries the ordering and the "/YY" is decorative,
+	// so 'FY2099/00-Q1' sorts after 'FY2026/27-Q4' rather than before it.
+	patternFiscalYear    = "YYYY"
+	patternFiscalQuarter = "Q"
 )
 
 // periodBucketExpr renders one grain over one anchor.
@@ -63,16 +84,101 @@ const (
 // a bind parameter through reportZoneToken, so this stays a static expression
 // with no bind position of its own to name.
 func periodBucketExpr(anchor, pattern string) string {
-	return "to_char(timezone(" + reportZoneToken + ", " + anchor + "), '" + pattern + "')"
+	return "to_char(" + zonedAnchor(anchor) + ", '" + pattern + "')"
+}
+
+// zonedAnchor is the anchor instant read on the installation's reporting clock
+// — the inner half every bucket expression below is built from.
+func zonedAnchor(anchor string) string {
+	return "timezone(" + reportZoneToken + ", " + anchor + ")"
+}
+
+// fiscalAnchor shifts the zoned anchor back so the fiscal year's first month
+// lands on January, which is what lets the ordinary calendar patterns read a
+// fiscal year and a fiscal quarter off it.
+//
+// A shift rather than arithmetic on the month number, because the two are not
+// the same at a year boundary: a fiscal year starting in April means 31 March
+// 2026 belongs to the year that began in April 2025, and only moving the
+// instant carries the year back with the month. `make_interval` also takes the
+// month count as a value, so the setting stays a bind parameter rather than
+// something formatted into the statement.
+func fiscalAnchor(anchor string) string {
+	return zonedAnchor(anchor) +
+		" - make_interval(months => " + reportFiscalStartMonthToken + " - 1)"
+}
+
+// fiscalYearLabel renders the year a bucket falls in, in the form that says
+// what the year actually is:
+//
+//	January start → '2026'      — a fiscal year that IS the calendar year
+//	April start   → 'FY2025/26' — a fiscal year that spans two of them
+//
+// The condition is the point, not a convenience. Every installation that
+// existed before this setting did runs on the January default, so the branch it
+// takes produces the byte-identical label it produced before — no report moves,
+// and no saved view starts asking for a span nobody chose. Spelling a calendar
+// year 'FY2026/27' would also just be false: it does not span 2027.
+//
+// The spanning form names BOTH years for the reason patternFiscalYear records.
+// Its second half is read off the shifted anchor plus a year rather than by
+// adding one to the first, so Postgres does the arithmetic and the century
+// rolls over on its own — 'FY2099/00' comes out right with nobody having
+// thought about it.
+func fiscalYearLabel(anchor string) string {
+	return calendarOrFiscal(
+		periodBucketExpr(anchor, patternYear),
+		spanningYearLabel(anchor),
+	)
+}
+
+// spanningYearLabel is the 'FY2025/26' half, without the calendar branch — so
+// the quarter label can build on it rather than nesting one CASE inside
+// another's ELSE.
+func spanningYearLabel(anchor string) string {
+	shifted := fiscalAnchor(anchor)
+	return "'FY' || to_char(" + shifted + ", '" + patternFiscalYear + "')" +
+		" || '/' || to_char(" + shifted + " + interval '1 year', 'YY')"
+}
+
+// calendarOrFiscal picks between the two spellings on the one condition that
+// separates them: a fiscal year starting in January IS the calendar year, and
+// every installation predating this setting runs on that default.
+func calendarOrFiscal(calendar, fiscal string) string {
+	return "CASE WHEN " + reportFiscalStartMonthToken + " = 1" +
+		" THEN " + calendar + " ELSE " + fiscal + " END"
+}
+
+// fiscalQuarterLabel renders the quarter WITHIN the fiscal year, so an
+// April-starting installation reads April–June as Q1 rather than as the
+// calendar's Q2:
+//
+//	January start → '2026-Q1'
+//	April start   → 'FY2025/26-Q4'
+//
+// Same condition and same reason as fiscalYearLabel: the January branch is what
+// every installation produced before this existed.
+func fiscalQuarterLabel(anchor string) string {
+	return calendarOrFiscal(
+		periodBucketExpr(anchor, patternQuarter),
+		spanningYearLabel(anchor)+
+			" || '-Q' || to_char("+fiscalAnchor(anchor)+", '"+patternFiscalQuarter+"')",
+	)
 }
 
 // periodDimensions is the three grains over one anchor, keyed by their wire
 // names (REPORT-PARAM-4). The set is closed: a caller asking for a grain
 // outside it is refused by the ordinary out-of-vocabulary path, never widened.
+//
+// The year and quarter are FISCAL, cut from the installation's configured
+// start month; the month is not, because a month is the same month under every
+// fiscal start. On the default January start both take their calendar branch
+// and render exactly what they rendered before this setting existed, which is
+// what keeps every existing report and every saved view where it was.
 func periodDimensions(anchor string) map[string]string {
 	return map[string]string{
-		fieldPeriodYear:    periodBucketExpr(anchor, patternYear),
-		fieldPeriodQuarter: periodBucketExpr(anchor, patternQuarter),
+		fieldPeriodYear:    fiscalYearLabel(anchor),
+		fieldPeriodQuarter: fiscalQuarterLabel(anchor),
 		fieldPeriodMonth:   periodBucketExpr(anchor, patternMonth),
 	}
 }

--- a/backend/internal/compose/reportsql.go
+++ b/backend/internal/compose/reportsql.go
@@ -264,6 +264,11 @@ const (
 	// reportBaseCurrencyToken stands in for the installation base currency's
 	// bind position.
 	reportBaseCurrencyToken = "<<installation-base-currency>>"
+	// reportFiscalStartMonthToken stands in for the month the installation's
+	// business year begins — the value that decides whether a period bucket
+	// reads as a calendar year or a fiscal one, and by how much the anchor
+	// shifts when it is the latter.
+	reportFiscalStartMonthToken = "<<installation-fiscal-start-month>>"
 	// reportDealScopeToken stands in for the caller's deal row-scope clause
 	// over a deal subquery aliased d — what keeps a per-project money total
 	// from disclosing a deal the same caller's deal list would withhold.
@@ -290,7 +295,11 @@ func bindReportTokens(
 ) (string, []any, error) {
 	args = slices.Clone(args)
 	arg := func(v any) int { args = append(args, v); return len(args) }
-	bindValue := func(token string, resolve func() (string, error)) error {
+	// `any` rather than `string`, because the fiscal start month is a number
+	// the statement both compares (= 1) and does arithmetic with. Rendering it
+	// as text and letting Postgres infer the type back is the kind of shortcut
+	// that works until a comparison silently becomes a text one.
+	bindValue := func(token string, resolve func() (any, error)) error {
 		if !strings.Contains(sql, token) {
 			return nil
 		}
@@ -301,10 +310,15 @@ func bindReportTokens(
 		sql = strings.ReplaceAll(sql, token, fmt.Sprintf("$%d", arg(value)))
 		return nil
 	}
-	if err := bindValue(reportZoneToken, func() (string, error) { return identity.TimezoneOf(ctx, tx) }); err != nil {
+	if err := bindValue(reportZoneToken, func() (any, error) { return identity.TimezoneOf(ctx, tx) }); err != nil {
 		return "", nil, err
 	}
-	if err := bindValue(reportBaseCurrencyToken, func() (string, error) { return identity.BaseCurrencyOf(ctx, tx) }); err != nil {
+	if err := bindValue(reportBaseCurrencyToken, func() (any, error) { return identity.BaseCurrencyOf(ctx, tx) }); err != nil {
+		return "", nil, err
+	}
+	if err := bindValue(reportFiscalStartMonthToken, func() (any, error) {
+		return identity.FiscalYearStartMonthOf(ctx, tx)
+	}); err != nil {
 		return "", nil, err
 	}
 	bindScope := func(token string, resolve func() (string, error)) error {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16832,6 +16832,21 @@ type InstallationSettings struct {
 	// for one reader keeps that reader's language.
 	BaseLanguage InstallationSettingsBaseLanguage `json:"base_language"`
 
+	// FiscalYearStartMonth The month the installation's business year begins, 1..12. January (1) is the
+	// default, which is the calendar year every installation reported by before this
+	// setting existed.
+	//
+	// It buckets period reports on READ and stores nothing, so changing it re-labels
+	// every report immediately and re-means no stored row. What it DOES re-mean is a
+	// saved report view: a period bucket's text travels out in a derivation handle and
+	// binds back as an equality filter, so a view saved under one fiscal start asks for
+	// a span of months nobody chose after it moves.
+	//
+	// The label spells both calendar years a non-January year spans — `FY2026/27` — so
+	// a reader can tell which twelve months a bucket covers without knowing the
+	// convention. A January year is not a span and keeps the plain `2026`.
+	FiscalYearStartMonth int `json:"fiscal_year_start_month"`
+
 	// MaxUploadBytes The largest upload request this installation accepts, in bytes — set by whoever
 	// operates it, not compiled into the build (OPS-CFG-12, DOC-PARAM-11). Read-only:
 	// it is a deployment fact, so PATCH does not carry it.
@@ -23128,6 +23143,14 @@ type UpdateInstallationSettingsRequest struct {
 	// BaseLanguage The language shared AI writing is written in. Never frozen: changing it re-means
 	// nothing already written, so artifacts stay in the language they were written in.
 	BaseLanguage *UpdateInstallationSettingsRequestBaseLanguage `json:"base_language,omitempty"`
+
+	// FiscalYearStartMonth The month the installation's business year begins, 1..12. Never frozen: it cuts
+	// reports on read and stores nothing.
+	//
+	// Moving it re-labels every period report at once, and re-points any saved report
+	// view whose filter names a period bucket — the report still runs and still looks
+	// right, over a different twelve months.
+	FiscalYearStartMonth *int `json:"fiscal_year_start_month,omitempty"`
 
 	// Name Rename the organization.
 	Name *string `json:"name,omitempty"`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16837,10 +16837,7 @@ type InstallationSettings struct {
 	// setting existed.
 	//
 	// It buckets period reports on READ and stores nothing, so changing it re-labels
-	// every report immediately and re-means no stored row. What it DOES re-mean is a
-	// saved report view: a period bucket's text travels out in a derivation handle and
-	// binds back as an equality filter, so a view saved under one fiscal start asks for
-	// a span of months nobody chose after it moves.
+	// every report immediately and re-means no stored row.
 	//
 	// The label spells both calendar years a non-January year spans — `FY2026/27` — so
 	// a reader can tell which twelve months a bucket covers without knowing the
@@ -23145,11 +23142,8 @@ type UpdateInstallationSettingsRequest struct {
 	BaseLanguage *UpdateInstallationSettingsRequestBaseLanguage `json:"base_language,omitempty"`
 
 	// FiscalYearStartMonth The month the installation's business year begins, 1..12. Never frozen: it cuts
-	// reports on read and stores nothing.
-	//
-	// Moving it re-labels every period report at once, and re-points any saved report
-	// view whose filter names a period bucket — the report still runs and still looks
-	// right, over a different twelve months.
+	// reports on read and stores nothing, so moving it re-labels every period report at
+	// once and re-means no stored row.
 	FiscalYearStartMonth *int `json:"fiscal_year_start_month,omitempty"`
 
 	// Name Rename the organization.

--- a/backend/internal/modules/identity/installationpatch_test.go
+++ b/backend/internal/modules/identity/installationpatch_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// encodeInstallationPatch's completeness, held rather than claimed.
+//
+// The comment above that function says every field of the patch appears in it
+// exactly once, and a field left out is a value that silently stops saving:
+// the form still shows it, the PATCH still carries it, the write still returns
+// 200, and the row never moves. Nothing failed when that claim was only a
+// comment — dropping a line from the encoder left every test in the tree green.
+//
+// So the list is DERIVED from InstallationPatch rather than restated here. A
+// sixth setting added to the struct fails this test until it is encoded, which
+// is the point: the fields that exist are the fields that must be written, and
+// only the struct knows what those are.
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEveryInstallationPatchFieldIsEncoded(t *testing.T) {
+	patchType := reflect.TypeOf(InstallationPatch{})
+
+	// A patch with EVERY field set, built by reflection so no field can be
+	// missed here either. A hand-written literal would have the same gap as
+	// the encoder it is checking.
+	filled := reflect.New(patchType).Elem()
+	for i := range patchType.NumField() {
+		field := filled.Field(i)
+		if field.Kind() != reflect.Pointer {
+			t.Fatalf("%s is %s, want a pointer — a sparse patch marks absence with nil",
+				patchType.Field(i).Name, field.Kind())
+		}
+		// A non-zero value, so an encoder that wrote the type's zero would
+		// still be distinguishable from one that wrote what it was given.
+		value := reflect.New(field.Type().Elem())
+		switch value.Elem().Kind() {
+		case reflect.String:
+			value.Elem().SetString("x")
+		case reflect.Int:
+			value.Elem().SetInt(7)
+		default:
+			t.Fatalf("%s holds %s, which this test does not know how to fill — "+
+				"give it a case rather than letting the field go unchecked",
+				patchType.Field(i).Name, value.Elem().Kind())
+		}
+		field.Set(value)
+	}
+
+	encoded, err := encodeInstallationPatch(filled.Interface().(InstallationPatch))
+	if err != nil {
+		t.Fatalf("encoding a fully-populated patch: %v", err)
+	}
+
+	if len(encoded) != patchType.NumField() {
+		t.Errorf("the encoder produced %d writes for %d patch fields — "+
+			"a field it does not encode is one that silently stops saving",
+			len(encoded), patchType.NumField())
+	}
+
+	// Every write carries bytes, and no key appears twice. A duplicated entry
+	// would pass the count above while leaving a real field unwritten.
+	seen := map[string]bool{}
+	for _, w := range encoded {
+		if w.raw == nil {
+			t.Errorf("%s encoded to nil bytes from a field that was set", w.entry.Key())
+		}
+		if seen[w.entry.Key()] {
+			t.Errorf("%s is encoded twice, so some other field is not encoded at all", w.entry.Key())
+		}
+		seen[w.entry.Key()] = true
+	}
+}
+
+// The other half: an absent field must write NOTHING, not a zero.
+//
+// This is the direction with teeth. `any(p)` on a nil typed pointer is not
+// equal to nil — the interface carries the type — so an encoder that widened
+// too early would see every absent field as present and write the type's zero
+// over it. For the fiscal month that zero is month 0, which is not a month.
+func TestAnAbsentInstallationPatchFieldEncodesToNothing(t *testing.T) {
+	encoded, err := encodeInstallationPatch(InstallationPatch{})
+	if err != nil {
+		t.Fatalf("encoding an empty patch: %v", err)
+	}
+	for _, w := range encoded {
+		if w.raw != nil {
+			t.Errorf("%s encoded %q from an absent field; the write loop would store it",
+				w.entry.Key(), string(w.raw))
+		}
+	}
+}

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -153,8 +153,19 @@ func (s *InstallationSettingsStore) baseCurrencyLock(ctx context.Context) (bool,
 
 // encodeInstallationPatch reduces every field of a sparse patch to its wire
 // bytes. Every field appears exactly once, and a field left out here is a value
-// that silently stops saving — which is why they are collected in one place
-// rather than encoded at the call site.
+// that silently stops saving — the form still shows it, the PATCH still carries
+// it, the write still returns 200, and the row never moves.
+//
+// Held by TestEveryInstallationPatchFieldIsEncoded, which derives the expected
+// list from InstallationPatch by reflection rather than restating it: a sixth
+// setting added to that struct fails until it is encoded here. The claim was a
+// comment first, and dropping a line from the slice below left the whole tree
+// green.
+//
+// The error returns are not dead despite json.Marshal never failing on the
+// string and int fields that exist today: encodePatchField is generic, and the
+// first field whose type has a MarshalJSON that can fail arrives without
+// touching this function.
 func encodeInstallationPatch(in InstallationPatch) ([]pendingWrite, error) {
 	name, err := encodePatchField(Name, in.Name)
 	if err != nil {

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -4,7 +4,7 @@
 package identity
 
 // The installation-settings surface (ADR-0090/A135): the module-facing shape
-// over the three settings identity owns. RBAC, validation, the freeze probe
+// over the settings identity owns. RBAC, validation, the freeze probe
 // and the audit-only write all live on the entries — this file is only the
 // read/patch shape a transport needs.
 
@@ -27,6 +27,8 @@ type InstallationSettings struct {
 	Timezone     string
 	BaseCurrency string
 	BaseLanguage string
+	// FiscalYearStartMonth is the month the business year begins, 1..12.
+	FiscalYearStartMonth int
 	// BaseCurrencyLocked and its reason let a client render the field
 	// read-only instead of discovering the refusal by attempting a write —
 	// the same information the write path would give, offered before the
@@ -36,14 +38,42 @@ type InstallationSettings struct {
 }
 
 // InstallationPatch is a sparse installation-settings write: a nil field is
-// left unchanged. Named fields rather than positional pointers, because the
-// values are all *string and a transposed pair would write a language into the
+// left unchanged. Named fields rather than positional pointers, because most of
+// them are *string and a transposed pair would write a language into the
 // currency row and pass the type checker.
 type InstallationPatch struct {
-	Name         *string
-	Timezone     *string
-	BaseCurrency *string
-	BaseLanguage *string
+	Name                 *string
+	Timezone             *string
+	BaseCurrency         *string
+	BaseLanguage         *string
+	FiscalYearStartMonth *int
+}
+
+// pendingWrite is one field of a sparse patch, already reduced to the two
+// things the write loop needs: which setting to write under, and the JSON to
+// write. `raw` nil means the field was absent and nothing is written.
+type pendingWrite struct {
+	entry settings.Definition
+	raw   []byte
+}
+
+// encodePatchField reduces one patch field to a pendingWrite, encoding it here
+// where its type is still known rather than handing the loop an `any`.
+//
+// Generic over the field's own type, which is what keeps the write typed: the
+// installation's fields are strings except the fiscal start month, and a loop
+// carrying `any` would accept a value of any type at all — including, silently,
+// a nil typed pointer, which is NOT equal to nil once it is inside an
+// interface.
+func encodePatchField[T any](entry settings.Definition, value *T) (pendingWrite, error) {
+	if value == nil {
+		return pendingWrite{entry: entry}, nil
+	}
+	raw, err := json.Marshal(*value)
+	if err != nil {
+		return pendingWrite{}, fmt.Errorf("identity: encoding %s: %w", entry.Key(), err)
+	}
+	return pendingWrite{entry: entry, raw: raw}, nil
 }
 
 // InstallationSettingsStore reads and patches the installation settings.
@@ -61,7 +91,7 @@ func NewInstallationSettings(db *database.DB, s *settings.Store) *InstallationSe
 	return &InstallationSettingsStore{db: db, settings: s}
 }
 
-// GetInstallation reads the three settings and the base currency's lock state.
+// GetInstallation reads the settings and the base currency's lock state.
 //
 // Named GetInstallation rather than Get deliberately. rbacgate_test.go resolves
 // gatedness by BARE FUNCTION NAME within a package — optimistic by design, so
@@ -87,13 +117,18 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 	if err != nil {
 		return InstallationSettings{}, err
 	}
+	fiscalStart, err := settings.Get(ctx, s.settings, FiscalYearStartMonth)
+	if err != nil {
+		return InstallationSettings{}, err
+	}
 	locked, why, err := s.baseCurrencyLock(ctx)
 	if err != nil {
 		return InstallationSettings{}, err
 	}
 	return InstallationSettings{
 		Name: name, Timezone: zone, BaseCurrency: currency, BaseLanguage: language,
-		BaseCurrencyLocked: locked, BaseCurrencyLockedReason: why,
+		FiscalYearStartMonth: fiscalStart,
+		BaseCurrencyLocked:   locked, BaseCurrencyLockedReason: why,
 	}, nil
 }
 
@@ -116,6 +151,34 @@ func (s *InstallationSettingsStore) baseCurrencyLock(ctx context.Context) (bool,
 	return locked, why, nil
 }
 
+// encodeInstallationPatch reduces every field of a sparse patch to its wire
+// bytes. Every field appears exactly once, and a field left out here is a value
+// that silently stops saving — which is why they are collected in one place
+// rather than encoded at the call site.
+func encodeInstallationPatch(in InstallationPatch) ([]pendingWrite, error) {
+	name, err := encodePatchField(Name, in.Name)
+	if err != nil {
+		return nil, err
+	}
+	zone, err := encodePatchField(Timezone, in.Timezone)
+	if err != nil {
+		return nil, err
+	}
+	currency, err := encodePatchField(BaseCurrency, in.BaseCurrency)
+	if err != nil {
+		return nil, err
+	}
+	language, err := encodePatchField(BaseLanguage, in.BaseLanguage)
+	if err != nil {
+		return nil, err
+	}
+	fiscal, err := encodePatchField(FiscalYearStartMonth, in.FiscalYearStartMonth)
+	if err != nil {
+		return nil, err
+	}
+	return []pendingWrite{name, zone, currency, language, fiscal}, nil
+}
+
 // UpdateInstallation applies a sparse patch. Named for the same reason as
 // GetInstallation above. A nil field is left unchanged; an unchanged value
 // writes nothing and audits nothing. Returns the settings after the write.
@@ -131,25 +194,20 @@ func (s *InstallationSettingsStore) UpdateInstallation(ctx context.Context, in I
 	if err := auth.Require(ctx, installationSettingsObject, principal.ActionUpdate); err != nil {
 		return InstallationSettings{}, err
 	}
-	patch := []struct {
-		entry *settings.Entry[string]
-		value *string
-	}{
-		{Name, in.Name},
-		{Timezone, in.Timezone},
-		{BaseCurrency, in.BaseCurrency},
-		{BaseLanguage, in.BaseLanguage},
+	// Each field is encoded where its own type is still known, so the loop
+	// below carries bytes rather than an `any` that would accept anything.
+	// Every field of the patch appears exactly once: one left out is a value
+	// that silently stops saving.
+	patch, err := encodeInstallationPatch(in)
+	if err != nil {
+		return InstallationSettings{}, err
 	}
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		for _, w := range patch {
-			if w.value == nil {
+			if w.raw == nil {
 				continue
 			}
-			raw, err := json.Marshal(*w.value)
-			if err != nil {
-				return fmt.Errorf("identity: encoding %s: %w", w.entry.Key(), err)
-			}
-			if err := s.settings.SetRawTx(ctx, tx, w.entry.Key(), raw); err != nil {
+			if err := s.settings.SetRawTx(ctx, tx, w.entry.Key(), w.raw); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -143,14 +143,17 @@ var BaseLanguage = settings.Define[string](
 // BaseCurrency, which freezes: a fiscal year is a way of cutting time, not a
 // value anything has already converted against.
 //
-// The one thing it does re-mean is a SAVED report view. A period bucket's text
-// travels out in a derivation handle and binds back as an equality filter
-// (reportperiod.go), so "FY2026/27" in somebody's saved view is matched against
-// what this setting produces today. Move the fiscal start and that view asks
-// for a span of months nobody chose — the report still runs and still looks
-// right. Nothing here can prevent that; it is why the label spells BOTH years
-// rather than one, so at least the answer a reader gets is unambiguous about
-// which twelve months it covers.
+// It does re-point a SAVED report view, which is a real gap rather than a
+// property of this setting: a period bucket's text travels out in a derivation
+// handle and binds back as an equality filter (reportperiod.go), so a view
+// saved under one fiscal start names a different span after it moves. Tracked
+// as its own decision — re-point, invalidate, or warn — rather than settled
+// here, because none of the three is obviously right and the label cannot fix
+// it either way.
+//
+// What the label DOES fix is the reader's half: spelling both years means the
+// answer they get is unambiguous about which twelve months it covers, even when
+// the filter that produced it is stale.
 var FiscalYearStartMonth = settings.Define[int](
 	"installation.fiscal_year_start_month",
 	installationSettingsObject,

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -133,9 +133,48 @@ var BaseLanguage = settings.Define[string](
 	},
 ).AsInstallationIdentity()
 
+// FiscalYearStartMonth is the month the installation's business year begins,
+// 1..12. January is the default, which is what every installation reported by
+// before this existed — so an installation that never touches it sees no
+// change, and no saved report view moves under it.
+//
+// It buckets reports on READ and stores nothing, so changing it re-labels every
+// period report immediately and re-means no stored row. That is the opposite of
+// BaseCurrency, which freezes: a fiscal year is a way of cutting time, not a
+// value anything has already converted against.
+//
+// The one thing it does re-mean is a SAVED report view. A period bucket's text
+// travels out in a derivation handle and binds back as an equality filter
+// (reportperiod.go), so "FY2026/27" in somebody's saved view is matched against
+// what this setting produces today. Move the fiscal start and that view asks
+// for a span of months nobody chose — the report still runs and still looks
+// right. Nothing here can prevent that; it is why the label spells BOTH years
+// rather than one, so at least the answer a reader gets is unambiguous about
+// which twelve months it covers.
+var FiscalYearStartMonth = settings.Define[int](
+	"installation.fiscal_year_start_month",
+	installationSettingsObject,
+	"update",
+	int(time.January),
+	func(month int) error {
+		if month < int(time.January) || month > int(time.December) {
+			return fmt.Errorf("a fiscal year starts in month 1..12, not %d", month)
+		}
+		return nil
+	},
+).AsInstallationIdentity()
+
 // Definitions is identity's contribution to the settings registry.
 func Definitions() []settings.Definition {
-	return []settings.Definition{Name, Timezone, BaseCurrency, BaseLanguage, SMTPPasswordRef, LicenseTokenRef}
+	return []settings.Definition{
+		Name,
+		Timezone,
+		BaseCurrency,
+		BaseLanguage,
+		FiscalYearStartMonth,
+		SMTPPasswordRef,
+		LicenseTokenRef,
+	}
 }
 
 // BaseCurrencyOf resolves the installation's reporting currency inside a
@@ -189,6 +228,18 @@ func NameOf(ctx context.Context, tx pgx.Tx) (string, error) {
 // installations get today anyway.
 func BaseLanguageOf(ctx context.Context, tx pgx.Tx) (string, error) {
 	return settings.GetTx(ctx, tx, BaseLanguage)
+}
+
+// FiscalYearStartMonthOf resolves the month the installation's business year
+// begins, inside a transaction the caller already holds.
+//
+// GetTx for the same reason BaseLanguageOf uses it: an installation
+// bootstrapped before this setting existed carries no row, and the default is
+// January — the calendar year those installations have always reported by. So
+// an absent row is not a broken installation, it is an older one that agrees
+// with the default.
+func FiscalYearStartMonthOf(ctx context.Context, tx pgx.Tx) (int, error) {
+	return settings.GetTx(ctx, tx, FiscalYearStartMonth)
 }
 
 // BaseLanguageForPrompt resolves the base language for a caller that holds a

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10111,6 +10111,22 @@ export interface components {
              */
             base_language: "en" | "de" | "vi";
             /**
+             * @description The month the installation's business year begins, 1..12. January (1) is the
+             *     default, which is the calendar year every installation reported by before this
+             *     setting existed.
+             *
+             *     It buckets period reports on READ and stores nothing, so changing it re-labels
+             *     every report immediately and re-means no stored row. What it DOES re-mean is a
+             *     saved report view: a period bucket's text travels out in a derivation handle and
+             *     binds back as an equality filter, so a view saved under one fiscal start asks for
+             *     a span of months nobody chose after it moves.
+             *
+             *     The label spells both calendar years a non-January year spans — `FY2026/27` — so
+             *     a reader can tell which twelve months a bucket covers without knowing the
+             *     convention. A January year is not a span and keeps the plain `2026`.
+             */
+            fiscal_year_start_month: number;
+            /**
              * @description True once a conversion rate has been frozen against the base currency — by a closed
              *     deal, a sent offer, a mirrored invoice, a contract, a commission entry, or a loaded
              *     rate sheet — after which it can no longer be changed (ADR-0085 §7).
@@ -10151,6 +10167,15 @@ export interface components {
              * @enum {string}
              */
             base_language?: "en" | "de" | "vi";
+            /**
+             * @description The month the installation's business year begins, 1..12. Never frozen: it cuts
+             *     reports on read and stores nothing.
+             *
+             *     Moving it re-labels every period report at once, and re-points any saved report
+             *     view whose filter names a period bucket — the report still runs and still looks
+             *     right, over a different twelve months.
+             */
+            fiscal_year_start_month?: number;
         };
         CaptureActivityResponse: {
             funnel: components["schemas"]["CaptureActivityFunnel"];

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10116,10 +10116,7 @@ export interface components {
              *     setting existed.
              *
              *     It buckets period reports on READ and stores nothing, so changing it re-labels
-             *     every report immediately and re-means no stored row. What it DOES re-mean is a
-             *     saved report view: a period bucket's text travels out in a derivation handle and
-             *     binds back as an equality filter, so a view saved under one fiscal start asks for
-             *     a span of months nobody chose after it moves.
+             *     every report immediately and re-means no stored row.
              *
              *     The label spells both calendar years a non-January year spans — `FY2026/27` — so
              *     a reader can tell which twelve months a bucket covers without knowing the
@@ -10169,11 +10166,8 @@ export interface components {
             base_language?: "en" | "de" | "vi";
             /**
              * @description The month the installation's business year begins, 1..12. Never frozen: it cuts
-             *     reports on read and stores nothing.
-             *
-             *     Moving it re-labels every period report at once, and re-points any saved report
-             *     view whose filter names a period bucket — the report still runs and still looks
-             *     right, over a different twelve months.
+             *     reports on read and stores nothing, so moving it re-labels every period report at
+             *     once and re-means no stored row.
              */
             fiscal_year_start_month?: number;
         };

--- a/frontend/src/format/fiscalyear.test.ts
+++ b/frontend/src/format/fiscalyear.test.ts
@@ -57,6 +57,30 @@ describe("the month's own name", () => {
     expect(monthName(1, "de")).toBe("Januar");
   });
 
+  it("names the month it was given from any reader's timezone", () => {
+    // The date behind the lookup is minted in UTC, so a formatter running on
+    // the reader's own clock reads it back in a different zone than it was
+    // written in — and midnight on the 1st is the worst instant for that: every
+    // zone behind UTC lands on the last day of the PREVIOUS month. This
+    // returned "December" for month 1 in America/New_York, so the fiscal-year
+    // picker offered a label one month off the value it saved.
+    //
+    // Driven through the formatter's own resolved zone rather than by setting
+    // TZ, because vitest cannot change the process zone mid-run. What it
+    // asserts instead is the property that makes the zone irrelevant: the same
+    // answer for a month whose UTC-midnight instant falls in the prior month
+    // for every negative offset.
+    const west = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "America/Los_Angeles",
+      month: "long",
+    }).format(new Date(Date.UTC(2026, 0, 1)));
+    // Proof the trap is real in the first place: read on a western clock, that
+    // instant IS December.
+    expect(west).toBe("December");
+    // And proof monthName does not fall into it.
+    expect(monthName(1, "en")).toBe("January");
+  });
+
   it("reads every month rather than only the ones a test happened to try", () => {
     // A guard against an off-by-one in the 0-indexed Date constructor: month 12
     // must be December, not January of the next year.

--- a/frontend/src/format/fiscalyear.test.ts
+++ b/frontend/src/format/fiscalyear.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { fiscalYearLabel } from "./fiscalyear";
+import { monthName } from "./format";
+
+// The label an admin is shown before they save a fiscal start, and the two
+// things about it that can be silently wrong.
+//
+// `backend/frontendfiscalyear_test.go` holds this against the SQL the server
+// actually cuts reports with. This file holds the values themselves, which that
+// gate cannot see: it reads shape out of both sources and cannot execute the
+// SQL, so an off-by-one here would pass it.
+
+describe("the label a fiscal year carries", () => {
+  it("spells a January year as the plain calendar year", () => {
+    // Not "FY2026/27", which would be false — a January year does not span
+    // 2027. This is also every installation that predates the setting, so it
+    // is the branch that must not change.
+    expect(fiscalYearLabel(1, 2026)).toBe("2026");
+  });
+
+  it("names both calendar years a non-January year spans", () => {
+    expect(fiscalYearLabel(4, 2026)).toBe("FY2026/27");
+    expect(fiscalYearLabel(10, 2026)).toBe("FY2026/27");
+    // A February start spans the same two years; the start month changes which
+    // months fall inside, never how many calendar years are crossed.
+    expect(fiscalYearLabel(2, 2026)).toBe("FY2026/27");
+  });
+
+  it("rolls the ending year over a century boundary", () => {
+    // The case a string slice of the first year gets wrong: 2099 + 1 is 2100,
+    // whose last two digits are "00" rather than "100".
+    expect(fiscalYearLabel(4, 2099)).toBe("FY2099/00");
+  });
+
+  it("keeps the labels sorting chronologically as text", () => {
+    // The property the whole period vocabulary rests on: a bucket value is
+    // BOTH what a reader sees and what sorts, so a report needs no separate
+    // sort key. A longer label could have broken it silently.
+    const labels = [
+      fiscalYearLabel(4, 2026),
+      fiscalYearLabel(4, 2024),
+      fiscalYearLabel(4, 2099),
+      fiscalYearLabel(4, 2025),
+    ];
+    expect([...labels].sort()).toEqual([
+      "FY2024/25",
+      "FY2025/26",
+      "FY2026/27",
+      "FY2099/00",
+    ]);
+  });
+});
+
+describe("the month's own name", () => {
+  it("is the reader's language, not a table of ours", () => {
+    expect(monthName(1, "en")).toBe("January");
+    expect(monthName(1, "de")).toBe("Januar");
+  });
+
+  it("reads every month rather than only the ones a test happened to try", () => {
+    // A guard against an off-by-one in the 0-indexed Date constructor: month 12
+    // must be December, not January of the next year.
+    expect(monthName(12, "en")).toBe("December");
+    const names = Array.from({ length: 12 }, (_, index) =>
+      monthName(index + 1, "en"),
+    );
+    expect(new Set(names).size).toBe(12);
+  });
+});

--- a/frontend/src/format/fiscalyear.ts
+++ b/frontend/src/format/fiscalyear.ts
@@ -16,10 +16,18 @@
  * mislabelling a report.
  *
  * That is why the preview is not derived from the server: asking it would mean
- * running a report to render a settings row. The mirror is held instead by
- * `backend/frontendfiscalyear_test.go`, which executes both spellings against
- * the same months and fails in either direction — the pattern
- * `values.MinorUnitExceptions()` is held against `format/minorunits.ts` by.
+ * running a report to render a settings row.
+ *
+ * Two things hold the two together, and neither is the whole job:
+ * `backend/frontendfiscalyear_test.go` reads both sources and checks that the
+ * January branch and the FY<full>/<two> shape still exist on both sides — it
+ * executes nothing, so it can see a shape change and not an arithmetic one.
+ * What the SQL actually produces is held by
+ * `TestWinLossPeriodBucketsFollowTheInstallationFiscalYear` and
+ * `TestTheFiscalMonthShiftIsExactAtTheYearsFirstDay` in
+ * `internal/compose/report_winloss_integration_test.go`, which run the real
+ * statement against Postgres. The values THIS module produces are held by
+ * `fiscalyear.test.ts` beside it.
  */
 
 /**

--- a/frontend/src/format/fiscalyear.ts
+++ b/frontend/src/format/fiscalyear.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/**
+ * How a period bucket reads for a given fiscal start — the SAME rule the server
+ * cuts reports with, spelled here so an admin can see the consequence of the
+ * setting before they save it.
+ *
+ * Two spellings of one rule, and this comment is where that is admitted. The
+ * authority is `fiscalYearLabel` in the backend's
+ * internal/compose/reportperiod.go, which builds the SQL a report is actually
+ * cut by: the server's label is what a report carries, what a saved view
+ * filters on, and what travels in a derivation handle. Nothing here reaches any
+ * of that — this module only PREVIEWS the shape on the settings screen, so a
+ * drift between the two misleads an admin for one screen rather than
+ * mislabelling a report.
+ *
+ * That is why the preview is not derived from the server: asking it would mean
+ * running a report to render a settings row. The mirror is held instead by
+ * `backend/frontendfiscalyear_test.go`, which executes both spellings against
+ * the same months and fails in either direction — the pattern
+ * `values.MinorUnitExceptions()` is held against `format/minorunits.ts` by.
+ */
+
+/**
+ * The label a fiscal year starting in `startMonth` carries, for a year that
+ * begins in `startYear`.
+ *
+ * A January start is the calendar year and is spelled as one — `2026`, not
+ * `FY2026/27`, which would be false: it does not span 2027. Every other start
+ * spans two calendar years and names both, because "FY2026" alone means the
+ * starting year to a British reader and the ending year to an Australian one,
+ * and this product is deployed in Europe and Vietnam at once.
+ */
+export function fiscalYearLabel(startMonth: number, startYear: number): string {
+  if (startMonth === 1) {
+    return String(startYear);
+  }
+  // The last two digits of the following year. Derived by adding rather than
+  // by slicing the string, so the century rolls over on its own: a year
+  // beginning in 2099 ends in 2100 and reads "FY2099/00".
+  const ends = String((startYear + 1) % 100).padStart(2, "0");
+  return `FY${startYear}/${ends}`;
+}

--- a/frontend/src/format/format.ts
+++ b/frontend/src/format/format.ts
@@ -106,6 +106,20 @@ export function formatMoneyCompact(
   }).format(major);
 }
 
+/**
+ * The month's own name in the reader's language, from Intl rather than a table
+ * of our own — a list of twelve month names per locale is a translation file
+ * that goes stale, and the platform already ships them.
+ *
+ * The day is fixed at the 1st and the year is arbitrary: only the month is
+ * rendered, and a month name does not depend on either.
+ */
+export function monthName(month: number, locale: Locale): string {
+  return new Intl.DateTimeFormat(INTL_LOCALE[locale], { month: "long" }).format(
+    new Date(Date.UTC(2026, month - 1, 1)),
+  );
+}
+
 export function formatNumber(value: number, locale: Locale): string {
   return new Intl.NumberFormat(INTL_LOCALE[locale]).format(value);
 }

--- a/frontend/src/format/format.ts
+++ b/frontend/src/format/format.ts
@@ -113,11 +113,25 @@ export function formatMoneyCompact(
  *
  * The day is fixed at the 1st and the year is arbitrary: only the month is
  * rendered, and a month name does not depend on either.
+ *
+ * `timeZone: "UTC"` is load-bearing, not tidiness. The instant is MINTED in UTC
+ * (`Date.UTC`), so formatting it on the reader's own clock reads it back in a
+ * different zone than it was written in — and midnight on the 1st is the worst
+ * possible instant for that, because any zone behind UTC lands on the last day
+ * of the PREVIOUS month. In America/New_York this returned "December" for
+ * month 1, so the fiscal-year picker offered a label one month off the value it
+ * saved.
+ *
+ * This is not a moment anybody is reading in their own zone: the argument is a
+ * month NUMBER, not a point in time, and the date is scaffolding for Intl's
+ * month table. Reading it back in the zone it was written in is what makes the
+ * scaffolding cancel out.
  */
 export function monthName(month: number, locale: Locale): string {
-  return new Intl.DateTimeFormat(INTL_LOCALE[locale], { month: "long" }).format(
-    new Date(Date.UTC(2026, month - 1, 1)),
-  );
+  return new Intl.DateTimeFormat(INTL_LOCALE[locale], {
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(2026, month - 1, 1)));
 }
 
 export function formatNumber(value: number, locale: Locale): string {

--- a/frontend/src/format/one-locale.test.ts
+++ b/frontend/src/format/one-locale.test.ts
@@ -506,6 +506,10 @@ const pinnedLocales: { file: string; why: string }[] = [
     why: "zoneOffsetMs formats in en-US with hourCycle h23 to READ an instant's wall clock back as numbers and derive a zone offset from it. The output is parsed, never shown, so a locale that varied would change the arithmetic rather than the wording.",
   },
   {
+    file: "format/fiscalyear.test.ts",
+    why: "Constructs a formatter on a named western clock to show that a UTC-minted 1st-of-the-month instant reads as the PREVIOUS month there — the trap monthName fell into. The claim is about a zone rather than a locale, and it is unwritable without naming both.",
+  },
+  {
     file: "format/format.test.ts",
     why: "Asserts that Intl ACCEPTS every fixed-offset zone this module refuses, which is the whole reason isRenderableZone exists. That claim is only writable by constructing a formatter with a named locale the assertion chose.",
   },

--- a/frontend/src/format/zone-by-purpose.test.ts
+++ b/frontend/src/format/zone-by-purpose.test.ts
@@ -184,6 +184,14 @@ const pinnedZones: { file: string; why: string }[] = [
     why: "The zone picker's option list — IANA names as DATA the control lists, not a zone anything is formatted in.",
   },
   {
+    file: "format/format.ts",
+    why: "monthName reads a UTC-minted date back in UTC to name a month. The zone is not a rendering choice: the instant is midnight on the 1st, so any reader's clock behind UTC lands on the previous month, and this returned December for January in America/New_York.",
+  },
+  {
+    file: "format/fiscalyear.test.ts",
+    why: "Proves that trap is real before proving monthName avoids it — reading the same UTC instant on a named western clock, which is the only way to show it lands in the previous month.",
+  },
+  {
     file: "format/calendarday.test.ts",
     why: "middayInstant and calendarDay take a zone and are proven by naming two of them; a machine-dependent zone would make the expectations unwritable.",
   },

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5293,6 +5293,9 @@ export const de = {
   "installationSettings.timezone": "Zeitzone für Auswertungen",
   "installationSettings.timezoneHint":
     "IANA-Zonenname (zum Beispiel Europe/Berlin). Die Uhr Ihrer Organisation: Periodengrenzen aller Auswertungen werden darin berechnet, und jedes Datum eines Datensatzes — Abschlusstermine, Rechnungstage, Verlaufsüberschriften — wird darin angezeigt, damit ein Datum für das ganze Team gleich lautet. Unabhängig von Ihrer eigenen Anzeigezeitzone.",
+  "installationSettings.fiscalYearStart": "Geschäftsjahr beginnt",
+  "installationSettings.fiscalYearStartHint":
+    "Der Monat, in dem Ihr Geschäftsjahr beginnt. Auswertungen gruppieren nach diesem Jahr und Quartal — ein Jahr, das nicht im Januar beginnt, wird mit beiden Kalenderjahren benannt, die es umfasst, etwa FY2026/27. Eine Änderung benennt alle Auswertungen sofort neu, und eine gespeicherte Ansicht mit Periodenfilter fragt danach andere Monate ab.",
   "installationSettings.baseCurrency": "Basiswährung",
   "installationSettings.baseCurrencyHint":
     "ISO-4217-Code, in den alle Beträge für Auswertungen umgerechnet werden. Änderbar, bis der erste Betrag dagegen umgerechnet wurde.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5326,6 +5326,9 @@ export const en = {
   "installationSettings.timezone": "Reporting timezone",
   "installationSettings.timezoneHint":
     "IANA zone name (for example Europe/Berlin). Your organization's own clock: report period boundaries are computed in it, and every record date — close dates, invoice days, timeline headings — is shown in it, so a date reads the same for the whole team. Separate from your own display timezone.",
+  "installationSettings.fiscalYearStart": "Financial year starts",
+  "installationSettings.fiscalYearStartHint":
+    "The month your business year begins. Reports group by this year and quarter — a year that does not start in January is labelled with both calendar years it spans, like FY2026/27. Changing it re-labels every report at once, and a saved report view filtered on a period will then ask for different months.",
   "installationSettings.baseCurrency": "Base currency",
   "installationSettings.baseCurrencyHint":
     "ISO-4217 code every amount converts to for roll-ups. Changeable until the first amount converts against it.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5240,6 +5240,9 @@ export const vi = {
   "installationSettings.timezone": "Múi giờ báo cáo",
   "installationSettings.timezoneHint":
     "Tên múi giờ IANA (ví dụ Europe/Berlin). Đồng hồ riêng của tổ chức bạn: ranh giới kỳ của mọi báo cáo được tính theo múi giờ này, và mọi ngày tháng của bản ghi — ngày chốt, ngày hoá đơn, tiêu đề dòng thời gian — đều hiển thị theo nó, để một ngày đọc giống nhau với cả nhóm. Tách biệt với múi giờ hiển thị của riêng bạn.",
+  "installationSettings.fiscalYearStart": "Năm tài chính bắt đầu",
+  "installationSettings.fiscalYearStartHint":
+    "Tháng bắt đầu năm tài chính của bạn. Báo cáo nhóm theo năm và quý này — năm không bắt đầu từ tháng 1 được đặt tên theo cả hai năm dương lịch mà nó trải qua, ví dụ FY2026/27. Thay đổi sẽ đặt lại tên mọi báo cáo ngay lập tức, và một khung nhìn đã lưu có lọc theo kỳ sẽ hỏi những tháng khác.",
   "installationSettings.baseCurrency": "Đơn vị tiền tệ cơ sở",
   "installationSettings.baseCurrencyHint":
     "Mã ISO-4217 mà mọi số tiền được quy đổi về khi tổng hợp. Có thể thay đổi cho đến khi số tiền đầu tiên được quy đổi theo nó.",

--- a/frontend/src/screens/installation-settings.test.tsx
+++ b/frontend/src/screens/installation-settings.test.tsx
@@ -192,6 +192,43 @@ describe("InstallationSettingsCard", () => {
     );
   });
 
+  // The two Select rows, which the text-field case above cannot stand in for.
+  // A `Select` is a button and a portalled listbox rather than an input, so it
+  // is reached by a different path — and that path used to query
+  // `[role="combobox"]`, which returns whichever combobox the form renders
+  // FIRST. With one Select that was right by luck; with two it sent every
+  // fiscal-year Edit to the language picker instead, and a third would have
+  // moved it again with nothing failing.
+  it("focuses the right picker when two rows are both Selects", async () => {
+    const user = userEvent.setup();
+    const { fetchMock } = backendFor(SETTINGS_EDITOR);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<InstallationSettingsCard />);
+
+    const dialog = await openFrom(user, /edit financial year starts/i);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        within(dialog).getByLabelText(/financial year starts/i),
+      ),
+    );
+  });
+
+  it("still focuses the language picker, which is the earlier of the two", async () => {
+    const user = userEvent.setup();
+    const { fetchMock } = backendFor(SETTINGS_EDITOR);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<InstallationSettingsCard />);
+
+    const dialog = await openFrom(user, /edit base language/i);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        within(dialog).getByLabelText(/base language/i),
+      ),
+    );
+  });
+
   it("renders the base currency read-only with the server's reason once it is locked", async () => {
     const user = userEvent.setup();
     const reason =

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -451,14 +451,28 @@ function InstallationProfileDialog({
   // the `autoFocus` attribute, the same way the sign-in page does it, so the
   // a11y lint's blanket rule against autofocus stays intact.
   const asked = useRef<HTMLInputElement>(null);
-  // The language field is a `Select` — a button and a portalled listbox, not an
-  // input — so it takes neither the ref the three text fields share nor one of
-  // its own. Its trigger is found through the form, which keeps the same
-  // promise the other three keep: the verb beside a fact leads to the fact.
+  // Two of the fields are a `Select` — a button and a portalled listbox, not an
+  // input — so neither takes the ref the text fields share. Their triggers are
+  // found through the form, which keeps the same promise the text fields keep:
+  // the verb beside a fact leads to the fact.
+  //
+  // Found by the fact each one EDITS, not by `[role="combobox"]`. There are two
+  // comboboxes here now, and a query for the role returns whichever the form
+  // renders first — so pressing Edit beside the fiscal year focused the
+  // language instead, and a third Select would have moved that again silently.
+  //
+  // `Field` generates its control id with `useId`, which is a React handle
+  // (`:r3:`) and carries no fact name, so the marker is written at the call
+  // site instead. Explicit rather than inferred: a selector guessing at a
+  // generated id would break the day React changes the format, and nothing
+  // would fail except the focus nobody tests by hand.
   const form = useRef<HTMLFormElement>(null);
   useEffect(() => {
-    if (focus === "base_language") {
-      form.current?.querySelector<HTMLElement>('[role="combobox"]')?.focus();
+    const picker = form.current?.querySelector<HTMLElement>(
+      `[data-fact="${focus}"] [role="combobox"]`,
+    );
+    if (picker) {
+      picker.focus();
       return;
     }
     asked.current?.focus();
@@ -540,77 +554,81 @@ function InstallationProfileDialog({
           )}
         </Field>
 
-        <Field
-          label={t("installationSettings.baseLanguage")}
-          hint={t("installationSettings.baseLanguageHint")}
-          error={refused.get("base_language")}
-        >
-          {(control) => (
-            <Select
-              {...control}
-              // `control.id` is spread through UNCHANGED: `Field` renders its
-              // label with `htmlFor` pointing at it, so replacing it would
-              // leave the combobox with no accessible name. The focus effect
-              // reads that same id back out of the DOM.
-              aria-describedby={describe(control)}
-              value={draft.base_language}
-              disabled={!canManage}
-              // Language names are proper nouns and deliberately untranslated,
-              // so every option is in a different language from the page around
-              // it — `lang` is WCAG 2.2 AA 3.1.2, and our locale codes are the
-              // BCP 47 subtags it wants.
-              options={LOCALES.map((locale) => ({
-                value: locale,
-                label: t(localeNameKey(locale)),
-                lang: locale,
-              }))}
-              // `Select` reports a string; narrowing it back through LOCALES is
-              // what makes it a locale without an assertion, and drops an
-              // answer the control was never offering.
-              onChange={(next) => {
-                const picked = LOCALES.find((locale) => locale === next);
-                if (picked) {
-                  onChange({ ...draft, base_language: picked });
-                }
-              }}
-            />
-          )}
-        </Field>
+        <div data-fact="base_language">
+          <Field
+            label={t("installationSettings.baseLanguage")}
+            hint={t("installationSettings.baseLanguageHint")}
+            error={refused.get("base_language")}
+          >
+            {(control) => (
+              <Select
+                {...control}
+                // `control.id` is spread through UNCHANGED: `Field` renders its
+                // label with `htmlFor` pointing at it, so replacing it would
+                // leave the combobox with no accessible name. The focus effect
+                // reads that same id back out of the DOM.
+                aria-describedby={describe(control)}
+                value={draft.base_language}
+                disabled={!canManage}
+                // Language names are proper nouns and deliberately untranslated,
+                // so every option is in a different language from the page around
+                // it — `lang` is WCAG 2.2 AA 3.1.2, and our locale codes are the
+                // BCP 47 subtags it wants.
+                options={LOCALES.map((locale) => ({
+                  value: locale,
+                  label: t(localeNameKey(locale)),
+                  lang: locale,
+                }))}
+                // `Select` reports a string; narrowing it back through LOCALES is
+                // what makes it a locale without an assertion, and drops an
+                // answer the control was never offering.
+                onChange={(next) => {
+                  const picked = LOCALES.find((locale) => locale === next);
+                  if (picked) {
+                    onChange({ ...draft, base_language: picked });
+                  }
+                }}
+              />
+            )}
+          </Field>
+        </div>
 
-        <Field
-          label={t("installationSettings.fiscalYearStart")}
-          hint={t("installationSettings.fiscalYearStartHint")}
-          error={refused.get("fiscal_year_start_month")}
-        >
-          {(control) => (
-            <Select
-              {...control}
-              aria-describedby={describe(control)}
-              value={String(draft.fiscal_year_start_month)}
-              disabled={!canManage}
-              // Twelve months, each labelled with what a report would then be
-              // called — "April — FY2026/27". A bare number would make the
-              // admin work out the consequence of every option; this states it.
-              options={MONTHS.map((month) => ({
-                value: String(month),
-                label: fiscalYearStartSummary(
-                  month,
-                  locale,
-                  new Date().getFullYear(),
-                ),
-              }))}
-              // `Select` reports a string. Narrowed back through MONTHS rather
-              // than parsed, so an answer the control never offered cannot
-              // reach the draft.
-              onChange={(next) => {
-                const picked = MONTHS.find((month) => String(month) === next);
-                if (picked) {
-                  onChange({ ...draft, fiscal_year_start_month: picked });
-                }
-              }}
-            />
-          )}
-        </Field>
+        <div data-fact="fiscal_year_start_month">
+          <Field
+            label={t("installationSettings.fiscalYearStart")}
+            hint={t("installationSettings.fiscalYearStartHint")}
+            error={refused.get("fiscal_year_start_month")}
+          >
+            {(control) => (
+              <Select
+                {...control}
+                aria-describedby={describe(control)}
+                value={String(draft.fiscal_year_start_month)}
+                disabled={!canManage}
+                // Twelve months, each labelled with what a report would then be
+                // called — "April — FY2026/27". A bare number would make the
+                // admin work out the consequence of every option; this states it.
+                options={MONTHS.map((month) => ({
+                  value: String(month),
+                  label: fiscalYearStartSummary(
+                    month,
+                    locale,
+                    new Date().getFullYear(),
+                  ),
+                }))}
+                // `Select` reports a string. Narrowed back through MONTHS rather
+                // than parsed, so an answer the control never offered cannot
+                // reach the draft.
+                onChange={(next) => {
+                  const picked = MONTHS.find((month) => String(month) === next);
+                  if (picked) {
+                    onChange({ ...draft, fiscal_year_start_month: picked });
+                  }
+                }}
+              />
+            )}
+          </Field>
+        </div>
 
         {/* Only what no field claimed. A refusal shown BOTH on the input and
             again in a paragraph below states one problem twice, and the

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -25,7 +25,9 @@ import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { ToastRegion, useToast } from "../design-system/toast";
-import { LOCALES, localeNameKey, useT } from "../i18n";
+import { fiscalYearLabel } from "../format/fiscalyear";
+import { monthName } from "../format/format";
+import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import {
   problemFieldErrorsOf,
   problemMessageOf,
@@ -35,17 +37,18 @@ import {
 
 // The installation settings surface (ADR-0090/A135): the organization's name,
 // the IANA zone every reporting period is computed in, the ISO-4217 base
-// currency every roll-up converts to, and the language AI writes the shared
-// record in. Every role reads them — a rep reading amounts benefits from
+// currency every roll-up converts to, the language AI writes the shared record
+// in, and the month its business year begins. Every role reads them — a rep reading amounts benefits from
 // knowing which currency they are in — and only admin/ops may change them, so
 // the facts are READ on the card for everyone and the verb that changes them is
 // refused with a reason for everyone else. Refusing without a reason is the
 // failure mode this avoids: it is indistinguishable from a bug, and a reader
 // cannot act on it either way.
 //
-// FOUR ROWS AND ONE FORM. The card is a list of decisions — what the
+// FIVE ROWS AND ONE FORM. The card is a list of decisions — what the
 // organization is called, when its periods start, which currency every amount
-// is re-expressed in, which language AI writes for the whole team in — so each
+// is re-expressed in, which language AI writes for the whole team in, and when
+// its financial year turns over — so each
 // is a row that shows its own answer, which is what lets a reader audit the
 // installation by travelling one column. The EDITING is one act: the server
 // takes ONE sparse PATCH, so the fields are submitted together with one Save,
@@ -79,6 +82,7 @@ const EDITABLE_FACTS = [
   "timezone",
   "base_currency",
   "base_language",
+  "fiscal_year_start_month",
 ] as const;
 
 // Which fact the reader pressed Edit on. The dialog always edits all of them —
@@ -166,6 +170,35 @@ function languageName(code: string, t: ReturnType<typeof useT>): string {
   return known ? t(localeNameKey(known)) : code;
 }
 
+// The fiscal-year row's own answer: the month it starts, and what a report will
+// then be labelled. "April — FY2026/27" rather than "4", because the number
+// answers a question nobody asked; the admin is deciding what their reports
+// will SAY, and this is the only place they see it before saving.
+//
+// The example year is a PARAMETER rather than `new Date()` read in here. The
+// caller holds the clock, so a test can state which year it is asserting
+// against — and the daily fe-clock-drift lane, which runs this suite 200 days
+// ahead, does not turn a correct string into a failure every new year.
+//
+// A month outside 1..12 renders as itself. Reachable the same way a stray
+// language code is: the contract and the setting both refuse it, but a row
+// written straight into the settings table can hold anything, and a row showing
+// the raw value is honest where a blank one is not.
+// The twelve months a fiscal year may start in, as the picker offers them.
+// Derived rather than typed out, so the list cannot go short of twelve.
+const MONTHS = Array.from({ length: 12 }, (_, index) => index + 1);
+
+export function fiscalYearStartSummary(
+  month: number,
+  locale: Locale,
+  exampleYear: number,
+): string {
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    return String(month);
+  }
+  return `${monthName(month, locale)} — ${fiscalYearLabel(month, exampleYear)}`;
+}
+
 // A frozen currency is frozen for an admin too, so the lock reason replaces the
 // advice about what to type — that advice is about a value nobody can set. The
 // row and the field inside the dialog say the same thing, from one expression,
@@ -192,6 +225,7 @@ function InstallationSettingsForm({
   canManage: boolean;
 }) {
   const t = useT();
+  const { locale } = useLocale();
   const toast = useToast();
   const [editing, setEditing] = useState<EditedFact | null>(null);
   // The save's only visible answer was the button going disabled, because the
@@ -334,6 +368,23 @@ function InstallationSettingsForm({
               t("installationSettings.baseLanguage"),
             )}
           />
+          <SettingRow
+            label={t("installationSettings.fiscalYearStart")}
+            description={t("installationSettings.fiscalYearStartHint")}
+            // The month's name and the span it produces, because the number
+            // alone answers the wrong question: an admin is deciding what a
+            // report will SAY, and "April — FY2026/27" shows that where "4"
+            // makes them work it out.
+            value={fiscalYearStartSummary(
+              settings.fiscal_year_start_month,
+              locale,
+              new Date().getFullYear(),
+            )}
+            control={editVerb(
+              "fiscal_year_start_month",
+              t("installationSettings.fiscalYearStart"),
+            )}
+          />
         </SettingList>
         {editing !== null && (
           <InstallationProfileDialog
@@ -394,6 +445,7 @@ function InstallationProfileDialog({
   onSubmit: () => void;
 }>) {
   const t = useT();
+  const { locale } = useLocale();
   const titleId = useId();
   // Focus lands on the field whose Edit was pressed — programmatic rather than
   // the `autoFocus` attribute, the same way the sign-in page does it, so the
@@ -519,6 +571,41 @@ function InstallationProfileDialog({
                 const picked = LOCALES.find((locale) => locale === next);
                 if (picked) {
                   onChange({ ...draft, base_language: picked });
+                }
+              }}
+            />
+          )}
+        </Field>
+
+        <Field
+          label={t("installationSettings.fiscalYearStart")}
+          hint={t("installationSettings.fiscalYearStartHint")}
+          error={refused.get("fiscal_year_start_month")}
+        >
+          {(control) => (
+            <Select
+              {...control}
+              aria-describedby={describe(control)}
+              value={String(draft.fiscal_year_start_month)}
+              disabled={!canManage}
+              // Twelve months, each labelled with what a report would then be
+              // called — "April — FY2026/27". A bare number would make the
+              // admin work out the consequence of every option; this states it.
+              options={MONTHS.map((month) => ({
+                value: String(month),
+                label: fiscalYearStartSummary(
+                  month,
+                  locale,
+                  new Date().getFullYear(),
+                ),
+              }))}
+              // `Select` reports a string. Narrowed back through MONTHS rather
+              // than parsed, so an answer the control never offered cannot
+              // reach the draft.
+              onChange={(next) => {
+                const picked = MONTHS.find((month) => String(month) === next);
+                if (picked) {
+                  onChange({ ...draft, fiscal_year_start_month: picked });
                 }
               }}
             />


### PR DESCRIPTION
Reports bucketed by calendar year only. A company whose financial year runs April to March could not see a report matching its own books — it re-added two calendar years to get one business year, every time.

`installation.fiscal_year_start_month` (1..12, default January) cuts the year and quarter grains from the configured month. Quarters move with the year, so an April-starting installation reads April–June as its first quarter rather than the calendar's second. The month grain is untouched: a month is the same month under every fiscal start.

## The label

Non-January years name **both** calendar years they span — `FY2026/27`, quarters `FY2026/27-Q1`.

Either short form is a real convention somewhere: the UK names a fiscal year for the year it starts in, Australia and Japan for the year it ends. Read by half the team it would mean the other twelve months, and this product is deployed in Europe and Vietnam at once. The label is also effectively permanent — a period bucket's text leaves in a derivation handle and binds back as an equality filter, so a saved view holds it — which makes five extra characters the cheaper side of that trade.

A January year keeps the plain `2026`. Spelling it `FY2026/27` would be false: it does not span 2027. That branch is also why **nothing existing moves** — every installation predating this setting runs on the January default and gets the byte-identical label it got before, so no report changes and no saved view starts asking for a span nobody chose.

Verified against Postgres rather than reasoned about, including the property the period vocabulary rests on: the labels still sort chronologically as text, and `FY2099/00` sorts after `FY2026/27` because the leading four-digit year carries the order and the `/YY` is decorative.

## Also moved

The company page's "won this quarter" figure takes the same fiscal cut. A reader who checks it against the win-loss report is comparing two answers to one question, and they have to be cut the same way.

## What the tests earned

**Four quarter cases proved nothing.** April and October are themselves calendar-quarter boundaries, so a cut ignoring the setting returned identical bounds — all four passed with the fiscal arithmetic deleted. They are rewritten around a February start, which shares no boundary with the calendar in any month.

**The mirror gate could not see the shift.** `frontendfiscalyear_test.go` holds the SQL label against the TypeScript preview by reading both sources and checking shape. Review found that deleting the `- 1` from the month shift left every assertion green while an April-start installation labelled 1 April 2026 as `FY2025/26-Q4`. The gate is right about what it holds; the arithmetic needed a database. The new integration test runs the real statement on an instant chosen to see it — 15 March survives a one-month error, 1 April does not.

## Review findings, all three fixed

1. **`monthName` named the wrong month west of UTC.** It minted a UTC date and formatted it on the reader's clock; midnight on the 1st lands in the previous month for every negative offset. The picker offered "December" for the value that saves as January in America/New_York. Three tests fail under `TZ=America/New_York` without the fix.
2. **The gate gap above**, closed by the integration test.
3. **The dialog focused the wrong picker.** `[role="combobox"]` returns whichever renders first — right by luck with one Select, wrong with two. The pre-existing timezone case broke with it, so the old selector fails two tests rather than one. Each Select now carries the fact it edits.

## Gates

`make check-backend`, `make check-fe` (4455 tests), `make craft-static` (0 findings), and `make test-integration` (43 packages, 0 skips) all green. Every fix above is mutation-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let installations start the fiscal year in any month and cut report years and quarters from that start. Previously we always used calendar years; now January stays as 2026 while non‑January renders as FY2026/27. Month buckets remain unchanged.

- Backend
  - Adds `installation.fiscal_year_start_month` (1–12, default 1). Exposes it in the API and passes it through the handler; validation lives on the setting entry and returns a 422 FieldFault that names the key and refused value.
  - Binds `<<installation-fiscal-start-month>>` in report SQL. Builds fiscal year and quarter labels off a shifted, timezone-aware anchor; months stay `YYYY-MM`.
  - Aligns the company page’s “won this quarter” with the same fiscal cut via `currentQuarterBounds(..., fiscalStart)`.
- Frontend
  - Adds a settings row and picker that shows “Month — FYyyyy/yy” (`fiscalYearLabel`, `monthName` formats in UTC). Focuses the correct `Select` when multiple pickers are present. Adds i18n.
- Tests and gates
  - Integration tests verify fiscal labeling and the exact shift at the year’s first day; win/loss buckets follow the installation’s fiscal year. Quarter-boundary unit tests use non‑calendar starts (e.g., February) to catch regressions.
  - Mirror gate compares Go and TS label SHAPE and now blanks comments to avoid false passes; includes its own acceptance test.
  - Adds a round‑trip test for writing/reading the fiscal start, and a completeness test ensuring all `InstallationPatch` fields are encoded; absent fields encode to no write.

- Rollout
  - Default January preserves existing behavior and labels; no saved view changes on upgrade.
  - Required action: changing `fiscal_year_start_month` immediately relabels periods and can repoint saved period filters. Review saved views after changing it.

<sup>Written for commit 61962e870fc9c4fd8947554a88ca63c8e55f44b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an installation setting to choose the fiscal year’s starting month.
  * Reports and saved period views now use fiscal-year and quarter labels based on the selected month.
  * Added localized fiscal-year summaries and month names in English, German, and Vietnamese.
  * Month-based reporting remains aligned with calendar months.

* **Bug Fixes**
  * Improved period boundary handling across time zones and calendar-year transitions.
  * Added validation to prevent invalid fiscal-year start months.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->