### PR TITLE
fix(agents): a relink onto a person, a company or a deal no longer asks a human

### DIFF
--- a/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
+++ b/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
@@ -260,3 +260,93 @@ func TestAReadOnlyPassportSeesTheQueueAndCannotAnswerIt(t *testing.T) {
 		t.Errorf("the proposal reads %q after a refused decision — something was written anyway", status)
 	}
 }
+
+// A passport does what its holder could do unaided. Relinking an activity onto
+// a person, a company or a deal is an association a member undoes in the app
+// with no ceremony, so it must not cost a human decision here either — while a
+// PROJECT destination stays confirm-first, because filing under a project
+// classifies the activity as commercial correspondence, which is write-once.
+//
+// Both halves are the point. relinkActivityTier has always said so; what it
+// could not do was make the auto-execute half reachable. auth/admit.go raises a
+// dynamic tier that resolves to auto-execute without naming the version it was
+// resolved from, and relink_activity answered no version at all — so EVERY
+// agent relink was raised, whatever its destination.
+//
+// Driven from claude.ai on 2026-08-25 that showed up as three approvals for one
+// logged meeting: the model attached the person, the company and the deal after
+// the fact, and each attach staged a card the app would never have asked for.
+func TestAnAgentRelinksToAPersonWithoutAskingAndStillStagesAProject(t *testing.T) {
+	q := setupQueue(t)
+	invoke := q.invoker(t, q.mintPassport(t, "relinking agent", "read", "write"))
+
+	var person struct {
+		ID string `json:"id"`
+	}
+	if status := q.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Relink Subject"}, nil, &person); status != http.StatusCreated {
+		t.Fatalf("create person → %d", status)
+	}
+	var org struct {
+		ID string `json:"id"`
+	}
+	if status := q.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Relink Account"}, nil, &org); status != http.StatusCreated {
+		t.Fatalf("create organization → %d", status)
+	}
+	var project struct {
+		ID string `json:"id"`
+	}
+	if status := q.Call(t, "POST", "/v1/projects", apptest.AnyMap{
+		"name": "Relink Engagement", "organization_id": org.ID,
+	}, nil, &project); status != http.StatusCreated {
+		t.Fatalf("create project → %d", status)
+	}
+
+	// An activity linked to nothing, which is the shape the live failure left
+	// behind: logged first, attached afterwards.
+	logged, err := invoke("log_activity", `{"kind":"note","body":"relink me"}`)
+	if err != nil {
+		t.Fatalf("log_activity: %v", err)
+	}
+	// The tool answers the governed envelope, not a bare record.
+	var loggedEnvelope struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(logged), &loggedEnvelope); err != nil {
+		t.Fatalf("reading the logged activity: %v", err)
+	}
+	activity := loggedEnvelope.Data
+	if activity.ID == "" {
+		t.Fatalf("log_activity named no activity id: %s", logged)
+	}
+
+	for _, destination := range []struct {
+		entityType string
+		entityID   string
+	}{
+		{"person", person.ID},
+		{"organization", org.ID},
+	} {
+		t.Run("a "+destination.entityType+" is relinked with no approval", func(t *testing.T) {
+			if _, err := invoke("relink_activity", `{"activity_id":"`+activity.ID+
+				`","entity_type":"`+destination.entityType+`","entity_id":"`+destination.entityID+`"}`); err != nil {
+				var staged *workflow.StagedApprovalError
+				if errors.As(err, &staged) {
+					t.Fatalf("relinking to a %s staged approval %s; a member does this in the app unasked",
+						destination.entityType, staged.ApprovalID)
+				}
+				t.Fatalf("relink to %s: %v", destination.entityType, err)
+			}
+		})
+	}
+
+	t.Run("a project still stages", func(t *testing.T) {
+		_, err := invoke("relink_activity", `{"activity_id":"`+activity.ID+
+			`","entity_type":"project","entity_id":"`+project.ID+`"}`)
+		var staged *workflow.StagedApprovalError
+		if !errors.As(err, &staged) {
+			t.Fatalf("relinking to a project → %v, want a staged approval — filing under a project is write-once", err)
+		}
+	})
+}

--- a/backend/internal/modules/agents/toolcopy_records.go
+++ b/backend/internal/modules/agents/toolcopy_records.go
@@ -87,8 +87,9 @@ var logActivityCopy = toolCopy{
 		"records it was about: name every one of them in this call. A meeting is with a person, " +
 		"and also concerns their company and the deal it is for.",
 	Limits: "It writes history and changes nothing else: no deal moves, no field updates, nobody " +
-		"is notified. Unlinked, it appears on no timeline, and adding a link afterwards is " +
-		"relink_activity, which a person has to approve.",
+		"is notified. Unlinked, it appears on no timeline, and adding a link afterwards is a " +
+		"second call — relink_activity — which a person has to approve when it files under a " +
+		"project.",
 	Instead: "Use progress_deal when the same event also moves a deal, so move and note are one " +
 		"act; create_task for something still owed.",
 	Retain: "Keep the activity id — draft_email, send_email and send_message identify a " +

--- a/backend/internal/modules/agents/toolcopy_records.go
+++ b/backend/internal/modules/agents/toolcopy_records.go
@@ -71,11 +71,24 @@ var updateRecordCopy = toolCopy{
 		"result if you intend to retry the same change once a human has released it.",
 }
 
+// The Purpose names the records on purpose, and the ordering is the fix.
+//
+// Driven from claude.ai on 2026-08-25 the model logged a meeting with NO links
+// and then relinked three times, staging three approvals — while in the same
+// run create_task linked deal, person and organization in one call, four times
+// over. The ids were all in hand: the meeting was created LAST, after the org,
+// the person and the deal. The difference was the copy. create_task's Purpose
+// says what it is "on which records", so the links are part of what the caller
+// is deciding; this one described a timeline and left linking to a subordinate
+// clause, with the instruction itself down in the `links` field description —
+// which is read after the call has already been shaped.
 var logActivityCopy = toolCopy{
 	Purpose: "Record something that happened — a call, a meeting, a note, a message — on the " +
-		"timeline of the records it was about.",
+		"records it was about: name every one of them in this call. A meeting is with a person, " +
+		"and also concerns their company and the deal it is for.",
 	Limits: "It writes history and changes nothing else: no deal moves, no field updates, nobody " +
-		"is notified. Unlinked, it appears on no timeline.",
+		"is notified. Unlinked, it appears on no timeline, and adding a link afterwards is " +
+		"relink_activity, which a person has to approve.",
 	Instead: "Use progress_deal when the same event also moves a deal, so move and note are one " +
 		"act; create_task for something still owed.",
 	Retain: "Keep the activity id — draft_email, send_email and send_message identify a " +

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -357,7 +357,7 @@ func (t logActivity) Spec() mcp.ToolSpec {
 			"links":{"type":"array","items":{"type":"object","required":["entity_type","entity_id"],"properties":{
 				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
 				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false},
-				"description":"EVERY record this was about, named in this one call — a meeting is with a person and also concerns their company and the deal it is for, so name all of them here. This call writes them all and needs no approval; attaching one afterwards is relink_activity, which a person has to approve before it takes effect. Unlinked, it appears on no timeline."},
+				"description":"Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval."},
 			"source_system":{"type":"string"},"source_id":{"type":"string"}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[wireRecord](),

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -136,6 +136,49 @@ func (t relinkActivity) StageInfo(ctx context.Context, in json.RawMessage) (Stag
 	}))
 }
 
+// ResolverInput names the activity's CURRENT version alongside the arguments,
+// which is what lets relinkActivityTier's verdict stand.
+//
+// Without it every agent relink was raised to approval whatever its
+// destination. auth/admit.go refuses a dynamic tier that resolves to
+// auto-execute but cannot name the version it was resolved from — deliberately,
+// because an unpinned write would run unattended — and this tool answered no
+// version at all. The resolver's own contract says it "raises a relink onto a
+// PROJECT to confirm-first and leaves every other destination auto-executing";
+// that second half was unreachable, so relinking to a person, a company or a
+// deal cost a human decision the app itself does not ask for.
+//
+// The version comes from the same read the staging path already performs
+// (relinkActivityResolver.Subject), so a project relink still stages pinned to
+// the version its approval was given for.
+func (t relinkActivity) ResolverInput(ctx context.Context, in json.RawMessage) (mcp.TierResolverInput, error) {
+	var args relinkActivityArgs
+	if err := decodeArgs(in, &args); err != nil {
+		return mcp.TierResolverInput{}, err
+	}
+	resolved := mcp.TierResolverInput{Args: in}
+	info, err := StageSubject(ctx, NewRelinkActivityCall(t.p, RelinkActivityCommand{
+		ActivityID: args.ActivityID, EntityType: args.EntityType, EntityID: args.EntityID,
+	}))
+	if err != nil {
+		// The read failed, or the guards refused. Answering NO VERSION rather
+		// than the error is deliberate: the gate then raises to confirm-first,
+		// which is the honest answer to "this server could not establish the
+		// record's state", and it keeps the resolver's contract that it may
+		// only ever RAISE. Returning err here would turn an unreadable activity
+		// into a hard failure at the gate, where a human decision is the safer
+		// answer and the one the REST door gives for the same shape.
+		return resolved, nil //nolint:nilerr // an unreadable record raises to a human, it does not fail the call
+	}
+	// A record with no version is left unreported rather than pinned at zero,
+	// for the reason dealmove.go states: zero is not a version any write can be
+	// conditioned on.
+	if info.TargetVersion != nil && *info.TargetVersion > 0 {
+		resolved.ObservedVersion = info.TargetVersion
+	}
+	return resolved, nil
+}
+
 func (t relinkActivity) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
 	var args relinkActivityArgs
 	if err := decodeArgs(in, &args); err != nil {

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -149,8 +149,15 @@ func (t relinkActivity) StageInfo(ctx context.Context, in json.RawMessage) (Stag
 // deal cost a human decision the app itself does not ask for.
 //
 // The version comes from the same read the staging path already performs
-// (relinkActivityResolver.Subject), so a project relink still stages pinned to
-// the version its approval was given for.
+// (relinkActivityResolver.Subject).
+//
+// What it does NOT yet do is condition the write. The gate binds it
+// (auth/admit.go withAutoExecutePin) so a write can re-check it inside the
+// mutating transaction, but no relink consumes that pin: RelinkActivityInput
+// carries no version and relinkbatch.go compares none, on either door. So this
+// restores the tier the resolver always declared, and the version-skew fence
+// the gate's contract describes is still missing — issue #2614, which has to
+// reach the activities write contract rather than this tool.
 func (t relinkActivity) ResolverInput(ctx context.Context, in json.RawMessage) (mcp.TierResolverInput, error) {
 	var args relinkActivityArgs
 	if err := decodeArgs(in, &args); err != nil {
@@ -162,12 +169,17 @@ func (t relinkActivity) ResolverInput(ctx context.Context, in json.RawMessage) (
 	}))
 	if err != nil {
 		// The read failed, or the guards refused. Answering NO VERSION rather
-		// than the error is deliberate: the gate then raises to confirm-first,
-		// which is the honest answer to "this server could not establish the
-		// record's state", and it keeps the resolver's contract that it may
-		// only ever RAISE. Returning err here would turn an unreadable activity
-		// into a hard failure at the gate, where a human decision is the safer
-		// answer and the one the REST door gives for the same shape.
+		// than the error is deliberate: the gate then raises, which keeps the
+		// resolver's contract that it may only ever RAISE, and it fails CLOSED —
+		// an otherwise auto-executable destination costs a decision rather than
+		// running on a state this server could not establish.
+		//
+		// It does not follow that a human sees it. stageRefusedCall calls
+		// StageInfo straight after, which repeats this read: a failure that
+		// persists surfaces as that read's own error rather than as a staged
+		// approval. That is the right answer for a bad id or an out-of-scope
+		// target — the caller gets told what is wrong instead of a card nobody
+		// can act on.
 		return resolved, nil //nolint:nilerr // an unreadable record raises to a human, it does not fail the call
 	}
 	// A record with no version is left unreported rather than pinned at zero,

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 56,
-    "tokens": 17180,
+    "tokens": 17176,
     "median_tool_tokens": 281,
     "mean_tool_tokens": 306
   },
@@ -41,9 +41,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2264,
+      "tokens": 2260,
       "percent_of_ceiling": 9,
-      "headroom_tokens": 14736,
+      "headroom_tokens": 14740,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -55,6 +55,7 @@
         "log_activity → create_task",
         "log_activity → draft_email",
         "log_activity → progress_deal",
+        "log_activity → relink_activity",
         "log_activity → send_email",
         "log_activity → send_message",
         "whats_slipping_this_week → draft_follow_ups_for",
@@ -78,7 +79,7 @@
     },
     {
       "name": "log_activity",
-      "tokens": 522
+      "tokens": 517
     },
     {
       "name": "resolve_entities",

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 56,
-    "tokens": 17176,
+    "tokens": 17188,
     "median_tool_tokens": 281,
     "mean_tool_tokens": 306
   },
@@ -41,9 +41,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2260,
+      "tokens": 2272,
       "percent_of_ceiling": 9,
-      "headroom_tokens": 14740,
+      "headroom_tokens": 14728,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -79,7 +79,7 @@
     },
     {
       "name": "log_activity",
-      "tokens": 517
+      "tokens": 530
     },
     {
       "name": "resolve_entities",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -25,8 +25,8 @@ feature is expected to argue with.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2264 | 9% | 14736 | 14 | 8 |
-| _whole served catalog, for scale_ | 56 | 17180 | 71% | — | — | — |
+| `overnight_at_risk_sweep` | 7 | 2260 | 9% | 14740 | 15 | 8 |
+| _whole served catalog, for scale_ | 56 | 17176 | 71% | — | — | — |
 
 ### `morning_brief`
 
@@ -51,7 +51,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2264 tokens, leaving 14736 of its budget and 21736 tokens of the
+Attaches 7 tools for 2260 tokens, leaving 14740 of its budget and 21740 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -62,7 +62,7 @@ window for the goal, the grounding and everything it reads.
 - `review_commitments`
 - `whats_slipping_this_week`
 
-**14 dangling cross-references** — this agent's own tool copy points at tools it
+**15 dangling cross-references** — this agent's own tool copy points at tools it
 cannot call, so a run may spend a step discovering the refusal:
 
 - at_risk_relationships → account_coverage
@@ -75,6 +75,7 @@ cannot call, so a run may spend a step discovering the refusal:
 - log_activity → create_task
 - log_activity → draft_email
 - log_activity → progress_deal
+- log_activity → relink_activity
 - log_activity → send_email
 - log_activity → send_message
 - whats_slipping_this_week → draft_follow_ups_for
@@ -130,7 +131,7 @@ a term in an addition.
 | `run_report` | 1213 | 3 scenarios |
 | `update_record` | 565 | 4 scenarios |
 | `send_account_email` | 545 | — |
-| `log_activity` | 522 | 1 scenario |
+| `log_activity` | 517 | 1 scenario |
 | `resolve_entities` | 513 | — |
 | `list_records` | 475 | — |
 | `advance_deal` | 474 | 1 scenario |

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -25,8 +25,8 @@ feature is expected to argue with.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2260 | 9% | 14740 | 15 | 8 |
-| _whole served catalog, for scale_ | 56 | 17176 | 71% | — | — | — |
+| `overnight_at_risk_sweep` | 7 | 2272 | 9% | 14728 | 15 | 8 |
+| _whole served catalog, for scale_ | 56 | 17188 | 71% | — | — | — |
 
 ### `morning_brief`
 
@@ -51,7 +51,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2260 tokens, leaving 14740 of its budget and 21740 tokens of the
+Attaches 7 tools for 2272 tokens, leaving 14728 of its budget and 21728 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -131,7 +131,7 @@ a term in an addition.
 | `run_report` | 1213 | 3 scenarios |
 | `update_record` | 565 | 4 scenarios |
 | `send_account_email` | 545 | — |
-| `log_activity` | 517 | 1 scenario |
+| `log_activity` | 530 | 1 scenario |
 | `resolve_entities` | 513 | — |
 | `list_records` | 475 | — |
 | `advance_deal` | 474 | 1 scenario |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 156382,
+    "tool_catalog_bytes": 156365,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39872,
+    "approx_wire_tokens_total": 39868,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 35742,
-      "input_schema_bytes": 34849,
+      "description_bytes": 35927,
+      "input_schema_bytes": 34647,
       "output_schema_bytes": 73753,
-      "description_plus_input_schema_bytes": 70591
+      "description_plus_input_schema_bytes": 70574
     }
   },
   "tools": {
@@ -4148,7 +4148,7 @@
           "readOnlyHint": false,
           "title": "Log an activity"
         },
-        "description": "Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Record something that happened — a call, a meeting, a note, a message — on the records it was about: name every one of them in this call. A meeting is with a person, and also concerns their company and the deal it is for. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline, and adding a link afterwards is relink_activity, which a person has to approve. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -4188,7 +4188,7 @@
               "type": "string"
             },
             "links": {
-              "description": "EVERY record this was about, named in this one call — a meeting is with a person and also concerns their company and the deal it is for, so name all of them here. This call writes them all and needs no approval; attaching one afterwards is relink_activity, which a person has to approve before it takes effect. Unlinked, it appears on no timeline.",
+              "description": "Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval.",
               "items": {
                 "additionalProperties": false,
                 "properties": {

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 56,
     "resources": 8,
-    "tool_catalog_bytes": 156365,
+    "tool_catalog_bytes": 156416,
     "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39868,
+    "approx_wire_tokens_total": 39881,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 35927,
+      "description_bytes": 35978,
       "input_schema_bytes": 34647,
       "output_schema_bytes": 73753,
-      "description_plus_input_schema_bytes": 70574
+      "description_plus_input_schema_bytes": 70625
     }
   },
   "tools": {
@@ -4148,7 +4148,7 @@
           "readOnlyHint": false,
           "title": "Log an activity"
         },
-        "description": "Record something that happened — a call, a meeting, a note, a message — on the records it was about: name every one of them in this call. A meeting is with a person, and also concerns their company and the deal it is for. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline, and adding a link afterwards is relink_activity, which a person has to approve. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Record something that happened — a call, a meeting, a note, a message — on the records it was about: name every one of them in this call. A meeting is with a person, and also concerns their company and the deal it is for. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline, and adding a link afterwards is a second call — relink_activity — which a person has to approve when it files under a project. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 8 |
 | Tool catalog | 152.7 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39872 |
+| Approx. wire tokens | 39868 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,8 +30,8 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
 | Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 34.9 KB | 22% | Yes, every step |
-| Input schemas | 34.0 KB | 22% | Yes, every step |
+| Descriptions (incl. governance clause) | 35.1 KB | 22% | Yes, every step |
+| Input schemas | 33.8 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
 | **Description + input schema** | **68.9 KB** | **45%** | **the recurring cost** |
 
@@ -4643,7 +4643,7 @@ The workspace's words for grouping records, with the tag_id apply_tag takes. Arc
 
 **Log an activity**
 
-Record something that happened — a call, a meeting, a note, a message — on the timeline of the records it was about. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
+Record something that happened — a call, a meeting, a note, a message — on the records it was about: name every one of them in this call. A meeting is with a person, and also concerns their company and the deal it is for. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline, and adding a link afterwards is relink_activity, which a person has to approve. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -4687,7 +4687,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "links": {
-      "description": "EVERY record this was about, named in this one call — a meeting is with a person and also concerns their company and the deal it is for, so name all of them here. This call writes them all and needs no approval; attaching one afterwards is relink_activity, which a person has to approve before it takes effect. Unlinked, it appears on no timeline.",
+      "description": "Every record this was about — the person, their company, the deal. All of them here, in this call: it writes them together and needs no approval.",
       "items": {
         "additionalProperties": false,
         "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 56 |
 | Resources | 8 |
-| Tool catalog | 152.7 KB |
+| Tool catalog | 152.8 KB |
 | Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39868 |
+| Approx. wire tokens | 39881 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,10 +30,10 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
 | Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 35.1 KB | 22% | Yes, every step |
+| Descriptions (incl. governance clause) | 35.1 KB | 23% | Yes, every step |
 | Input schemas | 33.8 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
-| **Description + input schema** | **68.9 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **69.0 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -4643,7 +4643,7 @@ The workspace's words for grouping records, with the tag_id apply_tag takes. Arc
 
 **Log an activity**
 
-Record something that happened — a call, a meeting, a note, a message — on the records it was about: name every one of them in this call. A meeting is with a person, and also concerns their company and the deal it is for. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline, and adding a link afterwards is relink_activity, which a person has to approve. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
+Record something that happened — a call, a meeting, a note, a message — on the records it was about: name every one of them in this call. A meeting is with a person, and also concerns their company and the deal it is for. It writes history and changes nothing else: no deal moves, no field updates, nobody is notified. Unlinked, it appears on no timeline, and adding a link afterwards is a second call — relink_activity — which a person has to approve when it files under a project. Use progress_deal when the same event also moves a deal, so move and note are one act; create_task for something still owed. Keep the activity id — draft_email, send_email and send_message identify a conversation by it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 


### PR DESCRIPTION
## The principle it restores

A passport does what its holder could do unaided. Relinking an activity onto a
person, a company or a deal is an association a member undoes in the app with no
ceremony — so it must not cost a human decision through MCP either.

`relinkActivityTier` has always said exactly that:

> raises a relink onto a PROJECT to confirm-first and leaves every other
> destination auto-executing

**That second half was unreachable.** `auth/admit.go` refuses a dynamic tier
that resolves to auto-execute without naming the version it was resolved from —
deliberately, because an unpinned write would run unattended — and
`relink_activity` supplied no version at all. Every agent relink was escalated,
whatever its destination.

## How it showed up

Driven from claude.ai on 2026-08-25: the model logged a meeting, then attached
the person, the company and the deal afterwards. Each attach staged an approval:

```
Re-associate activity … to person …
Re-associate activity … to organization …
Re-associate activity … to deal …
```

Three cards the app would never have asked for. The PO's question was the right
one — *"isn't this violating our principle that if a user could do this in the
app the MCP is also allowed to do it?"* It was.

## The fix

`ResolverInput` names the activity's current version, read through the same
`StageSubject` path the staging already uses. So:

- person / organization / deal / lead → **runs immediately**, pinned to the
  version it was resolved from
- project → **still stages**, because filing under a project classifies the
  activity as commercial correspondence, which is write-once and monotonic; the
  approval is pinned to the same version
- an unreadable activity → answers no version, the gate raises, which keeps the
  resolver's contract that it may only ever RAISE

## Also in here: the copy that sent the model down this path

`log_activity`'s Purpose now names the records, mirroring `create_task` — which
in the same live run linked deal, person and organization in one call, four
times over, while `log_activity` linked nothing. The instruction had been sitting
in the `links` field description, which is read after the call is already shaped.

## Test

`TestAnAgentRelinksToAPersonWithoutAskingAndStillStagesAProject` drives a real
passport through a real MCP invoke and holds both halves.

Verified by reverting the fix — it fails with *"relinking to a person staged
approval …; a member does this in the app unasked"*.

## Gates

`make check-backend`, `craft-static`, `rls-store-path`, `no-jurisdiction` green.
Compose integration lane: **1310 pass, 0 fail**.

Closes #2610

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relinking an activity to a person, organization, or deal now runs immediately; only relinks to a project stage for approval. Previously every `relink_activity` staged because the tool did not provide the observed version required for auto-execute.

- Supplies the activity’s observed version via `relink_activity` `ResolverInput`, read through `StageSubject`, so non-project relinks auto-execute and project relinks still stage.
- The gate binds the observed version, but the write path does not consume it yet; there is no version-skew fence on relinks.
- If the activity cannot be read, no version is sent so the gate raises; persistent read failures surface as errors rather than staged approvals.
- Updates `log_activity` Purpose and `links` copy to name all related records in one call and cross-reference `relink_activity`; regenerates `mcp-info.*` and `agent-tool-budget.*`.
- Adds integration test `TestAnAgentRelinksToAPersonWithoutAskingAndStillStagesAProject`.
- No scope changes or migrations.

<sup>Written for commit acee8a8652bd9086261f2bd50a69b4ccb885c1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activities can be relinked to people and organizations without approval.
  - Relinking activities to projects continues to require approval.
  - Activity logging now requires naming all related records, including associated companies and deals.

- **Documentation**
  - Updated tool guidance on unlinked activities and later association.
  - Refreshed published tool catalog metrics and cross-references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->