### PR TITLE
fix(deals): the buyer sees the whole room, and a preview shows where a reply goes

### DIFF
--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -458,6 +458,23 @@ a:not([class]):focus-visible {
   color: var(--textMeta);
 }
 
+/* The failure said in the surrounding type's size. Eleven sites across both
+   sides of the Deal Room write `t-small t-danger` for a refusal or a request
+   that failed, and no sheet declared it — so every one of them rendered in
+   meta grey, which reads as an aside rather than a problem. It sets colour
+   only: it is always worn over a size class, and a second font-size here
+   would fight whichever one that is.
+
+   `.co-error` below says nearly the same thing and is the older spelling: it
+   sets a size as well, and one screen uses it against this one's thirteen.
+   Two names for "this failed" is one too many — folding that single caller
+   into this class is the resolution, and it is not done here because it
+   belongs in its own change rather than riding along with a Deal Room fix. */
+.t-danger {
+  color: var(--danger);
+  font-weight: var(--fw-medium);
+}
+
 /* The quiet aside and the spoken failure. Five screens ask for these two —
    the LinkedIn dialogs, the reach panel, the import screen — and no stylesheet
    answered, so every "this is only background" line rendered at full body

--- a/frontend/src/screens/buyerroom.css
+++ b/frontend/src/screens/buyerroom.css
@@ -18,6 +18,18 @@
   gap: var(--space-6);
 }
 
+/* Flex items shrink by default, and this column is a flex item of a scroller
+   with a definite height. Without this the panels are compressed to fit the
+   viewport instead of the page growing, and `.panel`'s `overflow: hidden`
+   discards the remainder — measured at 1006x588, the documents panel drew
+   155px of 575px and the conversation 80px of 291px, so a buyer saw a
+   filename and no threads, no composer, and no scrollbar to reveal them.
+   The seller's room never hit this because `.wrap` is `flex: none`; the buyer
+   route is railless and has no `.wrap`. */
+.buyer-column > * {
+  flex: none;
+}
+
 .buyer-header h1 {
   margin: var(--space-2) 0 0;
 }

--- a/frontend/src/screens/buyerroom.stories.tsx
+++ b/frontend/src/screens/buyerroom.stories.tsx
@@ -28,6 +28,29 @@ const ROOM = {
   steward_name: "Ada Admin",
 };
 
+// The railless shell frame, reproduced because the bug this screen shipped
+// lived ENTIRELY in it. `room` is in RAIL_LESS_SCREENS, so Shell renders
+// `.app.railless > .main > .scroll` around it: `.main` is a flex column with
+// `overflow: hidden` and `.scroll` is `flex: 1`, which hands the page a
+// definite height. Under that height the buyer column's panels were shrunk to
+// fit and `.panel { overflow: hidden }` discarded the rest — the documents
+// panel drew 155px of 575px, so the buyer saw a filename and none of the
+// threads or composer beneath it.
+//
+// Mounted bare in StoryProviders, as this file used to, there is no bounded
+// height, nothing shrinks, and the story renders a page the product cannot
+// produce. The height is fixed rather than viewport-relative so the constraint
+// exists in a docs frame too.
+function RaillessFrame({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <div className="app railless" style={{ height: "640px" }}>
+      <main className="main">
+        <div className="scroll">{children}</div>
+      </main>
+    </div>
+  );
+}
+
 function room(routes: RouteMap, session = true) {
   return () => {
     installFetchStub(routes);
@@ -38,7 +61,9 @@ function room(routes: RouteMap, session = true) {
     }
     return (
       <StoryProviders>
-        <BuyerRoomScreen />
+        <RaillessFrame>
+          <BuyerRoomScreen />
+        </RaillessFrame>
       </StoryProviders>
     );
   };

--- a/frontend/src/screens/buyerroom.stories.tsx
+++ b/frontend/src/screens/buyerroom.stories.tsx
@@ -126,3 +126,90 @@ export const Expired: Story = {
 export const DeadLink: Story = {
   render: room({}, false),
 };
+
+// The refused states. They exist because a rep uses `View as buyer` to
+// check what their buyer sees, and a refused reader who is shown NO write
+// control reads exactly like a buyer who may comment — the pages are
+// identical, which is the opposite of what a preview is for. So each of these
+// has to show the affordance in its disabled state, carrying the reason.
+
+const DOCUMENT = {
+  id: "doc-1",
+  group_key: "commercial",
+  title: "Rahmenvertrag",
+  position: 1,
+  filename: "rahmenvertrag.pdf",
+  content_type: "application/pdf",
+  byte_size: 182_000,
+};
+
+const SELLER = { side: "seller", name: "Ada Admin" };
+
+const THREAD = {
+  id: "th-1",
+  room_id: "room-1",
+  document_id: "doc-1",
+  required_change: false,
+  state: "open",
+  author: SELLER,
+  created_at: "2026-08-22T10:00:00Z",
+  comments: [
+    {
+      id: "c-1",
+      thread_id: "th-1",
+      body: "Which clause covers the notice period?",
+      author: SELLER,
+      created_at: "2026-08-22T10:00:00Z",
+    },
+  ],
+};
+
+function previewRoutes(documents: unknown[], threads: unknown[]): RouteMap {
+  return {
+    "GET /public/rooms/me": () =>
+      jsonResponse({
+        access: "live",
+        // A preview seat as the server actually mints it: read-only. The
+        // capability matters as well as the flag — a fixture that left this
+        // `comment` would draw a live composer and quietly document a page
+        // the product never serves.
+        participant: { ...PARTICIPANT, capability: "view" },
+        preview: true,
+        steward_name: "Ada Admin",
+        room: ROOM,
+      }),
+    "GET /public/rooms/documents": () => jsonResponse({ data: documents }),
+    "GET /public/rooms/threads": () => jsonResponse({ data: threads }),
+  };
+}
+
+// A rep previewing a room that HAS documents: every card carries a refused
+// "Ask about this document", and the reason is stated once on the room panel
+// below rather than repeated under each file.
+export const PreviewWithDocuments: Story = {
+  render: room(previewRoutes([DOCUMENT], [THREAD])),
+};
+
+// A rep previewing a room with nothing in it yet — the first thing anyone
+// previews, and the state that shipped with no control at all: the refusal
+// sentence with nothing to attach it to. The room composer draws its own
+// button here, because there is no document card to carry one.
+export const PreviewEmptyRoom: Story = {
+  render: room(previewRoutes([], [])),
+};
+
+// Not a preview: a real buyer invited with the read-only `view` capability.
+// Same refused controls, a different sentence.
+export const ViewOnlySeat: Story = {
+  render: room({
+    "GET /public/rooms/me": () =>
+      jsonResponse({
+        access: "live",
+        participant: { ...PARTICIPANT, capability: "view" },
+        steward_name: "Ada Admin",
+        room: ROOM,
+      }),
+    "GET /public/rooms/documents": () => jsonResponse({ data: [DOCUMENT] }),
+    "GET /public/rooms/threads": () => jsonResponse({ data: [THREAD] }),
+  }),
+};

--- a/frontend/src/screens/buyerroom.test.tsx
+++ b/frontend/src/screens/buyerroom.test.tsx
@@ -354,3 +354,44 @@ describe("a preview never gets a working composer", () => {
     expect(await screen.findByLabelText("New thread")).toBeTruthy();
   });
 });
+
+// `BuyerRoomAccess` is a plain string on the wire, not a union, so the
+// compiler cannot enumerate the states and a server that grows a fifth one
+// reaches this build untouched. A write gate that lists the states it refuses
+// hands that state a working composer; one that names the single state it
+// admits refuses it. This test supplies a state no build has heard of, which
+// is the only way to check the DEFAULT rather than the four known branches.
+describe("an access state this build does not know", () => {
+  it("cannot write", async () => {
+    stubRoom({
+      "GET /public/rooms/me": () =>
+        jsonResponse({ ...LIVE, access: "quarantined" }),
+      "GET /public/rooms/documents": () => jsonResponse({ data: [] }),
+      "GET /public/rooms/threads": () => jsonResponse({ data: [] }),
+    });
+    globalThis.sessionStorage.setItem("margince.room.session", "mdrs_session");
+    render(<BuyerRoomScreen />);
+
+    const start = await screen.findByRole("button", { name: "New thread" });
+    expect(start).toBeDisabled();
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+
+  it("is not told the room is closed, because that would be a guess", async () => {
+    stubRoom({
+      "GET /public/rooms/me": () =>
+        jsonResponse({ ...LIVE, access: "quarantined" }),
+      "GET /public/rooms/documents": () => jsonResponse({ data: [] }),
+      "GET /public/rooms/threads": () => jsonResponse({ data: [] }),
+    });
+    globalThis.sessionStorage.setItem("margince.room.session", "mdrs_session");
+    render(<BuyerRoomScreen />);
+
+    expect(await screen.findByText("This room is now read-only.")).toBeTruthy();
+    expect(
+      screen.queryByText(
+        "This room is closed; what it shared is a record now.",
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/buyerroom.test.tsx
+++ b/frontend/src/screens/buyerroom.test.tsx
@@ -312,3 +312,45 @@ describe("BuyerRoomScreen", () => {
     ).toBeTruthy();
   });
 });
+
+// Whether the reader may write and why they may not are one decision. They
+// were two, and they disagreed: `conversationRefusal` named a preview and the
+// write test never mentioned one, so a preview session whose seat carried
+// `comment` was handed a working composer while the page told it a preview
+// cannot write. Only the server minting every preview seat read-only kept
+// that off the screen.
+describe("a preview never gets a working composer", () => {
+  it("refuses the write even when the seat itself says comment", async () => {
+    stubRoom({
+      "GET /public/rooms/me": () => jsonResponse({ ...LIVE, preview: true }),
+      "GET /public/rooms/documents": () => jsonResponse({ data: [] }),
+      "GET /public/rooms/threads": () => jsonResponse({ data: [] }),
+    });
+    globalThis.sessionStorage.setItem("margince.room.session", "mdrs_session");
+    render(<BuyerRoomScreen />);
+
+    // LIVE's participant carries `capability: "comment"`, so a write gate that
+    // reads only the capability admits this reader.
+    expect(LIVE.participant.capability).toBe("comment");
+
+    const start = await screen.findByRole("button", { name: "New thread" });
+    expect(start).toBeDisabled();
+    // No open composer anywhere: a disabled button beside a live textarea
+    // would still let the reader type and press Post.
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+
+  it("still gives a commenting buyer a working composer", async () => {
+    stubRoom({
+      "GET /public/rooms/me": () => jsonResponse(LIVE),
+      "GET /public/rooms/documents": () => jsonResponse({ data: [] }),
+      "GET /public/rooms/threads": () => jsonResponse({ data: [] }),
+    });
+    globalThis.sessionStorage.setItem("margince.room.session", "mdrs_session");
+    render(<BuyerRoomScreen />);
+
+    // The admit case, without which the refusal above passes against a page
+    // that refuses everybody.
+    expect(await screen.findByLabelText("New thread")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/buyerroom.tsx
+++ b/frontend/src/screens/buyerroom.tsx
@@ -683,6 +683,14 @@ function RoomView({
 }>) {
   const t = useT();
   const steward = view.steward_name ?? t("buyer.stewardUnknown");
+  // Whether this reader may write is the ANSWER to `conversationRefusal`, not
+  // a second opinion sitting beside it: a reader who was given a reason may
+  // not write, and one who may write has no reason to show. Spelled apart the
+  // two drifted — the refusal named a preview and the write test never
+  // mentioned one, so a preview whose seat carried `comment` would have been
+  // handed a live composer. That combination does not arise today only
+  // because the server mints every preview seat read-only.
+  const writeRefusal = conversationRefusal(view, t);
   if (view.access === "paused" || view.access === "expired") {
     return (
       <>
@@ -738,10 +746,8 @@ function RoomView({
       <BuyerBoard
         token={token}
         onSessionLost={onSessionLost}
-        mayWrite={
-          view.access === "live" && view.participant.capability !== "view"
-        }
-        refusal={conversationRefusal(view, t)}
+        mayWrite={writeRefusal === undefined}
+        refusal={writeRefusal}
       />
     </>
   );

--- a/frontend/src/screens/buyerroom.tsx
+++ b/frontend/src/screens/buyerroom.tsx
@@ -654,8 +654,16 @@ const ACCESS_TITLE: Record<string, MessageKey> = {
 };
 
 // Why this reader may not write in the conversation, in the order that
-// binds first: a preview never writes, a closed room takes nothing more, a
-// read-only seat may only read. Undefined when they may.
+// binds first: a preview never writes, a room that is not open takes nothing
+// more, a read-only seat may only read. Undefined when they may.
+//
+// The access test names the ONE state that admits a write rather than the
+// states that refuse one. `BuyerRoomAccess` is a plain string on the wire, not
+// a union, so the compiler cannot say which values exist and a fifth state
+// added on the server would reach this untouched — listing the refusals means
+// it arrives here writable, which is the wrong way for a write gate to be
+// wrong. `paused` and `expired` do not reach this code today (RoomView answers
+// them with their own screen first), and this does not rely on that.
 function conversationRefusal(
   view: BuyerRoomView,
   t: ReturnType<typeof useT>,
@@ -665,6 +673,12 @@ function conversationRefusal(
   }
   if (view.access === "closed") {
     return t("buyer.closed");
+  }
+  if (view.access !== "live") {
+    // Any other non-live state, including one this build has never heard of.
+    // `buyer.closedNote` rather than `buyer.closed`: "this room is closed" is
+    // a claim, and it is false for a paused room.
+    return t("buyer.closedNote");
   }
   if (view.participant.capability === "view") {
     return t("threads.readOnly");

--- a/frontend/src/screens/dealroomthreads.test.tsx
+++ b/frontend/src/screens/dealroomthreads.test.tsx
@@ -196,17 +196,70 @@ describe("a board nobody may write to", () => {
     expect(reason?.textContent).toContain(REFUSAL);
   });
 
+  // A room with no documents has no card to carry the affordance, and this is
+  // the case a rep previewing a NEW room lands on first. Before, they saw a
+  // sentence and nothing else, which is indistinguishable from a room where
+  // nobody may ever write.
+  it("shows the affordance in a room that has no documents yet", () => {
+    render(
+      <LocaleProvider initial="en">
+        <DocumentBoard
+          title="Documents"
+          sub="Everything shared with the buyer"
+          groups={[]}
+          documents={[]}
+          threads={[]}
+          empty="No documents yet"
+          verbs={{ mayRequireChange: false, refusal: REFUSAL }}
+        />
+      </LocaleProvider>,
+    );
+    const start = screen.getByRole("button", { name: "New thread" });
+    expect(start).toBeDisabled();
+    const reason = document.getElementById(
+      start.getAttribute("aria-describedby") as string,
+    );
+    expect(reason?.textContent).toContain(REFUSAL);
+  });
+
   it("says the reason once, not under every document", () => {
-    draw({ refusal: REFUSAL });
+    // TWO documents: the count is what distinguishes "stated once and pointed
+    // at" from "repeated under each file", and with one document both spell
+    // the same number.
+    render(
+      <LocaleProvider initial="en">
+        <DocumentBoard
+          title="Documents"
+          sub="Everything shared with the buyer"
+          groups={[{ key: "contract", label: "Contract" }]}
+          documents={[DOCUMENT, { ...DOCUMENT, id: "doc-2", title: "Anhang" }]}
+          threads={[]}
+          empty="No documents yet"
+          verbs={{ mayRequireChange: false, refusal: REFUSAL }}
+        />
+      </LocaleProvider>,
+    );
+    // Both cards carry a refused control...
+    expect(
+      screen.getAllByRole("button", { name: "Ask about this document" }),
+    ).toHaveLength(2);
+    // ...and every one of them points at the SAME single sentence.
     expect(screen.getAllByText(REFUSAL)).toHaveLength(1);
+    const ids = screen
+      .getAllByRole("button", { name: "Ask about this document" })
+      .map((b) => b.getAttribute("aria-describedby"));
+    expect(new Set(ids).size).toBe(1);
   });
 
   it("offers no composer at all when there is no reason to give", () => {
     // No `refusal` and no `open`: nothing to say and nothing to press, so the
-    // card must not grow a dead control with an empty explanation.
+    // board must not grow a dead control with an empty explanation. The room
+    // composer is the one that would, since it draws a button unconditionally
+    // once a refusal exists.
     draw({});
     expect(
       screen.queryByRole("button", { name: "Ask about this document" }),
     ).toBeNull();
+    expect(screen.queryByRole("button", { name: "New thread" })).toBeNull();
   });
 });

--- a/frontend/src/screens/dealroomthreads.test.tsx
+++ b/frontend/src/screens/dealroomthreads.test.tsx
@@ -170,3 +170,43 @@ describe("a refused new thread", () => {
     expect(screen.queryByText(/dealroom\.open_thread/)).toBeNull();
   });
 });
+
+// A reader who may NOT write — a seller previewing the room, a read-only
+// seat, a closed room. What they see has to answer two questions at once:
+// that writing is refused, and WHERE writing would otherwise happen. Drawing
+// nothing answers only the first, and a rep previewing their own room then
+// cannot tell a commenting buyer's page from a read-only one, because the two
+// render identically.
+describe("a board nobody may write to", () => {
+  const REFUSAL = "A preview cannot write.";
+
+  it("still shows where a reply would go, refused and reasoned", () => {
+    draw({ refusal: REFUSAL });
+
+    const ask = screen.getByRole("button", {
+      name: "Ask about this document",
+    });
+    // Refused, not absent: the affordance is on the page and cannot be used.
+    expect(ask).toBeDisabled();
+    // And the reason reaches a screen reader from the control itself, rather
+    // than living only in prose somewhere below it.
+    const describedBy = ask.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const reason = document.getElementById(describedBy as string);
+    expect(reason?.textContent).toContain(REFUSAL);
+  });
+
+  it("says the reason once, not under every document", () => {
+    draw({ refusal: REFUSAL });
+    expect(screen.getAllByText(REFUSAL)).toHaveLength(1);
+  });
+
+  it("offers no composer at all when there is no reason to give", () => {
+    // No `refusal` and no `open`: nothing to say and nothing to press, so the
+    // card must not grow a dead control with an empty explanation.
+    draw({});
+    expect(
+      screen.queryByRole("button", { name: "Ask about this document" }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/dealroomthreads.tsx
+++ b/frontend/src/screens/dealroomthreads.tsx
@@ -24,6 +24,12 @@ import "./dealroomthreads.css";
 // are the caller's decisions, and the only things that differ between the
 // two screens.
 
+// The one element carrying "why you may not write here". The room panel's
+// composer prints it; every refused document button points at it with
+// `aria-describedby` rather than repeating it. Both live in this file and the
+// room panel is unconditional, so the reference cannot dangle.
+const REFUSAL_ID = "deal-room-write-refusal";
+
 export type DealRoomThread = components["schemas"]["DealRoomThread"];
 
 export type ThreadVerbs = Readonly<{
@@ -340,10 +346,34 @@ function ThreadComposer({
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   if (!verbs.open) {
-    // The refusal is said once, on the room panel, not under every document.
-    return !collapsible && verbs.refusal ? (
-      <p className="t-small">{verbs.refusal}</p>
-    ) : null;
+    // A reader who may not write still sees WHERE writing would happen: the
+    // button in its disabled state, carrying the reason. Rendering nothing
+    // here made a preview show a room with no reply affordance at all, so a
+    // rep checking what their buyer sees could not tell a commenting seat
+    // from a read-only one — the two drew the same page.
+    //
+    // The room panel keeps the sentence in prose; a document card would
+    // repeat it under every file, so there the reason rides the control.
+    if (!verbs.refusal) {
+      return null;
+    }
+    return collapsible ? (
+      <div className="card-actions">
+        {/* `reasonId`, not `reason`: every document on the board is refused by
+            the ONE fact the room panel already states, and printing that
+            sentence under each file says it as many times as there are files.
+            Naming it once and pointing each control at it says it once and
+            still reaches a screen reader from every one of them. */}
+        <Button small variant="ghost" reasonId={REFUSAL_ID}>
+          <MessageSquare aria-hidden />
+          {label}
+        </Button>
+      </div>
+    ) : (
+      <p className="t-small t-danger" id={REFUSAL_ID}>
+        {verbs.refusal}
+      </p>
+    );
   }
   const open = verbs.open;
   if (!openForm) {

--- a/frontend/src/screens/dealroomthreads.tsx
+++ b/frontend/src/screens/dealroomthreads.tsx
@@ -352,27 +352,33 @@ function ThreadComposer({
     // rep checking what their buyer sees could not tell a commenting seat
     // from a read-only one — the two drew the same page.
     //
-    // The room panel keeps the sentence in prose; a document card would
-    // repeat it under every file, so there the reason rides the control.
+    // The room composer states the sentence and draws its own button; a
+    // document card draws the button alone and points at that sentence. Both
+    // draw one, because a room with NO documents has no card to carry it —
+    // and an empty room shown to a preview is exactly where a rep most needs
+    // to see that a buyer would have somewhere to write.
     if (!verbs.refusal) {
       return null;
     }
-    return collapsible ? (
-      <div className="card-actions">
-        {/* `reasonId`, not `reason`: every document on the board is refused by
-            the ONE fact the room panel already states, and printing that
-            sentence under each file says it as many times as there are files.
-            Naming it once and pointing each control at it says it once and
-            still reaches a screen reader from every one of them. */}
-        <Button small variant="ghost" reasonId={REFUSAL_ID}>
-          <MessageSquare aria-hidden />
-          {label}
-        </Button>
-      </div>
-    ) : (
-      <p className="t-small t-danger" id={REFUSAL_ID}>
-        {verbs.refusal}
-      </p>
+    return (
+      <>
+        {collapsible ? null : (
+          <p className="t-small t-danger" id={REFUSAL_ID}>
+            {verbs.refusal}
+          </p>
+        )}
+        <div className="card-actions">
+          {/* `reasonId`, not `reason`: every control on the board is refused
+              by the ONE fact the room panel states, and printing that sentence
+              under each of them says it as many times as there are files.
+              Naming it once and pointing each control at it says it once and
+              still reaches a screen reader from every one of them. */}
+          <Button small variant="ghost" reasonId={REFUSAL_ID}>
+            <MessageSquare aria-hidden />
+            {label}
+          </Button>
+        </div>
+      </>
     );
   }
   const open = verbs.open;


### PR DESCRIPTION
## What was wrong

The buyer's Deal Room clipped most of its own content away, so a buyer could not see or answer comments on files. Reported from the running product.

`.buyer-column` is a flex column inside a scroller with a definite height, so its panels were shrunk to fit the viewport rather than the page growing, and `.panel { overflow: hidden }` discarded the remainder.

Measured at 1006x588 with one document and one thread:

| Panel | Drawn | Content | Destroyed |
|---|---|---|---|
| Documents | 155px | 575px | 420px |
| Conversation | 80px | 291px | 211px |

The page did not scroll — `scrollHeight` equalled `clientHeight` — so there was no way to reach the rest. The reply box rendered on every load and sat off the page.

The seller's room never hit this: it renders inside `.wrap`, which is `flex: none`. The buyer route is railless and has no `.wrap`.

## Why no test caught it

`buyerroom.stories.tsx` mounted the screen in `StoryProviders` alone — no bounded height, so nothing shrank and the story rendered a page the product cannot produce. It now renders inside the railless frame (`.app.railless > .main > .scroll`) that `Shell` actually builds.

## Two more defects the same page exposed

**`t-danger` was declared in no stylesheet.** Twelve production sites across both sides of the Deal Room write `t-small t-danger` for a refusal or a failed request, so every one rendered in meta grey. Declared in `base.css` beside the other type utilities, colour only, since it is always worn over a size class.

**A reader who may not write saw no write affordance at all.** `ThreadComposer` returned `null`, so a rep previewing their own room could not tell a commenting buyer's page from a read-only one — the two drew the same page, which is the opposite of what a preview is for. Both composers now draw their button in its disabled state, carrying the reason through `aria-describedby`; the sentence is stated once and every control points at it.

The write refusal itself is unchanged and still correct: a preview must not record a rep's question as the buyer's.

## Verified

Clicked through on a real deal room on a running stack, as a preview session:

- page scrolls, **0px clipped**
- both refused controls disabled, both resolving to the one reason element
- refusal renders `rgb(185,28,28)` instead of grey

`make check-fe` green (4,485 tests), `make craft-static` clean, all 62 stories render.

Every new test was mutation-checked against the exact prior implementation. Two written in the first pass were vacuous and are rewritten — a single-document fixture cannot tell "stated once" from "repeated per file".

## Filed, not fixed here

- #2583 — `StatStrip` orphans a slot when the count does not divide the folded column count (the deal strip's 4 readings, 640–1088px). Two candidate fixes were tried and rejected; the real one touches a component 8 screens use.
- #2584 — a buyer's file comments vanish silently when the file is archived or the room is paused.

Refs #2583, #2584

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes buyer Deal Room clipping and makes reply affordances visible but disabled in previews/read-only states. Old: panels shrank, composers vanished or could go live in preview, and unknown access could write. New: panels don’t shrink; room and document composers render disabled buttons that reference one shared refusal; previews never get a working composer; only `live` access admits writing; unknown access renders read‑only.

- Review notes
  - CSS: `.buyer-column > * { flex: none }` stops panel shrink; adds `.t-danger` utility.
  - Gating: `mayWrite` derives from a single refusal source; admits only `live`; non‑live (incl. unknown) shows the read‑only note.
  - Accessibility/UX: refused controls are disabled buttons with `aria-describedby` pointing at one refusal element; empty rooms also show the refused “New thread” button.
  - Stories/tests: buyer room renders in the railless frame; new stories for preview with docs, preview empty, and view‑only seats; tests ensure previews cannot write and unknown access is read‑only; document board tests assert one shared refusal across multiple documents.

<sup>Written for commit c0e4e1fe8ee99f0e3a1b150dd77da7f11479bd85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Deal 360 status insights for offer value, forecast timing, stakeholder engagement, momentum, and next actions.
  * Added stakeholder seat details with engagement states and withheld-name handling.
  * Added shared relative-date formatting and expanded German, English, and Vietnamese deal translations.
* **Bug Fixes**
  * Meetings and calls can no longer be linked directly to organizations.
  * Improved read-only Deal Room and buyer-room controls, accessibility, scrolling, and Deal 360 layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->