### PR TITLE
fix(seed-demo): a re-seed corrects only the rows the seeder wrote

### DIFF
--- a/backend/tools/seed-demo/ownership.go
+++ b/backend/tools/seed-demo/ownership.go
@@ -133,10 +133,17 @@ func hashIndex(key string, n int) int {
 func setOrganizationOwner(c *client, orgID, ownerID string) (bool, error) {
 	var current struct {
 		OwnerID string `json:"owner_id"`
+		Source  string `json:"source"`
 		Version int    `json:"version"`
 	}
 	if err := c.get("/v1/organizations/"+orgID, nil, &current); err != nil {
 		return false, fmt.Errorf("reading it back: %w", err)
+	}
+	// A company somebody else owns the record for keeps its owner. Reassigning
+	// an account by hand is a normal thing to do in a demo installation, and a
+	// re-seed that undid it would make the seeder unsafe to re-run.
+	if !seederOwns(current.Source) {
+		return false, nil
 	}
 	if current.OwnerID == ownerID {
 		return false, nil
@@ -162,10 +169,16 @@ func setStaffOwner(c *client, orgID, ownerID string, mode runMode) (int, error) 
 		}
 		var current struct {
 			OwnerID string `json:"owner_id"`
+			Source  string `json:"source"`
 			Version int    `json:"version"`
 		}
 		if err := c.get("/v1/people/"+personID, nil, &current); err != nil {
 			return changed, fmt.Errorf("reading person %s: %w", personID, err)
+		}
+		// Same rule as the company above: a hand-added or hand-edited person
+		// keeps their owner.
+		if !seederOwns(current.Source) {
+			continue
 		}
 		if current.OwnerID == ownerID {
 			continue
@@ -207,4 +220,21 @@ func employeesOf(c *client, orgID string) ([]string, error) {
 		return nil, fmt.Errorf("listing employments: %w", err)
 	}
 	return out, nil
+}
+
+// seederOwns says whether a record's `source` is one this tool wrote.
+//
+// The three phases that CORRECT a record already on file — owner, lifecycle,
+// relationship types — consult this first. They are replace-writes: they
+// compute the value the dataset says a company should have and PATCH it when
+// the live row disagrees. On a record somebody edited by hand that is not
+// convergence, it is reverting their edit, and a demo installation is exactly
+// where such edits live.
+//
+// So those phases now only correct rows this seeder created. A company added
+// through the UI, or one whose source a person changed, keeps whatever owner,
+// lifecycle and types it carries. Creation is untouched: a record the dataset
+// names and the database lacks is still created.
+func seederOwns(source string) bool {
+	return source == seedSource || source == inventedPersonSource
 }

--- a/backend/tools/seed-demo/records.go
+++ b/backend/tools/seed-demo/records.go
@@ -296,9 +296,15 @@ func seedLifecycle(c *client, cfg demoConfig, refs pipelineRefs, plan map[string
 				changed++
 				continue
 			}
-			current, version, err := organizationLifecycle(c, orgID)
+			current, version, source, err := organizationLifecycle(c, orgID)
 			if err != nil {
 				return changed, err
+			}
+			// A company whose record somebody else owns keeps the lifecycle
+			// stage it carries. Moving an account along the pipeline by hand is
+			// the demo's whole point; a re-seed must not walk it back.
+			if !seederOwns(source) {
+				continue
 			}
 			if current == stage {
 				continue
@@ -315,15 +321,16 @@ func seedLifecycle(c *client, cfg demoConfig, refs pipelineRefs, plan map[string
 	return changed, nil
 }
 
-func organizationLifecycle(c *client, orgID string) (stage string, version int, err error) {
+func organizationLifecycle(c *client, orgID string) (stage string, version int, source string, err error) {
 	var out struct {
 		Lifecycle string `json:"lifecycle"`
+		Source    string `json:"source"`
 		Version   int    `json:"version"`
 	}
 	if err := c.get("/v1/organizations/"+orgID, nil, &out); err != nil {
-		return "", 0, fmt.Errorf("reading organization %s: %w", orgID, err)
+		return "", 0, "", fmt.Errorf("reading organization %s: %w", orgID, err)
 	}
-	return out.Lifecycle, out.Version, nil
+	return out.Lifecycle, out.Version, out.Source, nil
 }
 
 // seedProducts fills the rate card the offers draw their line items from.

--- a/backend/tools/seed-demo/relationships.go
+++ b/backend/tools/seed-demo/relationships.go
@@ -77,6 +77,12 @@ func seedRelationshipTypes(c *client, cfg demoConfig, refs pipelineRefs, mode ru
 		if err != nil {
 			return changed, fmt.Errorf("reading %s: %w", domain, err)
 		}
+		// relationship_types is a REPLACE-set, so this phase is the most
+		// destructive of the three: a type somebody added by hand is dropped,
+		// not merged. Only rows this seeder wrote are retyped.
+		if !seederOwns(current.Source) {
+			continue
+		}
 		want := withPartnerKept(relationshipTypesFor(domain, current.Lifecycle, cfg), current.Types)
 		if sameTypes(current.Types, want) {
 			continue
@@ -131,11 +137,13 @@ func sameTypes(a, b []string) bool {
 func organizationTypes(c *client, orgID string) (struct {
 	Lifecycle string   `json:"lifecycle"`
 	Types     []string `json:"relationship_types"`
+	Source    string   `json:"source"`
 	Version   int      `json:"version"`
 }, error) {
 	var out struct {
 		Lifecycle string   `json:"lifecycle"`
 		Types     []string `json:"relationship_types"`
+		Source    string   `json:"source"`
 		Version   int      `json:"version"`
 	}
 	err := c.get("/v1/organizations/"+orgID, nil, &out)

--- a/backend/tools/seed-demo/relationships_test.go
+++ b/backend/tools/seed-demo/relationships_test.go
@@ -135,3 +135,27 @@ func TestADualRolePartnerIsPromotedBeforeItIsTyped(t *testing.T) {
 		}
 	}
 }
+
+// TestSeederOwnsOnlyItsOwnRows pins the rule that makes a re-seed safe on a
+// demo installation somebody has been working in: the three phases that
+// CORRECT a record already on file — owner, lifecycle, relationship types —
+// consult seederOwns first, so a company added or edited through the UI keeps
+// what a person put there.
+func TestSeederOwnsOnlyItsOwnRows(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   bool
+	}{
+		{seedSource, true},
+		{inventedPersonSource, true},
+		{"", false},
+		{"manual", false},
+		{"human", false},
+		{"import:hubspot", false},
+		{"seed:demo ", false},
+	} {
+		if got := seederOwns(tc.source); got != tc.want {
+			t.Errorf("seederOwns(%q) = %v, want %v", tc.source, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

`make seed-dev` walks every company and person and forces three values back to what the dataset says — the **owner**, the **lifecycle stage**, and the **relationship types**. It never asked who set them.

So a re-seed silently undid work somebody did by hand: reassigning an account, moving a company along the pipeline, adding a type. On a demo installation that isn't convergence, it's reverting a person's edit — and a demo installation is exactly where such edits live.

`relationship_types` needed it most: it's a replace-set, so a type added by hand was **dropped**, not merged.

## The fix

The three *correcting* phases consult `seederOwns` and skip a record whose `source` is not this tool's.

**Creating is untouched.** A record the dataset names and the database lacks is still created, so the seeder still fills an empty database exactly as before. Only overwriting became conditional.

`seederOwns` lives in `ownership.go` rather than `seed.go`: the question it answers is who owns a record, two of its three callers are the owner phases already in that file, and `seed.go` was one line under the 500-line cap.

## Provenance

Authored in a parallel session and left uncommitted in the shared checkout. I recovered it while bringing `main` current, rebased it onto today's `main`, and verified it there — it was written against a version of `seed-demo/` that has since been restructured, and it still applies and builds clean.

## Verified

- `go build` and `go test` clean in `backend/tools`
- `golangci-lint run ./seed-demo/...` — **0 issues**
- `make craft-static` — 0 blocker, 0 major, 0 minor
- The table test was checked against the mutation it exists to catch: with the guard forced to `true`, it fails

## One note on the full gate

`make check-backend` currently fails at `lint-modules` with forbidigo findings in `.tmp/worktrees/logact/` and `.tmp/worktrees/dealrooms/` — two live worktrees holding another session's uncommitted work, swept in because that target walks the filesystem rather than the diff. None of the findings are in this branch, and this module lints clean on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-seed in `seed-demo` now corrects only records the seeder wrote, preventing user edits from being reverted. Previously it always reset owner, lifecycle stage, and relationship types for every organization/person; now it skips rows whose `source` is not the seeder.

- Owner, lifecycle, and relationship-type updates call `seederOwns` and proceed only for `source` in {`seedSource`, `inventedPersonSource`}.
- Creation is unchanged: missing records are still created; only overwrites are conditional.
- Lifecycle and relationship-type reads now include `source`; guarding relationship types (a replace-set) avoids dropping manually added types.
- Review notes: ownership check lives in `ownership.go`; calls added in owner/lifecycle/relationships paths; a unit test pins `seederOwns` behavior.

<sup>Written for commit ada11a8d65e2b7a7e0bae0bb43a0125e73e5e060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demo data seeding now preserves manually created or edited organizations and people.
  * Existing lifecycle details and relationship types managed outside the demo seeder are no longer overwritten.
  * Seeder updates are limited to records it originally created, preventing unintended changes to imported or manually maintained data.
* **Tests**
  * Added coverage to verify that only recognized seeder-owned records are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->