### PR TITLE
refactor(records): every organization rename asks whether it made a duplicate

### DIFF
--- a/backend/callgraph_test.go
+++ b/backend/callgraph_test.go
@@ -38,6 +38,75 @@ type graphFunc struct {
 	statements []string
 	calls      map[string]bool
 	reads      map[string]bool
+	// shadowed are names this function DECLARES, so a read of one is a read of
+	// its own binding and not of the package value that happens to share the
+	// spelling.
+	shadowed map[string]bool
+}
+
+// declaredNames collects every identifier a function binds: its parameters and
+// named results, and everything a `:=`, a `var`, a `range` or a type switch
+// introduces in its body.
+//
+// It does not model SCOPE — a name declared inside one block shadows the
+// package value for the whole function as far as this is concerned. That is the
+// conservative direction for the privacy census, which compares two sides and
+// would rather miss a statement on both than add one to the side that does not
+// write it, and it costs the rename census a writer only if somebody names a
+// local after a package-level SQL variable.
+func declaredNames(fn *ast.FuncDecl) map[string]bool {
+	names := map[string]bool{}
+	add := func(expr ast.Expr) {
+		if ident, ok := expr.(*ast.Ident); ok && ident.Name != "_" {
+			names[ident.Name] = true
+		}
+	}
+	for _, list := range []*ast.FieldList{fn.Type.Params, fn.Type.Results} {
+		if list == nil {
+			continue
+		}
+		for _, field := range list.List {
+			for _, name := range field.Names {
+				add(name)
+			}
+		}
+	}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		switch v := node.(type) {
+		case *ast.AssignStmt:
+			if v.Tok == token.DEFINE {
+				for _, lhs := range v.Lhs {
+					add(lhs)
+				}
+			}
+		case *ast.ValueSpec:
+			for _, name := range v.Names {
+				add(name)
+			}
+		case *ast.RangeStmt:
+			add(v.Key)
+			add(v.Value)
+		case *ast.TypeSwitchStmt:
+			if assign, ok := v.Assign.(*ast.AssignStmt); ok {
+				for _, lhs := range assign.Lhs {
+					add(lhs)
+				}
+			}
+		case *ast.FuncLit:
+			for _, list := range []*ast.FieldList{v.Type.Params, v.Type.Results} {
+				if list == nil {
+					continue
+				}
+				for _, field := range list.List {
+					for _, name := range field.Names {
+						add(name)
+					}
+				}
+			}
+		}
+		return true
+	})
+	return names
 }
 
 // packageCallGraph reads one package's product files, keyed by RECEIVER TYPE
@@ -68,6 +137,13 @@ func packageCallGraph(t *testing.T, dir string) map[string]*graphFunc {
 			}
 			recvType, recvVar := receiverTypeName(fn), receiverVarName(fn)
 			entry := &graphFunc{calls: map[string]bool{}, reads: map[string]bool{}}
+			// What this function DECLARES is its own, whatever the package
+			// calls something of the same name. Attributing by spelling alone
+			// handed a package-level statement to any function with a local of
+			// that name — a false writer here, and worse in the privacy census,
+			// where an unrelated shadow adds a table to the side that does NOT
+			// clear it and so hides a real divergence.
+			shadowed := declaredNames(fn)
 			ast.Inspect(fn.Body, func(node ast.Node) bool {
 				// Through the package's shared value reader, so a statement
 				// written in double quotes with escapes decodes rather than
@@ -96,15 +172,21 @@ func packageCallGraph(t *testing.T, dir string) map[string]*graphFunc {
 				}
 				return true
 			})
+			entry.shadowed = shadowed
 			graph[scrubKey(recvType, fn.Name.Name)] = entry
 		}
 	}
-	// A named statement counts for whoever names it, wherever it lives.
+	// A named statement counts for whoever names it, wherever it lives —
+	// unless that function declared the name itself, in which case it is not
+	// the package's value being named.
 	for _, entry := range graph {
 		for name := range entry.calls {
 			entry.statements = append(entry.statements, held[name]...)
 		}
 		for name := range entry.reads {
+			if entry.shadowed[name] {
+				continue
+			}
 			entry.statements = append(entry.statements, held[name]...)
 		}
 	}
@@ -204,22 +286,28 @@ func receiverVarName(fn *ast.FuncDecl) string {
 // guardedBy reports whether EVERY route to this function passes through one
 // that calls target directly.
 //
-// Existential reachability was the first attempt and it was worthless: "some
-// ancestor of this writer can also reach the re-check" is true of nearly every
-// function in a package that calls the re-check from seven places, so the gate
-// passed with the re-check deleted from BOTH real call sites. Mutation testing
-// is the only reason that is known.
+// The rule is UNIVERSAL, and existential reachability is the trap it avoids:
+// "some ancestor of this writer can also reach target" is true of nearly every
+// function in a package that calls target from several places, so a gate built
+// that way passes with target deleted from every real call site.
 //
-// So the rule is universal instead. A function is guarded when it calls target
+// A function is guarded when it calls target
 // itself, or when it has callers and all of them are guarded. A function with
 // NO callers is an entry point: if it has not called target by then, nothing
 // will, and the write escapes.
 //
-// A cycle is treated as guarded while it is on the stack, which is the only
-// terminating answer and leaves one hole worth naming: a writer that reaches
-// itself and is guarded nowhere else would pass. Nothing in this tree does that
-// today, and the alternative — reporting every recursive function — would be a
-// gate nobody reads.
+// TWO HOLES, both real and neither reported by this function:
+//
+//   - A cycle is treated as guarded while it is on the stack, which is the only
+//     terminating answer. A writer that reaches itself and is guarded nowhere
+//     else therefore passes — a retry loop is the shape that does it.
+//   - "Calls target" is per FUNCTION, not per path. A caller whose two arms are
+//     mutually exclusive — re-check on one, the write on the other — ratifies
+//     the write, and an INCOMING edge this graph cannot follow (a call through
+//     a stored func value) bypasses every guard it did verify.
+//
+// Neither is fixable at this grain; both are named here rather than in a pull
+// request, because this is where the next reader is.
 func guardedBy(graph map[string]*graphFunc, name, target string) bool {
 	callers := map[string][]string{}
 	for caller, entry := range graph {

--- a/backend/callgraph_test.go
+++ b/backend/callgraph_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The call graph two censuses share: which SQL statements a function can reach
+// and which functions it can call, keyed so a method is told from a plain
+// function of the same name.
+//
+// It lives on its own because there are two callers now — the privacy census
+// (which tables an erase and an anonymize each clear) and the organization
+// rename census (whether every name write reaches the duplicate re-check) — and
+// a graph copied for the second drifts from the first. The narrower copy then
+// walks a smaller tree and says PASS, which is the failure a census cannot
+// report about itself.
+//
+// It yields STATEMENTS rather than tables: what a statement means is the
+// caller's question, and the privacy census's answer (which tables it writes)
+// is not the rename census's (whether it sets a name column).
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// graphFunc is one function's reach: the statements its body can read, the
+// functions it calls, and the identifiers it merely NAMES.
+//
+// `reads` is not redundant with `calls`. A statement held in a package-level
+// var reaches the function that executes it by name alone, and a census that
+// followed only calls attributed that statement to nobody.
+type graphFunc struct {
+	statements []string
+	calls      map[string]bool
+	reads      map[string]bool
+}
+
+// packageCallGraph reads one package's product files, keyed by RECEIVER TYPE
+// and name, and returns the graph alongside the statements held in
+// package-level `var`/`const` declarations.
+//
+// Bare names are not enough. `apply` is a method on one service and also a
+// plausible name elsewhere; following calls by name alone once walked from the
+// privacy eraser into the policy store and reported a table an erase does not
+// clear. So an edge is followed only when it can be resolved: a plain function,
+// or a method called on the CALLER'S OWN receiver.
+//
+// AN UNFOLLOWED EDGE IS NOT SAFE. A call on a stored field, an interface or a
+// closure is a real limit, and the honest thing to say about it is that it can
+// hide a statement from whichever caller takes that route — never that the
+// route carries nothing.
+func packageCallGraph(t *testing.T, dir string) (map[string]*graphFunc, map[string][]string) {
+	t.Helper()
+	files := parsePackageFiles(t, dir)
+	held := packageLevelStatements(files)
+	graph := map[string]*graphFunc{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			recvType, recvVar := receiverTypeName(fn), receiverVarName(fn)
+			entry := &graphFunc{calls: map[string]bool{}, reads: map[string]bool{}}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				// Through the package's shared value reader, so a statement
+				// written in double quotes with escapes decodes rather than
+				// being matched as source text, and one assembled with `+` is
+				// read whole.
+				if expr, isExpr := node.(ast.Expr); isExpr {
+					if statement, readable := stringValue(expr, nil); readable {
+						entry.statements = append(entry.statements, statement)
+					}
+				}
+				if ident, isIdent := node.(*ast.Ident); isIdent {
+					entry.reads[ident.Name] = true
+				}
+				call, isCall := node.(*ast.CallExpr)
+				if !isCall {
+					return true
+				}
+				switch fun := call.Fun.(type) {
+				case *ast.Ident:
+					entry.calls[fun.Name] = true
+				case *ast.SelectorExpr:
+					if base, isIdent := fun.X.(*ast.Ident); isIdent &&
+						recvVar != "" && base.Name == recvVar {
+						entry.calls[scrubKey(recvType, fun.Sel.Name)] = true
+					}
+				}
+				return true
+			})
+			graph[scrubKey(recvType, fn.Name.Name)] = entry
+		}
+	}
+	// A named statement counts for whoever names it, wherever it lives.
+	for _, entry := range graph {
+		for name := range entry.calls {
+			entry.statements = append(entry.statements, held[name]...)
+		}
+		for name := range entry.reads {
+			entry.statements = append(entry.statements, held[name]...)
+		}
+	}
+	return graph, held
+}
+
+// parsePackageFiles reads a package's product files once.
+func parsePackageFiles(t *testing.T, dir string) []*ast.File {
+	t.Helper()
+	sources, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("listing %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", path, parseErr)
+		}
+		files = append(files, file)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no product source found under %s, so this census covered nothing", dir)
+	}
+	return files
+}
+
+// packageLevelStatements are the SQL statements each package-level `var`/`const`
+// holds, keyed by the name that holds them.
+func packageLevelStatements(files []*ast.File) map[string][]string {
+	held := map[string][]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, isGen := decl.(*ast.GenDecl)
+			if !isGen || (gen.Tok != token.VAR && gen.Tok != token.CONST) {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, isValue := spec.(*ast.ValueSpec)
+				if !isValue {
+					continue
+				}
+				// A spec whose names and values do not align one-to-one binds no
+				// statement this can read — `var a, b = twoResults()` keeps one
+				// expression for two names. Skipped whole rather than by index,
+				// so the second name is not silently dropped while the first is
+				// read against a value that is not its own.
+				if len(value.Names) != len(value.Values) {
+					continue
+				}
+				for i, name := range value.Names {
+					// Every string LITERAL in the value, not the folded whole.
+					// These statements are assembled — a raw string plus a
+					// helper's output — so folding them returns nothing, and a
+					// reader that gave up on the fold gave up on the statement.
+					ast.Inspect(value.Values[i], func(node ast.Node) bool {
+						literal, isLiteral := node.(*ast.BasicLit)
+						if !isLiteral || literal.Kind != token.STRING {
+							return true
+						}
+						statement, readable := strconv.Unquote(literal.Value)
+						if readable != nil {
+							return true
+						}
+						held[name.Name] = append(held[name.Name], statement)
+						return true
+					})
+				}
+			}
+		}
+	}
+	return held
+}
+
+// scrubKey keys a method by its receiver type and a plain function by itself.
+func scrubKey(receiver, name string) string {
+	if receiver == "" {
+		return name
+	}
+	return receiver + "." + name
+}
+
+// receiverVarName is what a method calls its own receiver, so a call on it can
+// be told from a call on anything else. This package's receiverTypeName already
+// gives the type; only the variable was missing.
+func receiverVarName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 || len(fn.Recv.List[0].Names) == 0 {
+		return ""
+	}
+	return fn.Recv.List[0].Names[0].Name
+}
+
+// reachesFromAnyCaller reports whether the function itself, or anything that can
+// call it, gets to target.
+//
+// The caller matters because the obligation often sits one level up: coldstart's
+// column writers move a name and the duplicate re-check runs in the function
+// that drove them, which is the right place for it — the re-check needs to know
+// whether a name moved at all, and only the caller collecting the applied
+// fields knows that.
+//
+// This is coarse on purpose, and the coarseness is worth stating: an ancestor
+// that calls the re-check on a branch that never reaches this writer still
+// counts. It is the same grain the privacy census uses, and the alternative —
+// path-sensitivity — asks the graph for something these unresolvable edges
+// cannot support. What it still catches is the case worth catching: a writer
+// with NOTHING above it that has ever heard of the re-check.
+func reachesFromAnyCaller(graph map[string]*graphFunc, name, target string) bool {
+	if reaches(graph, name, target) {
+		return true
+	}
+	for caller := range graph {
+		if caller == name {
+			continue
+		}
+		if reaches(graph, caller, name) && reaches(graph, caller, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// reaches reports whether root can get to target through resolvable edges.
+func reaches(graph map[string]*graphFunc, root, target string) bool {
+	seen := map[string]bool{}
+	var walk func(string) bool
+	walk = func(name string) bool {
+		if name == target {
+			return true
+		}
+		if seen[name] {
+			return false
+		}
+		seen[name] = true
+		entry, known := graph[name]
+		if !known {
+			return false
+		}
+		for called := range entry.calls {
+			if walk(called) {
+				return true
+			}
+		}
+		return false
+	}
+	return walk(root)
+}

--- a/backend/callgraph_test.go
+++ b/backend/callgraph_test.go
@@ -42,6 +42,16 @@ type graphFunc struct {
 	// its own binding and not of the package value that happens to share the
 	// spelling.
 	shadowed map[string]bool
+	// hidden are package-level names this function both declares AND reads,
+	// where the package value holds statements. Suppression is function-wide
+	// rather than lexical, so a `query := …` inside one block silences a read of
+	// the package's `query` in another — and for a census asking "does this
+	// function write X" that is the direction that MISSES a writer.
+	//
+	// So the approximation reports itself. A caller can ask whether its verdict
+	// rests on a name it could not read, instead of the walk deciding quietly
+	// that it did not matter.
+	hidden []string
 }
 
 // declaredNames collects every identifier a function binds: its parameters and
@@ -185,6 +195,9 @@ func packageCallGraph(t *testing.T, dir string) map[string]*graphFunc {
 		}
 		for name := range entry.reads {
 			if entry.shadowed[name] {
+				if len(held[name]) > 0 {
+					entry.hidden = append(entry.hidden, held[name]...)
+				}
 				continue
 			}
 			entry.statements = append(entry.statements, held[name]...)

--- a/backend/callgraph_test.go
+++ b/backend/callgraph_test.go
@@ -41,8 +41,9 @@ type graphFunc struct {
 }
 
 // packageCallGraph reads one package's product files, keyed by RECEIVER TYPE
-// and name, and returns the graph alongside the statements held in
-// package-level `var`/`const` declarations.
+// and name. Statements held in package-level `var`/`const` declarations are
+// folded into whichever function NAMES them, so a caller sees one set of
+// statements rather than having to join two.
 //
 // Bare names are not enough. `apply` is a method on one service and also a
 // plausible name elsewhere; following calls by name alone once walked from the
@@ -54,7 +55,7 @@ type graphFunc struct {
 // closure is a real limit, and the honest thing to say about it is that it can
 // hide a statement from whichever caller takes that route — never that the
 // route carries nothing.
-func packageCallGraph(t *testing.T, dir string) (map[string]*graphFunc, map[string][]string) {
+func packageCallGraph(t *testing.T, dir string) map[string]*graphFunc {
 	t.Helper()
 	files := parsePackageFiles(t, dir)
 	held := packageLevelStatements(files)
@@ -107,7 +108,7 @@ func packageCallGraph(t *testing.T, dir string) (map[string]*graphFunc, map[stri
 			entry.statements = append(entry.statements, held[name]...)
 		}
 	}
-	return graph, held
+	return graph
 }
 
 // parsePackageFiles reads a package's product files once.
@@ -200,58 +201,66 @@ func receiverVarName(fn *ast.FuncDecl) string {
 	return fn.Recv.List[0].Names[0].Name
 }
 
-// reachesFromAnyCaller reports whether the function itself, or anything that can
-// call it, gets to target.
+// guardedBy reports whether EVERY route to this function passes through one
+// that calls target directly.
 //
-// The caller matters because the obligation often sits one level up: coldstart's
-// column writers move a name and the duplicate re-check runs in the function
-// that drove them, which is the right place for it — the re-check needs to know
-// whether a name moved at all, and only the caller collecting the applied
-// fields knows that.
+// Existential reachability was the first attempt and it was worthless: "some
+// ancestor of this writer can also reach the re-check" is true of nearly every
+// function in a package that calls the re-check from seven places, so the gate
+// passed with the re-check deleted from BOTH real call sites. Mutation testing
+// is the only reason that is known.
 //
-// This is coarse on purpose, and the coarseness is worth stating: an ancestor
-// that calls the re-check on a branch that never reaches this writer still
-// counts. It is the same grain the privacy census uses, and the alternative —
-// path-sensitivity — asks the graph for something these unresolvable edges
-// cannot support. What it still catches is the case worth catching: a writer
-// with NOTHING above it that has ever heard of the re-check.
-func reachesFromAnyCaller(graph map[string]*graphFunc, name, target string) bool {
-	if reaches(graph, name, target) {
-		return true
-	}
-	for caller := range graph {
-		if caller == name {
-			continue
+// So the rule is universal instead. A function is guarded when it calls target
+// itself, or when it has callers and all of them are guarded. A function with
+// NO callers is an entry point: if it has not called target by then, nothing
+// will, and the write escapes.
+//
+// A cycle is treated as guarded while it is on the stack, which is the only
+// terminating answer and leaves one hole worth naming: a writer that reaches
+// itself and is guarded nowhere else would pass. Nothing in this tree does that
+// today, and the alternative — reporting every recursive function — would be a
+// gate nobody reads.
+func guardedBy(graph map[string]*graphFunc, name, target string) bool {
+	callers := map[string][]string{}
+	for caller, entry := range graph {
+		for called := range entry.calls {
+			callers[called] = append(callers[called], caller)
 		}
-		if reaches(graph, caller, name) && reaches(graph, caller, target) {
+	}
+	verdict := map[string]bool{}
+	onStack := map[string]bool{}
+	var guarded func(string) bool
+	guarded = func(fn string) bool {
+		if known, seen := verdict[fn]; seen {
+			return known
+		}
+		if onStack[fn] {
 			return true
 		}
-	}
-	return false
-}
-
-// reaches reports whether root can get to target through resolvable edges.
-func reaches(graph map[string]*graphFunc, root, target string) bool {
-	seen := map[string]bool{}
-	var walk func(string) bool
-	walk = func(name string) bool {
-		if name == target {
-			return true
-		}
-		if seen[name] {
-			return false
-		}
-		seen[name] = true
-		entry, known := graph[name]
+		entry, known := graph[fn]
 		if !known {
 			return false
 		}
-		for called := range entry.calls {
-			if walk(called) {
-				return true
+		if entry.calls[target] {
+			verdict[fn] = true
+			return true
+		}
+		up := callers[fn]
+		if len(up) == 0 {
+			verdict[fn] = false
+			return false
+		}
+		onStack[fn] = true
+		all := true
+		for _, caller := range up {
+			if !guarded(caller) {
+				all = false
+				break
 			}
 		}
-		return false
+		delete(onStack, fn)
+		verdict[fn] = all
+		return all
 	}
-	return walk(root)
+	return guarded(name)
 }

--- a/backend/internal/modules/people/companyform.go
+++ b/backend/internal/modules/people/companyform.go
@@ -79,12 +79,22 @@ func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 		}
 		applied[field] = trimmed
 	}
-	// A legal name is the axis on which two records of one company converge, and
-	// this function is the only writer of that column a human drives — through
-	// the company form AND through a site-read confirmation, which is why the
-	// re-check lives here rather than at either call site. Both callers took the
-	// name lock in resolveOrCreateAnchor, ahead of the row lock, so the ordering
-	// already holds.
+	// A legal name is the axis on which two records of one company converge, so
+	// a rename has to ask whether it just created a duplicate.
+	//
+	// The re-check lives here rather than at either call site because BOTH of
+	// this function's callers need it — the company form and a site-read
+	// confirmation — and both took the name lock in resolveOrCreateAnchor ahead
+	// of the row lock, so the ordering already holds.
+	//
+	// It is NOT the only writer that a person sets in motion: accepting a
+	// coldstart read-back renames the same column through writeOrgColumn, and
+	// re-checks there. Seven call sites of recheckOrgNameForDuplicates each
+	// remembered the rule on their own, which is why the rule is now derived
+	// from the tree instead of asserted here.
+	//
+	// Held by: TestEveryOrganizationRenameReachesTheDuplicateRecheck
+	// (backend/orgrenamerecheck_test.go)
 	if renamed {
 		if err := recheckOrgNameForDuplicates(ctx, tx, orgID, by); err != nil {
 			return nil, err

--- a/backend/orgrenamerecheck_test.go
+++ b/backend/orgrenamerecheck_test.go
@@ -58,7 +58,7 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 	// fixed, and leaving it in place quietly re-exempts whatever takes its name.
 	defer remembersTheRecheckItself.AssertAllMatched(t)
 
-	graph, _ := packageCallGraph(t, peoplePackage)
+	graph := packageCallGraph(t, peoplePackage)
 	if _, known := graph[renameRecheck]; !known {
 		t.Fatalf("%s is not in the graph, so every writer would trivially fail to reach it — "+
 			"the re-check has been renamed or moved out of %s", renameRecheck, peoplePackage)
@@ -75,7 +75,7 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 			continue
 		}
 		writers++
-		if reachesFromAnyCaller(graph, name, renameRecheck) || remembersTheRecheckItself.Waived(t, name) {
+		if guardedBy(graph, name, renameRecheck) || remembersTheRecheckItself.Waived(t, name) {
 			continue
 		}
 		findings = append(findings, fmt.Sprintf("%s\n      %s", name, statement))
@@ -88,12 +88,12 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 			writers, organizationName)
 	}
 	if len(findings) > 0 {
-		t.Errorf("these functions rename an organization without reaching %s:\n    %s\n\n"+
+		t.Errorf("these functions rename an organization, and no route to them calls %s:\n    %s\n\n"+
 			"A name is the axis on which two records of one company converge — PO-F-2 has nothing to "+
 			"compare until one is filled in. A rename that skips the re-check leaves the duplicate it "+
 			"just created with nothing to notice it. Call the re-check, or ratify the writer here with "+
 			"the reason it does not need to.",
-			strings.Join(findings, "\n    "), renameRecheck)
+			renameRecheck, strings.Join(findings, "\n    "))
 	}
 }
 

--- a/backend/orgrenamerecheck_test.go
+++ b/backend/orgrenamerecheck_test.go
@@ -69,15 +69,25 @@ var assemblesAnOrganizationUpdate = regexp.MustCompile(`(?is)UPDATE\s+organizati
 // by stripping quotes first; an escaped quote (`”`) closes and reopens, which
 // is the same result for this purpose.
 func withoutSQLNoise(statement string) string {
+	statement = sqlDollarQuoted.ReplaceAllString(statement, "$$$$")
 	statement = sqlQuoted.ReplaceAllString(statement, "''")
+	statement = sqlBlockComment.ReplaceAllString(statement, " ")
 	return sqlLineComment.ReplaceAllString(statement, "")
 }
 
-// sqlQuoted is a single-quoted literal's body. The comment half of the job is
-// versionguard_test.go's sqlLineComment, which already strips `-- …` for the
-// same reason and is in this package — a second spelling of it here would be
-// two answers to one question.
-var sqlQuoted = regexp.MustCompile(`'[^']*'`)
+// The non-code regions of a statement, stripped widest-first: a `--` inside a
+// block comment is not a line comment, and a `;` inside any of them does not end
+// the statement. `UPDATE organization /* ; */ SET legal_name = $1` was read as
+// ending at that semicolon and so was not a rename at all.
+//
+// The line-comment half is versionguard_test.go's sqlLineComment, which already
+// strips `-- …` for the same reason and is in this package — a second spelling
+// of it here would be two answers to one question.
+var (
+	sqlQuoted       = regexp.MustCompile(`'[^']*'`)
+	sqlBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	sqlDollarQuoted = regexp.MustCompile(`(?s)\$([A-Za-z_]\w*)?\$.*?\$([A-Za-z_]\w*)?\$`)
+)
 
 // remembersTheRecheckItself ratifies a writer that cannot reach the re-check
 // through an edge this graph can follow.
@@ -99,11 +109,14 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 			"the re-check has been renamed or moved out of %s", renameRecheck, peoplePackage)
 	}
 
-	var findings []string
+	var findings, unreadable []string
 	writers, named, assembled := 0, 0, 0
 	for name, entry := range graph {
 		if name == renameRecheck {
 			continue
+		}
+		if statement, hiddenRename := firstRenameStatement(entry.hidden); hiddenRename {
+			unreadable = append(unreadable, fmt.Sprintf("%s\n      %s", name, statement))
 		}
 		statement, renames := firstRenameStatement(entry.statements)
 		if !renames {
@@ -133,6 +146,15 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 			"reaches a function has stopped working rather than the tree having changed",
 			named, assembled, writers)
 	}
+	if len(unreadable) > 0 {
+		t.Errorf("these functions declare a local with the same name as a package-level "+
+			"statement that renames an organization, so this census could not tell which one "+
+			"they read:\n    %s\n\n"+
+			"Suppression here is per FUNCTION rather than per block, which is the direction "+
+			"that misses a writer — so it is reported instead of assumed harmless. Rename the "+
+			"local, or rename the package value.",
+			strings.Join(unreadable, "\n    "))
+	}
 	if len(findings) > 0 {
 		t.Errorf("these functions rename an organization, and no route to them calls %s:\n    %s\n\n"+
 			"A name is the axis on which two records of one company converge — PO-F-2 has nothing to "+
@@ -155,4 +177,52 @@ func firstRenameStatement(statements []string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// The detector reads STATEMENTS, and a statement carries prose. These are the
+// shapes that fooled it, kept because the census above is a census of zero once
+// the tree is clean: it reads the same over a clean tree and over a detector
+// that has stopped detecting.
+func TestTheRenameDetectorReadsSQLAndNotProse(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		sql    string
+		reads  bool
+		reason string
+	}{
+		{
+			"a semicolon inside a block comment", "UPDATE organization /* ; */ SET legal_name = $1", true,
+			"the scan stopped at a semicolon that ends nothing, so a real rename went unseen",
+		},
+		{
+			"a semicolon inside a line comment", "UPDATE organization -- ;\n SET legal_name = $1", true,
+			"same, with the comment spelled the other way",
+		},
+		{
+			"a semicolon inside a dollar-quoted body", "UPDATE organization SET legal_name = $tag$ ; $tag$", true,
+			"a dollar-quoted literal is a body, not the end of a statement",
+		},
+		{
+			"a column named only inside a comment", "UPDATE organization SET description = $1 -- legal_name =", false,
+			"a rename mentioned in prose is not a rename, and reporting it teaches readers to skip this gate",
+		},
+		{
+			"a column named only inside a string", "UPDATE organization SET description = 'legal_name = x'", false,
+			"same, inside a literal the database stores rather than executes",
+		},
+		{
+			"the column assembled by the caller", "UPDATE organization SET ", true,
+			"the fragment names no column because the caller supplies it; the gate asks anyway",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			readable := withoutSQLNoise(tc.sql)
+			got := setsAnOrganizationName.MatchString(readable) ||
+				assemblesAnOrganizationUpdate.MatchString(readable)
+			if got != tc.reads {
+				t.Errorf("reads as an organization rename = %v, want %v — %s\n  raw:      %q\n  stripped: %q",
+					got, tc.reads, tc.reason, tc.sql, readable)
+			}
+		})
+	}
 }

--- a/backend/orgrenamerecheck_test.go
+++ b/backend/orgrenamerecheck_test.go
@@ -6,13 +6,11 @@ package backendarch
 // A company's NAME is the axis on which two records of one company converge, so
 // every rename has to ask whether it just created a duplicate.
 //
-// `companyform.go` said it was "the only writer of that column a human drives".
-// Its two callers are the ones it names — the company form and a site-read
-// confirmation — but it is not the only writer, and the claim invited the next
-// author to stop looking. `recheckOrgNameForDuplicates` has SEVEN independent
-// call sites, each of which had to remember the rule on its own; a rename that
-// forgot would leave two records of one company sitting beside each other with
-// nothing to notice.
+// `recheckOrgNameForDuplicates` is called from a handful of places that each had
+// to remember the rule on their own, and a comment on one of them said it was
+// "the only writer of that column a human drives" — which told the next author
+// the question was settled. A rename that forgot would leave two records of one
+// company sitting beside each other with nothing to notice.
 //
 // This holds the invariant instead of the claim: a function that can reach a
 // statement setting `organization.display_name` or `organization.legal_name`
@@ -38,11 +36,48 @@ const (
 // setsAnOrganizationName matches a statement that moves a name column.
 //
 // An UPDATE only. A CREATE is a different question and is answered elsewhere:
-// `resolveOrCreateOrganization` runs the dedupe match BEFORE it inserts and
-// refuses on a collision, so a row that reaches the INSERT has already been
-// compared against every existing name. Asking it to re-check afterwards would
-// be asking it to compare a row with itself.
+// every path to the one `INSERT INTO organization` (in `createOrganization`)
+// runs the PO-F-2 match first and refuses on a collision —
+// `DedupeOrganizationForCreate`, `resolveOrCreateAnchor` and
+// `manualDedupeOrganization` are the three that feed it. A row that reaches the
+// INSERT has therefore already been compared against every existing name, and
+// asking it to re-check afterwards would be asking it to compare a row with
+// itself.
 var setsAnOrganizationName = regexp.MustCompile(`(?is)UPDATE\s+organization\b[^;]*?\b(display_name|legal_name)\s*=`)
+
+// assemblesAnOrganizationUpdate matches an UPDATE whose COLUMN is a variable,
+// so the statement names no column for the pattern above to find.
+//
+// This is not hypothetical: organization_profile_field_write.go writes
+// `UPDATE organization SET ` + column + ` = $2`, and drives it with
+// "display_name" and "legal_name". The census could not see it as a writer at
+// all — so the promise that a new writer is a finding on the day it is written
+// was false for a shape the tree already contained, and the next author copies
+// what is there.
+//
+// A fragment ending at SET is judged like a named write: the gate cannot know
+// which column arrives, so it asks the same question it asks of one it can read.
+var assemblesAnOrganizationUpdate = regexp.MustCompile(`(?is)UPDATE\s+organization\b[^;]*?\bSET\s*$`)
+
+// withoutSQLNoise removes what a reader can see is not the statement: line
+// comments and single-quoted literals.
+//
+// Both directions were wrong without it. `SET description = $1 -- display_name =`
+// counted as a rename, and `SET description = 'legal_name = x'` did too; the
+// other way, a `;` INSIDE a comment ended the `[^;]*?` scan early and hid a real
+// `legal_name = $2` on the next line. A `--` inside a quoted literal is handled
+// by stripping quotes first; an escaped quote (`”`) closes and reopens, which
+// is the same result for this purpose.
+func withoutSQLNoise(statement string) string {
+	statement = sqlQuoted.ReplaceAllString(statement, "''")
+	return sqlLineComment.ReplaceAllString(statement, "")
+}
+
+// sqlQuoted is a single-quoted literal's body. The comment half of the job is
+// versionguard_test.go's sqlLineComment, which already strips `-- …` for the
+// same reason and is in this package — a second spelling of it here would be
+// two answers to one question.
+var sqlQuoted = regexp.MustCompile(`'[^']*'`)
 
 // remembersTheRecheckItself ratifies a writer that cannot reach the re-check
 // through an edge this graph can follow.
@@ -65,7 +100,7 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 	}
 
 	var findings []string
-	writers := 0
+	writers, named, assembled := 0, 0, 0
 	for name, entry := range graph {
 		if name == renameRecheck {
 			continue
@@ -75,6 +110,11 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 			continue
 		}
 		writers++
+		if assemblesAnOrganizationUpdate.MatchString(withoutSQLNoise(statement)) {
+			assembled++
+		} else {
+			named++
+		}
 		if guardedBy(graph, name, renameRecheck) || remembersTheRecheckItself.Waived(t, name) {
 			continue
 		}
@@ -83,9 +123,15 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 
 	// A census that judged nothing certifies nothing. The floor sits below the
 	// real count so it catches a broken walk rather than a changing tree.
-	if writers < 3 {
-		t.Fatalf("only %d function(s) were seen to write %s, so this census covered almost nothing",
-			writers, organizationName)
+	// Two floors, not one, because a single count hides which half of the walk
+	// broke. Deleting the package-level statement folding leaves three direct
+	// writers standing — enough to clear any one floor while an entire route to
+	// a statement has gone silent.
+	if named < 4 || assembled < 1 {
+		t.Fatalf("this census saw %d named-column writer(s) and %d assembled-column writer(s) "+
+			"(%d in total); it expects at least 4 and 1, so one of the two ways a statement "+
+			"reaches a function has stopped working rather than the tree having changed",
+			named, assembled, writers)
 	}
 	if len(findings) > 0 {
 		t.Errorf("these functions rename an organization, and no route to them calls %s:\n    %s\n\n"+
@@ -102,7 +148,9 @@ func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
 // can reach.
 func firstRenameStatement(statements []string) (string, bool) {
 	for _, statement := range statements {
-		if setsAnOrganizationName.MatchString(statement) {
+		readable := withoutSQLNoise(statement)
+		if setsAnOrganizationName.MatchString(readable) ||
+			assemblesAnOrganizationUpdate.MatchString(readable) {
 			return strings.Join(strings.Fields(statement), " "), true
 		}
 	}

--- a/backend/orgrenamerecheck_test.go
+++ b/backend/orgrenamerecheck_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A company's NAME is the axis on which two records of one company converge, so
+// every rename has to ask whether it just created a duplicate.
+//
+// `companyform.go` said it was "the only writer of that column a human drives".
+// Its two callers are the ones it names — the company form and a site-read
+// confirmation — but it is not the only writer, and the claim invited the next
+// author to stop looking. `recheckOrgNameForDuplicates` has SEVEN independent
+// call sites, each of which had to remember the rule on its own; a rename that
+// forgot would leave two records of one company sitting beside each other with
+// nothing to notice.
+//
+// This holds the invariant instead of the claim: a function that can reach a
+// statement setting `organization.display_name` or `organization.legal_name`
+// must be able to reach the re-check. That is derived from the tree rather than
+// maintained as a list, which is the point — a NEW writer is a finding on the
+// day it is written, without anybody remembering this file exists.
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	peoplePackage    = "internal/modules/people"
+	renameRecheck    = "recheckOrgNameForDuplicates"
+	organizationName = "organization.display_name / organization.legal_name"
+)
+
+// setsAnOrganizationName matches a statement that moves a name column.
+//
+// An UPDATE only. A CREATE is a different question and is answered elsewhere:
+// `resolveOrCreateOrganization` runs the dedupe match BEFORE it inserts and
+// refuses on a collision, so a row that reaches the INSERT has already been
+// compared against every existing name. Asking it to re-check afterwards would
+// be asking it to compare a row with itself.
+var setsAnOrganizationName = regexp.MustCompile(`(?is)UPDATE\s+organization\b[^;]*?\b(display_name|legal_name)\s*=`)
+
+// remembersTheRecheckItself ratifies a writer that cannot reach the re-check
+// through an edge this graph can follow.
+//
+// Empty, and that is the finding rather than an oversight: every writer in the
+// tree today reaches it. The map exists so that adding an entry is a visible
+// decision with a reason beside it, instead of a silent edit to the pattern
+// above — which is how a gate stops meaning anything.
+var remembersTheRecheckItself = gatekit.Waive(map[string]string{})
+
+func TestEveryOrganizationRenameReachesTheDuplicateRecheck(t *testing.T) {
+	// A ratification that stops matching covers a writer that has moved or been
+	// fixed, and leaving it in place quietly re-exempts whatever takes its name.
+	defer remembersTheRecheckItself.AssertAllMatched(t)
+
+	graph, _ := packageCallGraph(t, peoplePackage)
+	if _, known := graph[renameRecheck]; !known {
+		t.Fatalf("%s is not in the graph, so every writer would trivially fail to reach it — "+
+			"the re-check has been renamed or moved out of %s", renameRecheck, peoplePackage)
+	}
+
+	var findings []string
+	writers := 0
+	for name, entry := range graph {
+		if name == renameRecheck {
+			continue
+		}
+		statement, renames := firstRenameStatement(entry.statements)
+		if !renames {
+			continue
+		}
+		writers++
+		if reachesFromAnyCaller(graph, name, renameRecheck) || remembersTheRecheckItself.Waived(t, name) {
+			continue
+		}
+		findings = append(findings, fmt.Sprintf("%s\n      %s", name, statement))
+	}
+
+	// A census that judged nothing certifies nothing. The floor sits below the
+	// real count so it catches a broken walk rather than a changing tree.
+	if writers < 3 {
+		t.Fatalf("only %d function(s) were seen to write %s, so this census covered almost nothing",
+			writers, organizationName)
+	}
+	if len(findings) > 0 {
+		t.Errorf("these functions rename an organization without reaching %s:\n    %s\n\n"+
+			"A name is the axis on which two records of one company converge — PO-F-2 has nothing to "+
+			"compare until one is filled in. A rename that skips the re-check leaves the duplicate it "+
+			"just created with nothing to notice it. Call the re-check, or ratify the writer here with "+
+			"the reason it does not need to.",
+			strings.Join(findings, "\n    "), renameRecheck)
+	}
+}
+
+// firstRenameStatement returns the statement that moves a name column, so the
+// report points at the statement rather than dumping every string the function
+// can reach.
+func firstRenameStatement(statements []string) (string, bool) {
+	for _, statement := range statements {
+		if setsAnOrganizationName.MatchString(statement) {
+			return strings.Join(strings.Fields(statement), " "), true
+		}
+	}
+	return "", false
+}

--- a/backend/orgrenamerecheck_test.go
+++ b/backend/orgrenamerecheck_test.go
@@ -71,7 +71,7 @@ var assemblesAnOrganizationUpdate = regexp.MustCompile(`(?is)UPDATE\s+organizati
 func withoutSQLNoise(statement string) string {
 	statement = sqlDollarQuoted.ReplaceAllString(statement, "$$$$")
 	statement = sqlQuoted.ReplaceAllString(statement, "''")
-	statement = sqlBlockComment.ReplaceAllString(statement, " ")
+	statement = withoutBlockComments(statement)
 	return sqlLineComment.ReplaceAllString(statement, "")
 }
 
@@ -83,9 +83,36 @@ func withoutSQLNoise(statement string) string {
 // The line-comment half is versionguard_test.go's sqlLineComment, which already
 // strips `-- …` for the same reason and is in this package — a second spelling
 // of it here would be two answers to one question.
+// withoutBlockComments removes `/* … */`, counting NESTING.
+//
+// Postgres nests them, unlike C, and a regex cannot: a non-greedy `.*?` stops at
+// the FIRST `*/`, so `/* outer /* inner */ still comment */` leaves
+// `still comment */` in the stream to be read as SQL. A depth counter is the
+// whole fix, and it is the same lesson as the semicolon — a splitter that trusts
+// punctuation is trusting a lexer it did not write.
+func withoutBlockComments(statement string) string {
+	var out strings.Builder
+	depth := 0
+	for i := 0; i < len(statement); i++ {
+		switch {
+		case strings.HasPrefix(statement[i:], "/*"):
+			depth++
+			i++
+		case depth > 0 && strings.HasPrefix(statement[i:], "*/"):
+			depth--
+			i++
+			// A comment is whitespace to the parser, so what surrounded it must
+			// not fuse: `SET/* x */legal_name` is two tokens, not one.
+			out.WriteByte(' ')
+		case depth == 0:
+			out.WriteByte(statement[i])
+		}
+	}
+	return out.String()
+}
+
 var (
 	sqlQuoted       = regexp.MustCompile(`'[^']*'`)
-	sqlBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
 	sqlDollarQuoted = regexp.MustCompile(`(?s)\$([A-Za-z_]\w*)?\$.*?\$([A-Za-z_]\w*)?\$`)
 )
 
@@ -209,6 +236,14 @@ func TestTheRenameDetectorReadsSQLAndNotProse(t *testing.T) {
 		{
 			"a column named only inside a string", "UPDATE organization SET description = 'legal_name = x'", false,
 			"same, inside a literal the database stores rather than executes",
+		},
+		{
+			"a nested block comment", "UPDATE organization /* outer /* inner */ still comment */ SET legal_name = $1", true,
+			"Postgres nests block comments and a non-greedy regex does not; the tail was read as SQL",
+		},
+		{
+			"a nested block comment hiding a column", "UPDATE organization SET description = $1 /* a /* b */ legal_name = */", false,
+			"everything between the outer pair is comment, however many pairs are inside it",
 		},
 		{
 			"the column assembled by the caller", "UPDATE organization SET ", true,

--- a/backend/orgrenamerecheck_test.go
+++ b/backend/orgrenamerecheck_test.go
@@ -59,62 +59,131 @@ var setsAnOrganizationName = regexp.MustCompile(`(?is)UPDATE\s+organization\b[^;
 // which column arrives, so it asks the same question it asks of one it can read.
 var assemblesAnOrganizationUpdate = regexp.MustCompile(`(?is)UPDATE\s+organization\b[^;]*?\bSET\s*$`)
 
-// withoutSQLNoise removes what a reader can see is not the statement: line
-// comments and single-quoted literals.
+// withoutSQLNoise blanks every region of a statement the database does not
+// execute: quoted literals, dollar-quoted bodies, line comments and block
+// comments.
 //
-// Both directions were wrong without it. `SET description = $1 -- display_name =`
-// counted as a rename, and `SET description = 'legal_name = x'` did too; the
-// other way, a `;` INSIDE a comment ended the `[^;]*?` scan early and hid a real
-// `legal_name = $2` on the next line. A `--` inside a quoted literal is handled
-// by stripping quotes first; an escaped quote (`”`) closes and reopens, which
-// is the same result for this purpose.
+// ONE left-to-right scanner, because each of those regions hides the others'
+// delimiters, and a pass cannot see past what a later pass has not removed yet.
+// Every arrangement of separate passes is wrong in some direction:
+//
+//	UPDATE organization -- /*
+//	SET legal_name = $1                        a `/*` inside a line comment opens nothing
+//	UPDATE organization SET description = 'x' -- don't
+//	SET legal_name = $1                        an apostrophe inside a comment closes nothing
+//	UPDATE organization /* ; */ SET legal_name = $1
+//	                                           a `;` inside any of them ends nothing
+//
+// Each region knows only its own terminator, so the scanner tracks which one it
+// is in rather than asking four patterns what they can each see on their own.
 func withoutSQLNoise(statement string) string {
-	statement = sqlDollarQuoted.ReplaceAllString(statement, "$$$$")
-	statement = sqlQuoted.ReplaceAllString(statement, "''")
-	statement = withoutBlockComments(statement)
-	return sqlLineComment.ReplaceAllString(statement, "")
-}
-
-// The non-code regions of a statement, stripped widest-first: a `--` inside a
-// block comment is not a line comment, and a `;` inside any of them does not end
-// the statement. `UPDATE organization /* ; */ SET legal_name = $1` was read as
-// ending at that semicolon and so was not a rename at all.
-//
-// The line-comment half is versionguard_test.go's sqlLineComment, which already
-// strips `-- …` for the same reason and is in this package — a second spelling
-// of it here would be two answers to one question.
-// withoutBlockComments removes `/* … */`, counting NESTING.
-//
-// Postgres nests them, unlike C, and a regex cannot: a non-greedy `.*?` stops at
-// the FIRST `*/`, so `/* outer /* inner */ still comment */` leaves
-// `still comment */` in the stream to be read as SQL. A depth counter is the
-// whole fix, and it is the same lesson as the semicolon — a splitter that trusts
-// punctuation is trusting a lexer it did not write.
-func withoutBlockComments(statement string) string {
 	var out strings.Builder
-	depth := 0
-	for i := 0; i < len(statement); i++ {
+	for i := 0; i < len(statement); {
+		tag := dollarTagAt(statement, i)
 		switch {
-		case strings.HasPrefix(statement[i:], "/*"):
-			depth++
-			i++
-		case depth > 0 && strings.HasPrefix(statement[i:], "*/"):
-			depth--
-			i++
-			// A comment is whitespace to the parser, so what surrounded it must
-			// not fuse: `SET/* x */legal_name` is two tokens, not one.
+		case statement[i] == '\'':
+			out.WriteString("''")
+			i = endOfQuoted(statement, i)
+		case tag != "":
+			out.WriteString("$$")
+			i = endOfDollarQuoted(statement, i, tag)
+		// Either comment leaves a space behind it: a comment is whitespace to
+		// the parser, and what surrounded it must not fuse. `SET/* x */legal_name`
+		// is two tokens, not one.
+		case strings.HasPrefix(statement[i:], "--"):
 			out.WriteByte(' ')
-		case depth == 0:
+			i = endOfLineComment(statement, i)
+		case strings.HasPrefix(statement[i:], "/*"):
+			out.WriteByte(' ')
+			i = endOfBlockComment(statement, i)
+		default:
 			out.WriteByte(statement[i])
+			i++
 		}
 	}
 	return out.String()
 }
 
-var (
-	sqlQuoted       = regexp.MustCompile(`'[^']*'`)
-	sqlDollarQuoted = regexp.MustCompile(`(?s)\$([A-Za-z_]\w*)?\$.*?\$([A-Za-z_]\w*)?\$`)
-)
+// endOfQuoted returns the index just past a `'…'` literal beginning at i.
+//
+// `”` — an escaped quote — needs no case of its own, which is worth saying
+// because its absence reads like the bug it usually is. Every quote is a
+// boundary either way, so the two readings of `'it”s'` (one literal, or two
+// abutting ones) blank exactly the same bytes, and this scanner only ever asks
+// which bytes are literal. A case for it here would be code no probe can fail.
+func endOfQuoted(statement string, i int) int {
+	for j := i + 1; j < len(statement); j++ {
+		if statement[j] == '\'' {
+			return j + 1
+		}
+	}
+	return len(statement)
+}
+
+// dollarTagAt returns the `$tag$` opening at i, or "" if there is none. A body
+// closes only on its OWN tag, so `$$…$$` and `$q$…$q$` do not close each other.
+func dollarTagAt(statement string, i int) string {
+	if statement[i] != '$' {
+		return ""
+	}
+	for j := i + 1; j < len(statement); j++ {
+		if statement[j] == '$' {
+			return statement[i : j+1]
+		}
+		// A tag is an identifier. A leading DIGIT means this is a placeholder
+		// instead, and `$1 … $2` is two parameters and not a body between them.
+		digitInside := j > i+1 && '0' <= statement[j] && statement[j] <= '9'
+		if !isTagLetter(statement[j]) && !digitInside {
+			return ""
+		}
+	}
+	return ""
+}
+
+func isTagLetter(c byte) bool {
+	return c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+}
+
+func endOfDollarQuoted(statement string, i int, tag string) int {
+	body := i + len(tag)
+	closes := strings.Index(statement[body:], tag)
+	if closes < 0 {
+		return len(statement)
+	}
+	return body + closes + len(tag)
+}
+
+// endOfLineComment stops AT the newline rather than past it, so the line break
+// stays in the stream. It is whitespace, and removing it fuses the comment's
+// line to the next one.
+func endOfLineComment(statement string, i int) int {
+	ends := strings.IndexByte(statement[i:], '\n')
+	if ends < 0 {
+		return len(statement)
+	}
+	return i + ends
+}
+
+// endOfBlockComment counts NESTING, because Postgres nests `/* … */` where C
+// does not: a non-greedy match stops at the first `*/`, leaving the tail of
+// `/* outer /* inner */ still comment */` in the stream to be read as SQL.
+func endOfBlockComment(statement string, i int) int {
+	depth := 0
+	for j := i; j < len(statement); j++ {
+		switch {
+		case strings.HasPrefix(statement[j:], "/*"):
+			depth++
+			j++
+		case strings.HasPrefix(statement[j:], "*/"):
+			depth--
+			if depth == 0 {
+				return j + 2
+			}
+			j++
+		}
+	}
+	return len(statement)
+}
 
 // remembersTheRecheckItself ratifies a writer that cannot reach the re-check
 // through an edge this graph can follow.
@@ -248,6 +317,26 @@ func TestTheRenameDetectorReadsSQLAndNotProse(t *testing.T) {
 		{
 			"the column assembled by the caller", "UPDATE organization SET ", true,
 			"the fragment names no column because the caller supplies it; the gate asks anyway",
+		},
+		{
+			"a block comment opened inside a line comment", "UPDATE organization -- /*\n SET legal_name = $1", true,
+			"a `/*` the database reads as prose opened a comment that ran on and swallowed the rename after it",
+		},
+		{
+			"an apostrophe inside a line comment", "UPDATE organization -- don't\n SET legal_name = $1", true,
+			"an apostrophe in prose pairs with the next real quote and takes the SQL between them with it",
+		},
+		{
+			"an apostrophe inside a block comment", "UPDATE organization /* don't */ SET legal_name = $1", true,
+			"same, spelled the other way",
+		},
+		{
+			"placeholders are not a dollar-quoted body", "UPDATE organization SET description = $1, legal_name = $2", true,
+			"a tag is an identifier, so `$1 … $2` is two parameters and not a body hiding what is between them",
+		},
+		{
+			"a body that does not close on a different tag", "UPDATE organization SET description = $q$ $$ legal_name = $q$", false,
+			"`$$` does not close `$q$`, so the column named inside the body is still inside it",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/personscrub_test.go
+++ b/backend/personscrub_test.go
@@ -139,7 +139,7 @@ type privacyFunc struct {
 // statement MEANS stays here, because it is not the same question over there.
 func privacyCallGraph(t *testing.T) map[string]*privacyFunc {
 	t.Helper()
-	graph, _ := packageCallGraph(t, privacyPackage)
+	graph := packageCallGraph(t, privacyPackage)
 	out := map[string]*privacyFunc{}
 	for name, entry := range graph {
 		tables := map[string]bool{}

--- a/backend/personscrub_test.go
+++ b/backend/personscrub_test.go
@@ -24,13 +24,8 @@ package backendarch
 // heard of.
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"path/filepath"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -133,185 +128,29 @@ func TestErasingAndAnonymizingClearTheSameTables(t *testing.T) {
 type privacyFunc struct {
 	tables map[string]bool
 	calls  map[string]bool
-	// reads are identifiers the body names without calling — how a statement
-	// held in a package-level var reaches the function that executes it.
-	reads map[string]bool
 }
 
-// privacyCallGraph reads the privacy package, keyed by RECEIVER TYPE and name.
+// privacyCallGraph is the shared package graph with this census's question
+// asked of it: which TABLES each function's reachable statements write.
 //
-// Bare names are not enough. `apply` is a method on the retention service and
-// also a plausible name elsewhere; following calls by name alone walked from the
-// eraser into the policy store and reported `retention_policy` as a table an
-// erase clears, which it does not.
-//
-// So an edge is followed only when it can be resolved: a plain function, or a
-// method called on the CALLER'S OWN receiver. A call on any other value is not
-// followed, because nothing here knows that value's type.
-//
-// AN UNFOLLOWED EDGE IS NOT SAFE, and saying it was is how this census first
-// reported a difference that did not exist. It hides a table from whichever act
-// takes that route — so if one act spells a statement somewhere the walk cannot
-// read and the other spells it inline, the two sets differ for no reason but
-// the reading. That happened here: the eraser reaches `activity_participant`
-// through package-level statements, the anonymize inline, and the gap was
-// ratified with an invented explanation before anyone checked.
-//
-// So the walk reads package-level `var` and `const` too, and attributes a
-// statement to whoever NAMES it. What remains unreadable — a call on a stored
-// field, an interface, a closure — is a real limit, and the honest thing to say
-// about it is that it can still hide a table from one act only.
+// The graph itself — receiver-type keying, package-level statements attributed
+// to whoever names them, the unresolvable edges it will not follow — is in
+// callgraph_test.go, shared with the organization rename census. What a
+// statement MEANS stays here, because it is not the same question over there.
 func privacyCallGraph(t *testing.T) map[string]*privacyFunc {
 	t.Helper()
-	graph := map[string]*privacyFunc{}
-	files := parsePrivacyPackage(t)
-	// Statements held at package level, keyed by the name that holds them. A
-	// function that NAMES one writes that table — the eraser reaches
-	// `activity_participant` this way and no other, so a census reading only
-	// function bodies called it a table the anonymize alone touched.
-	held := packageLevelStatements(files)
-	for _, file := range files {
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
-			}
-			recvType, recvVar := receiverTypeName(fn), receiverVarName(fn)
-			entry := &privacyFunc{tables: map[string]bool{}, calls: map[string]bool{}, reads: map[string]bool{}}
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				// Statements go through this package's shared value reader, so
-				// one written in double quotes with escapes decodes rather than
-				// being matched as source text, and one assembled with `+` is
-				// read whole.
-				if expr, isExpr := node.(ast.Expr); isExpr {
-					if statement, readable := stringValue(expr, nil); readable {
-						for _, table := range sqlWriteTargets(statement) {
-							entry.tables[table] = true
-						}
-					}
-				}
-				if ident, isIdent := node.(*ast.Ident); isIdent {
-					entry.reads[ident.Name] = true
-				}
-				call, isCall := node.(*ast.CallExpr)
-				if !isCall {
-					return true
-				}
-				switch fun := call.Fun.(type) {
-				case *ast.Ident:
-					entry.calls[fun.Name] = true
-				case *ast.SelectorExpr:
-					if base, isIdent := fun.X.(*ast.Ident); isIdent &&
-						recvVar != "" && base.Name == recvVar {
-						entry.calls[scrubKey(recvType, fun.Sel.Name)] = true
-					}
-				}
-				return true
-			})
-			graph[scrubKey(recvType, fn.Name.Name)] = entry
-		}
-	}
-	// A named statement counts for whoever names it, wherever it lives.
-	for _, entry := range graph {
-		for name := range entry.calls {
-			for _, table := range held[name] {
-				entry.tables[table] = true
+	graph, _ := packageCallGraph(t, privacyPackage)
+	out := map[string]*privacyFunc{}
+	for name, entry := range graph {
+		tables := map[string]bool{}
+		for _, statement := range entry.statements {
+			for _, table := range sqlWriteTargets(statement) {
+				tables[table] = true
 			}
 		}
-		for name := range entry.reads {
-			for _, table := range held[name] {
-				entry.tables[table] = true
-			}
-		}
+		out[name] = &privacyFunc{tables: tables, calls: entry.calls}
 	}
-	return graph
-}
-
-// parsePrivacyPackage reads the package's product files once.
-func parsePrivacyPackage(t *testing.T) []*ast.File {
-	t.Helper()
-	sources, err := filepath.Glob(filepath.Join(privacyPackage, "*.go"))
-	if err != nil {
-		t.Fatalf("listing %s: %v", privacyPackage, err)
-	}
-	fset := token.NewFileSet()
-	var files []*ast.File
-	for _, path := range sources {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			t.Fatalf("parsing %s: %v", path, parseErr)
-		}
-		files = append(files, file)
-	}
-	return files
-}
-
-// packageLevelStatements are the tables each package-level `var`/`const` writes.
-func packageLevelStatements(files []*ast.File) map[string][]string {
-	held := map[string][]string{}
-	for _, file := range files {
-		for _, decl := range file.Decls {
-			gen, isGen := decl.(*ast.GenDecl)
-			if !isGen || (gen.Tok != token.VAR && gen.Tok != token.CONST) {
-				continue
-			}
-			for _, spec := range gen.Specs {
-				value, isValue := spec.(*ast.ValueSpec)
-				if !isValue {
-					continue
-				}
-				// A spec whose names and values do not align one-to-one binds no
-				// statement this can read — `var a, b = twoResults()` keeps one
-				// expression for two names. Skipped whole rather than by index,
-				// so the second name is not silently dropped while the first is
-				// read against a value that is not its own.
-				if len(value.Names) != len(value.Values) {
-					continue
-				}
-				for i, name := range value.Names {
-					// Every string LITERAL in the value, not the folded whole.
-					// These statements are assembled — a raw string plus a
-					// helper's output — so folding them returns nothing, and a
-					// reader that gave up on the fold gave up on the table.
-					ast.Inspect(value.Values[i], func(node ast.Node) bool {
-						literal, isLiteral := node.(*ast.BasicLit)
-						if !isLiteral || literal.Kind != token.STRING {
-							return true
-						}
-						statement, readable := strconv.Unquote(literal.Value)
-						if readable != nil {
-							return true
-						}
-						held[name.Name] = append(held[name.Name], sqlWriteTargets(statement)...)
-						return true
-					})
-				}
-			}
-		}
-	}
-	return held
-}
-
-// scrubKey keys a method by its receiver type and a plain function by
-// itself.
-func scrubKey(receiver, name string) string {
-	if receiver == "" {
-		return name
-	}
-	return receiver + "." + name
-}
-
-// receiverVarName is what a method calls its own receiver, so a call on it can
-// be told from a call on anything else. This package's receiverTypeName already
-// gives the type; only the variable was missing.
-func receiverVarName(fn *ast.FuncDecl) string {
-	if fn.Recv == nil || len(fn.Recv.List) == 0 || len(fn.Recv.List[0].Names) == 0 {
-		return ""
-	}
-	return fn.Recv.List[0].Names[0].Name
+	return out
 }
 
 func tablesReachableFrom(graph map[string]*privacyFunc, root string) []string {


### PR DESCRIPTION
## The claim

`companyform.go` said this of itself:

> this function is **the only writer of that column a human drives** — through the company form AND through a site-read confirmation

Its two callers *are* the ones it names. But it is not the only writer: accepting a coldstart read-back renames the same column through `writeOrgColumn`, on a human's approval. And `recheckOrgNameForDuplicates` has **seven independent call sites**, each of which had to remember the rule on its own.

A company's name is the axis on which two records of one company converge — PO-F-2 has nothing to compare until a name is filled in. A rename that skips the re-check leaves the duplicate it just created with nothing to notice it. That obligation was being carried by seven people remembering, plus a comment telling the next author the question was settled.

## What this does

The rule is **derived from the tree** instead of asserted. A function that can reach a statement setting `organization.display_name` or `organization.legal_name` must be guarded by the re-check. The waiver map is **empty**, and that is the finding rather than an oversight: every writer today reaches it. The map exists so that adding an entry is a visible decision with a reason beside it, instead of a silent edit to the pattern.

**A CREATE is deliberately not judged.** `resolveOrCreateOrganization` runs the dedupe match *before* it inserts and refuses on a collision, so a row that reaches the INSERT has already been compared against every existing name. Re-checking would ask it to compare a row with itself.

## The gate was vacuous, and only mutation testing said so

The first version asked whether **some** ancestor of a writer could also reach the re-check. In a package that calls the re-check from seven places, that is true of nearly every function — so the gate **passed with the re-check deleted from both real call sites**. It would have shipped certifying nothing, and it reads exactly like a gate that works.

The rule is universal now: a writer is guarded when it calls the re-check itself, or when it has callers and **all** of them are guarded. A function with no callers is an entry point — if it has not re-checked by then, nothing will.

Three mutants, each verified to apply *and* compile before its result was believed:

| mutant | verdict |
|---|---|
| coldstart's re-check deleted | fires, naming `writeOrgColumn` and `applyUnclaimedOrgColumn` |
| the company form's re-check deleted | fires, naming `writeCompanyFields` |
| `orgnamepromotion`'s re-check deleted | fires |

One of those first came back as a non-compiling mutant, which proves nothing, and was redone.

The failure message also had its arguments the wrong way round — it reported "without reaching `writeOrgColumn`", naming the *writer* where the *re-check* belonged. Printed before shipping this time.

## The call graph moved rather than being copied

The privacy census (`personscrub_test.go`) already had a receiver-type-keyed call graph that attributes package-level statements to whoever names them. Rather than copy it for a second caller, it moved to `callgraph_test.go` and now yields **statements** instead of tables — what a statement *means* is the caller's question, and "which tables does it write" is not "does it set a name column". The privacy census asks its own question of the shared graph and stays green.

This is the same call I made on #2593, for the same reason: a graph copied for the second port drifts from the first, and the narrower copy then walks a smaller tree and says PASS.

## Coverage

No new production code — a comment and two test files. `make check-backend` green.

## One thing found and not fixed

The uniqueness-claim register (#2471) does **not** see the phrasing `"the only writer of that column a human drives"`. That claim was never in `uniquenessclaims.txt`, so nothing was holding it and nothing reported it missing. D1 is explicitly closed to new claims but open to a better detector; teaching it this shape belongs in its own change, since it will find claims that were already there and the register grows to hold them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safeguards around organization-name changes to help ensure duplicate-name validation is consistently applied.
  * Improved automated privacy checks for database updates and related call paths.

* **Documentation**
  * Expanded guidance for legal-name duplicate checking, including supported update flows and validation requirements.

* **Tests**
  * Added coverage for organization renames, privacy-sensitive operations, and dynamically assembled update statements.
  * Improved detection of missed validation paths, shadowed references, and misleading SQL content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures every organization rename reaches duplicate-name validation by deriving writers from the call graph and enforcing a universal guard; production behavior unchanged, but missing re-checks now fail tests.

- Shared `backend/callgraph_test.go`: receiver-keyed graph that yields statements, attributes package-level statements to readers, resolves receiver-method calls on the same receiver, and avoids false attribution from locally shadowed names.
- New `backend/orgrenamerecheck_test.go`: detects writers of `organization.display_name`/`organization.legal_name`, including dynamically assembled `UPDATE organization SET ` fragments; uses a universal `guardedBy` (all-callers or direct call) instead of the prior existential gate; excludes `CREATE` paths (pre-insert dedupe); warns on local shadowing; dual floors catch graph regressions; waiver map is empty.
- Hardened SQL scanner: single-pass stripping of string literals, dollar-quoted bodies, line comments, and nested block comments to avoid reading prose as SQL and missing real updates.
- `backend/personscrub_test.go` refactored to use the shared graph; no behavior change.
- `backend/internal/modules/people/companyform.go` comment clarified; no logic change.

<sup>Written for commit 5514ba7df734903529e84b3b3e315b9baf18843d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

