### PR TITLE
test(compose): a scope-count failure prints the counts

### DIFF
--- a/backend/internal/compose/integration/aiscope_integration_test.go
+++ b/backend/internal/compose/integration/aiscope_integration_test.go
@@ -87,8 +87,17 @@ func TestAskScopedToOneProjectDropsTheOtherEngagementAndReportsTheScope(t *testi
 	}
 	// Eight activities on the account; the scope drops the other
 	// engagement's mail, task and meeting.
-	if answer.Scope.InScope == nil || answer.Scope.Total == nil || *answer.Scope.InScope != 5 || *answer.Scope.Total != 8 {
-		t.Errorf("scope counts = %v of %v, want 5 of 8", answer.Scope.InScope, answer.Scope.Total)
+	if answer.Scope.InScope == nil || answer.Scope.Total == nil {
+		t.Fatalf("scope counts = %v of %v, want both reported", answer.Scope.InScope, answer.Scope.Total)
+	}
+	// The counts are named once and read by both the comparison and the
+	// message: spelled twice, a changed expectation leaves the failure
+	// reporting the number it no longer wants. And dereferenced, because
+	// %v on the pointers prints where the counts live, never what they are.
+	wantInScope, wantTotal := 5, 8
+	if *answer.Scope.InScope != wantInScope || *answer.Scope.Total != wantTotal {
+		t.Errorf("scope counts = %d of %d, want %d of %d",
+			*answer.Scope.InScope, *answer.Scope.Total, wantInScope, wantTotal)
 	}
 
 	unscoped, err := svc.Ask(e.Admin(), ids.From[ids.OrganizationKind](f.org), crmcontracts.OrganizationQuestionWhatsOpen)
@@ -134,8 +143,17 @@ func TestOrganizationBriefScopedToOneProjectWritesFromTheScopedSummaryOnly(t *te
 	if scoped.Scope == nil || scoped.Scope.ProjectId != crmcontracts.Id(f.erp.UUID) {
 		t.Fatalf("scope = %+v, want %s", scoped.Scope, f.erpKey)
 	}
-	if scoped.Scope.InScope == nil || scoped.Scope.Total == nil || *scoped.Scope.InScope != 4 || *scoped.Scope.Total != 7 {
-		t.Errorf("scope counts = %v of %v, want 4 of 7", scoped.Scope.InScope, scoped.Scope.Total)
+	if scoped.Scope.InScope == nil || scoped.Scope.Total == nil {
+		t.Fatalf("scope counts = %v of %v, want both reported", scoped.Scope.InScope, scoped.Scope.Total)
+	}
+	// The counts are named once and read by both the comparison and the
+	// message: spelled twice, a changed expectation leaves the failure
+	// reporting the number it no longer wants. And dereferenced, because
+	// %v on the pointers prints where the counts live, never what they are.
+	wantInScope, wantTotal := 4, 7
+	if *scoped.Scope.InScope != wantInScope || *scoped.Scope.Total != wantTotal {
+		t.Errorf("scope counts = %d of %d, want %d of %d",
+			*scoped.Scope.InScope, *scoped.Scope.Total, wantInScope, wantTotal)
 	}
 
 	lane.prompt = ""
@@ -197,8 +215,17 @@ func TestMeetingBriefTakesARequestedProjectForAnUnattributedMeeting(t *testing.T
 	}
 	// The attendee's nine activities include both meetings; the scope drops
 	// the other engagement's four.
-	if brief.Scope.InScope == nil || brief.Scope.Total == nil || *brief.Scope.InScope != 5 || *brief.Scope.Total != 9 {
-		t.Errorf("scope counts = %v of %v, want 5 of 9", brief.Scope.InScope, brief.Scope.Total)
+	if brief.Scope.InScope == nil || brief.Scope.Total == nil {
+		t.Fatalf("scope counts = %v of %v, want both reported", brief.Scope.InScope, brief.Scope.Total)
+	}
+	// The counts are named once and read by both the comparison and the
+	// message: spelled twice, a changed expectation leaves the failure
+	// reporting the number it no longer wants. And dereferenced, because
+	// %v on the pointers prints where the counts live, never what they are.
+	wantInScope, wantTotal := 5, 9
+	if *brief.Scope.InScope != wantInScope || *brief.Scope.Total != wantTotal {
+		t.Errorf("scope counts = %d of %d, want %d of %d",
+			*brief.Scope.InScope, *brief.Scope.Total, wantInScope, wantTotal)
 	}
 	text := meetingBriefText(brief)
 	if strings.Contains(text, "Rack") {


### PR DESCRIPTION
## Found while diagnosing the red main

Three assertions in `aiscope_integration_test.go` compare dereferenced counts and then print the **pointers**:

```
scope counts = 0x477b190a0d40 of 0x477b190a0d48, want 5 of 8
```

The one number a reader needs is the one the message cannot carry. This is not theoretical — during this morning's `#2576` breakage I had to patch the test locally just to learn the counts were `4 of 6`, and that number was what identified the cause.

## A second defect the first one hid

The `want 5 of 8` is a hardcoded string duplicating the comparison constants. Mutating the total to `99`, the old shape still printed:

```
scope counts = 5 of 8, want 5 of 8
```

— a message asserting the expectation it had just stopped holding. The pair is now named once and read by both the comparison and the message, so the same mutation now prints `want 5 of 99`.

Same class as the AC-overlay count in #2520: a literal duplicated between the check and the prose drifts, and the prose is the half a reader believes.

## Evidence

Both mutants run and their output read, rather than inferred from the diff:

| | old shape | new shape |
|---|---|---|
| counts printed | `0x477b190a0d40 of 0x477b190a0d48` | `5 of 8` |
| expectation mutated to 99 | `want 5 of 8` | `want 5 of 99` |

Affected tests pass; `make check-backend` exits 0.

## Not included

The `#2576` breakage itself was fixed on main by `be4f058` while I was working on it — an additive migration withdrawing the trigger, the same approach I had reached, with the sharper reason: the prep assembly path has no employment hop at all, so the refusal did not break fixtures, it made a meeting unable to name its company on every context surface. I dropped my version rather than ship a duplicate; this is the one piece of that work that stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three scope-count test assertions so failures print actual counts and keep expectations single-sourced. Previously, failures printed pointer addresses and duplicated the expected pair, which could drift from the comparison.

- In `backend/internal/compose/integration/aiscope_integration_test.go`, check for nil counts and fail fast; otherwise compare dereferenced values and format as "%d of %d".
- Define `wantInScope` and `wantTotal` once per test and use them for both the comparison and the error message.
- Test-only change; no production behavior impact.

<sup>Written for commit 494704f2fc4a721ea683849fba160b3ccfa2cdad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration-test validation for scoped questions, organization briefs, and meeting briefs.
  * Added clearer checks for missing values and more informative failure messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->