### PR TITLE
fix(frontend): the seats panel says it is unavailable rather than vanishing

### DIFF
--- a/frontend/src/screens/deal360/dealseats.tsx
+++ b/frontend/src/screens/deal360/dealseats.tsx
@@ -17,9 +17,10 @@
 
 import type { components } from "../../api/schema";
 import { Badge } from "../../design-system/atoms";
-import { PanelBody } from "../../design-system/panel";
+import { Panel, PanelBody } from "../../design-system/panel";
 import { sectionState } from "../../design-system/surfacestate";
 import { useT } from "../../i18n";
+import { OverlayUnavailable } from "../common";
 import { dealRoleLabel, RailPanel } from "../record360";
 import "../network.css";
 
@@ -36,12 +37,28 @@ export function DealSeats({
   coverage,
   withheld,
   pending,
+  overlay = false,
 }: Readonly<{
   coverage?: DealCoverage;
   withheld: boolean;
   pending: boolean;
+  overlay?: boolean;
 }>) {
   const t = useT();
+  // The seats are a native relationship read the mirror does not serve. The
+  // panel still appears and says so, because a section that simply vanishes in
+  // overlay is indistinguishable from a deal nobody is on — which is the whole
+  // reason every other 360 panel spells this state rather than rendering
+  // nothing. It moved here from the coverage card, and that card said it too.
+  if (overlay) {
+    return (
+      <Panel title={t("deal.seats.title")}>
+        <PanelBody>
+          <OverlayUnavailable />
+        </PanelBody>
+      </Panel>
+    );
+  }
   const seats = coverage?.stakeholders ?? [];
   const ours = coverage?.our_side ?? [];
   const state = sectionState(

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3505,7 +3505,12 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                 t,
               )}
               aside={
-                overlay ? undefined : (
+                overlay ? (
+                  // The room and the mail asides are genuinely absent under a
+                  // mirror. The seats are not: they are a native read the
+                  // mirror does not serve, and saying so is the panel's job.
+                  <DealSeats overlay withheld={false} pending={false} />
+                ) : (
                   <>
                     {/* Context first: who these people are, before the verbs
                         that act on them. The seats moved out of the main


### PR DESCRIPTION
## uat has been red on main since 10:46

`AC-overlay-7` counts four unavailable panels on Deal 360 and finds three. Reproduced on clean `origin/main` (`a4940c5`) before changing anything.

**#2576 broke it, not #2575.** #2575 is the PR whose run reported the failure, but it touches **no frontend files at all** — it is a backend `workspace.slug` retirement. I checked every frontend-touching commit since the last green uat: #2576's own uat run failed with the identical `Expected: 4 / Received: 3`, and #2558, #2394, #2553, #2525, #2526 all passed theirs.

#2576 also merged **before a single check reported** — every one of its 23 check-runs completed between 11:00 and 11:31 against a 10:46:35 merge. It took down the integration lane the same way (fixed separately by `be4f058`), and uat with it.

## Which panel, measured rather than reasoned

I probed the rendered page in overlay rather than reading the diff for a likely culprit:

```
PANEL 0 ["Angebote"]          offers
PANEL 1 ["Verwandte Belege"]  related documents
PANEL 2 ["Verlauf"]           history
TOTAL: 3
```

The missing fourth is the **seats**. #2576 moved them out of `DealCoverageCard` into `deal360/dealseats.tsx` in the rail, and the rail's aside is dropped wholesale under a mirror — `aside={overlay ? undefined : (…)}`. The section stopped existing, and nothing said why.

## Why this is an oversight and not a decision

The evidence is in the tree: `network.tsx` still carries the coverage card's own `{overlay && <OverlayUnavailable />}`. The card is simply no longer mounted on the deal page. **The guarantee was written down and the move took the panel out from under it** — the `overlay ? undefined` predates the seats arriving in that aside.

## The fix

`DealSeats` takes an `overlay` prop and renders the panel with `<OverlayUnavailable />`. The room and mail asides stay absent under a mirror — those genuinely are not there — while the seats render and say why they are empty.

A section that vanishes is indistinguishable from a deal nobody is on. That is the whole reason every other 360 panel spells this state instead of rendering nothing.

Note the design system's `SectionState` has an `"unavailable"` member, but it renders `state.unavailable`, a different string from the `overlay.unavailable` copy every counted panel uses — so this goes through `<OverlayUnavailable />` like its siblings rather than through the state machine.

## Evidence

```
AC-overlay grep:  8 passed (3.3s)
full playwright:  94 passed, 14 skipped (19.9s)
```

`make check-fe` exits 0.

## If I have read the intent wrong

If the seats were meant to be absent under a mirror like the room and mail asides, then the alternative is to drop the AC count to 3 and say in the comment that the rail is not shown in overlay. I did not take that route because it would encode a silent disappearance as expected, and because the coverage card's surviving overlay branch says the opposite. Happy to be overruled by whoever owns #2576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the seats panel in Deal 360 overlay and marks it unavailable instead of hiding it. Previously the seats panel disappeared under overlay; now it renders with “unavailable,” restoring the expected four-panel count.

**Changes**
- `DealSeats` accepts an `overlay` prop and, when true, renders a `Panel` with `OverlayUnavailable`.
- `DealScreen` mounts the seats aside in overlay (`<DealSeats overlay withheld={false} pending={false} />`) instead of omitting the aside; room and mail asides remain absent.
- Uses `OverlayUnavailable` to match existing panel copy; does not switch to `SectionState.unavailable`.

<sup>Written for commit 60e2d4ff9b5dad54a21dfbf2024a22cf7c39b929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the deal record sidebar’s overlay mode with a clear unavailable-state panel.
  * Ensured the sidebar renders consistently in overlay mode while preserving existing seats, room, and email views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->