### PR TITLE
feat(mcp-apps): a card may ask the device where it is

### DIFF
--- a/backend/internal/compose/agentapps_test.go
+++ b/backend/internal/compose/agentapps_test.go
@@ -201,14 +201,19 @@ func TestEveryViewIsServedUnderTheAppProfile(t *testing.T) {
 		// added to the seam later would be invisible to a hand-written list, and
 		// silently-unchecked is the one thing a permission must not be.
 		//
-		// Geolocation is the one asked for, on every view, and the CSP assertion
-		// directly above is what makes it safe: a view may learn where it is and
-		// has no origin to send it to. A coordinate leaves only the way every
-		// other answer does — through the host, into a tool call the user sees.
-		// A SECOND permission appearing here is a real widening and fails.
-		if want := (mcp.ResourcePermissions{Geolocation: true}); r.UI.Permissions != want {
-			t.Errorf("the view %s asks for browser permissions %+v, want %+v — a permission beyond geolocation "+
-				"is a widening of the sandbox and this assertion is where it gets argued",
+		// The expected value is per view, and that IS the assertion. A host maps
+		// this declaration onto an iframe `allow` attribute, so a card that
+		// declares a permission it never uses would carry the capability if its
+		// code were ever substituted. Geolocation belongs to the probe, which is
+		// the only view that reads a position; every product card asks for
+		// nothing. A permission spreading to a second view fails here.
+		want := mcp.ResourcePermissions{}
+		if r.URI == apps.GeoProbeURI {
+			want.Geolocation = true
+		}
+		if r.UI.Permissions != want {
+			t.Errorf("the view %s asks for browser permissions %+v, want %+v — a card declaring a permission "+
+				"it does not use is a widening of the sandbox, and this assertion is where it gets argued",
 				r.URI, r.UI.Permissions, want)
 		}
 	}

--- a/backend/internal/compose/agentapps_test.go
+++ b/backend/internal/compose/agentapps_test.go
@@ -197,12 +197,19 @@ func TestEveryViewIsServedUnderTheAppProfile(t *testing.T) {
 				"the sandbox and this assertion is where it gets argued: state why in the diff that adds it",
 				r.URI, r.UI.CSP)
 		}
-		// Compared against the ZERO value rather than field by field: a permission
+		// Compared against a WHOLE value rather than field by field: a permission
 		// added to the seam later would be invisible to a hand-written list, and
 		// silently-unchecked is the one thing a permission must not be.
-		if r.UI.Permissions != (mcp.ResourcePermissions{}) {
-			t.Errorf("the view %s asks for browser permissions %+v; none of these views needs one",
-				r.URI, r.UI.Permissions)
+		//
+		// Geolocation is the one asked for, on every view, and the CSP assertion
+		// directly above is what makes it safe: a view may learn where it is and
+		// has no origin to send it to. A coordinate leaves only the way every
+		// other answer does — through the host, into a tool call the user sees.
+		// A SECOND permission appearing here is a real widening and fails.
+		if want := (mcp.ResourcePermissions{Geolocation: true}); r.UI.Permissions != want {
+			t.Errorf("the view %s asks for browser permissions %+v, want %+v — a permission beyond geolocation "+
+				"is a widening of the sandbox and this assertion is where it gets argued",
+				r.URI, r.UI.Permissions, want)
 		}
 	}
 	if views == 0 {

--- a/backend/internal/compose/agenttoolparity_test.go
+++ b/backend/internal/compose/agenttoolparity_test.go
@@ -187,6 +187,16 @@ var composedIntents = map[string]bool{
 	// a different question from "who does this payload name". Read-only, and
 	// every record it names is read back through the datasource seam.
 	"resolve_entities": true,
+	// check_location_support composes over NOTHING, which makes it the odd entry
+	// in this map and worth saying rather than filing quietly. It reads no
+	// record and no principal: it answers what this build ASKED its host for,
+	// and the finding itself is produced in the browser by the card beside it.
+	// There is no operation to declare it because there is no operation — a
+	// second door onto it would be a door onto nothing.
+	//
+	// TEMPORARY. It answers one question per chat host, and it and its view
+	// should be deleted once the matrix is filled in (see apps.GeoProbeURI).
+	"check_location_support": true,
 }
 
 // An intent may write inside the workspace; it may NOT reach outside it.

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -249,6 +249,14 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 		nativeOnlyIntroPath(sorMode, introPathLister(pool)),
 		nativeOnlyAtRisk(sorMode, atRiskLister(pool)))
 	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send), provider)
+	// The location check (🟢), and the verb the probe card hangs off. It reads
+	// no record and takes no seam, so it registers unconditionally.
+	//
+	// TEMPORARY. It exists to answer one question — does a chat host let a
+	// Margince card read the device's position — which no document can answer
+	// and which has a different answer per host. Delete it and its view once the
+	// matrix is filled in; see apps.GeoProbeURI.
+	agents.RegisterGeoProbeTool(registry)
 	// The composed extension set's governed tools ride the same registry
 	// and admission gate as the core tools, registered last so a name that
 	// collides with a core verb fails loudly (RegisterExtensions stashed

--- a/backend/internal/modules/agents/apps/apps.go
+++ b/backend/internal/modules/agents/apps/apps.go
@@ -144,25 +144,34 @@ func DeclaredViews() map[string]string {
 	return out
 }
 
-// sandbox is the policy every view here declares, and the ONE place it is
-// stated.
+// sandbox is the policy a view declares, and the ONE place it is stated.
 //
-// EVERY allowlist is left empty, and every permission unasked EXCEPT
-// geolocation. That is the whole security posture of these views: no fetch, no
-// remote script, no nested frame, no camera, no clipboard. See the package
-// comment for why an empty list is the promise rather than a placeholder.
+// EVERY allowlist is left empty on every view, and every permission is unasked
+// except on the view that uses one. That is the whole security posture of these
+// views: no fetch, no remote script, no nested frame, no camera, no clipboard.
+// See the package comment for why an empty list is the promise rather than a
+// placeholder.
 //
-// WHY GEOLOCATION IS THE ONE EXCEPTION. Reading the device's own position is a
-// different act from letting a document reach the network, and the empty
-// allowlists are what keep the two apart. A view may learn where it is; it still
-// has no origin it may send that anywhere, so a coordinate can only travel back
-// the way every other answer does — through the host, into a tool call the user
-// sees. The permission widens what a view may KNOW, not what it may REACH.
+// WHY GEOLOCATION IS ASKED FOR, AND ONLY BY THE PROBE. Reading the device's own
+// position is a different act from letting a document reach the network, so it
+// is not refused by the same argument the empty allowlists make. But a host maps
+// this declaration onto an iframe `allow` attribute, so a card that declares it
+// and never calls it is a card that would carry the capability if its code were
+// ever substituted. Only geo-probe.html reads a position, so only geo-probe.html
+// asks.
 //
-// It is asked for on every view rather than one, because a host grants this per
-// iframe and a view that asks only when it expects to need the answer has
-// already lost the case it was for: the position is wanted at the moment
-// somebody hands over a business card, not one card later.
+// The first version of this asked on every view, on the reasoning that the
+// position is wanted the moment somebody hands over a business card rather than
+// one card later. That is a real product argument and it may come back — but it
+// belongs in the diff that makes a product card actually read a position, not
+// ahead of one. Least privilege is the default until a view needs otherwise.
+//
+// WHAT AN EMPTY CSP DOES NOT BUY, stated because the obvious reading is wrong: a
+// view still has window.parent.postMessage, which is how the bridge talks to its
+// host at all, and no origin allowlist governs it. So a coordinate in a view is
+// reachable by the host, and the containment here is that the ONE view holding
+// one is a probe that displays it and sends nothing. It is NOT that the sandbox
+// makes a coordinate unsendable. See #2619.
 //
 // A HOST MAY REFUSE, and that is the expected outcome until proven otherwise —
 // the extension says hosts "MAY honor these permissions… but are not required
@@ -172,10 +181,11 @@ func DeclaredViews() map[string]string {
 //
 // It is one function because the policy reaches a host TWICE — on the catalogue
 // and on the read — and those are the two answers that must not be allowed to
-// differ. A second literal would be a second chance to widen one of them.
-func sandbox() *mcp.ResourceUI {
+// differ. A second literal would be a second chance to widen one of them, which
+// is why the per-view part is a parameter rather than a second policy.
+func sandbox(uri string) *mcp.ResourceUI {
 	return &mcp.ResourceUI{
-		Permissions: mcp.ResourcePermissions{Geolocation: true},
+		Permissions: mcp.ResourcePermissions{Geolocation: uri == GeoProbeURI},
 		// PrefersBorder, because these render as a panel of rows beside a
 		// conversation and read better with an edge than bleeding into it.
 		PrefersBorder: true,
@@ -192,7 +202,7 @@ func describe(v view) mcp.Resource {
 		// filter on the resource surface applies to it exactly as to any other
 		// document — a passport with no read grant is not shown these.
 		RequiredScope: principal.ScopeRead,
-		UI:            sandbox(),
+		UI:            sandbox(v.uri),
 	}
 }
 
@@ -237,7 +247,7 @@ func (p *Provider) ReadResource(_ context.Context, uri string) (mcp.ResourceCont
 	// The policy travels WITH the bytes, from the same function the catalogue
 	// entry took it from — so a host that read this document without listing
 	// first sandboxes it under exactly the rules it would have been told.
-	return mcp.ResourceContents{URI: uri, MIMEType: mcp.AppMIMEType, Text: text, UI: sandbox()}, nil
+	return mcp.ResourceContents{URI: uri, MIMEType: mcp.AppMIMEType, Text: text, UI: sandbox(uri)}, nil
 }
 
 var _ mcp.ResourceProvider = (*Provider)(nil)

--- a/backend/internal/modules/agents/apps/apps.go
+++ b/backend/internal/modules/agents/apps/apps.go
@@ -61,6 +61,16 @@ const (
 	// listing slot and an admission surface to display an answer the caller
 	// already has.
 	PipelineReviewURI = "ui://margince/pipeline-review.html"
+	// GeoProbeURI answers whether THIS host lets a view read the device's
+	// position. It renders no record and answers no tool.
+	//
+	// IT IS A PROBE AND IS MEANT TO BE DELETED. The extension says a host "MAY
+	// honor these permissions… but are not required to", so whether a coordinate
+	// is readable is a fact about claude.ai on web, on Android, on iOS and on
+	// desktop — four answers, none of them derivable from a document. Once the
+	// matrix is filled in, this view has told us the only thing it knows and
+	// should stop occupying a slot in resources/list.
+	GeoProbeURI = "ui://margince/geo-probe.html"
 )
 
 // view is one published document's identity. The document itself is not here:
@@ -109,6 +119,12 @@ var catalog = []view{
 		title:       "Pipeline review",
 		description: "The deals at risk this week, worst first, with the evidence each risk claim rests on.",
 	},
+	{
+		uri:         GeoProbeURI,
+		name:        "geo_probe_view",
+		title:       "Location check",
+		description: "Whether this host lets a view read the device's position, and the browser's own words when it does not.",
+	},
 }
 
 // DeclaredViews is every view this build declares, as URI → the title its
@@ -131,16 +147,35 @@ func DeclaredViews() map[string]string {
 // sandbox is the policy every view here declares, and the ONE place it is
 // stated.
 //
-// EVERY allowlist is left empty, and every permission unasked. That is the whole
-// security posture of these views: no fetch, no remote script, no nested frame,
-// no camera, no clipboard. See the package comment for why an empty list is the
-// promise rather than a placeholder.
+// EVERY allowlist is left empty, and every permission unasked EXCEPT
+// geolocation. That is the whole security posture of these views: no fetch, no
+// remote script, no nested frame, no camera, no clipboard. See the package
+// comment for why an empty list is the promise rather than a placeholder.
+//
+// WHY GEOLOCATION IS THE ONE EXCEPTION. Reading the device's own position is a
+// different act from letting a document reach the network, and the empty
+// allowlists are what keep the two apart. A view may learn where it is; it still
+// has no origin it may send that anywhere, so a coordinate can only travel back
+// the way every other answer does — through the host, into a tool call the user
+// sees. The permission widens what a view may KNOW, not what it may REACH.
+//
+// It is asked for on every view rather than one, because a host grants this per
+// iframe and a view that asks only when it expects to need the answer has
+// already lost the case it was for: the position is wanted at the moment
+// somebody hands over a business card, not one card later.
+//
+// A HOST MAY REFUSE, and that is the expected outcome until proven otherwise —
+// the extension says hosts "MAY honor these permissions… but are not required
+// to". Asking costs nothing when refused: the browser denies the call and the
+// view carries on without a position. So no view may treat a coordinate as
+// something it will get.
 //
 // It is one function because the policy reaches a host TWICE — on the catalogue
 // and on the read — and those are the two answers that must not be allowed to
 // differ. A second literal would be a second chance to widen one of them.
 func sandbox() *mcp.ResourceUI {
 	return &mcp.ResourceUI{
+		Permissions: mcp.ResourcePermissions{Geolocation: true},
 		// PrefersBorder, because these render as a panel of rows beside a
 		// conversation and read better with an edge than bleeding into it.
 		PrefersBorder: true,

--- a/backend/internal/modules/agents/apps/forbidden.json
+++ b/backend/internal/modules/agents/apps/forbidden.json
@@ -23,7 +23,6 @@
     "navigator.sendBeacon",
     "RTCPeerConnection",
     "location.replace",
-    "navigator.geolocation",
     "WebAssembly",
     "blob:",
     "javascript:",

--- a/backend/internal/modules/agents/apps/hold_test.go
+++ b/backend/internal/modules/agents/apps/hold_test.go
@@ -304,11 +304,11 @@ func TestTheRealProviderSendsItsPolicyWithTheDocument(t *testing.T) {
 	if !contents.UI.CSP.Empty() {
 		t.Errorf("the read policy names an origin this view may reach: %+v", contents.UI.CSP)
 	}
-	// Geolocation is the one permission these views ask for, and asking for it is
-	// exactly why the CSP above still has to be empty: a view may learn where it
-	// is, and has nowhere to send that. Pinned member by member so a second
-	// permission added later fails here rather than riding in unnoticed.
-	if want := (mcp.ResourcePermissions{Geolocation: true}); contents.UI.Permissions != want {
+	// A product card asks for NO permission. Only the probe reads a position, and
+	// a card that declares a capability it never uses would carry it if its code
+	// were ever substituted. Compared as a whole value, so a permission arriving
+	// on this view later fails here rather than riding in unnoticed.
+	if want := (mcp.ResourcePermissions{}); contents.UI.Permissions != want {
 		t.Errorf("the read policy is not the declared one: got %+v, want %+v", contents.UI.Permissions, want)
 	}
 	// The claim this test carries: the two answers a host can get are the same
@@ -329,6 +329,39 @@ func TestTheRealProviderSendsItsPolicyWithTheDocument(t *testing.T) {
 	// stop covering a member added later, which is the drift this test exists for.
 	if !reflect.DeepEqual(*listed, *contents.UI) {
 		t.Errorf("the catalogue and the read disagree: listed %+v, read %+v", *listed, *contents.UI)
+	}
+
+	// And the SAME two questions for the one view whose policy differs. A policy
+	// that varies per view is a policy that can disagree per view, so the probe
+	// is where the catalogue-versus-read claim is actually load-bearing: a
+	// sandbox() reading anything other than the URI it was handed would show up
+	// here and nowhere else.
+	probe, err := p.ReadResource(context.Background(), GeoProbeURI)
+	if err != nil {
+		t.Fatalf("reading the probe view: %v", err)
+	}
+	if probe.UI == nil {
+		t.Fatal("the probe was read with no sandbox policy attached to the bytes")
+	}
+	if want := (mcp.ResourcePermissions{Geolocation: true}); probe.UI.Permissions != want {
+		t.Errorf("the probe's read policy is not the declared one: got %+v, want %+v", probe.UI.Permissions, want)
+	}
+	// Asking for a position does not buy an origin. The probe displays what it
+	// read and sends it nowhere, and an empty allowlist here is half of why.
+	if !probe.UI.CSP.Empty() {
+		t.Errorf("the probe names an origin it may reach: %+v", probe.UI.CSP)
+	}
+	var listedProbe *mcp.ResourceUI
+	for _, r := range p.Resources(context.Background()) {
+		if r.URI == GeoProbeURI {
+			listedProbe = r.UI
+		}
+	}
+	if listedProbe == nil {
+		t.Fatal("the probe is not in the catalogue this provider publishes")
+	}
+	if !reflect.DeepEqual(*listedProbe, *probe.UI) {
+		t.Errorf("the catalogue and the read disagree on the probe: listed %+v, read %+v", *listedProbe, *probe.UI)
 	}
 }
 

--- a/backend/internal/modules/agents/apps/hold_test.go
+++ b/backend/internal/modules/agents/apps/hold_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -300,8 +301,34 @@ func TestTheRealProviderSendsItsPolicyWithTheDocument(t *testing.T) {
 	if contents.UI == nil {
 		t.Fatal("a view was read with no sandbox policy attached to the bytes")
 	}
-	if !contents.UI.CSP.Empty() || contents.UI.Permissions != (mcp.ResourcePermissions{}) {
-		t.Errorf("the read policy widens the sandbox: %+v", contents.UI)
+	if !contents.UI.CSP.Empty() {
+		t.Errorf("the read policy names an origin this view may reach: %+v", contents.UI.CSP)
+	}
+	// Geolocation is the one permission these views ask for, and asking for it is
+	// exactly why the CSP above still has to be empty: a view may learn where it
+	// is, and has nowhere to send that. Pinned member by member so a second
+	// permission added later fails here rather than riding in unnoticed.
+	if want := (mcp.ResourcePermissions{Geolocation: true}); contents.UI.Permissions != want {
+		t.Errorf("the read policy is not the declared one: got %+v, want %+v", contents.UI.Permissions, want)
+	}
+	// The claim this test carries: the two answers a host can get are the same
+	// one. A policy read from the catalogue would label the wrong document when
+	// two providers share a URI.
+	var listed *mcp.ResourceUI
+	for _, r := range p.Resources(context.Background()) {
+		if r.URI == AccountBriefURI {
+			listed = r.UI
+		}
+	}
+	if listed == nil {
+		t.Fatal("the view read above is not in the catalogue this provider publishes")
+	}
+	// reflect.DeepEqual rather than !=: ResourceCSP carries slices, so the whole
+	// policy is not a comparable type. The point is that the two answers agree in
+	// full, so comparing the whole value is what is wanted — field by field would
+	// stop covering a member added later, which is the drift this test exists for.
+	if !reflect.DeepEqual(*listed, *contents.UI) {
+		t.Errorf("the catalogue and the read disagree: listed %+v, read %+v", *listed, *contents.UI)
 	}
 }
 

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -189,6 +189,7 @@ func fullRegistry(t *testing.T) *Registry {
 		func(context.Context, ids.UUID) ([]IntroRoute, bool, error) { return nil, false, nil },
 		func(context.Context) (AtRiskReport, error) { return AtRiskReport{}, nil })
 	RegisterCommsTools(r, &recordingComms{}, &multiLinkProvider{})
+	RegisterGeoProbeTool(r)
 	RegisterLifecycleTools(r, nil, inertLifecycle{}, inertLifecycle{}, inertLifecycle{})
 	RegisterEnrichTool(r, nil, inertLifecycle{})
 	RegisterQueryTool(r, nil, func(context.Context, json.RawMessage) (QueryAnswer, error) {

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -249,6 +249,12 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 		func(context.Context, ids.UUID) ([]IntroRoute, bool, error) { return nil, false, errSeamReached },
 		func(context.Context) (AtRiskReport, error) { return AtRiskReport{}, errSeamReached })
 	RegisterCommsTools(r, &recordingComms{}, seamProbeProvider{})
+	// Registered so the registrar-parity gate stays satisfied, though it takes
+	// no seam and declares no argument at all — the walk below probes
+	// format:uuid properties, so this tool contributes nothing and is skipped on
+	// its own. Wiring it anyway is what keeps "every registrar is invoked here"
+	// a rule with no exceptions to remember.
+	RegisterGeoProbeTool(r)
 	RegisterLifecycleTools(r, seamProbeProvider{},
 		seamProbeLifecycle{}, seamProbeLifecycle{}, seamProbeLifecycle{})
 	RegisterEnrichTool(r, seamProbeProvider{}, seamProbeLifecycle{})

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1114,6 +1114,105 @@
       "warnings"
     ]
   },
+  "check_location_support": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "answered_by": {
+            "type": "string"
+          },
+          "declared_permission": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answered_by",
+          "declared_permission",
+          "note"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "commit_import": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/tools_geoprobe.go
+++ b/backend/internal/modules/agents/tools_geoprobe.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The check_location_support tool (🟢): the verb the location check hangs off.
+//
+// WHY A TOOL EXISTS AT ALL FOR A VIEW THAT NEEDS NO DATA. On this surface a view
+// is "a document hung off a tool that already answers" — a host is told to
+// render a card as part of a tool's result, and never fetches one on its own. A
+// published document no tool names is one no host will ever show, which the
+// composed-surface sweep refuses by name (TestEveryServedViewIsNamedByATool).
+// So the probe needs a verb, and this is the smallest honest one.
+//
+// WHAT IT ANSWERS. Nothing about the device — a server cannot know where a
+// caller is, and this tool does not guess. It answers what the SERVER has done:
+// that its views ask their host for geolocation, and that the answer to whether
+// the host grants it can only be read in the card beside this text. The finding
+// is produced in the browser, by the view, and it is the browser's own error
+// string that carries it.
+//
+// IT IS A PROBE AND IS MEANT TO BE DELETED, along with the view, once every host
+// in the matrix has answered. See apps.GeoProbeURI.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents/apps"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+var checkLocationSupportCopy = toolCopy{
+	Purpose: "Find out whether this chat host lets a Margince card read the device's location, " +
+		"which is what would let a contact be tagged with the event you are standing at.",
+	Limits: "It does not read a location and cannot: the answer comes from the card shown beside " +
+		"this result, and only after the person using it presses the button on that card. " +
+		"A host is free to refuse, and refusing is the expected outcome until one is shown not to.",
+	Instead: "To record where something happened, put it in the activity you log with log_activity; " +
+		"this tool tags nothing and writes nothing.",
+}
+
+// LocationSupport is what the server can say on its own: what it asked for, and
+// where the actual answer has to come from.
+type LocationSupport struct {
+	// Declared is the permission this build's views request of their host.
+	Declared string `json:"declared_permission"`
+	// AnsweredBy names the surface that produces the finding, because it is not
+	// this one.
+	AnsweredBy string `json:"answered_by"`
+	// Note is the sentence a client with no view renders instead of the card.
+	// A host without the Apps extension gets a straight answer rather than a
+	// reference to a panel it will never show.
+	Note string `json:"note"`
+}
+
+type checkLocationSupportTool struct{}
+
+func (t checkLocationSupportTool) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "check_location_support", Title: "Can a card read this device's location", Version: toolVersionV1,
+		Description:   checkLocationSupportCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		// No OpenAPIOp: there is no REST operation behind this and there should
+		// not be one. It reads no record, so a second door onto it would be a
+		// door onto nothing. search_context is the standing precedent for a tool
+		// with no twin.
+		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),
+		OutputSchema: schemaFor[LocationSupport](),
+		// The whole point of the tool. The card is where the browser is, and the
+		// browser is the only thing that can answer.
+		UI: &mcp.ToolUI{ResourceURI: apps.GeoProbeURI},
+	}
+}
+
+func (t checkLocationSupportTool) Handle(context.Context, json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(LocationSupport{
+		Declared:   "geolocation",
+		AnsweredBy: "the Location check card shown beside this answer",
+		Note: "This build's cards ask their host for permission to read the device's position. " +
+			"Whether the host grants it is the host's decision and cannot be read from here. " +
+			"Open the card beside this answer and press Read my location: the message it prints " +
+			"is the finding. Wording about a permissions policy means the host never allowed the " +
+			"card to ask, and nobody was prompted.",
+	})
+}
+
+// RegisterGeoProbeTool wires the location check.
+//
+// Unconditional, unlike the seam-backed registrations around it: it depends on
+// no store and no reader, so there is no absent seam that would make it lie.
+func RegisterGeoProbeTool(r *Registry) {
+	r.Register(checkLocationSupportTool{})
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -4,10 +4,10 @@
   "per_agent_listing_budget": 17000,
   "whole_catalog_floor": 21000,
   "catalog": {
-    "tools": 56,
-    "tokens": 17188,
-    "median_tool_tokens": 281,
-    "mean_tool_tokens": 306
+    "tools": 57,
+    "tokens": 17352,
+    "median_tool_tokens": 275,
+    "mean_tool_tokens": 304
   },
   "agents": [
     {
@@ -256,6 +256,10 @@
     {
       "name": "account_coverage",
       "tokens": 178
+    },
+    {
+      "name": "check_location_support",
+      "tokens": 163
     },
     {
       "name": "read_project_360",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2272 | 9% | 14728 | 15 | 8 |
-| _whole served catalog, for scale_ | 56 | 17188 | 71% | — | — | — |
+| _whole served catalog, for scale_ | 57 | 17352 | 72% | — | — | — |
 
 ### `morning_brief`
 
@@ -119,7 +119,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 281 tokens, mean 306, across 56 served tools.
+Median 275 tokens, mean 304, across 57 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -176,6 +176,7 @@ a term in an addition.
 | `remove_tag` | 190 | — |
 | `list_channel_providers` | 181 | — |
 | `account_coverage` | 178 | 2 scenarios |
+| `check_location_support` | 163 | — |
 | `read_project_360` | 163 | — |
 | `read_approval` | 160 | — |
 | `commit_import` | 149 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -11,8 +11,8 @@
     "tools": 57,
     "resources": 9,
     "tool_catalog_bytes": 158363,
-    "resource_catalog_bytes": 3678,
-    "approx_wire_tokens_total": 40510,
+    "resource_catalog_bytes": 3513,
+    "approx_wire_tokens_total": 40469,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
@@ -10402,9 +10402,6 @@
               "frameDomains": [],
               "resourceDomains": []
             },
-            "permissions": {
-              "geolocation": {}
-            },
             "prefersBorder": true
           }
         },
@@ -10422,9 +10419,6 @@
               "connectDomains": [],
               "frameDomains": [],
               "resourceDomains": []
-            },
-            "permissions": {
-              "geolocation": {}
             },
             "prefersBorder": true
           }
@@ -10444,9 +10438,6 @@
               "frameDomains": [],
               "resourceDomains": []
             },
-            "permissions": {
-              "geolocation": {}
-            },
             "prefersBorder": true
           }
         },
@@ -10465,9 +10456,6 @@
               "frameDomains": [],
               "resourceDomains": []
             },
-            "permissions": {
-              "geolocation": {}
-            },
             "prefersBorder": true
           }
         },
@@ -10485,9 +10473,6 @@
               "connectDomains": [],
               "frameDomains": [],
               "resourceDomains": []
-            },
-            "permissions": {
-              "geolocation": {}
             },
             "prefersBorder": true
           }

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 56,
-    "resources": 8,
-    "tool_catalog_bytes": 156416,
-    "resource_catalog_bytes": 3108,
-    "approx_wire_tokens_total": 39881,
+    "tools": 57,
+    "resources": 9,
+    "tool_catalog_bytes": 158363,
+    "resource_catalog_bytes": 3678,
+    "approx_wire_tokens_total": 40510,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 35978,
-      "input_schema_bytes": 34647,
-      "output_schema_bytes": 73753,
-      "description_plus_input_schema_bytes": 70625
+      "description_bytes": 36586,
+      "input_schema_bytes": 34709,
+      "output_schema_bytes": 74699,
+      "description_plus_input_schema_bytes": 71295
     }
   },
   "tools": {
@@ -1553,6 +1553,129 @@
           "type": "object"
         },
         "title": "Check calendar availability"
+      },
+      {
+        "_meta": {
+          "ui": {
+            "resourceUri": "ui://margince/geo-probe.html",
+            "visibility": [
+              "model",
+              "app"
+            ]
+          }
+        },
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Can a card read this device's location"
+        },
+        "description": "Find out whether this chat host lets a Margince card read the device's location, which is what would let a contact be tagged with the event you are standing at. It does not read a location and cannot: the answer comes from the card shown beside this result, and only after the person using it presses the button on that card. A host is free to refuse, and refusing is the expected outcome until one is shown not to. To record where something happened, put it in the activity you log with log_activity; this tool tags nothing and writes nothing. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {},
+          "type": "object"
+        },
+        "name": "check_location_support",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "answered_by": {
+                  "type": "string"
+                },
+                "declared_permission": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "answered_by",
+                "declared_permission",
+                "note"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Can a card read this device's location"
       },
       {
         "annotations": {
@@ -10279,6 +10402,9 @@
               "frameDomains": [],
               "resourceDomains": []
             },
+            "permissions": {
+              "geolocation": {}
+            },
             "prefersBorder": true
           }
         },
@@ -10296,6 +10422,9 @@
               "connectDomains": [],
               "frameDomains": [],
               "resourceDomains": []
+            },
+            "permissions": {
+              "geolocation": {}
             },
             "prefersBorder": true
           }
@@ -10315,6 +10444,9 @@
               "frameDomains": [],
               "resourceDomains": []
             },
+            "permissions": {
+              "geolocation": {}
+            },
             "prefersBorder": true
           }
         },
@@ -10332,6 +10464,9 @@
               "connectDomains": [],
               "frameDomains": [],
               "resourceDomains": []
+            },
+            "permissions": {
+              "geolocation": {}
             },
             "prefersBorder": true
           }
@@ -10351,6 +10486,9 @@
               "frameDomains": [],
               "resourceDomains": []
             },
+            "permissions": {
+              "geolocation": {}
+            },
             "prefersBorder": true
           }
         },
@@ -10359,17 +10497,39 @@
         "name": "pipeline_review_view",
         "title": "Pipeline review",
         "uri": "ui://margince/pipeline-review.html"
+      },
+      {
+        "_meta": {
+          "ui": {
+            "csp": {
+              "baseUriDomains": [],
+              "connectDomains": [],
+              "frameDomains": [],
+              "resourceDomains": []
+            },
+            "permissions": {
+              "geolocation": {}
+            },
+            "prefersBorder": true
+          }
+        },
+        "description": "Whether this host lets a view read the device's position, and the browser's own words when it does not.",
+        "mimeType": "text/html;profile=mcp-app",
+        "name": "geo_probe_view",
+        "title": "Location check",
+        "uri": "ui://margince/geo-probe.html"
       }
     ],
     "resultType": "complete",
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":56,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"commit_import\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":57,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",
     "ui://margince/commitments.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",
+    "ui://margince/geo-probe.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",
     "ui://margince/handoff.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",
     "ui://margince/pipeline-review.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",
     "ui://margince/relationship-map.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -14,8 +14,8 @@ receives it. This page is rendered from that file.
 | Tools | 57 |
 | Resources | 9 |
 | Tool catalog | 154.7 KB |
-| Resource catalog | 3.6 KB |
-| Approx. wire tokens | 40510 |
+| Resource catalog | 3.4 KB |
+| Approx. wire tokens | 40469 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -168,9 +168,6 @@ The ranked brief queue, with the factor decomposition each item ranked on.
       "frameDomains": [],
       "resourceDomains": []
     },
-    "permissions": {
-      "geolocation": {}
-    },
     "prefersBorder": true
   }
 }
@@ -196,9 +193,6 @@ The colleagues who know a contact, warmest first, with the interactions behind e
       "connectDomains": [],
       "frameDomains": [],
       "resourceDomains": []
-    },
-    "permissions": {
-      "geolocation": {}
     },
     "prefersBorder": true
   }
@@ -226,9 +220,6 @@ The promises still outstanding, oldest first, with who owes each one and how far
       "frameDomains": [],
       "resourceDomains": []
     },
-    "permissions": {
-      "geolocation": {}
-    },
     "prefersBorder": true
   }
 }
@@ -255,9 +246,6 @@ What the delivery side is being given for one project, with each gap beside the 
       "frameDomains": [],
       "resourceDomains": []
     },
-    "permissions": {
-      "geolocation": {}
-    },
     "prefersBorder": true
   }
 }
@@ -283,9 +271,6 @@ The deals at risk this week, worst first, with the evidence each risk claim rest
       "connectDomains": [],
       "frameDomains": [],
       "resourceDomains": []
-    },
-    "permissions": {
-      "geolocation": {}
     },
     "prefersBorder": true
   }

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 56 |
-| Resources | 8 |
-| Tool catalog | 152.8 KB |
-| Resource catalog | 3.0 KB |
-| Approx. wire tokens | 39881 |
+| Tools | 57 |
+| Resources | 9 |
+| Tool catalog | 154.7 KB |
+| Resource catalog | 3.6 KB |
+| Approx. wire tokens | 40510 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 72.0 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 35.1 KB | 23% | Yes, every step |
-| Input schemas | 33.8 KB | 22% | Yes, every step |
-| _Names, annotations, punctuation_ | 11.8 KB | 7% | Partly |
-| **Description + input schema** | **69.0 KB** | **45%** | **the recurring cost** |
+| Output schemas | 72.9 KB | 47% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 35.7 KB | 23% | Yes, every step |
+| Input schemas | 33.9 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 12.1 KB | 7% | Partly |
+| **Description + input schema** | **69.6 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -45,7 +45,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 
 ## Index
 
-### Resources (8)
+### Resources (9)
 
 - [`margince://capabilities`](#capabilities) — What this installation can do
 - [`margince://schema/query`](#query_vocabulary) — Workspace query vocabulary
@@ -55,8 +55,9 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/commitments.html`](#commitments_view) — Open commitments
 - [`ui://margince/handoff.html`](#handoff_view) — Delivery handoff
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
+- [`ui://margince/geo-probe.html`](#geo_probe_view) — Location check
 
-### Tools (56)
+### Tools (57)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -69,6 +70,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.7 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.8 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
+| [`check_location_support`](#check_location_support) | Can a card read this device's location | yes | [`ui://margince/geo-probe.html`](#geo_probe_view) | 1.8 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.7 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 2.7 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
@@ -166,6 +168,9 @@ The ranked brief queue, with the factor decomposition each item ranked on.
       "frameDomains": [],
       "resourceDomains": []
     },
+    "permissions": {
+      "geolocation": {}
+    },
     "prefersBorder": true
   }
 }
@@ -191,6 +196,9 @@ The colleagues who know a contact, warmest first, with the interactions behind e
       "connectDomains": [],
       "frameDomains": [],
       "resourceDomains": []
+    },
+    "permissions": {
+      "geolocation": {}
     },
     "prefersBorder": true
   }
@@ -218,6 +226,9 @@ The promises still outstanding, oldest first, with who owes each one and how far
       "frameDomains": [],
       "resourceDomains": []
     },
+    "permissions": {
+      "geolocation": {}
+    },
     "prefersBorder": true
   }
 }
@@ -244,6 +255,9 @@ What the delivery side is being given for one project, with each gap beside the 
       "frameDomains": [],
       "resourceDomains": []
     },
+    "permissions": {
+      "geolocation": {}
+    },
     "prefersBorder": true
   }
 }
@@ -269,6 +283,38 @@ The deals at risk this week, worst first, with the evidence each risk claim rest
       "connectDomains": [],
       "frameDomains": [],
       "resourceDomains": []
+    },
+    "permissions": {
+      "geolocation": {}
+    },
+    "prefersBorder": true
+  }
+}
+```
+
+</details>
+
+### geo_probe_view
+
+`ui://margince/geo-probe.html` · text/html;profile=mcp-app
+
+**Location check**
+
+Whether this host lets a view read the device's position, and the browser's own words when it does not.
+
+<details><summary>Sandbox policy (<code>_meta.ui</code>)</summary>
+
+```json
+{
+  "ui": {
+    "csp": {
+      "baseUriDomains": [],
+      "connectDomains": [],
+      "frameDomains": [],
+      "resourceDomains": []
+    },
+    "permissions": {
+      "geolocation": {}
     },
     "prefersBorder": true
   }
@@ -1806,6 +1852,132 @@ Find when a host is free, so a time can be proposed to someone. It reads free/bu
       "required": [
         "slots",
         "truncated"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### check_location_support
+
+**Can a card read this device's location**
+
+Find out whether this chat host lets a Margince card read the device's location, which is what would let a contact be tagged with the event you are standing at. It does not read a location and cannot: the answer comes from the card shown beside this result, and only after the person using it presses the button on that card. A host is free to refuse, and refusing is the expected outcome until one is shown not to. To record where something happened, put it in the activity you log with log_activity; this tool tags nothing and writes nothing. (Governance: runs immediately; requires passport scope "read".)
+
+Renders its result in [`ui://margince/geo-probe.html`](#geo_probe_view), visible to `model`, `app`.
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "answered_by": {
+          "type": "string"
+        },
+        "declared_permission": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "answered_by",
+        "declared_permission",
+        "note"
       ],
       "type": "object"
     },

--- a/frontend/scripts/vite-inline-views.ts
+++ b/frontend/scripts/vite-inline-views.ts
@@ -33,7 +33,24 @@ const COPYRIGHT = "SPDX-FileCopyrightText: 2026 Gradion";
 
 /** The shared admission vocabulary. Read from disk rather than imported so this
  *  module works identically under vitest, under a vite build and under the dev
- *  server, none of which agree about JSON import assertions. */
+ *  server, none of which agree about JSON import assertions.
+ *
+ *  WHY `navigator.geolocation` IS NOT IN IT, since it was until the geolocation
+ *  permission landed and the vocabulary is JSON and cannot say so itself. It sat
+ *  under `offOrigin`, among the network reaches — `fetch(`, `WebSocket(`,
+ *  `navigator.sendBeacon`. It does not belong there: reading the device's
+ *  position sends nothing anywhere. It was swept in with the calls it resembles
+ *  rather than judged on what it does.
+ *
+ *  The promise `offOrigin` keeps is that a view has no origin to reach, and that
+ *  promise is untouched — every network token above still stands, and the
+ *  published CSP still names no origin at all. A view may now learn where it is,
+ *  and still has nowhere to send it: a coordinate leaves only the way every
+ *  other answer does, through the host and into a tool call the user sees.
+ *
+ *  The permission the host must grant is the second fence, and the one that
+ *  actually decides. See sandbox() in the api's apps package for the
+ *  declaration, and src/mcp-apps/geo.ts for the read. */
 const VOCABULARY: Record<string, string[]> = JSON.parse(
   readFileSync(resolve(HERE, "../src/mcp-apps/forbidden.json"), "utf8"),
 );

--- a/frontend/src/mcp-apps/forbidden.json
+++ b/frontend/src/mcp-apps/forbidden.json
@@ -23,7 +23,6 @@
     "navigator.sendBeacon",
     "RTCPeerConnection",
     "location.replace",
-    "navigator.geolocation",
     "WebAssembly",
     "blob:",
     "javascript:",

--- a/frontend/src/mcp-apps/geo-probe/index.html
+++ b/frontend/src/mcp-apps/geo-probe/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Location check</title>
+  </head>
+  <body>
+    <main id="root"></main>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/frontend/src/mcp-apps/geo-probe/main.ts
+++ b/frontend/src/mcp-apps/geo-probe/main.ts
@@ -37,7 +37,9 @@ const MEANING: Record<string, string> = {
   "host-blocked":
     "The host did not allow this frame to ask. Nobody was prompted. This is the host's decision, not yours and not a bug here.",
   "user-declined":
-    "A prompt was shown and refused, or the system withheld it. The permission itself got through — try again and accept to confirm.",
+    "A prompt was shown and refused. The permission itself got through — try again and accept to confirm.",
+  "refused-unclassified":
+    "Refused, and this build does not recognise the wording. It could be the host blocking the frame or a person declining — read the message above, and add it to the patterns in geo.ts once you know which.",
   unavailable:
     "This document has no geolocation API at all, which usually means it is not a secure context.",
   timeout:

--- a/frontend/src/mcp-apps/geo-probe/main.ts
+++ b/frontend/src/mcp-apps/geo-probe/main.ts
@@ -28,7 +28,7 @@
 // left sitting in resources/list forever.
 
 import { el, onResult } from "../bridge";
-import { describeEnvironment, readPosition, type GeoResult } from "../geo";
+import { describeEnvironment, type GeoResult, readPosition } from "../geo";
 import "../view.css";
 
 /** What each refusal means for the person reading it — the finding in a
@@ -40,7 +40,8 @@ const MEANING: Record<string, string> = {
     "A prompt was shown and refused, or the system withheld it. The permission itself got through — try again and accept to confirm.",
   unavailable:
     "This document has no geolocation API at all, which usually means it is not a secure context.",
-  timeout: "Allowed, and asked, but no fix arrived in time. Not a permission problem.",
+  timeout:
+    "Allowed, and asked, but no fix arrived in time. Not a permission problem.",
   "position-unavailable":
     "Allowed, and asked, but the device could not produce a position. Not a permission problem.",
 };
@@ -79,7 +80,9 @@ function report(into: HTMLElement, result: GeoResult): void {
       ["message", result.message],
     ]),
   );
-  into.appendChild(el("p", "meta", MEANING[result.refusal] ?? "Unrecognised refusal."));
+  into.appendChild(
+    el("p", "meta", MEANING[result.refusal] ?? "Unrecognised refusal."),
+  );
 }
 
 function render(root: HTMLElement): void {

--- a/frontend/src/mcp-apps/geo-probe/main.ts
+++ b/frontend/src/mcp-apps/geo-probe/main.ts
@@ -1,0 +1,134 @@
+// The location check: does an MCP App view, inside THIS host, get to read the
+// device's position?
+//
+// WHY IT IS A VIEW OF ITS OWN AND NOT A LINE ON A PRODUCT CARD. The other five
+// views state plainly that they render and nothing else — "a button here would
+// be this view inventing authority it was not given". A button that asks the
+// browser for a permission is exactly such a thing. Rather than weaken that
+// rule on a card a customer sees, the question gets its own surface where a
+// control is the entire point.
+//
+// WHAT IT IS FOR. The deck's business-card scenario ends with the assistant
+// noticing you are at a conference and offering the venue as a tag. Every route
+// to that fact either asks the user or guesses from an IP address. The device
+// knows, and whether a view may ask it is the host's decision — the extension
+// says a host "MAY honor these permissions… but are not required to". Nobody
+// can read that decision out of a spec. It has to be run, per host: web,
+// Android, iOS, desktop.
+//
+// WHAT ANSWER IT PRODUCES. Not a yes or a no — the browser's own error string.
+// "disabled in this document by permissions policy" means the iframe carries no
+// allow attribute and nobody was ever prompted. "User denied Geolocation" means
+// a person saw a prompt and said no. Those are the same numeric code and they
+// mean opposite things: the first is the host refusing, the second is the
+// feature working.
+//
+// THIS IS A PROBE, NOT A PRODUCT SURFACE. It answers one question, and once
+// every host in the matrix has answered it, it should be deleted rather than
+// left sitting in resources/list forever.
+
+import { el, onResult } from "../bridge";
+import { describeEnvironment, readPosition, type GeoResult } from "../geo";
+import "../view.css";
+
+/** What each refusal means for the person reading it — the finding in a
+ *  sentence, since the raw string is evidence and not an explanation. */
+const MEANING: Record<string, string> = {
+  "host-blocked":
+    "The host did not allow this frame to ask. Nobody was prompted. This is the host's decision, not yours and not a bug here.",
+  "user-declined":
+    "A prompt was shown and refused, or the system withheld it. The permission itself got through — try again and accept to confirm.",
+  unavailable:
+    "This document has no geolocation API at all, which usually means it is not a secure context.",
+  timeout: "Allowed, and asked, but no fix arrived in time. Not a permission problem.",
+  "position-unavailable":
+    "Allowed, and asked, but the device could not produce a position. Not a permission problem.",
+};
+
+/** rowsOf renders a label/value table without building markup from a string. */
+function rowsOf(pairs: ReadonlyArray<readonly [string, string]>): HTMLElement {
+  const rows = el("div", "rows");
+  for (const [label, value] of pairs) {
+    const row = el("div", "row");
+    row.appendChild(el("span", "name", label));
+    row.appendChild(el("span", "state", value));
+    rows.appendChild(row);
+  }
+  return rows;
+}
+
+/** report replaces the outcome panel with what the last read actually said. */
+function report(into: HTMLElement, result: GeoResult): void {
+  into.replaceChildren();
+  if (result.ok) {
+    into.appendChild(el("div", "section-title", "Granted"));
+    into.appendChild(
+      rowsOf([
+        ["latitude", String(result.latitude)],
+        ["longitude", String(result.longitude)],
+        ["accuracy", `${Math.round(result.accuracyM)} m`],
+      ]),
+    );
+    return;
+  }
+  into.appendChild(el("div", "section-title", `Refused — ${result.refusal}`));
+  into.appendChild(
+    rowsOf([
+      ["code", String(result.code)],
+      // Verbatim. This string is the finding.
+      ["message", result.message],
+    ]),
+  );
+  into.appendChild(el("p", "meta", MEANING[result.refusal] ?? "Unrecognised refusal."));
+}
+
+function render(root: HTMLElement): void {
+  root.replaceChildren();
+  root.appendChild(el("h1", undefined, "Location check"));
+  root.appendChild(
+    el(
+      "p",
+      "meta",
+      "Does this host let a view read the device's position? Press the button. The message text is the answer.",
+    ),
+  );
+
+  const outcome = el("div", "section");
+  outcome.appendChild(el("div", "empty", "Not asked yet."));
+
+  const button = el("button", "probe-button", "Read my location");
+  // A real button element, so it is focusable and works from a keyboard without
+  // this view adding a single handler for it.
+  button.addEventListener("click", () => {
+    outcome.replaceChildren(el("div", "empty", "Asking…"));
+    // The promise never rejects, by construction — see geo.ts. No catch here
+    // would hide anything, because there is nothing to catch.
+    void readPosition().then((result) => report(outcome, result));
+  });
+
+  root.appendChild(button);
+  root.appendChild(outcome);
+
+  const env = el("div", "section");
+  env.appendChild(el("div", "section-title", "Environment"));
+  env.appendChild(el("div", "empty", "Reading…"));
+  root.appendChild(env);
+  // Environment first and without asking: the first question about a refusal is
+  // always whether the frame could ever have succeeded, and every field here is
+  // available before any prompt.
+  void describeEnvironment().then((found) => {
+    env.replaceChildren(el("div", "section-title", "Environment"));
+    env.appendChild(rowsOf(Object.entries(found)));
+  });
+}
+
+// This view answers no tool, so it draws on load rather than waiting for a
+// result. The handler is still registered: a host that pushes one anyway gets a
+// redraw instead of a view that silently ignores it.
+onResult(() => {
+  const root = document.getElementById("root");
+  if (root !== null) render(root);
+});
+
+const initial = document.getElementById("root");
+if (initial !== null) render(initial);

--- a/frontend/src/mcp-apps/geo.test.ts
+++ b/frontend/src/mcp-apps/geo.test.ts
@@ -1,0 +1,71 @@
+// The classifier's whole job is to keep two opposite findings apart, so this is
+// where that claim is held.
+//
+// A geolocation refusal arrives as code 1 whether the HOST never let the frame
+// ask or a PERSON was asked and said no. Those mean opposite things: the first
+// says the deck's location scenario cannot be built on this host, the second
+// says it can and somebody declined. The messages that distinguish them are not
+// standardised — every engine words them differently — which is exactly why the
+// mapping needs tests rather than confidence.
+
+import { describe, expect, it } from "vitest";
+
+import { classify } from "./geo";
+
+/** A stand-in for the browser's error object, which cannot be constructed. */
+function err(code: number, message: string): GeolocationPositionError {
+  return {
+    code,
+    message,
+    PERMISSION_DENIED: 1,
+    POSITION_UNAVAILABLE: 2,
+    TIMEOUT: 3,
+  } as GeolocationPositionError;
+}
+
+describe("a refused position", () => {
+  // The wording the 2026-08-19 artifact probe actually produced, plus the
+  // variants other engines are known to use. This case is the one the view
+  // exists to detect.
+  it.each([
+    "Geolocation has been disabled in this document by permissions policy.",
+    "Geolocation has been disabled in this document by Permissions Policy.",
+    "Geolocation has been disabled in this document by Feature Policy.",
+    "Access to the feature is disallowed by permissions policy",
+  ])("is a host block when the message says %j", (message) => {
+    expect(classify(err(1, message))).toBe("host-blocked");
+  });
+
+  it.each([
+    "User denied Geolocation",
+    "User denied geolocation prompt",
+    "Origin does not have permission to use the Geolocation service: denied by the user",
+  ])("is a decline when the message says %j", (message) => {
+    expect(classify(err(1, message))).toBe("user-declined");
+  });
+
+  // THE REGRESSION THIS FILE WAS WRITTEN FOR. An earlier version defaulted every
+  // unmatched code-1 message to "user-declined", so an unfamiliar host block
+  // told the tester "the permission got through, try again and accept" — the
+  // opposite of the truth, stated confidently, about the one question the probe
+  // exists to answer. An unknown wording has to read as unknown.
+  it.each(["Position acquisition failed", "kCLErrorDomain error 1", ""])(
+    "is unclassified rather than a guess when the message says %j",
+    (message) => {
+      expect(classify(err(1, message))).toBe("refused-unclassified");
+    },
+  );
+
+  // The two codes that are NOT about permission at all. Reading either as a
+  // refusal would send somebody looking for a host setting over a device that
+  // simply had no fix.
+  it("is a timeout when the code says so, whatever the message", () => {
+    expect(classify(err(3, "User denied Geolocation"))).toBe("timeout");
+  });
+
+  it("is position-unavailable when the code says so, whatever the message", () => {
+    expect(classify(err(2, "disabled by permissions policy"))).toBe(
+      "position-unavailable",
+    );
+  });
+});

--- a/frontend/src/mcp-apps/geo.ts
+++ b/frontend/src/mcp-apps/geo.ts
@@ -39,8 +39,21 @@ const MAX_AGE_MS = 60_000;
 export type GeoRefusal =
   /** The iframe carries no `allow="geolocation"`. Nobody was ever prompted. */
   | "host-blocked"
-  /** A prompt was shown and refused, or the OS withheld it. */
+  /** A prompt was shown and refused, and the message says so. */
   | "user-declined"
+  /**
+   * Refused with a code-1 message this code does not recognise.
+   *
+   * It is a state of its own rather than a default, and that is the point. Code
+   * 1 covers a permissions-policy block, an insecure context, a person
+   * declining, AND a persistent OS-level denial, and the messages are not
+   * standardised — every engine words them differently. Folding an unfamiliar
+   * message into "user-declined" would tell a tester the permission got through
+   * and to try again, which is the exact OPPOSITE conclusion when the truth was
+   * a host block, and retrying cannot help. Saying "unrecognised" is worth more
+   * than a confident guess: `message` carries the evidence either way.
+   */
+  | "refused-unclassified"
   /** The API is not present — an old browser, or a non-secure context. */
   | "unavailable"
   /** Asked and allowed, but no fix arrived in time. */
@@ -72,23 +85,35 @@ export type GeoResult =
       readonly code: number;
     };
 
+/** Engine wordings that mean the frame was never allowed to ask. */
+const HOST_BLOCKED =
+  /permissions?\s+policy|feature\s+policy|disabled in this document/i;
+
+/** Engine wordings that mean a person was asked and refused. */
+const USER_DECLINED = /user\s+denied|denied by (the )?user|user\s+declined/i;
+
 /**
  * classify turns a GeolocationPositionError into the distinction that matters.
  *
- * The permissions-policy wording is matched case-insensitively and loosely
- * because it is not specified anywhere — it is what engines happen to say, and
- * Chrome, Firefox and Safari each word it differently. A miss here is not
- * dangerous: it degrades to "user-declined", and `message` still carries the
- * truth for anyone reading the detail.
+ * BOTH sides are matched, and anything else is "refused-unclassified" rather
+ * than a guess. Code 1 is PERMISSION_DENIED for four different reasons — a
+ * permissions-policy block, an insecure context, a person declining, a
+ * persistent OS denial — and the messages are not standardised. An earlier
+ * version defaulted an unmatched message to "user-declined", which would have
+ * told a tester "the permission got through, try again and accept" for a host
+ * block where retrying can never work: the opposite of the truth, stated
+ * confidently. Two positive matchers and an explicit unknown cannot do that.
+ *
+ * The patterns are what engines happen to say rather than anything specified,
+ * so they will need extending. `message` is carried verbatim either way, which
+ * is what makes an unrecognised wording a finding rather than a dead end.
  */
-function classify(err: GeolocationPositionError): GeoRefusal {
+export function classify(err: GeolocationPositionError): GeoRefusal {
   if (err.code === err.TIMEOUT) return "timeout";
   if (err.code === err.POSITION_UNAVAILABLE) return "position-unavailable";
-  return /permissions?\s+policy|feature\s+policy|disabled in this document/i.test(
-    err.message,
-  )
-    ? "host-blocked"
-    : "user-declined";
+  if (HOST_BLOCKED.test(err.message)) return "host-blocked";
+  if (USER_DECLINED.test(err.message)) return "user-declined";
+  return "refused-unclassified";
 }
 
 /**

--- a/frontend/src/mcp-apps/geo.ts
+++ b/frontend/src/mcp-apps/geo.ts
@@ -49,7 +49,12 @@ export type GeoRefusal =
   | "position-unavailable";
 
 export type GeoResult =
-  | { readonly ok: true; readonly latitude: number; readonly longitude: number; readonly accuracyM: number }
+  | {
+      readonly ok: true;
+      readonly latitude: number;
+      readonly longitude: number;
+      readonly accuracyM: number;
+    }
   | {
       readonly ok: false;
       readonly refusal: GeoRefusal;
@@ -79,7 +84,9 @@ export type GeoResult =
 function classify(err: GeolocationPositionError): GeoRefusal {
   if (err.code === err.TIMEOUT) return "timeout";
   if (err.code === err.POSITION_UNAVAILABLE) return "position-unavailable";
-  return /permissions?\s+policy|feature\s+policy|disabled in this document/i.test(err.message)
+  return /permissions?\s+policy|feature\s+policy|disabled in this document/i.test(
+    err.message,
+  )
     ? "host-blocked"
     : "user-declined";
 }
@@ -118,7 +125,13 @@ export function readPosition(): Promise<GeoResult> {
           longitude: pos.coords.longitude,
           accuracyM: pos.coords.accuracy,
         }),
-      (err) => resolve({ ok: false, refusal: classify(err), code: err.code, message: err.message }),
+      (err) =>
+        resolve({
+          ok: false,
+          refusal: classify(err),
+          code: err.code,
+          message: err.message,
+        }),
       { enableHighAccuracy: true, timeout: TIMEOUT_MS, maximumAge: MAX_AGE_MS },
     );
   });
@@ -136,8 +149,13 @@ export function readPosition(): Promise<GeoResult> {
  */
 export async function describeEnvironment(): Promise<Record<string, string>> {
   const env: Record<string, string> = {
-    api: typeof navigator !== "undefined" && "geolocation" in navigator ? "present" : "absent",
-    secureContext: String(typeof window !== "undefined" && window.isSecureContext),
+    api:
+      typeof navigator !== "undefined" && "geolocation" in navigator
+        ? "present"
+        : "absent",
+    secureContext: String(
+      typeof window !== "undefined" && window.isSecureContext,
+    ),
     framed: String(typeof window !== "undefined" && window.self !== window.top),
   };
   try {
@@ -145,12 +163,19 @@ export async function describeEnvironment(): Promise<Record<string, string>> {
     if (permissions?.query) {
       // The name is a PermissionName the DOM lib types as a union; "geolocation"
       // is a member of it, so this needs no assertion.
-      env.permissionState = (await permissions.query({ name: "geolocation" })).state;
+      env.permissionState = (
+        await permissions.query({ name: "geolocation" })
+      ).state;
     } else {
       env.permissionState = "query-unavailable";
     }
-  } catch (e) {
-    env.permissionState = `query-threw: ${e instanceof Error ? e.message : String(e)}`;
+  } catch {
+    // The thrown message is deliberately NOT shown. `permissions.query` throws
+    // for a name an engine does not implement, and every such message is about
+    // the query rather than about geolocation — so it would be an engine's own
+    // words on the screen saying nothing a reader can act on. That it could not
+    // be asked IS the whole finding, and the real answer comes from the read.
+    env.permissionState = "query-threw";
   }
   return env;
 }

--- a/frontend/src/mcp-apps/geo.ts
+++ b/frontend/src/mcp-apps/geo.ts
@@ -1,0 +1,156 @@
+// Reading the device's position from inside a view, and — far more often —
+// finding out precisely why it could not be read.
+//
+// WHY THIS EXISTS AT ALL. A rep hands over a business card at a conference. The
+// useful thing is not the card, it is that the person filing it is standing in
+// the hall: the venue is the tag, and nobody should have to type it. Every other
+// route to that fact either asks the user (which makes it a form, not a
+// convenience) or guesses from an IP address (which on conference wifi names the
+// wrong city). The device already knows.
+//
+// WHY IT IS SEPARATE FROM bridge.ts. The bridge is the transport, and it is the
+// one thing every view depends on to render at all. This is a sensor read that
+// usually fails, on a permission the host is free to refuse. Keeping it apart
+// means a view that never asks carries none of it, and a change here cannot
+// break the handshake.
+//
+// THE PERMISSION IS DECLARED SERVER-SIDE, in apps.sandbox() — a view asks for
+// geolocation in the `_meta.ui` its resource is published with, and the host
+// turns that into an iframe `allow` attribute IF it chooses to. The extension is
+// explicit that a host "MAY honor these permissions… but are not required to",
+// so refusal is a normal outcome and not an error to report as a fault.
+//
+// WHAT A CALLER MAY ASSUME: nothing. There is no position until there is one,
+// this never throws, and it never rejects. A view that renders differently
+// depending on whether it got an answer has already made the answer required.
+
+/** How long to wait before giving up on a fix. */
+const TIMEOUT_MS = 15_000;
+
+/** How stale a cached position may be before a fresh fix is required. */
+const MAX_AGE_MS = 60_000;
+
+/**
+ * Why a position could not be read, distinguished by what a reader can DO about
+ * it. The browser's own numeric codes do not separate the two cases that matter
+ * most: a host that never allowed the frame to ask, and a person who was asked
+ * and said no. Both arrive as code 1.
+ */
+export type GeoRefusal =
+  /** The iframe carries no `allow="geolocation"`. Nobody was ever prompted. */
+  | "host-blocked"
+  /** A prompt was shown and refused, or the OS withheld it. */
+  | "user-declined"
+  /** The API is not present — an old browser, or a non-secure context. */
+  | "unavailable"
+  /** Asked and allowed, but no fix arrived in time. */
+  | "timeout"
+  /** Allowed, but the device could not produce a position. */
+  | "position-unavailable";
+
+export type GeoResult =
+  | { readonly ok: true; readonly latitude: number; readonly longitude: number; readonly accuracyM: number }
+  | {
+      readonly ok: false;
+      readonly refusal: GeoRefusal;
+      /**
+       * The browser's own message, verbatim and untrimmed.
+       *
+       * This is the field the whole module exists to produce. "Geolocation has
+       * been disabled in this document by permissions policy" is a finding about
+       * the HOST; "User denied Geolocation" is a finding about a person. They
+       * are the same numeric code and they mean opposite things, so the string
+       * is the evidence and paraphrasing it destroys it.
+       */
+      readonly message: string;
+      /** The browser's numeric code, or -1 where no error object existed. */
+      readonly code: number;
+    };
+
+/**
+ * classify turns a GeolocationPositionError into the distinction that matters.
+ *
+ * The permissions-policy wording is matched case-insensitively and loosely
+ * because it is not specified anywhere — it is what engines happen to say, and
+ * Chrome, Firefox and Safari each word it differently. A miss here is not
+ * dangerous: it degrades to "user-declined", and `message` still carries the
+ * truth for anyone reading the detail.
+ */
+function classify(err: GeolocationPositionError): GeoRefusal {
+  if (err.code === err.TIMEOUT) return "timeout";
+  if (err.code === err.POSITION_UNAVAILABLE) return "position-unavailable";
+  return /permissions?\s+policy|feature\s+policy|disabled in this document/i.test(err.message)
+    ? "host-blocked"
+    : "user-declined";
+}
+
+/**
+ * readPosition asks the device where it is.
+ *
+ * It resolves either way and never rejects, so a caller writes no try/catch and
+ * cannot accidentally make a refused permission look like a crash. Calling it
+ * more than once is fine; each call is an independent request.
+ *
+ * NOTE ON THE PROMPT. Where the host does allow it, the browser may show a
+ * permission prompt on the first call. That is the user's decision to make and
+ * the reason this is never called on load — a view that asks the moment it
+ * renders spends the one prompt it gets before anybody wanted the feature.
+ */
+export function readPosition(): Promise<GeoResult> {
+  return new Promise<GeoResult>((resolve) => {
+    if (typeof navigator === "undefined" || !("geolocation" in navigator)) {
+      resolve({
+        ok: false,
+        refusal: "unavailable",
+        code: -1,
+        message: "navigator.geolocation is not present in this document",
+      });
+      return;
+    }
+    // A settled promise ignores later calls, so the guard is not for
+    // correctness — it is so a late success cannot look like a second answer to
+    // anyone reading this and wondering.
+    navigator.geolocation.getCurrentPosition(
+      (pos) =>
+        resolve({
+          ok: true,
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracyM: pos.coords.accuracy,
+        }),
+      (err) => resolve({ ok: false, refusal: classify(err), code: err.code, message: err.message }),
+      { enableHighAccuracy: true, timeout: TIMEOUT_MS, maximumAge: MAX_AGE_MS },
+    );
+  });
+}
+
+/**
+ * describeEnvironment reports what this document can see about its own sandbox,
+ * WITHOUT asking for a position.
+ *
+ * It is here because the first question about a failed read is always whether
+ * the frame was ever in a position to succeed, and every field below is
+ * available before any prompt. `permissions.query` is the one that answers
+ * "would it even ask?" — but it is unimplemented in some engines and throws for
+ * an unsupported name in others, so it is treated as best-effort.
+ */
+export async function describeEnvironment(): Promise<Record<string, string>> {
+  const env: Record<string, string> = {
+    api: typeof navigator !== "undefined" && "geolocation" in navigator ? "present" : "absent",
+    secureContext: String(typeof window !== "undefined" && window.isSecureContext),
+    framed: String(typeof window !== "undefined" && window.self !== window.top),
+  };
+  try {
+    const permissions = navigator.permissions;
+    if (permissions?.query) {
+      // The name is a PermissionName the DOM lib types as a union; "geolocation"
+      // is a member of it, so this needs no assertion.
+      env.permissionState = (await permissions.query({ name: "geolocation" })).state;
+    } else {
+      env.permissionState = "query-unavailable";
+    }
+  } catch (e) {
+    env.permissionState = `query-threw: ${e instanceof Error ? e.message : String(e)}`;
+  }
+  return env;
+}

--- a/frontend/src/mcp-apps/view.css
+++ b/frontend/src/mcp-apps/view.css
@@ -208,3 +208,35 @@ h1 {
 .scroll {
   overflow-x: auto;
 }
+
+/* The ONE control on these views, and it belongs to the location check alone.
+   The product views render and offer nothing to press — see their own headers
+   for why. This exists because asking the browser for a permission has to be a
+   deliberate act by a person, and a permission prompt fired on load spends the
+   one chance a host gives before anybody wanted the feature. */
+.probe-button {
+  display: block;
+  width: 100%;
+  margin-bottom: var(--space-4);
+  border: 0;
+  border-radius: 8px;
+  padding: var(--space-3) var(--space-4);
+  background: var(--accent);
+  color: var(--textOnAccent);
+  font: inherit;
+  font-weight: 600;
+  /* A touch target a thumb hits on a phone, which is where this gets run. */
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.probe-button:hover {
+  background: var(--accentBrand);
+}
+
+/* Keyboard focus stays visible. A control a host renders inside its own chrome
+   is one a person may well reach by tab rather than by pointer. */
+.probe-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/frontend/src/mcp-apps/view.css
+++ b/frontend/src/mcp-apps/view.css
@@ -237,6 +237,6 @@ h1 {
 /* Keyboard focus stays visible. A control a host renders inside its own chrome
    is one a person may well reach by tab rather than by pointer. */
 .probe-button:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--focus-ring);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Why

The vision deck's business-card scenario ends with the assistant noticing you are at a conference and offering the venue as a tag. Every route to that fact either **asks the user** — which makes it a form, not a convenience — or **guesses from an IP address**, which on conference wifi names the wrong city. The device already knows.

Whether a view may ask it is the **host's** decision. The MCP Apps extension is explicit that a host *"MAY honor these permissions… but are not required to"*, so this cannot be settled by reading a spec: it has a different answer on claude.ai web, on Android, on iOS and on desktop. This PR makes the question askable.

An earlier probe (19 Aug) tested this through a claude.ai **artifact** and got `"Geolocation has been disabled in this document by permissions policy"` — the iframe `allow` attribute. But an artifact and an MCP App view are different embedding paths, so that was strong evidence and not proof. This settles it.

## What changed

**`sandbox()` declares `Geolocation: true`, on every view rather than one.** A host grants this per iframe, and a view that asks only when it expects to need an answer has already lost the case it was for: the position is wanted when somebody hands over a card, not one card later.

**`navigator.geolocation` came off the admission vocabulary.** It sat under `offOrigin`, among `fetch(`, `WebSocket(` and `sendBeacon` — swept in with the calls it resembles rather than judged on what it does. Reading a sensor sends nothing anywhere.

The promise `offOrigin` keeps is untouched: every network token still stands and the published CSP still names no origin, so **a view may now learn where it is and still has nowhere to send it**. A coordinate leaves only the way every other answer does — through the host, into a tool call the user sees. The reasoning lives in `vite-inline-views.ts`, since JSON cannot carry a comment.

**A `geo-probe` view and a `check_location_support` tool, which exist to be DELETED.** The five product views state that they render and nothing else, and a button that asks for a permission is exactly the authority they refuse — so the question got its own surface instead of weakening a card a customer sees.

## Verified

`_meta.ui` on the wire, from the regenerated `mcp-info.json`:

```
ui://margince/account-brief.html      perms={'geolocation': {}}  csp=all lists empty
ui://margince/relationship-map.html   perms={'geolocation': {}}  csp=all lists empty
ui://margince/commitments.html        perms={'geolocation': {}}  csp=all lists empty
ui://margince/handoff.html            perms={'geolocation': {}}  csp=all lists empty
ui://margince/pipeline-review.html    perms={'geolocation': {}}  csp=all lists empty
ui://margince/geo-probe.html          perms={'geolocation': {}}  csp=all lists empty
```

`{"geolocation": {}}` is the extension's presence-based shape, not a boolean flag.

The built probe document contains the geolocation call and **zero** `http://` or `https://` origins, so it passed both halves of the admission gate.

## Gates

`make check-backend`, `make check-fe`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` — all green.

Two existing gates were **tightened rather than relaxed**. Both compared the policy against the zero value; both now pin `Geolocation:true` as a whole value, so a *second* permission still fails. Proven by reverting the declaration:

```
hold_test.go:312: the read policy is not the declared one:
  got {Geolocation:false}, want {Geolocation:true}
agentapps_test.go:210: the view ui://margince/account-brief.html asks for
  browser permissions {Geolocation:false}, want {Geolocation:true}
  [and the five other views]
```

Two house rules caught real violations in the second commit: the focus ring spelled its own width instead of reading `--focus-ring`, and `describeEnvironment` put a caught error's own message on screen. Both fixed. The browser's *geolocation* error message is still shown verbatim — that is the finding this view exists to produce.

## What this does NOT do

It does not make the deck's scenario work. It makes it **testable**. The host may still refuse, and refusal stays the expected outcome until a run shows otherwise. The four-host matrix is the next step.

Refs #2616

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a temporary location probe view and tool to test host geolocation support. Previously all views declared geolocation; now only the probe does, while CSP stays origin-empty so product cards remain permissionless.

- Policy: `sandbox(uri)` now sets permissions per view; `ui://margince/geo-probe.html` declares `geolocation`, all product views declare none. Tests pin the full UI policy on catalog and read, and fail any second permission.
- Admission vocabulary: remove `navigator.geolocation` from the off-origin forbid list; all network denies remain unchanged.
- Probe surface: adds `check_location_support` (registers unconditionally) and a `geo-probe` view with a single button; no data reads or network calls. Shows the browser’s message verbatim and classifies refusals (host-blocked vs user-declined; unknown stays unknown). Unit tests cover the classifier.
- Security clarification: an empty CSP does not restrict `postMessage`; containment is that the probe sends nothing, not that the sandbox makes coordinates unsendable.
- Docs and gates: regenerate `mcp-info` and tool budget; tighten gates to compare full UI policy values; fix focus ring token use and avoid surfacing non-actionable env-query errors.

<sup>Written for commit c7370bfca146f678f31c15e14e95bdd4be5a59a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a location-support check that explains whether geolocation is available without reading or storing location data.
  - Added an interactive location check view with clear results for successful, denied, unavailable, or host-blocked access.
  - Limited geolocation permission requests to the dedicated location check view; existing views no longer request it.

- **Documentation**
  - Updated published tool and resource catalogs with the location check and revised totals and usage metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->