### PR TITLE
fix(seed-demo): stop sending a project key the server mints

### DIFF
--- a/backend/tools/seed-demo/surfaces.go
+++ b/backend/tools/seed-demo/surfaces.go
@@ -233,9 +233,17 @@ func seedProjects(c *client, refs pipelineRefs, plan map[string]profile, mode ru
 			continue
 		}
 		name := projectNameFor(localeFor(domain), refs.orgNameByID[orgID])
-		if existing[projectIndexKey(orgID, name)] {
+		index := projectIndexKey(orgID, name)
+		if existing[index] {
 			continue
 		}
+		// Claimed in the SAME map the snapshot filled, because the index is no
+		// longer unique per plan entry: two domains that resolve to one
+		// organization derive one name, and a snapshot taken before the loop
+		// cannot see the project the loop itself just created. The old key was
+		// per-domain and could not collide, so this is the cost of indexing by
+		// what the server leaves us.
+		existing[index] = true
 		if mode == modeDryRun {
 			created++
 			continue

--- a/backend/tools/seed-demo/surfaces.go
+++ b/backend/tools/seed-demo/surfaces.go
@@ -219,7 +219,7 @@ func seedLists(c *client, refs pipelineRefs, mode runMode) (int, error) {
 // created in.
 func seedProjects(c *client, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
 	created := 0
-	existing, err := projectKeys(c, mode)
+	existing, err := projectIndex(c, mode)
 	if err != nil {
 		return 0, err
 	}
@@ -232,22 +232,15 @@ func seedProjects(c *client, refs pipelineRefs, plan map[string]profile, mode ru
 		if !ok {
 			continue
 		}
-		key := projectKey(domain)
-		if existing[key] {
+		name := projectNameFor(localeFor(domain), refs.orgNameByID[orgID])
+		if existing[projectIndexKey(orgID, name)] {
 			continue
 		}
 		if mode == modeDryRun {
 			created++
 			continue
 		}
-		locale := localeFor(domain)
-		body := jsonBody{
-			"name":            projectNameFor(locale, refs.orgNameByID[orgID]),
-			"key":             key,
-			"organization_id": orgID,
-			"source":          seedSource,
-			"started_at":      refs.date(-(30 + hashIndex("projstart:"+domain, 180))),
-		}
+		body := projectCreateBody(orgID, name, refs.date(-(30 + hashIndex("projstart:"+domain, 180))))
 		if owner, ok := refs.usersByRef[refs.ownerRefByDomain[domain]]; ok {
 			body["owner_id"] = owner
 		}
@@ -290,10 +283,6 @@ func advanceProject(c *client, projectID, want, domain string) error {
 	return nil
 }
 
-func projectKey(domain string) string {
-	return fmt.Sprintf("SEED-%s", shortDomain(domain))
-}
-
 func projectNameFor(locale docLocale, company string) string {
 	switch locale {
 	case localeVI:
@@ -305,20 +294,50 @@ func projectNameFor(locale docLocale, company string) string {
 	}
 }
 
-func projectKeys(c *client, mode runMode) (map[string]bool, error) {
+// projectCreateBody is the create payload, in one place so what it does NOT
+// carry is visible: no "key". The server mints a project's key from its name and
+// refuses a caller who sends one (422 read_only, projects/keymint.go) — the key
+// is the token a person types in a subject line to file mail under a project, so
+// it is not a demo's to choose.
+//
+// Nothing else may be added loosely either: this contract takes extra body
+// properties as CUSTOM FIELD values, so a stray key is not ignored here, it is
+// data. Every field below is one the contract declares.
+func projectCreateBody(orgID, name, startedAt string) jsonBody {
+	return jsonBody{
+		"name":            name,
+		"organization_id": orgID,
+		"source":          seedSource,
+		"started_at":      startedAt,
+	}
+}
+
+// projectIndexKey identifies a seeded project by what the seeder still controls.
+//
+// Convergence used to ask "does a project with MY key exist", which is a
+// question a caller who no longer mints the key cannot ask. Organization plus
+// name is the pair the seeder derives deterministically (projectNameFor over the
+// company name), so a second run recognises its own work and creates nothing —
+// and two companies with the same project name stay two projects.
+func projectIndexKey(orgID, name string) string {
+	return orgID + "\x00" + name
+}
+
+func projectIndex(c *client, mode runMode) (map[string]bool, error) {
 	out := map[string]bool{}
 	if mode == modeDryRun {
 		return out, nil
 	}
 	err := c.getAll("/v1/projects", nil, func(raw json.RawMessage) error {
 		var rows []struct {
-			Key string `json:"key"`
+			Name           string `json:"name"`
+			OrganizationID string `json:"organization_id"`
 		}
 		if err := json.Unmarshal(raw, &rows); err != nil {
 			return err
 		}
 		for _, row := range rows {
-			out[row.Key] = true
+			out[projectIndexKey(row.OrganizationID, row.Name)] = true
 		}
 		return nil
 	})

--- a/backend/tools/seed-demo/surfaces_test.go
+++ b/backend/tools/seed-demo/surfaces_test.go
@@ -47,3 +47,21 @@ func TestProjectIndexKeyDistinguishesNameAndOrganization(t *testing.T) {
 		t.Error("two differently named projects in one organization share an index entry")
 	}
 }
+
+// Two domains can resolve to ONE organization — an alias, or two dataset entries
+// merged into the same company — and one organization gives one derived name. The
+// old per-domain key could not collide, so a snapshot taken before the loop was
+// enough; this index can, and a snapshot cannot see what the loop itself created.
+func TestProjectIndexClaimsANameWithinTheSameRun(t *testing.T) {
+	index := map[string]bool{}
+	first := projectIndexKey("org-1", "Acme — Rollout")
+
+	if index[first] {
+		t.Fatal("an empty index reports a project as present")
+	}
+	index[first] = true
+
+	if !index[projectIndexKey("org-1", "Acme — Rollout")] {
+		t.Error("the second plan entry for one organization does not see the first entry's claim, so the project is created twice")
+	}
+}

--- a/backend/tools/seed-demo/surfaces_test.go
+++ b/backend/tools/seed-demo/surfaces_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import "testing"
+
+// A project's key is minted by the server from its name (projects/keymint.go),
+// and a caller that sends one is refused outright — "a project's key is assigned
+// by the server from its name and cannot be set or changed", 422 read_only. The
+// refusal is deliberate: the key is what a person types in a subject line to
+// file mail under a project, so a caller-chosen one becomes a matcher nobody
+// audited.
+//
+// This seeder sent one. The whole run died on the first project, after the
+// companies, people and paper were already written, which is the shape of
+// failure this test exists to keep out: the phases AFTER projects — quotas,
+// consent, lifecycle, relationship types and the owner assignment that runs
+// last — never happened at all.
+func TestProjectCreateBodySendsNoKey(t *testing.T) {
+	body := projectCreateBody("org-1", "Acme — Rollout", "2026-01-01")
+
+	if _, sent := body["key"]; sent {
+		t.Error("the create body carries a key; the server mints it and refuses a caller's own (422 read_only)")
+	}
+	if body["name"] != "Acme — Rollout" {
+		t.Errorf("name = %v, want the name the key will be minted from", body["name"])
+	}
+	if body["organization_id"] != "org-1" {
+		t.Errorf("organization_id = %v, want org-1", body["organization_id"])
+	}
+}
+
+// Convergence has to survive the key going away with it. The seeder used to ask
+// "does a project with MY key exist" — a question it can no longer ask, because
+// it no longer knows the key. A second run that cannot recognise its own work
+// creates every project twice.
+func TestProjectIndexKeyDistinguishesNameAndOrganization(t *testing.T) {
+	same := projectIndexKey("org-1", "Acme — Rollout")
+	if same != projectIndexKey("org-1", "Acme — Rollout") {
+		t.Error("the same project indexes differently on two calls, so a second run would duplicate it")
+	}
+	if same == projectIndexKey("org-2", "Acme — Rollout") {
+		t.Error("two organizations' identically named projects share an index entry, so the second is skipped")
+	}
+	if same == projectIndexKey("org-1", "Acme — Einführung") {
+		t.Error("two differently named projects in one organization share an index entry")
+	}
+}


### PR DESCRIPTION
## The problem

`1da94847` made the server mint a project's key from its name and refuse a caller-supplied one — `422 read_only`, *"a project's key is assigned by the server from its name and cannot be set or changed"*. `tools/seed-demo` still sent `SEED-<domain>`, so every demo seed died on its first project:

```
seed-demo: projects: project for communicode.de: POST /v1/projects: HTTP 422
  {"code":"validation_error","detail":"a project's key is assigned by the server
   from its name and cannot be set or changed",
   "details":{"errors":[{"code":"read_only","field":"key", ...
```

Where it died is what made it expensive. The projects phase sits *after* the companies, people, employments, contracts and documents are written and *before* quotas, consent, lifecycle, relationship types and the owner assignment that runs last. So a run reported several minutes of success and then left an installation whose records have no owners — which reads as a seeder that half works rather than one refused outright.

## The change

Dropping the field is not enough on its own: convergence asked *"does a project with MY key exist"*, a question a caller who no longer mints the key cannot ask. Left as it was, a second run would create every project again.

- The create body moves into `projectCreateBody`, so what it does **not** carry is visible in one place. That matters more here than it looks: this contract takes extra body properties as CUSTOM FIELD values, so a stray key is not ignored, it is data.
- `projectIndex` keys existing projects by organization + name — the pair the seeder still derives deterministically (`projectNameFor` over the company name). A second run recognises its own work, and two companies with identically named projects stay two projects.
- `projectKey` is deleted rather than left unused.

Two tests, both stating the failure they keep out: the create body carries no `key`, and the index distinguishes name and organization.

## Verification

Against a running installation with the demo dataset (192 companies):

```
surfaces:      39 new (tags, lists, custom fields, projects, quotas)
owners:        195 organization(s), 821 person/people
facts:         12387 applied
verify:        OK — every seeded record is owned, employed, linked and staged
```

Second run, same installation: `0 new` in every phase, `verify: OK` — convergence holds on the new index.

## AI disclosure

Assisted — written with AI help, reviewed and owned by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `tools/seed-demo` from sending a project key and makes seeding idempotent without it. The server now mints project keys from names and rejects caller-supplied keys (422), which previously killed runs late in the pipeline.

- Centralizes the create payload in `projectCreateBody` and excludes `key`, avoiding stray custom fields.
- Replaces key-based convergence with `projectIndex` keyed by organization + name, and claims the index during the run so multiple domains resolving to one organization do not create duplicates.
- Removes the unused `projectKey`; adds tests for no `key` in the payload, index uniqueness across organization/name, and within-run claiming.

**Rollout**
- No migrations. Safe to deploy; rerunning the seeder will not create duplicates.

<sup>Written for commit a15b79cf6b6a6205e6add1ac9ff894263224f85d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved demo project seeding to recognize existing projects by organization and project name.
  - Prevented duplicate projects when names are reused across different organizations or during the same seeding run.
  - Project creation now uses server-generated project identifiers while preserving project names and organization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->