### PR TITLE
feat(seed): the demo has deal rooms, with paper in them and questions on it

### DIFF
--- a/backend/tools/seed-demo/dealroompaper.go
+++ b/backend/tools/seed-demo/dealroompaper.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The paper a deal room puts in front of its buyer.
+//
+// Split from dealrooms.go, which holds the room itself and the conversation
+// in it. This half is only about documents: finding the contract the dataset
+// names, rendering its page a second time against the DEAL, and telling the
+// room to show it.
+//
+// The second copy is the point of the file. A room document must point at an
+// attachment filed on the room's deal (`entity_type: deal`); the contract PDF
+// every other phase writes is filed on the ORGANIZATION, because that is
+// where a contract's paper belongs and where the account page reads it from.
+// The two cannot be one row, and collapsing them would mean removing a
+// document from an account silently emptied a room.
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// seedRoomDocuments puts the deal's paper in front of the buyer, uploading a
+// deal-scoped copy first because the account's copy is filed elsewhere.
+//
+// Returns the attachment id per contract ref, so a thread can name the
+// document it is about.
+func seedRoomDocuments(c *client, room demoDealRoom, roomID, dealID string, refs pipelineRefs) (map[string]string, int, error) {
+	byContract := map[string]string{}
+	if len(room.Documents) == 0 {
+		return byContract, 0, nil
+	}
+
+	onFile, err := dealRoomDocuments(c, roomID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	added := 0
+	for i, doc := range room.Documents {
+		contract, err := contractByRef(c, refs, doc.Contract)
+		if err != nil {
+			return nil, added, err
+		}
+		title := doc.Title
+		if title == "" {
+			title = contract.Title
+		}
+		if id, ok := onFile[title]; ok {
+			byContract[doc.Contract] = id
+			continue
+		}
+
+		attachmentID, err := uploadDealCopy(c, contract, dealID, refs)
+		if err != nil {
+			return nil, added, err
+		}
+		body := jsonBody{
+			"attachment_id": attachmentID,
+			"group_key":     doc.Group,
+			"title":         title,
+			"position":      i,
+			"source":        seedSource,
+		}
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := c.post("/v1/deal-rooms/"+roomID+"/documents", body, &out); err != nil {
+			return nil, added, fmt.Errorf("adding %s: %w", title, err)
+		}
+		byContract[doc.Contract] = out.ID
+		added++
+	}
+	return byContract, added, nil
+}
+
+// dealRoomDocuments is what the room already shows, keyed by the buyer-facing
+// title -- which is what the dataset names it by, and what a re-run has to
+// recognise so it does not upload a second copy of the same page.
+func dealRoomDocuments(c *client, roomID string) (map[string]string, error) {
+	var page struct {
+		Data []struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"data"`
+	}
+	if err := c.get("/v1/deal-rooms/"+roomID+"/documents", nil, &page); err != nil {
+		return nil, fmt.Errorf("listing the room's documents: %w", err)
+	}
+	out := make(map[string]string, len(page.Data))
+	for _, row := range page.Data {
+		out[row.Title] = row.ID
+	}
+	return out, nil
+}
+
+// uploadDealCopy files a contract's page against the DEAL.
+//
+// The same render the account's copy gets. It is a second attachment row on
+// purpose: the account copy is the company's paper and this one is what a
+// named buyer was shown in a room, and collapsing them would mean removing a
+// document from an account silently emptied a room.
+func uploadDealCopy(c *client, contract seededContract, dealID string, refs pipelineRefs) (string, error) {
+	body := renderPDF(contractPage(contract, refs))
+	attachmentID, err := c.upload("/v1/attachments", documentFilename(contract), body, map[string]string{
+		"entity_type": "deal",
+		"entity_id":   dealID,
+		"contract_id": contract.ID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("uploading the deal copy of %s: %w", contract.Title, err)
+	}
+	metadata := jsonBody{
+		"category":  "contract",
+		"title":     contract.Title,
+		"doc_state": docStateFor(contract.Status),
+	}
+	if err := c.patch("/v1/attachments/"+attachmentID+"/metadata", metadata, nil); err != nil {
+		return "", fmt.Errorf("setting the deal copy's metadata: %w", err)
+	}
+	return attachmentID, nil
+}
+
+// contractByRef resolves a dataset contract ref to the row on file, by the
+// company it names and the title it carries -- the same pair ensureContract
+// converges on.
+func contractByRef(c *client, refs pipelineRefs, ref string) (seededContract, error) {
+	for _, want := range refs.contractsByRef {
+		if want.Ref != ref {
+			continue
+		}
+		orgID, ok := refs.orgsByDom[strings.ToLower(want.Company)]
+		if !ok {
+			return seededContract{}, fmt.Errorf("contract %s names company %q, which is not seeded", ref, want.Company)
+		}
+		found, err := contractOn(c, orgID, want.Title)
+		if err != nil {
+			return seededContract{}, err
+		}
+		if found.ID == "" {
+			return seededContract{}, fmt.Errorf("contract %s (%q) is not on file", ref, want.Title)
+		}
+		return found, nil
+	}
+	return seededContract{}, fmt.Errorf("no contract has ref %q", ref)
+}
+
+func contractOn(c *client, orgID, title string) (seededContract, error) {
+	var page struct {
+		Data []seededContract `json:"data"`
+	}
+	// Under the ORGANIZATION, not /v1/contracts: a contract belongs to an
+	// account and the workspace-wide path does not accept a GET at all.
+	if err := c.get("/v1/organizations/"+orgID+"/contracts", url.Values{"limit": {"50"}}, &page); err != nil {
+		return seededContract{}, fmt.Errorf("listing contracts for %s: %w", orgID, err)
+	}
+	for _, row := range page.Data {
+		if strings.EqualFold(row.Title, title) {
+			if row.OrganizationID == "" {
+				row.OrganizationID = orgID
+			}
+			return row, nil
+		}
+	}
+	return seededContract{}, nil
+}

--- a/backend/tools/seed-demo/dealrooms.go
+++ b/backend/tools/seed-demo/dealrooms.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The buyer's side of a deal: a room, the paper it puts in front of them, the
+// people invited to read it, and the questions they asked.
+//
+// Everything else this tool writes is the SELLER's view. A deal room is the
+// one surface a customer sees, and a demo that opens one to an empty page
+// cannot show what the product is for -- the room is only worth anything when
+// there are documents in it and somebody has asked something about one.
+//
+// The documents are next door in dealroompaper.go, because a room's paper
+// turned out to be a concept of its own: a room document cannot reuse the
+// contract PDF the account already holds, and the reasons fill a file.
+//
+// Rooms are seeded LIVE. A room is created live and reaches nobody until
+// somebody is invited, so an uninvited room is private without a second gate.
+// The invitations here are the demo's whole point, so they follow immediately.
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// demoDealRoom is one buyer-facing room, named by the deal it projects.
+type demoDealRoom struct {
+	Ref  string `json:"ref"`
+	Deal string `json:"deal"`
+	// Title and Welcome are what the buyer reads first. Both are written in
+	// the CUSTOMER's language, like the contract PDFs and unlike the internal
+	// notes -- a room is correspondence, not a working note.
+	Title   string `json:"title"`
+	Welcome string `json:"welcome_message"`
+	// Steward is a user ref. Omitted, the deal's owner keeps it, which is what
+	// the API does on its own; naming one is for the case where the person a
+	// buyer should ask is not the person carrying the number.
+	Steward string `json:"steward"`
+	// Participants are the buyer's people. Every one of them is somebody who
+	// already exists on the account, named by email so the dataset cannot
+	// invent a contact the room would then be alone in knowing.
+	Participants []demoRoomParticipant `json:"participants"`
+	// Documents are contracts by ref. The room shows the paper of the deal it
+	// belongs to, so each named contract must sit on that same deal.
+	Documents []demoRoomDocument `json:"documents"`
+	// Threads are the questions asked and what was answered.
+	Threads []demoRoomThread `json:"threads"`
+}
+
+type demoRoomParticipant struct {
+	// Email identifies a person already seeded on the account. FullName is
+	// what the room shows; it is restated rather than looked up because the
+	// invitation carries its own copy and a buyer sees that one.
+	Email    string `json:"email"`
+	FullName string `json:"full_name"`
+	// Capability is `view` or `comment`. Left empty the API defaults to view,
+	// which is the least that lets somebody read the room.
+	Capability string `json:"capability"`
+}
+
+type demoRoomDocument struct {
+	Contract string `json:"contract"`
+	Group    string `json:"group"`
+	Title    string `json:"title"`
+}
+
+// demoRoomThread is one exchange. Opener is the question, Replies are what
+// followed it in order, and the seeder posts them as the SELLER's side --
+// which is the only side this tool can write, since a buyer comment arrives
+// through a credential nobody here holds.
+type demoRoomThread struct {
+	// Document names a room document by CONTRACT ref, so a thread hangs off
+	// the paper it is about. Omitted, the thread is room-level.
+	Document string `json:"document"`
+	// RequiredChange marks a thread the seller still owes an answer on. Only
+	// meaningful on a document thread.
+	RequiredChange bool     `json:"required_change"`
+	Body           string   `json:"body"`
+	Replies        []string `json:"replies"`
+	// Resolved closes the thread: the seller saying the point is settled.
+	Resolved bool `json:"resolved"`
+}
+
+// dealRoomCounts is what this phase wrote.
+type dealRoomCounts struct {
+	rooms, documents, participants, threads, comments int
+}
+
+// seedDealRooms opens a room per dataset entry and fills it.
+//
+// Runs after seedPaper, and must: a room document points at an attachment on
+// the deal, and the contracts have to exist before their paper can be
+// rendered from them.
+func seedDealRooms(c *client, cfg demoConfig, refs pipelineRefs, mode runMode) (dealRoomCounts, error) {
+	var n dealRoomCounts
+	for _, room := range cfg.DealRooms {
+		dealID, err := dealIDFor(c, cfg, refs, room.Deal)
+		if err != nil {
+			return n, fmt.Errorf("deal room %s: %w", room.Ref, err)
+		}
+		if dealID == "" {
+			return n, fmt.Errorf("deal room %s names deal %q, which is not seeded", room.Ref, room.Deal)
+		}
+		if mode == modeDryRun {
+			n.rooms++
+			n.documents += len(room.Documents)
+			n.participants += len(room.Participants)
+			n.threads += len(room.Threads)
+			continue
+		}
+
+		roomID, created, err := ensureDealRoom(c, room, dealID, refs)
+		if err != nil {
+			return n, fmt.Errorf("deal room %s: %w", room.Ref, err)
+		}
+		if created {
+			n.rooms++
+		}
+
+		docIDs, added, err := seedRoomDocuments(c, room, roomID, dealID, refs)
+		if err != nil {
+			return n, fmt.Errorf("deal room %s: %w", room.Ref, err)
+		}
+		n.documents += added
+
+		invited, err := seedRoomParticipants(c, room, roomID)
+		if err != nil {
+			return n, fmt.Errorf("deal room %s: %w", room.Ref, err)
+		}
+		n.participants += invited
+
+		threads, comments, err := seedRoomThreads(c, room, roomID, docIDs)
+		if err != nil {
+			return n, fmt.Errorf("deal room %s: %w", room.Ref, err)
+		}
+		n.threads += threads
+		n.comments += comments
+	}
+	return n, nil
+}
+
+// ensureDealRoom opens the room, or finds the one a previous run opened.
+//
+// Convergence is the deal: at most one active room per deal, and a second
+// create answers 409 `deal_room_already_open`. So the listing by deal_id is
+// the whole of the check -- there is no name to match on and no second room
+// to confuse it with.
+func ensureDealRoom(c *client, room demoDealRoom, dealID string, refs pipelineRefs) (id string, created bool, err error) {
+	existing, err := findDealRoom(c, dealID)
+	if err != nil {
+		return "", false, err
+	}
+	if existing != "" {
+		return existing, false, nil
+	}
+
+	body := jsonBody{
+		"deal_id": dealID,
+		"title":   room.Title,
+		"source":  seedSource,
+	}
+	addIfSet(body, "welcome_message", room.Welcome)
+	if steward, ok := refs.usersByRef[room.Steward]; ok {
+		body["steward_user_id"] = steward
+	}
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := c.post("/v1/deal-rooms", body, &out); err != nil {
+		// The already-open refusal names nothing, so re-read rather than
+		// parse it: a room created moments ago is exactly the case a search
+		// behind an index has not caught up with, and the listing by deal is
+		// a direct read rather than a search.
+		if isConflict(err) {
+			again, findErr := findDealRoom(c, dealID)
+			if findErr != nil {
+				return "", false, findErr
+			}
+			if again != "" {
+				return again, false, nil
+			}
+		}
+		return "", false, fmt.Errorf("opening the room: %w", err)
+	}
+	return out.ID, true, nil
+}
+
+func findDealRoom(c *client, dealID string) (string, error) {
+	var page struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	query := url.Values{"deal_id": {dealID}, "limit": {"5"}}
+	if err := c.get("/v1/deal-rooms", query, &page); err != nil {
+		return "", fmt.Errorf("listing rooms for deal %s: %w", dealID, err)
+	}
+	if len(page.Data) == 0 {
+		return "", nil
+	}
+	return page.Data[0].ID, nil
+}
+
+// seedRoomParticipants invites the buyer's people.
+//
+// Re-inviting an address already in the room is refused
+// (409 `deal_room_participant_already_invited`), which is the convergence:
+// the listing says who is in, and anybody already there is left alone rather
+// than re-invited, because a fresh invitation invalidates the link the last
+// one sent.
+func seedRoomParticipants(c *client, room demoDealRoom, roomID string) (int, error) {
+	if len(room.Participants) == 0 {
+		return 0, nil
+	}
+	onFile, err := dealRoomParticipants(c, roomID)
+	if err != nil {
+		return 0, err
+	}
+	invited := 0
+	for _, person := range room.Participants {
+		if onFile[strings.ToLower(person.Email)] {
+			continue
+		}
+		body := jsonBody{
+			"full_name": person.FullName,
+			"email":     person.Email,
+			"source":    seedSource,
+		}
+		addIfSet(body, "capability", person.Capability)
+		if err := c.post("/v1/deal-rooms/"+roomID+"/participants", body, nil); err != nil {
+			if isConflict(err) {
+				continue
+			}
+			return invited, fmt.Errorf("inviting %s: %w", person.Email, err)
+		}
+		invited++
+	}
+	return invited, nil
+}
+
+func dealRoomParticipants(c *client, roomID string) (map[string]bool, error) {
+	var page struct {
+		Data []struct {
+			Email string `json:"email"`
+		} `json:"data"`
+	}
+	if err := c.get("/v1/deal-rooms/"+roomID+"/participants", nil, &page); err != nil {
+		return nil, fmt.Errorf("listing the room's participants: %w", err)
+	}
+	out := make(map[string]bool, len(page.Data))
+	for _, row := range page.Data {
+		out[strings.ToLower(row.Email)] = true
+	}
+	return out, nil
+}
+
+// seedRoomThreads opens the questions and answers them.
+//
+// Convergence is the opening comment's body: a thread is identified by what
+// it asked, because the API mints the id and the dataset has no way to name
+// one. Two threads opening with the same sentence would be one thread here,
+// which is a constraint the dataset note states rather than a bug to work
+// around -- two identical questions in one room is not a demo anybody wants.
+func seedRoomThreads(c *client, room demoDealRoom, roomID string, docIDs map[string]string) (threads, comments int, err error) {
+	if len(room.Threads) == 0 {
+		return 0, 0, nil
+	}
+	onFile, err := dealRoomThreads(c, roomID)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, thread := range room.Threads {
+		existing, seen := onFile[thread.Body]
+		threadID := existing.id
+		if !seen {
+			body := jsonBody{"body": thread.Body, "source": seedSource}
+			if thread.Document != "" {
+				docID, ok := docIDs[thread.Document]
+				if !ok {
+					return threads, comments, fmt.Errorf(
+						"thread names document %q, which this room does not show", thread.Document)
+				}
+				body["document_id"] = docID
+				if thread.RequiredChange {
+					body["required_change"] = true
+				}
+			}
+			var out struct {
+				ID string `json:"id"`
+			}
+			if err := c.post("/v1/deal-rooms/"+roomID+"/threads", body, &out); err != nil {
+				return threads, comments, fmt.Errorf("opening a thread: %w", err)
+			}
+			threadID = out.ID
+			threads++
+		}
+
+		// Replies are matched by body too, so a re-run adds only what is
+		// missing rather than saying everything twice.
+		for _, reply := range thread.Replies {
+			if seen && existing.comments[reply] {
+				continue
+			}
+			if err := c.post("/v1/deal-rooms/"+roomID+"/threads/"+threadID+"/comments",
+				jsonBody{"body": reply, "source": seedSource}, nil); err != nil {
+				return threads, comments, fmt.Errorf("replying in a thread: %w", err)
+			}
+			comments++
+		}
+
+		// Resolving an already resolved thread answers 200 unchanged, so this
+		// needs no check of its own.
+		if thread.Resolved && !existing.resolved {
+			if err := c.post("/v1/deal-rooms/"+roomID+"/threads/"+threadID+"/resolve", jsonBody{}, nil); err != nil {
+				return threads, comments, fmt.Errorf("resolving a thread: %w", err)
+			}
+		}
+	}
+	return threads, comments, nil
+}
+
+// roomThread is one thread as it stands: its id, what has been said in it,
+// and whether it is closed.
+type roomThread struct {
+	id       string
+	comments map[string]bool
+	resolved bool
+}
+
+func dealRoomThreads(c *client, roomID string) (map[string]roomThread, error) {
+	var page struct {
+		Data []struct {
+			ID       string `json:"id"`
+			Resolved bool   `json:"resolved"`
+			Comments []struct {
+				Body string `json:"body"`
+			} `json:"comments"`
+		} `json:"data"`
+	}
+	if err := c.get("/v1/deal-rooms/"+roomID+"/threads", nil, &page); err != nil {
+		return nil, fmt.Errorf("listing the room's threads: %w", err)
+	}
+	out := make(map[string]roomThread, len(page.Data))
+	for _, row := range page.Data {
+		if len(row.Comments) == 0 {
+			continue
+		}
+		said := make(map[string]bool, len(row.Comments))
+		for _, comment := range row.Comments {
+			said[comment.Body] = true
+		}
+		// Keyed by the OPENING comment, which is what the dataset writes as
+		// the thread's body.
+		out[row.Comments[0].Body] = roomThread{id: row.ID, comments: said, resolved: row.Resolved}
+	}
+	return out, nil
+}

--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -24,6 +24,7 @@ type demoConfig struct {
 	Leads            []demoLead          `json:"leads"`
 	Activities       []demoActivity      `json:"activities"`
 	Contracts        []demoContract      `json:"contracts"`
+	DealRooms        []demoDealRoom      `json:"deal_rooms"`
 	Projects         []demoProject       `json:"projects"`
 	Products         []demoProduct       `json:"products"`
 	Offers           []demoOffer         `json:"offers"`

--- a/backend/tools/seed-demo/seed.go
+++ b/backend/tools/seed-demo/seed.go
@@ -127,7 +127,7 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 		stakeholders: stakeholders, activities: activities,
 		contracts: paper.contracts, generatedContracts: paper.generatedContracts,
 		products: catalogue.products, offers: catalogue.offers,
-		documents: paper.documents, looseDocs: paper.looseDocs,
+		documents: paper.documents, looseDocs: paper.looseDocs, rooms: paper.rooms,
 		consents: consents, lifecycles: lifecycles, surfaces: catalogue.surfaces, fxRates: fxRates,
 		projects:     projects,
 		partnerEdges: catalogue.partnerEdges, relTypes: standing.relTypes,
@@ -141,6 +141,7 @@ func seedPipeline(c *client, seats *sessions, cfg demoConfig, companies []compan
 type paperCounts struct {
 	contracts, generatedContracts int
 	documents, looseDocs          int
+	rooms                         dealRoomCounts
 }
 
 // seedPaper files the agreements and the documents that hang off them.
@@ -165,6 +166,12 @@ func seedPaper(c *client, cfg demoConfig, refs pipelineRefs, plan map[string]pro
 	if n.looseDocs, err = seedLooseDocuments(c, refs, plan, mode); err != nil {
 		return n, err
 	}
+	// The rooms come last of all: a room document points at an attachment on
+	// the DEAL, and the contract it renders has to be on file before its page
+	// can be rendered from it.
+	if n.rooms, err = seedDealRooms(c, cfg, refs, mode); err != nil {
+		return n, err
+	}
 	return n, nil
 }
 
@@ -178,6 +185,7 @@ type pipelineCounts struct {
 	contracts, generatedContracts int
 	products, offers              int
 	documents, looseDocs          int
+	rooms                         dealRoomCounts
 	consents, lifecycles          int
 	surfaces, fxRates             int
 	projects                      int
@@ -196,6 +204,8 @@ func reportPipeline(n pipelineCounts) {
 	fmt.Printf("products:      %d new\n", n.products)
 	fmt.Printf("offers:        %d new\n", n.offers)
 	fmt.Printf("documents:     %d uploaded (%d contract PDFs, %d account documents)\n", n.documents+n.looseDocs, n.documents, n.looseDocs)
+	fmt.Printf("deal rooms:    %d new (%d document(s), %d invited, %d thread(s), %d reply/replies)\n",
+		n.rooms.rooms, n.rooms.documents, n.rooms.participants, n.rooms.threads, n.rooms.comments)
 	fmt.Printf("fx rates:      %d loaded\n", n.fxRates)
 	fmt.Printf("projects:      %d new\n", n.projects)
 	fmt.Printf("surfaces:      %d new (tags, lists, project staffing, quotas)\n", n.surfaces)


### PR DESCRIPTION
## What

The seeder had no deal-room support of any kind. `grep -rn "deal_room" backend/tools/seed-demo/` returned nothing, so the one surface a **customer** sees demoed as an empty page.

`demo.json` now carries a `deal_rooms` array — the room, the buyer's people, the contracts it puts in front of them, and the threads they opened. The dataset side is in gradionhq/margince-demo-database.

## The attachment problem

This is why it is not simply a new phase alongside the others.

A room document must point at an attachment filed on the room's **deal** (`entity_type: deal`); any other id answers 404. Every contract PDF this tool writes is filed on the **organization**, because that is where a contract's paper belongs and where the account page reads it from.

Confirmed against a seeded database before writing anything: **93 attachments, all on organizations, none on a deal.** So the room could not have reused a single one.

The phase re-renders the same page and files a second copy against the deal. Deliberate rather than wasteful: the account copy is the company's paper, this one is what a named buyer was shown in a room. Collapsing them would mean removing a document from an account silently emptied a room.

## Convergence

None of these records has a ref the API accepts, so each converges on something real:

| Record | Converges on |
|---|---|
| room | the **deal** — at most one active room per deal, a second create answers 409 |
| document | the buyer-facing title |
| participant | the email — re-inviting would invalidate the link already sent, so anyone already in is left alone |
| thread | the opening comment's body |
| reply | its own body |

Only the seller's side is written. A buyer comment arrives through a credential nobody here holds.

## Verified

Against a live stack, with the dataset's four rooms:

- 4 rooms, 4 documents, 11 participants, 7 threads, 16 comments
- **4 deal-scoped attachments where there were none**
- a second run creates nothing
- `verify: OK`
- `go build`, `go vet`, `go test ./tools/seed-demo/` all pass

One thread is left unanswered on purpose — `required_change`, unresolved, one comment. A room where every question is tidily closed shows the feature; a room with something still owed shows the job.

## Also

`/v1/contracts` does not accept a GET (405) — found while testing. A contract belongs to an account, so the listing is `/v1/organizations/{id}/contracts`, the path `seedDocuments` already uses.

Split across two files because craft-static (correctly) flagged 513 lines: `dealrooms.go` holds the room and its conversation, `dealroompaper.go` the documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds demo deal rooms end-to-end so buyers see populated rooms instead of empty pages. Previously the seeder wrote only seller-side data; now it creates rooms, shows deal paper, invites participants, and posts Q&A, with idempotent re-runs.

- Creates one active room per deal; falls back on listing by `deal_id` after 409 conflicts.
- Shows contract paper by re-rendering PDFs as deal-scoped attachments; cannot reuse org-scoped attachments; sets metadata on upload.
- Invites participants by email (skips already invited to avoid invalidating links).
- Seeds threads keyed by opening body; replies keyed by body; resolve is idempotent.
- Uses `/v1/organizations/{id}/contracts` for listings (fixes 405 on `/v1/contracts`).
- Adds `deal_rooms` to `demo.json`; dataset must include valid contract refs on the same deal and participant emails.

<sup>Written for commit 89967f21b908758c0dd1c373c7866431cc6db900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demo data seeding for deal rooms.
  * Deal rooms can include documents, participants, discussion threads, replies, and resolution states.
  * Added buyer-facing deal-room document support with automatic contract matching.
  * CLI reporting now includes deal-room, document, participant, thread, and reply totals.

* **Bug Fixes**
  * Prevented duplicate rooms, documents, invitations, threads, and comments during repeated seeding.
  * Added validation and clearer error handling for missing deals and documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->