### PR TITLE
fix(deals): a threadless-deal fixture has been touched

### DIFF
--- a/backend/internal/compose/integration/network_http_integration_test.go
+++ b/backend/internal/compose/integration/network_http_integration_test.go
@@ -104,6 +104,20 @@ func TestDealCoverageFlagsAThreadlessDealAndExplainsWhy(t *testing.T) {
 	}
 	dealID, _ := deal["id"].(string)
 
+	// One captured touch, because the finding is deliberately held back until
+	// there is one: engagement needs a two-way exchange, so on a deal nobody
+	// has contacted EVERY seat is unengaged by construction and the warning
+	// would fire on every deal somebody just created. Seeding the touch keeps
+	// this test on the case it is named for — a deal that HAS been worked and
+	// is still single-threaded — rather than on the calendar.
+	var touch apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
+		"kind": "note", "body": "Kickoff call notes",
+		"links": []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
+	}, nil, &touch); status != http.StatusCreated {
+		t.Fatalf("capturing a touch on the deal: %d", status)
+	}
+
 	var got dealCoverageDTO
 	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/coverage", nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("coverage status = %d, want 200", status)

--- a/backend/internal/compose/networktools_integration_test.go
+++ b/backend/internal/compose/networktools_integration_test.go
@@ -192,10 +192,34 @@ func seedOpenDeal(t *testing.T, e *integration.Env) ids.UUID {
 			VALUES ($1, 'Qualified', 0) RETURNING id`, pipelineID).Scan(&stageID); err != nil {
 			return err
 		}
-		return tx.QueryRow(ctx, `
+		if err := tx.QueryRow(ctx, `
 			INSERT INTO deal (name, stage_id, pipeline_id, owner_id, source, captured_by)
 			VALUES ('Threadless', $1, $2, $3, 'manual', 'human:test')
-			RETURNING id`, stageID, pipelineID, e.Rep1).Scan(&dealID)
+			RETURNING id`, stageID, pipelineID, e.Rep1).Scan(&dealID); err != nil {
+			return err
+		}
+		// One captured touch. The coverage rules hold their findings back
+		// until a deal has been contacted at all: engagement needs a two-way
+		// exchange, so on an untouched deal every seat is unengaged by
+		// construction and the warnings describe the calendar rather than the
+		// deal. Every caller of this helper is asking the sweep what it FOUND,
+		// so an untouched deal would give them a clean pipeline to assert on.
+		//
+		// The link is inserted and deal.last_activity_at is left alone: the
+		// move_last_activity trigger sets it from the activity, and a seed that
+		// wrote the column itself would be agreeing with a value production
+		// never produced.
+		var activityID ids.UUID
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO activity (kind, subject, source, captured_by)
+			VALUES ('note', 'Kickoff notes', 'manual', 'human:test')
+			RETURNING id`).Scan(&activityID); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO activity_link (activity_id, entity_type, deal_id)
+			VALUES ($1, 'deal', $2)`, activityID, dealID)
+		return err
 	}, "seeding the deal")
 	return dealID
 }


### PR DESCRIPTION
## main is red — four tests, two packages, one cause

`main-health` failed at 15:00 on `80c586e`. Reproduced locally on bare `origin/main` before changing anything; a second session reproduced it independently in a detached worktree.

```
--- FAIL: TestDealCoverageFlagsAThreadlessDealAndExplainsWhy
    network_http_integration_test.go:125: a deal with no engaged contacts raised no single-threaded risk: []
--- FAIL: TestTheAtRiskSweepReportsItsOwnReach
    networktools_integration_test.go:127: a deal with no engaged contacts raised no finding
--- FAIL: TestTheAtRiskSweepSaysADealCouldNotBeAssessedRatherThanCallingItClean
--- FAIL: TestTheRiskRetrieverCarriesTheWithholdingRatherThanAnEmptySection
```

All four in **one PR** so main goes green in one merge rather than two.

## Whose change, established rather than assumed

**#2602**, and it merged **14 minutes before its own verdict**: merged 14:32:20, its `ci` completed 14:46:12 as a failure, with the identical shards (1, 4, 5, RLS/e2e) and the identical test.

I checked #2593 rather than assuming, since it is adjacent (`LiveMemberSQL`, "someone who still works here", next door to "engaged contacts"): merged 14:39:59 with its `ci` **green at 14:37:41**, two minutes before. Cleared.

## The rule is right; the fixtures asserted the case it suppresses

#2602 gated the coverage findings behind a new `EverTouched`, and its reasoning holds:

> engagement requires a two-way exchange, so before any contact is captured EVERY seat is unengaged by construction and this fires on every deal somebody just created. That is a statement about the calendar, not about the deal, and a warning that is always on is a warning nobody reads.

Four fixtures create a deal and immediately assert the finding — exactly the suppressed case. So they now capture one touch, which puts each test back on the case its own name claims: **a deal that has been worked and is still single-threaded**, rather than one nobody has opened yet. Lowering the assertions instead would have deleted the coverage of the rule.

## One detail worth the reviewer's eye

`seedOpenDeal` inserts the activity and its `activity_link` and **leaves `deal.last_activity_at` alone**. The `move_last_activity` trigger derives that column from the activity; a seed writing it directly would be agreeing with a value production never produces. `EverTouched` reads `last_activity_at IS NOT NULL`, so the trigger is the thing under test here, not a convenience.

All three `seedOpenDeal` callers want a deal the sweep has a finding on — including the withholding test, which needs a finding to withhold — so the touch belongs in the helper rather than at one call site.

## Evidence

```
--- PASS: TestDealCoverageFlagsAThreadlessDealAndExplainsWhy (0.88s)
--- PASS: TestTheAtRiskSweepReportsItsOwnReach (0.84s)
--- PASS: TestTheAtRiskSweepSaysADealCouldNotBeAssessedRatherThanCallingItClean (0.05s)
--- PASS: TestTheRiskRetrieverCarriesTheWithholdingRatherThanAnEmptySection (0.04s)
```

`make check-backend` exits 0. (An earlier run failed on `no space left on device` and a build-cache entry vanishing mid-link — a concurrent build filled the disk; unrelated to this change and clear on retry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores risk-coverage tests by capturing one touch on seeded deals. Previously, untouched deals raised no single-threaded risk after findings were gated behind `EverTouched`; now fixtures simulate a worked-but-threadless deal.

- `seedOpenDeal` now inserts one `activity` and `activity_link` for the new deal and leaves `deal.last_activity_at` for the `move_last_activity` trigger to set.
- `backend/internal/compose/integration/network_http_integration_test.go` posts a touch via `/v1/activities` before requesting deal coverage.
- Test-only change; no production code modified.

<sup>Written for commit 73c3936d09b32682a7bcff8dab9110669d547aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test coverage for deals that have been worked through a single note activity.
  * Updated test setup to reflect activity timestamps generated by the system automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->