### PR TITLE
fix(seed): reseeding files existing activities under their project

### DIFF
--- a/backend/tools/seed-demo/activityproject_test.go
+++ b/backend/tools/seed-demo/activityproject_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -105,8 +106,9 @@ func TestProjectRelinkFor(t *testing.T) {
 		seededProject{ID: "migration", StartedAt: "2025-10-28"},
 		seededProject{ID: "second-tenant", StartedAt: "2026-08-06"},
 	)
-	// A mail from during the migration, which is what the fixtures are about.
 	act := demoActivity{Company: "acme.test", DaysAgo: 214}
+	// During the migration, long before the second tenant began.
+	const during = "2026-01-22T09:00:00Z"
 
 	for _, tc := range []struct {
 		name     string
@@ -120,7 +122,7 @@ func TestProjectRelinkFor(t *testing.T) {
 			// exists, carries no project link, and reseeding never gave it
 			// one because the create path replays instead of re-linking.
 			name:     "unfiled activity is filed",
-			existing: seededActivity{ID: "a1"},
+			existing: seededActivity{ID: "a1", OccurredAt: during},
 			act:      act,
 			wantID:   "migration",
 			wantMove: true,
@@ -129,7 +131,7 @@ func TestProjectRelinkFor(t *testing.T) {
 			// What the old list-order linker left behind: filed under a
 			// project that had not started when the mail was sent.
 			name:     "wrongly filed activity is moved",
-			existing: seededActivity{ID: "a1", ProjectID: "second-tenant"},
+			existing: seededActivity{ID: "a1", OccurredAt: during, ProjectID: "second-tenant"},
 			act:      act,
 			wantID:   "migration",
 			wantMove: true,
@@ -137,7 +139,7 @@ func TestProjectRelinkFor(t *testing.T) {
 		{
 			// A converged installation. The pass must be silent.
 			name:     "correctly filed activity is left alone",
-			existing: seededActivity{ID: "a1", ProjectID: "migration"},
+			existing: seededActivity{ID: "a1", OccurredAt: during, ProjectID: "migration"},
 			act:      act,
 			wantMove: false,
 		},
@@ -145,14 +147,22 @@ func TestProjectRelinkFor(t *testing.T) {
 			// Older than every project on the account, so it is about none of
 			// them. Filing it anyway stamps a record that had no reason to be.
 			name:     "activity predating every project is left alone",
-			existing: seededActivity{ID: "a1"},
-			act:      demoActivity{Company: "acme.test", DaysAgo: 900},
+			existing: seededActivity{ID: "a1", OccurredAt: "2024-01-05T09:00:00Z"},
+			act:      act,
 			wantMove: false,
 		},
 		{
 			name:     "activity on a company with no project is left alone",
+			existing: seededActivity{ID: "a1", OccurredAt: during},
+			act:      demoActivity{Company: "nobody.test"},
+			wantMove: false,
+		},
+		{
+			// An activity the server returned without a date cannot be dated
+			// against, and guessing is what this function exists to avoid.
+			name:     "activity with no occurred_at is left alone",
 			existing: seededActivity{ID: "a1"},
-			act:      demoActivity{Company: "nobody.test", DaysAgo: 30},
+			act:      act,
 			wantMove: false,
 		},
 	} {
@@ -165,5 +175,94 @@ func TestProjectRelinkFor(t *testing.T) {
 				t.Errorf("project = %q, want %q", gotID, tc.wantID)
 			}
 		})
+	}
+}
+
+// TestTheReconciliationDatesByTheRecordNotTheDataset — the drift a review
+// caught, and the reason projectRelinkFor takes its date from the stored row.
+//
+// days_ago is relative to the day the seeder RUNS. occurred_at was frozen by
+// the first run and never moves again. So on any later day the two disagree,
+// and a pass that dated by the offset would decide an activity nothing had
+// touched now belongs to a different project — then relink it, stamping
+// six-year retention that cannot be lifted.
+func TestTheReconciliationDatesByTheRecordNotTheDataset(t *testing.T) {
+	refs := refsWithProjects(
+		seededProject{ID: "migration", StartedAt: "2025-10-28"},
+		seededProject{ID: "second-tenant", StartedAt: "2026-08-06"},
+	)
+	// The record says this mail was sent during the migration, and that does
+	// not change however long ago the seeder last ran.
+	existing := seededActivity{ID: "a1", OccurredAt: "2026-01-22T09:00:00Z", ProjectID: "migration"}
+
+	// The same entry read on a day when its days_ago offset would now land
+	// after the second tenant started. Dating by the offset would move it.
+	act := demoActivity{Company: "acme.test", DaysAgo: 1}
+	if _, move := projectRelinkFor(refs, act, existing); move {
+		t.Error("the pass dated by the dataset offset and would relink an activity nothing had changed")
+	}
+	if want := projectForActivity(refs, act); want != "second-tenant" {
+		t.Fatalf("the fixture no longer demonstrates the drift: offset dating gives %q", want)
+	}
+}
+
+// TestASeededActivityIsIdentifiedByBothHalvesOfItsKey — source_id alone is
+// not an identity.
+//
+// The database is unique on (source_system, source_id), and this tool's own
+// ids are "act-0", "act-1" — spellings any connector is free to use. While the
+// activity index only counted rows, a collision merely miscounted. Now that it
+// decides which activity gets RELINKED, the same collision would file a
+// stranger's mail under a demo project and stamp it with six-year retention
+// that cannot be lifted.
+func TestASeededActivityIsIdentifiedByBothHalvesOfItsKey(t *testing.T) {
+	page := json.RawMessage(`[
+	  {"id":"theirs","source_system":"gmail","source_id":"act-0","occurred_at":"2026-01-22T09:00:00Z",
+	   "links":[{"entity_type":"organization","entity_id":"org-2"}]},
+	  {"id":"ours","source_system":"seed","source_id":"act-0","occurred_at":"2026-01-22T09:00:00Z",
+	   "links":[{"entity_type":"organization","entity_id":"org-1"}]}
+	]`)
+	seen := map[string]seededActivity{}
+	if err := indexSeededActivities(page, seen); err != nil {
+		t.Fatalf("indexing the page: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Errorf("indexed %d activities, want only the seeded one", len(seen))
+	}
+	got, ok := seen["act-0"]
+	if !ok {
+		t.Fatal("the seeded activity was not indexed at all")
+	}
+	if got.ID != "ours" {
+		t.Errorf("act-0 resolved to %q — a row from another source system claimed the key", got.ID)
+	}
+	if got.OrganizationID != "org-1" {
+		t.Errorf("organization = %q, want org-1", got.OrganizationID)
+	}
+}
+
+// TestTheIndexReadsBothLinksItActsOn — the reconciliation decides from the
+// project link (what is filed now) and the organization link (whether this is
+// even the right row), so a page that carries both must yield both.
+func TestTheIndexReadsBothLinksItActsOn(t *testing.T) {
+	page := json.RawMessage(`[
+	  {"id":"a1","source_system":"seed","source_id":"act-7","occurred_at":"2026-01-22T09:00:00Z",
+	   "links":[{"entity_type":"organization","entity_id":"org-1"},
+	            {"entity_type":"person","entity_id":"p-1"},
+	            {"entity_type":"project","entity_id":"proj-1"}]}
+	]`)
+	seen := map[string]seededActivity{}
+	if err := indexSeededActivities(page, seen); err != nil {
+		t.Fatalf("indexing the page: %v", err)
+	}
+	got := seen["act-7"]
+	if got.ProjectID != "proj-1" {
+		t.Errorf("project = %q, want proj-1", got.ProjectID)
+	}
+	if got.OrganizationID != "org-1" {
+		t.Errorf("organization = %q, want org-1", got.OrganizationID)
+	}
+	if got.OccurredAt == "" {
+		t.Error("occurred_at was dropped; the reconciliation dates against it")
 	}
 }

--- a/backend/tools/seed-demo/activityproject_test.go
+++ b/backend/tools/seed-demo/activityproject_test.go
@@ -93,3 +93,77 @@ func TestAProjectWithNoStartDateIsTheLastResort(t *testing.T) {
 		t.Errorf("linked to %q, want the project that has a start date", got)
 	}
 }
+
+// TestProjectRelinkFor covers every state an activity already on file can be
+// in when the reconciliation pass reaches it.
+//
+// Each relink is a write on a surface that stamps a six-year retention class
+// the database will not let anyone lift, so "do nothing" is the answer that
+// has to be right most often.
+func TestProjectRelinkFor(t *testing.T) {
+	refs := refsWithProjects(
+		seededProject{ID: "migration", StartedAt: "2025-10-28"},
+		seededProject{ID: "second-tenant", StartedAt: "2026-08-06"},
+	)
+	// A mail from during the migration, which is what the fixtures are about.
+	act := demoActivity{Company: "acme.test", DaysAgo: 214}
+
+	for _, tc := range []struct {
+		name     string
+		existing seededActivity
+		act      demoActivity
+		wantID   string
+		wantMove bool
+	}{
+		{
+			// The shape a pre-projects installation is in: the activity
+			// exists, carries no project link, and reseeding never gave it
+			// one because the create path replays instead of re-linking.
+			name:     "unfiled activity is filed",
+			existing: seededActivity{ID: "a1"},
+			act:      act,
+			wantID:   "migration",
+			wantMove: true,
+		},
+		{
+			// What the old list-order linker left behind: filed under a
+			// project that had not started when the mail was sent.
+			name:     "wrongly filed activity is moved",
+			existing: seededActivity{ID: "a1", ProjectID: "second-tenant"},
+			act:      act,
+			wantID:   "migration",
+			wantMove: true,
+		},
+		{
+			// A converged installation. The pass must be silent.
+			name:     "correctly filed activity is left alone",
+			existing: seededActivity{ID: "a1", ProjectID: "migration"},
+			act:      act,
+			wantMove: false,
+		},
+		{
+			// Older than every project on the account, so it is about none of
+			// them. Filing it anyway stamps a record that had no reason to be.
+			name:     "activity predating every project is left alone",
+			existing: seededActivity{ID: "a1"},
+			act:      demoActivity{Company: "acme.test", DaysAgo: 900},
+			wantMove: false,
+		},
+		{
+			name:     "activity on a company with no project is left alone",
+			existing: seededActivity{ID: "a1"},
+			act:      demoActivity{Company: "nobody.test", DaysAgo: 30},
+			wantMove: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotMove := projectRelinkFor(refs, tc.act, tc.existing)
+			if gotMove != tc.wantMove {
+				t.Fatalf("move = %v, want %v", gotMove, tc.wantMove)
+			}
+			if gotMove && gotID != tc.wantID {
+				t.Errorf("project = %q, want %q", gotID, tc.wantID)
+			}
+		})
+	}
+}

--- a/backend/tools/seed-demo/activityprojects.go
+++ b/backend/tools/seed-demo/activityprojects.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Which project a piece of correspondence belongs to, and how an installation
+// that got the answer wrong — or never had one — is repaired.
+
+// relinkActivitiesToProjects files the activities that were already on file
+// under the project they belong to.
+//
+// It exists because posting an activity again does NOT re-link it. The create
+// path is idempotent on source_system+source_id, and a replay returns the
+// existing row before it reaches insertActivityLinks (activities/activity.go,
+// logActivityInTx) — deliberately, because that path is a read with a read's
+// row-scope gate, not a write. So an installation seeded before projects
+// carried activities kept every timeline empty no matter how often it was
+// reseeded, and only a seed from an empty database showed the links.
+//
+// The fix belongs here rather than in the replay path: /v1/activities/{id}/relink
+// is the endpoint the product already offers for exactly this — associate an
+// activity that exists with a record it belongs to. It is idempotent on
+// (activity, entity_type, entity_id) and preserves the original source and
+// captured_by, so re-running changes nothing and the provenance still reads as
+// a seeded capture rather than a re-capture.
+func relinkActivitiesToProjects(c *client, cfg demoConfig, refs pipelineRefs, seen map[string]seededActivity, mode runMode) error {
+	if mode == modeDryRun {
+		return nil
+	}
+	for i, act := range cfg.Activities {
+		existing, ok := seen[fmt.Sprintf("act-%d", i)]
+		if !ok || existing.ID == "" {
+			// Not on file before this run, so the create above linked it.
+			continue
+		}
+		want, move := projectRelinkFor(refs, act, existing)
+		if !move {
+			continue
+		}
+		// replace_existing_of_type, because at most one project link is
+		// allowed per activity (uq_activity_link_project) — adding a second
+		// would be refused, and the activity may be filed under the project
+		// an older seeder picked by list order rather than by date.
+		body := jsonBody{
+			"entity_type":              "project",
+			"entity_id":                want,
+			"replace_existing_of_type": true,
+		}
+		if err := c.post("/v1/activities/"+existing.ID+"/relink", body, nil); err != nil {
+			return fmt.Errorf("filing activity %d (%s on %s) under its project: %w", i, act.Kind, act.Company, err)
+		}
+	}
+	return nil
+}
+
+// projectRelinkFor decides whether an activity already on file has to be
+// moved, and to which project.
+//
+// Separate from the loop that performs it because the decision is the part
+// worth testing: every relink is a write on a surface that stamps a six-year
+// retention class the database will not let anyone lift, so a pass that moved
+// what was already right would write for no reason and stamp records that had
+// no business being stamped.
+func projectRelinkFor(refs pipelineRefs, act demoActivity, existing seededActivity) (projectID string, move bool) {
+	want := projectForActivity(refs, act)
+	if want == "" {
+		// Older than every project on the account, so it belongs to none.
+		// Inventing a link here is worse than leaving it: the stamp is
+		// permanent and unfiling does not lift it.
+		return "", false
+	}
+	if existing.ProjectID == want {
+		return "", false
+	}
+	return want, true
+}
+
+// projectForActivity picks which of a company's projects a mail, call or
+// meeting belongs to: the LATEST one that had already started when it
+// happened.
+//
+// The company's projects arrive oldest first, so this walks forward and keeps
+// the last one still in the past. Simply taking the first project a company
+// had put all nine of valantic's mails about the Shopsystem migration onto
+// "Zweiter Mandant im Shopsystem", which starts nine months after the last of
+// them — a timeline that could not have happened.
+//
+// An activity older than every project links to none. That is the honest
+// answer: correspondence from before any delivery work began was not about
+// delivery work.
+func projectForActivity(refs pipelineRefs, act demoActivity) string {
+	projects := refs.projectsByCompany[strings.ToLower(act.Company)]
+	if len(projects) == 0 {
+		return ""
+	}
+	// The same offset seedActivities computes, as a date, so it compares
+	// against started_at on its own terms.
+	occurred := -act.DaysAgo
+	if act.DaysIn > 0 {
+		occurred = act.DaysIn
+	}
+	when := refs.date(occurred)
+
+	chosen := ""
+	for _, proj := range projects {
+		// A project with no start date cannot be dated against, and sorts
+		// last; it is only reached when nothing better has been found.
+		if proj.StartedAt == "" || proj.StartedAt > when {
+			continue
+		}
+		chosen = proj.ID
+	}
+	return chosen
+}

--- a/backend/tools/seed-demo/activityprojects.go
+++ b/backend/tools/seed-demo/activityprojects.go
@@ -38,6 +38,16 @@ func relinkActivitiesToProjects(c *client, cfg demoConfig, refs pipelineRefs, se
 			// Not on file before this run, so the create above linked it.
 			continue
 		}
+		// The stored row must be the account this entry is about. A source id
+		// here is the entry's POSITION ("act-0", "act-1") and the dataset
+		// gives activities no ref of their own, so inserting an entry in the
+		// middle of the array renames every row after it. Relinking on a
+		// mismatched id would file one company's mail under another company's
+		// project and stamp it with retention nobody can lift, so a
+		// disagreement means leave it alone.
+		if orgID, ok := refs.orgsByDom[strings.ToLower(act.Company)]; !ok || existing.OrganizationID != orgID {
+			continue
+		}
 		want, move := projectRelinkFor(refs, act, existing)
 		if !move {
 			continue
@@ -67,7 +77,14 @@ func relinkActivitiesToProjects(c *client, cfg demoConfig, refs pipelineRefs, se
 // what was already right would write for no reason and stamp records that had
 // no business being stamped.
 func projectRelinkFor(refs pipelineRefs, act demoActivity, existing seededActivity) (projectID string, move bool) {
-	want := projectForActivity(refs, act)
+	// Dated against the record, not the dataset — see projectForActivityOn.
+	// An activity on file whose occurred_at the server did not return cannot
+	// be dated at all, and guessing is what this function exists to avoid.
+	when, _, found := strings.Cut(existing.OccurredAt, "T")
+	if !found || when == "" {
+		return "", false
+	}
+	want := projectForActivityOn(refs, act.Company, when)
 	if want == "" {
 		// Older than every project on the account, so it belongs to none.
 		// Inventing a link here is worse than leaving it: the stamp is
@@ -94,17 +111,28 @@ func projectRelinkFor(refs pipelineRefs, act demoActivity, existing seededActivi
 // answer: correspondence from before any delivery work began was not about
 // delivery work.
 func projectForActivity(refs pipelineRefs, act demoActivity) string {
-	projects := refs.projectsByCompany[strings.ToLower(act.Company)]
-	if len(projects) == 0 {
-		return ""
-	}
-	// The same offset seedActivities computes, as a date, so it compares
-	// against started_at on its own terms.
+	// The offset the dataset gives, as a date. Right for an activity being
+	// written now, because that is the same clock the create call uses.
 	occurred := -act.DaysAgo
 	if act.DaysIn > 0 {
 		occurred = act.DaysIn
 	}
-	when := refs.date(occurred)
+	return projectForActivityOn(refs, act.Company, refs.date(occurred))
+}
+
+// projectForActivityOn is projectForActivity against a date the caller names.
+//
+// The reconciliation pass needs this because it must NOT use the dataset's
+// offset. days_ago is relative to the day the seeder runs, while the
+// occurred_at on file was frozen by the first run and never moves again — so
+// on any later day the two disagree, and a pass that dated by the offset would
+// decide an unchanged activity now belongs to a different project. It would
+// then relink it, which stamps six-year retention that cannot be lifted.
+func projectForActivityOn(refs pipelineRefs, company, when string) string {
+	projects := refs.projectsByCompany[strings.ToLower(company)]
+	if len(projects) == 0 {
+		return ""
+	}
 
 	chosen := ""
 	for _, proj := range projects {

--- a/backend/tools/seed-demo/generated.go
+++ b/backend/tools/seed-demo/generated.go
@@ -211,7 +211,7 @@ func seedGeneratedLeads(c *client, refs pipelineRefs, plan map[string]profile, m
 		if existing[sourceID] == "" {
 			body := jsonBody{
 				"source":        seedSource,
-				"source_system": "seed",
+				"source_system": seedSourceSystem,
 				"source_id":     sourceID,
 				"status":        leadCreateStatus(p.LeadState),
 				"full_name":     first + " " + last,

--- a/backend/tools/seed-demo/pipeline.go
+++ b/backend/tools/seed-demo/pipeline.go
@@ -154,7 +154,7 @@ func seedLeads(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (int,
 		// re-running finds the same lead rather than filing a second one.
 		body := jsonBody{
 			"source":        seedSource,
-			"source_system": "seed",
+			"source_system": seedSourceSystem,
 			"source_id":     lead.Ref,
 			"status":        lead.Status,
 		}

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -66,7 +66,7 @@ func seedActivities(c *client, seats *sessions, cfg demoConfig, refs pipelineRef
 			"kind":          act.Kind,
 			"occurred_at":   refs.timestamp(occurred),
 			"source":        seedSource,
-			"source_system": "seed",
+			"source_system": seedSourceSystem,
 			"source_id":     fmt.Sprintf("act-%d", i),
 			"links":         links,
 		}
@@ -182,36 +182,54 @@ func activityLinks(c *client, refs pipelineRefs, act demoActivity, orgID string)
 func loadActivitySourceIDs(c *client) (map[string]seededActivity, error) {
 	seen := map[string]seededActivity{}
 	err := c.getAll("/v1/activities", nil, func(raw json.RawMessage) error {
-		var rows []struct {
-			ID       string `json:"id"`
-			SourceID string `json:"source_id"`
-			Links    []struct {
-				EntityType string `json:"entity_type"`
-				EntityID   string `json:"entity_id"`
-			} `json:"links"`
-		}
-		if err := json.Unmarshal(raw, &rows); err != nil {
-			return err
-		}
-		for _, row := range rows {
-			if row.SourceID == "" {
-				continue
-			}
-			found := seededActivity{ID: row.ID}
-			for _, link := range row.Links {
-				if link.EntityType == "project" {
-					found.ProjectID = link.EntityID
-					break
-				}
-			}
-			seen[row.SourceID] = found
-		}
-		return nil
+		return indexSeededActivities(raw, seen)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing activities: %w", err)
 	}
 	return seen, nil
+}
+
+// indexSeededActivities adds one page of activities to the index, keeping only
+// the rows this tool captured.
+func indexSeededActivities(raw json.RawMessage, seen map[string]seededActivity) error {
+	var rows []struct {
+		ID           string `json:"id"`
+		SourceSystem string `json:"source_system"`
+		SourceID     string `json:"source_id"`
+		OccurredAt   string `json:"occurred_at"`
+		Links        []struct {
+			EntityType string `json:"entity_type"`
+			EntityID   string `json:"entity_id"`
+		} `json:"links"`
+	}
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		// BOTH halves of the key, because source_id alone is not one.
+		// The database is unique on (source_system, source_id), and the
+		// seeder's own ids are "act-0", "act-1" — spellings a connector
+		// is free to use too. Keying on the id alone once only miscounted
+		// how many rows a run created; now that this map decides which
+		// activity gets relinked, the same collision would file somebody
+		// else's mail under a demo project and stamp it with six-year
+		// retention that cannot be lifted.
+		if row.SourceSystem != seedSourceSystem || row.SourceID == "" {
+			continue
+		}
+		found := seededActivity{ID: row.ID, OccurredAt: row.OccurredAt}
+		for _, link := range row.Links {
+			switch link.EntityType {
+			case "project":
+				found.ProjectID = link.EntityID
+			case "organization":
+				found.OrganizationID = link.EntityID
+			}
+		}
+		seen[row.SourceID] = found
+	}
+	return nil
 }
 
 // seededActivity is one activity already on file, as the reconciliation pass
@@ -220,6 +238,18 @@ func loadActivitySourceIDs(c *client) (map[string]seededActivity, error) {
 type seededActivity struct {
 	ID        string
 	ProjectID string
+	// OccurredAt is when the activity says it happened, as the server stored
+	// it. The reconciliation dates against THIS rather than against the
+	// dataset's days_ago offset: the offset is relative to the day the seeder
+	// runs, and occurred_at was frozen on the first run and never moves after
+	// it, so on any later day the two disagree.
+	OccurredAt string
+	// OrganizationID is the account this activity is filed on. The
+	// reconciliation checks it against the dataset entry before touching
+	// anything: source ids here are positional ("act-0", "act-1"), so
+	// reordering the activities array silently remaps which stored row an
+	// index names, and relinking the wrong one cannot be undone.
+	OrganizationID string
 }
 
 // seedLifecycle says where each account stands with us.

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -24,7 +24,7 @@ func seedActivities(c *client, seats *sessions, cfg demoConfig, refs pipelineRef
 	// One read for the phase: which source ids already exist. Counting what
 	// this run genuinely created needs the before-state, and asking per
 	// activity was the seeder's worst quadratic.
-	seenSourceIDs := map[string]bool{}
+	seenSourceIDs := map[string]seededActivity{}
 	if mode != modeDryRun {
 		loaded, err := loadActivitySourceIDs(c)
 		if err != nil {
@@ -93,7 +93,7 @@ func seedActivities(c *client, seats *sessions, cfg demoConfig, refs pipelineRef
 		// Idempotent on source_system+source_id, so a re-run replays the same
 		// row and the reply cannot tell a create from a convergence. The
 		// source ids present before this phase say what was genuinely absent.
-		before := seenSourceIDs[fmt.Sprintf("act-%d", i)]
+		_, before := seenSourceIDs[fmt.Sprintf("act-%d", i)]
 		if err := author.post("/v1/activities", body, nil); err != nil {
 			if _, ok := conflictingID(err); ok {
 				continue
@@ -113,6 +113,9 @@ func seedActivities(c *client, seats *sessions, cfg demoConfig, refs pipelineRef
 		if !before {
 			created++
 		}
+	}
+	if err := relinkActivitiesToProjects(c, cfg, refs, seenSourceIDs, mode); err != nil {
+		return created, err
 	}
 	return created, nil
 }
@@ -170,63 +173,38 @@ func activityLinks(c *client, refs pipelineRefs, act demoActivity, orgID string)
 	return links, nil
 }
 
-// projectForActivity picks which of a company's projects a mail, call or
-// meeting belongs to: the LATEST one that had already started when it
-// happened.
-//
-// The company's projects arrive oldest first, so this walks forward and keeps
-// the last one still in the past. Simply taking the first project a company
-// had put all nine of valantic's mails about the Shopsystem migration onto
-// "Zweiter Mandant im Shopsystem", which starts nine months after the last of
-// them — a timeline that could not have happened.
-//
-// An activity older than every project links to none. That is the honest
-// answer: correspondence from before any delivery work began was not about
-// delivery work.
-func projectForActivity(refs pipelineRefs, act demoActivity) string {
-	projects := refs.projectsByCompany[strings.ToLower(act.Company)]
-	if len(projects) == 0 {
-		return ""
-	}
-	// The same offset seedActivities computes, as a date, so it compares
-	// against started_at on its own terms.
-	occurred := -act.DaysAgo
-	if act.DaysIn > 0 {
-		occurred = act.DaysIn
-	}
-	when := refs.date(occurred)
-
-	chosen := ""
-	for _, proj := range projects {
-		// A project with no start date cannot be dated against, and sorts
-		// last; it is only reached when nothing better has been found.
-		if proj.StartedAt == "" || proj.StartedAt > when {
-			continue
-		}
-		chosen = proj.ID
-	}
-	return chosen
-}
-
 // loadActivitySourceIDs reads the source_id of every activity ONCE.
 //
 // It replaces a per-activity search that listed activities on every call and
 // stopped at 200 rows. Both halves were bugs waiting for scale: the search was
 // O(activities²) over a run, and the cap meant activity 201 was never found,
 // so a converging re-run filed a duplicate of it instead of recognising it.
-func loadActivitySourceIDs(c *client) (map[string]bool, error) {
-	seen := map[string]bool{}
+func loadActivitySourceIDs(c *client) (map[string]seededActivity, error) {
+	seen := map[string]seededActivity{}
 	err := c.getAll("/v1/activities", nil, func(raw json.RawMessage) error {
 		var rows []struct {
+			ID       string `json:"id"`
 			SourceID string `json:"source_id"`
+			Links    []struct {
+				EntityType string `json:"entity_type"`
+				EntityID   string `json:"entity_id"`
+			} `json:"links"`
 		}
 		if err := json.Unmarshal(raw, &rows); err != nil {
 			return err
 		}
 		for _, row := range rows {
-			if row.SourceID != "" {
-				seen[row.SourceID] = true
+			if row.SourceID == "" {
+				continue
 			}
+			found := seededActivity{ID: row.ID}
+			for _, link := range row.Links {
+				if link.EntityType == "project" {
+					found.ProjectID = link.EntityID
+					break
+				}
+			}
+			seen[row.SourceID] = found
 		}
 		return nil
 	})
@@ -234,6 +212,14 @@ func loadActivitySourceIDs(c *client) (map[string]bool, error) {
 		return nil, fmt.Errorf("listing activities: %w", err)
 	}
 	return seen, nil
+}
+
+// seededActivity is one activity already on file, as the reconciliation pass
+// needs to see it: its id, so it can be relinked, and the project it is filed
+// under, so a pass that has nothing to do does nothing.
+type seededActivity struct {
+	ID        string
+	ProjectID string
 }
 
 // seedLifecycle says where each account stands with us.

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -23,6 +23,11 @@ import (
 // is never ours to set.
 const seedSource = "seed:demo"
 
+// seedSourceSystem is the system half of the idempotency key on every row this
+// tool captures. Paired with a source_id it is what the database is unique on,
+// so anything that looks a seeded row up by id alone has only half a key.
+const seedSourceSystem = "seed"
+
 type counts struct {
 	orgsCreated, orgsExisting     int
 	peopleCreated, peopleExisting int


### PR DESCRIPTION
Closes #2599.

## The bug

Re-seeding an installation never gave its activities a project link. Only a seed from an **empty** database worked, so every demo database that predates projects kept empty timelines however often it was reseeded — and `verify` still said OK, so nothing warned you.

The cause is not in the seeder. Posting an activity is idempotent on `source_system`+`source_id`, and the replay path returns the existing row *before* it reaches `insertActivityLinks` (`activities/activity.go`, `logActivityInTx`).

## Why the fix is not in the replay path

That early return is deliberate. The replay path is a **read**, with a read's row-scope gate — it resolves an idempotency key and must not disclose someone else's activity. Making it write links would turn a read into a write for every mail-capture caller, not just the seeder.

So the seeder reconciles afterwards, using the endpoint the product already offers for exactly this: `POST /v1/activities/{id}/relink`. It is idempotent on `(activity, entity_type, entity_id)` and preserves the original `source`/`captured_by`, so records still read as seeded captures rather than re-captures.

## Only writing what is wrong

A relink stamps a **six-year retention class the database will not let anyone lift** (`retentionstampproject.go`). So `projectRelinkFor` is conservative:

| state | action |
|---|---|
| unfiled | file it |
| filed under the wrong project | move it (`replace_existing_of_type`) |
| filed correctly | leave alone |
| older than every project on the account | leave unfiled |

## Verified

Against a database put into the broken state on purpose:

| step | project links |
|---|---|
| fresh seed | 83 |
| links deleted (simulating a pre-projects install) | 0 |
| reseed on current `main` — **the bug** | 0 |
| reseed with this change | **83** |

The repaired distribution is identical to a fresh seed's. A second run adds nothing — 83 `activity_relink` audit rows after two runs, retention stamps steady at 98. Provenance is intact: `source` is still `seed:demo` and `captured_by` still spreads across the six seat users, not collapsed onto the admin that performed the relink. And a direct check finds **zero** activities filed under a project that started after them.

## Notes

`records.go` crossed the 500-line cap, so the "which project does this correspondence belong to" code moved to `activityprojects.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reseeding now files existing activities under their correct project and avoids unsafe relinks. Previously, reseeds left activities unlinked; a reconciliation pass now uses `POST /v1/activities/{id}/relink` to link or move only when needed.

- Adds a reconciliation pass (`relinkActivitiesToProjects`) after activity creation; uses `replace_existing_of_type` on `POST /v1/activities/{id}/relink` and skips in dry-run.
- Indexes existing activities by full key `(source_system, source_id)` and only for `seedSourceSystem`; `loadActivitySourceIDs` now returns id, occurred_at, organization, and current project for safe decisions.
- Dates decisions by the stored `occurred_at` (not dataset offsets), and verifies the stored organization matches the dataset entry before writing.
- Only writes when an activity is unfiled or filed under the wrong project; leaves correctly filed activities and those older than all projects unfiled.
- Relinks are idempotent and preserve `source`/`captured_by`; a second reseed is a no-op.
- Standardizes `source_system` via `seedSourceSystem` in activities and leads seeding; moves project logic (`projectForActivity`, `projectRelinkFor`) to `backend/tools/seed-demo/activityprojects.go` with focused tests.
- No migration required; to backfill existing demo databases, rerun the seeder once.

<sup>Written for commit a96debd94e3f251755f9d9004ce3a5e312c3039d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Demo data seeding now correctly links activities to the appropriate projects based on timing and company.
  * Existing project links are updated when activities are incorrectly assigned, while unnecessary changes are avoided.
  * Activities without a matching project remain unlinked.
  * Dry-run seeding no longer modifies existing activities.
  * Repeated seeding now reliably recognizes previously seeded records and preserves their organization, project, and occurrence details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->