### PR TITLE
test(approvals): a credential does not release the proposal it made

### DIFF
--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -304,23 +304,34 @@ func TestACredentialDoesNotReleaseTheProposalItMade(t *testing.T) {
 			if tc.want && err != nil {
 				t.Fatalf("refused a decision it may make: %v", err)
 			}
-			if !tc.want && err == nil {
-				t.Fatal("a credential released the proposal it made")
+			if !tc.want {
+				if err == nil {
+					t.Fatal("a credential released the proposal it made")
+				}
+				// The SENTINEL, not merely an error: swapping the refusal for an
+				// unrelated internal failure would leave a bare non-nil check
+				// green while the caller stopped seeing a 403.
+				if !errors.Is(err, apperrors.ErrPermissionDenied) {
+					t.Fatalf("refused with %v, want a permission denial", err)
+				}
 			}
 		})
 	}
 }
 
-// A HUMAN is never caught by the rule, whatever passport staged the row: the
-// person answering in a chat window is the person answering in a browser tab
-// (ADR-0055), and agentMayDecide returns early for them. Held here so a future
-// spelling that reads the row's passport before the principal's type cannot
-// lock the lender out of their own inbox.
+// A HUMAN is never caught by the rule, and the case that matters is the one the
+// type switch alone does not describe: a human whose OWN UserID is what the
+// staging passport was minted by. agentMayDecide returns early for every
+// non-agent, so this is a guard on the ORDER of that function rather than on new
+// behaviour — a spelling that read the row's passport before the principal's
+// type would lock the lender out of the inbox they lent from, and nothing else
+// in this file pairs a human with a passport-staged row.
 func TestTheHumanBehindACredentialStillDecidesItsProposal(t *testing.T) {
-	passport := ids.From[ids.PassportKind](ids.NewV7())
-	human := principal.Principal{Type: principal.PrincipalHuman, UserID: ids.NewV7()}
+	lender := ids.NewV7()
+	passport := ids.From[ids.PassportKind](lender)
+	human := principal.Principal{Type: principal.PrincipalHuman, UserID: lender}
 	if err := agentMayDecide(human, row{Kind: "advance_deal", PassportID: &passport}, true); err != nil {
-		t.Fatalf("a human was refused their own agent's proposal: %v", err)
+		t.Fatalf("a human was refused a proposal their own credential staged: %v", err)
 	}
 }
 

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -263,6 +263,67 @@ func TestAgentReleaseSpendsTheCapsTheReleaseSpends(t *testing.T) {
 // releases put on the wire is a message — one governed on the timeline object.
 // A misspelling fails here rather than silently admitting the send it meant to
 // bound.
+// The rule the whole confirm-first tier rests on: a credential does not release
+// the proposal it made. Without it a passport stages a 🟡 action, approves its
+// own row and re-issues the call, and the confirmation was of nothing.
+//
+// It needs its own test rather than a row in the caps table above, because it is
+// the only rule about the PAIRING of a row and a principal — every principal in
+// that table carries a zero PassportID, which short-circuits this condition
+// before it is reached. That is how the rule went untested through several
+// refactors (#2585): the function was covered, this branch of it was not.
+func TestACredentialDoesNotReleaseTheProposalItMade(t *testing.T) {
+	mine := ids.NewV7()
+	theirs := ids.NewV7()
+	proposer := principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:test", OnBehalfOf: ids.NewV7(),
+		PassportID: mine, Scopes: principal.NewScopeSet(principal.ScopeWrite),
+	}
+	stagedBy := func(id ids.UUID) row {
+		passport := ids.From[ids.PassportKind](id)
+		return row{Kind: "advance_deal", PassportID: &passport}
+	}
+
+	cases := []struct {
+		name    string
+		a       row
+		approve bool
+		want    bool // admitted
+	}{
+		{"the proposer cannot approve its own row", stagedBy(mine), true, false},
+		// Deliberately allowed: an agent that changes its mind takes its own
+		// request off somebody's desk rather than leaving it there.
+		{"but it may still reject its own row", stagedBy(mine), false, true},
+		{"another credential's row it may approve", stagedBy(theirs), true, true},
+		// serverProposed: a row nobody's passport staged is not self-approval.
+		{"a server-proposed row is nobody's own", row{Kind: "advance_deal"}, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := agentMayDecide(proposer, tc.a, tc.approve)
+			if tc.want && err != nil {
+				t.Fatalf("refused a decision it may make: %v", err)
+			}
+			if !tc.want && err == nil {
+				t.Fatal("a credential released the proposal it made")
+			}
+		})
+	}
+}
+
+// A HUMAN is never caught by the rule, whatever passport staged the row: the
+// person answering in a chat window is the person answering in a browser tab
+// (ADR-0055), and agentMayDecide returns early for them. Held here so a future
+// spelling that reads the row's passport before the principal's type cannot
+// lock the lender out of their own inbox.
+func TestTheHumanBehindACredentialStillDecidesItsProposal(t *testing.T) {
+	passport := ids.From[ids.PassportKind](ids.NewV7())
+	human := principal.Principal{Type: principal.PrincipalHuman, UserID: ids.NewV7()}
+	if err := agentMayDecide(human, row{Kind: "advance_deal", PassportID: &passport}, true); err != nil {
+		t.Fatalf("a human was refused their own agent's proposal: %v", err)
+	}
+}
+
 func TestEverySendingKindIsAKindWhoseReleaseIsAMessage(t *testing.T) {
 	for kind := range sendingKinds {
 		grants, err := decisionGrantsFor(kind, nil)


### PR DESCRIPTION
Found by auditing the MCP surface against the vision deck.

## The rule, and why it is load-bearing

`agentMayDecide` (`backend/internal/modules/approvals/decidingactor.go`) holds
the rule the whole confirm-first tier rests on, and states it itself:

> THE PROPOSER DOES NOT CONFIRM ITS OWN PROPOSAL. A 🟡 call is refused so a
> person sees what the agent wanted before it happens; a credential that could
> then approve the row it just staged and re-issue the call has walked through
> the tier by itself, and the confirmation was of nothing.

Without it, a passport stages an action, approves its own row, re-issues the
call — and the human is never in the loop, while every approval record still
reads as properly decided.

## Nothing exercised it

`TestAgentReleaseSpendsTheCapsTheReleaseSpends` is the table covering that
function. **None of its nine cases sets `PassportID`** — every principal carries
the zero value, so `p.PassportID != ids.Nil` is false and the branch is never
reached.

Proved by sabotage: appending `&& false` to the condition (so it still compiles)
left `go test ./internal/modules/approvals/` **green**.

## What is added

`TestACredentialDoesNotReleaseTheProposalItMade` pairs a row with the principal
that staged it — the one thing the caps table cannot express — and holds four
answers:

| case | expected |
|---|---|
| the proposer approves its own row | refused |
| the proposer rejects its own row | admitted — taking your own request off somebody's desk cannot escalate |
| another credential's row, approve | admitted |
| a server-proposed row (`PassportID` nil) | admitted — nobody's own |

`TestTheHumanBehindACredentialStillDecidesItsProposal` holds the human arm:
`agentMayDecide` returns early for a human principal whatever passport staged
the row (ADR-0055), so a future spelling that read the row's passport before the
principal's type would lock the lender out of their own inbox.

Both verified by the same sabotage — the first now fails with *"a credential
released the proposal it made"*.

## Gates

`make check-backend`, `craft-static`, `rls-store-path`, `no-jurisdiction` green.
Approvals integration lane: 94 pass.

Closes #2585

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a credential from approving the proposal it staged and preserves human override behavior by adding targeted tests for `agentMayDecide`. This closes a coverage gap that could let self-approval regressions bypass confirm-first and human review.

- Rejects self-approval, allows self-rejection, admits other-credential approvals, and admits server-proposed rows.
- Verifies humans can always decide proposals their credential staged (ADR-0055), pairing the passport minted from the same user ID to guard the function’s order.
- Asserts the denial by the sentinel `apperrors.ErrPermissionDenied` to prevent masking authorization failures.
- Test-only changes in `backend/internal/modules/approvals/service_test.go`; no production code changes.
- Closes #2585.

<sup>Written for commit c987acb45ced766579ebdad605b9a8fe3b2e34d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage to verify self-approval attempts are specifically rejected with a permission error.
  * Confirmed human approval works when the approver matches the lender identity associated with the staging credential.
  * Added regression coverage for approval authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->