### PR TITLE
fix(agents): the location check answers the conformance sweep

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -119,6 +119,13 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		// there is nothing for a caller to narrow by — and the empty object is
 		// the shape the schema declares.
 		{"list_channel_providers", `{}`},
+		// No arguments, and there can be none: the schema declares an empty
+		// object and forbids every other member, so the second call its
+		// neighbours carry is impossible rather than merely redundant. It is
+		// also the one tool here that reads nothing off its context, so the
+		// seal supplies freshness, evidence and warnings unaided — an absent
+		// one would show here first.
+		{"check_location_support", `{}`},
 		{"search_records", `{"q":"Conformance"}`},
 		{"search_records", `{"q":"Conformance","record_type":"person","limit":5}`},
 		// A query that matches nothing: the empty answer has to keep the shape


### PR DESCRIPTION
`main` is red on `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas`, in
`integration / integration shard (1/6)` and `integration / integration (RLS + erasure + HTTP e2e)`.

```
toolschema_conformance_integration_test.go:210: check_location_support is registered but never
invoked here, so nothing holds its result to the schema or the envelope. Add a call above, or
name the seam it needs in unreachableInThisLane.
```

#2617 registered `check_location_support` and updated `agenttoolparity_test.go`, but not the
tool-schema conformance sweep. `assertEveryRegisteredToolIsAccountedFor` derives its census from the
registry rather than from the table beside it, which is why a tool added without a call fails loudly
instead of being silently absent — the gate working as designed.

## The fix

A call, not a waiver. `unreachableInThisLane` names, for each entry, the seam this lane cannot stand
up — an object store, a calendar, an outbound provider, a drafting path. `check_location_support`
composes over nothing: no store, no reader, no provider, empty input object, and
`RegisterGeoProbeTool` is unconditional precisely because there is no seam whose absence could make
it lie. A waiver here would have to name a seam that does not exist.

Its answer is also worth holding to the schema on its own merits: `LocationSupport` is a
hand-written literal, which is the shape most able to drift from the schema that declares it.

## Verification

`go vet -tags=integration ./internal/compose/integration/` passes, `gofmt` clean, `craft static
--strict` reports 0 blocker / 0 major / 0 minor on the changed file.

**I could not run the integration lane locally**: it needs a real Postgres via Docker, and the Docker
daemon on this machine is currently hung — both sockets accept the connection and neither answers
`/_ping`. So the assertion that this call passes rests on CI, not on a local run. Flagging that
rather than implying a reproduction I did not do.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invokes `check_location_support` in the tool-schema conformance sweep so CI validates its schema and envelope. Previously it was registered but not invoked, causing `assertEveryRegisteredToolIsAccountedFor` to fail.

- Adds {"check_location_support","{}"} to `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas`; leaves `unreachableInThisLane` unchanged.
- No waiver or config changes; the tool has no external seams and its literal answer is now held to the declared schema to catch drift.

<sup>Written for commit ecea667ba67d0bff684290fd240a523f7b63b967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration schema-conformance coverage for location support checks with empty inputs.
  * Verified the structure of the returned response envelope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->