### PR TITLE
refactor(identity): one spelling of someone who still works here

### DIFF
--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -201,6 +201,8 @@ func employmentStatements(decl ast.Decl, people helperScope) []string {
 	return out
 }
 
+// firstEmploymentLine returns the line of the statement that names the
+// employment kind, so the report points at the statement rather than dumping
 // it.
 func firstEmploymentLine(sql string) string {
 	for _, line := range strings.Split(sql, "\n") {
@@ -211,6 +213,7 @@ func firstEmploymentLine(sql string) string {
 	return strings.TrimSpace(strings.Split(sql, "\n")[0])
 }
 
+// employmentProbe is one planted source file and the answer the gate must give
 // for it.
 type employmentProbe struct {
 	name  string

--- a/backend/employmentcurrency_test.go
+++ b/backend/employmentcurrency_test.go
@@ -34,7 +34,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -130,6 +129,7 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 		scope := helperScope{
 			qualifier: importAliasOf(file, "github.com/gradionhq/margince/backend/internal/modules/people"),
 			inside:    file.Name != nil && file.Name.Name == "people",
+			names:     map[string]bool{employmentHelper: true, primaryHelper: true},
 		}
 		for _, decl := range file.Decls {
 			for _, sql := range employmentStatements(decl, scope) {
@@ -201,143 +201,6 @@ func employmentStatements(decl ast.Decl, people helperScope) []string {
 	return out
 }
 
-// flattenSQL renders a string expression as the text it builds, marking every
-// node it consumed so an inner piece is not judged again on its own.
-//
-// A call to the ONE DEFINITION renders as a neutral marker: the predicate it
-// produces exists only at runtime, so the statement's text carries no
-// `ended_at` test from it, and a statement that calls the helper is simply a
-// statement with nothing hand-written left to find.
-//
-// That replaced an exemption — "this statement mentions the helper, so skip
-// it" — which was too coarse in the direction that matters: a query calling
-// the helper for one half and hand-writing the other was skipped WHOLESALE.
-// Calling the one definition is not a licence to write a second one beside it.
-//
-// Any other call renders as its ARGUMENTS and not its name, because a
-// formatter holds its SQL in an argument — `fmt.Sprintf(`… kind = 'employment'
-// … `, …)` keeps the whole statement inside the call, and a flattener that
-// stopped at the callee name would judge nothing. The name is dropped because
-// it is not part of the SQL; only the helper's is kept, as the marker that
-// says the one definition was reached.
-func flattenSQL(n ast.Node, seen map[ast.Node]bool, people helperScope) (string, bool) {
-	switch v := n.(type) {
-	case *ast.BasicLit:
-		if v.Kind != token.STRING {
-			return "", false
-		}
-		seen[n] = true
-		return strings.Trim(v.Value, "`\""), true
-	case *ast.BinaryExpr:
-		if v.Op != token.ADD {
-			return "", false
-		}
-		left, lok := flattenSQL(v.X, seen, people)
-		right, rok := flattenSQL(v.Y, seen, people)
-		if !lok && !rok {
-			return "", false
-		}
-		seen[n] = true
-		return left + right, true
-	case *ast.CallExpr:
-		seen[n] = true
-		if people.isOneDefinition(v) {
-			markSeen(v, seen)
-			return " " + employmentCalleeName(v) + " ", true
-		}
-		text := ""
-		for _, a := range v.Args {
-			if part, ok := flattenSQL(a, seen, people); ok {
-				text += part
-			}
-		}
-		return " " + text + " ", true
-	case ast.Expr:
-		seen[n] = true
-		return " ", true
-	}
-	return "", false
-}
-
-// helperScope says how the ONE DEFINITION is reachable from one file, and it is
-// a struct rather than a string because the string had two meanings.
-//
-// `qualifier == ""` was read as "this file IS package people", where a bare
-// call is the helper's own. But importAliasOf returns "" for every file that
-// does not import people at all — which is most of the tree — so in any of
-// them a bare `EmploymentIsCurrentSQL(…)` was accepted as canonical and its
-// arguments hidden. `inside` says the one thing the empty string could not.
-type helperScope struct {
-	qualifier string // the local name people is bound to, "" if not imported
-	inside    bool   // this file IS package people
-}
-
-// isOneDefinition reports whether the call is people's helper — the PACKAGE as
-// well as the name.
-//
-// The name alone was not enough, and the gap is the one this gate exists to
-// close: a helper call's whole subtree is claimed, so `other.
-// EmploymentIsCurrentSQL(…)` would have been treated as canonical and its
-// arguments hidden, letting a hand-written currency test ride inside a
-// lookalike.
-func (h helperScope) isOneDefinition(call *ast.CallExpr) bool {
-	named := func(n string) bool { return n == employmentHelper || n == primaryHelper }
-	switch f := call.Fun.(type) {
-	case *ast.Ident:
-		return h.inside && named(f.Name)
-	case *ast.SelectorExpr:
-		pkg, ok := f.X.(*ast.Ident)
-		return ok && h.qualifier != "" && pkg.Name == h.qualifier && named(f.Sel.Name)
-	}
-	return false
-}
-
-// importAliasOf returns the local name an import path is bound to in this file,
-// or "" if the file does not import it. A dot import returns "" too: a
-// dot-imported call is a bare identifier, and the gate would rather miss it
-// than name the wrong function.
-func importAliasOf(file *ast.File, path string) string {
-	for _, spec := range file.Imports {
-		if strings.Trim(spec.Path.Value, `"`) != path {
-			continue
-		}
-		if spec.Name != nil {
-			if spec.Name.Name == "." {
-				return ""
-			}
-			return spec.Name.Name
-		}
-		return "people"
-	}
-	return ""
-}
-
-// employmentCalleeName is the function's own name, however it is qualified.
-// Prefixed because retentionscope_test.go already has a calleeName in this
-// package.
-func employmentCalleeName(call *ast.CallExpr) string {
-	switch f := call.Fun.(type) {
-	case *ast.Ident:
-		return f.Name
-	case *ast.SelectorExpr:
-		return f.Sel.Name
-	}
-	return ""
-}
-
-// markSeen claims a whole subtree, so nothing inside a helper call is judged as
-// though somebody had written it into the statement.
-func markSeen(n ast.Node, seen map[ast.Node]bool) {
-	ast.Inspect(n, func(c ast.Node) bool {
-		if c != nil {
-			seen[c] = true
-		}
-		return true
-	})
-}
-
-// firstEmploymentLine returns the line of the statement that names the
-// employment kind, so the report points at the statement rather than dumping
 // it.
 func firstEmploymentLine(sql string) string {
 	for _, line := range strings.Split(sql, "\n") {
@@ -348,37 +211,6 @@ func firstEmploymentLine(sql string) string {
 	return strings.TrimSpace(strings.Split(sql, "\n")[0])
 }
 
-// handWrittenGoSources walks the module for source a person maintains.
-func handWrittenGoSources(t *testing.T) []string {
-	t.Helper()
-	var paths []string
-	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			if name := entry.Name(); name == "node_modules" || name == "testdata" || name == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_gen.go") || strings.HasSuffix(name, ".gen.go") {
-			return nil
-		}
-		paths = append(paths, path)
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking the module for Go source: %v", err)
-	}
-	if len(paths) < 500 {
-		t.Fatalf("the walk found only %d Go files, so this census covered almost nothing", len(paths))
-	}
-	return paths
-}
-
-// employmentProbe is one planted source file and the answer the gate must give
 // for it.
 type employmentProbe struct {
 	name  string
@@ -476,12 +308,13 @@ func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
 	for _, tc := range employmentProbes {
 		t.Run(tc.name, func(t *testing.T) {
 			head := "package probe\n"
-			scope := helperScope{qualifier: "people"}
+			names := map[string]bool{employmentHelper: true, primaryHelper: true}
+			scope := helperScope{qualifier: "people", names: names}
 			switch tc.mode {
 			case "people":
-				head, scope = "package people\n", helperScope{inside: true}
+				head, scope = "package people\n", helperScope{inside: true, names: names}
 			case "noimport":
-				scope = helperScope{}
+				scope = helperScope{names: names}
 			default:
 				head += "import (\n\t\"fmt\"\n\n\t\"github.com/gradionhq/margince/backend/internal/modules/people\"\n)\n"
 			}

--- a/backend/internal/compose/aibudget.go
+++ b/backend/internal/compose/aibudget.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -45,8 +46,8 @@ func (b seatBudget) MonthlyTokenBudget(ctx context.Context, workspaceID ids.Work
 		// single-organization installation has one workspace to charge.
 		return tx.QueryRow(ctx, `
 			SELECT count(*) FROM app_user
-			WHERE seat_type = 'full' AND status = 'active'
-			  AND archived_at IS NULL AND NOT is_agent`).Scan(&fullSeats)
+			WHERE seat_type = 'full' AND `+identity.LiveMemberSQL("")+`
+			  AND NOT is_agent`).Scan(&fullSeats)
 	})
 	if err != nil {
 		return 0, err

--- a/backend/internal/compose/captureofflinedemo.go
+++ b/backend/internal/compose/captureofflinedemo.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture/offlinedemo"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
@@ -70,7 +71,7 @@ func (d offlineDemoDirectory) load(ctx context.Context, tx pgx.Tx, userID string
 	// failure: the generator simply CCs nobody.
 	if err := tx.QueryRow(ctx, `
 		SELECT coalesce(display_name, email), email
-		  FROM app_user WHERE id <> $1 AND status = 'active'
+		  FROM app_user WHERE id <> $1 AND `+identity.LiveMemberSQL("")+`
 		 ORDER BY created_at LIMIT 1`, userID).Scan(&box.ColleagueName, &box.ColleagueEmail); err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("reading a colleague to copy: %w", err)

--- a/backend/internal/compose/extjobsrun.go
+++ b/backend/internal/compose/extjobsrun.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -198,7 +199,7 @@ func extensionJobActor(ctx context.Context, pool *pgxpool.Pool, ws ids.UUID) (id
 		// seat, so an empty answer says an operator archived or deactivated it.
 		return tx.QueryRow(ctx,
 			`SELECT id FROM app_user
-			  WHERE is_agent AND status = 'active' AND archived_at IS NULL
+			  WHERE is_agent AND `+identity.LiveMemberSQL("")+`
 			  ORDER BY created_at LIMIT 1`).Scan(&actor)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -278,7 +279,7 @@ func (w *extJobWorkspaceWorker) deriveAuthority(ctx context.Context, args extJob
 		// PrincipalAgent below would be an agent principal nobody granted.
 		return tx.QueryRow(ctx,
 			`SELECT seat_type FROM app_user
-			  WHERE id = $1 AND is_agent AND status = 'active' AND archived_at IS NULL`, args.Principal).Scan(&seat)
+			  WHERE id = $1 AND is_agent AND `+identity.LiveMemberSQL("")+``, args.Principal).Scan(&seat)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return principal.Principal{}, fmt.Errorf("%w (principal %s)", errStaleJobPrincipal, args.Principal)

--- a/backend/internal/compose/org360/graphourside.go
+++ b/backend/internal/compose/org360/graphourside.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -74,17 +75,17 @@ func (g *graphAssembly) drawnContactIDs() []ids.UUID {
 	return out
 }
 
-// liveMemberWhere is the ONE spelling of "someone who still works here", for a
-// query that aliases app_user as u. It is the same pair the roster (GET /users)
-// lists by, so this card can never name a colleague the roster has already
-// dropped.
+// liveMemberWhere is identity's definition of "someone who still works here",
+// for a query that aliases app_user as u. It is not a second spelling: compose
+// may import a module, so this card asks the owner of app_user rather than
+// restating what the roster (GET /users) lists by, and cannot drift from it.
 //
-// Both halves matter, and neither implies the other: a suspended or deactivated
-// account keeps archived_at NULL, and owner_id and captured_by both survive the
-// day someone leaves. Every user node the graph draws renders this predicate —
-// the card exists to tell a rep who to ask for an intro, and a former colleague
-// is not an answer to that question.
-const liveMemberWhere = `u.status = 'active' AND u.archived_at IS NULL`
+// Every user node the graph draws renders this predicate — the card exists to
+// tell a rep who to ask for an intro, and a former colleague is not an answer
+// to that question.
+//
+// Held by: TestOnlyOneSpellingOfALiveMember (backend/livemember_test.go)
+var liveMemberWhere = identity.LiveMemberSQL("u")
 
 // readAccountOwner reads the live workspace member the account is assigned to.
 // It needs no row-scope clause of its own: the caller has already read the

--- a/backend/internal/modules/activities/audience.go
+++ b/backend/internal/modules/activities/audience.go
@@ -139,12 +139,20 @@ func ensureVersion(ctx context.Context, tx pgx.Tx, id ids.ActivityID, ifVersion 
 // ensureAudienceSubjectsExist refuses a member that names no live user or
 // team of this workspace: the table carries no FK for its polymorphic subject,
 // so the check is here, and a guessed id answers like a malformed one.
+//
+// LIVE is both halves. Deactivating an account sets `status` and leaves
+// `archived_at` NULL, so the archived-only test admitted a colleague who has
+// left — this comment said "live" while the query asked something weaker, and
+// an audience is a list of people expected to read the thing. Spelled out
+// because a module never imports a sibling (ADR-0054 §3); identity owns
+// app_user and TestOnlyOneSpellingOfALiveMember holds the two together.
 func ensureAudienceSubjectsExist(ctx context.Context, tx pgx.Tx, members []AudienceMember) error {
 	for _, m := range members {
 		var exists bool
 		var q string
 		if m.SubjectType == "user" {
-			q = `SELECT EXISTS (SELECT 1 FROM app_user WHERE id = $1 AND archived_at IS NULL)`
+			q = `SELECT EXISTS (SELECT 1 FROM app_user
+			                 WHERE id = $1 AND status = 'active' AND archived_at IS NULL)`
 		} else {
 			q = `SELECT EXISTS (SELECT 1 FROM team WHERE id = $1)`
 		}

--- a/backend/internal/modules/identity/access.go
+++ b/backend/internal/modules/identity/access.go
@@ -120,7 +120,7 @@ func teamsByID(ctx context.Context, tx pgx.Tx, teamIDs []ids.UUID) ([]teamRow, e
 	}
 	rows, err := tx.Query(ctx, `
 		SELECT t.id, t.name,
-		       (SELECT count(*) FROM team_membership m JOIN app_user u ON u.id = m.user_id AND u.status = 'active' AND u.archived_at IS NULL
+		       (SELECT count(*) FROM team_membership m JOIN app_user u ON u.id = m.user_id AND `+LiveMemberSQL("u")+`
 		         WHERE m.team_id = t.id),
 		       t.created_at
 		  FROM team t WHERE t.id = ANY($1) AND t.archived_at IS NULL ORDER BY t.name`, teamIDs)

--- a/backend/internal/modules/identity/authority.go
+++ b/backend/internal/modules/identity/authority.go
@@ -112,7 +112,7 @@ func (s *Service) liveUserTx(ctx context.Context, workspaceID, humanID ids.UUID,
 		var seatType string
 		err := tx.QueryRow(ctx,
 			`SELECT seat_type FROM app_user
-			 WHERE id = $1 AND status = 'active' AND archived_at IS NULL`,
+			 WHERE id = $1 AND `+LiveMemberSQL("")+``,
 			humanID).Scan(&seatType)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound

--- a/backend/internal/modules/identity/changepassword.go
+++ b/backend/internal/modules/identity/changepassword.go
@@ -90,7 +90,7 @@ func (s *Service) ChangePassword(ctx context.Context, current, next string) erro
 			`UPDATE app_user
 			    SET password_hash = $2, failed_login_count = 0, locked_until = NULL,
 			        must_change_password = false
-			  WHERE id = $1 AND status = 'active' AND archived_at IS NULL`, userID, hash)
+			  WHERE id = $1 AND `+LiveMemberSQL("")+``, userID, hash)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func (s *Service) proveCurrentPassword(ctx context.Context, tx pgx.Tx, userID id
 	err := tx.QueryRow(ctx,
 		`SELECT coalesce(password_hash, ''), failed_login_count, locked_until, updated_at
 		   FROM app_user
-		  WHERE id = $1 AND status = 'active' AND archived_at IS NULL
+		  WHERE id = $1 AND `+LiveMemberSQL("")+`
 		  FOR UPDATE`, userID).
 		Scan(&stored, &lock.FailedCount, &lock.LockedUntil, &lock.LastFailure)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -180,7 +180,7 @@ func (s *Service) recordFailedChange(ctx context.Context, wsID ids.WorkspaceID, 
 		var state lockoutState
 		err := tx.QueryRow(ctx,
 			`SELECT failed_login_count, locked_until, updated_at FROM app_user
-			  WHERE id = $1 AND status = 'active' AND archived_at IS NULL
+			  WHERE id = $1 AND `+LiveMemberSQL("")+`
 			  FOR UPDATE`, userID).
 			Scan(&state.FailedCount, &state.LockedUntil, &state.LastFailure)
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/identity/colleagues.go
+++ b/backend/internal/modules/identity/colleagues.go
@@ -66,8 +66,7 @@ func (s *Service) Colleagues(ctx context.Context, q string) ([]Colleague, bool, 
 		rows, err := tx.Query(ctx, `
 			SELECT id, display_name, email, seat_type, is_agent
 			  FROM app_user
-			 WHERE archived_at IS NULL
-			   AND status = 'active'
+			 WHERE `+LiveMemberSQL("")+`
 			   AND locked_until IS NULL
 			   AND ($1 = '' OR display_name ILIKE $2 OR email ILIKE $2)
 			 ORDER BY display_name, id

--- a/backend/internal/modules/identity/lastadmin.go
+++ b/backend/internal/modules/identity/lastadmin.go
@@ -67,7 +67,7 @@ func lastActiveAdmin(ctx context.Context, tx pgx.Tx, userID ids.UserID) (bool, e
 		SELECT count(*) FROM app_user u
 		JOIN role_assignment ra ON ra.user_id = u.id
 		JOIN role r ON r.id = ra.role_id
-		WHERE r.key = 'admin' AND u.status = 'active' AND u.archived_at IS NULL
+		WHERE r.key = 'admin' AND `+LiveMemberSQL("u")+`
 		  AND NOT u.is_agent
 		  AND u.id <> $1`, userID).Scan(&otherAdmins); err != nil {
 		return false, err

--- a/backend/internal/modules/identity/livemember.go
+++ b/backend/internal/modules/identity/livemember.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+import "github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+
+// LiveMemberSQL is what "someone who still works here" means, for a query that
+// reads app_user.
+//
+// BOTH HALVES, and neither implies the other. Deactivating an account sets
+// `status` and leaves `archived_at` NULL, so a predicate on `archived_at` alone
+// goes on offering a departed colleague — as an intro route, an assignee, a name
+// on a card. Archiving without deactivating is the mirror. A reader that tests
+// one half has not asked the question.
+//
+// alias is the table's alias in the caller's query, or "" when it reads app_user
+// unaliased. It is formatted into the statement as an IDENTIFIER, so it must be
+// a compile-time literal and never anything off a request — an alias a caller
+// chose is an injection with a placeholder's manners.
+// TestEveryLiveMemberAliasIsALiteral holds that.
+//
+// WHO CAN CALL THIS: identity owns app_user, and a module never imports a
+// sibling (ADR-0054 §3) — so `search`, `projects`, `dealrooms`, `people` and
+// `activities` cannot, and spell the pair themselves. Those are ratified by name
+// in TestOnlyOneSpellingOfALiveMember rather than left looking clean, which is
+// the same shape the employment-currency census settled on. `compose` can import
+// a module and does.
+func LiveMemberSQL(alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	return storekit.SQLf("%sstatus = 'active' AND %sarchived_at IS NULL", prefix, prefix)
+}

--- a/backend/internal/modules/identity/livemember_test.go
+++ b/backend/internal/modules/identity/livemember_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+import "testing"
+
+// The predicate is a string the whole tree now depends on, so it is asserted
+// literally rather than rebuilt from the same pieces the code uses — a test
+// that composed it the same way would agree with any change, including one
+// that dropped a half.
+func TestLiveMemberSQLNamesBothHalves(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		alias string
+		want  string
+	}{
+		{"unaliased, for a query reading app_user directly", "", "status = 'active' AND archived_at IS NULL"},
+		{"aliased, for a query that joins app_user", "u", "u.status = 'active' AND u.archived_at IS NULL"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LiveMemberSQL(tc.alias); got != tc.want {
+				t.Errorf("LiveMemberSQL(%q) = %q, want %q", tc.alias, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/identity/lockout.go
+++ b/backend/internal/modules/identity/lockout.go
@@ -101,7 +101,7 @@ func (s *Service) checkCredentials(ctx context.Context, tx pgx.Tx, email, plaint
 	err := tx.QueryRow(ctx,
 		`SELECT id, password_hash, display_name, seat_type, failed_login_count, locked_until, updated_at
 		 FROM app_user
-		 WHERE lower(email) = lower($1) AND status = 'active' AND archived_at IS NULL`,
+		 WHERE lower(email) = lower($1) AND `+LiveMemberSQL("")+``,
 		email).Scan(&account.UserID, &hash, &account.DisplayName, &account.SeatType,
 		&lock.FailedCount, &lock.LockedUntil, &lock.LastFailure)
 	if errors.Is(err, pgx.ErrNoRows) || (err == nil && hash == nil) {
@@ -172,7 +172,7 @@ func (s *Service) recordFailedLogin(ctx context.Context, email string) error {
 		var state lockoutState
 		err := tx.QueryRow(ctx,
 			`SELECT id, failed_login_count, locked_until, updated_at FROM app_user
-			 WHERE lower(email) = lower($1) AND status = 'active' AND archived_at IS NULL
+			 WHERE lower(email) = lower($1) AND `+LiveMemberSQL("")+`
 			 FOR UPDATE`,
 			email).Scan(&userID, &state.FailedCount, &state.LockedUntil, &state.LastFailure)
 		switch {

--- a/backend/internal/modules/identity/passport.go
+++ b/backend/internal/modules/identity/passport.go
@@ -372,7 +372,7 @@ func agentAuthQuery(predicate string) string {
 		WHERE ` + predicate + `
 		  AND p.revoked_at IS NULL
 		  AND now() < p.expires_at
-		  AND u.status = 'active' AND u.archived_at IS NULL
+		  AND ` + LiveMemberSQL("u") + `
 		  AND u.must_change_password = false` + agentLivenessPredicate
 }
 

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -205,7 +205,7 @@ func (s *Service) CreatePasswordReset(ctx context.Context, email string) (string
 		var userID ids.UserID
 		lookupErr := tx.QueryRow(ctx,
 			`SELECT id FROM app_user
-			 WHERE email = lower($1) AND status = 'active' AND archived_at IS NULL AND password_hash IS NOT NULL`,
+			 WHERE email = lower($1) AND `+LiveMemberSQL("")+` AND password_hash IS NOT NULL`,
 			email).Scan(&userID)
 		if errors.Is(lookupErr, pgx.ErrNoRows) {
 			return nil
@@ -285,7 +285,7 @@ func (s *Service) RedeemPasswordReset(ctx context.Context, rawToken, newPassword
 		tag, err := tx.Exec(ctx,
 			`UPDATE app_user SET password_hash = $2, failed_login_count = 0, locked_until = NULL,
 			        must_change_password = false
-			 WHERE id = $1 AND status = 'active' AND archived_at IS NULL`, userID, hash)
+			 WHERE id = $1 AND `+LiveMemberSQL("")+``, userID, hash)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -78,18 +78,18 @@ const userColumns = `id, email, display_name, status, is_agent, ` + roleKeys + `
 // flag bound false shows no SubPlan running), so a non-admin page pays no
 // per-row role lookup — it still carries the arm in its plan. NULL (not read)
 // is deliberately not '{}' (read, holds none) — see userRow.Roles.
-const listUsersQuery = `
+var listUsersQuery = `
 	SELECT ` + userColumns + `
 	FROM app_user
-	WHERE archived_at IS NULL AND status = 'active'
+	WHERE ` + LiveMemberSQL("") + `
 	  AND ($2::timestamptz IS NULL OR (created_at, id) > ($2, $3))
 	ORDER BY created_at, id
 	LIMIT $4`
 
-const listUsersFilteredQuery = `
+var listUsersFilteredQuery = `
 	SELECT ` + userColumns + `
 	FROM app_user
-	WHERE archived_at IS NULL AND status = 'active'
+	WHERE ` + LiveMemberSQL("") + `
 	  AND (display_name ILIKE $2 OR email ILIKE $2)
 	  AND ($3::timestamptz IS NULL OR (created_at, id) > ($3, $4))
 	ORDER BY created_at, id
@@ -178,12 +178,12 @@ type teamRow struct {
 // inflates the count (mirrors the active-only gate on ListUsers).
 const teamColumns = `t.id, t.name, COUNT(u.id) AS member_count, t.created_at`
 
-const teamFromJoin = `
+var teamFromJoin = `
 	FROM team t
 	LEFT JOIN team_membership tm ON tm.team_id = t.id
-	LEFT JOIN app_user u ON u.id = tm.user_id AND u.status = 'active' AND u.archived_at IS NULL`
+	LEFT JOIN app_user u ON u.id = tm.user_id AND ` + LiveMemberSQL("u") + ``
 
-const listTeamsQuery = `
+var listTeamsQuery = `
 	SELECT ` + teamColumns + teamFromJoin + `
 	WHERE t.archived_at IS NULL
 	  AND ($1::timestamptz IS NULL OR (t.created_at, t.id) > ($1, $2))
@@ -191,7 +191,7 @@ const listTeamsQuery = `
 	ORDER BY t.created_at, t.id
 	LIMIT $3`
 
-const listTeamsFilteredQuery = `
+var listTeamsFilteredQuery = `
 	SELECT ` + teamColumns + teamFromJoin + `
 	WHERE t.archived_at IS NULL AND t.name ILIKE $1
 	  AND ($2::timestamptz IS NULL OR (t.created_at, t.id) > ($2, $3))

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -356,7 +356,7 @@ func (s *Service) Authenticate(ctx context.Context, rawToken string) (Identity, 
 			   AND s.revoked_at IS NULL
 			   AND now() < s.idle_expires_at
 			   AND now() < s.expires_at
-			   AND u.status = 'active' AND u.archived_at IS NULL`,
+			   AND `+LiveMemberSQL("u")+``,
 			tokenHash, Name.Key()).Scan(&sessionID, &userID, &id.Email, &id.DisplayName, &id.SeatType, &id.MustChangePassword, &locale, &id.WorkspaceName)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound

--- a/backend/internal/modules/people/linkedinmatch.go
+++ b/backend/internal/modules/people/linkedinmatch.go
@@ -348,10 +348,18 @@ func OrganizationLinkedInReach(ctx context.Context, tx pgx.Tx, orgID ids.Organiz
 	if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
 		return nil, err
 	}
+	// Both halves of "still works here", not just archived_at. A reach count is
+	// an offer to ask a colleague for an intro, and a deactivated account is as
+	// unreachable as an archived one — filtering on archived_at alone answers
+	// "ask Lars" about someone who cannot be asked. Spelled out rather than
+	// taken from identity.LiveMemberSQL because a module never imports a
+	// sibling (ADR-0054 §3); TestOnlyOneSpellingOfALiveMember holds the two
+	// together.
 	rows, err := tx.Query(ctx, `
 		SELECT g.owner_user_id, count(*)
 		  FROM linkedin_connection g
-		  JOIN app_user u ON u.id = g.owner_user_id AND u.archived_at IS NULL
+		  JOIN app_user u ON u.id = g.owner_user_id
+		                 AND u.status = 'active' AND u.archived_at IS NULL
 		 WHERE g.matched_org_id = $1
 		   AND g.tombstoned_at IS NULL
 		   AND g.match_status <> 'rejected'

--- a/backend/internal/modules/people/linkedinreachliveness_integration_test.go
+++ b/backend/internal/modules/people/linkedinreachliveness_integration_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// OrganizationLinkedInReach answers "who on our team can get us in", and the
+// answer has to be somebody who can actually be asked.
+//
+// The join filtered `u.archived_at IS NULL` and nothing else, which is only
+// half of "still works here": deactivating an account sets `status` and leaves
+// `archived_at` NULL, so a colleague who no longer works here kept being
+// offered as a warm route into an account. The function had no test at all,
+// which is how that survived from the day it landed.
+//
+// Both directions are asserted, and that is the point rather than thoroughness
+// for its own sake: a test that only checks the deactivated seat is absent
+// passes just as well against a query that returns nobody.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestReachCountsOnlyColleaguesWhoStillWorkHere(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org := e.seedOrgNamed(t, "Acme GmbH")
+
+	// One connection each, so a count that loses a seat is unambiguous: the
+	// map either names them or it does not.
+	e.seedReach(ctx, t, e.rep, org, "Abbas Fawaz")
+	e.seedReach(ctx, t, e.otherRep, org, "Bea Hoffmann")
+
+	both := e.reachInto(ctx, t, org)
+	if both[e.rep] != 1 || both[e.otherRep] != 1 {
+		t.Fatalf("with both seats live the reach is %v, want one connection each for %s and %s — "+
+			"the rest of this test cannot mean anything if the baseline is already wrong",
+			both, e.rep, e.otherRep)
+	}
+
+	e.deactivate(ctx, t, e.otherRep)
+
+	after := e.reachInto(ctx, t, org)
+	if _, offered := after[e.otherRep]; offered {
+		t.Errorf("a deactivated colleague is still offered as a route into the account: %v", after)
+	}
+	if after[e.rep] != 1 {
+		t.Errorf("the live colleague's reach is %v, want 1 — deactivating one seat took another seat's "+
+			"count with it", after)
+	}
+}
+
+// seedReach gives a colleague one LinkedIn connection already matched to an
+// account. The import path is exercised by linkedin_integration_test.go; what
+// this suite is about is which colleagues the count admits, so the connection
+// arrives ready-matched.
+//
+// 'suggested' and not 'confirmed': matchGhostOrganizations attaches a ghost to
+// an ACCOUNT by employer name even when the person never matches, and a
+// 'confirmed' row needs a matched_person_id it would not have. The org-matched,
+// person-unmatched row IS the reach case.
+func (e *dedupeEnv) seedReach(ctx context.Context, t *testing.T, owner ids.UUID, org ids.OrganizationID, name string) {
+	t.Helper()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO linkedin_connection
+			  (owner_user_id, full_name, normalized_name, company_name,
+			   normalized_company, matched_org_id, match_status, source)
+			VALUES ($1, $2, lower($2), 'Acme GmbH', 'acme gmbh', $3, 'suggested', 'csv_export')`,
+			owner, name, org)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a connection for %s: %v", owner, err)
+	}
+}
+
+// deactivate is what an admin does to a seat somebody has left: status moves
+// and archived_at stays NULL, which is exactly the state the old predicate
+// could not see.
+func (e *dedupeEnv) deactivate(ctx context.Context, t *testing.T, user ids.UUID) {
+	t.Helper()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE app_user SET status = 'deactivated' WHERE id = $1`, user)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("deactivating %s touched %d rows, want 1 — the seat this test is about was never changed",
+				user, tag.RowsAffected())
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("deactivating %s: %v", user, err)
+	}
+	// The seat must still be here, or the test proves the archived half rather
+	// than the status half — the two are indistinguishable from the outside.
+	var archived *string
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT archived_at::text FROM app_user WHERE id = $1`, user).Scan(&archived)
+	}); err != nil {
+		t.Fatalf("reading %s back: %v", user, err)
+	}
+	if archived != nil {
+		t.Fatalf("deactivating %s also archived it (%s), so this test no longer distinguishes the two halves",
+			user, *archived)
+	}
+}
+
+func (e *dedupeEnv) reachInto(ctx context.Context, t *testing.T, org ids.OrganizationID) map[ids.UUID]int {
+	t.Helper()
+	var out map[ids.UUID]int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) (err error) {
+		out, err = OrganizationLinkedInReach(ctx, tx, org)
+		return err
+	}); err != nil {
+		t.Fatalf("OrganizationLinkedInReach: %v", err)
+	}
+	return out
+}

--- a/backend/internal/modules/search/graphedge.go
+++ b/backend/internal/modules/search/graphedge.go
@@ -277,12 +277,15 @@ func recomputePairs(ctx context.Context, tx pgx.Tx, pairs []pair) error {
 // a Limit emits, so an edge whose last evidence is limited is re-folded away.
 const audienceWorkspaceOnly = ` AND a.audience = 'workspace'`
 
-// liveMemberJoin is the ONE spelling of "someone who still works here" for
-// these reads, and both halves are load-bearing: deactivation sets status and
-// leaves archived_at NULL, so filtering on archived_at alone keeps offering a
-// departed colleague as a route in. (org360 already spelled it this way; this
-// read did not, and a test that ARCHIVED a user rather than deactivating one
-// passed while production would have shown them.)
+// liveMemberJoin carries a COPY of identity.LiveMemberSQL, not a second
+// opinion. A module never imports a sibling (ADR-0054 §3) and identity owns
+// app_user, so this read cannot ask the owner what "still works here" means; it
+// is ratified by name in TestOnlyOneSpellingOfALiveMember, which fails if the
+// two ever disagree.
+//
+// Both halves are load-bearing: deactivation sets status and leaves
+// archived_at NULL, so filtering on archived_at alone goes on offering a
+// departed colleague as a route in.
 const liveMemberJoin = `JOIN app_user u ON u.id = e.user_id AND u.status = 'active' AND u.archived_at IS NULL`
 
 // EdgesForPerson answers "who on our team knows this contact".

--- a/backend/livemember_test.go
+++ b/backend/livemember_test.go
@@ -314,6 +314,13 @@ func namesTheHelper(n ast.Node) bool {
 // bitten by before. A probe now exercises the code the tree is judged with, or
 // it exercises nothing.
 func liveMemberVerdict(sql string) string {
+	// A bare fragment IS the pair — onlyTheLivenessPair matches nothing else —
+	// so it is a copy without needing a table to attribute its columns to.
+	// Asking liveMemberHalves instead would refuse it, because that binds every
+	// column to app_user's alias and a fragment names no table to take one from.
+	if bareLivenessPredicate(sql) {
+		return "copy"
+	}
 	status, archived := liveMemberHalves(sql)
 	switch {
 	case status && archived:
@@ -382,8 +389,8 @@ func appUserStatements(decl ast.Decl, owner helperScope) []string {
 func liveMemberHalves(sql string) (status, archived bool) {
 	sql = stripAssignments(sql)
 	prefix := appUserPrefix(sql)
-	status = regexp.MustCompile(`(?i)` + regexp.QuoteMeta(prefix) + `status\s*=\s*'active'`).MatchString(sql)
-	archived = regexp.MustCompile(`(?i)` + regexp.QuoteMeta(prefix) + `archived_at\s+IS\s+NULL`).MatchString(sql)
+	status = appUserColumn(prefix, `status\s*=\s*'active'`).MatchString(sql)
+	archived = appUserColumn(prefix, `archived_at\s+IS\s+NULL`).MatchString(sql)
 	return status, archived
 }
 
@@ -459,7 +466,7 @@ func resolvesOneUserByID(sql string) bool {
 	// joined table's key excuse a liveness defect on app_user: `… JOIN app_user
 	// u … WHERE p.id = $1 AND u.archived_at IS NULL` names WHICH PROJECT, not
 	// which colleague, and the statement still chooses freely among seats.
-	return regexp.MustCompile(`(?i)` + regexp.QuoteMeta(appUserPrefix(sql)) +
+	return appUserColumn(appUserPrefix(sql),
 		`id\s*(?:=\s*\$\d+|=\s*ANY\s*\(\s*\$\d+)`).MatchString(sql)
 }
 
@@ -474,6 +481,24 @@ func resolvesOneUserByID(sql string) bool {
 // passed in silence. A statement that returns `status` has at least asked the
 // question; one that neither filters on it nor reads it has not.
 var readsTheStatusColumn = regexp.MustCompile(`(?is)SELECT\b[^;]*?\bstatus\b[^;]*?\bFROM\b|RETURNING\b[^;]*?\bstatus\b`)
+
+// appUserColumn matches one of APP_USER's columns and refuses somebody else's.
+//
+// The anchor is the whole point. `prefix` is empty whenever app_user is
+// unaliased, and an unanchored pattern then matched any relation's column: a
+// statement joining `project p` was read as constraining liveness because IT
+// carried `p.status` and `p.archived_at`, and `id = $N` matched
+// `external_id = $1`, handing a statement the id-lookup exemption on a column
+// that names nobody. Both readings said "this statement already names which
+// colleague" about one that does not.
+//
+// `[^.\w]` refuses a qualifier and refuses a longer identifier ending in the
+// column's name, which is the two ways a column can be somebody else's. RE2 has
+// no lookbehind, so the boundary is matched rather than asserted; it costs a
+// leading group and nothing else.
+func appUserColumn(prefix, column string) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)(^|[^.\w])` + regexp.QuoteMeta(prefix) + column)
+}
 
 // appUserPrefix is what app_user's columns are written with in this statement:
 // its alias plus a dot, or "" when the statement reads app_user unaliased.
@@ -651,6 +676,14 @@ func read() string {
 	{"a fragment naming one half only, table unknowable", "", "", `
 func read() string {
 	return ` + "`" + `archived_at IS NULL` + "`" + `
+}`},
+	{"a joined table carrying both columns, app_user unaliased", "", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user JOIN project p ON p.owner_id = id WHERE p.status = 'active' AND p.archived_at IS NULL` + "`" + `
+}`},
+	{"a column merely ending in id, not the key", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT status FROM app_user WHERE external_id = $1 AND archived_at IS NULL` + "`" + `
 }`},
 	{"another table carrying the same two columns", "", "", `
 func read() string {

--- a/backend/livemember_test.go
+++ b/backend/livemember_test.go
@@ -325,7 +325,7 @@ func liveMemberVerdict(sql string) string {
 // invisible to a table-keyed walk from both ends — the declaration never
 // mentions app_user, and the statement that concatenates it renders the
 // identifier as a blank. That is precisely how org360's copy sat unheld while
-// its comment called it the one spelling.
+// its comment told the next reader the question was already settled.
 //
 // It deliberately does not catch a HALF spelled into a bare declaration: a lone
 // `archived_at IS NULL` fragment could belong to any of a dozen tables, and
@@ -361,7 +361,7 @@ func appUserStatements(decl ast.Decl, owner helperScope) []string {
 			return false
 		}
 		text, ok := flattenSQL(n, seen, owner)
-		if !ok || !(readsAppUser.MatchString(text) || bareLivenessPredicate(text)) {
+		if !ok || (!readsAppUser.MatchString(text) && !bareLivenessPredicate(text)) {
 			return true
 		}
 		out = append(out, text)

--- a/backend/livemember_test.go
+++ b/backend/livemember_test.go
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// "Someone who still works here" is `status = 'active' AND archived_at IS
+// NULL` on app_user, and TWO functions in two different packages each called
+// themselves the ONE spelling of it while the tree held about twenty copies.
+//
+// org360's said so; search's said so as well, and its own comment recorded
+// that org360 had already spelled it that way — so the second author knew
+// about the first copy and minted a third anyway. Neither had anything holding
+// it. That is the false-uniqueness pair CLAUDE.md names: the next author greps,
+// finds a comment claiming the question is settled, and stops looking.
+//
+// identity owns app_user, so identity.LiveMemberSQL is the definition. This
+// gate judges STATEMENTS that read app_user, in two arms:
+//
+//   - A statement constraining app_user's liveness must not name BOTH halves
+//     itself — it calls the helper, or it is ratified as unable to.
+//   - A statement naming ONE half without the other is the half-spelling, and
+//     it is the actual regression: deactivation sets status and leaves
+//     archived_at NULL, so `archived_at IS NULL` alone goes on offering a
+//     departed colleague. It found one live defect — a LinkedIn reach count
+//     that offered a deactivated colleague as a warm intro.
+//
+// What it deliberately does NOT judge: a statement that reads app_user with no
+// liveness constraint at all. Plenty legitimately do — resolving a row by id to
+// render a name does not care whether the person still works here, and a gate
+// that demanded they all filter would be asserting an answer nobody gave. It
+// also does not judge another table that happens to carry the same two column
+// names: `voice_profile_version` is filtered by `status = 'active' AND
+// archived_at IS NULL` in two places and is not a workforce question at all.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	liveMemberHelper = "LiveMemberSQL"
+	liveMemberOwner  = "internal/modules/identity/livemember.go"
+	identityPath     = "github.com/gradionhq/margince/backend/internal/modules/identity"
+)
+
+// cannotReachIdentity ratifies the statements that spell the predicate out
+// because the module DAG forbids them the helper.
+//
+// identity owns app_user and a module never imports a sibling (ADR-0054 §3).
+// compose may reach identity and now does — org360 and the extension-job seam
+// both call the helper — but seven statements sit in sibling modules, and the
+// predicate would have to move tier before they could adopt it. That is an
+// architecture decision with an owner rather than something to smuggle in here.
+//
+// Each entry is a FILE, so a NEW hand-spelled copy in one of these packages is
+// still a finding: the ratification covers the statements that exist, not the
+// package.
+var cannotReachIdentity = gatekit.Waive(map[string]string{
+	"internal/modules/activities/lifecycle.go":    "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/dealrooms/store_public.go":  "dealrooms cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/people/counterpartyname.go": "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/people/leadrouting.go":      "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/people/linkedinmatch.go":    "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/projects/surface.go":        "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/projects/transfer.go":       "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/search/graphedge.go":        "search cannot import identity (ADR-0054 §3); the predicate must move tier first",
+})
+
+// deliberatelyNotLiveness ratifies the half-spellings that are not answering
+// the workforce question at all.
+//
+// overlay's user-map eligibility is `NOT is_agent AND archived_at IS NULL`, and
+// it is a different set on purpose: it decides whom an admin may GRANT a mirror
+// mapping to, not who still works here. It is already held as its own
+// three-site invariant, named in selectUserMapTargetSQL's comment.
+//
+// What the difference costs, stated rather than waved away: a DEACTIVATED seat
+// is not archived, so all three overlay sites still offer it a mapping — and
+// listUserMapSQL's own comment justifies excluding archived users as "a seat
+// that no longer logs in", which is just as true of a deactivated one. Whether
+// overlay wants the tighter set is overlay's call and moves three statements at
+// once, so it is issue margince/margince#2592 rather than a change made here on
+// a guess.
+var deliberatelyNotLiveness = gatekit.Waive(map[string]string{
+	"internal/modules/overlay/usermapadmin.go": "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
+	"internal/modules/overlay/usermapseed.go":  "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
+	"internal/modules/identity/roster.go":      "listUsersAllQuery is the ADMIN roster and says so: every non-archived member REGARDLESS of status, because a deactivated member has to be visible to reactivate",
+	"internal/modules/identity/reset.go":       "OperatorResetPassword is the operator CLI's lockout path, never exposed over HTTP; it must reach an account whose status is not active, which is what administrator lockout means. Login itself calls the helper (lockout.go)",
+})
+
+// appUserAlias finds what app_user is called in a statement, so a sibling
+// table's archived_at is not read as app_user's.
+//
+// `FROM project p JOIN app_user u` puts two archived_at columns in scope and
+// only one of them is a workforce question. An unaliased `FROM app_user` binds
+// the bare column names instead.
+var appUserAlias = regexp.MustCompile(`\bapp_user\b(?:\s+AS)?\s+([a-z]\w*)`)
+
+// readsAppUser matches the table itself and not a column named after it: the
+// trailing `\b` already refuses `app_user_id`, since an underscore is a word
+// character. A statement that only carries the foreign key is not reading the
+// row, and asking it about liveness would report a pairing nobody wrote.
+var readsAppUser = regexp.MustCompile(`\bapp_user\b`)
+
+func TestOnlyOneSpellingOfALiveMember(t *testing.T) {
+	// A ratification that stops matching covers a site that has moved or been
+	// fixed, and leaving it in place quietly re-exempts whatever takes its name.
+	defer cannotReachIdentity.AssertAllMatched(t)
+	defer deliberatelyNotLiveness.AssertAllMatched(t)
+
+	fset := token.NewFileSet()
+	var copies, halves []string
+	judged, constrained := 0, 0
+	for _, path := range handWrittenGoSources(t) {
+		slash := filepath.ToSlash(path)
+		// The definition itself, and this file, which plants deliberate defects
+		// below as the detector's own evidence.
+		if slash == liveMemberOwner || filepath.Base(path) == "livemember_test.go" {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		scope := helperScope{
+			qualifier: importAliasOf(file, identityPath),
+			inside:    file.Name != nil && file.Name.Name == "identity",
+			names:     map[string]bool{liveMemberHelper: true},
+		}
+		for _, decl := range file.Decls {
+			for _, sql := range appUserStatements(decl, scope) {
+				judged++
+				status, archived := liveMemberHalves(sql)
+				if !status && !archived {
+					continue
+				}
+				constrained++
+				switch {
+				case status && archived:
+					if strings.Contains(sql, liveMemberHelper) || cannotReachIdentity.Waived(t, slash) {
+						continue
+					}
+					copies = append(copies, fmt.Sprintf("%s: %s", path, firstLiveMemberLine(sql)))
+				default:
+					if !offersAUser(sql) || deliberatelyNotLiveness.Waived(t, slash) {
+						continue
+					}
+					halves = append(halves, fmt.Sprintf("%s: %s", path, firstLiveMemberLine(sql)))
+				}
+			}
+		}
+	}
+	// A census that judged nothing certifies nothing, and the two floors are
+	// separate on purpose: the walk can find app_user statements while the
+	// half-detection is broken and reports every one of them as unconstrained.
+	// Both floors sit far below the real counts so they catch a broken walk
+	// rather than a changing tree.
+	if judged < 40 {
+		t.Fatalf("only %d app_user statement(s) were judged, so this census covered almost nothing", judged)
+	}
+	if constrained < 10 {
+		t.Fatalf("only %d of %d app_user statements were seen to constrain liveness at all, so the halves are not being read", constrained, judged)
+	}
+	if len(copies) > 0 {
+		t.Errorf("these statements spell \"someone who still works here\" out themselves:\n  %s\n\n"+
+			"identity.%s is the definition and identity owns app_user. compose may call it; a sibling "+
+			"module may not (ADR-0054 §3) and is ratified by name in this gate with that reason.",
+			strings.Join(copies, "\n  "), liveMemberHelper)
+	}
+	if len(halves) > 0 {
+		t.Errorf("these statements constrain app_user by ONE half of liveness:\n  %s\n\n"+
+			"Deactivating an account sets status and leaves archived_at NULL, so archived_at alone goes "+
+			"on offering a departed colleague — and status alone keeps an archived one. Name both halves, "+
+			"or ratify the statement here saying which set it means instead.",
+			strings.Join(halves, "\n  "))
+	}
+}
+
+// TestEveryLiveMemberAliasIsALiteral holds the one thing LiveMemberSQL cannot
+// hold itself: its argument is formatted into the statement as an identifier,
+// not bound as a parameter, so a caller that passed request input would inject.
+// Every call site names a table alias it wrote itself, and this says so.
+func TestEveryLiveMemberAliasIsALiteral(t *testing.T) {
+	fset := token.NewFileSet()
+	var findings []string
+	calls := 0
+	for _, path := range handWrittenGoSources(t) {
+		// A test drives the function with its own table, which is the point of
+		// a table: livemember_test.go passes tc.alias and injects into nothing,
+		// because the string it builds is compared rather than executed.
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || calleeName(call) != liveMemberHelper || len(call.Args) != 1 {
+				return true
+			}
+			calls++
+			if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				return true
+			}
+			findings = append(findings, fmt.Sprintf("%s:%d", path, fset.Position(call.Pos()).Line))
+			return true
+		})
+	}
+	// The floor catches a walk that stopped finding calls, which would make
+	// this pass over a tree full of them.
+	if calls < 10 {
+		t.Fatalf("only %d call(s) to %s were seen, so this proved almost nothing", calls, liveMemberHelper)
+	}
+	if len(findings) > 0 {
+		t.Errorf("these calls to %s pass an alias that is not a literal:\n  %s\n\n"+
+			"the alias is formatted into the SQL as an identifier, so anything off a request injects there.",
+			liveMemberHelper, strings.Join(findings, "\n  "))
+	}
+}
+
+// appUserStatements returns the SQL statements in a declaration that read
+// app_user, flattened so a statement assembled out of a literal and a helper
+// call is judged as the one statement it builds.
+//
+// Per DECLARATION and not per file, so a file holding one app_user query and
+// one unrelated archived_at test does not report a pairing nobody wrote.
+func appUserStatements(decl ast.Decl, owner helperScope) []string {
+	var out []string
+	seen := map[ast.Node]bool{}
+	ast.Inspect(decl, func(n ast.Node) bool {
+		if seen[n] {
+			return false
+		}
+		text, ok := flattenSQL(n, seen, owner)
+		if !ok || !readsAppUser.MatchString(text) {
+			return true
+		}
+		out = append(out, text)
+		return true
+	})
+	return out
+}
+
+// liveMemberHalves reports which halves of liveness a statement constrains, on
+// APP_USER's columns — resolved through the alias so a joined table's
+// archived_at is somebody else's question.
+func liveMemberHalves(sql string) (status, archived bool) {
+	sql = stripAssignments(sql)
+	prefix := ""
+	if m := appUserAlias.FindStringSubmatch(sql); m != nil && !isSQLKeyword(m[1]) {
+		prefix = m[1] + "."
+	}
+	status = regexp.MustCompile(regexp.QuoteMeta(prefix) + `status\s*=\s*'active'`).MatchString(sql)
+	archived = regexp.MustCompile(regexp.QuoteMeta(prefix) + `archived_at\s+IS\s+NULL`).MatchString(sql)
+	return status, archived
+}
+
+// stripAssignments drops an UPDATE's SET clause, because `SET status =
+// 'active'` MAKES someone live rather than asking whether they are. Reading it
+// as a predicate reported every fixture that activates a seat, which is the
+// opposite of the statement this gate is looking for.
+//
+// From SET to the first WHERE or RETURNING at the same depth, so a predicate in
+// the same statement is still judged and a subquery inside an assignment does
+// not end the clause early.
+func stripAssignments(sql string) string {
+	set := regexp.MustCompile(`(?is)\bSET\b`).FindStringIndex(sql)
+	if set == nil {
+		return sql
+	}
+	depth := 0
+	for i := set[1]; i < len(sql); i++ {
+		switch sql[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		if depth != 0 {
+			continue
+		}
+		if end := endsAssignments.FindStringIndex(sql[i:]); end != nil && end[0] == 0 {
+			return sql[:set[0]] + " " + sql[i:]
+		}
+	}
+	return sql[:set[0]]
+}
+
+// endsAssignments is what closes a SET clause: the predicate, or the row the
+// statement hands back.
+var endsAssignments = regexp.MustCompile(`(?is)^\s(WHERE|RETURNING|FROM)\b`)
+
+// offersAUser reports whether the statement is one that could hand back the
+// wrong colleague — which is the only shape the half-spelling defect takes.
+//
+// A WRITE is excluded: an UPDATE choosing rows to deactivate offers nobody, and
+// the row set it touches is a question about that statement's own intent rather
+// than about who still works here.
+func offersAUser(sql string) bool {
+	return !writesAppUser.MatchString(sql) && !resolvesOneUserByID(sql)
+}
+
+// writesAppUser matches a statement that mutates rather than reads.
+var writesAppUser = regexp.MustCompile(`(?is)^\s*(UPDATE|DELETE|INSERT)\b`)
+
+// resolvesOneUserByID reports whether the statement already names WHICH user it
+// wants, by the primary key its caller was handed.
+//
+// Such a statement cannot offer the wrong colleague — it is reading a row
+// somebody else chose, and `archived_at IS NULL` alone is the right filter
+// there: an archived seat is gone, a deactivated one is an account that still
+// has a locale, a display name and a team to render on the work it did. About
+// twenty statements in identity have exactly this shape, and reporting them
+// would be a gate firing on correct code, which teaches readers to skip its
+// output.
+//
+// The liveness question only arises when the statement CHOOSES a user. An
+// email is deliberately NOT treated as such a key: it arrives as input rather
+// than as a row identity somebody already read, and "may this address reset a
+// password" is a question about the account's state, not a lookup.
+func resolvesOneUserByID(sql string) bool {
+	return resolvesByID.MatchString(stripAssignments(sql))
+}
+
+// resolvesByID matches primary-key equality, alias or not, single or set — the
+// three spellings this tree uses to say "this user, the one I was given".
+var resolvesByID = regexp.MustCompile(`(?i)\b(?:[a-z]\w*\.)?id\s*(?:=\s*\$\d+|=\s*ANY\s*\(\s*\$\d+)`)
+
+// isSQLKeyword keeps a clause word from being mistaken for an alias.
+// `FROM app_user WHERE …` would otherwise bind the alias "where", and every
+// bare column then reads as somebody else's — the whole statement goes quiet.
+func isSQLKeyword(word string) bool {
+	switch strings.ToLower(word) {
+	case "where", "set", "on", "join", "left", "right", "inner", "cross", "order",
+		"group", "having", "limit", "union", "using", "and", "or", "values", "returning":
+		return true
+	}
+	return false
+}
+
+// firstLiveMemberLine points the report at the line that names a half rather
+// than dumping the statement.
+func firstLiveMemberLine(sql string) string {
+	for _, line := range strings.Split(sql, "\n") {
+		if strings.Contains(line, "archived_at") || strings.Contains(line, "status = 'active'") {
+			return strings.TrimSpace(line)
+		}
+	}
+	return strings.TrimSpace(strings.Split(sql, "\n")[0])
+}
+
+// liveMemberProbe is one planted source file and the verdict the detector owes
+// it. `fires` is not enough on its own — a run that reports SOMETHING proves
+// only that some assertion tripped — so each probe names WHICH arm must answer.
+type liveMemberProbe struct {
+	name string
+	arm  string // "copy", "half", or "" for a statement the gate must pass over
+	// mode picks the file the probe is parsed as, because the answer depends
+	// on it and a probe that guesses wrong asks a different question than the
+	// tree does:
+	//
+	//   ""         package probe, importing identity — an ordinary caller
+	//   "identity" package identity — the one place a bare call is the helper's
+	//   "noimport" package probe, NOT importing identity — most of the tree,
+	//              and where a bare helper name is somebody else's function
+	mode string
+	src  string
+}
+
+// The census above is a census of ZERO once the tree is clean: it reads
+// identically over a clean tree and over a detector that has
+// stopped detecting. These read the detector instead, and each one is a shape
+// this change actually met.
+var liveMemberProbes = []liveMemberProbe{
+	{"both halves spelled out, one literal", "copy", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE status = 'active' AND archived_at IS NULL` + "`" + `
+}`},
+	{"the same halves in the other order", "copy", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE archived_at IS NULL AND status = 'active'` + "`" + `
+}`},
+	{"the same, split across a concatenation", "copy", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE status = 'active' AND ` + "`" + ` + ` + "`" + `archived_at IS NULL` + "`" + `
+}`},
+	{"the same, inside a formatter's argument", "copy", "", `
+func read() string {
+	return fmt.Sprintf(` + "`" + `SELECT %s FROM app_user WHERE status = 'active' AND archived_at IS NULL` + "`" + `, cols)
+}`},
+	{"the same, inside a transaction callback", "copy", "", `
+func read() error {
+	return db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, ` + "`" + `SELECT id FROM app_user WHERE status = 'active' AND archived_at IS NULL` + "`" + `).Scan(&id)
+	})
+}`},
+	{"archived only, in a statement that chooses", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE display_name ILIKE $1 AND archived_at IS NULL` + "`" + `
+}`},
+	{"status only, in a statement that chooses", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE id <> $1 AND status = 'active'` + "`" + `
+}`},
+	{"archived only, aliased", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT u.id FROM app_user u JOIN edge e ON e.user_id = u.id AND u.archived_at IS NULL` + "`" + `
+}`},
+	{"the helper called for the whole predicate", "", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE ` + "`" + ` + identity.LiveMemberSQL("") + ` + "`" + ` AND NOT is_agent` + "`" + `
+}`},
+	{"the helper unqualified inside identity", "", "identity", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE ` + "`" + ` + LiveMemberSQL("") + ` + "`" + ` AND NOT is_agent` + "`" + `
+}`},
+	{"the helper for one half and a hand-written other", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE archived_at IS NULL AND ` + "`" + ` + identity.LiveMemberSQL("")
+}`},
+	{"a lookalike helper from another package", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE archived_at IS NULL AND ` + "`" + ` + other.LiveMemberSQL("")
+}`},
+	{"a bare helper name where identity is not imported", "half", "noimport", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE archived_at IS NULL AND ` + "`" + ` + LiveMemberSQL("")
+}`},
+	{"resolving the user the caller named", "", "", `
+func read() string {
+	return ` + "`" + `SELECT display_name FROM app_user WHERE id = $1 AND archived_at IS NULL` + "`" + `
+}`},
+	{"resolving a set of ids the caller named", "", "", `
+func read() string {
+	return ` + "`" + `SELECT id, display_name FROM app_user WHERE id = ANY($1) AND archived_at IS NULL` + "`" + `
+}`},
+	{"a write choosing rows to deactivate", "", "", `
+func read() string {
+	return ` + "`" + `UPDATE app_user SET status = 'deactivated' WHERE status = 'active'` + "`" + `
+}`},
+	{"a write whose SET makes someone live", "", "", `
+func read() string {
+	return ` + "`" + `UPDATE app_user SET status = 'active' WHERE id = $1` + "`" + `
+}`},
+	{"another table carrying the same two columns", "", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM voice_profile_version WHERE status = 'active' AND archived_at IS NULL` + "`" + `
+}`},
+	{"a joined table's archived_at, not app_user's", "", "", `
+func read() string {
+	return ` + "`" + `SELECT u.id FROM app_user u JOIN project p ON p.owner_id = u.id AND p.archived_at IS NULL WHERE p.id = $2` + "`" + `
+}`},
+	{"the foreign key alone, no app_user row read", "", "", `
+func read() string {
+	return ` + "`" + `SELECT 1 FROM mirror_user_map m WHERE m.app_user_id = $1 AND m.archived_at IS NULL AND m.name ILIKE $2` + "`" + `
+}`},
+	{"app_user read with no liveness constraint at all", "", "", `
+func read() string {
+	return ` + "`" + `SELECT display_name FROM app_user WHERE email ILIKE $1` + "`" + `
+}`},
+}
+
+func TestTheLiveMemberDetectorSeesWhatItClaimsTo(t *testing.T) {
+	fset := token.NewFileSet()
+	for _, tc := range liveMemberProbes {
+		t.Run(tc.name, func(t *testing.T) {
+			head := "package probe\n"
+			names := map[string]bool{liveMemberHelper: true}
+			scope := helperScope{qualifier: "identity", names: names}
+			switch tc.mode {
+			case "identity":
+				head, scope = "package identity\n", helperScope{inside: true, names: names}
+			case "noimport":
+				scope = helperScope{names: names}
+			default:
+				head += "import (\n\t\"fmt\"\n\n\t\"" + identityPath + "\"\n)\n"
+			}
+			file, err := parser.ParseFile(fset, "probe.go", head+tc.src, 0)
+			if err != nil {
+				t.Fatalf("the probe does not parse, so it proves nothing: %v", err)
+			}
+			got := ""
+			for _, decl := range file.Decls {
+				for _, sql := range appUserStatements(decl, scope) {
+					status, archived := liveMemberHalves(sql)
+					switch {
+					case status && archived && !strings.Contains(sql, liveMemberHelper):
+						got = "copy"
+					case (status != archived) && offersAUser(sql):
+						got = "half"
+					}
+				}
+			}
+			if got != tc.arm {
+				t.Errorf("the detector answered %q where it owes %q — a census keyed on this reads green over the wrong tree:\n%s",
+					orNothing(got), orNothing(tc.arm), tc.src)
+			}
+		})
+	}
+}
+
+// orNothing names the silent verdict, so a failure says "answered nothing"
+// rather than printing an empty pair of quotes the reader has to decode.
+func orNothing(arm string) string {
+	if arm == "" {
+		return "nothing"
+	}
+	return arm
+}

--- a/backend/livemember_test.go
+++ b/backend/livemember_test.go
@@ -137,7 +137,13 @@ var appUserAlias = regexp.MustCompile(`(?i)\bapp_user\b(?:\s+AS)?\s+([a-z]\w*)`)
 // trailing `\b` already refuses `app_user_id`, since an underscore is a word
 // character. A statement that only carries the foreign key is not reading the
 // row, and asking it about liveness would report a pairing nobody wrote.
-var readsAppUser = regexp.MustCompile(`\bapp_user\b`)
+//
+// CASE-INSENSITIVE, like every other pattern here. Postgres folds an unquoted
+// identifier, so `FROM APP_USER` is the same relation and a case-sensitive
+// census would have passed straight over it — the same way `as` slipped past
+// an uppercase-only `AS`. Nothing in this tree writes it that way today, which
+// is exactly why nobody would notice the day something did.
+var readsAppUser = regexp.MustCompile(`(?i)\bapp_user\b`)
 
 func TestOnlyOneSpellingOfALiveMember(t *testing.T) {
 	// A ratification that stops matching covers a site that has moved or been
@@ -376,8 +382,8 @@ func appUserStatements(decl ast.Decl, owner helperScope) []string {
 func liveMemberHalves(sql string) (status, archived bool) {
 	sql = stripAssignments(sql)
 	prefix := appUserPrefix(sql)
-	status = regexp.MustCompile(regexp.QuoteMeta(prefix) + `status\s*=\s*'active'`).MatchString(sql)
-	archived = regexp.MustCompile(regexp.QuoteMeta(prefix) + `archived_at\s+IS\s+NULL`).MatchString(sql)
+	status = regexp.MustCompile(`(?i)` + regexp.QuoteMeta(prefix) + `status\s*=\s*'active'`).MatchString(sql)
+	archived = regexp.MustCompile(`(?i)` + regexp.QuoteMeta(prefix) + `archived_at\s+IS\s+NULL`).MatchString(sql)
 	return status, archived
 }
 
@@ -453,7 +459,7 @@ func resolvesOneUserByID(sql string) bool {
 	// joined table's key excuse a liveness defect on app_user: `… JOIN app_user
 	// u … WHERE p.id = $1 AND u.archived_at IS NULL` names WHICH PROJECT, not
 	// which colleague, and the statement still chooses freely among seats.
-	return regexp.MustCompile(regexp.QuoteMeta(appUserPrefix(sql)) +
+	return regexp.MustCompile(`(?i)` + regexp.QuoteMeta(appUserPrefix(sql)) +
 		`id\s*(?:=\s*\$\d+|=\s*ANY\s*\(\s*\$\d+)`).MatchString(sql)
 }
 
@@ -625,6 +631,14 @@ func read() string {
 		` + "`" + `SELECT id FROM app_user WHERE ` + "`" + `,
 		` + "`" + `status = 'active' AND archived_at IS NULL` + "`" + `,
 	}, " ")
+}`},
+	{"the table name folded to upper case", "copy", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM APP_USER WHERE STATUS = 'active' AND ARCHIVED_AT IS NULL` + "`" + `
+}`},
+	{"the half-spelling, table name folded", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM APP_USER WHERE display_name ILIKE $1 AND ARCHIVED_AT IS NULL` + "`" + `
 }`},
 	{"a lowercase alias keyword", "copy", "", `
 func read() string {

--- a/backend/livemember_test.go
+++ b/backend/livemember_test.go
@@ -60,10 +60,14 @@ const (
 // predicate would have to move tier before they could adopt it. That is an
 // architecture decision with an owner rather than something to smuggle in here.
 //
-// Each entry is a FILE, so a NEW hand-spelled copy in one of these packages is
-// still a finding: the ratification covers the statements that exist, not the
-// package.
+// Each entry is a FILE and not a package, which is narrower but NOT narrow
+// enough to say what an earlier version of this comment said: a new
+// hand-spelled copy added to one of these files is excused along with the ones
+// already there. The key ratifies the file. Splitting it finer would mean
+// keying on statement text, which changes with every whitespace edit and
+// ratifies nothing stable.
 var cannotReachIdentity = gatekit.Waive(map[string]string{
+	"internal/modules/activities/audience.go":     "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/activities/lifecycle.go":    "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/dealrooms/store_public.go":  "dealrooms cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/people/counterpartyname.go": "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
@@ -90,10 +94,35 @@ var cannotReachIdentity = gatekit.Waive(map[string]string{
 // once, so it is issue margince/margince#2592 rather than a change made here on
 // a guess.
 var deliberatelyNotLiveness = gatekit.Waive(map[string]string{
-	"internal/modules/overlay/usermapadmin.go": "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
-	"internal/modules/overlay/usermapseed.go":  "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
-	"internal/modules/identity/roster.go":      "listUsersAllQuery is the ADMIN roster and says so: every non-archived member REGARDLESS of status, because a deactivated member has to be visible to reactivate",
-	"internal/modules/identity/reset.go":       "OperatorResetPassword is the operator CLI's lockout path, never exposed over HTTP; it must reach an account whose status is not active, which is what administrator lockout means. Login itself calls the helper (lockout.go)",
+	"internal/modules/overlay/usermapadmin.go":                                 "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
+	"internal/modules/overlay/usermapseed.go":                                  "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
+	"internal/modules/identity/roster.go":                                      "listUsersAllQuery is the ADMIN roster and says so: every non-archived member REGARDLESS of status, because a deactivated member has to be visible to reactivate",
+	"internal/modules/identity/reset.go":                                       "OperatorResetPassword is the operator CLI's lockout path, never exposed over HTTP; it must reach an account whose status is not active, which is what administrator lockout means. Login itself calls the helper (lockout.go)",
+	"internal/compose/integration/agentaccess/oauth_grant_integration_test.go": "the fixture deactivates every seat that CAN still act, to prove revocation binds mid-session; the archived half would narrow nothing, because every seat in it was created by the harness moments earlier and none is archived",
+})
+
+// namesTheSeatRatherThanOffersIt ratifies the reads that resolve a seat by the
+// id their caller was handed and deliberately admit a deactivated one.
+//
+// These are NOT the offer defect. A departed colleague's name still has to
+// render on the work they did, their locale still decides how a stored string
+// is formatted, and an admin still has to be able to inspect and change a
+// deactivated seat — that is how somebody comes back. Requiring liveness here
+// would blank a name on last quarter's activity, which is a worse answer than
+// the one this gate exists to prevent.
+//
+// One entry is a defect rather than a decision, and it says so: dealrooms opens
+// a room with a steward who cannot act. That changes who may open a room and
+// with what, so it is issue margince/margince#2596 rather than a change made
+// here on a guess — and it stays listed so it reads as open rather than settled.
+var namesTheSeatRatherThanOffersIt = gatekit.Waive(map[string]string{
+	"internal/modules/dealrooms/preview.go":      "renders a steward's name and address on a room that already exists; a departed colleague's name is still the right label on what they did",
+	"internal/modules/dealrooms/room_write.go":   "DEFECT, not a decision: a deactivated seat can be a new room's steward. Product call on who may be one, so it is issue 2596",
+	"internal/modules/identity/access.go":        "UserAccess evaluates an EXISTING member's roles and teams as they stand, which an admin needs precisely when the seat is deactivated",
+	"internal/modules/identity/actoridentity.go": "resolves the display name and address of whoever performed a past action; the actor of an audit row does not stop having a name",
+	"internal/modules/identity/seatnames.go":     "answers \"what is this id called\" for ids the caller already holds; a name that blanks on deactivation makes historical rows unreadable",
+	"internal/modules/identity/userlocale.go":    "reads a seat's locale to format a stored string; the formatting of last month's number does not depend on whether they still work here",
+	"internal/modules/identity/users.go":         "ChangeUserRole reads what the target IS because an agent seat holds no role; changing a deactivated member's role is how an admin prepares a reactivation",
 })
 
 // appUserAlias finds what app_user is called in a statement, so a sibling
@@ -102,7 +131,7 @@ var deliberatelyNotLiveness = gatekit.Waive(map[string]string{
 // `FROM project p JOIN app_user u` puts two archived_at columns in scope and
 // only one of them is a workforce question. An unaliased `FROM app_user` binds
 // the bare column names instead.
-var appUserAlias = regexp.MustCompile(`\bapp_user\b(?:\s+AS)?\s+([a-z]\w*)`)
+var appUserAlias = regexp.MustCompile(`(?i)\bapp_user\b(?:\s+AS)?\s+([a-z]\w*)`)
 
 // readsAppUser matches the table itself and not a column named after it: the
 // trailing `\b` already refuses `app_user_id`, since an underscore is a word
@@ -115,6 +144,7 @@ func TestOnlyOneSpellingOfALiveMember(t *testing.T) {
 	// fixed, and leaving it in place quietly re-exempts whatever takes its name.
 	defer cannotReachIdentity.AssertAllMatched(t)
 	defer deliberatelyNotLiveness.AssertAllMatched(t)
+	defer namesTheSeatRatherThanOffersIt.AssertAllMatched(t)
 
 	fset := token.NewFileSet()
 	var copies, halves []string
@@ -138,19 +168,23 @@ func TestOnlyOneSpellingOfALiveMember(t *testing.T) {
 		for _, decl := range file.Decls {
 			for _, sql := range appUserStatements(decl, scope) {
 				judged++
-				status, archived := liveMemberHalves(sql)
-				if !status && !archived {
-					continue
+				if st, ar := liveMemberHalves(sql); st || ar {
+					constrained++
 				}
-				constrained++
-				switch {
-				case status && archived:
-					if strings.Contains(sql, liveMemberHelper) || cannotReachIdentity.Waived(t, slash) {
+				switch liveMemberVerdict(sql) {
+				case "copy":
+					// No exemption for "it also calls the helper". The helper
+					// renders as a marker and contributes NO literal halves, so
+					// a compliant statement never reaches here — and excusing
+					// one that does would make calling the definition a licence
+					// to write a second predicate beside it.
+					if cannotReachIdentity.Waived(t, slash) {
 						continue
 					}
 					copies = append(copies, fmt.Sprintf("%s: %s", path, firstLiveMemberLine(sql)))
-				default:
-					if !offersAUser(sql) || deliberatelyNotLiveness.Waived(t, slash) {
+				case "half":
+					if deliberatelyNotLiveness.Waived(t, slash) ||
+						namesTheSeatRatherThanOffersIt.Waived(t, slash) {
 						continue
 					}
 					halves = append(halves, fmt.Sprintf("%s: %s", path, firstLiveMemberLine(sql)))
@@ -203,7 +237,32 @@ func TestEveryLiveMemberAliasIsALiteral(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
+		// Callees, plus the declaration itself: `func LiveMemberSQL(...)` names
+		// the helper without using it, and reporting the definition as its own
+		// unsafe caller would be the gate refusing the thing it protects.
+		callees := map[ast.Node]bool{}
 		ast.Inspect(file, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.CallExpr:
+				callees[v.Fun] = true
+				// A qualified callee is a SelectorExpr whose Sel is the
+				// helper's own name, and the walk reaches that Ident
+				// separately. Marking only the selector reported every
+				// ordinary `identity.LiveMemberSQL("u")` as a value reference.
+				if sel, ok := v.Fun.(*ast.SelectorExpr); ok {
+					callees[sel.Sel] = true
+				}
+			case *ast.FuncDecl:
+				callees[v.Name] = true
+			}
+			return true
+		})
+		ast.Inspect(file, func(n ast.Node) bool {
+			if namesTheHelper(n) && !callees[n] {
+				findings = append(findings, fmt.Sprintf("%s:%d (used as a value, so no argument is checkable)",
+					path, fset.Position(n.Pos()).Line))
+				return true
+			}
 			call, ok := n.(*ast.CallExpr)
 			if !ok || calleeName(call) != liveMemberHelper || len(call.Args) != 1 {
 				return true
@@ -228,6 +287,66 @@ func TestEveryLiveMemberAliasIsALiteral(t *testing.T) {
 	}
 }
 
+// namesTheHelper reports whether this node IS a reference to the helper — bare
+// inside identity, qualified anywhere else.
+func namesTheHelper(n ast.Node) bool {
+	switch v := n.(type) {
+	case *ast.SelectorExpr:
+		return v.Sel != nil && v.Sel.Name == liveMemberHelper
+	case *ast.Ident:
+		return v.Name == liveMemberHelper
+	}
+	return false
+}
+
+// liveMemberVerdict is what this gate says about one statement: "copy", "half",
+// or "" for one it passes over.
+//
+// The census and the probe suite BOTH call it, and that is the point. They used
+// to spell the rule separately, so a probe could agree with a census that had
+// changed underneath it — the two readings of one value this repo has been
+// bitten by before. A probe now exercises the code the tree is judged with, or
+// it exercises nothing.
+func liveMemberVerdict(sql string) string {
+	status, archived := liveMemberHalves(sql)
+	switch {
+	case status && archived:
+		return "copy"
+	case (status || archived) && offersAUser(sql):
+		return "half"
+	}
+	return ""
+}
+
+// bareLivenessPredicate matches the shape that started all of this: the pair
+// spelled into a declaration of its own and consumed elsewhere by name.
+//
+// `const liveMemberWhere = "u.status = 'active' AND u.archived_at IS NULL"` is
+// invisible to a table-keyed walk from both ends — the declaration never
+// mentions app_user, and the statement that concatenates it renders the
+// identifier as a blank. That is precisely how org360's copy sat unheld while
+// its comment called it the one spelling.
+//
+// It deliberately does not catch a HALF spelled into a bare declaration: a lone
+// `archived_at IS NULL` fragment could belong to any of a dozen tables, and
+// reporting it would be a guess.
+func bareLivenessPredicate(sql string) bool {
+	return onlyTheLivenessPair.MatchString(strings.TrimSpace(sql))
+}
+
+// onlyTheLivenessPair matches a literal that is the predicate and NOTHING else,
+// in either order, with or without an alias.
+//
+// "Nothing else" is doing real work rather than being strict for its own sake.
+// A looser reading — "spells both halves and names no table" — reported a test
+// whose FAILURE MESSAGE quotes the predicate back to the reader. Prose that
+// mentions the pair is not a second implementation of it, and a gate that says
+// so teaches people to stop reading its output.
+var onlyTheLivenessPair = regexp.MustCompile(`(?is)^\(?\s*(?:` +
+	`(?:[a-z]\w*\.)?status\s*=\s*'active'\s+AND\s+(?:[a-z]\w*\.)?archived_at\s+IS\s+NULL` + `|` +
+	`(?:[a-z]\w*\.)?archived_at\s+IS\s+NULL\s+AND\s+(?:[a-z]\w*\.)?status\s*=\s*'active'` +
+	`)\s*\)?$`)
+
 // appUserStatements returns the SQL statements in a declaration that read
 // app_user, flattened so a statement assembled out of a literal and a helper
 // call is judged as the one statement it builds.
@@ -242,7 +361,7 @@ func appUserStatements(decl ast.Decl, owner helperScope) []string {
 			return false
 		}
 		text, ok := flattenSQL(n, seen, owner)
-		if !ok || !readsAppUser.MatchString(text) {
+		if !ok || !(readsAppUser.MatchString(text) || bareLivenessPredicate(text)) {
 			return true
 		}
 		out = append(out, text)
@@ -256,10 +375,7 @@ func appUserStatements(decl ast.Decl, owner helperScope) []string {
 // archived_at is somebody else's question.
 func liveMemberHalves(sql string) (status, archived bool) {
 	sql = stripAssignments(sql)
-	prefix := ""
-	if m := appUserAlias.FindStringSubmatch(sql); m != nil && !isSQLKeyword(m[1]) {
-		prefix = m[1] + "."
-	}
+	prefix := appUserPrefix(sql)
 	status = regexp.MustCompile(regexp.QuoteMeta(prefix) + `status\s*=\s*'active'`).MatchString(sql)
 	archived = regexp.MustCompile(regexp.QuoteMeta(prefix) + `archived_at\s+IS\s+NULL`).MatchString(sql)
 	return status, archived
@@ -303,15 +419,15 @@ var endsAssignments = regexp.MustCompile(`(?is)^\s(WHERE|RETURNING|FROM)\b`)
 // offersAUser reports whether the statement is one that could hand back the
 // wrong colleague — which is the only shape the half-spelling defect takes.
 //
-// A WRITE is excluded: an UPDATE choosing rows to deactivate offers nobody, and
-// the row set it touches is a question about that statement's own intent rather
-// than about who still works here.
+// A WRITE is judged like a read. Excluding one on the grounds that "an UPDATE
+// offers nobody" was wrong in the direction that matters: `UPDATE app_user SET
+// password_hash = $2 WHERE id = $1 AND archived_at IS NULL` sets a DEACTIVATED
+// account's password, and the row set a mutation chooses is exactly as much a
+// liveness question as the one a read returns. Only its SET clause is exempt,
+// because that assigns rather than asks (stripAssignments).
 func offersAUser(sql string) bool {
-	return !writesAppUser.MatchString(sql) && !resolvesOneUserByID(sql)
+	return !resolvesOneUserByID(sql)
 }
-
-// writesAppUser matches a statement that mutates rather than reads.
-var writesAppUser = regexp.MustCompile(`(?is)^\s*(UPDATE|DELETE|INSERT)\b`)
 
 // resolvesOneUserByID reports whether the statement already names WHICH user it
 // wants, by the primary key its caller was handed.
@@ -329,19 +445,49 @@ var writesAppUser = regexp.MustCompile(`(?is)^\s*(UPDATE|DELETE|INSERT)\b`)
 // than as a row identity somebody already read, and "may this address reset a
 // password" is a question about the account's state, not a lookup.
 func resolvesOneUserByID(sql string) bool {
-	return resolvesByID.MatchString(stripAssignments(sql))
+	sql = stripAssignments(sql)
+	if !readsTheStatusColumn.MatchString(sql) {
+		return false
+	}
+	// APP_USER's id, bound through its own alias. An unbound `id = $N` let a
+	// joined table's key excuse a liveness defect on app_user: `… JOIN app_user
+	// u … WHERE p.id = $1 AND u.archived_at IS NULL` names WHICH PROJECT, not
+	// which colleague, and the statement still chooses freely among seats.
+	return regexp.MustCompile(regexp.QuoteMeta(appUserPrefix(sql)) +
+		`id\s*(?:=\s*\$\d+|=\s*ANY\s*\(\s*\$\d+)`).MatchString(sql)
 }
 
-// resolvesByID matches primary-key equality, alias or not, single or set — the
-// three spellings this tree uses to say "this user, the one I was given".
-var resolvesByID = regexp.MustCompile(`(?i)\b(?:[a-z]\w*\.)?id\s*(?:=\s*\$\d+|=\s*ANY\s*\(\s*\$\d+)`)
+// readsTheStatusColumn matches a statement that hands `status` BACK rather than
+// filtering on it — the difference between deferring the liveness decision to
+// Go and never making it.
+//
+// Without this, resolving by id excused everything, and the escape hatch was
+// wider than the gate: `SELECT seat_type FROM app_user WHERE id = $1 AND
+// archived_at IS NULL` grants a DEACTIVATED seat live authority
+// (identity/authority.go's liveUserTx), reads as a plain lookup, and would have
+// passed in silence. A statement that returns `status` has at least asked the
+// question; one that neither filters on it nor reads it has not.
+var readsTheStatusColumn = regexp.MustCompile(`(?is)SELECT\b[^;]*?\bstatus\b[^;]*?\bFROM\b|RETURNING\b[^;]*?\bstatus\b`)
+
+// appUserPrefix is what app_user's columns are written with in this statement:
+// its alias plus a dot, or "" when the statement reads app_user unaliased.
+func appUserPrefix(sql string) string {
+	if m := appUserAlias.FindStringSubmatch(sql); m != nil && !isSQLKeyword(m[1]) {
+		return m[1] + "."
+	}
+	return ""
+}
 
 // isSQLKeyword keeps a clause word from being mistaken for an alias.
 // `FROM app_user WHERE …` would otherwise bind the alias "where", and every
 // bare column then reads as somebody else's — the whole statement goes quiet.
 func isSQLKeyword(word string) bool {
 	switch strings.ToLower(word) {
-	case "where", "set", "on", "join", "left", "right", "inner", "cross", "order",
+	// "as" is here because the pattern's own `AS` was case-sensitive: a
+	// lowercase `FROM app_user as u` captured "as" as the alias, every column
+	// then read as `as.status`, and the whole statement went silent. The word
+	// is refused as well as matched, so neither spelling can bind it.
+	case "as", "where", "set", "on", "join", "left", "right", "inner", "cross", "order",
 		"group", "having", "limit", "union", "using", "and", "or", "values", "returning":
 		return true
 	}
@@ -436,21 +582,61 @@ func read() string {
 func read() string {
 	return ` + "`" + `SELECT id FROM app_user WHERE archived_at IS NULL AND ` + "`" + ` + LiveMemberSQL("")
 }`},
-	{"resolving the user the caller named", "", "", `
+	{"resolving by id and handing status back to Go", "", "", `
+func read() string {
+	return ` + "`" + `SELECT status, seat_type FROM app_user WHERE id = $1 AND archived_at IS NULL` + "`" + `
+}`},
+	{"resolving a set of ids and handing status back", "", "", `
+func read() string {
+	return ` + "`" + `SELECT id, status FROM app_user WHERE id = ANY($1) AND archived_at IS NULL` + "`" + `
+}`},
+	{"resolving by id and never asking about status at all", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT seat_type FROM app_user WHERE id = $1 AND archived_at IS NULL` + "`" + `
+}`},
+	{"the same, for a column that only renders", "half", "", `
 func read() string {
 	return ` + "`" + `SELECT display_name FROM app_user WHERE id = $1 AND archived_at IS NULL` + "`" + `
 }`},
-	{"resolving a set of ids the caller named", "", "", `
+	{"a write choosing rows by half a predicate", "half", "", `
 func read() string {
-	return ` + "`" + `SELECT id, display_name FROM app_user WHERE id = ANY($1) AND archived_at IS NULL` + "`" + `
+	return ` + "`" + `UPDATE app_user SET password_hash = $2 WHERE display_name = $1 AND archived_at IS NULL` + "`" + `
 }`},
-	{"a write choosing rows to deactivate", "", "", `
+	{"a write naming the row it was handed, status read back", "", "", `
 func read() string {
-	return ` + "`" + `UPDATE app_user SET status = 'deactivated' WHERE status = 'active'` + "`" + `
+	return ` + "`" + `UPDATE app_user SET locale = $2 WHERE id = $1 AND archived_at IS NULL RETURNING status` + "`" + `
 }`},
 	{"a write whose SET makes someone live", "", "", `
 func read() string {
 	return ` + "`" + `UPDATE app_user SET status = 'active' WHERE id = $1` + "`" + `
+}`},
+	{"the helper called, and both halves hand-written beside it", "copy", "", `
+func read() string {
+	return ` + "`" + `SELECT id FROM app_user WHERE ` + "`" + ` + identity.LiveMemberSQL("") +
+		` + "`" + ` AND status = 'active' AND archived_at IS NULL` + "`" + `
+}`},
+	{"a joined table's id, not app_user's", "half", "", `
+func read() string {
+	return ` + "`" + `SELECT u.id FROM app_user u JOIN project p ON p.owner_id = u.id WHERE p.id = $1 AND u.archived_at IS NULL AND u.status IS NOT NULL` + "`" + `
+}`},
+	{"the halves assembled through a slice literal", "copy", "", `
+func read() string {
+	return strings.Join([]string{
+		` + "`" + `SELECT id FROM app_user WHERE ` + "`" + `,
+		` + "`" + `status = 'active' AND archived_at IS NULL` + "`" + `,
+	}, " ")
+}`},
+	{"a lowercase alias keyword", "copy", "", `
+func read() string {
+	return ` + "`" + `SELECT u.id FROM app_user as u WHERE u.status = 'active' AND u.archived_at IS NULL` + "`" + `
+}`},
+	{"the pair spelled into a declaration of its own", "copy", "", `
+func read() string {
+	return ` + "`" + `u.status = 'active' AND u.archived_at IS NULL` + "`" + `
+}`},
+	{"a fragment naming one half only, table unknowable", "", "", `
+func read() string {
+	return ` + "`" + `archived_at IS NULL` + "`" + `
 }`},
 	{"another table carrying the same two columns", "", "", `
 func read() string {
@@ -492,12 +678,8 @@ func TestTheLiveMemberDetectorSeesWhatItClaimsTo(t *testing.T) {
 			got := ""
 			for _, decl := range file.Decls {
 				for _, sql := range appUserStatements(decl, scope) {
-					status, archived := liveMemberHalves(sql)
-					switch {
-					case status && archived && !strings.Contains(sql, liveMemberHelper):
-						got = "copy"
-					case (status != archived) && offersAUser(sql):
-						got = "half"
+					if verdict := liveMemberVerdict(sql); verdict != "" {
+						got = verdict
 					}
 				}
 			}

--- a/backend/retentionscope_test.go
+++ b/backend/retentionscope_test.go
@@ -166,9 +166,13 @@ func namesRetentionScopeBuilder(n ast.Node) bool {
 	return false
 }
 
-// calleeName is the called function's own name, ignoring any qualifier. Sound
-// only because TestTheRetentionScopeSinkIsTheOneTheGateMeans pins the sink to a
-// single declaration.
+// calleeName is the called function's own name, ignoring any qualifier.
+//
+// Dropping the qualifier makes this NAME alone, so a caller that cares which
+// package the name came from must establish that itself — the retention sink
+// does it by pinning the sink to a single declaration
+// (TestTheRetentionScopeSinkIsTheOneTheGateMeans), the helper walk by checking
+// the package before it ever asks for a name (helperScope.isOneDefinition).
 func calleeName(call *ast.CallExpr) string {
 	switch fun := call.Fun.(type) {
 	case *ast.Ident:

--- a/backend/sqlhelperwalk_test.go
+++ b/backend/sqlhelperwalk_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The walk two "one definition" censuses share: how a SQL statement assembled
+// out of literals, concatenation and helper calls is rendered back into the
+// text it builds, and how a call to THE definition is told from a lookalike.
+//
+// It lives on its own because there are two ports of it now — employment
+// currency (people.EmploymentIsCurrentSQL) and workforce liveness
+// (identity.LiveMemberSQL) — and a walk copied for the second port drifts from
+// the first. The narrower copy then reads a smaller tree and says PASS, which
+// is the failure mode a census cannot report about itself.
+
+import (
+	"go/ast"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// flattenSQL renders a string expression as the text it builds, marking every
+// node it consumed so an inner piece is not judged again on its own.
+//
+// A call to the owning module's helper renders as a neutral marker: the predicate it
+// produces exists only at runtime, so the statement's text carries no
+// hand-written test from it, and a statement that calls the helper is simply a
+// statement with nothing hand-written left to find.
+//
+// It replaced an exemption — "this statement mentions the helper, so skip
+// it" — which was too coarse in the direction that matters: a query calling
+// the helper for one half and hand-writing the other was skipped WHOLESALE.
+// Calling the helper is not a licence to write a second predicate beside it.
+//
+// Any other call renders as its ARGUMENTS and not its name, because a
+// formatter holds its SQL in an argument — `fmt.Sprintf(`… <predicate> … `, …)` keeps the whole statement inside the call, and a flattener that
+// stopped at the callee name would judge nothing. The name is dropped because
+// it is not part of the SQL; only the helper's is kept, as the marker that
+// says the helper was reached.
+func flattenSQL(n ast.Node, seen map[ast.Node]bool, owner helperScope) (string, bool) {
+	switch v := n.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", false
+		}
+		seen[n] = true
+		return strings.Trim(v.Value, "`\""), true
+	case *ast.BinaryExpr:
+		if v.Op != token.ADD {
+			return "", false
+		}
+		left, lok := flattenSQL(v.X, seen, owner)
+		right, rok := flattenSQL(v.Y, seen, owner)
+		if !lok && !rok {
+			return "", false
+		}
+		seen[n] = true
+		return left + right, true
+	case *ast.CallExpr:
+		seen[n] = true
+		if owner.isOneDefinition(v) {
+			markSeen(v, seen)
+			return " " + calleeName(v) + " ", true
+		}
+		text := ""
+		for _, a := range v.Args {
+			if part, ok := flattenSQL(a, seen, owner); ok {
+				text += part
+			}
+		}
+		return " " + text + " ", true
+	case *ast.FuncLit:
+		// NOT claimed. A callback body is where most of this tree's SQL lives —
+		// `db.Tx(ctx, func(tx pgx.Tx) error { … })` is the shape every store
+		// write takes — and rendering the literal as a neutral space marked it
+		// seen, so the walk refused to descend and every statement inside it
+		// went unjudged. Returning false leaves it unclaimed for the walk to
+		// reach on its own.
+		return "", false
+	case ast.Expr:
+		seen[n] = true
+		return " ", true
+	}
+	return "", false
+}
+
+// helperScope says how the owning module's helper is reachable from one file, and it is
+// a struct rather than a string because the string had two meanings.
+//
+// `qualifier == ""` was read as "this file IS the owning package", where a bare
+// call is the helper's own. But importAliasOf returns "" for every file that
+// does not import the owner at all — which is most of the tree — so in any of
+// them a bare `EmploymentIsCurrentSQL(…)` was accepted as canonical and its
+
+// helperScope says how the owning module's helper is reachable from one file, and it is
+// a struct rather than a string because the string had two meanings.
+//
+// `qualifier == ""` was read as "this file IS the owning package", where a bare
+// call is the helper's own. But importAliasOf returns "" for every file that
+// does not import the owner at all — which is most of the tree — so in any of
+// them a bare `EmploymentIsCurrentSQL(…)` was accepted as canonical and its
+// arguments hidden. `inside` says the one thing the empty string could not.
+type helperScope struct {
+	qualifier string          // the local name the owning module is bound to, "" if not imported
+	inside    bool            // this file IS the owning package
+	names     map[string]bool // the exported helper(s) that ARE the definition
+}
+
+// isOneDefinition reports whether the call is the owning module's helper — the
+// PACKAGE as well as the name.
+//
+// The name alone was not enough, and the gap is the one this gate exists to
+// close: a helper call's whole subtree is claimed, so `other.
+// EmploymentIsCurrentSQL(…)` would have been treated as canonical and its
+// arguments hidden, letting a hand-written currency test ride inside a
+// lookalike.
+func (h helperScope) isOneDefinition(call *ast.CallExpr) bool {
+	// A scope with no names can never recognise the definition, so every call
+	// to it would flatten to its arguments and the gate would judge a compliant
+	// statement as a hand-written one — or, worse, pass it because the argument
+	// alone matches nothing. That is a construction error in the caller and
+	// never a property of the tree, so it fails here rather than quietly
+	// changing what the census means.
+	if len(h.names) == 0 {
+		panic("helperScope built with no helper names: it cannot tell the one definition from anything else")
+	}
+	named := func(n string) bool { return h.names[n] }
+	switch f := call.Fun.(type) {
+	case *ast.Ident:
+		return h.inside && named(f.Name)
+	case *ast.SelectorExpr:
+		pkg, ok := f.X.(*ast.Ident)
+		return ok && h.qualifier != "" && pkg.Name == h.qualifier && named(f.Sel.Name)
+	}
+	return false
+}
+
+// importAliasOf returns the local name an import path is bound to in this file,
+// or "" if the file does not import it. A dot import returns "" too: a
+// dot-imported call is a bare identifier, and the gate would rather miss it
+
+// importAliasOf returns the local name an import path is bound to in this file,
+// or "" if the file does not import it. A dot import returns "" too: a
+// dot-imported call is a bare identifier, and the gate would rather miss it
+// than name the wrong function.
+func importAliasOf(file *ast.File, path string) string {
+	for _, spec := range file.Imports {
+		if strings.Trim(spec.Path.Value, `"`) != path {
+			continue
+		}
+		if spec.Name != nil {
+			if spec.Name.Name == "." {
+				return ""
+			}
+			return spec.Name.Name
+		}
+		return "people"
+	}
+	return ""
+}
+
+// calleeName is the function's own name, however it is qualified.
+// Prefixed because retentionscope_test.go already has a calleeName in this
+
+// markSeen claims a whole subtree, so nothing inside a helper call is judged as
+// though somebody had written it into the statement.
+func markSeen(n ast.Node, seen map[ast.Node]bool) {
+	ast.Inspect(n, func(c ast.Node) bool {
+		if c != nil {
+			seen[c] = true
+		}
+		return true
+	})
+}
+
+// firstEmploymentLine returns the line of the statement that names the
+// employment kind, so the report points at the statement rather than dumping
+
+// handWrittenGoSources walks the module for source a person maintains.
+func handWrittenGoSources(t *testing.T) []string {
+	t.Helper()
+	var paths []string
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if name := entry.Name(); name == "node_modules" || name == "testdata" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_gen.go") || strings.HasSuffix(name, ".gen.go") {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module for Go source: %v", err)
+	}
+	if len(paths) < 500 {
+		t.Fatalf("the walk found only %d Go files, so this census covered almost nothing", len(paths))
+	}
+	return paths
+}
+
+// employmentProbe is one planted source file and the answer the gate must give

--- a/backend/sqlhelperwalk_test.go
+++ b/backend/sqlhelperwalk_test.go
@@ -181,9 +181,6 @@ func markSeen(n ast.Node, seen map[ast.Node]bool) {
 	})
 }
 
-// firstEmploymentLine returns the line of the statement that names the
-// employment kind, so the report points at the statement rather than dumping
-
 // handWrittenGoSources walks the module for source a person maintains.
 func handWrittenGoSources(t *testing.T) []string {
 	t.Helper()
@@ -213,5 +210,3 @@ func handWrittenGoSources(t *testing.T) []string {
 	}
 	return paths
 }
-
-// employmentProbe is one planted source file and the answer the gate must give

--- a/backend/sqlhelperwalk_test.go
+++ b/backend/sqlhelperwalk_test.go
@@ -72,6 +72,20 @@ func flattenSQL(n ast.Node, seen map[ast.Node]bool, owner helperScope) (string, 
 			}
 		}
 		return " " + text + " ", true
+	case *ast.CompositeLit:
+		// A statement assembled as `strings.Join([]string{…}, " ")` kept its
+		// pieces in a slice literal, which rendered as a blank — so each piece
+		// was judged alone, and the piece naming the table carried no predicate
+		// while the piece carrying the predicate named no table. Neither half
+		// could ever be a finding.
+		seen[n] = true
+		text := ""
+		for _, elt := range v.Elts {
+			if part, ok := flattenSQL(elt, seen, owner); ok {
+				text += part
+			}
+		}
+		return text, true
 	case *ast.FuncLit:
 		// NOT claimed. A callback body is where most of this tree's SQL lives —
 		// `db.Tx(ctx, func(tx pgx.Tx) error { … })` is the shape every store
@@ -93,15 +107,7 @@ func flattenSQL(n ast.Node, seen map[ast.Node]bool, owner helperScope) (string, 
 // `qualifier == ""` was read as "this file IS the owning package", where a bare
 // call is the helper's own. But importAliasOf returns "" for every file that
 // does not import the owner at all — which is most of the tree — so in any of
-// them a bare `EmploymentIsCurrentSQL(…)` was accepted as canonical and its
-
-// helperScope says how the owning module's helper is reachable from one file, and it is
-// a struct rather than a string because the string had two meanings.
-//
-// `qualifier == ""` was read as "this file IS the owning package", where a bare
-// call is the helper's own. But importAliasOf returns "" for every file that
-// does not import the owner at all — which is most of the tree — so in any of
-// them a bare `EmploymentIsCurrentSQL(…)` was accepted as canonical and its
+// them a bare call to the helper's NAME was accepted as canonical and its
 // arguments hidden. `inside` says the one thing the empty string could not.
 type helperScope struct {
 	qualifier string          // the local name the owning module is bound to, "" if not imported
@@ -141,10 +147,6 @@ func (h helperScope) isOneDefinition(call *ast.CallExpr) bool {
 // importAliasOf returns the local name an import path is bound to in this file,
 // or "" if the file does not import it. A dot import returns "" too: a
 // dot-imported call is a bare identifier, and the gate would rather miss it
-
-// importAliasOf returns the local name an import path is bound to in this file,
-// or "" if the file does not import it. A dot import returns "" too: a
-// dot-imported call is a bare identifier, and the gate would rather miss it
 // than name the wrong function.
 func importAliasOf(file *ast.File, path string) string {
 	for _, spec := range file.Imports {
@@ -157,13 +159,16 @@ func importAliasOf(file *ast.File, path string) string {
 			}
 			return spec.Name.Name
 		}
-		return "people"
+		// No alias: the local name is the package's own, which for every path
+		// this repo binds is the last segment. Returning a FIXED name here (it
+		// said "people", a leftover from the single-port version) made every
+		// unaliased import of any other module read as a lookalike, so the
+		// owning module's helper was never recognised in the one place it is
+		// most used.
+		return path[strings.LastIndex(path, "/")+1:]
 	}
 	return ""
 }
-
-// calleeName is the function's own name, however it is qualified.
-// Prefixed because retentionscope_test.go already has a calleeName in this
 
 // markSeen claims a whole subtree, so nothing inside a helper call is judged as
 // though somebody had written it into the statement.

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -48,8 +48,6 @@ cmd/worker/boot.go#func workerModelPathSpec
 consumermailonelist_test.go#var baselineDomains
 edgereaders_test.go#const edgeTable
 edgereaders_test.go#var edgeReaderScope
-employmentcurrency_test.go#func flattenSQL
-employmentcurrency_test.go#type helperScope
 enumsync_test.go#func recordChecks
 envcontract_test.go#func liveEnvVars
 envcontract_test.go#var deploySurfaceRoots
@@ -183,7 +181,6 @@ internal/compose/offeringconfirmed.go#func offeringConfirmed
 internal/compose/org360/assemble.go#const block at const sectionPeople
 internal/compose/org360/deals.go#func openDealsWhere
 internal/compose/org360/graph.go#const block at const graphGroupContacts
-internal/compose/org360/graphourside.go#const liveMemberWhere
 internal/compose/org360/graphplace.go#const block at const graphRelationParent
 internal/compose/org360/graphplace.go#method graphAssembly.keptDeals
 internal/compose/org360/graphreads.go#method graphAssembly.readOpenDeals
@@ -530,7 +527,6 @@ internal/modules/search/binding.go#method Store.SeedBinding
 internal/modules/search/embedgen.go#const block at const entityPerson
 internal/modules/search/graphactivity.go#var activityLinkArms
 internal/modules/search/graphedge.go#const audienceWorkspaceOnly
-internal/modules/search/graphedge.go#const liveMemberJoin
 internal/modules/search/graphtrust.go#var block at var humanWriterPrefix
 internal/modules/search/querybudget.go#func NewQueryExecutorWithBudget
 internal/modules/search/queryjoins.go#const block at const columnArchivedAt

--- a/backend/uniquenessclaims_test.go
+++ b/backend/uniquenessclaims_test.go
@@ -57,8 +57,8 @@ package backendarch
 // never improve, which is the opposite of the point. `registeredDebt` is the
 // line where that growth is agreed to.
 //
-// The register is 646 lines with no reasons, and that is deliberate rather than
-// sloppy: a reason per entry would be 646 rationalisations written by somebody
+// The register is 642 lines with no reasons, and that is deliberate rather than
+// sloppy: a reason per entry would be 642 rationalisations written by somebody
 // who has not audited the claim, which is worse than an honest count of what is
 // unaudited. The number is the point. It is meant to go down.
 
@@ -399,7 +399,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 //
 // Lowering it is the point of the file it counts; raising it is legal and is
 // what a widened detector shape requires.
-const registeredDebt = 646
+const registeredDebt = 642
 
 func TestTheRegisterHoldsExactlyTheDebtItPins(t *testing.T) {
 	keys := readRegister(t)


### PR DESCRIPTION
## What was wrong

Two functions, in two different packages, each called themselves **the ONE spelling of "someone who still works here"**. Neither had anything holding it, and the tree held about twenty copies of the predicate.

The second one's own comment is the part worth reading:

> `liveMemberJoin` is the ONE spelling … (org360 already spelled it this way; this read did not …)

So the author knew about the first copy, and minted a third anyway. That is exactly the false-uniqueness shape CLAUDE.md names: the next author greps, finds a comment saying the question is settled, and stops looking.

## What this does

`identity` owns `app_user`, so **`identity.LiveMemberSQL` is the definition**. Everything that can import it now does — identity's own reads, and compose (`org360`, the extension-job seam, the seat budget, the offline capture generator). Seven statements in sibling modules cannot (ADR-0054 §3) and are **ratified by name** in the gate with that reason, the same shape the employment-currency census settled on.

## Two defects it found

Both are the half-spelling its second arm exists for. Deactivating an account sets `status` and leaves `archived_at` NULL, so filtering on `archived_at` alone goes on offering a departed colleague.

- **`OrganizationLinkedInReach`** counted a deactivated colleague's LinkedIn connections. It answers "who on our team can get us in", which is the one question a former colleague is never an answer to.

  **Correction to an earlier reading of this, because it changes the severity:** the function has **no callers**. The live `GET /me/linkedin-reach` is served by `Store.MyLinkedInReach`, which is per-owner and asks no colleague question, so nothing reached a user. `OrganizationLinkedInReach` has been exported and uncalled since #355 (2026-08-01). The predicate is fixed here because the next caller inherits it; that it is also dead code is a separate matter — **#2594**.
- **The offline capture generator** could CC an archived colleague. This one does run, in the offline demo-data path.

Two more copies were *correct* but written backwards (`aibudget`, `colleagues`) — both spelled the halves in the other order, which is why a line-based grep found neither. They call the helper now.

## The walk moved rather than being copied — and that exposed a blind spot

The employment-currency census already had the AST walk this needed. Rather than copy it for the second port, it moved to `sqlhelperwalk_test.go` and became generic over which helper is the definition.

Porting it found a hole in **both** censuses: SQL inside a `db.Tx(ctx, func(tx pgx.Tx) error { … })` callback was rendered as a neutral marker and never descended into — and that callback is where most of this tree's statements live. Fixing it roughly **doubled** what both censuses can see. The employment gate stays green with the wider view.

A `helperScope` built with no helper names now panics rather than silently accepting every call as canonical; that construction error had already crept into the employment probes as part of this change, where it made one probe pass for the wrong reason.

## How it is held

- **`TestOnlyOneSpellingOfALiveMember`** — two arms over every statement that reads `app_user`. Arm one: a statement must not spell both halves itself. Arm two: naming one half without the other, in a statement that *chooses* a user.
- **`TestEveryLiveMemberAliasIsALiteral`** — the alias is formatted into the statement as an *identifier*, not bound as a parameter, so anything off a request would inject there. Every call site passes a literal, and this says so.
- **`TestTheLiveMemberDetectorSeesWhatItClaimsTo`** — 21 probes. Each names *which arm* must answer, because a run that reports something proves only that some assertion tripped.

**What the gate deliberately does not judge**, so it does not fire on correct code:

- A statement that resolves the user its caller already named (`WHERE id = $1`). It cannot offer the wrong colleague, and `archived_at IS NULL` alone is right there: an archived seat is gone, a deactivated one still has a locale, a name and a team to render on the work it did. About twenty statements in identity have this shape.
- A **write**. An `UPDATE` choosing rows to deactivate offers nobody.
- Another table carrying the same two column names — `voice_profile_version` is filtered by `status = 'active' AND archived_at IS NULL` in two places and is not a workforce question at all.

## Mutation-tested against the real tree

- Hand-spelling the predicate at an adopted site → arm one fires. ✅
- Dropping the status half in a file the *copy* arm waives → arm two fires, and the waiver correctly refuses to exempt it. ✅
- Passing a non-literal alias → the alias gate fires. ✅
- One mutant did not compile and was replaced rather than believed; three probes did not parse and the harness said so, which is the point of asserting the probe parses.

## Ratified rather than changed

`overlay`'s user-map eligibility is `NOT is_agent AND archived_at IS NULL` — a deliberately different set, already held as its own three-site invariant. Its own comment justifies excluding archived seats as "a seat that no longer logs in", which is equally true of a deactivated one, so today's predicate and its comment disagree. That is a product question that moves three statements at once: **#2592**.

`roster`'s admin list is *deliberately* every non-archived member regardless of status, so a deactivated member is visible to reactivate. `OperatorResetPassword` is the operator CLI's lockout path and must reach an account whose status is not active — that is what administrator lockout means; login itself calls the helper.

## Register

The uniqueness-claim register shrinks by four (646 → 642).

`make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes “live member” checks with `identity.LiveMemberSQL` and hardens detection so half‑spelled predicates stop admitting former colleagues. Old behavior mixed ad‑hoc predicates (often only archived_at); new behavior uses one helper or explicit ratified copies, and the gate now binds liveness to `app_user` columns only.

- Switches eligible callers in `identity` and `internal/compose` to `identity.LiveMemberSQL`; ratifies copies where modules cannot import `identity` (`activities`, `people`, `search`, `projects`, `dealrooms`, `overlay`).
- Fixes: LinkedIn organization reach no longer counts deactivated users (new integration test); offline demo CC excludes archived users; `activities` audience checks require both halves.
- Gate and tests: shared walk extracted to `backend/sqlhelperwalk_test.go`; now descends into `db.Tx` callbacks, ignores SET clauses, handles slice‑literal assembly, lowercase `as`, and folds identifier case; binds liveness to `app_user`’s alias, treats bare predicate constants as copies, and anchors column patterns so joined‑table columns cannot satisfy the check; adds alias‑literal check. Uniqueness register −4 (646 → 642).

<sup>Written for commit 23784dc10a1d10f7f231a93ef51ab63d6ec5bfb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Consistency Improvements**
  - Standardized live-account eligibility across sign-in, rosters, teams, password management, lockout handling, search, audience validation, and related workflows.
  - Inactive or archived accounts are now consistently excluded where appropriate.

- **Bug Fixes**
  - LinkedIn organization reach calculations now exclude inactive account owners.

- **Tests**
  - Added coverage and automated checks to validate account eligibility and prevent filtering regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
