### PR TITLE
feat(deals): the deal card advises a first move, and the header says whose deal it is

### DIFF
--- a/backend/internal/compose/dealstatus/lanefailure_test.go
+++ b/backend/internal/compose/dealstatus/lanefailure_test.go
@@ -25,7 +25,10 @@ import (
 	"testing"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -42,15 +45,28 @@ func (l *refusingLane) Complete(context.Context, model.Request) (model.Response,
 // real one would make two runs of the same test stamp different cards.
 func cardClock() time.Time { return time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC) }
 
-// cardFacts is the minimum a card can be written from.
+// cardFacts is the minimum a card can be written from AND asked about.
+//
+// The timeline row is load-bearing: write() does not ask a lane about a deal
+// with nothing to cite, because every sentence the model could return would be
+// dropped for want of a citation. A fixture with no activity therefore tests
+// the refusal-to-ask, not the lane, and these tests are about the lane.
 func cardFacts(t *testing.T) facts {
 	t.Helper()
 	return facts{
 		deal: crmcontracts.Deal{Name: "Nordwind", Status: "open"},
+		timeline: []crmcontracts.Activity{{
+			Id:         openapi_types.UUID(ids.NewV7()),
+			Kind:       "email",
+			Subject:    ptr("Angebot"),
+			OccurredAt: cardClock().Add(-48 * time.Hour),
+		}},
 		now:  cardClock(),
 		lang: "de",
 	}
 }
+
+func ptr[T any](v T) *T { return &v }
 
 func TestAWiredLaneThatDidNotAnswerIsReportedSoItsFallbackIsNotCached(t *testing.T) {
 	lane := &refusingLane{}

--- a/backend/internal/compose/dealstatus/lanefailure_test.go
+++ b/backend/internal/compose/dealstatus/lanefailure_test.go
@@ -123,3 +123,46 @@ func TestACardHeldBackByTheCallFloorIsNotAFailure(t *testing.T) {
 		t.Error("a card held back by the call floor was reported as a lane failure")
 	}
 }
+
+// The lane is not asked about a deal with nothing to cite.
+//
+// This is a refusal to ask rather than a new degrade: with no timeline and no
+// open tasks the citable set is empty, keepGrounded drops every sentence for
+// want of a citation, and ParseStatus then refuses the empty story. The reply
+// was discarded whatever it said, so the call bought a model round-trip and up
+// to laneDeadline of the reader's wait to reach the floor already in hand.
+//
+// The pair is the point: the second half proves the guard is about the CITABLE
+// SET and not about deals in general, so a lane that can be used still is.
+func TestTheLaneIsNotAskedAboutADealWithNothingToCite(t *testing.T) {
+	lane := &refusingLane{}
+	s := &Service{lane: lane, now: cardClock}
+	f := cardFacts(t)
+	f.timeline = nil
+
+	card, laneFailed := s.write(context.Background(), f, decideMove(f), project(f, decideMove(f)), true)
+
+	if lane.asked {
+		t.Error("the lane was asked about a deal with nothing to cite, and its answer could only be discarded")
+	}
+	if laneFailed {
+		t.Error("not asking was reported as a lane failure, which would stop the floor being cached")
+	}
+	if card.GeneratedBy != crmcontracts.Deterministic {
+		t.Errorf("the card claims to be %q when no model wrote it", card.GeneratedBy)
+	}
+}
+
+func TestALaneIsStillAskedWhenThereIsSomethingToCite(t *testing.T) {
+	// The admit case. Without it the test above passes against a build that
+	// never asks a lane at all.
+	lane := &refusingLane{}
+	s := &Service{lane: lane, now: cardClock}
+	f := cardFacts(t)
+
+	s.write(context.Background(), f, decideMove(f), project(f, decideMove(f)), true)
+
+	if !lane.asked {
+		t.Error("a deal with a citable activity did not reach the lane")
+	}
+}

--- a/backend/internal/compose/dealstatus/move.go
+++ b/backend/internal/compose/dealstatus/move.go
@@ -63,6 +63,9 @@ func decideMove(f facts) crmcontracts.DealStatusCardMove {
 			map[string]any{"activity_id": inbound.Id},
 			evidenceOf(inbound, "Unanswered: "+subjectOf(inbound)))
 	}
+	if opening, ok := firstOutreach(f); ok {
+		return opening
+	}
 	return move(ActionCreateTask, nextStepReason(f),
 		map[string]any{
 			"subject": "Agree the next step on " + f.deal.Name,
@@ -70,6 +73,92 @@ func decideMove(f facts) crmcontracts.DealStatusCardMove {
 			"source":  "ui",
 		},
 		lastContactEvidence(f)...)
+}
+
+// The stakeholder roles this file reasons about. They are the wire values
+// compose/network serves on a coverage seat, not this package's own
+// vocabulary — spelling one inline is how it ends up a typo that never
+// matches, which fails silently because a role that matches nothing simply
+// produces no advice.
+//
+// Held by: TestTheRoleVocabularyIsSpelledOnce (rolevocabulary_test.go)
+const (
+	roleChampion      = "champion"
+	roleEconomicBuyer = "economic_buyer"
+	roleDecisionMaker = "decision_maker"
+	roleInfluencer    = "influencer"
+)
+
+// openingRoles is who to write to first, best answer first. A champion will
+// carry the conversation internally; an economic buyer can decide; a
+// decision-maker or an influencer is a way in. A blocker is deliberately
+// absent — opening a deal by writing to the person most likely to refuse it is
+// not a first move, and suggesting it would be worse than saying nothing.
+var openingRoles = []string{roleChampion, roleEconomicBuyer, roleDecisionMaker, roleInfluencer}
+
+// firstOutreach is the move on a deal nobody has contacted yet.
+//
+// Without it such a deal was told "Nothing has been logged on this deal yet —
+// agree the next step", which restates the empty timeline the reader is
+// looking at and names no person, no role and no verb they could not have
+// worked out themselves. A deal with named seats and no contact has exactly
+// one obvious next move, and the records already say who it is with.
+//
+// It refuses to guess in three cases, and each one returns no move rather than
+// a vague one: a deal that has been contacted (the later rules own it), a deal
+// with no seats at all, and a deal whose only seats hold roles this cannot
+// order. The last is the one worth stating — an unrecognized role is not a
+// reason to write to somebody, and picking arbitrarily would put a stranger's
+// name in an instruction.
+func firstOutreach(f facts) (crmcontracts.DealStatusCardMove, bool) {
+	if _, contacted := lastContact(f); contacted {
+		return crmcontracts.DealStatusCardMove{}, false
+	}
+	for _, role := range openingRoles {
+		seat, ok := namedRole(f.seats, role)
+		if !ok {
+			continue
+		}
+		return move(ActionDraftEmail, openingReason(seat, len(f.seats)), nil), true
+	}
+	return crmcontracts.DealStatusCardMove{}, false
+}
+
+// openingReason says who to open with and why they are the one.
+//
+// It carries the seat COUNT because that is the fact a reader checks the
+// advice against: "four people are named and none has been contacted" is
+// checkable against the page, where "reach out" is not.
+func openingReason(seat Seat, seats int) string {
+	who := roleWord(seat.Role)
+	if seat.Name != "" {
+		who = seat.Name + ", the " + roleWord(seat.Role)
+	}
+	if seats == 1 {
+		return fmt.Sprintf("Nobody has been contacted yet. Open with %s.", who)
+	}
+	return fmt.Sprintf("%d people are named on this deal and none has been contacted. Open with %s.", seats, who)
+}
+
+// roleWords is the wire value on the left, the words a sentence uses on the
+// right. Two of them read the same and are still two different things: the key
+// is what compose/network stores, the value is English prose, and a rename on
+// either side must not silently move the other.
+var roleWords = map[string]string{
+	roleChampion:      "champion",
+	roleEconomicBuyer: "economic buyer",
+	roleDecisionMaker: "decision-maker",
+	roleInfluencer:    "influencer",
+}
+
+// roleWord is a stakeholder role as a sentence says it. An unknown role is
+// returned as it is stored rather than dropped: the card would otherwise write
+// "Open with Maria Schmidt, the ." for a role added after this build.
+func roleWord(role string) string {
+	if word, known := roleWords[role]; known {
+		return word
+	}
+	return role
 }
 
 func move(action, reason string, args map[string]any, evidence ...crmcontracts.DealNextBestActionEvidence) crmcontracts.DealStatusCardMove {

--- a/backend/internal/compose/dealstatus/move.go
+++ b/backend/internal/compose/dealstatus/move.go
@@ -162,6 +162,13 @@ func roleWord(role string) string {
 }
 
 func move(action, reason string, args map[string]any, evidence ...crmcontracts.DealNextBestActionEvidence) crmcontracts.DealStatusCardMove {
+	// An empty object for a verb that takes no operand, never a nil map. The
+	// contract types `arguments` as an object, and a nil map behind a non-nil
+	// pointer serializes as `"arguments": null` — off-contract, and a client
+	// reading it as an object gets null where it indexes.
+	if args == nil {
+		args = map[string]any{}
+	}
 	out := crmcontracts.DealStatusCardMove{Action: action, Reason: reason, Arguments: &args}
 	out.Evidence = append([]crmcontracts.DealNextBestActionEvidence{}, evidence...)
 	return out

--- a/backend/internal/compose/dealstatus/move_test.go
+++ b/backend/internal/compose/dealstatus/move_test.go
@@ -4,6 +4,8 @@
 package dealstatus
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -335,5 +337,29 @@ func TestADealWithNoSeatsSaysNothingItCannotKnow(t *testing.T) {
 
 	if mv.Action == ActionDraftEmail {
 		t.Error("the card advised writing an email on a deal with nobody to write to")
+	}
+}
+
+// `arguments` is typed as an object in the contract, so a move that takes no
+// operand ships an empty one.
+//
+// Asserted through the WIRE, not the Go value: a nil map behind a non-nil
+// pointer is invisible in Go — `mv.Arguments != nil` passes — and only
+// becomes `"arguments": null` when it is marshalled. A client that reads the
+// field as an object gets null where it indexes.
+func TestAMoveWithNoOperandShipsAnEmptyObjectNotNull(t *testing.T) {
+	f := facts{deal: openDeal(), now: testNow, seats: []Seat{
+		{Role: "champion", Name: "Roland Martinez"},
+	}}
+
+	encoded, err := json.Marshal(decideMove(f))
+	if err != nil {
+		t.Fatalf("marshalling the move: %v", err)
+	}
+	if bytes.Contains(encoded, []byte(`"arguments":null`)) {
+		t.Errorf("the move serialized arguments as null, which the contract types as an object: %s", encoded)
+	}
+	if !bytes.Contains(encoded, []byte(`"arguments":{}`)) {
+		t.Errorf("a move with no operand did not ship an empty object: %s", encoded)
 	}
 }

--- a/backend/internal/compose/dealstatus/move_test.go
+++ b/backend/internal/compose/dealstatus/move_test.go
@@ -4,6 +4,7 @@
 package dealstatus
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -226,5 +227,113 @@ func TestAWithheldRowIsNeverNamedAsTheOperand(t *testing.T) {
 	f := facts{deal: openDeal(), now: testNow, timeline: []crmcontracts.Activity{withheldMail}}
 	if mv := decideMove(f); mv.Action == ActionDraftEmail {
 		t.Fatal("a withheld mail was offered as the one to answer")
+	}
+}
+
+// A deal nobody has contacted yet used to be told "Nothing has been logged on
+// this deal yet — agree the next step", which restates the empty timeline the
+// reader is already looking at. These tests pin the sentence that replaced it:
+// who to write to, and the count a reader can check it against.
+
+func TestTheFirstMoveOnAnUncontactedDealNamesWhoToOpenWith(t *testing.T) {
+	f := facts{deal: openDeal(), now: testNow, seats: []Seat{
+		{Role: "blocker", Name: "Patrick Ganzmann"},
+		{Role: "champion", Name: "Roland Martinez"},
+		{Role: "economic_buyer", Name: "Philipp Königs"},
+	}}
+
+	mv := decideMove(f)
+
+	if mv.Action != ActionDraftEmail {
+		t.Errorf("the move on an uncontacted deal is %q, not a first email", mv.Action)
+	}
+	if !strings.Contains(mv.Reason, "Roland Martinez") {
+		t.Errorf("the advice does not name who to open with: %q", mv.Reason)
+	}
+	if !strings.Contains(mv.Reason, "champion") {
+		t.Errorf("the advice does not say why that person: %q", mv.Reason)
+	}
+	// The count is what makes the sentence checkable against the page.
+	if !strings.Contains(mv.Reason, "3 people") {
+		t.Errorf("the advice does not say how many are named: %q", mv.Reason)
+	}
+}
+
+func TestTheFirstMoveNeverOpensWithTheBlocker(t *testing.T) {
+	// A deal whose ONLY named seat is the person most likely to refuse it. No
+	// advice is the right answer; naming them would be worse than silence.
+	f := facts{deal: openDeal(), now: testNow, seats: []Seat{
+		{Role: "blocker", Name: "Patrick Ganzmann"},
+	}}
+
+	mv := decideMove(f)
+
+	if mv.Action == ActionDraftEmail {
+		t.Error("the card told the rep to open the deal by writing to its blocker")
+	}
+	if strings.Contains(mv.Reason, "Patrick Ganzmann") {
+		t.Errorf("the blocker was named as the way in: %q", mv.Reason)
+	}
+}
+
+func TestTheFirstMoveTakesTheBestAvailableRole(t *testing.T) {
+	// No champion: the economic buyer is the next best answer, not a fallback
+	// to "agree the next step".
+	f := facts{deal: openDeal(), now: testNow, seats: []Seat{
+		{Role: "influencer", Name: "Ines Eschbacher"},
+		{Role: "economic_buyer", Name: "Philipp Königs"},
+	}}
+
+	mv := decideMove(f)
+
+	if !strings.Contains(mv.Reason, "Philipp Königs") {
+		t.Errorf("the economic buyer was not chosen over the influencer: %q", mv.Reason)
+	}
+	if !strings.Contains(mv.Reason, "economic buyer") {
+		t.Errorf("the role is not said in words a sentence can carry: %q", mv.Reason)
+	}
+}
+
+func TestASeatTheReaderMayNotNameStillCarriesItsRole(t *testing.T) {
+	// The reader holds deal:read without person:read, so the seam supplies the
+	// seats unnamed. The role is not the secret and the advice still works.
+	f := facts{deal: openDeal(), now: testNow, seats: []Seat{{Role: "champion"}}}
+
+	mv := decideMove(f)
+
+	if mv.Action != ActionDraftEmail {
+		t.Errorf("an unnamed champion produced no opening move: %q", mv.Action)
+	}
+	if !strings.Contains(mv.Reason, "champion") {
+		t.Errorf("the role was dropped along with the name: %q", mv.Reason)
+	}
+}
+
+func TestAContactedDealKeepsItsOwnMove(t *testing.T) {
+	// The opening move is for a deal with NO contact. Once somebody has
+	// written, the later rules own the answer and this must not displace them.
+	f := facts{
+		deal:     openDeal(),
+		now:      testNow,
+		timeline: []crmcontracts.Activity{inboundMail(testNow.Add(-24 * time.Hour))},
+		seats:    []Seat{{Role: "champion", Name: "Roland Martinez"}},
+	}
+
+	mv := decideMove(f)
+
+	if strings.Contains(mv.Reason, "Nobody has been contacted") {
+		t.Errorf("a deal with an inbound mail was called uncontacted: %q", mv.Reason)
+	}
+}
+
+func TestADealWithNoSeatsSaysNothingItCannotKnow(t *testing.T) {
+	// Nobody is named, so there is nobody to open with. The card falls back to
+	// its old sentence rather than inventing a person.
+	f := facts{deal: openDeal(), now: testNow}
+
+	mv := decideMove(f)
+
+	if mv.Action == ActionDraftEmail {
+		t.Error("the card advised writing an email on a deal with nobody to write to")
 	}
 }

--- a/backend/internal/compose/dealstatus/rolevocabulary_test.go
+++ b/backend/internal/compose/dealstatus/rolevocabulary_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dealstatus
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The stakeholder role strings are wire values compose/network puts on a
+// coverage seat, and this package MATCHES on them. A second spelling does not
+// fail to compile — it fails to match, so the opening move silently stops
+// finding the champion on every deal, and a test that does not already know
+// the right string cannot tell.
+//
+// WHAT THIS GATE CANNOT SEE, stated because it decides the gate's shape: two
+// of the wire values are also ordinary English words, and `roleWords` renders
+// "champion" as the word "champion". A literal alone therefore does not say
+// whether the author meant the wire value or the prose. So the gate reads
+// COMPARISONS and switch cases — the places a mistyped wire value silently
+// stops matching — and deliberately not every string in the package. A
+// display string that happens to equal a role is not the defect; a `==` or a
+// `case` against a bare literal is.
+//
+// A parse rather than a grep for the same reason: a grep counts the const
+// declarations and the words inside these comments.
+func TestTheRoleVocabularyIsSpelledOnce(t *testing.T) {
+	declared := map[string]string{
+		"champion":       "roleChampion",
+		"economic_buyer": "roleEconomicBuyer",
+		"decision_maker": "roleDecisionMaker",
+		"influencer":     "roleInfluencer",
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	offenders := 0
+	scanned := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		scanned++
+		ast.Inspect(file, func(n ast.Node) bool {
+			for _, lit := range comparedLiterals(n) {
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				if constName, governed := declared[value]; governed {
+					offenders++
+					t.Errorf("%s compares against the role %q as a bare literal; use %s, which is the one spelling this package matches on",
+						fset.Position(lit.Pos()), value, constName)
+				}
+			}
+			return true
+		})
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no files, so this gate would pass over an empty package")
+	}
+	if offenders > 0 {
+		t.Logf("scanned %d non-test file(s) in the package", scanned)
+	}
+}
+
+// comparedLiterals is the string literals a node TESTS a value against: the
+// operands of == and !=, and the values of a switch case. Those are the sites
+// where a mistyped role silently stops matching. A literal being returned,
+// assigned or printed is not one of them.
+func comparedLiterals(n ast.Node) []*ast.BasicLit {
+	var out []*ast.BasicLit
+	add := func(e ast.Expr) {
+		if lit, ok := e.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			out = append(out, lit)
+		}
+	}
+	switch node := n.(type) {
+	case *ast.BinaryExpr:
+		if node.Op == token.EQL || node.Op == token.NEQ {
+			add(node.X)
+			add(node.Y)
+		}
+	case *ast.CaseClause:
+		for _, e := range node.List {
+			add(e)
+		}
+	}
+	return out
+}

--- a/backend/internal/compose/dealstatus/seats.go
+++ b/backend/internal/compose/dealstatus/seats.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dealstatus
+
+import (
+	"context"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// Seat is one person on the deal, as the card needs them: who they are, what
+// role they hold, and whether they have spoken with us both ways inside the
+// engagement window.
+//
+// Name is empty when the reader may not read that person. The seat still
+// counts — how many people carry a deal is not the secret, only who they are —
+// and the card names roles it cannot name people for.
+type Seat struct {
+	Role    string
+	Name    string
+	Engaged bool
+}
+
+// SeatReader answers who sits on a deal.
+//
+// A port rather than a store call, because the answer is assembled by
+// compose/network's CoverageFor, and a module may not import a compose
+// subpackage (ADR-0054 §3). The edge is injected in compose, which is where
+// the one existing assembler is bound — writing a second seat read here would
+// be the duplicate the coverage seam exists to prevent, and it would be the
+// copy without CoverageFor's edge admission.
+//
+// A reader refused the stakeholder edge gets NO seats and no error: the card
+// then says nothing about who is on the deal, which is true for them. That is
+// the same shape CoverageFor already uses for a withheld section.
+type SeatReader func(ctx context.Context, dealID ids.DealID, now time.Time) ([]Seat, error)
+
+// namedRole returns the first seat holding the role, preferring one this
+// reader may name: a role the card can attach a person to is worth more than
+// the same role as an anonymous count, and an unnamed seat still proves the
+// role is filled.
+func namedRole(seats []Seat, role string) (Seat, bool) {
+	var unnamed Seat
+	var found bool
+	for _, s := range seats {
+		if s.Role != role {
+			continue
+		}
+		if s.Name != "" {
+			return s, true
+		}
+		if !found {
+			unnamed, found = s, true
+		}
+	}
+	return unnamed, found
+}

--- a/backend/internal/compose/dealstatus/service.go
+++ b/backend/internal/compose/dealstatus/service.go
@@ -53,6 +53,7 @@ type Service struct {
 	deals          *deals.Store
 	activities     *activities.Store
 	rooms          *dealrooms.Store
+	seatsOf        SeatReader
 	lane           Completer
 	routingVersion string
 	now            func() time.Time
@@ -61,6 +62,15 @@ type Service struct {
 // NewService binds the reads. Each store carries its own gates.
 func NewService(pool *pgxpool.Pool, d *deals.Store, a *activities.Store, r *dealrooms.Store, now func() time.Time) *Service {
 	return &Service{pool: pool, deals: d, activities: a, rooms: r, now: now}
+}
+
+// WithSeats binds the read that says who is on the deal. Without it the card
+// is written from the deal and its timeline alone, which is what it did before
+// the seats were reachable — a working card that cannot name a first move on a
+// deal nobody has contacted yet.
+func (s *Service) WithSeats(read SeatReader) *Service {
+	s.seatsOf = read
+	return s
 }
 
 // WithLane binds the deal_health lane that writes the card's words. Without
@@ -82,7 +92,12 @@ type facts struct {
 	moreTasks bool
 	room      *crmcontracts.DealRoom
 	threads   []crmcontracts.DealRoomThread
-	now       time.Time
+	// seats are the people on the deal with their roles. Empty when nobody is
+	// named AND when the reader may not read the stakeholder edge — the card
+	// cannot tell those apart and says nothing about seats in either case,
+	// which is the honest answer for both.
+	seats []Seat
+	now   time.Time
 	// lang is the installation's base language, which the card is written in.
 	// A status card is filed on the deal and read by anyone who opens it, so it
 	// takes the shared language rather than the reader's — the same rule that
@@ -201,6 +216,20 @@ func (s *Service) write(
 	if s.lane == nil || !askModel {
 		return floor, false
 	}
+	// A deal with nothing to cite cannot be written by the model, so it is not
+	// asked. Every story sentence must carry a citation that resolves against
+	// the timeline or the open tasks (keepGrounded), and ParseStatus refuses a
+	// reply whose story is then empty — so with neither, the lane's answer is
+	// discarded whatever it says. Asking anyway spent a model call and up to
+	// laneDeadline of the reader's wait to arrive at the floor that was
+	// already in hand.
+	//
+	// This is a REFUSAL TO ASK, not a new degrade: the card served here is the
+	// same floor the same deal got before, and generated_by already says
+	// deterministic. What changes is that the reader gets it at once.
+	if len(citableIDs(in)) == 0 {
+		return floor, false
+	}
 	laneCtx, cancel := context.WithTimeout(ctx, laneDeadline)
 	defer cancel()
 	written, err := s.ask(laneCtx, in, f.lang)
@@ -254,6 +283,13 @@ func (s *Service) gather(ctx context.Context, dealID ids.DealID) (facts, error) 
 	f.openTasks, f.moreTasks = open, more
 	if err := s.gatherRoom(ctx, dealID, &f); err != nil {
 		return facts{}, err
+	}
+	if s.seatsOf != nil {
+		seats, err := s.seatsOf(ctx, dealID, f.now)
+		if err != nil {
+			return facts{}, fmt.Errorf("deal status: reading who is on the deal: %w", err)
+		}
+		f.seats = seats
 	}
 	f.lang = identity.BaseLanguageForPrompt(ctx, s.pool)
 	return f, nil

--- a/backend/internal/compose/dealstatusseam.go
+++ b/backend/internal/compose/dealstatusseam.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Who is on a deal, as the status card reads it.
+//
+// The card and the coverage chips sit on one screen and used to answer this
+// question from different places — the chips through compose/network's
+// CoverageFor, the card not at all. This binds the card to the SAME assembler,
+// so a deal's seats are read once and the two surfaces cannot disagree about
+// who is on it or how many there are.
+//
+// Writing a second seat read in dealstatus would have been the shorter path
+// and the wrong one: CoverageFor carries the stakeholder edge admission
+// (auth.EdgeReadAdmitted) that turns a denial into a named omission, and a
+// copy would have been the version without it.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/compose/dealstatus"
+	"github.com/gradionhq/margince/backend/internal/compose/network"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// dealSeatReader reads the deal's seats with their roles and names.
+//
+// One transaction for the coverage and the names, the way the coverage handler
+// reads them: a seat list and the names for it taken from two snapshots can
+// name somebody who is no longer on the deal.
+//
+// A reader refused the stakeholder edge gets no seats, not an error —
+// CoverageFor answers a denial with an empty stakeholder list and a named
+// omission, and the card's contract with the reader is that it says less
+// rather than failing. A reader who may see the seats but not the people gets
+// the seats unnamed, which is people.PersonNamesTx's own posture.
+func dealSeatReader(pool *pgxpool.Pool) dealstatus.SeatReader {
+	peopleStore := people.NewStore(InstallationDB(pool))
+	return func(ctx context.Context, dealID ids.DealID, now time.Time) ([]dealstatus.Seat, error) {
+		var seats []dealstatus.Seat
+		err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+			coverage, err := network.CoverageFor(ctx, tx, dealID, now)
+			if err != nil {
+				return err
+			}
+			names, err := seatNamesForCard(ctx, tx, peopleStore, coverage)
+			if err != nil {
+				return err
+			}
+			seats = make([]dealstatus.Seat, 0, len(coverage.Stakeholders))
+			for _, s := range coverage.Stakeholders {
+				seats = append(seats, dealstatus.Seat{
+					Role: s.Role, Name: names[s.PersonID], Engaged: s.Engaged,
+				})
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return seats, nil
+	}
+}
+
+// seatNamesForCard names the seats, or names none of them.
+//
+// The permission-denied arm is the same one the coverage handler takes: a
+// reader holding deal:read without person:read still gets the deal's shape —
+// how many people carry it, in what roles — and simply no names. The card then
+// writes "the champion" where it would have written a person.
+func seatNamesForCard(
+	ctx context.Context, tx pgx.Tx, store *people.Store, coverage network.DealCoverage,
+) (map[ids.UUID]string, error) {
+	if len(coverage.Stakeholders) == 0 {
+		return map[ids.UUID]string{}, nil
+	}
+	seated := make([]ids.PersonID, 0, len(coverage.Stakeholders))
+	for _, s := range coverage.Stakeholders {
+		seated = append(seated, ids.From[ids.PersonKind](s.PersonID))
+	}
+	names, err := store.PersonNamesTx(ctx, tx, seated)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return map[ids.UUID]string{}, nil
+		}
+		return nil, err
+	}
+	return names, nil
+}

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -114,7 +114,8 @@ func (s *Server) wirePerson360(pool *pgxpool.Pool) {
 	// through the verb the move names, and the only row it writes is its own
 	// per-reader cache entry.
 	s.dealStatusSvc = dealstatus.NewService(
-		pool, s.dealsStore, activities.NewStore(InstallationDB(pool)), dealrooms.NewStore(InstallationDB(pool)), time.Now)
+		pool, s.dealsStore, activities.NewStore(InstallationDB(pool)), dealrooms.NewStore(InstallationDB(pool)), time.Now).
+		WithSeats(dealSeatReader(pool))
 	s.dealStatusHandlers = dealstatus.NewHandlers(s.dealStatusSvc)
 	// No provider is registered, which is the supported configuration rather
 	// than a gap: the surface answers "not connected" and writes nothing

--- a/backend/internal/compose/network/coveragefacts.go
+++ b/backend/internal/compose/network/coveragefacts.go
@@ -43,6 +43,11 @@ type dealFacts struct {
 	status         string
 	organizationID ids.UUID
 	lastTouchAt    time.Time
+	// everTouched says an activity has actually been captured against the
+	// deal, which lastTouchAt cannot answer: it coalesces to the creation
+	// date, so a deal nobody has contacted and one contacted the day it was
+	// written down carry the same instant.
+	everTouched bool
 }
 
 // readDealFacts loads the deal row the rules decide on.
@@ -56,8 +61,9 @@ func readDealFacts(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (dealFacts
 	var out dealFacts
 	var org *ids.UUID
 	err := tx.QueryRow(ctx, `
-		SELECT status, organization_id, coalesce(last_activity_at, created_at)
-		  FROM deal WHERE id = $1`, dealID).Scan(&out.status, &org, &out.lastTouchAt)
+		SELECT status, organization_id, coalesce(last_activity_at, created_at),
+		       last_activity_at IS NOT NULL
+		  FROM deal WHERE id = $1`, dealID).Scan(&out.status, &org, &out.lastTouchAt, &out.everTouched)
 	if err != nil {
 		return out, fmt.Errorf("network: reading the deal a coverage view describes: %w", err)
 	}

--- a/backend/internal/compose/network/risk.go
+++ b/backend/internal/compose/network/risk.go
@@ -104,6 +104,13 @@ type DealCoverage struct {
 	// that as "do not judge", so a hand-built fixture cannot accidentally
 	// assert a cold deal it never described.
 	LastTouchAt time.Time
+	// EverTouched says a touch has actually been captured, as opposed to
+	// LastTouchAt standing in with the deal's creation. The engagement rules
+	// read it to tell a deal nobody has worked from one that is simply new:
+	// engagement requires a two-way exchange, so before any contact exists
+	// every seat is unengaged by construction and the findings that follow
+	// from that describe the calendar rather than the deal.
+	EverTouched bool
 	// DepartedPersonIDs are the stakeholders whose employment at the account
 	// has ended. Gathered rather than folded because it takes a second read,
 	// and carried as ids so the fold stays pure.
@@ -187,7 +194,7 @@ func CoverageFor(ctx context.Context, tx pgx.Tx, dealID ids.DealID, now time.Tim
 	if err != nil {
 		return out, err
 	}
-	out.Status, out.LastTouchAt = facts.status, facts.lastTouchAt
+	out.Status, out.LastTouchAt, out.EverTouched = facts.status, facts.lastTouchAt, facts.everTouched
 
 	stakeholders, err := deals.Stakeholders(ctx, tx, dealID, now)
 	if err != nil {
@@ -246,13 +253,23 @@ func foldRisks(c DealCoverage, now time.Time) []Risk {
 	}
 
 	// REPORT-PARAM-1, verbatim: distinct_engaged_contacts < 2.
+	//
+	// Held back until the deal has been touched at all, for the reason
+	// ourSideMinInteractions exists a few lines down: engagement requires a
+	// two-way exchange inside the window, so before any contact is captured
+	// EVERY seat is unengaged by construction and this fires on every deal
+	// somebody just created. That is a statement about the calendar, not about
+	// the deal, and a warning that is always on is a warning nobody reads.
+	//
+	// The finding still arrives the moment there is something to find: one
+	// captured touch is enough to make the count mean what it says.
 	engaged := make([]ids.UUID, 0, len(c.Stakeholders))
 	for _, s := range c.Stakeholders {
 		if s.Engaged {
 			engaged = append(engaged, s.PersonID)
 		}
 	}
-	if len(engaged) < reportThreadingFloor {
+	if c.EverTouched && len(engaged) < reportThreadingFloor {
 		risks = append(risks, Risk{
 			Kind: RiskSingleThreadedTheirs, DealID: c.DealID, PersonIDs: engaged,
 			Summary: "fewer than two engaged contacts — the deal rests on one relationship",
@@ -267,7 +284,13 @@ func foldRisks(c DealCoverage, now time.Time) []Risk {
 	// A deal with seats but no engaged champion. Distinct from
 	// single-threading: three engaged contacts and no champion among them is
 	// a deal nobody inside is arguing for.
-	if !hasEngagedChampion(c.Stakeholders) && len(c.Stakeholders) > 0 {
+	//
+	// Same hold as above, and it mattered more here: this rule reads "engaged"
+	// while the deal page's readings strip reads the role alone, so an
+	// untouched deal with a named champion showed "a champion is named" and
+	// "No engaged champion" side by side on one screen. Both were true and the
+	// pair read as a fault.
+	if c.EverTouched && !hasEngagedChampion(c.Stakeholders) && len(c.Stakeholders) > 0 {
 		risks = append(risks, Risk{
 			Kind: RiskCoverageGap, DealID: c.DealID,
 			Summary: "no engaged champion — nobody inside the account is carrying this",

--- a/backend/internal/compose/network/risk_test.go
+++ b/backend/internal/compose/network/risk_test.go
@@ -159,6 +159,28 @@ func TestTheEngagementRulesWaitForTheFirstTouch(t *testing.T) {
 	}
 }
 
+// The hold is on "never touched", NOT on "not touched lately", and the two
+// come apart at exactly the deal these rules matter most for: one that went
+// quiet months ago. Engagement is a 90-day window, so a deal last touched 120
+// days ago has EverTouched true and no engaged seat — both findings are real
+// and both must still be reported.
+func TestALongSilentDealStillReportsItsEngagementFindings(t *testing.T) {
+	old := DealCoverage{
+		DealID: ids.NewV7(), EverTouched: true, LastTouchAt: daysAgo(120),
+		Status: dealStatusOpen,
+		Stakeholders: []deals.DealStakeholder{
+			seat(false, roleChampion), seat(false, "user"),
+		},
+	}
+	got := kinds(foldRisks(old, testNow))
+	if !got[RiskSingleThreadedTheirs] {
+		t.Error("a deal silent for 120 days is not flagged single-threaded")
+	}
+	if !got[RiskCoverageGap] {
+		t.Error("a deal silent for 120 days is not flagged for its quiet champion")
+	}
+}
+
 func TestADealWithNoSeatsAtAllRaisesNoCoverageGap(t *testing.T) {
 	// An empty deal is early, not uncovered. Flagging it would put a risk chip
 	// on every deal the moment it is created, and a warning that is always on

--- a/backend/internal/compose/network/risk_test.go
+++ b/backend/internal/compose/network/risk_test.go
@@ -39,7 +39,7 @@ func TestSingleThreadedIsTheReportingRuleVerbatim(t *testing.T) {
 	// REPORT-PARAM-1: distinct_engaged_contacts < 2. One engaged contact is
 	// single-threaded however many seats the deal has — an unengaged seat is
 	// a name on a list, not a relationship.
-	one := DealCoverage{DealID: ids.NewV7(), Stakeholders: []deals.DealStakeholder{
+	one := DealCoverage{DealID: ids.NewV7(), EverTouched: true, Stakeholders: []deals.DealStakeholder{
 		seat(true, roleChampion), seat(false, "user"), seat(false, "legal"),
 	}}
 	if !kinds(foldRisks(one, testNow))[RiskSingleThreadedTheirs] {
@@ -103,7 +103,7 @@ func TestACoverageGapIsAboutTheChampionNotTheCount(t *testing.T) {
 	// Three engaged contacts and no champion among them: well covered by the
 	// threading rule, and still nobody inside is arguing for the deal. The two
 	// findings are different questions and must not collapse into one.
-	noChampion := DealCoverage{DealID: ids.NewV7(), Stakeholders: []deals.DealStakeholder{
+	noChampion := DealCoverage{DealID: ids.NewV7(), EverTouched: true, Stakeholders: []deals.DealStakeholder{
 		seat(true, "user"), seat(true, "legal"), seat(true, "finance"),
 	}}
 	got := kinds(foldRisks(noChampion, testNow))
@@ -116,11 +116,46 @@ func TestACoverageGapIsAboutTheChampionNotTheCount(t *testing.T) {
 
 	// A champion who exists but has gone quiet does not count: the seat is not
 	// the relationship.
-	quietChampion := DealCoverage{DealID: ids.NewV7(), Stakeholders: []deals.DealStakeholder{
+	quietChampion := DealCoverage{DealID: ids.NewV7(), EverTouched: true, Stakeholders: []deals.DealStakeholder{
 		seat(false, roleChampion), seat(true, "user"), seat(true, "legal"),
 	}}
 	if !kinds(foldRisks(quietChampion, testNow))[RiskCoverageGap] {
 		t.Error("an unengaged champion counted as an engaged one — a name on a seat is not advocacy")
+	}
+}
+
+// The same argument as TestADealWithNoSeatsAtAllRaisesNoCoverageGap, one step
+// further: a deal with seats but NO captured contact is early too.
+//
+// Engagement requires a two-way exchange, so before the first touch every seat
+// is unengaged by construction and both engagement rules fire on every deal
+// somebody just created. The rep then meets two warning chips on a deal five
+// minutes old, which is what trains them to stop reading chips.
+//
+// The pair matters: the second half proves the findings still ARRIVE once
+// there is something to find, so this is a hold rather than a removal.
+func TestTheEngagementRulesWaitForTheFirstTouch(t *testing.T) {
+	seats := []deals.DealStakeholder{
+		seat(false, roleChampion), seat(false, "user"), seat(false, "legal"),
+	}
+	untouched := DealCoverage{DealID: ids.NewV7(), Stakeholders: seats}
+	got := kinds(foldRisks(untouched, testNow))
+	if got[RiskSingleThreadedTheirs] {
+		t.Error("a deal nobody has contacted yet is flagged single-threaded, which is true of every new deal")
+	}
+	if got[RiskCoverageGap] {
+		t.Error("a deal nobody has contacted yet is flagged for having no engaged champion")
+	}
+
+	// One captured touch and the same seats: both findings now mean what they
+	// say, and both are reported.
+	touched := DealCoverage{DealID: ids.NewV7(), EverTouched: true, Stakeholders: seats}
+	got = kinds(foldRisks(touched, testNow))
+	if !got[RiskSingleThreadedTheirs] {
+		t.Error("a contacted deal with no engaged seat is not flagged single-threaded")
+	}
+	if !got[RiskCoverageGap] {
+		t.Error("a contacted deal with an unengaged champion is not flagged as a coverage gap")
 	}
 }
 

--- a/frontend/src/screens/deal360/deal360.stories.tsx
+++ b/frontend/src/screens/deal360/deal360.stories.tsx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { components } from "../../api/schema";
-import { StoryProviders } from "../story-utils";
+import { installFetchStub, jsonResponse, StoryProviders } from "../story-utils";
 import { DealFacts } from "./dealfacts";
 import { DealPulse } from "./dealpulse";
 import { DealSeats } from "./dealseats";
@@ -205,20 +205,38 @@ const STAGES = [
  * only be answered by opening Edit.
  */
 export const Facts: Story = {
-  render: () => (
-    <StoryProviders>
-      <DealFacts
-        deal={{
-          amount_minor: 6_400_000,
-          currency: "EUR",
-          stage_id: "st-1",
-          owner_id: "u-1",
-        }}
-        stages={STAGES}
-        locale="en"
-      />
-    </StoryProviders>
-  ),
+  render: () => {
+    // The roster the owner name resolves through — the same read every
+    // EntityRef in the app uses. Without it this story would document the
+    // unresolved-owner fallback as the normal state.
+    installFetchStub({
+      "GET /users": () =>
+        jsonResponse({
+          data: [
+            {
+              id: "u-1",
+              display_name: "Sofia Meier",
+              email: "sofia@example.com",
+            },
+          ],
+          page: { next_cursor: null },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <DealFacts
+          deal={{
+            amount_minor: 6_400_000,
+            currency: "EUR",
+            stage_id: "st-1",
+            owner_id: "u-1",
+          }}
+          stages={STAGES}
+          locale="en"
+        />
+      </StoryProviders>
+    );
+  },
 };
 
 /**

--- a/frontend/src/screens/deal360/deal360.stories.tsx
+++ b/frontend/src/screens/deal360/deal360.stories.tsx
@@ -4,6 +4,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { components } from "../../api/schema";
 import { StoryProviders } from "../story-utils";
+import { DealFacts } from "./dealfacts";
 import { DealPulse } from "./dealpulse";
 import { DealSeats } from "./dealseats";
 import { DealStrip } from "./dealstrip";
@@ -186,6 +187,61 @@ export const SeatsUnsupportedInOverlay: Story = {
   render: () => (
     <StoryProviders>
       <DealSeats pending={false} withheld={false} overlay={true} />
+    </StoryProviders>
+  ),
+};
+
+const STAGES = [
+  { id: "st-1", name: "Qualified" },
+  { id: "st-2", name: "Proposal" },
+];
+
+/**
+ * The three facts beside the deal's name: what it is worth, where it sits on
+ * the board, and whose deal it is.
+ *
+ * The owner is the one that did not exist anywhere on this page before — not
+ * the header, not the rail, not the readings — so "whose deal is this" could
+ * only be answered by opening Edit.
+ */
+export const Facts: Story = {
+  render: () => (
+    <StoryProviders>
+      <DealFacts
+        deal={{
+          amount_minor: 6_400_000,
+          currency: "EUR",
+          stage_id: "st-1",
+          owner_id: "u-1",
+        }}
+        stages={STAGES}
+        locale="en"
+      />
+    </StoryProviders>
+  ),
+};
+
+/**
+ * Unassigned, and the amount withheld from this reader.
+ *
+ * Both are stated rather than blank. An empty owner reads as a rendering
+ * fault where "Unassigned" is a fact somebody can act on, and a bare dash for
+ * the value would say "this deal is worth nothing" — a different claim from
+ * "you may not see it".
+ */
+export const FactsWithheldAndUnassigned: Story = {
+  render: () => (
+    <StoryProviders>
+      <DealFacts
+        deal={{
+          amount_minor: null,
+          currency: "EUR",
+          stage_id: "st-2",
+          masked_fields: ["amount_minor"],
+        }}
+        stages={STAGES}
+        locale="en"
+      />
     </StoryProviders>
   ),
 };

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -3,10 +3,12 @@
 
 /** @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../../api/schema";
 import { LocaleProvider } from "../../i18n";
+import { DealFacts } from "./dealfacts";
 import { DealPulse } from "./dealpulse";
 import { DealSeats } from "./dealseats";
 import { DealStrip } from "./dealstrip";
@@ -311,5 +313,90 @@ describe("the rail says who is on the deal", () => {
     );
     expect(screen.getByText("A contact you cannot read")).toBeInTheDocument();
     expect(screen.getByText("No two-way contact")).toBeInTheDocument();
+  });
+});
+
+// The three facts a rep checks first: value, stage, owner.
+//
+// Before this box the owner was on no part of the page — not the header, not
+// the rail, not the readings — so "whose deal is this" could only be answered
+// by opening Edit. The amount was rendered twice in one header instead.
+describe("the header says what it is worth, where it is, and whose it is", () => {
+  const stages = [
+    { id: "st-1", name: "Qualified" },
+    { id: "st-2", name: "Proposal" },
+  ];
+
+  function showFacts(node: React.ReactNode) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={client}>
+        <LocaleProvider initial="en">{node}</LocaleProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  it("names the stage rather than showing its id", () => {
+    showFacts(
+      <DealFacts
+        deal={{ amount_minor: 6_400_000, currency: "EUR", stage_id: "st-1" }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    expect(screen.getByText("Qualified")).toBeInTheDocument();
+    expect(screen.queryByText("st-1")).not.toBeInTheDocument();
+  });
+
+  it("says a deal is unassigned rather than leaving the owner blank", () => {
+    showFacts(
+      <DealFacts
+        deal={{ amount_minor: 1000, currency: "EUR", stage_id: "st-1" }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    // An empty value here reads as a rendering fault. "Unassigned" is a fact
+    // about the deal, and it is the one a rep acts on.
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
+  });
+
+  it("names the field it may not show rather than printing a dash", () => {
+    // A rep who may read the deal but not its amount. A bare "—" would read
+    // as "this deal has no value", which is a different and wrong statement.
+    showFacts(
+      <DealFacts
+        deal={{
+          amount_minor: null,
+          currency: "EUR",
+          stage_id: "st-1",
+          masked_fields: ["amount_minor"],
+        }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    expect(screen.getByText("Value")).toBeInTheDocument();
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+  });
+
+  it("never prints a stage id the pipeline cannot name", () => {
+    // The case a null stage_id CANNOT test: an id that is present and does not
+    // resolve. An overlay-mirror deal carries the incumbent's own pipeline id,
+    // and a deal read before its pipeline finishes loading has stages empty —
+    // both reach the fallback with a real uuid in hand, and printing it puts a
+    // machine identifier where a reader expects "Qualified".
+    const foreign = "01a02be8-c8d5-7d9b-bb60-a5e1ad68533c";
+    showFacts(
+      <DealFacts
+        deal={{ amount_minor: 1000, currency: "EUR", stage_id: foreign }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    expect(screen.getByText("Stage")).toBeInTheDocument();
+    expect(screen.queryByText(foreign)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/deal360/dealfacts.css
+++ b/frontend/src/screens/deal360/dealfacts.css
@@ -1,0 +1,35 @@
+/* The deal's standing, beside its name. Tokens only (make ds-purity). */
+
+.deal-facts {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: var(--space-1) var(--space-4);
+  margin: 0;
+  align-content: start;
+}
+
+/* Each fact is its own row of the grid, so the labels form one column and the
+   values another however long either runs. `display: contents` rather than a
+   wrapper box: the <div> is here because <dl> pairs need one for valid markup,
+   and it must not become a grid cell of its own. */
+.deal-facts-item {
+  display: contents;
+}
+
+.deal-facts dt {
+  color: var(--textMeta);
+  font-size: var(--fs-sm);
+  white-space: nowrap;
+}
+
+.deal-facts dd {
+  margin: 0;
+  color: var(--textPrimary);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  /* The value column is the one that can run long — a stage name, a full name
+     — and a deal header is not the place for it to push the actions off the
+     row. */
+  max-inline-size: 18ch;
+  overflow-wrap: anywhere;
+}

--- a/frontend/src/screens/deal360/dealfacts.css
+++ b/frontend/src/screens/deal360/dealfacts.css
@@ -2,7 +2,11 @@
 
 .deal-facts {
   display: grid;
-  grid-template-columns: auto auto;
+  /* max-content, not auto: `auto` lets the columns absorb whatever width the
+     header gives them, which pushed the labels and values to opposite ends of
+     the page with a hand-span of nothing between. The pair reads as one fact
+     only while it sits together. */
+  grid-template-columns: max-content max-content;
   gap: var(--space-1) var(--space-4);
   margin: 0;
   align-content: start;

--- a/frontend/src/screens/deal360/dealfacts.tsx
+++ b/frontend/src/screens/deal360/dealfacts.tsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The three facts a rep checks before anything else: what it is worth, where
+// it sits on the board, and whose deal it is.
+//
+// They were not readable together. The amount was in the subtitle AND in the
+// readings strip, the stage was only the chip row below the fold, and the
+// owner was on no part of the page at all — so "whose deal is this" could not
+// be answered without opening Edit. This is RecordView's `controls` slot, the
+// same one the company page puts its standing in, so the two records read the
+// same way.
+//
+// Read-only on purpose. Stage and owner are both writable through Edit deal,
+// and a control here that looked editable but only navigated would be worse
+// than a label; making them editable in place is a deliberate change to how
+// the deal is written, not a side effect of showing it.
+
+import { FieldGuard } from "../../design-system/rbac";
+import { formatMoney } from "../../format/format";
+import type { Locale } from "../../i18n";
+import { useT } from "../../i18n";
+import { rosterMissLabel, useRoster, useRosterPartial } from "../entityref";
+import "./dealfacts.css";
+
+type Deal = {
+  amount_minor?: number | null;
+  currency?: string | null;
+  stage_id?: string | null;
+  owner_id?: string | null;
+  masked_fields?: readonly string[];
+};
+
+type Stage = { id: string; name: string };
+
+/**
+ * DealFacts is the deal's standing: value, stage, owner.
+ *
+ * The stage NAME comes from the pipeline the page has already read, not a
+ * second request — the caller passes the stages it sorted for the chip row.
+ * The owner name comes from the shared roster the rest of the app resolves
+ * users through, so it hits the same cache entry every EntityRef does.
+ */
+export function DealFacts({
+  deal,
+  stages,
+  locale,
+}: Readonly<{
+  deal: Deal;
+  stages: readonly Stage[];
+  locale: Locale;
+}>) {
+  const t = useT();
+  // Only asked for when there is an owner to name: an unowned deal needs no
+  // roster read to say so.
+  const roster = useRoster("user", Boolean(deal.owner_id));
+  const partial = useRosterPartial("user", Boolean(deal.owner_id));
+  const masked = deal.masked_fields ?? [];
+  const stage = stages.find((s) => s.id === deal.stage_id);
+  return (
+    <dl className="deal-facts">
+      <div className="deal-facts-item">
+        <dt>{t("deals.amount")}</dt>
+        <dd>{amount(deal, masked, locale)}</dd>
+      </div>
+      <div className="deal-facts-item">
+        <dt>{t("deals.stage")}</dt>
+        {/* An em dash rather than the stage id: a deal in overlay mode carries
+            no native pipeline row, and printing a UUID where a stage name goes
+            reads as a fault. */}
+        <dd>{stage?.name ?? "—"}</dd>
+      </div>
+      <div className="deal-facts-item">
+        <dt>{t("list.owner")}</dt>
+        <dd>{owner(deal, roster, partial, t)}</dd>
+      </div>
+    </dl>
+  );
+}
+
+// The value, or the reason it is not shown. A rep who may read the deal but
+// not its amount sees the field named and masked, which is what the subtitle
+// did before this box took the amount over.
+function amount(
+  deal: Deal,
+  masked: readonly string[],
+  locale: Locale,
+): React.ReactNode {
+  if (masked.includes("amount_minor")) {
+    return <FieldGuard mode="masked" />;
+  }
+  if (deal.amount_minor == null || !deal.currency) {
+    return "—";
+  }
+  return formatMoney(deal.amount_minor, deal.currency, locale);
+}
+
+// Who owns it. An unowned deal says so rather than showing a blank, and a
+// roster that has not answered says which of the three silences it is —
+// still reading, read failed, or walked short of this user.
+function owner(
+  deal: Deal,
+  roster: ReturnType<typeof useRoster>,
+  partial: boolean,
+  t: ReturnType<typeof useT>,
+): string {
+  if (!deal.owner_id) {
+    return t("co.pulse.unowned");
+  }
+  // `"display_name" in entry` is the roster's own discriminant: the list is
+  // users AND teams, and a deal is owned by a user.
+  const found = (roster.data ?? []).find(
+    (entry) => "display_name" in entry && entry.id === deal.owner_id,
+  );
+  if (found && "display_name" in found) {
+    return found.display_name;
+  }
+  return rosterMissLabel(roster, partial, t, t("ref.notInRoster"));
+}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -83,6 +83,7 @@ import type { CreateField } from "./create";
 import { CreateAction } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
+import { DealFacts } from "./deal360/dealfacts";
 import { DealPulse } from "./deal360/dealpulse";
 import { DealSeats } from "./deal360/dealseats";
 import { DealStrip } from "./deal360/dealstrip";
@@ -3054,10 +3055,7 @@ type DealTab = (typeof DEAL_TABS)[number];
  * the record — and withholds both when the reader may not open it, which is
  * why the ids are not printed as a fallback.
  */
-function DealSubtitle({
-  deal,
-  locale,
-}: Readonly<{ deal: Deal; locale: Locale }>) {
+function DealSubtitle({ deal }: Readonly<{ deal: Deal }>) {
   const t = useT();
   // Joined with a visible separator rather than left as bare adjacent spans:
   // record-sub is a plain text line with no gap of its own, so three spans
@@ -3070,15 +3068,9 @@ function DealSubtitle({
   // and the partner are three different things to be refused.
   const masked = deal.masked_fields ?? [];
   const facts: ReactNode[] = [];
-  if (masked.includes("amount_minor")) {
-    facts.push(
-      <>
-        {t("deals.amount")} <FieldGuard mode="masked" />
-      </>,
-    );
-  } else if (deal.amount_minor != null && deal.currency) {
-    facts.push(formatMoney(deal.amount_minor, deal.currency, locale));
-  }
+  // The amount is NOT here. It has a labelled row in DealFacts beside the
+  // name, and it was previously rendered twice in one header — unlabelled
+  // here and again as THE MONEY reading.
   if (masked.includes("organization_id")) {
     facts.push(
       <>
@@ -3461,8 +3453,12 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
           return (
             <RecordView
               name={deal.name}
-              subtitle={<DealSubtitle deal={deal} locale={locale} />}
+              subtitle={<DealSubtitle deal={deal} />}
               zone={recordZone}
+              controls={
+                <DealFacts deal={deal} stages={stages} locale={locale} />
+              }
+              actionsInline
               badges={
                 <DealBadges
                   deal={deal}


### PR DESCRIPTION
## What was wrong

A deal created today with four named contacts said:

> Nothing has been logged on this deal yet — agree the next step.

That restates the empty timeline the reader is looking at. Beside it sat two warning chips, and the readings strip said **"a champion is named"** while the chips said **"No engaged champion"** — both true, on one screen, reading as a fault.

Four causes, all fixed here.

## 1. The advice names a person

`facts` carried the deal, its health, timeline, tasks and room — but not the seats. So the card could not say the one useful thing about an untouched deal, even though the coverage chips directly above it were already reading exactly that.

`compose/dealstatusseam.go` binds the card to the **same assembler** those chips use (`network.CoverageFor`), so the two cannot disagree about who is on the deal. Names come from `people.PersonNamesTx`, which carries both halves of the person gate.

The same deal now reads:

> 3 people are named on this deal and none has been contacted. Open with Roland Martinez, the champion.

The **blocker is not an opening role**. Telling a rep to open a deal by writing to the person most likely to refuse it is worse than saying nothing, and a test pins that.

## 2. The model is not asked when its answer cannot survive

Every story sentence must cite the timeline or the open tasks, and `ParseStatus` refuses a reply whose story is then empty. On a deal with neither, the model's answer was **discarded whatever it said** — so the call bought a model round-trip and up to 15s of the reader's wait to arrive at the floor already in hand.

Same card, served at once. This is a refusal to ask, not a new degrade.

## 3. Two risk rules wait for the first touch

`single_threaded_theirs` and `coverage_gap` both read "engaged", which requires a two-way exchange — so before any contact every seat is unengaged by construction and both fired on **100% of new deals**.

This is the guard `ourSideMinInteractions` already applies a few lines away, for the same stated reason: *"a young deal rather than a concentrated one"*.

It also ends the contradiction: the chip and the strip disagreed only while the deal was untouched.

The hold is on **never touched**, not **not touched lately** — a deal last touched 120 days ago still reports both findings, and a test says so.

## 4. The header carries value, stage and owner

The owner was on **no part of the page** — not the header, not the rail, not the readings — so whose deal it is could only be answered by opening Edit. The amount was rendered twice instead, and is now once.

Read-only on purpose: a control that looks editable and only navigates is worse than a label. It uses RecordView's existing `controls` slot, the same one the company page puts its standing in.

## Review

Codex found one MAJOR, fixed here: `move` wrapped whatever map it was given, so the new move's nil arguments became `"arguments": null` on the wire, where the contract types the field as an object. Fixed in `move` rather than the call site, and the test asserts the **marshalled bytes** — a test on the Go value cannot see this defect at all.

Its other five checks came back clean, including the two I most wanted checked: seat names cannot reach a caller without `person:read`, and the per-reader cache cannot serve a named card to a reader who may not see names (the seat facts flow into the fingerprint through the move's reason).

## Gates

`make check-backend` 0, `make check-fe` 0 (4,503 tests), `make craft-static` clean, 15 stories render — re-run after rebasing onto current main.

Every new test was checked against the mutation it exists to catch. The role-vocabulary gate was checked by planting the defect it guards, and it was **narrowed after its first run** because it could not tell a wire value from an English word that happens to match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advises the first outreach on untouched deals and shows value, stage, and owner in the deal header. Fixes contradictory chips vs. strip, removes model calls that could not influence the card, and defers engagement-risk chips until the first captured touch.

- Backend
  - First outreach: picks the best available role in order (champion, economic buyer, decision-maker, influencer), never the blocker; reads seats from the same assembler the coverage chips use (`network.CoverageFor`) and names people only when `person:read` permits; role wire values are centralized and gated by a test; `move` now always serializes `arguments` as `{}` for verbs with no operand.
  - Model calls are skipped when there is nothing to cite (no timeline, no open tasks); the deterministic floor is served immediately instead of discarding the lane’s reply.
  - Engagement risks (`single_threaded_theirs`, `coverage_gap`) wait for `EverTouched`; both still report on long-silent deals.

- Frontend
  - New `DealFacts` control in the header shows amount (once), stage name, and owner; falls back to a mask indicator for withheld amounts, an em dash for unknown stage, and “Unassigned” for no owner; read-only by design.
  - Subtitle no longer repeats the amount; stories/tests cover header facts and roster resolution.

<sup>Written for commit 05f93ef661db2ffd63ecdbb1569a95b62dca2073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deal facts to record headers, including amount, stage, and owner details.
  - Added stakeholder-aware first outreach recommendations for open deals.
  - Added role and engagement information to deal status evaluation.
- **Bug Fixes**
  - Suppressed unsupported engagement risks and outreach suggestions before a deal’s first contact.
  - Improved handling of missing, masked, unnamed, or unavailable deal information.
  - Ensured empty move arguments are represented consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->