### PR TITLE
refactor(frontend): onboarding stops drawing its own cards

### DIFF
--- a/frontend/src/design-system/onecard.test.ts
+++ b/frontend/src/design-system/onecard.test.ts
@@ -66,22 +66,38 @@ function rules(css: string): Rule[] {
  */
 function cardChrome(): readonly string[] {
   const atoms = readFileSync(join(designSystem, "atoms.css"), "utf8");
-  const card = rules(withoutComments(atoms)).find(
+  const declared = rules(withoutComments(atoms)).filter(
     (r) => r.selector === ".card",
   );
-  if (card === undefined) {
+  // EXACTLY one, not the first. `.find()` silently adopts whichever comes
+  // first, so a second `.card { … }` anywhere in the file — a media query
+  // override, a leftover — becomes the subject and the gate goes looking for
+  // the wrong declarations. It failed loudly when I planted one; that was luck,
+  // and with a rarer declaration in the first rule it degrades to green while
+  // blind.
+  if (declared.length !== 1) {
     throw new Error(
-      "no `.card` rule in atoms.css — this gate has lost its subject",
+      `atoms.css declares .card ${declared.length} times; this gate needs exactly one to read its subject from`,
     );
   }
-  return declarations(card.body);
+  return declarations(declared[0].body);
 }
 
 /** The `property: value` pairs in a rule body, normalised for whitespace. */
 function declarations(body: string): readonly string[] {
   return body
     .split(";")
-    .map((part) => part.trim().replace(/\s+/g, " "))
+    .map((part) =>
+      part
+        .trim()
+        .replace(/\s+/g, " ")
+        // Around the colon too. Collapsing only runs of whitespace left
+        // `background:var(--bgElevated)` unequal to `background: var(...)`, so
+        // the same card written without a space escaped entirely — not a
+        // variant, the identical card, defeated by a spelling a formatter would
+        // erase. This gate exists for the hand that does not run the formatter.
+        .replace(/\s*:\s*/g, ": "),
+    )
     .filter((part) => part.length > 0);
 }
 
@@ -93,8 +109,14 @@ describe("one card surface", () => {
   it("finds stylesheets to judge", () => {
     // A census that read nothing certifies nothing, and this one is a census of
     // zero once the tree is clean — it reads the same over a clean tree and a
-    // broken walk.
-    expect(outside.length).toBeGreaterThan(5);
+    // broken walk. The floor was 5 against a real 80, which a walk reaching only
+    // the top level and `src/app/` clears with every screen unvisited, so it
+    // also names a file it must have reached.
+    expect(outside.length).toBeGreaterThan(40);
+    expect(
+      outside.some((path) => path.endsWith("screens/onboarding.css")),
+      "the walk did not reach src/screens/, where every card this gate was written for lived",
+    ).toBe(true);
   });
 
   it("is drawn only by the design system", () => {

--- a/frontend/src/design-system/onecard.test.ts
+++ b/frontend/src/design-system/onecard.test.ts
@@ -1,0 +1,120 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// `Card` is the one card surface, and a hand-rolled one is a second card the
+// moment any of its chrome moves — which is not a warning, it is a description
+// of what this tree did. `onboarding.css` grew SIX card classes: `.rcard` was
+// byte-identical to `.card`, `.finding-card` dropped the shadow and swapped the
+// background, `.legal-preview-card` reached for a stronger border, and
+// `.fact-card` / `.legal-card` were the same card twice — identical chrome with
+// text rules that had already drifted apart.
+//
+// So the rule is derived rather than remembered: a rule outside the design
+// system that declares `.card`'s OWN chrome — the same four token values, plus
+// the card shadow — is a second card, whatever it is called.
+//
+// WHAT IT DELIBERATELY DOES NOT CATCH, because a gate that fires on correct code
+// teaches people to skip its output. "A border, a radius and a padded
+// background" describes 64 rules in this tree — chips, search fields, plates,
+// callouts — and almost none of them is a card. So this asks the narrow
+// question it can answer: is this the card surface, copied. A VARIANT of it
+// (`.finding-card` dropped the shadow and swapped the background) is a design
+// decision somebody has to make, not a duplicate a test can name, and reporting
+// every one would be this gate asserting an answer nobody gave.
+
+const frontendRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const designSystem = join(frontendRoot, "src", "design-system");
+
+function stylesheets(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "node_modules" || entry.name === "dist"
+        ? []
+        : stylesheets(path);
+    }
+    return entry.name.endsWith(".css") ? [path] : [];
+  });
+}
+
+/** One `selector { … }` rule, as written. */
+type Rule = Readonly<{ selector: string; body: string }>;
+
+/** CSS comments are not rules, and one sitting above a rule was being read as
+ * its selector. */
+function withoutComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function rules(css: string): Rule[] {
+  const found: Rule[] = [];
+  // Non-greedy to the first `}`, which is why a nested block (a media query,
+  // `:is()` with braces) is not matched as one rule — the rules INSIDE it are,
+  // which is what this asks about anyway.
+  for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    found.push({ selector: match[1].trim(), body: match[2] });
+  }
+  return found;
+}
+
+/**
+ * `.card`'s own declarations, read from the design system rather than repeated
+ * here — a hardcoded copy of the chrome would be the very thing this forbids,
+ * and would stop matching the day somebody restyles the real card.
+ */
+function cardChrome(): readonly string[] {
+  const atoms = readFileSync(join(designSystem, "atoms.css"), "utf8");
+  const card = rules(withoutComments(atoms)).find(
+    (r) => r.selector === ".card",
+  );
+  if (card === undefined) {
+    throw new Error(
+      "no `.card` rule in atoms.css — this gate has lost its subject",
+    );
+  }
+  return declarations(card.body);
+}
+
+/** The `property: value` pairs in a rule body, normalised for whitespace. */
+function declarations(body: string): readonly string[] {
+  return body
+    .split(";")
+    .map((part) => part.trim().replace(/\s+/g, " "))
+    .filter((part) => part.length > 0);
+}
+
+describe("one card surface", () => {
+  const outside = stylesheets(join(frontendRoot, "src")).filter(
+    (path) => !path.startsWith(designSystem),
+  );
+
+  it("finds stylesheets to judge", () => {
+    // A census that read nothing certifies nothing, and this one is a census of
+    // zero once the tree is clean — it reads the same over a clean tree and a
+    // broken walk.
+    expect(outside.length).toBeGreaterThan(5);
+  });
+
+  it("is drawn only by the design system", () => {
+    const chrome = cardChrome();
+    const second: string[] = [];
+    for (const path of outside) {
+      for (const rule of rules(withoutComments(readFileSync(path, "utf8")))) {
+        const declared = new Set(declarations(rule.body));
+        if (chrome.every((property) => declared.has(property))) {
+          second.push(`${relative(frontendRoot, path)}: ${rule.selector}`);
+        }
+      }
+    }
+    expect(
+      second,
+      "these rules draw a card surface outside the design system. `Card` is the " +
+        "one card — `as` picks the element, `className` still carries whatever " +
+        "content styling the screen owns. A copy drifts silently: the two cards " +
+        "this replaced had identical chrome and text rules that had already " +
+        "disagreed, and nobody chose the difference.",
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/design-system/onecard.test.ts
+++ b/frontend/src/design-system/onecard.test.ts
@@ -11,9 +11,11 @@ import { describe, expect, it } from "vitest";
 // `.fact-card` / `.legal-card` were the same card twice — identical chrome with
 // text rules that had already drifted apart.
 //
-// So the rule is derived rather than remembered: a rule outside the design
-// system that declares `.card`'s OWN chrome — the same four token values, plus
-// the card shadow — is a second card, whatever it is called.
+// So the rule is derived rather than remembered: any rule that declares
+// `.card`'s OWN chrome — the same four token values, plus the card shadow — is
+// a second card, whatever it is called and wherever it sits. The design system
+// is judged too, minus the one rule this reads its subject from: a second card
+// beside the real one is the same defect and harder to notice.
 //
 // WHAT IT DELIBERATELY DOES NOT CATCH, because a gate that fires on correct code
 // teaches people to skip its output. "A border, a radius and a padded
@@ -26,6 +28,11 @@ import { describe, expect, it } from "vitest";
 
 const frontendRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const designSystem = join(frontendRoot, "src", "design-system");
+// The one rule this gate reads its subject FROM, and so the one rule it must
+// not report as a copy of itself. Everything else in the design system is
+// judged like any screen: a second card here is the same defect and harder to
+// see, because it sits beside the real one.
+const cardSource = join(designSystem, "atoms.css");
 
 function stylesheets(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -65,7 +72,7 @@ function rules(css: string): Rule[] {
  * and would stop matching the day somebody restyles the real card.
  */
 function cardChrome(): readonly string[] {
-  const atoms = readFileSync(join(designSystem, "atoms.css"), "utf8");
+  const atoms = readFileSync(cardSource, "utf8");
   const declared = rules(withoutComments(atoms)).filter(
     (r) => r.selector === ".card",
   );
@@ -83,7 +90,7 @@ function cardChrome(): readonly string[] {
   return declarations(declared[0].body);
 }
 
-/** The `property: value` pairs in a rule body, normalised for whitespace. */
+/** The `property: value` pairs in a rule body, in one spelling. */
 function declarations(body: string): readonly string[] {
   return body
     .split(";")
@@ -96,15 +103,52 @@ function declarations(body: string): readonly string[] {
         // the same card written without a space escaped entirely — not a
         // variant, the identical card, defeated by a spelling a formatter would
         // erase. This gate exists for the hand that does not run the formatter.
-        .replace(/\s*:\s*/g, ": "),
+        .replace(/\s*:\s*/g, ": ")
+        // And inside the parentheses, for the same reason: `var(--bgElevated )`
+        // computes identically and compares unequal.
+        .replace(/\(\s+/g, "(")
+        .replace(/\s+\)/g, ")"),
     )
-    .filter((part) => part.length > 0);
+    .filter((part) => part.length > 0)
+    .flatMap(longhand);
+}
+
+/**
+ * The same chrome, written the other way. A clone is usually a paste, but the
+ * hand that retypes it writes `background-color` where the source says
+ * `background`, and a gate comparing declaration TEXT reads that as a different
+ * card — green over the identical surface.
+ *
+ * Only the two shorthands `.card` actually uses, expanded in the ONE form each
+ * takes there. A general CSS shorthand expander is a different program, and one
+ * that guessed wrong would make this gate fire on rules that are not cards —
+ * which costs more than what the narrow version misses, because a gate that
+ * fires on correct code teaches readers to skip it. Both sides run through
+ * here, so a shorthand this does not know still compares against itself.
+ */
+function longhand(declaration: string): readonly string[] {
+  const colon = declaration.indexOf(": ");
+  if (colon < 0) {
+    return [declaration];
+  }
+  const property = declaration.slice(0, colon);
+  const value = declaration.slice(colon + 2);
+  if (property === "background" && !value.includes(" ")) {
+    return [`background-color: ${value}`];
+  }
+  const border = /^(\S+) (\S+) (\S+)$/.exec(value);
+  if (property === "border" && border !== null) {
+    return [
+      `border-width: ${border[1]}`,
+      `border-style: ${border[2]}`,
+      `border-color: ${border[3]}`,
+    ];
+  }
+  return [declaration];
 }
 
 describe("one card surface", () => {
-  const outside = stylesheets(join(frontendRoot, "src")).filter(
-    (path) => !path.startsWith(designSystem),
-  );
+  const sheets = stylesheets(join(frontendRoot, "src"));
 
   it("finds stylesheets to judge", () => {
     // A census that read nothing certifies nothing, and this one is a census of
@@ -112,18 +156,27 @@ describe("one card surface", () => {
     // broken walk. The floor was 5 against a real 80, which a walk reaching only
     // the top level and `src/app/` clears with every screen unvisited, so it
     // also names a file it must have reached.
-    expect(outside.length).toBeGreaterThan(40);
+    expect(sheets.length).toBeGreaterThan(40);
     expect(
-      outside.some((path) => path.endsWith("screens/onboarding.css")),
+      sheets.some((path) => path.endsWith("screens/onboarding.css")),
       "the walk did not reach src/screens/, where every card this gate was written for lived",
+    ).toBe(true);
+    expect(
+      sheets.some(
+        (path) => path.startsWith(designSystem) && path !== cardSource,
+      ),
+      "the walk did not reach the design system's other stylesheets, where a second card sits beside the real one",
     ).toBe(true);
   });
 
   it("is drawn only by the design system", () => {
     const chrome = cardChrome();
     const second: string[] = [];
-    for (const path of outside) {
+    for (const path of sheets) {
       for (const rule of rules(withoutComments(readFileSync(path, "utf8")))) {
+        if (path === cardSource && rule.selector === ".card") {
+          continue;
+        }
         const declared = new Set(declarations(rule.body));
         if (chrome.every((property) => declared.has(property))) {
           second.push(`${relative(frontendRoot, path)}: ${rule.selector}`);
@@ -132,7 +185,7 @@ describe("one card surface", () => {
     }
     expect(
       second,
-      "these rules draw a card surface outside the design system. `Card` is the " +
+      "these rules draw a second card surface. `Card` is the " +
         "one card — `as` picks the element, `className` still carries whatever " +
         "content styling the screen owns. A copy drifts silently: the two cards " +
         "this replaced had identical chrome and text rules that had already " +

--- a/frontend/src/screens/onboarding-build-scene.css
+++ b/frontend/src/screens/onboarding-build-scene.css
@@ -84,15 +84,15 @@
   opacity: 0.5;
   filter: blur(1px);
 }
+/* A blurred silhouette of the cards the build is about to produce — decoration,
+   and `aria-hidden` because of it. It is a real `Card` rather than a drawn
+   likeness of one so that it cannot stop resembling what it depicts: a ghost
+   holding its own copy of the chrome goes on showing the OLD card the day the
+   real one changes. Only what makes it a ghost is left here. */
 .ob-build-ghost {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding: var(--space-4);
-  border: 1px solid var(--borderSubtle);
-  border-radius: var(--r-md);
-  background: var(--bgElevated);
-  box-shadow: var(--shadow-card);
   animation: ob-build-ghost-in calc(var(--obBuildMs) * 0.32)
     calc(var(--obBuildMs) * (0.12 + 0.08 * var(--obGhost)))
     cubic-bezier(0.23, 1, 0.32, 1) both;

--- a/frontend/src/screens/onboarding-build-scene.tsx
+++ b/frontend/src/screens/onboarding-build-scene.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { Card } from "../design-system/atoms";
 import { usePrefersReducedMotion } from "../design-system/motion";
 import { useT } from "../i18n";
 import { Wordmark } from "./auth";
@@ -209,10 +210,10 @@ function GhostCard({
 }: Readonly<{ rows: readonly string[]; index: number }>) {
   const vars: SceneVars = { "--obGhost": index };
   return (
-    <div className="ob-build-ghost" style={vars}>
+    <Card as="div" className="ob-build-ghost" style={vars}>
       {rows.map((width) => (
         <span className="ob-build-ghost-row" key={width} style={{ width }} />
       ))}
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/screens/onboarding-company-form.tsx
+++ b/frontend/src/screens/onboarding-company-form.tsx
@@ -187,7 +187,7 @@ export function CompanyStep({
                 <button
                   key={`${fact.field}:${fact.value_key}`}
                   type="button"
-                  className={`choice-card ${selected ? "selected" : ""}`}
+                  className={`choice-card fact-card ${selected ? "selected" : ""}`}
                   aria-pressed={selected}
                   disabled={saveDisabled(factSelection, selected)}
                   onClick={() => factSelection.toggle(fact)}
@@ -284,7 +284,7 @@ function LegalEntityChoice({
             <button
               key={`${entity.name}-${entity.source_url}`}
               type="button"
-              className={`choice-card ${selected ? "selected" : ""}`}
+              className={`choice-card legal-card ${selected ? "selected" : ""}`}
               aria-pressed={selected}
               onClick={() => onPick(entity)}
             >

--- a/frontend/src/screens/onboarding-company-form.tsx
+++ b/frontend/src/screens/onboarding-company-form.tsx
@@ -187,12 +187,12 @@ export function CompanyStep({
                 <button
                   key={`${fact.field}:${fact.value_key}`}
                   type="button"
-                  className={`fact-card ${selected ? "selected" : ""}`}
+                  className={`choice-card ${selected ? "selected" : ""}`}
                   aria-pressed={selected}
                   disabled={saveDisabled(factSelection, selected)}
                   onClick={() => factSelection.toggle(fact)}
                 >
-                  <span className="fact-check">
+                  <span className="choice-check">
                     {selected ? <Check aria-hidden /> : <Circle aria-hidden />}
                   </span>
                   <span>
@@ -284,11 +284,11 @@ function LegalEntityChoice({
             <button
               key={`${entity.name}-${entity.source_url}`}
               type="button"
-              className={`legal-card ${selected ? "selected" : ""}`}
+              className={`choice-card ${selected ? "selected" : ""}`}
               aria-pressed={selected}
               onClick={() => onPick(entity)}
             >
-              <span className="fact-check">
+              <span className="choice-check">
                 {selected ? <Check aria-hidden /> : <Circle aria-hidden />}
               </span>
               <span>

--- a/frontend/src/screens/onboarding-evidence.test.tsx
+++ b/frontend/src/screens/onboarding-evidence.test.tsx
@@ -8,7 +8,7 @@ import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { ReadEvidence } from "./onboarding-read";
+import { FACT_PREVIEW_LIMIT, ReadEvidence } from "./onboarding-read";
 
 // The evidence panel shows three kinds of finding — a legal entity, a profile
 // field and a live fact — and each one is a card. They are cards through the
@@ -40,6 +40,20 @@ function grounded(
   };
 }
 
+function surplusFacts(
+  count: number,
+): components["schemas"]["CompanySiteReadFact"][] {
+  return Array.from({ length: count }, (_unused, index) => ({
+    category: "offering" as const,
+    field: "service",
+    value_key: `offering:service:${index}`,
+    value: `Service ${index}`,
+    evidence_snippet: `We run service ${index}.`,
+    evidence_url: "https://gradion.com/services",
+    confidence: 0.8,
+  }));
+}
+
 const READ = {
   id: "11111111-1111-4111-8111-111111111111",
   target_kind: "onboarding",
@@ -66,6 +80,10 @@ const READ = {
       evidence_url: "https://gradion.com/about",
       confidence: 0.95,
     },
+    // Past the preview limit on purpose. A fixture that stays under it cannot
+    // tell "one card per finding" from "one card per finding the panel shows",
+    // and those stop agreeing at exactly the point the cap bites.
+    ...surplusFacts(FACT_PREVIEW_LIMIT + 1),
   ],
   comparisons: [],
   people: [],
@@ -75,7 +93,7 @@ const READ = {
   proposal_hash: "proposal-2",
   created_at: "2026-07-22T08:00:00Z",
   updated_at: "2026-07-22T08:00:01Z",
-} as const satisfies CompanySiteRead;
+} satisfies CompanySiteRead;
 
 function render(read: CompanySiteRead) {
   return rtlRender(
@@ -123,14 +141,17 @@ describe("the evidence panel", () => {
   // from the left side, and a card this panel did not put there is extra on the
   // right. A screen that grows its own card again fails here rather than in
   // somebody's eye, months later, over a shadow that is one pixel out.
-  it("draws one card per finding and nothing else", () => {
+  it("draws one card per finding it shows, and nothing else", () => {
     const { container } = render(READ);
 
-    const findings =
+    // Facts are capped, and the cap is part of the claim rather than an
+    // exception to it: the panel draws a card for each finding it SHOWS.
+    expect(READ.facts.length).toBeGreaterThan(FACT_PREVIEW_LIMIT);
+    const shown =
       (READ.legal_entities?.length ?? 0) +
       READ.profile_fields.length +
-      READ.facts.length;
-    expect(container.querySelectorAll(".card")).toHaveLength(findings);
+      Math.min(READ.facts.length, FACT_PREVIEW_LIMIT);
+    expect(container.querySelectorAll(".card")).toHaveLength(shown);
     expect(
       container.querySelectorAll(
         ".legal-preview-card:not(.card), .finding-card:not(.card)",

--- a/frontend/src/screens/onboarding-evidence.test.tsx
+++ b/frontend/src/screens/onboarding-evidence.test.tsx
@@ -43,15 +43,21 @@ function grounded(
 function surplusFacts(
   count: number,
 ): components["schemas"]["CompanySiteReadFact"][] {
-  return Array.from({ length: count }, (_unused, index) => ({
-    category: "offering" as const,
-    field: "service",
-    value_key: `offering:service:${index}`,
-    value: `Service ${index}`,
-    evidence_snippet: `We run service ${index}.`,
-    evidence_url: "https://gradion.com/services",
-    confidence: 0.8,
-  }));
+  // The callback's return is annotated rather than asserted: `Array.from`
+  // infers its element type FROM the callback, so nothing flows in to narrow
+  // `category` to its union member and the object needs to say what it is.
+  return Array.from(
+    { length: count },
+    (_unused, index): components["schemas"]["CompanySiteReadFact"] => ({
+      category: "offering",
+      field: "service",
+      value_key: `offering:service:${index}`,
+      value: `Service ${index}`,
+      evidence_snippet: `We run service ${index}.`,
+      evidence_url: "https://gradion.com/services",
+      confidence: 0.8,
+    }),
+  );
 }
 
 const READ = {

--- a/frontend/src/screens/onboarding-evidence.test.tsx
+++ b/frontend/src/screens/onboarding-evidence.test.tsx
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { ReadEvidence } from "./onboarding-read";
+
+// The evidence panel shows three kinds of finding — a legal entity, a profile
+// field and a live fact — and each one is a card. They are cards through the
+// design system's Card, not through three descriptions of a card kept in this
+// screen's stylesheet, and the count below is what holds that: a finding that
+// stops being a Card stops being counted, whatever it still looks like.
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+
+const LEGAL_ENTITY = {
+  name: "Gradion GmbH",
+  registered_address: "Hafenstraße 1, Hamburg",
+  register_number: "HRB 12345",
+  source_url: "https://gradion.com/impressum",
+};
+
+function grounded(
+  field: components["schemas"]["ColdStartField"]["field"],
+  value: string,
+  snippet: string,
+): components["schemas"]["ColdStartField"] {
+  return {
+    field,
+    value,
+    evidence_snippet: snippet,
+    source_kind: "url",
+    source_url: "https://gradion.com",
+    confidence: 0.9,
+  };
+}
+
+const READ = {
+  id: "11111111-1111-4111-8111-111111111111",
+  target_kind: "onboarding",
+  organization_id: null,
+  root_url: "https://gradion.com",
+  status: "ready",
+  status_code: null,
+  status_detail: null,
+  next_attempt_at: null,
+  phase: null,
+  pages_read: 2,
+  pages: [{ url: "https://gradion.com", status: "fetched", kind: "home" }],
+  profile_fields: [
+    grounded("legal_name", "Gradion GmbH", "© 2026 Gradion GmbH"),
+    grounded("industry", "Manufacturing", "We serve manufacturers."),
+  ],
+  facts: [
+    {
+      category: "company",
+      field: "founded_year",
+      value_key: "company:founded_year:2011",
+      value: "Founded 2011",
+      evidence_snippet: "Founded in Hamburg in 2011.",
+      evidence_url: "https://gradion.com/about",
+      confidence: 0.95,
+    },
+  ],
+  comparisons: [],
+  people: [],
+  legal_entities: [LEGAL_ENTITY],
+  warnings: [],
+  draft_version: 2,
+  proposal_hash: "proposal-2",
+  created_at: "2026-07-22T08:00:00Z",
+  updated_at: "2026-07-22T08:00:01Z",
+} as const satisfies CompanySiteRead;
+
+function render(read: CompanySiteRead) {
+  return rtlRender(
+    <LocaleProvider initial="en">
+      <ReadEvidence read={read} />
+    </LocaleProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("the evidence panel", () => {
+  it("shows a legal entity as printed, in a card", () => {
+    const { container } = render(READ);
+
+    const entity = container.querySelector(".legal-preview-card");
+    expect(entity).toHaveClass("card");
+    expect(entity?.tagName).toBe("ARTICLE");
+    expect(entity).toHaveTextContent("Gradion GmbH");
+    expect(entity).toHaveTextContent("Hafenstraße 1, Hamburg");
+    expect(entity).toHaveTextContent("HRB 12345");
+  });
+
+  it("shows a profile field with its evidence, in a card named for the field", () => {
+    render(READ);
+
+    const finding = screen.getByTestId("finding-industry");
+    expect(finding).toHaveClass("card");
+    expect(finding).toHaveTextContent("Manufacturing");
+    expect(finding).toHaveTextContent("We serve manufacturers.");
+    // The confidence a reader acts on, rounded where they can see it.
+    expect(finding).toHaveTextContent("90%");
+  });
+
+  it("shows a live fact with its evidence, in a card", () => {
+    const { container } = render(READ);
+
+    const fact = container.querySelector(".live-fact-preview .finding-card");
+    expect(fact).toHaveClass("card");
+    expect(fact).toHaveTextContent("Founded 2011");
+    expect(fact).toHaveTextContent("Founded in Hamburg in 2011.");
+  });
+
+  // The count, both directions at once: a finding that is not a Card is missing
+  // from the left side, and a card this panel did not put there is extra on the
+  // right. A screen that grows its own card again fails here rather than in
+  // somebody's eye, months later, over a shadow that is one pixel out.
+  it("draws one card per finding and nothing else", () => {
+    const { container } = render(READ);
+
+    const findings =
+      (READ.legal_entities?.length ?? 0) +
+      READ.profile_fields.length +
+      READ.facts.length;
+    expect(container.querySelectorAll(".card")).toHaveLength(findings);
+    expect(
+      container.querySelectorAll(
+        ".legal-preview-card:not(.card), .finding-card:not(.card)",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("shows nothing at all when the read found nothing", () => {
+    const { container } = render({
+      ...READ,
+      profile_fields: [],
+      facts: [],
+      legal_entities: [],
+      pages: [],
+      warnings: [],
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -862,6 +862,11 @@ function CoreJourney({ active }: Readonly<{ active: number }>) {
   );
 }
 
+// The evidence panel PREVIEWS facts rather than listing them: past a dozen it
+// stops being something a reader takes in at a glance, and the confirm step is
+// where the whole set is chosen from anyway.
+export const FACT_PREVIEW_LIMIT = 12;
+
 function readablePage(rawURL: string) {
   const pageURL = new URL(rawURL);
   const path = pageURL.pathname.replace(/\/$/, "");
@@ -936,7 +941,7 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
         <section className="live-fact-preview">
           <h2>{t("ob.factsTitle")}</h2>
           <div className="finding-grid">
-            {read.facts.slice(0, 12).map((fact) => (
+            {read.facts.slice(0, FACT_PREVIEW_LIMIT).map((fact) => (
               <Card
                 as="article"
                 key={`${fact.category}:${fact.field}:${fact.value_key}`}

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -15,7 +15,7 @@ import {
 import { type ReactNode, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { Button } from "../design-system/atoms";
+import { Button, Card } from "../design-system/atoms";
 import type { MarginceCoreState } from "../design-system/margince-core";
 import { MarginceWorkbench } from "../design-system/margince-workbench";
 import { formatDateTime } from "../format/format";
@@ -889,7 +889,8 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
           <p>{t("ob.legalFoundBody")}</p>
           <div className="legal-preview-grid">
             {legalEntities.map((entity) => (
-              <article
+              <Card
+                as="article"
                 key={`${entity.name}:${entity.register_number ?? ""}:${entity.source_url}`}
                 className="legal-preview-card"
               >
@@ -903,7 +904,7 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
                 {entity.register_number && (
                   <small>{entity.register_number}</small>
                 )}
-              </article>
+              </Card>
             ))}
           </div>
         </section>
@@ -914,10 +915,11 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
           <p>{t("ob.coreFindingsBody")}</p>
           <div className="finding-grid">
             {read.profile_fields.map((field) => (
-              <article
+              <Card
+                as="article"
                 key={field.field}
                 className="finding-card"
-                data-finding-id={field.field}
+                testId={`finding-${field.field}`}
               >
                 <div className="finding-label">
                   <Check aria-hidden /> {coldFieldLabel(field.field, t)}
@@ -925,7 +927,7 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
                 </div>
                 <strong>{field.value}</strong>
                 <blockquote>“{field.evidence_snippet}”</blockquote>
-              </article>
+              </Card>
             ))}
           </div>
         </>
@@ -935,7 +937,8 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
           <h2>{t("ob.factsTitle")}</h2>
           <div className="finding-grid">
             {read.facts.slice(0, 12).map((fact) => (
-              <article
+              <Card
+                as="article"
                 key={`${fact.category}:${fact.field}:${fact.value_key}`}
                 className="finding-card"
               >
@@ -945,7 +948,7 @@ export function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {
                 </div>
                 <strong>{fact.value}</strong>
                 <blockquote>“{fact.evidence_snippet}”</blockquote>
-              </article>
+              </Card>
             ))}
           </div>
         </section>

--- a/frontend/src/screens/onboarding-results.tsx
+++ b/frontend/src/screens/onboarding-results.tsx
@@ -1,6 +1,6 @@
 import { Check, CheckCircle2, Lock, Sparkles } from "lucide-react";
 import type { components } from "../api/schema";
-import { Disclosure } from "../design-system/atoms";
+import { Card, Disclosure } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
@@ -91,7 +91,7 @@ export function ResultsStep({
       )}
       <div className="rcards">
         {cards.map((c) => (
-          <div key={c.title} className="rcard">
+          <Card key={c.title} as="div" className="rcard">
             <div className="rh">
               <span className="ck">
                 <Check aria-hidden />
@@ -99,7 +99,7 @@ export function ResultsStep({
               {t(c.title)}
             </div>
             <p>{t(c.body)}</p>
-          </div>
+          </Card>
         ))}
       </div>
       {/* Where the pipeline came from is background: true, worth having, and

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -210,13 +210,6 @@
   gap: var(--space-3);
   margin-top: var(--space-6);
 }
-.rcard {
-  background: var(--bgElevated);
-  border: 1px solid var(--borderSubtle);
-  border-radius: var(--r-md);
-  padding: var(--space-4);
-  box-shadow: var(--shadow-card);
-}
 .rcard .rh {
   display: flex;
   align-items: center;
@@ -644,14 +637,6 @@
   gap: var(--space-3);
   margin-top: var(--space-4);
 }
-.legal-preview-card {
-  display: grid;
-  gap: var(--space-2);
-  padding: var(--space-4);
-  border: 1px solid var(--borderStrong);
-  border-radius: var(--r-md);
-  background: var(--bgElevated);
-}
 .legal-preview-card strong,
 .legal-preview-card span,
 .legal-preview-card small {
@@ -717,13 +702,6 @@
   grid-template-columns: 1fr 1fr;
   gap: var(--space-3);
   padding: var(--space-5);
-}
-.finding-card {
-  min-width: 0;
-  padding: var(--space-4);
-  border: 1px solid var(--borderSubtle);
-  border-radius: var(--r-md);
-  background: var(--bgPage);
 }
 .finding-label {
   display: flex;
@@ -1232,7 +1210,19 @@
   gap: var(--space-3);
   margin-top: var(--space-3);
 }
-.legal-card {
+/* The one card a reader PICKS: a fact to keep, a legal entity to adopt. It is
+   a button, not a surface, which is why it is not `Card` — `Card` is a section
+   of a page and this is a press target with a pressed state.
+
+   It replaces two classes whose base rules were byte-identical and whose text
+   rules were not: one gave the value line a secondary colour and a readable
+   line-height and the other did not, and the evidence line's air was 4px on one
+   and 8px on the other. Nobody chose either difference — the second card was
+   copied from the first and drifted — and the tell was that the legal card
+   already borrowed `.choice-check` from the fact card's block, so the two were
+   never really separate. Where they disagreed this keeps the considered value:
+   the coloured, leaded value line, and the wider gap before the quote. */
+.choice-card {
   display: flex;
   align-items: flex-start;
   gap: var(--space-3);
@@ -1244,28 +1234,33 @@
   background: var(--bgElevated);
   cursor: pointer;
 }
-.legal-card.selected {
+.choice-card.selected {
   border-color: var(--accent);
   background: var(--accentLight);
 }
-.legal-card b,
-.legal-card span span,
-.legal-card small {
+.choice-check svg {
+  width: 14px;
+  color: var(--accent);
+}
+.choice-card b,
+.choice-card span span,
+.choice-card small {
   display: block;
 }
-.legal-card b {
+.choice-card b {
   font-size: var(--fs-meta);
 }
-.legal-card span span {
+.choice-card span span {
   margin-top: var(--space-1);
   color: var(--textSecondary);
   font-size: var(--fs-meta);
   line-height: var(--lh-normal);
 }
-.legal-card small {
-  margin-top: var(--space-1);
+.choice-card small {
+  margin-top: var(--space-2);
   color: var(--textTertiary);
   font-size: var(--fs-meta);
+  line-height: var(--lh-normal);
 }
 @media (max-width: 720px) {
   .legal-grid {
@@ -1296,44 +1291,6 @@
   grid-template-columns: 1fr 1fr;
   gap: var(--space-3);
   margin-top: var(--space-3);
-}
-.fact-card {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-3);
-  padding: var(--space-4);
-  color: var(--textPrimary);
-  text-align: left;
-  border: 1px solid var(--borderSubtle);
-  border-radius: var(--r-md);
-  background: var(--bgElevated);
-  cursor: pointer;
-}
-.fact-card.selected {
-  border-color: var(--accent);
-  background: var(--accentLight);
-}
-.fact-check svg {
-  width: 14px;
-  color: var(--accent);
-}
-.fact-card b,
-.fact-card span span,
-.fact-card small {
-  display: block;
-}
-.fact-card b {
-  font-size: var(--fs-meta);
-}
-.fact-card span span {
-  margin-top: var(--space-1);
-  font-size: var(--fs-meta);
-}
-.fact-card small {
-  margin-top: var(--space-2);
-  color: var(--textTertiary);
-  font-size: var(--fs-meta);
-  line-height: var(--lh-normal);
 }
 .understanding-reveal {
   margin: var(--space-6) 0;

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -1228,9 +1228,9 @@
    button with a pressed state, not a surface, which is why it is not `Card` —
    `Card` is a section of a page.
 
-   One class, because the fact picker and the legal picker are the same card
-   asking about different things. Two of them drift: the text rules disagree
-   before anybody notices the chrome is identical. */
+   One class, because the fact picker and the legal picker are the SAME control:
+   a check, a name, a detail line, a line of fine print. What they do not share
+   is what those lines mean, and that is what the two modifiers below carry. */
 .choice-card {
   display: flex;
   align-items: flex-start;
@@ -1261,14 +1261,24 @@
 }
 .choice-card span span {
   margin-top: var(--space-1);
-  color: var(--textSecondary);
   font-size: var(--fs-meta);
-  line-height: var(--lh-normal);
 }
 .choice-card small {
-  margin-top: var(--space-2);
   color: var(--textTertiary);
   font-size: var(--fs-meta);
+}
+/* The detail line is the fact's VALUE — the thing the reader is choosing — so it
+   keeps the card's own colour. Under a legal entity the same line is the
+   registered address, which is detail beneath the name, and reads as such. */
+.legal-card span span {
+  color: var(--textSecondary);
+  line-height: var(--lh-normal);
+}
+.legal-card small {
+  margin-top: var(--space-1);
+}
+.fact-card small {
+  margin-top: var(--space-2);
   line-height: var(--lh-normal);
 }
 @media (max-width: 720px) {

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -637,6 +637,12 @@
   gap: var(--space-3);
   margin-top: var(--space-4);
 }
+/* What `Card` does not bring: `.card` declares no display, and these lines are a
+   stack with air between them rather than flowing text. */
+.legal-preview-card {
+  display: grid;
+  gap: var(--space-2);
+}
 .legal-preview-card strong,
 .legal-preview-card span,
 .legal-preview-card small {
@@ -696,6 +702,14 @@
   50% {
     opacity: 0.35;
   }
+}
+/* `.finding-grid` sizes its columns `1fr 1fr` rather than `minmax(0, 1fr)`, so a
+   grid item's automatic minimum size is its CONTENT — one unbreakable value (a
+   URL, a long domain) widens the column past its share and the row overflows.
+   This is the guard against that, and it is not chrome, so `Card` does not
+   bring it. */
+.finding-card {
+  min-width: 0;
 }
 .finding-grid {
   display: grid;
@@ -1210,18 +1224,13 @@
   gap: var(--space-3);
   margin-top: var(--space-3);
 }
-/* The one card a reader PICKS: a fact to keep, a legal entity to adopt. It is
-   a button, not a surface, which is why it is not `Card` — `Card` is a section
-   of a page and this is a press target with a pressed state.
+/* The one card a reader PICKS: a fact to keep, a legal entity to adopt. It is a
+   button with a pressed state, not a surface, which is why it is not `Card` —
+   `Card` is a section of a page.
 
-   It replaces two classes whose base rules were byte-identical and whose text
-   rules were not: one gave the value line a secondary colour and a readable
-   line-height and the other did not, and the evidence line's air was 4px on one
-   and 8px on the other. Nobody chose either difference — the second card was
-   copied from the first and drifted — and the tell was that the legal card
-   already borrowed `.choice-check` from the fact card's block, so the two were
-   never really separate. Where they disagreed this keeps the considered value:
-   the coloured, leaded value line, and the wider gap before the quote. */
+   One class, because the fact picker and the legal picker are the same card
+   asking about different things. Two of them drift: the text rules disagree
+   before anybody notices the chrome is identical. */
 .choice-card {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## What was there

`onboarding.css` had **six card classes**, and the design system has one `Card`.

| class | how it differed from `.card` |
|---|---|
| `.rcard` | **byte-identical**, five properties, same tokens |
| `.finding-card` | dropped the shadow, swapped `bgElevated` → `bgPage` |
| `.legal-preview-card` | reached for `borderStrong`, dropped the shadow |
| `.fact-card` | — |
| `.legal-card` | — |

`.fact-card` and `.legal-card` are the interesting pair: **identical chrome** — ten declarations, byte for byte — with three text rules that differ. One gives the middle line a secondary colour and a readable line-height; the other gives it neither. The fine print's air is 4px on one and 8px on the other.

I first read those three as drift and merged them. That was wrong, and review caught it: **the same markup means different things on the two cards.** The middle line is the fact's *value* — the thing the reader is picking — and the legal entity's *registered address*, which is detail beneath the name above it. Merging the rules took the fact card's values wherever the two disagreed, and dimmed the value line to secondary text. Nobody chose that.

## What this does

The four **surfaces** are `Card` now, keeping their class as the hook for the content styling each screen legitimately owns — only the *chrome* was duplicated, and the descendant rules are local by right.

The two **picked** cards share one `.choice-card` for the chrome, which is the half that really was duplicated. The three text rules that were never the same stay on `.legal-card` / `.fact-card` modifiers, with what the middle line *means* written beside them.

## The one judgement worth arguing with

**The picked cards are not `Card`, and I think that is right.** A picked card is a `<button>` with `aria-pressed`, not a section of a page — `Card`'s own doc says a hand-rolled `<div className="card">` is a second card, and the answer to *that* is `Card`; the answer to a press target is not.

I started down the tidier road and stopped: `ChoiceList` (a radio group) fits the legal picker exactly, and I wrote a `CheckList` sibling for the fact picker. Then I threw it away. The fact cards carry **three levels of text** — a bold field label, the value, a quoted evidence snippet — where `Choice` has `label` and `description`, and they carry a **selection cap** that disables the unpicked ones. Converting them is a redesign of the fact picker, not a refactor of it. And `CheckList` would have shipped with **no caller**, which is the thing CLAUDE.md forbids outright.

So: one class instead of two, and the card-shaped selection control stays a screen concern until somebody decides the redesign.

## The gate

It reads `.card`'s own declarations **out of `atoms.css`** rather than repeating them — a hardcoded copy of the chrome would be the very thing it forbids, and would stop matching the day somebody restyles the real card.

Both sides are canonicalized through one function, because a gate comparing declaration TEXT loses to every equivalent spelling of the same card. Three read green before review: longhand `background-color` and `border-*`; whitespace inside `var( )`; and every design-system stylesheet, which it excluded wholesale rather than excluding the one rule it reads its subject from. Each now fires, verified by planting it. Widening the scan to the design system found nothing — which is the answer, not a reason not to have asked.

It asks the narrow question it can answer: *is this the card surface, copied.* The first version asked "does this draw a border, a radius and a padded background" and reported **64 rules** — chips, search fields, plates, callouts — almost none of them a card. A gate that fires on correct code teaches people to skip its output, so it does not judge a *variant*: `.finding-card` dropping the shadow was a design decision somebody has to make, not a duplicate a test can name.

**It found a seventh clone on its first run.** `.ob-build-ghost` — the blurred, `aria-hidden` silhouette behind the build scene — carried the full card chrome so it would look like the cards it depicts. It is a real `Card` now, so it cannot stop resembling what it depicts the day the real one changes.

Mutation-tested: planting a fresh `.card` clone in `onboarding.css` fires and names it; removing it goes green.

## Visual changes, deliberate

Three surfaces adopt the design system's chrome and therefore move:

- `.finding-card` gains the card shadow; background `bgPage` → `bgElevated`.
- `.legal-preview-card` gains the shadow; border `borderStrong` → `borderSubtle`.
- The picked cards do **not** move. Their chrome was identical to begin with, and every declaration where the two differed is preserved on the side that owns it — verified against `main` declaration by declaration, and again in a running page with `getComputedStyle`.

`.rcard` and `.ob-build-ghost` are byte-identical adoptions and cannot move.

## Coverage

The three `Card` renders in the evidence panel were new uncovered lines and put SonarCloud's new-code coverage at 70%. `onboarding-evidence.test.tsx` covers all three and counts cards against findings in both directions — a finding that stops being a `Card` goes missing on one side, a card the panel did not draw is extra on the other. Verified by reverting one render to a hand-rolled `<article>`: two tests fail.

The count respects the fact preview cap rather than ignoring it. `FACT_PREVIEW_LIMIT` is named and exported, the fixture crosses it, and raising the cap by one fails the count.

`make check-fe` green (4510 + 36 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Onboarding stops drawing its own cards. Read-only surfaces render through `Card`, and the two selection cards become one `.choice-card`, removing duplicated chrome while keeping fact vs legal text differences.

- Render `.rcard`, `.finding-card`, `.legal-preview-card`, and `.ob-build-ghost` with `Card` (`as="div" | "article"`). Keep class hooks. Restore `.legal-preview-card { display: grid; gap }` and `.finding-card { min-width: 0 }`.
- Selection controls use `.choice-card` (a `<button>` with `aria-pressed`) with `.fact-card`/`.legal-card` modifiers for their differing text rules.
- Evidence panel draws each finding as a `Card` and enforces one card per finding. Export `FACT_PREVIEW_LIMIT = 12` and use it in code and tests.
- Add `frontend/src/design-system/onecard.test.ts` to fail on any second `.card` chrome; normalize whitespace (including inside `var()`), expand `background`/`border` shorthands, and require exactly one `.card` rule in `atoms.css`.
- Add `frontend/src/screens/onboarding-evidence.test.tsx` to assert legal entity, profile field, and live fact render as `Card` only. Tighten fixtures by annotating the fact generator’s return type to fully type-check fields.

**Migration**
- Update selectors/tests from `data-finding-id` to `data-testid="finding-<field>"`.
- Replace `.fact-card`/`.legal-card` with `.choice-card` plus `.fact-card`/`.legal-card` modifiers. Rename `.fact-check` to `.choice-check`.

<sup>Written for commit 8b8a8e09335b5f0596ee55f88f779e4255026695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized onboarding screens on shared card components and styling.
  * Consolidated legal-entity and fact-selection cards for a more consistent experience.
  * Improved legal previews and finding-card layouts, including handling for long content.
  * Limited fact previews to 12 items for a clearer, more focused experience.
  * Preserved existing selection behavior, accessibility, content, and animations.
* **Tests**
  * Added coverage for onboarding evidence cards and fact-preview limits.
  * Added safeguards against duplicate card styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
