### PR TITLE
feat(seed): projects are named by the dataset, and carry their correspondence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ workspace/
 /backend/tools/gen-perfdoc/gen-perfdoc.exe
 /backend/tools/contract-overlay/contract-overlay
 /backend/tools/contract-overlay/contract-overlay.exe
+/seed-demo

--- a/backend/tools/seed-demo/activityproject_test.go
+++ b/backend/tools/seed-demo/activityproject_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// refsWithProjects builds the minimum pipelineRefs projectForActivity reads:
+// a fixed "now" so date offsets are stable, and one company's projects in the
+// oldest-first order loadProjects guarantees.
+func refsWithProjects(projects ...seededProject) pipelineRefs {
+	return pipelineRefs{
+		now:               time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
+		projectsByCompany: map[string][]seededProject{"acme.test": projects},
+	}
+}
+
+// TestActivityPicksTheProjectThatHadStarted — the defect this rule exists for.
+//
+// valantic has two projects: the Shopsystem migration from October, and a
+// second tenant that starts in August the following year. All nine of the
+// account's mails are about the migration. Taking whichever project the API
+// listed first put every one of them on the second tenant — onto a project
+// that begins nine months after the last of those mails was sent, which is a
+// timeline that could not have happened.
+func TestActivityLinksToTheProjectThatHadAlreadyStarted(t *testing.T) {
+	refs := refsWithProjects(
+		seededProject{ID: "migration", StartedAt: "2025-10-28"},
+		seededProject{ID: "second-tenant", StartedAt: "2026-08-06"},
+	)
+
+	// A mail from 214 days ago — after the migration began, long before the
+	// second tenant did.
+	got := projectForActivity(refs, demoActivity{Company: "acme.test", DaysAgo: 214})
+	if got != "migration" {
+		t.Errorf("a mail sent during the migration linked to %q, want migration", got)
+	}
+
+	// A mail from last week belongs to the newer work, which had started by then.
+	got = projectForActivity(refs, demoActivity{Company: "acme.test", DaysAgo: 7})
+	if got != "second-tenant" {
+		t.Errorf("a mail sent after the second tenant began linked to %q, want second-tenant", got)
+	}
+}
+
+// TestActivityOlderThanEveryProjectLinksToNone — correspondence from before
+// any delivery work began was not about delivery work, and saying it was is a
+// worse answer than saying nothing.
+func TestActivityOlderThanEveryProjectLinksToNone(t *testing.T) {
+	refs := refsWithProjects(seededProject{ID: "migration", StartedAt: "2025-10-28"})
+
+	if got := projectForActivity(refs, demoActivity{Company: "acme.test", DaysAgo: 900}); got != "" {
+		t.Errorf("a mail predating every project linked to %q, want no link at all", got)
+	}
+}
+
+// TestActivityOnACompanyWithNoProjectLinksToNone — the ~180 crawled companies
+// the planner gives no project to, which must not panic on an absent map key.
+func TestActivityOnACompanyWithNoProjectLinksToNone(t *testing.T) {
+	refs := refsWithProjects()
+	if got := projectForActivity(refs, demoActivity{Company: "nobody.test", DaysAgo: 30}); got != "" {
+		t.Errorf("a company with no project linked to %q, want no link", got)
+	}
+	if got := projectForActivity(refs, demoActivity{Company: "acme.test", DaysAgo: 30}); got != "" {
+		t.Errorf("an empty project list linked to %q, want no link", got)
+	}
+}
+
+// TestAFutureActivityLinksToWhatHasStarted — a booked meeting or an open task
+// carries DaysIn rather than DaysAgo, and is dated forward.
+func TestAFutureActivityLinksToWhatHasStarted(t *testing.T) {
+	refs := refsWithProjects(
+		seededProject{ID: "migration", StartedAt: "2025-10-28"},
+		seededProject{ID: "second-tenant", StartedAt: "2026-08-06"},
+	)
+	if got := projectForActivity(refs, demoActivity{Company: "acme.test", DaysIn: 14}); got != "second-tenant" {
+		t.Errorf("a task due in a fortnight linked to %q, want second-tenant", got)
+	}
+}
+
+// TestAProjectWithNoStartDateIsTheLastResort — started_at is nullable on the
+// contract, so a project can carry none. It cannot be dated against, and must
+// never displace one that can be.
+func TestAProjectWithNoStartDateIsTheLastResort(t *testing.T) {
+	refs := refsWithProjects(
+		seededProject{ID: "dated", StartedAt: "2025-10-28"},
+		seededProject{ID: "undated"},
+	)
+	if got := projectForActivity(refs, demoActivity{Company: "acme.test", DaysAgo: 30}); got != "dated" {
+		t.Errorf("linked to %q, want the project that has a start date", got)
+	}
+}

--- a/backend/tools/seed-demo/contracts.go
+++ b/backend/tools/seed-demo/contracts.go
@@ -46,7 +46,7 @@ func seedContracts(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (
 		if successors[contract.Ref] {
 			continue
 		}
-		id, isNew, err := ensureContract(c, contract, refs, mode)
+		id, isNew, err := ensureContract(c, cfg, contract, refs, mode)
 		if err != nil {
 			return created, err
 		}
@@ -68,7 +68,7 @@ func seedContracts(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (
 	return created, nil
 }
 
-func ensureContract(c *client, contract demoContract, refs pipelineRefs, mode runMode) (id string, isNew bool, err error) {
+func ensureContract(c *client, cfg demoConfig, contract demoContract, refs pipelineRefs, mode runMode) (id string, isNew bool, err error) {
 	orgID, ok := refs.orgsByDom[strings.ToLower(contract.Company)]
 	if !ok {
 		return "", false, fmt.Errorf("contract %s names company %q, which is not seeded", contract.Ref, contract.Company)
@@ -77,11 +77,27 @@ func ensureContract(c *client, contract demoContract, refs pipelineRefs, mode ru
 		return "", true, nil
 	}
 
-	existing, err := findContract(c, orgID, contract.Title)
+	existing, hasDeal, err := findContract(c, orgID, contract.Title)
 	if err != nil {
 		return "", false, err
 	}
 	if existing != "" {
+		// Converging means repairing, not only skipping. A contract seeded
+		// before demoContract.Deal was read by anything carries no deal, and
+		// a run that just walked past it would leave every earlier
+		// installation detached forever — which is also what keeps its PDF
+		// out of a deal room.
+		if contract.Deal != "" && !hasDeal {
+			dealID, err := dealIDFor(c, cfg, refs, contract.Deal)
+			if err != nil {
+				return "", false, fmt.Errorf("contract %s: %w", contract.Ref, err)
+			}
+			if dealID != "" {
+				if err := c.patch("/v1/contracts/"+existing, jsonBody{"deal_id": dealID}, nil); err != nil {
+					return "", false, fmt.Errorf("attaching contract %s to its deal: %w", contract.Ref, err)
+				}
+			}
+		}
 		return existing, false, nil
 	}
 
@@ -89,6 +105,18 @@ func ensureContract(c *client, contract demoContract, refs pipelineRefs, mode ru
 		"organization_id": orgID,
 		"title":           contract.Title,
 		"auto_renew":      contract.AutoRenew,
+	}
+	// The deal this agreement came out of. demoContract.Deal has been declared
+	// since the type was written and read by nothing, so every contract sat
+	// unattached to the opportunity that won it — which also put the contract
+	// PDFs out of reach of a deal room, since a room's documents must be
+	// attachments filed on that room's deal.
+	if contract.Deal != "" {
+		dealID, err := dealIDFor(c, cfg, refs, contract.Deal)
+		if err != nil {
+			return "", false, fmt.Errorf("contract %s: %w", contract.Ref, err)
+		}
+		addIfSet(body, "deal_id", dealID)
 	}
 	addIfSet(body, "contract_number", contract.ContractNumber)
 	addIfSet(body, "value_basis", contract.ValueBasis)
@@ -240,20 +268,24 @@ func contractStatus(c *client, id string) (string, error) {
 	return out.Status, nil
 }
 
-func findContract(c *client, orgID, title string) (string, error) {
+// findContract answers with the contract's id and whether it already names a
+// deal. The second half is what lets a re-run repair a contract that was
+// seeded before demoContract.Deal was read by anything.
+func findContract(c *client, orgID, title string) (id string, hasDeal bool, err error) {
 	var page struct {
 		Data []struct {
-			ID    string `json:"id"`
-			Title string `json:"title"`
+			ID     string `json:"id"`
+			Title  string `json:"title"`
+			DealID string `json:"deal_id"`
 		} `json:"data"`
 	}
 	if err := c.get("/v1/organizations/"+orgID+"/contracts", url.Values{"limit": {"50"}}, &page); err != nil {
-		return "", fmt.Errorf("listing contracts for %s: %w", orgID, err)
+		return "", false, fmt.Errorf("listing contracts for %s: %w", orgID, err)
 	}
 	for _, row := range page.Data {
 		if strings.EqualFold(row.Title, title) {
-			return row.ID, nil
+			return row.ID, row.DealID != "", nil
 		}
 	}
-	return "", nil
+	return "", false, nil
 }

--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -24,6 +24,7 @@ type demoConfig struct {
 	Leads            []demoLead          `json:"leads"`
 	Activities       []demoActivity      `json:"activities"`
 	Contracts        []demoContract      `json:"contracts"`
+	Projects         []demoProject       `json:"projects"`
 	Products         []demoProduct       `json:"products"`
 	Offers           []demoOffer         `json:"offers"`
 	Consent          []demoConsent       `json:"consent"`
@@ -204,6 +205,37 @@ type demoContract struct {
 type demoCancelTerms struct {
 	NoticeInDays    int `json:"notice_in_days"`
 	EffectiveInDays int `json:"effective_in_days"`
+}
+
+// demoProject is one piece of delivery work, named by the dataset rather than
+// derived from the company name.
+//
+// It exists because the generated name — "<Company> — Einführung" and its two
+// translations — says only that a project happened, never what it was. A
+// dataset entry says "Ersatzteilportal", "Cong dat hang dai ly", "Phase 1 →
+// Phase 2", which is the difference between a list of rows and a list of
+// projects.
+//
+// Phase is the phase the project ENDS in, not one it is created in: the
+// seeder advances through initiative → pursuing → delivering → closed and
+// stops at this one, so the phase history reads as work. The close reason is
+// NOT carried here — it follows the account's language, from
+// company-locale.json, via projectCloseReason.
+//
+// Company is a domain under siteresults/, the same as everywhere else. A
+// company the dataset does not name still gets the generated project from the
+// profile plan, so this array names the accounts worth telling a story about
+// and leaves the long tail alone.
+type demoProject struct {
+	Ref         string `json:"ref"`
+	Company     string `json:"company"`
+	Name        string `json:"name"`
+	Phase       string `json:"phase"`
+	Description string `json:"description"`
+	// StartedInDays is an offset like every other date in this file: negative
+	// is the past, which is where a delivery project's start always is.
+	StartedInDays int    `json:"started_in_days"`
+	Owner         string `json:"owner"`
 }
 
 type demoProduct struct {

--- a/backend/tools/seed-demo/generatedpaper.go
+++ b/backend/tools/seed-demo/generatedpaper.go
@@ -51,7 +51,11 @@ func seedGeneratedContracts(c *client, refs pipelineRefs, plan map[string]profil
 			if isGeneratedSuccessor(contracts, contract.Ref) {
 				continue
 			}
-			id, isNew, err := ensureContract(c, contract, local, mode)
+			// An empty config, deliberately: a generated contract never names a
+			// deal ref, so there is no dataset for ensureContract to resolve
+			// one against, and handing it the real one would only invite a
+			// lookup that cannot fire.
+			id, isNew, err := ensureContract(c, demoConfig{}, contract, local, mode)
 			if err != nil {
 				return created, err
 			}

--- a/backend/tools/seed-demo/locale.go
+++ b/backend/tools/seed-demo/locale.go
@@ -354,3 +354,21 @@ func currencyFor(locale docLocale) string {
 		return "EUR"
 	}
 }
+
+// projectCloseReason is why a project finished, in the account's language.
+//
+// This used to be one German literal sent to every account, so a Vietnamese
+// customer's project closed with "Abgeschlossen und uebergeben" on it. The
+// rule the dataset states in company-locale.json is that an account's records
+// speak the account's language, and a close reason is a record: it is written
+// onto the phase-history row and shown on the project.
+func projectCloseReason(locale docLocale) string {
+	switch locale {
+	case localeVI:
+		return "Hoan thanh va ban giao"
+	case localeEN:
+		return "Completed and handed over"
+	default:
+		return "Abgeschlossen und uebergeben"
+	}
+}

--- a/backend/tools/seed-demo/pipeline.go
+++ b/backend/tools/seed-demo/pipeline.go
@@ -32,6 +32,10 @@ type pipelineRefs struct {
 	// dealsByCompany is filled after the deals are seeded, so an activity can
 	// link to the deal it moved.
 	dealsByCompany map[string][]string
+	// projectsByCompany holds the seeded projects, keyed by company domain and
+	// ordered oldest first, so an activity can link to the delivery work it
+	// was about.
+	projectsByCompany map[string][]seededProject
 	// anchorName and orgNameByID name the parties a document prints.
 	anchorName  string
 	orgNameByID map[string]string
@@ -63,16 +67,17 @@ func (r pipelineRefs) timestamp(days int) string {
 // once, so each phase is a straight write rather than a search.
 func loadPipelineRefs(c *client, cfg demoConfig, now time.Time) (pipelineRefs, error) {
 	refs := pipelineRefs{
-		contractsByRef:   cfg.Contracts,
-		dealsByCompany:   map[string][]string{},
-		ownerRefByDomain: map[string]string{},
-		orgNameByID:      map[string]string{},
-		domainByOrgID:    map[string]string{},
-		anchorName:       cfg.Anchor.LegalName,
-		usersByRef:       map[string]string{},
-		orgsByDom:        map[string]string{},
-		stagesByNm:       map[string]string{},
-		now:              now,
+		contractsByRef:    cfg.Contracts,
+		dealsByCompany:    map[string][]string{},
+		projectsByCompany: map[string][]seededProject{},
+		ownerRefByDomain:  map[string]string{},
+		orgNameByID:       map[string]string{},
+		domainByOrgID:     map[string]string{},
+		anchorName:        cfg.Anchor.LegalName,
+		usersByRef:        map[string]string{},
+		orgsByDom:         map[string]string{},
+		stagesByNm:        map[string]string{},
+		now:               now,
 	}
 
 	var users struct {

--- a/backend/tools/seed-demo/profile.go
+++ b/backend/tools/seed-demo/profile.go
@@ -272,6 +272,9 @@ func pinnedDomains(cfg demoConfig) map[string]string {
 	for _, act := range cfg.Activities {
 		note(act.Company)
 	}
+	for _, proj := range cfg.Projects {
+		note(proj.Company)
+	}
 	for _, domain := range cfg.FinanceCustomers {
 		note(domain)
 	}

--- a/backend/tools/seed-demo/projects.go
+++ b/backend/tools/seed-demo/projects.go
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// seedProjects files the delivery work a customer's won deal turned into.
+//
+// A project is born in its first phase and ADVANCED, like a deal: the phase a
+// project is in is the record of what happened to it, not a column you can be
+// created in.
+//
+// Two passes, in this order, because they answer different questions. The
+// DATASET pass writes the projects demo.json names: a real project name, a
+// description, and the phase the story reaches. The PLAN pass then fills the
+// long tail from the profile weights, with the derived "<Company> —
+// Einführung" name, for the ~180 crawled companies the dataset says nothing
+// about. Dataset first so that when both name the same company the told story
+// wins and the generated one is skipped as already-existing.
+func seedProjects(c *client, cfg demoConfig, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	created := 0
+	existing, err := projectIndex(c, mode)
+	if err != nil {
+		return 0, err
+	}
+	n, err := seedDatasetProjects(c, cfg, refs, existing, mode)
+	if err != nil {
+		return created, err
+	}
+	created += n
+
+	for _, domain := range sortedDomains(plan) {
+		p := plan[domain]
+		if p.Pinned || p.Project == "" {
+			continue
+		}
+		orgID, ok := refs.orgsByDom[domain]
+		if !ok {
+			continue
+		}
+		name := projectNameFor(localeFor(domain), refs.orgNameByID[orgID])
+		index := projectIndexKey(orgID, name)
+		if existing[index] {
+			continue
+		}
+		// Claimed in the SAME map the snapshot filled, because the index is no
+		// longer unique per plan entry: two domains that resolve to one
+		// organization derive one name, and a snapshot taken before the loop
+		// cannot see the project the loop itself just created. The old key was
+		// per-domain and could not collide, so this is the cost of indexing by
+		// what the server leaves us.
+		existing[index] = true
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		body := projectCreateBody(orgID, name, refs.date(-(30 + hashIndex("projstart:"+domain, 180))))
+		if owner, ok := refs.usersByRef[refs.ownerRefByDomain[domain]]; ok {
+			body["owner_id"] = owner
+		}
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := c.post("/v1/projects", body, &out); err != nil {
+			if _, conflict := conflictingID(err); conflict {
+				continue
+			}
+			return created, fmt.Errorf("project for %s: %w", domain, err)
+		}
+		created++
+		if err := advanceProject(c, out.ID, p.Project, domain); err != nil {
+			return created, err
+		}
+	}
+	return created, nil
+}
+
+// seedDatasetProjects writes the projects demo.json names.
+//
+// It does NOT consult the profile plan, which is the point: the plan only
+// gives a project to a company its weights made a `customer`, and it skips
+// every pinned company outright (surfaces.go, the Pinned guard below) — which
+// is exactly the golden accounts the dataset is written about. A project named
+// here is created because the dataset says this account has one.
+func seedDatasetProjects(c *client, cfg demoConfig, refs pipelineRefs, existing map[string]bool, mode runMode) (int, error) {
+	created := 0
+	for i, proj := range cfg.Projects {
+		domain := strings.ToLower(strings.TrimSpace(proj.Company))
+		orgID, ok := refs.orgsByDom[domain]
+		if !ok {
+			return created, fmt.Errorf("project %d (%s) names company %q, which is not seeded", i, proj.Ref, proj.Company)
+		}
+		// Trimmed, because the server trims a project's name before storing
+		// it (projects/handlers.go). Converging on the untrimmed spelling
+		// would index " Portal " against a row stored as "Portal", miss it on
+		// the next run, and file a second project.
+		name := strings.TrimSpace(proj.Name)
+		if name == "" {
+			return created, fmt.Errorf("project %d (%s) has no name", i, proj.Ref)
+		}
+		index := projectIndexKey(orgID, name)
+		if existing[index] {
+			continue
+		}
+		existing[index] = true
+		if mode == modeDryRun {
+			created++
+			continue
+		}
+		body := projectCreateBody(orgID, name, refs.date(proj.StartedInDays))
+		addIfSet(body, "description", proj.Description)
+		// The dataset may name the owner; otherwise the account's owner keeps
+		// their own delivery work, which is what resolveOwners already decided.
+		ownerRef := proj.Owner
+		if ownerRef == "" {
+			ownerRef = refs.ownerRefByDomain[domain]
+		}
+		if owner, ok := refs.usersByRef[ownerRef]; ok {
+			body["owner_id"] = owner
+		}
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := c.post("/v1/projects", body, &out); err != nil {
+			if _, conflict := conflictingID(err); conflict {
+				continue
+			}
+			return created, fmt.Errorf("project %s: %w", proj.Ref, err)
+		}
+		created++
+		if err := advanceProject(c, out.ID, proj.Phase, domain); err != nil {
+			return created, err
+		}
+	}
+	return created, nil
+}
+
+// projectPhaseOrder is the sequence a project walks. A phase is reached by
+// stepping through the ones before it, so the history reads as work rather
+// than as an assertion.
+var projectPhaseOrder = []string{"initiative", "pursuing", "delivering", "closed"}
+
+func advanceProject(c *client, projectID, want, domain string) error {
+	// A phase this ladder does not contain would otherwise walk the whole way
+	// and stop at `closed`, so a dataset typo — "deliverng", or an empty
+	// string — would silently close a project that is still running. Say so
+	// instead.
+	if !isProjectPhase(want) {
+		return fmt.Errorf("project for %s wants phase %q, which is not one of %v", domain, want, projectPhaseOrder)
+	}
+	for _, phase := range projectPhaseOrder {
+		body := jsonBody{"to_phase": phase}
+		if phase == "closed" {
+			// Closing needs a reason, the same way losing a deal does — and
+			// it is written in the account's language, not always in German.
+			body["reason"] = projectCloseReason(localeFor(domain))
+		}
+		if err := c.post("/v1/projects/"+projectID+"/advance", body, nil); err != nil && !isConflict(err) {
+			return fmt.Errorf("advancing %s to %s: %w", domain, phase, err)
+		}
+		if phase == want {
+			return nil
+		}
+	}
+	return nil
+}
+
+// isProjectPhase reports whether a phase is one advanceProject can arrive at.
+func isProjectPhase(phase string) bool {
+	for _, rung := range projectPhaseOrder {
+		if rung == phase {
+			return true
+		}
+	}
+	return false
+}
+
+func projectNameFor(locale docLocale, company string) string {
+	switch locale {
+	case localeVI:
+		return company + " — Trien khai"
+	case localeEN:
+		return company + " — Rollout"
+	default:
+		return company + " — Einführung"
+	}
+}
+
+// projectCreateBody is the create payload, in one place so what it does NOT
+// carry is visible: no "key". The server mints a project's key from its name and
+// refuses a caller who sends one (422 read_only, projects/keymint.go) — the key
+// is the token a person types in a subject line to file mail under a project, so
+// it is not a demo's to choose.
+//
+// Nothing else may be added loosely either: this contract takes extra body
+// properties as CUSTOM FIELD values, so a stray key is not ignored here, it is
+// data. Every field below is one the contract declares.
+func projectCreateBody(orgID, name, startedAt string) jsonBody {
+	return jsonBody{
+		"name":            name,
+		"organization_id": orgID,
+		"source":          seedSource,
+		"started_at":      startedAt,
+	}
+}
+
+// projectIndexKey identifies a seeded project by what the seeder still controls.
+//
+// Convergence used to ask "does a project with MY key exist", which is a
+// question a caller who no longer mints the key cannot ask. Organization plus
+// name is the pair the seeder derives deterministically (projectNameFor over the
+// company name), so a second run recognises its own work and creates nothing —
+// and two companies with the same project name stay two projects.
+func projectIndexKey(orgID, name string) string {
+	return orgID + "\x00" + name
+}
+
+func projectIndex(c *client, mode runMode) (map[string]bool, error) {
+	out := map[string]bool{}
+	if mode == modeDryRun {
+		return out, nil
+	}
+	err := c.getAll("/v1/projects", nil, func(raw json.RawMessage) error {
+		var rows []struct {
+			Name           string `json:"name"`
+			OrganizationID string `json:"organization_id"`
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			out[projectIndexKey(row.OrganizationID, row.Name)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing projects: %w", err)
+	}
+	return out, nil
+}
+
+// loadProjects records the id of every seeded project, keyed by its company,
+// so an activity can link to the delivery work it describes.
+//
+// Like loadDeals it reads the installation's OWN projects rather than walking
+// demo.json, because the generated projects are projects too: a company the
+// dataset does not name still has delivery work, and its correspondence
+// should reach it.
+func (r *pipelineRefs) loadProjects(c *client) error {
+	domainByOrg := map[string]string{}
+	for domain, orgID := range r.orgsByDom {
+		domainByOrg[orgID] = domain
+	}
+	r.projectsByCompany = map[string][]seededProject{}
+	byDomain := map[string][]seededProject{}
+	if err := c.getAll("/v1/projects", nil, func(raw json.RawMessage) error {
+		var rows []struct {
+			ID             string `json:"id"`
+			OrganizationID string `json:"organization_id"`
+			StartedAt      string `json:"started_at"`
+		}
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			domain, ok := domainByOrg[row.OrganizationID]
+			if !ok {
+				continue
+			}
+			byDomain[domain] = append(byDomain[domain], seededProject{ID: row.ID, StartedAt: row.StartedAt})
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Oldest first, and that order is load-bearing rather than tidiness.
+	//
+	// A company with two projects gets its correspondence filed against the
+	// FIRST one an activity could plausibly be about, and activityLinks takes
+	// the head of this slice. Taking whatever order the API happened to
+	// return put every one of valantic's nine mails about the Shopsystem
+	// migration onto "Zweiter Mandant im Shopsystem" — a project that starts
+	// nine months AFTER the last of them, so the timeline it built was one
+	// that could not have happened.
+	//
+	// A project with no start date sorts last: it is the one an activity has
+	// the weakest claim to belong to.
+	for domain, projects := range byDomain {
+		sort.Slice(projects, func(i, j int) bool {
+			a, b := projects[i].StartedAt, projects[j].StartedAt
+			if (a == "") != (b == "") {
+				return b == ""
+			}
+			if a != b {
+				return a < b
+			}
+			return projects[i].ID < projects[j].ID
+		})
+		r.projectsByCompany[domain] = projects
+	}
+	return nil
+}
+
+// seededProject is one project as loadProjects read it back, kept only long
+// enough to order a company's projects by when they started.
+type seededProject struct {
+	ID        string
+	StartedAt string
+}
+
+// seedDeliveryAndItsRecord writes the projects and then the activities, in
+// that order.
+//
+// The order is the whole point. An activity links to the project it was about
+// — the kickoff meeting, the acceptance mail, the escalation call — and cannot
+// link to a row that does not exist yet. Projects used to be created inside
+// seedSurfaces, several phases after the activities were written, which is why
+// not one project in the demo carried a single activity.
+func seedDeliveryAndItsRecord(c *client, seats *sessions, cfg demoConfig, refs *pipelineRefs, plan map[string]profile, mode runMode) (projects, activities int, err error) {
+	projects, err = seedProjectsAndIndexThem(c, cfg, refs, plan, mode)
+	if err != nil {
+		return projects, 0, err
+	}
+	activities, err = seedActivities(c, seats, cfg, *refs, mode)
+	if err != nil {
+		return projects, activities, err
+	}
+	return projects, activities, nil
+}
+
+// seedProjectsAndIndexThem writes the projects and then reads them back, so
+// the activities that follow can link to the delivery work they describe.
+//
+// The read-back is separate from the write on purpose: a converging re-run
+// creates no project at all, and a pass that only knew what it had just
+// created would leave every project from an earlier run unreachable to the
+// activities forever.
+func seedProjectsAndIndexThem(c *client, cfg demoConfig, refs *pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
+	projects, err := seedProjects(c, cfg, *refs, plan, mode)
+	if err != nil {
+		return projects, err
+	}
+	if mode == modeDryRun {
+		return projects, nil
+	}
+	if err := refs.loadProjects(c); err != nil {
+		return projects, err
+	}
+	return projects, nil
+}

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -161,7 +161,51 @@ func activityLinks(c *client, refs pipelineRefs, act demoActivity, orgID string)
 		links = append(links, jsonBody{"entity_type": "deal", "entity_id": deal})
 		break // one deal: an account with two is ambiguous, and guessing wrong is worse than not guessing
 	}
+	// And the delivery work, so a project has a timeline rather than a start
+	// date and nothing else. One project per activity is not a style choice
+	// here: uq_activity_link_project makes it a database constraint.
+	if project := projectForActivity(refs, act); project != "" {
+		links = append(links, jsonBody{"entity_type": "project", "entity_id": project})
+	}
 	return links, nil
+}
+
+// projectForActivity picks which of a company's projects a mail, call or
+// meeting belongs to: the LATEST one that had already started when it
+// happened.
+//
+// The company's projects arrive oldest first, so this walks forward and keeps
+// the last one still in the past. Simply taking the first project a company
+// had put all nine of valantic's mails about the Shopsystem migration onto
+// "Zweiter Mandant im Shopsystem", which starts nine months after the last of
+// them — a timeline that could not have happened.
+//
+// An activity older than every project links to none. That is the honest
+// answer: correspondence from before any delivery work began was not about
+// delivery work.
+func projectForActivity(refs pipelineRefs, act demoActivity) string {
+	projects := refs.projectsByCompany[strings.ToLower(act.Company)]
+	if len(projects) == 0 {
+		return ""
+	}
+	// The same offset seedActivities computes, as a date, so it compares
+	// against started_at on its own terms.
+	occurred := -act.DaysAgo
+	if act.DaysIn > 0 {
+		occurred = act.DaysIn
+	}
+	when := refs.date(occurred)
+
+	chosen := ""
+	for _, proj := range projects {
+		// A project with no start date cannot be dated against, and sorts
+		// last; it is only reached when nothing better has been found.
+		if proj.StartedAt == "" || proj.StartedAt > when {
+			continue
+		}
+		chosen = proj.ID
+	}
+	return chosen
 }
 
 // loadActivitySourceIDs reads the source_id of every activity ONCE.

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -85,7 +85,7 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 	if err != nil {
 		return err
 	}
-	activities, err := seedActivities(c, seats, cfg, refs, mode)
+	projects, activities, err := seedDeliveryAndItsRecord(c, seats, cfg, &refs, plan, mode)
 	if err != nil {
 		return err
 	}
@@ -124,6 +124,7 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 		products: catalogue.products, offers: catalogue.offers,
 		documents: paper.documents, looseDocs: paper.looseDocs,
 		consents: consents, lifecycles: lifecycles, surfaces: catalogue.surfaces, fxRates: fxRates,
+		projects:     projects,
 		partnerEdges: catalogue.partnerEdges, relTypes: standing.relTypes,
 		dualPartners: standing.dualPartners, inventedPeople: inventedPeople, inventedLinks: inventedLinks,
 		ownedOrgs: ownedOrgs, ownedPeople: ownedPeople,
@@ -174,6 +175,7 @@ type pipelineCounts struct {
 	documents, looseDocs          int
 	consents, lifecycles          int
 	surfaces, fxRates             int
+	projects                      int
 	partnerEdges, relTypes        int
 	dualPartners                  int
 	inventedPeople, inventedLinks int
@@ -190,7 +192,8 @@ func reportPipeline(n pipelineCounts) {
 	fmt.Printf("offers:        %d new\n", n.offers)
 	fmt.Printf("documents:     %d uploaded (%d contract PDFs, %d account documents)\n", n.documents+n.looseDocs, n.documents, n.looseDocs)
 	fmt.Printf("fx rates:      %d loaded\n", n.fxRates)
-	fmt.Printf("surfaces:      %d new (tags, lists, custom fields, projects, quotas)\n", n.surfaces)
+	fmt.Printf("projects:      %d new\n", n.projects)
+	fmt.Printf("surfaces:      %d new (tags, lists, project staffing, quotas)\n", n.surfaces)
 	fmt.Printf("partner edges: %d new (referrals, co-sells, served accounts)\n", n.partnerEdges)
 	fmt.Printf("rel. types:    %d set (what each company IS to us)\n", n.relTypes)
 	fmt.Printf("dual partners: %d customer(s) also promoted to partner\n", n.dualPartners)

--- a/backend/tools/seed-demo/surfaces.go
+++ b/backend/tools/seed-demo/surfaces.go
@@ -31,11 +31,14 @@ func seedSurfaces(c *client, seats *sessions, cfg demoConfig, refs pipelineRefs,
 	}{
 		{"tags", func() (int, error) { return seedTags(c, refs, plan, mode) }},
 		{"lists", func() (int, error) { return seedLists(c, refs, mode) }},
-		{"projects", func() (int, error) { return seedProjects(c, refs, plan, mode) }},
-		// After projects, and reading them back rather than taking their ids
-		// from the step above: a re-run creates no project, so a pass that
-		// staffed only what it had just created would leave every earlier
-		// project empty forever.
+		// Projects themselves are NOT here — they are created earlier, before
+		// seedActivities, because an activity links to the project it was
+		// about and cannot link to a row that does not exist yet.
+		//
+		// Staffing them stays here, and reads them back rather than taking
+		// ids from the pass that made them: a re-run creates no project, so a
+		// pass that staffed only what it had just created would leave every
+		// earlier project empty forever.
 		{"project stakeholders", func() (int, error) { return seedProjectStakeholders(c, mode) }},
 		{"quotas", func() (int, error) { return seedQuotas(c, cfg, refs, mode) }},
 	} {
@@ -211,149 +214,6 @@ func seedLists(c *client, refs pipelineRefs, mode runMode) (int, error) {
 // the product's own state rather than a hole in the seeder. The code that
 // would fill it is deleted rather than commented out; this note is the
 // record, and the day the handler lands it is three POSTs to write.
-
-// seedProjects files the delivery work a customer's won deal turned into.
-//
-// A project is born in its first phase and ADVANCED, like a deal: the phase a
-// project is in is the record of what happened to it, not a column you can be
-// created in.
-func seedProjects(c *client, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {
-	created := 0
-	existing, err := projectIndex(c, mode)
-	if err != nil {
-		return 0, err
-	}
-	for _, domain := range sortedDomains(plan) {
-		p := plan[domain]
-		if p.Pinned || p.Project == "" {
-			continue
-		}
-		orgID, ok := refs.orgsByDom[domain]
-		if !ok {
-			continue
-		}
-		name := projectNameFor(localeFor(domain), refs.orgNameByID[orgID])
-		index := projectIndexKey(orgID, name)
-		if existing[index] {
-			continue
-		}
-		// Claimed in the SAME map the snapshot filled, because the index is no
-		// longer unique per plan entry: two domains that resolve to one
-		// organization derive one name, and a snapshot taken before the loop
-		// cannot see the project the loop itself just created. The old key was
-		// per-domain and could not collide, so this is the cost of indexing by
-		// what the server leaves us.
-		existing[index] = true
-		if mode == modeDryRun {
-			created++
-			continue
-		}
-		body := projectCreateBody(orgID, name, refs.date(-(30 + hashIndex("projstart:"+domain, 180))))
-		if owner, ok := refs.usersByRef[refs.ownerRefByDomain[domain]]; ok {
-			body["owner_id"] = owner
-		}
-		var out struct {
-			ID string `json:"id"`
-		}
-		if err := c.post("/v1/projects", body, &out); err != nil {
-			if _, conflict := conflictingID(err); conflict {
-				continue
-			}
-			return created, fmt.Errorf("project for %s: %w", domain, err)
-		}
-		created++
-		if err := advanceProject(c, out.ID, p.Project, domain); err != nil {
-			return created, err
-		}
-	}
-	return created, nil
-}
-
-// projectPhaseOrder is the sequence a project walks. A phase is reached by
-// stepping through the ones before it, so the history reads as work rather
-// than as an assertion.
-var projectPhaseOrder = []string{"initiative", "pursuing", "delivering", "closed"}
-
-func advanceProject(c *client, projectID, want, domain string) error {
-	for _, phase := range projectPhaseOrder {
-		body := jsonBody{"to_phase": phase}
-		if phase == "closed" {
-			// Closing needs a reason, the same way losing a deal does.
-			body["reason"] = "Abgeschlossen und uebergeben"
-		}
-		if err := c.post("/v1/projects/"+projectID+"/advance", body, nil); err != nil && !isConflict(err) {
-			return fmt.Errorf("advancing %s to %s: %w", domain, phase, err)
-		}
-		if phase == want {
-			return nil
-		}
-	}
-	return nil
-}
-
-func projectNameFor(locale docLocale, company string) string {
-	switch locale {
-	case localeVI:
-		return company + " — Trien khai"
-	case localeEN:
-		return company + " — Rollout"
-	default:
-		return company + " — Einführung"
-	}
-}
-
-// projectCreateBody is the create payload, in one place so what it does NOT
-// carry is visible: no "key". The server mints a project's key from its name and
-// refuses a caller who sends one (422 read_only, projects/keymint.go) — the key
-// is the token a person types in a subject line to file mail under a project, so
-// it is not a demo's to choose.
-//
-// Nothing else may be added loosely either: this contract takes extra body
-// properties as CUSTOM FIELD values, so a stray key is not ignored here, it is
-// data. Every field below is one the contract declares.
-func projectCreateBody(orgID, name, startedAt string) jsonBody {
-	return jsonBody{
-		"name":            name,
-		"organization_id": orgID,
-		"source":          seedSource,
-		"started_at":      startedAt,
-	}
-}
-
-// projectIndexKey identifies a seeded project by what the seeder still controls.
-//
-// Convergence used to ask "does a project with MY key exist", which is a
-// question a caller who no longer mints the key cannot ask. Organization plus
-// name is the pair the seeder derives deterministically (projectNameFor over the
-// company name), so a second run recognises its own work and creates nothing —
-// and two companies with the same project name stay two projects.
-func projectIndexKey(orgID, name string) string {
-	return orgID + "\x00" + name
-}
-
-func projectIndex(c *client, mode runMode) (map[string]bool, error) {
-	out := map[string]bool{}
-	if mode == modeDryRun {
-		return out, nil
-	}
-	err := c.getAll("/v1/projects", nil, func(raw json.RawMessage) error {
-		var rows []struct {
-			Name           string `json:"name"`
-			OrganizationID string `json:"organization_id"`
-		}
-		if err := json.Unmarshal(raw, &rows); err != nil {
-			return err
-		}
-		for _, row := range rows {
-			out[projectIndexKey(row.OrganizationID, row.Name)] = true
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("listing projects: %w", err)
-	}
-	return out, nil
-}
 
 // seedQuotas gives every seller a target for the current quarter, so the
 // attainment the product computes from closed-won deals has something to be a

--- a/backend/tools/seed-demo/surfaces_test.go
+++ b/backend/tools/seed-demo/surfaces_test.go
@@ -65,3 +65,78 @@ func TestProjectIndexClaimsANameWithinTheSameRun(t *testing.T) {
 		t.Error("the second plan entry for one organization does not see the first entry's claim, so the project is created twice")
 	}
 }
+
+// TestProjectCloseReasonFollowsTheAccountsLanguage — a Vietnamese customer's
+// project used to close with "Abgeschlossen und uebergeben" written on it,
+// because the reason was one German literal sent to every account. The rule
+// company-locale.json states is that an account's records speak the account's
+// language, and a close reason is a record: it is written onto the
+// phase-history row and shown on the project.
+func TestProjectCloseReasonFollowsTheAccountsLanguage(t *testing.T) {
+	seen := map[string]docLocale{}
+	for _, locale := range []docLocale{localeDE, localeVI, localeEN} {
+		reason := projectCloseReason(locale)
+		if reason == "" {
+			t.Fatalf("locale %s has no close reason; advancing to closed needs one (422 closed_reason_required)", locale)
+		}
+		if other, dup := seen[reason]; dup {
+			t.Errorf("locale %s and %s close with the same words %q, so one of them is untranslated", locale, other, reason)
+		}
+		seen[reason] = locale
+	}
+	// The same WinAnsi limit the contract PDFs live under: a reason with a
+	// combining mark in it renders as a dot.
+	for _, r := range projectCloseReason(localeVI) {
+		if r > 127 {
+			t.Errorf("the Vietnamese close reason contains %q (U+%04X); it must fold to ASCII", r, r)
+		}
+	}
+}
+
+// TestDatasetProjectsAreNamedByTheDataset — the whole reason demoProject
+// exists. A generated name says only that a project happened; the point of a
+// dataset entry is that it says WHAT the project was.
+func TestDatasetProjectsAreNamedByTheDataset(t *testing.T) {
+	proj := demoProject{
+		Ref:           "proj-x",
+		Company:       "vuletech.com",
+		Name:          "Cong tra cuu phu tung thay the",
+		Phase:         "closed",
+		Description:   "the spare-parts portal",
+		StartedInDays: -540,
+	}
+	body := projectCreateBody("org-1", proj.Name, "2026-01-01")
+	addIfSet(body, "description", proj.Description)
+
+	if body["name"] != proj.Name {
+		t.Errorf("name = %v, want the dataset's own %q", body["name"], proj.Name)
+	}
+	if body["description"] != proj.Description {
+		t.Errorf("description = %v, want %q", body["description"], proj.Description)
+	}
+	// The generated name is what the dataset entry exists to displace.
+	if generated := projectNameFor(localeVI, "VULETECH"); body["name"] == generated {
+		t.Errorf("the dataset name equals the generated one %q, which defeats the point", generated)
+	}
+	if _, sent := body["key"]; sent {
+		t.Error("the create body carries a key; the server mints it and refuses a caller's own")
+	}
+}
+
+// TestEveryProjectPhaseIsReachable — a phase is reached by advancing through
+// the ones before it, never set directly, so a dataset entry naming a phase
+// outside the order would advance to the end and stop somewhere else silently.
+func TestEveryProjectPhaseIsReachable(t *testing.T) {
+	for _, phase := range []string{"initiative", "pursuing", "delivering", "closed"} {
+		found := false
+		for _, rung := range projectPhaseOrder {
+			if rung == phase {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("phase %q is in the contract's enum but not in projectPhaseOrder, so a dataset entry naming it never arrives", phase)
+		}
+	}
+}


### PR DESCRIPTION
Projects were the weakest record type in the demo: every one called `<Company> — Einführung`, not one carrying a single activity, and Vietnamese customers' projects closing with a German reason.

## What changed

**Named by the dataset.** `demo.json` gains a `projects` array (ref, company, name, phase, description, started_in_days, owner). `seedProjects` runs a dataset pass before the profile-plan pass. Companies the dataset does not name still get the generated project, so the ~180-company long tail is unaffected.

**Carrying their correspondence.** `seedProjects` used to run inside `seedSurfaces`, several phases *after* `seedActivities` — so no project existed when the activities were written. That, not the missing dataset key, is why every timeline was empty. Project creation now runs before the activities, and `activityLinks` files each activity against the latest project that had already started when it happened.

**Closing in the account's language.** `advanceProject`'s hardcoded `"Abgeschlossen und uebergeben"` becomes `projectCloseReason(locale)`, following `company-locale.json`. This reaches the generated projects too.

**Contract → deal.** `demoContract.Deal` was declared since the type was written and read by nothing, so no contract named the deal that won it. `ensureContract` now sends `deal_id`, and a re-run patches contracts seeded before this change. This is a prerequisite for the deal-room work — a room's documents must be attachments filed on that room's deal.

## Verified

Against a fresh seed on an isolated stack: 22 projects (10 dataset + 12 generated), **83 activity links where there were none**, close reasons in three languages, `verify: OK`.

The date-ordering rule is load-bearing. Taking whichever project the API listed first put all nine of valantic's mails about the Shopsystem migration onto `Zweiter Mandant im Shopsystem`, which starts nine months after the last of them.

| project | started | activities |
|---|---|---|
| Cổng tra cứu phụ tùng thay thế | 2025-02-10 | 16 |
| Tích hợp SAP tổng kho — thầu phụ cho FPT IS | 2025-07-10 | 16 |
| Shopsystem-Migration | 2025-10-28 | 9 |
| Zweiter Mandant im Shopsystem | 2026-08-06 | 0 |

## Notes

`surfaces.go` and `pipeline.go` crossed the 500-line cap, so the project code moved to its own `projects.go`.

Dataset side (the `projects` array itself) is written in `margince-demo-database` by a parallel session and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Projects are now seeded from the dataset and activities link to the correct project. Previously projects used generated names, had no activity links, and always closed with a German reason; now they are dataset-named, created before activities, and close in the account’s language.

- `demo.json` adds a `projects` array (ref, company, name, phase, description, started_in_days, owner). `seedProjects` runs before `seedActivities` and before surfaces.
- Activities link to the latest project that had already started when they occurred; older-than-all projects link to none. Projects are ordered oldest-first when indexed.
- Project closing uses `projectCloseReason(locale)` instead of a hardcoded string.
- Contracts now attach to their deal: `ensureContract` resolves and sends `deal_id`; re-runs patch older contracts missing it.
- Project seeding logic moves to `projects.go`; `pipelineRefs` gains `projectsByCompany`. `surfaces.go` no longer creates projects, only staffs them.
- Tests cover activity-to-project linking and localized close reasons. Reporting shows “projects: N new”.

**Rollout**
- No schema changes. Re-run the seeder to: create dataset-named projects, backfill activity links, and attach existing contracts to their deals.

<sup>Written for commit 92cd1142edb54a2a9c9a5fa1b8ab4328807f35af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for seeding demo projects with configurable names, descriptions, owners, phases, staffing, and company associations.
  * Demo activities can now link to the most relevant project based on activity timing.
  * Added localized project completion messaging for English, German, and Vietnamese.
  * Demo contracts now preserve or restore their associated deals.

* **Bug Fixes**
  * Improved handling of existing projects and contracts during repeated demo data generation.

* **Tests**
  * Added coverage for project phases, localization, activity linking, and dataset-defined project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->