### PR TITLE
fix(desktop): the bundle installs a unit's frontend dependencies before typechecking them

### DIFF
--- a/desktop/build/build-app.ps1
+++ b/desktop/build/build-app.ps1
@@ -79,11 +79,11 @@ function Build-Frontend {
     }
 
     # Install at the REPO ROOT, build in frontend/. The lockfile is a root pnpm
-    # workspace -- a unit's frontend layer is a member of it -- so there is no
-    # frontend\pnpm-lock.yaml to install against, and --frozen-lockfile run
-    # from frontend\ would either resolve the root lockfile from a
-    # subdirectory or rewrite it. The Dockerfile's web stage splits the two
-    # steps for the same reason and is the reference for this lane.
+    # workspace, so there is no frontend\pnpm-lock.yaml to install against, and
+    # --frozen-lockfile run from frontend\ would either resolve the root
+    # lockfile from a subdirectory or rewrite it. The Dockerfile's web stage
+    # splits the two steps for the same reason and is the reference for this
+    # lane.
     #
     # --ignore-scripts matches every other frontend install in this repo: the
     # lockfile pins what is installed, and this stops a dependency's lifecycle
@@ -91,6 +91,28 @@ function Build-Frontend {
     Push-Location $RepoRoot
     try {
         Invoke-Native 'pnpm install' 'pnpm' 'install' '--frozen-lockfile' '--ignore-scripts'
+    } finally {
+        Pop-Location
+    }
+
+    # THEN the composed workspace, and the order is load-bearing -- the same
+    # order `make fe-typecheck-composed` documents, and the same second install
+    # build-app.sh performs. A unit's frontend layer is NOT a member of the root
+    # workspace (pnpm-workspace.yaml says why), so its react,
+    # @tanstack/react-query and @types/react come from the GENERATED workspace
+    # below. Without this the root install leaves a unit's screen resolving
+    # neither its peers nor its dev deps, and `pnpm build:composed` typechecks
+    # exactly those screens -- failing with TS2307 "cannot find module 'react'"
+    # in a unit's file, which names neither this script nor the missing step.
+    #
+    # --no-frozen-lockfile because that lockfile is generated build output.
+    $composedWorkspace = Join-Path $RepoRoot 'build\composition-frontend\workspace'
+    if (-not (Test-Path (Join-Path $composedWorkspace 'pnpm-workspace.yaml'))) {
+        throw "gen-composition did not produce $composedWorkspace\pnpm-workspace.yaml, so a unit's frontend dependencies cannot be resolved"
+    }
+    Push-Location $composedWorkspace
+    try {
+        Invoke-Native 'pnpm install (composed workspace)' 'pnpm' 'install' '--no-frozen-lockfile' '--ignore-scripts'
     } finally {
         Pop-Location
     }

--- a/desktop/build/build-app.sh
+++ b/desktop/build/build-app.sh
@@ -72,17 +72,43 @@ build_frontend() {
   fi
 
   # Install at the REPO ROOT, build in frontend/. The lockfile is a root pnpm
-  # workspace — a unit's frontend layer is a member of it — so there is no
-  # frontend/pnpm-lock.yaml to install against, and --frozen-lockfile run from
-  # frontend/ would either resolve the root lockfile from a subdirectory or
-  # rewrite it. The Dockerfile's web stage splits the two steps for the same
-  # reason and is the reference for this lane.
+  # workspace, so there is no frontend/pnpm-lock.yaml to install against, and
+  # --frozen-lockfile run from frontend/ would either resolve the root lockfile
+  # from a subdirectory or rewrite it. The Dockerfile's web stage splits the two
+  # steps for the same reason and is the reference for this lane.
   #
   # --ignore-scripts matches every other frontend install in this repo (the
   # Dockerfile, scripts/verify-boot.sh, the CI lane): a lockfile pins WHAT is
   # installed, and this stops a dependency's lifecycle script from running
   # arbitrary code on the build machine on the way in.
   (cd "$ROOT" && pnpm install --frozen-lockfile --ignore-scripts)
+  # THEN the composed workspace, and the order is load-bearing — the same order
+  # `make fe-typecheck-composed` documents.
+  #
+  # A unit's frontend layer is NOT a member of the root workspace
+  # (pnpm-workspace.yaml says why: membership would make an installation that
+  # enables its own frontend-bearing unit unable to run --frozen-lockfile
+  # against an upstream-owned lockfile). Its react, @tanstack/react-query and
+  # @types/react are linked out of frontend/node_modules by the GENERATED
+  # workspace instead, so the root install alone leaves a unit screen resolving
+  # neither its peers nor its dev deps — and the composed build below
+  # typechecks those screens.
+  #
+  # This lane got away without it while the root lockfile still carried stale
+  # `extensions/*/frontend` entries from the era when they WERE members: they
+  # supplied the peers by accident. A lockfile regeneration correctly dropped
+  # them, and this build broke on the next change to touch desktop/ — the
+  # failure being TS2307 "cannot find module 'react'" in a unit's screen, which
+  # names neither this script nor the missing step.
+  #
+  # --no-frozen-lockfile because that lockfile is generated build output, which
+  # is what the Makefile's own invocation says at greater length.
+  local composed_ws="$ROOT/build/composition-frontend/workspace"
+  if [ ! -f "$composed_ws/pnpm-workspace.yaml" ]; then
+    echo "FAIL: gen-composition did not produce $composed_ws/pnpm-workspace.yaml, so a unit's frontend dependencies cannot be resolved" >&2
+    exit 1
+  fi
+  (cd "$composed_ws" && pnpm install --no-frozen-lockfile --ignore-scripts)
   (cd "$ROOT/frontend" &&
     MARGINCE_COMPOSITION_FRONTEND="$registry" pnpm gen:composed-types &&
     MARGINCE_COMPOSITION_FRONTEND="$registry" pnpm build:composed)


### PR DESCRIPTION

The desktop build installs at the repo root and then runs the COMPOSED frontend
build, which typechecks every enabled unit's screen. A unit's frontend layer is
not a member of the root workspace — `pnpm-workspace.yaml` says why, at length:
membership would stop an installation that enables its own frontend-bearing unit
from running `--frozen-lockfile` against an upstream-owned lockfile. Its react,
@tanstack/react-query and @types/react come from the GENERATED workspace under
build/composition-frontend/workspace instead.

So the root install alone leaves a unit's screen resolving neither its peers nor
its dev deps, and the composed build then typechecks exactly those screens.
`make fe-typecheck-composed` performs both installs in order and documents the
order as load-bearing; this lane performed only the first.

It got away with it while the root lockfile still carried stale
`extensions/*/frontend` entries from the era when they WERE members — they
supplied the peers by accident. A lockfile regeneration correctly dropped them,
and nothing failed until the next change touched desktop/ and triggered this
lane. The failure names neither this script nor the missing step:

    ../extensions/notes/frontend/screen.tsx(22,47): error TS2307:
      Cannot find module 'react' or its corresponding type declarations.

Reproduced by clearing the per-unit node_modules the composed install creates
(`extensions/*/frontend/node_modules`) plus build/composition-frontend, and
rebuilding: 4 TS2307 errors without the added install, zero with it. Clearing
only the generated workspace's own node_modules is NOT enough to reproduce —
the per-unit directories persist and keep the build passing, which is why this
went unnoticed on a machine that had built once.

The stale half of the comment goes too: it asserted that a unit's frontend layer
IS a member of the root workspace, which stopped being true when membership
moved to the composed workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend build reliability by ensuring generated workspaces have all required dependencies installed.
  * Added validation and clearer handling when the generated workspace is unavailable.
  * Preserved existing type-generation and build steps after dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->