### PR TITLE
fix(contract-api): a confidence this contract cannot carry is not served

### DIFF
--- a/backend/internal/compose/person360/providerclaimconfidence_test.go
+++ b/backend/internal/compose/person360/providerclaimconfidence_test.go
@@ -5,12 +5,12 @@ package person360
 
 // A provider's confidence reaches this contract through `value_json`, which
 // carries no CHECK. The column beside it is bounded 0..1 and is NOT where this
-// number comes from — so between a vendor and a reader there was nothing at
-// all.
+// number comes from, so the bound on it governs nothing here.
 //
-// The contract declares the field `minimum: 0, maximum: 1`. A vendor that
-// scores out of 100, which is a normal thing for a vendor to do, would put 87
-// on it, and the page renders a confidence as a percentage.
+// The contract declares the field `minimum: 0, maximum: 1`, and the page renders
+// a confidence as a percentage — so a vendor scoring out of 100 would read as
+// 8700%. Every Surfe score in this tree is a proportion today; what is guarded
+// is that nothing makes it one.
 
 import (
 	"encoding/json"
@@ -65,6 +65,38 @@ func TestAConfidenceTheContractCannotCarryIsNotServed(t *testing.T) {
 				t.Errorf("dropped a confidence of %v, which the contract can carry", *tc.score)
 			case tc.want != nil && *got != *tc.want:
 				t.Errorf("served %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+// The claim's own column is the fallback when an entry carries no score of its
+// own, and it passes through the same guard. The column is CHECK-bounded, so a
+// value that fails here cannot come from a live database — but the guard runs
+// after the fallback merge, and a branch with no test is a branch that stops
+// working quietly.
+func TestTheColumnFallbackPassesThroughTheSameGuard(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		column float64
+		want   *float32
+	}{
+		{"a bounded column is used when the entry has no score", 0.42, providerPtr(float32(0.42))},
+		{"an out-of-range column states nothing either", 42, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			claim := phoneClaim(t, nil)
+			claim.confidence = providerPtr(tc.column)
+			var out crmcontracts.PersonProviderProfile
+			if err := foldPhones(claim, &out); err != nil {
+				t.Fatalf("folding: %v", err)
+			}
+			got := out.MobilePhones[0].Confidence
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("served %v from a column of %v", *got, tc.column)
+			case tc.want != nil && (got == nil || *got != *tc.want):
+				t.Errorf("served %v, want %v", got, *tc.want)
 			}
 		})
 	}

--- a/backend/internal/compose/person360/providerclaimconfidence_test.go
+++ b/backend/internal/compose/person360/providerclaimconfidence_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package person360
+
+// A provider's confidence reaches this contract through `value_json`, which
+// carries no CHECK. The column beside it is bounded 0..1 and is NOT where this
+// number comes from — so between a vendor and a reader there was nothing at
+// all.
+//
+// The contract declares the field `minimum: 0, maximum: 1`. A vendor that
+// scores out of 100, which is a normal thing for a vendor to do, would put 87
+// on it, and the page renders a confidence as a percentage.
+
+import (
+	"encoding/json"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/provider"
+)
+
+func phoneClaim(t *testing.T, confidence *float64) storedClaim {
+	t.Helper()
+	entry := map[string]any{"value": "+49 151 2345678"}
+	if confidence != nil {
+		entry["confidence"] = *confidence
+	}
+	raw, err := json.Marshal([]map[string]any{entry})
+	if err != nil {
+		t.Fatalf("encoding the fixture claim: %v", err)
+	}
+	return storedClaim{key: string(provider.ClaimMobilePhones), value: raw, provider: "surfe"}
+}
+
+func TestAConfidenceTheContractCannotCarryIsNotServed(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		score *float64
+		want  *float32
+	}{
+		{"a proportion is carried", providerPtr(0.87), providerPtr(float32(0.87))},
+		{"zero is a real confidence, not an absent one", providerPtr(0.0), providerPtr(float32(0))},
+		{"one is in range", providerPtr(1.0), providerPtr(float32(1))},
+		{"a vendor scoring out of 100 states nothing here", providerPtr(87.0), nil},
+		{"just over the bound is still over it", providerPtr(1.0000001), nil},
+		{"a negative score is not a confidence", providerPtr(-0.5), nil},
+		{"no score at all", nil, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out crmcontracts.PersonProviderProfile
+			if err := foldPhones(phoneClaim(t, tc.score), &out); err != nil {
+				t.Fatalf("folding: %v", err)
+			}
+			if len(out.MobilePhones) != 1 {
+				t.Fatalf("got %d phones, want the number itself to survive whatever the score was",
+					len(out.MobilePhones))
+			}
+			got := out.MobilePhones[0].Confidence
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("served confidence %v for a score of %v — the contract declares this "+
+					"field 0..1, and a page renders it as a percentage", *got, *tc.score)
+			case tc.want != nil && got == nil:
+				t.Errorf("dropped a confidence of %v, which the contract can carry", *tc.score)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("served %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+// The number is what the row was bought for. However a vendor scales its
+// certainty, the phone is unaffected — so an unstatable score must cost the
+// confidence and nothing else.
+func TestAnUnstatableScoreNeverCostsTheNumber(t *testing.T) {
+	var out crmcontracts.PersonProviderProfile
+	if err := foldPhones(phoneClaim(t, providerPtr(87.0)), &out); err != nil {
+		t.Fatalf("folding: %v", err)
+	}
+	if len(out.MobilePhones) != 1 || out.MobilePhones[0].Value != "+49 151 2345678" {
+		t.Errorf("phones = %+v — an out-of-range confidence took the number with it", out.MobilePhones)
+	}
+}

--- a/backend/internal/compose/person360/providerclaimfold.go
+++ b/backend/internal/compose/person360/providerclaimfold.go
@@ -68,6 +68,30 @@ func (s *Service) foldClaims(ctx context.Context, tx pgx.Tx, personID ids.Person
 	return nil
 }
 
+// statableConfidence reports whether a score is one this contract can carry: a
+// proportion, zero through one.
+//
+// HERE rather than at each provider, because this is the one place a bounded
+// contract field is written and it is reached by every claim source. The value
+// arrives through `value_json`, which carries no CHECK — the column beside it
+// does, and that column is not where this number comes from. So between a
+// vendor and a reader there was nothing: a vendor scoring out of 100, which is
+// a normal thing for a vendor to do, would put 87 on a field the contract
+// declares `maximum: 1`, and a page rendering it as a percentage would say
+// 8700%.
+//
+// An unstatable score drops the CONFIDENCE, never the value beside it. The
+// phone number is what the row was bought for and is unaffected by how a vendor
+// scales its certainty; the confidence is optional in the contract precisely so
+// it can be absent. Saying nothing about how sure we are beats saying something
+// the contract cannot express.
+//
+// NaN and the infinities fall out of the comparison rather than needing a test
+// of their own — neither is >= 0.
+func statableConfidence(score float64) bool {
+	return score >= 0 && score <= 1
+}
+
 // foldOne decodes one claim onto the profile. An unreadable value is an error
 // rather than a silent omission: the row was paid for, and a page that quietly
 // dropped it would tell the reader the provider returned nothing.
@@ -154,7 +178,7 @@ func foldPhones(c storedClaim, out *crmcontracts.PersonProviderProfile) error {
 			confidence = c.confidence
 		}
 		phone := crmcontracts.PersonProviderPhone{Value: p.Value}
-		if confidence != nil {
+		if confidence != nil && statableConfidence(*confidence) {
 			// The contract carries a float32 because a confidence is a band,
 			// not a measurement; the extra precision would imply one.
 			phone.Confidence = providerPtr(float32(*confidence))

--- a/backend/internal/compose/person360/providerclaimfold.go
+++ b/backend/internal/compose/person360/providerclaimfold.go
@@ -71,23 +71,41 @@ func (s *Service) foldClaims(ctx context.Context, tx pgx.Tx, personID ids.Person
 // statableConfidence reports whether a score is one this contract can carry: a
 // proportion, zero through one.
 //
-// HERE rather than at each provider, because this is the one place a bounded
-// contract field is written and it is reached by every claim source. The value
-// arrives through `value_json`, which carries no CHECK — the column beside it
-// does, and that column is not where this number comes from. So between a
-// vendor and a reader there was nothing: a vendor scoring out of 100, which is
-// a normal thing for a vendor to do, would put 87 on a field the contract
-// declares `maximum: 1`, and a page rendering it as a percentage would say
-// 8700%.
+// HERE rather than at each provider, because this is the one place a PROVIDER
+// CLAIM's confidence reaches the contract, and every claim source passes
+// through it. A check at each provider would be one per provider, and the next
+// one added would not have it.
+//
+// The value arrives through `value_json`, which carries no CHECK. The
+// `confidence` COLUMN beside it does — and is not where this number comes from,
+// which is what made the path look guarded while carrying none of the traffic.
+// A vendor scoring out of 100 would put 87 on a field the contract declares
+// `maximum: 1`, and the page renders a confidence as a percentage.
+//
+// This is HARDENING, not a live defect: every Surfe score in this tree is a
+// proportion. The number is vendor-controlled and nothing validated it, which
+// is reason enough.
+//
+// `compose/enrichextract.go` guards the same invariant for extracted fields and
+// answers it differently — it drops the whole field and treats zero as invalid.
+// Both are right for their own input: an extracted value is model-fabricated
+// and worth nothing without a confidence, where a phone number was paid for and
+// stands on its own. Named here so the difference reads as a choice.
 //
 // An unstatable score drops the CONFIDENCE, never the value beside it. The
 // phone number is what the row was bought for and is unaffected by how a vendor
 // scales its certainty; the confidence is optional in the contract precisely so
 // it can be absent. Saying nothing about how sure we are beats saying something
-// the contract cannot express.
+// the contract cannot express — and clamping would assert maximal certainty
+// while normalising would guess a scale the vendor never declared.
 //
-// NaN and the infinities fall out of the comparison rather than needing a test
-// of their own — neither is >= 0.
+// Guarded at READ rather than at write, so `value_json` keeps what the vendor
+// actually asserted: a scale corrected later restores every confidence, and the
+// Art. 15 export still shows what was received.
+//
+// NaN fails `>= 0`; the infinities fail one bound each — `+Inf >= 0` is TRUE
+// and only the upper bound stops it. Neither needs a test of its own, but the
+// reason they are excluded is not the same reason.
 func statableConfidence(score float64) bool {
 	return score >= 0 && score <= 1
 }


### PR DESCRIPTION
## The defect

`PersonProviderPhone.confidence` is declared in the contract as:

```yaml
confidence: { type: [number, 'null'], minimum: 0, maximum: 1 }
```

The value that reaches it comes from a provider claim's **`value_json`**, which carries no CHECK. The `confidence` **column** beside it *is* bounded 0–1 — and is not where this number comes from.

So the whole path was unguarded:

```
Surfe confidenceScore  →  value_json (no CHECK)  →  person360 foldPhones  →  served
```

**A vendor that scores out of 100 — a normal thing for a vendor to do — puts `87` on a field the contract says is at most `1`.** The page renders a confidence as a percentage, so a reader would be shown 8700%.

Nothing in the tree validated it, and nothing failed: the bounded column made the path *look* guarded while carrying none of the traffic.

## Why the guard is at the fold

`foldPhones` is the **one place a bounded contract field is written**, and every claim source reaches it — Surfe today, the offline fixture, whatever is added next. A check at each provider would be one check per provider, and the next provider would not have it.

## An unstatable score costs the confidence, never the number

The phone number is what the row was bought for, and it is unaffected by how a vendor scales its certainty. The contract makes `confidence` optional precisely so it can be absent.

**Saying nothing about how sure we are beats saying something the contract cannot express.**

Zero is carried rather than dropped — it is a real confidence, and its absence means something different.

## Verification

| case | served |
|---|---|
| `0.87` | `0.87` |
| `0` | `0` — a real confidence, not an absent one |
| `1` | `1` |
| **`87`** (vendor scoring out of 100) | **nothing** |
| `1.0000001` | nothing |
| `-0.5` | nothing |
| absent | nothing |

Plus: an out-of-range score never takes the number with it.

Mutation-proven — removing the guard fails on exactly the case that matters:

```
served confidence 87 for a score of 87 — the contract declares this field 0..1,
and a page renders it as a percentage
```

`make check-backend` green.

## Scope note

The audit item that led here also listed `enrichextract.go`'s `(0,1]` against six `[0,1]`, and three float widths. Those are a separate question — whether zero is a legal confidence — and are not touched. This PR is the one where an unbounded value reaches a bounded contract field, which is the half with a reader on the other end.

Branched from `50f57116` rather than current main, which is red on an unrelated migration (#2576). Will rebase before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents out‑of‑range confidences from being served in `PersonProviderPhone.confidence`. Previously unbounded values from `value_json` could set 87 and render 8700%; now the fold serves confidences only in [0,1] and omits invalid ones while always keeping the phone number.

- Adds `statableConfidence` in `backend/internal/compose/person360/providerclaimfold.go` and applies it in `foldPhones`; sets `Confidence` only when the score is within [0,1] (NaN, +Inf, and −Inf are rejected by the appropriate bound). Zero remains a valid confidence.
- Adds `backend/internal/compose/person360/providerclaimconfidence_test.go` to cover valid (0, 0.87, 1), invalid (>1, <0), absence, and the column fallback path; asserts the phone value is never dropped.
- Clarifies comments: this is the one place a provider claim’s confidence reaches the contract; explains why each unstatable value is excluded; documents the difference from `compose/enrichextract.go`; and states why the guard runs at read time.

<sup>Written for commit dacd1b08b6018c7b4d99aa2a3ac051ec68d23699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile phone data handling by accepting only valid confidence scores between 0 and 1.
  * Preserved phone values when confidence information is missing or invalid.
  * Added fallback handling for claim-level confidence scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->