### PR TITLE
feat(capture): an organization event queues its enrich pass now

### DIFF
--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -435,6 +435,8 @@ func startProjectionLanes(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Cl
 	// matcher above and the same reason: matching only at write time means every
 	// later arrival is a match nobody will ever make.
 	startPersonAutoEnrich(ctx, pool, rdb, background, logger, stdout)
+
+	startOrgAutoEnrichTrigger(ctx, pool, rdb, background, logger, stdout)
 }
 
 // startWebhookLane starts the cg:webhooks delivery consumer, whose deliverer is

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -202,6 +202,13 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		return lanes, err
 	}
 
+	// A company appearing queues its workspace's enrich pass now; the daily
+	// sweep stays the reconciler. Beside the enqueuing lanes rather than the
+	// projections because a failed inserter must fail the boot.
+	if err := startOrgAutoEnrichTrigger(laneCtx, pool, rdb, lanes.background, logger, stdout); err != nil {
+		return lanes, err
+	}
+
 	announceGeocoding(cfg.geocodeBaseURL, stdout)
 
 	if err := startWebhookLane(laneCtx, cfg, pool, rdb, &lanes, logger, stdout); err != nil {
@@ -435,8 +442,6 @@ func startProjectionLanes(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Cl
 	// matcher above and the same reason: matching only at write time means every
 	// later arrival is a match nobody will ever make.
 	startPersonAutoEnrich(ctx, pool, rdb, background, logger, stdout)
-
-	startOrgAutoEnrichTrigger(ctx, pool, rdb, background, logger, stdout)
 }
 
 // startWebhookLane starts the cg:webhooks delivery consumer, whose deliverer is

--- a/backend/cmd/worker/orgautoenrich.go
+++ b/backend/cmd/worker/orgautoenrich.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Wiring the organization auto-enrich trigger.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// startOrgAutoEnrichTrigger starts the cg:org-auto-enrich consumer: an
+// organization appearing or changing queues the workspace's auto-enrich pass
+// now, instead of leaving a freshly created company without a dossier until
+// the next daily sweep. The runner is insert-only — the consumer queues the
+// pass, and this worker's River side works it like any sweep-scheduled one.
+func startOrgAutoEnrichTrigger(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) {
+	inserter, err := jobs.NewInserter(pool, logger)
+	if err != nil {
+		// The sweep still covers every organization within a day, so a
+		// missing trigger degrades promptness, not coverage — said out loud
+		// because a silent absence reads exactly like a healthy lane.
+		logger.Error("worker: org auto-enrich trigger not started, companies wait for the daily sweep", "err", err)
+		return
+	}
+	trigger := compose.NewOrgAutoEnrichTrigger(pool, inserter, logger)
+	_, _ = fmt.Fprintln(stdout, "worker queueing enrich passes as organizations appear (cg:org-auto-enrich)")
+	background.Go(func() { runSubscriber(ctx, rdb, "cg:org-auto-enrich", trigger.HandleEvent, logger, 0) })
+}

--- a/backend/cmd/worker/orgautoenrich.go
+++ b/backend/cmd/worker/orgautoenrich.go
@@ -24,16 +24,16 @@ import (
 // now, instead of leaving a freshly created company without a dossier until
 // the next daily sweep. The runner is insert-only — the consumer queues the
 // pass, and this worker's River side works it like any sweep-scheduled one.
-func startOrgAutoEnrichTrigger(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) {
+// A failed inserter fails the boot, like the provider-enrich lane's: it only
+// fails when a River client cannot be built against the pool, which is a
+// process-wide misconfiguration, not one lane's weather.
+func startOrgAutoEnrichTrigger(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) error {
 	inserter, err := jobs.NewInserter(pool, logger)
 	if err != nil {
-		// The sweep still covers every organization within a day, so a
-		// missing trigger degrades promptness, not coverage — said out loud
-		// because a silent absence reads exactly like a healthy lane.
-		logger.Error("worker: org auto-enrich trigger not started, companies wait for the daily sweep", "err", err)
-		return
+		return fmt.Errorf("worker: the enrich-trigger inserter: %w", err)
 	}
 	trigger := compose.NewOrgAutoEnrichTrigger(pool, inserter, logger)
 	_, _ = fmt.Fprintln(stdout, "worker queueing enrich passes as organizations appear (cg:org-auto-enrich)")
 	background.Go(func() { runSubscriber(ctx, rdb, "cg:org-auto-enrich", trigger.HandleEvent, logger, 0) })
+	return nil
 }

--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -10,10 +10,13 @@ package compose
 // The anchor is excluded; cold start has already read it. Per workspace, when
 // the capture_auto_enrich flag is on, it enqueues a deep read
 // (system:capture_auto_enrich, auto-applied on completion) for each due org —
-// newest first, under an atomically-reserved daily cap. It
-// is the ONE trigger and the self-healing reconciler in one: a missed org is
-// simply picked up next pass. The deep-read worker's auto-apply lane
-// (deepread.go) records the terminal outcome on the sweep's cursor.
+// newest first, under an atomically-reserved daily cap. It is the
+// self-healing reconciler: the prompt trigger is the organization-event
+// consumer (orgautoenrich.go), which queues this same workspace pass the
+// moment a company appears, and anything that slips through — the worker
+// down, an enqueue lost — is simply picked up next daily pass. The
+// deep-read worker's auto-apply lane (deepread.go) records the terminal
+// outcome on the sweep's cursor.
 
 import (
 	"context"

--- a/backend/internal/compose/orgautoenrich.go
+++ b/backend/internal/compose/orgautoenrich.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The prompt half of captured-organization auto-enrich: an organization
+// event queues the workspace's enrich pass NOW.
+//
+// The daily sweep (captureautoenrich.go) is the reconciler, and before this
+// consumer it was also the only trigger for a company a person or an agent
+// CREATED — so one minted five minutes after the sweep waited a day for its
+// dossier, which is exactly the moment its creator is looking at the empty
+// page. THE TRIGGER IS THE EVENT, NOT THE WRITER (the person-auto-enrich
+// rule): organization.created and organization.updated reach the outbox
+// because the write shape puts them there, so manual entry, the MCP tools,
+// a site-read confirm and an import all land here without any of them
+// knowing this consumer exists.
+//
+// It queues the WORKSPACE PASS, not a read for the event's organization.
+// The pass already owns every gate — the auto-enrich setting, the daily
+// budget, the cursor backoff, the dossier check — and re-derives which
+// organizations are due, so this consumer cannot become a second spelling
+// of that decision, and a burst of creates costs redundant no-op passes
+// rather than redundant crawls.
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+)
+
+// OrgAutoEnrichTrigger queues one auto-enrich workspace pass per
+// organization event.
+type OrgAutoEnrichTrigger struct {
+	pool    *pgxpool.Pool
+	enqueue *jobs.Runner
+	log     *slog.Logger
+}
+
+// NewOrgAutoEnrichTrigger builds the trigger over an insert-only jobs runner.
+func NewOrgAutoEnrichTrigger(pool *pgxpool.Pool, enqueue *jobs.Runner, log *slog.Logger) *OrgAutoEnrichTrigger {
+	return &OrgAutoEnrichTrigger{pool: pool, enqueue: enqueue, log: log}
+}
+
+// HandleEvent routes one envelope. An event this consumer does not care about
+// answers nil, so the group keeps flowing rather than wedging on somebody
+// else's traffic. An enqueue failure comes back as an error and the bus
+// redelivers — safe, because a redelivered event only queues another no-op
+// pass, and the sweep still reconciles whatever slips through.
+func (g *OrgAutoEnrichTrigger) HandleEvent(ctx context.Context, env events.Envelope) error {
+	switch env.Type {
+	// Every event that can make an organization newly due: appearing,
+	// gaining a domain (a company save's domain change arrives as
+	// organization.updated), or inheriting one in a merge. An archive needs
+	// no reaction — the pass only ever starts reads, and an archived
+	// organization is not due.
+	case "organization.created", "organization.updated", "organization.merged":
+	default:
+		return nil
+	}
+	// The envelope carries no tenant (ADR-0091 §6); the store's handle names it.
+	ws, err := InstallationDB(g.pool).Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	// One pass per event, no uniqueness — per oneOffChildOpts' own warning: a
+	// pass already RUNNING may have read the workspace before this event's
+	// rows landed, and River refuses a unique-state list that exempts
+	// running, so any dedupe here could drop exactly the organization the
+	// event fired about. The redundant passes a burst produces are a few
+	// SELECTs each: every gate they re-check — the cursor, the in-flight
+	// dossier index, the budget reservation — already makes a second pass
+	// over the same organization a no-op.
+	child := CaptureAutoEnrichWorkspaceArgs{Workspace: ws.UUID}
+	return g.enqueue.Enqueue(ctx, child, oneOffChildOpts(child.Kind()))
+}

--- a/backend/internal/compose/orgautoenrich.go
+++ b/backend/internal/compose/orgautoenrich.go
@@ -17,21 +17,34 @@ package compose
 // knowing this consumer exists.
 //
 // It queues the WORKSPACE PASS, not a read for the event's organization.
-// The pass already owns every gate — the auto-enrich setting, the daily
-// budget, the cursor backoff, the dossier check — and re-derives which
-// organizations are due, so this consumer cannot become a second spelling
-// of that decision, and a burst of creates costs redundant no-op passes
-// rather than redundant crawls.
+// The pass owns the gates — the daily budget, the cursor backoff, the
+// dossier check, and the auto-enrich setting for the enrich half (its
+// domain-triage half deliberately runs whatever the setting says; see
+// sweepWorkspace) — and re-derives which organizations are due, so this
+// consumer cannot become a second spelling of that decision, and a burst
+// of creates collapses onto one queued pass.
 
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 )
+
+// orgAutoEnrichFreshWindow is how old an organization event may be and still
+// queue a pass. This consumer exists for PROMPTNESS alone — the daily sweep
+// already owns everything older — and the bound is what makes first
+// deployment safe: a new consumer group is created at stream position 0
+// (events.Subscriber), so the first boot replays the organization stream's
+// whole history into this handler, and without the bound every historical
+// event would mint a job. An hour is generous for a live event's delivery
+// lag (the relay ships in seconds) while excluding any replayed backlog.
+const orgAutoEnrichFreshWindow = time.Hour
 
 // OrgAutoEnrichTrigger queues one auto-enrich workspace pass per
 // organization event.
@@ -49,9 +62,13 @@ func NewOrgAutoEnrichTrigger(pool *pgxpool.Pool, enqueue *jobs.Runner, log *slog
 // HandleEvent routes one envelope. An event this consumer does not care about
 // answers nil, so the group keeps flowing rather than wedging on somebody
 // else's traffic. An enqueue failure comes back as an error and the bus
-// redelivers — safe, because a redelivered event only queues another no-op
-// pass, and the sweep still reconciles whatever slips through.
+// redelivers — safe, because a redelivered event dedupes onto the pass the
+// first delivery queued, and the sweep still reconciles whatever slips
+// through.
 func (g *OrgAutoEnrichTrigger) HandleEvent(ctx context.Context, env events.Envelope) error {
+	if env.Entity.Type != string(recordTypeOrganization) {
+		return nil
+	}
 	switch env.Type {
 	// Every event that can make an organization newly due: appearing,
 	// gaining a domain (a company save's domain change arrives as
@@ -62,19 +79,38 @@ func (g *OrgAutoEnrichTrigger) HandleEvent(ctx context.Context, env events.Envel
 	default:
 		return nil
 	}
+	// A stale event has no promptness left to buy: it is either a replayed
+	// backlog (a freshly created consumer group starts at stream position 0)
+	// or a delivery the bus held for hours, and in both cases the daily
+	// sweep's next pass already covers whatever it announced. Skipping is
+	// nil, not an error — erroring would redeliver the same stale event.
+	if time.Since(env.OccurredAt) > orgAutoEnrichFreshWindow {
+		return nil
+	}
 	// The envelope carries no tenant (ADR-0091 §6); the store's handle names it.
 	ws, err := InstallationDB(g.pool).Workspace(ctx)
 	if err != nil {
 		return err
 	}
-	// One pass per event, no uniqueness — per oneOffChildOpts' own warning: a
-	// pass already RUNNING may have read the workspace before this event's
-	// rows landed, and River refuses a unique-state list that exempts
-	// running, so any dedupe here could drop exactly the organization the
-	// event fired about. The redundant passes a burst produces are a few
-	// SELECTs each: every gate they re-check — the cursor, the in-flight
-	// dossier index, the budget reservation — already makes a second pass
-	// over the same organization a no-op.
+	// The uniqueness is the flood bound: any authenticated writer can emit
+	// organization.updated in a loop (the store's emit has no value-changed
+	// guard), and without it every event would land its own row on the
+	// shared default queue. ByArgs over the active states collapses a burst
+	// onto the one pass already queued or running for this workspace.
+	//
+	// The states include running because River requires it in any custom
+	// list, and that opens the one hole this trigger accepts: a company
+	// created while a pass is mid-run can be deduped against a pass that
+	// listed the due organizations before the new row landed, and then
+	// waits for the reconciling sweep instead of being read promptly. The
+	// alternative — no uniqueness — trades that bounded promptness miss for
+	// an unbounded queue, which is the worse failure. Same args and states
+	// as the fleet dispatcher's insert (workspaceSweepOpts), so the two
+	// doors dedupe against each other instead of stacking; the sweep-tag
+	// gauges may therefore occasionally count a day's coverage against a
+	// trigger-queued pass that did the identical work untagged.
 	child := CaptureAutoEnrichWorkspaceArgs{Workspace: ws.UUID}
-	return g.enqueue.Enqueue(ctx, child, oneOffChildOpts(child.Kind()))
+	opts := oneOffChildOpts(child.Kind())
+	opts.UniqueOpts = river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}
+	return g.enqueue.Enqueue(ctx, child, opts)
 }

--- a/backend/internal/compose/orgautoenrich_integration_test.go
+++ b/backend/internal/compose/orgautoenrich_integration_test.go
@@ -5,9 +5,12 @@
 
 package compose
 
-// The cg:org-auto-enrich trigger: an organization event queues the workspace's
-// auto-enrich pass NOW, a burst of them collapses onto one queued pass, and
-// traffic that is not its business queues nothing.
+// The cg:org-auto-enrich trigger against the real queue: an organization
+// event queues the workspace's auto-enrich pass NOW, addressed to the right
+// workspace, and a burst collapses onto the one pass already queued. The
+// refusal arm — events the trigger ignores — is the unit lane's
+// (orgautoenrich_test.go), where a nil pool proves the refusal precedes the
+// query.
 
 import (
 	"context"
@@ -29,17 +32,6 @@ func TestAnOrganizationEventQueuesTheEnrichPassNow(t *testing.T) {
 	ctx := context.Background()
 	kind := CaptureAutoEnrichWorkspaceArgs{}.Kind()
 
-	// An archive can only make organizations LESS due, so it must queue
-	// nothing — and it must answer nil, because the group carries every
-	// organization event and a consumer that errored on one would wedge the
-	// stream for the rest.
-	if err := trigger.HandleEvent(ctx, envelopeFor(e.WS, "organization.archived", "organization", ids.NewV7())); err != nil {
-		t.Errorf("an archive event errored: %v", err)
-	}
-	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 0 {
-		t.Fatalf("an archive event queued %d enrich pass(es), want none", n)
-	}
-
 	// A create queues exactly one pass, addressed to the installation's own
 	// workspace — the envelope carries no tenant, so naming the wrong one
 	// here would run the pass against nobody's data and read as a no-op.
@@ -59,15 +51,14 @@ func TestAnOrganizationEventQueuesTheEnrichPassNow(t *testing.T) {
 		t.Errorf("the queued pass names workspace %q, want the installation's %q", workspace, e.WS)
 	}
 
-	// A second event queues its own pass rather than deduping onto the first:
-	// a pass already claimed by a worker may have listed the due organizations
-	// before this event's rows landed, so dropping the event could strand
-	// exactly the company it announced. Redundancy is the cheap side — the
-	// pass's own gates make a repeat over the same organization a no-op.
+	// A burst dedupes onto the pass already queued: the uniqueness is the
+	// flood bound, because any authenticated writer can emit
+	// organization.updated in a loop and every event landing its own row
+	// would bury the shared default queue.
 	if err := trigger.HandleEvent(ctx, envelopeFor(e.WS, "organization.updated", "organization", ids.NewV7())); err != nil {
 		t.Fatalf("organization.updated: %v", err)
 	}
-	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 2 {
-		t.Fatalf("two organization events left %d queued enrich pass(es), want one each", n)
+	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 1 {
+		t.Fatalf("a second event left %d queued enrich pass(es), want the burst deduped onto 1", n)
 	}
 }

--- a/backend/internal/compose/orgautoenrich_integration_test.go
+++ b/backend/internal/compose/orgautoenrich_integration_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The cg:org-auto-enrich trigger: an organization event queues the workspace's
+// auto-enrich pass NOW, a burst of them collapses onto one queued pass, and
+// traffic that is not its business queues nothing.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAnOrganizationEventQueuesTheEnrichPassNow(t *testing.T) {
+	e := integration.Setup(t)
+	inserter, err := jobs.NewInserter(e.Pool, slog.Default())
+	if err != nil {
+		t.Fatalf("NewInserter: %v", err)
+	}
+	trigger := NewOrgAutoEnrichTrigger(e.Pool, inserter, slog.Default())
+	ctx := context.Background()
+	kind := CaptureAutoEnrichWorkspaceArgs{}.Kind()
+
+	// An archive can only make organizations LESS due, so it must queue
+	// nothing — and it must answer nil, because the group carries every
+	// organization event and a consumer that errored on one would wedge the
+	// stream for the rest.
+	if err := trigger.HandleEvent(ctx, envelopeFor(e.WS, "organization.archived", "organization", ids.NewV7())); err != nil {
+		t.Errorf("an archive event errored: %v", err)
+	}
+	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 0 {
+		t.Fatalf("an archive event queued %d enrich pass(es), want none", n)
+	}
+
+	// A create queues exactly one pass, addressed to the installation's own
+	// workspace — the envelope carries no tenant, so naming the wrong one
+	// here would run the pass against nobody's data and read as a no-op.
+	if err := trigger.HandleEvent(ctx, envelopeFor(e.WS, "organization.created", "organization", ids.NewV7())); err != nil {
+		t.Fatalf("organization.created: %v", err)
+	}
+	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 1 {
+		t.Fatalf("organization.created queued %d enrich pass(es), want exactly 1", n)
+	}
+	var workspace string
+	if err := e.Pool.QueryRow(ctx,
+		`SELECT coalesce(args->>'workspace_id', '') FROM river_job WHERE kind = $1`, kind,
+	).Scan(&workspace); err != nil {
+		t.Fatalf("reading the queued pass: %v", err)
+	}
+	if workspace != e.WS.String() {
+		t.Errorf("the queued pass names workspace %q, want the installation's %q", workspace, e.WS)
+	}
+
+	// A second event queues its own pass rather than deduping onto the first:
+	// a pass already claimed by a worker may have listed the due organizations
+	// before this event's rows landed, so dropping the event could strand
+	// exactly the company it announced. Redundancy is the cheap side — the
+	// pass's own gates make a repeat over the same organization a no-op.
+	if err := trigger.HandleEvent(ctx, envelopeFor(e.WS, "organization.updated", "organization", ids.NewV7())); err != nil {
+		t.Fatalf("organization.updated: %v", err)
+	}
+	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 2 {
+		t.Fatalf("two organization events left %d queued enrich pass(es), want one each", n)
+	}
+}

--- a/backend/internal/compose/orgautoenrich_test.go
+++ b/backend/internal/compose/orgautoenrich_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// orgEvent builds the envelope the trigger reads, occurring now.
+func orgEvent(eventType string, id ids.UUID) events.Envelope {
+	return events.Envelope{
+		Type:       eventType,
+		OccurredAt: time.Now().UTC(),
+		Entity:     events.EntityRef{Type: "organization", ID: id},
+	}
+}
+
+// The trigger must ignore what it cannot act on WITHOUT touching the pool.
+// The nil pool is the assertion: anything that reached the database here
+// would panic, so a pass proves the refusal happened at the envelope.
+func TestOrgAutoEnrichTriggerIgnoresWhatItCannotActOn(t *testing.T) {
+	g := &OrgAutoEnrichTrigger{}
+	ctx := context.Background()
+
+	stale := orgEvent("organization.created", ids.NewV7())
+	stale.OccurredAt = stale.OccurredAt.Add(-2 * orgAutoEnrichFreshWindow)
+
+	for name, env := range map[string]events.Envelope{
+		"an archive can only make organizations less due":                orgEvent("organization.archived", ids.NewV7()),
+		"a verb outside the set that can make an organization newly due": orgEvent("organization.geocoded", ids.NewV7()),
+		"an unrelated entity type":                                       {Type: "organization.created", OccurredAt: time.Now().UTC(), Entity: events.EntityRef{Type: "person", ID: ids.NewV7()}},
+		// A stale event is a replayed backlog (a new consumer group starts at
+		// stream position 0) or a delivery held for hours; queueing one job
+		// per historical event would flood the queue on the first boot after
+		// deployment, and the daily sweep owns everything that old.
+		"an event older than the freshness window": stale,
+	} {
+		if err := g.HandleEvent(ctx, env); err != nil {
+			t.Errorf("%s: HandleEvent returned %v, want a silent skip", name, err)
+		}
+	}
+}

--- a/backend/internal/shared/kernel/events/events_test.go
+++ b/backend/internal/shared/kernel/events/events_test.go
@@ -175,6 +175,10 @@ func TestGroupStreamSetsMatchSpecTable(t *testing.T) {
 		// resolution is what most unmatched ghosts are waiting on.
 		"cg:linkedin-match":     {"gw:events:crm:organization", "gw:events:crm:person"},
 		"cg:person-auto-enrich": {"gw:events:crm:person"},
+		// The prompt half of captured-organization auto-enrich: an
+		// organization appearing or changing queues the workspace's enrich
+		// pass now rather than on the next daily sweep.
+		"cg:org-auto-enrich": {"gw:events:crm:organization"},
 		// Automatic enrichment from a licensed provider (ADR-0101). Its own
 		// group rather than a second handler on the pass above: that one
 		// reads pages already crawled, this one SPENDS credits, and a

--- a/backend/internal/shared/kernel/events/groups.go
+++ b/backend/internal/shared/kernel/events/groups.go
@@ -87,6 +87,18 @@ func Groups() []Group {
 		// keyed on the contact, and an account appearing enriches nobody
 		// until a person is filed against it, which is itself a person event.
 		{Name: "cg:person-auto-enrich", Streams: forEntities(personStreamEntity)},
+		// The prompt half of captured-organization auto-enrich (ADR-0072
+		// arc): an organization appearing or changing queues the workspace's
+		// enrich pass NOW instead of leaving a company created between two
+		// daily sweeps without a dossier for up to a day. Its own group
+		// rather than a second handler on cg:linkedin-match for the standing
+		// reason: that consumer belongs to search-adjacent matching, this one
+		// to capture enrichment, and the two must not share a cursor. It
+		// listens on the organization stream alone — the pass it queues
+		// re-derives which organizations are due from the database, so no
+		// other entity's event can make one due that this stream's events do
+		// not already announce.
+		{Name: "cg:org-auto-enrich", Streams: forEntities(organizationStreamEntity)},
 		// Automatic enrichment from a LICENSED provider (ADR-0101/PI-EVT-1).
 		// Its own group rather than a second handler on the pass above,
 		// because the two differ in what a failure costs: that one reads a

--- a/docs/explanation/write-backbone.md
+++ b/docs/explanation/write-backbone.md
@@ -218,11 +218,11 @@ already committed:
 
 ## 5. The consumer side — groups & dedupe
 
-`internal/platform/events/subscriber.go` + `dedupe.go`. The catalog declares fifteen consumer
+`internal/platform/events/subscriber.go` + `dedupe.go`. The catalog declares seventeen consumer
 groups; each sees every event once and scales horizontally inside the group. Because Redis groups
 partition only by stream, the workspace and actor filters run in-process.
 
-**What each group does — and which are live.** Eleven are wired to a subscriber today; the other four
+**What each group does — and which are live.** Thirteen are wired to a subscriber today; the other four
 are catalog-declared placeholders with no consumer yet (honest status — the streams carry events, but
 nothing reads these groups). `TestEveryDeclaredConsumerGroupIsSubscribedSomewhere` in
 `backend/consumerlanes_test.go` holds the split: a new group with neither a lane nor a place in the
@@ -236,9 +236,11 @@ broken and nothing at runtime says a word about it.
 | `cg:audience-rescope` | narrow the derived signals citing a message whose audience changed | **live** (worker) |
 | `cg:linkedin-match` | attach a LinkedIn ghost as its contact or employer appears | **live** (worker) |
 | `cg:commissions` | accrue a partner's commission on a won deal, and reverse it on a reopen | **live** (worker) |
+| `cg:deal-room-timeline` | write what happened in a Deal Room onto the deal's timeline | **live** (worker) |
 | `cg:ai-activity` | project every AI-backed occurrence into `ai_task_run`, the table the rail will read once the read moves onto it | **live** (worker) |
 | `cg:person-auto-enrich` | fill a contact from what their employer's site already published | **live** (worker) |
 | `cg:person-data` | fill a contact from a licensed provider, spending credits | **live** (worker) |
+| `cg:org-auto-enrich` | queue a company's auto-enrich pass the moment it appears, instead of on the next daily sweep | **live** (worker) |
 | `cg:overnight-agent` | on `approval.decided`, resume the parked Surface-B run with the human's answer | **live** (worker; only when a model is configured) |
 | `cg:workflows` | dispatch the automation/workflow engine off matching events | **live** (worker) |
 | `cg:webhooks` | deliver subscribed events to outbound endpoints | **live** (api's inline relay) |


### PR DESCRIPTION
## What

A company created between two daily auto-enrich sweeps waited up to a day for its website dossier. The sweep (`capture_auto_enrich_sweep`, 24h + run-at-boot) was the ONLY trigger — creating a company via the MCP tools, the web UI or an import queued nothing. Observed live: an MCP-created company landed five minutes after the boot sweep and sat un-enriched.

## How

New `cg:org-auto-enrich` consumer (`backend/internal/compose/orgautoenrich.go`): `organization.created` / `organization.updated` / `organization.merged` immediately queues the existing `capture_auto_enrich_workspace` pass for the installation workspace, via an insert-only jobs runner in the worker role.

- The pass keeps every gate — the `capture.auto_enrich` setting, the 500/day budget, the cursor backoff, the in-flight dossier dedupe — so the event only moves WHEN it runs, never what it may do.
- One pass per event, no River uniqueness: a pass already running may have listed the due organizations before the event's rows landed, and River refuses a unique-state list that exempts `running` — deduping could drop exactly the company the event announced. A redundant pass is a few SELECTs and a no-op.
- The daily sweep stays as the reconciler; its "ONE trigger" comment in `captureautoenrich.go` is updated to match.
- Integration test `TestAnOrganizationEventQueuesTheEnrichPassNow` covers: ignored event queues nothing, a create queues one pass for the right workspace, a second event queues its own pass.

`make check` green; the integration test ran via `make test-it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Organization events now queue their workspace auto-enrich pass immediately, removing up to a 24h wait; previously only the daily sweep triggered enrichment. The sweep remains the reconciler; all gates, budgets, and backoffs stay unchanged.

- Adds `cg:org-auto-enrich` to enqueue `capture_auto_enrich_workspace` on `organization.created`, `organization.updated`, and `organization.merged`; ignores archives and non-organization events; targets the installation workspace.
- Bounds queue growth: River uniqueness (ByArgs + active states) collapses bursts to one pass per workspace; a 1h freshness window skips stale/replayed events; daily sweep recovers anything missed.
- Wires the consumer into the worker; inserter init failure now fails boot (misconfiguration) instead of degrading to sweep-only.
- Updates event-group routing to include the organization stream; adds unit and integration tests; updates docs to reflect the live group.

<sup>Written for commit b6b587c03073900e3458e7a5a018b826857b31ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization creation, updates, and merges now trigger workspace-wide auto-enrichment.
  - Enrichment jobs are consolidated during bursts to avoid duplicate processing.
  - Daily sweeps remain available to recover missed events or unavailable workers.

- **Bug Fixes**
  - Startup failures for enrichment processing are now surfaced instead of silently falling back.
  - Unsupported, unrelated, or stale organization events are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->