### PR TITLE
fix(agents): the tool surface names the language stored prose is written in

### DIFF
--- a/backend/internal/compose/promptlang/promptlang.go
+++ b/backend/internal/compose/promptlang/promptlang.go
@@ -62,11 +62,7 @@ const Heading = "LANGUAGE\n"
 // nobody named, which is the failure this package exists to remove. English is
 // what these prompts produced before this package existed.
 func Rule(lang string) string {
-	name := englishName(lang)
-	if name == "" {
-		name = englishName(string(textlang.English))
-	}
-	return Heading + `Write every human-readable sentence of your output in ` + name + `.
+	return Heading + `Write every human-readable sentence of your output in ` + LanguageName(lang) + `.
 Write naturally in that language rather than translating English phrasing.
 Leave everything that is not a sentence exactly as it is given: JSON keys, enum
 and status values, ids, urls, email addresses, people's names, company names,
@@ -74,8 +70,23 @@ and any text you are quoting from a source. Translating one of those changes
 what it refers to.`
 }
 
+// LanguageName is the language's name in English, for any surface that tells
+// a model which language to write in — the prompt rule below, and the tool
+// surface that answers the same question to an agent running elsewhere.
+//
+// A code the product does not ship answers English, which is the fallback Rule
+// documents above and the one every caller wants: the surfaces that call this
+// hand the answer straight to a model, and a blank there instructs it in no
+// language at all.
+func LanguageName(lang string) string {
+	if name := englishName(lang); name != "" {
+		return name
+	}
+	return englishName(string(textlang.English))
+}
+
 // englishName is the language's name in English. Empty for anything the product
-// does not ship, which is what Rule refuses on.
+// does not ship, which is what LanguageName falls back on.
 func englishName(lang string) string {
 	switch textlang.Lang(lang) {
 	case textlang.English:

--- a/backend/internal/compose/whoamiseam.go
+++ b/backend/internal/compose/whoamiseam.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/compose/promptlang"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 )
@@ -23,6 +24,12 @@ import (
 // omission here: the question is "who is the caller", which a caller may always
 // know. What it cannot do is answer for anybody else — the principal decides
 // the subject, never an argument.
+//
+// The prose language is resolved HERE rather than in identity, because it is a
+// composition of two settings that belong to different owners: the member's
+// own choice and the installation's base language. identity keeps answering
+// the honest empty for a person who never chose, and this seam turns that into
+// the answer the agent can act on.
 func actingIdentity(pool *pgxpool.Pool) agents.IdentityReader {
 	service := identity.NewService(pool)
 	return func(ctx context.Context) (agents.ActingIdentity, error) {
@@ -31,13 +38,28 @@ func actingIdentity(pool *pgxpool.Pool) agents.IdentityReader {
 			return agents.ActingIdentity{}, err
 		}
 		return agents.ActingIdentity{
-			UserID:      profile.UserID,
-			DisplayName: profile.DisplayName,
-			Email:       profile.Email,
-			Locale:      profile.Locale,
-			Timezone:    profile.Timezone,
+			UserID:        profile.UserID,
+			DisplayName:   profile.DisplayName,
+			Email:         profile.Email,
+			Locale:        profile.Locale,
+			ProseLanguage: proseLanguage(ctx, pool, profile.Locale),
+			Timezone:      profile.Timezone,
 		}, nil
 	}
+}
+
+// proseLanguage names the language stored prose must be written in: the
+// member's own choice, or the installation's base language when they never
+// made one.
+//
+// It answers a language name rather than a code ("German", not "de"), for the
+// reason promptlang.Rule already gives: the reader is a model writing a
+// sentence, and a two-letter code is a lookup it can get wrong.
+func proseLanguage(ctx context.Context, pool *pgxpool.Pool, locale string) string {
+	if locale == "" {
+		locale = identity.BaseLanguageForPrompt(ctx, pool)
+	}
+	return promptlang.LanguageName(locale)
 }
 
 // colleagueLister reads the workspace roster.

--- a/backend/internal/compose/whoamiseam_integration_test.go
+++ b/backend/internal/compose/whoamiseam_integration_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What language the tool surface tells an agent to write stored prose in.
+//
+// The answer must never be empty, because the failure it replaces is an agent
+// with no instruction inferring a language from the workspace around it: an
+// English conversation in an English workspace produced German notes, since
+// nobody had chosen a locale and nothing named the installation's own.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+)
+
+func TestTheAgentIsAlwaysToldWhichLanguageToWriteStoredProseIn(t *testing.T) {
+	e := integration.Setup(t)
+	read := actingIdentity(e.Pool)
+
+	// A member who never chose a language is the common case, and the one the
+	// German-note bug was found in. The installation's base language answers
+	// for them rather than nothing at all.
+	e.WsExec(t, `UPDATE app_user SET locale = NULL WHERE id = $1`, e.AdminUser)
+	who, err := read(e.Admin())
+	if err != nil {
+		t.Fatalf("reading the acting identity: %v", err)
+	}
+	if who.Locale != "" {
+		t.Errorf("locale is %q, want empty — a person who chose nothing must not read as a choice", who.Locale)
+	}
+	if who.ProseLanguage != "English" {
+		t.Errorf("prose_language is %q for a member with no locale, want the installation's English", who.ProseLanguage)
+	}
+
+	// A member's own choice wins over the installation's, and is answered as a
+	// language name rather than a code: the reader is a model writing a
+	// sentence, not a lookup table.
+	e.WsExec(t, `UPDATE app_user SET locale = 'de' WHERE id = $1`, e.AdminUser)
+	who, err = read(e.Admin())
+	if err != nil {
+		t.Fatalf("reading the acting identity after choosing German: %v", err)
+	}
+	if who.ProseLanguage != "German" {
+		t.Errorf("prose_language is %q for a member who chose de, want German", who.ProseLanguage)
+	}
+}
+
+// A principal with no human behind it answers no identity at all, and the
+// language must still be a language: the field is declared always-present, and
+// a caller that reads it into a prompt would otherwise instruct the model in
+// nothing.
+func TestAnUnattributedCallStillNamesALanguage(t *testing.T) {
+	e := integration.Setup(t)
+	who, err := actingIdentity(e.Pool)(context.Background())
+	if err != nil {
+		t.Fatalf("reading the acting identity with no principal: %v", err)
+	}
+	if who.ProseLanguage == "" {
+		t.Error("prose_language is empty for an unattributed call; the field is promised on every answer")
+	}
+}

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -118,9 +118,8 @@ const recordFieldsDescription = "The crm.yaml body for the record_type. The fiel
 	RecordFieldsURI + " — that document, not this description, is what says what a write may " +
 	"name. An extra key must be cf_<slug> for a custom field; any other key is refused BY NAME " +
 	"and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost. " +
-	"Any field holding a sentence a colleague will read — a description, a summary, a note — is " +
-	"written in the language whoami reports as prose_language, whatever language this conversation " +
-	"is in; names and quoted text are never translated."
+	"Any field holding a sentence — a description, a summary, a note — is written in whoami's " +
+	"prose_language, whatever language this conversation is in."
 
 // customFieldPrefix is the only shape an extra key may take: the
 // customfields engine derives every column it adds as cf_<slug>, so a key
@@ -217,7 +216,16 @@ const timestampNote = `,"description":"RFC 3339 WITH a zone offset (…T16:35:00
 // It names no language itself. These specs are compiled once and served to
 // every installation, so the value is whoami's to resolve per caller and this
 // text's job is to send the model there.
-const proseLanguageNote = `"Prose a colleague will read. Write it in the language whoami reports as prose_language, whatever language this conversation is in. Do not translate names, company names or quoted text."`
+//
+// Two lines rather than one repeated: every byte here is re-sent on every step
+// of every Surface-B run and held by every client for a whole session, and the
+// same forty words twice made log_activity the second most expensive tool on
+// the surface. The second field names the first instead of restating it.
+const proseLanguageNote = `"Prose a colleague reads. Write it in whoami's prose_language, whatever language this conversation is in; do not translate names or quoted text."`
+
+// proseLanguageSeeSubject points a second prose argument at the rule above
+// rather than paying for it twice.
+const proseLanguageSeeSubject = `"Prose a colleague reads. Same language rule as subject."`
 
 // stageIDNote is appended to every stage-id argument the tool surface takes.
 // Two tools declared it as a bare format:uuid, which named the requirement

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -117,7 +117,10 @@ const recordFieldsDescription = "The crm.yaml body for the record_type. The fiel
 	"record_type takes, which of them are REQUIRED, and their shapes are published at " +
 	RecordFieldsURI + " — that document, not this description, is what says what a write may " +
 	"name. An extra key must be cf_<slug> for a custom field; any other key is refused BY NAME " +
-	"and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost."
+	"and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost. " +
+	"Any field holding a sentence a colleague will read — a description, a summary, a note — is " +
+	"written in the language whoami reports as prose_language, whatever language this conversation " +
+	"is in; names and quoted text are never translated."
 
 // customFieldPrefix is the only shape an extra key may take: the
 // customfields engine derives every column it adds as cf_<slug>, so a key
@@ -200,6 +203,21 @@ func rejectUnknownFields(shapes map[datasource.EntityType]reflect.Type, recordTy
 // spent on exactly that before the reason was visible, so the requirement is
 // stated where it is read rather than left implied by a keyword.
 const timestampNote = `,"description":"RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused."`
+
+// proseLanguageNote is the description on every argument that stores a
+// sentence a colleague will later read.
+//
+// The surface used to say nothing here, and a model with no instruction infers
+// a language from whatever context it has — a workspace named in German, a
+// Berlin timezone, records somebody else wrote — so an entirely English
+// conversation produced German notes in an English workspace. whoami answers
+// the language, but only a caller that thinks to ask; the schema is read on
+// every call, which is why the instruction lives here too.
+//
+// It names no language itself. These specs are compiled once and served to
+// every installation, so the value is whoami's to resolve per caller and this
+// text's job is to send the model there.
+const proseLanguageNote = `"Prose a colleague will read. Write it in the language whoami reports as prose_language, whatever language this conversation is in. Do not translate names, company names or quoted text."`
 
 // stageIDNote is appended to every stage-id argument the tool surface takes.
 // Two tools declared it as a bare format:uuid, which named the requirement

--- a/backend/internal/modules/agents/results_identity.go
+++ b/backend/internal/modules/agents/results_identity.go
@@ -24,7 +24,10 @@ type WhoamiResult struct {
 	DisplayName  string   `json:"display_name"`
 	Email        string   `json:"email"`
 	Locale       string   `json:"locale,omitempty"`
-	Timezone     string   `json:"timezone,omitempty"`
+	// ProseLanguage is what stored prose must be written in — always present,
+	// where locale is absent until somebody chooses one.
+	ProseLanguage string `json:"prose_language"`
+	Timezone      string `json:"timezone,omitempty"`
 }
 
 // ListColleaguesResult is the workspace roster. Empty is a real answer — a

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -7811,6 +7811,9 @@
           "locale": {
             "type": "string"
           },
+          "prose_language": {
+            "type": "string"
+          },
           "timezone": {
             "type": "string"
           }
@@ -7818,7 +7821,8 @@
         "required": [
           "acting_user_id",
           "display_name",
-          "email"
+          "email",
+          "prose_language"
         ]
       },
       "evidence": {

--- a/backend/internal/modules/agents/toolcopy_whoami.go
+++ b/backend/internal/modules/agents/toolcopy_whoami.go
@@ -7,6 +7,8 @@ package agents
 var whoamiCopy = toolCopy{
 	Purpose: "Name the human this passport acts for: their id, display name, email and language.",
 	Limits:  "It reads only, and answers this call's acting user — not a directory.",
-	Retain: "acting_user_id is what owner_id and assignee_id take for \"me\". Write stored prose " +
-		"in locale when it is set.",
+	Retain: "acting_user_id is what owner_id and assignee_id take for \"me\". prose_language is " +
+		"the language every stored sentence is written in — a note, a description, a summary — " +
+		"whatever language the conversation itself is in; it is always answered, where locale is " +
+		"absent until this person chooses one.",
 }

--- a/backend/internal/modules/agents/toollist.go
+++ b/backend/internal/modules/agents/toollist.go
@@ -56,6 +56,13 @@ func invocableByCaller(ctx context.Context, spec mcp.ToolSpec) bool {
 	if p.Type != principal.PrincipalAgent {
 		return true
 	}
+	// A tool answering who the caller is stays offered whatever the passport
+	// is scoped to do; mcp.ToolSpec.SelfDescribing says why, and the
+	// admission gate reads the same flag so the listing cannot offer what the
+	// gate would then refuse.
+	if spec.SelfDescribing {
+		return true
+	}
 	return p.Scopes.Has(spec.RequiredScope)
 }
 

--- a/backend/internal/modules/agents/toollist_test.go
+++ b/backend/internal/modules/agents/toollist_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Which tools a passport is offered, on the scope axis.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// A passport scoped only to write is still told who it writes as.
+//
+// The write tools' arguments say to write stored prose in the language whoami
+// reports, so a caller offered them and refused whoami is handed an
+// instruction it cannot follow — it spends a call finding that out and then
+// guesses the language anyway, which is the guess the instruction exists to
+// remove. Scopes are exact membership, so write does not imply read and this
+// is not hypothetical.
+func TestAWriteOnlyPassportIsStillOfferedItsOwnIdentity(t *testing.T) {
+	offered := func(scopes ...principal.Scope) []string {
+		ctx := agentHolding(scopes...)
+		var names []string
+		for _, spec := range []mcp.ToolSpec{whoami{}.Spec(), logActivity{}.Spec()} {
+			if invocableByCaller(ctx, spec) {
+				names = append(names, spec.Name)
+			}
+		}
+		return names
+	}
+
+	writeOnly := offered(principal.ScopeWrite)
+	if !slices.Contains(writeOnly, "whoami") {
+		t.Errorf("a write-only passport is offered %v — whoami answers its own seat and must be among them", writeOnly)
+	}
+	if !slices.Contains(writeOnly, "log_activity") {
+		t.Errorf("a write-only passport is offered %v, without the write tool it is scoped for", writeOnly)
+	}
+
+	// The widening is whoami's alone: a read-only passport must still be
+	// refused the tools that write.
+	readOnly := offered(principal.ScopeRead)
+	if slices.Contains(readOnly, "log_activity") {
+		t.Errorf("a read-only passport is offered %v — a write tool must not be among them", readOnly)
+	}
+}

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -351,7 +351,7 @@ func (t logActivity) Spec() mcp.ToolSpec {
 			"kind":{"type":"string","enum":` + activityKindEnum + `},
 			"channel_provider":{"type":"string","description":"Required when kind is \"message\", else refused; a provider list_channel_providers names."},
 			"subject":{"type":"string","description":` + proseLanguageNote + `},
-			"body":{"type":"string","description":` + proseLanguageNote + `},
+			"body":{"type":"string","description":` + proseLanguageSeeSubject + `},
 			"occurred_at":{"type":"string","format":"date-time"` + timestampNote + `},
 			"direction":{"type":"string","enum":["inbound","outbound"]},
 			"due_at":{"type":"string","format":"date-time"` + timestampNote + `},

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -350,7 +350,8 @@ func (t logActivity) Spec() mcp.ToolSpec {
 		InputSchema: schema(`{"type":"object","required":["kind"],"properties":{
 			"kind":{"type":"string","enum":` + activityKindEnum + `},
 			"channel_provider":{"type":"string","description":"Required when kind is \"message\", else refused; a provider list_channel_providers names."},
-			"subject":{"type":"string"},"body":{"type":"string"},
+			"subject":{"type":"string","description":` + proseLanguageNote + `},
+			"body":{"type":"string","description":` + proseLanguageNote + `},
 			"occurred_at":{"type":"string","format":"date-time"` + timestampNote + `},
 			"direction":{"type":"string","enum":["inbound","outbound"]},
 			"due_at":{"type":"string","format":"date-time"` + timestampNote + `},

--- a/backend/internal/modules/agents/tools_whoami.go
+++ b/backend/internal/modules/agents/tools_whoami.go
@@ -13,6 +13,13 @@ package agents
 // which is how a German sentence ended up in an English workspace's company
 // description.
 //
+// Locale alone did not close that, because it is empty until somebody picks a
+// language and most people never do: an English workspace whose members had
+// chosen nothing still got German records off an English conversation. So the
+// answer carries ProseLanguage as well — the member's choice where they made
+// one, the installation's base language otherwise — and it is never empty,
+// because a field that is usually absent teaches the reader to ignore it.
+//
 // A tool rather than a field on the capabilities resource: that document is
 // shape-versioned and cached, while identity is per-call and must never be
 // served from a cache belonging to a different passport.
@@ -34,8 +41,14 @@ type ActingIdentity struct {
 	// Locale is the language this person chose, empty when they never did.
 	// The caller decides what to do with empty rather than being handed a
 	// default that cannot be told apart from a choice.
-	Locale   string
-	Timezone string
+	Locale string
+	// ProseLanguage is that decision already made: the language stored prose
+	// must be written in, resolved from the member's choice or the
+	// installation's base language. Unlike Locale it is never empty, so the
+	// agent is never left to infer a language from the workspace's timezone
+	// and currency.
+	ProseLanguage string
+	Timezone      string
 }
 
 // IdentityReader answers who the call acts for. Declared here and implemented
@@ -73,10 +86,11 @@ func (t whoami) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage,
 	// it is who is asking. Stamping it would put the caller's own seat in the
 	// evidence list of every call that begins by asking who they are.
 	return json.Marshal(WhoamiResult{
-		ActingUserID: who.UserID,
-		DisplayName:  who.DisplayName,
-		Email:        who.Email,
-		Locale:       who.Locale,
-		Timezone:     who.Timezone,
+		ActingUserID:  who.UserID,
+		DisplayName:   who.DisplayName,
+		Email:         who.Email,
+		Locale:        who.Locale,
+		ProseLanguage: who.ProseLanguage,
+		Timezone:      who.Timezone,
 	})
 }

--- a/backend/internal/modules/agents/tools_whoami.go
+++ b/backend/internal/modules/agents/tools_whoami.go
@@ -71,7 +71,7 @@ func (t whoami) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "whoami", Title: "Who this passport acts for", Version: toolVersionV1,
 		Description:   whoamiCopy.render(),
-		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		RequiredScope: principal.ScopeRead, SelfDescribing: true, Tier: mcp.TierAutoExecute,
 		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),
 		OutputSchema: schemaFor[WhoamiResult](),
 	}

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -91,7 +91,12 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 		return ctx, nil
 	}
 
-	if !p.Scopes.Has(spec.RequiredScope) {
+	// A tool that answers who the CALLER is passes the scope axis whatever the
+	// passport holds — mcp.ToolSpec.SelfDescribing carries the reason, and the
+	// listing filter reads the same flag, so what is offered is what is
+	// admitted. Every check below still applies: the seat, the re-derived
+	// RBAC and the quota are not waived by knowing whose seat it is.
+	if !spec.SelfDescribing && !p.Scopes.Has(spec.RequiredScope) {
 		return ctx, fmt.Errorf("gate: %s needs scope %q: %w", spec.Name, spec.RequiredScope, apperrors.ErrScopeExceeded)
 	}
 

--- a/backend/internal/shared/ports/mcp/mcp.go
+++ b/backend/internal/shared/ports/mcp/mcp.go
@@ -73,7 +73,21 @@ type ToolSpec struct {
 	Description   string
 	Version       string
 	RequiredScope principal.Scope
-	Tier          RiskTier
+	// SelfDescribing marks a tool that answers who the CALLER is, which every
+	// passport may ask whatever else it is scoped to do.
+	//
+	// It does not relax RequiredScope, and must not: ReadOnly is derived from
+	// that field, so a tool that reads has to keep saying so. This is the
+	// separate question of whether the scope model applies at all, and for
+	// the caller's own identity it does not — the answer is the seat the
+	// passport was minted for, which its holder supplied and every write it
+	// makes already stamps into on_behalf_of.
+	//
+	// Without it a write-only passport is offered the writing tools and
+	// refused the identity they tell it to consult, so an instruction meant
+	// to remove a guess costs a failed call and then the guess anyway.
+	SelfDescribing bool
+	Tier           RiskTier
 	// TierResolver is non-nil iff Tier == TierDynamic; the admission gate
 	// calls it with the validated args plus the resolved pipeline context.
 	TierResolver TierResolver

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 57,
-    "tokens": 17352,
+    "tokens": 17533,
     "median_tool_tokens": 275,
-    "mean_tool_tokens": 304
+    "mean_tool_tokens": 307
   },
   "agents": [
     {
@@ -41,9 +41,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2272,
+      "tokens": 2330,
       "percent_of_ceiling": 9,
-      "headroom_tokens": 14728,
+      "headroom_tokens": 14670,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -71,15 +71,15 @@
     },
     {
       "name": "update_record",
-      "tokens": 565
+      "tokens": 603
+    },
+    {
+      "name": "log_activity",
+      "tokens": 588
     },
     {
       "name": "send_account_email",
       "tokens": 545
-    },
-    {
-      "name": "log_activity",
-      "tokens": 530
     },
     {
       "name": "resolve_entities",
@@ -106,6 +106,10 @@
       "tokens": 431
     },
     {
+      "name": "create_record",
+      "tokens": 429
+    },
+    {
       "name": "query_workspace",
       "tokens": 402
     },
@@ -116,10 +120,6 @@
     {
       "name": "search_records",
       "tokens": 392
-    },
-    {
-      "name": "create_record",
-      "tokens": 391
     },
     {
       "name": "enrich",
@@ -278,12 +278,12 @@
       "tokens": 148
     },
     {
-      "name": "list_tags",
-      "tokens": 102
+      "name": "whoami",
+      "tokens": 136
     },
     {
-      "name": "whoami",
-      "tokens": 88
+      "name": "list_tags",
+      "tokens": 102
     },
     {
       "name": "read_import_report",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -25,8 +25,8 @@ feature is expected to argue with.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 3 | 992 | 4% | 16008 | 4 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2272 | 9% | 14728 | 15 | 8 |
-| _whole served catalog, for scale_ | 57 | 17352 | 72% | — | — | — |
+| `overnight_at_risk_sweep` | 7 | 2330 | 9% | 14670 | 15 | 8 |
+| _whole served catalog, for scale_ | 57 | 17533 | 73% | — | — | — |
 
 ### `morning_brief`
 
@@ -51,7 +51,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2272 tokens, leaving 14728 of its budget and 21728 tokens of the
+Attaches 7 tools for 2330 tokens, leaving 14670 of its budget and 21670 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -119,7 +119,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 304, across 57 served tools.
+Median 275 tokens, mean 307, across 57 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -129,19 +129,19 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 1213 | 3 scenarios |
-| `update_record` | 565 | 4 scenarios |
+| `update_record` | 603 | 4 scenarios |
+| `log_activity` | 588 | 1 scenario |
 | `send_account_email` | 545 | — |
-| `log_activity` | 530 | 1 scenario |
 | `resolve_entities` | 513 | — |
 | `list_records` | 475 | — |
 | `advance_deal` | 474 | 1 scenario |
 | `send_email` | 471 | 1 scenario |
 | `progress_deal` | 435 | 3 scenarios |
 | `book_meeting` | 431 | — |
+| `create_record` | 429 | 1 scenario |
 | `query_workspace` | 402 | 3 scenarios |
 | `preview_import` | 396 | — |
 | `search_records` | 392 | 6 scenarios |
-| `create_record` | 391 | 1 scenario |
 | `enrich` | 386 | — |
 | `search_context` | 352 | — |
 | `prep_for_meeting` | 333 | — |
@@ -181,8 +181,8 @@ a term in an addition.
 | `read_approval` | 160 | — |
 | `commit_import` | 149 | — |
 | `list_colleagues` | 148 | — |
+| `whoami` | 136 | — |
 | `list_tags` | 102 | — |
-| `whoami` | 88 | — |
 | `read_import_report` | 80 | — |
 | `read_import_run` | 75 | — |
 

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 57,
     "resources": 9,
-    "tool_catalog_bytes": 158363,
+    "tool_catalog_bytes": 159140,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 40469,
+    "approx_wire_tokens_total": 40663,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
-      "description_bytes": 36586,
-      "input_schema_bytes": 34709,
-      "output_schema_bytes": 74699,
-      "description_plus_input_schema_bytes": 71295
+      "description_bytes": 36775,
+      "input_schema_bytes": 35245,
+      "output_schema_bytes": 74751,
+      "description_plus_input_schema_bytes": 72020
     }
   },
   "tools": {
@@ -1832,7 +1832,7 @@
               "type": "string"
             },
             "fields": {
-              "description": "The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost.",
+              "description": "The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost. Any field holding a sentence — a description, a summary, a note — is written in whoami's prose_language, whatever language this conversation is in.",
               "type": "object"
             },
             "idempotency_key": {
@@ -4276,6 +4276,7 @@
           "additionalProperties": false,
           "properties": {
             "body": {
+              "description": "Prose a colleague reads. Same language rule as subject.",
               "type": "string"
             },
             "channel_provider": {
@@ -4350,6 +4351,7 @@
               "type": "string"
             },
             "subject": {
+              "description": "Prose a colleague reads. Write it in whoami's prose_language, whatever language this conversation is in; do not translate names or quoted text.",
               "type": "string"
             }
           },
@@ -9744,7 +9746,7 @@
               "type": "string"
             },
             "fields": {
-              "description": "Only sent fields change. Fields a human last edited are not applied: they are staged for approval and named in the result's staged_approval. The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost.",
+              "description": "Only sent fields change. Fields a human last edited are not applied: they are staged for approval and named in the result's staged_approval. The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost. Any field holding a sentence — a description, a summary, a note — is written in whoami's prose_language, whatever language this conversation is in.",
               "type": "object"
             },
             "id": {
@@ -10245,7 +10247,7 @@
           "readOnlyHint": true,
           "title": "Who this passport acts for"
         },
-        "description": "Name the human this passport acts for: their id, display name, email and language. It reads only, and answers this call's acting user — not a directory. acting_user_id is what owner_id and assignee_id take for \"me\". Write stored prose in locale when it is set. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Name the human this passport acts for: their id, display name, email and language. It reads only, and answers this call's acting user — not a directory. acting_user_id is what owner_id and assignee_id take for \"me\". prose_language is the language every stored sentence is written in — a note, a description, a summary — whatever language the conversation itself is in; it is always answered, where locale is absent until this person chooses one. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {},
@@ -10269,6 +10271,9 @@
                 "locale": {
                   "type": "string"
                 },
+                "prose_language": {
+                  "type": "string"
+                },
                 "timezone": {
                   "type": "string"
                 }
@@ -10276,7 +10281,8 @@
               "required": [
                 "acting_user_id",
                 "display_name",
-                "email"
+                "email",
+                "prose_language"
               ],
               "type": "object"
             },

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 57 |
 | Resources | 9 |
-| Tool catalog | 154.7 KB |
+| Tool catalog | 155.4 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 40469 |
+| Approx. wire tokens | 40663 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 72.9 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 35.7 KB | 23% | Yes, every step |
-| Input schemas | 33.9 KB | 21% | Yes, every step |
+| Output schemas | 73.0 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 35.9 KB | 23% | Yes, every step |
+| Input schemas | 34.4 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.1 KB | 7% | Partly |
-| **Description + input schema** | **69.6 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **70.3 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -72,7 +72,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`check_location_support`](#check_location_support) | Can a card read this device's location | yes | [`ui://margince/geo-probe.html`](#geo_probe_view) | 1.8 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.7 KB |
-| [`create_record`](#create_record) | Create a record |  |  | 2.7 KB |
+| [`create_record`](#create_record) | Create a record |  |  | 2.8 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 2.9 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 2.9 KB |
@@ -87,7 +87,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
-| [`log_activity`](#log_activity) | Log an activity |  |  | 3.2 KB |
+| [`log_activity`](#log_activity) | Log an activity |  |  | 3.4 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 4.0 KB |
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
@@ -114,10 +114,10 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.3 KB |
 | [`send_email`](#send_email) | Send an email |  |  | 3.0 KB |
 | [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.3 KB |
-| [`update_record`](#update_record) | Update a record |  |  | 3.6 KB |
+| [`update_record`](#update_record) | Update a record |  |  | 3.8 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
 | [`who_knows`](#who_knows) | Who knows this contact | yes | [`ui://margince/relationship-map.html`](#relationship_map_view) | 2.2 KB |
-| [`whoami`](#whoami) | Who this passport acts for | yes |  | 1.5 KB |
+| [`whoami`](#whoami) | Who this passport acts for | yes |  | 1.8 KB |
 
 ## Resources
 
@@ -2215,7 +2215,7 @@ Create a person, organization, deal, lead, project, activity or relationship tha
       "type": "string"
     },
     "fields": {
-      "description": "The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost.",
+      "description": "The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost. Any field holding a sentence — a description, a summary, a note — is written in whoami's prose_language, whatever language this conversation is in.",
       "type": "object"
     },
     "idempotency_key": {
@@ -4809,6 +4809,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
   "additionalProperties": false,
   "properties": {
     "body": {
+      "description": "Prose a colleague reads. Same language rule as subject.",
       "type": "string"
     },
     "channel_provider": {
@@ -4883,6 +4884,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
       "type": "string"
     },
     "subject": {
+      "description": "Prose a colleague reads. Write it in whoami's prose_language, whatever language this conversation is in; do not translate names or quoted text.",
       "type": "string"
     }
   },
@@ -10526,7 +10528,7 @@ Change stored field values on a record that already exists — a corrected title
       "type": "string"
     },
     "fields": {
-      "description": "Only sent fields change. Fields a human last edited are not applied: they are staged for approval and named in the result's staged_approval. The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost.",
+      "description": "Only sent fields change. Fields a human last edited are not applied: they are staged for approval and named in the result's staged_approval. The crm.yaml body for the record_type. The fields each record_type takes, which of them are REQUIRED, and their shapes are published at margince://schema/record-fields — that document, not this description, is what says what a write may name. An extra key must be cf_\u003cslug\u003e for a custom field; any other key is refused BY NAME and never dropped in silence, so a wrong guess is answered with the vocabulary rather than lost. Any field holding a sentence — a description, a summary, a note — is written in whoami's prose_language, whatever language this conversation is in.",
       "type": "object"
     },
     "id": {
@@ -11039,7 +11041,7 @@ Renders its result in [`ui://margince/relationship-map.html`](#relationship_map_
 
 **Who this passport acts for**
 
-Name the human this passport acts for: their id, display name, email and language. It reads only, and answers this call's acting user — not a directory. acting_user_id is what owner_id and assignee_id take for "me". Write stored prose in locale when it is set. (Governance: runs immediately; requires passport scope "read".)
+Name the human this passport acts for: their id, display name, email and language. It reads only, and answers this call's acting user — not a directory. acting_user_id is what owner_id and assignee_id take for "me". prose_language is the language every stored sentence is written in — a note, a description, a summary — whatever language the conversation itself is in; it is always answered, where locale is absent until this person chooses one. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -11073,6 +11075,9 @@ Name the human this passport acts for: their id, display name, email and languag
         "locale": {
           "type": "string"
         },
+        "prose_language": {
+          "type": "string"
+        },
         "timezone": {
           "type": "string"
         }
@@ -11080,7 +11085,8 @@ Name the human this passport acts for: their id, display name, email and languag
       "required": [
         "acting_user_id",
         "display_name",
-        "email"
+        "email",
+        "prose_language"
       ],
       "type": "object"
     },


### PR DESCRIPTION
## What

An entirely English conversation with the MCP agent produced **German** CRM records in an English workspace (`installation.base_language = "en"`). The German then spread: the email drafter reads the language of the record it is grounded on, so a German note produced a German draft to a contact in Ho Chi Minh City.

Nothing on the tool surface said what language to write in. `log_activity`'s `subject` and `body` carried no description at all, and `whoami`'s `locale` — the only hint that existed — is empty until a member picks a language, which most never do. With no instruction the model inferred one from the workspace around it (Berlin timezone, EUR, German records somebody else wrote).

The `whoami` source comment already predicted this: *"It also could not know which language to write stored prose in, which is how a German sentence ended up in an English workspace's company description."*

## How

- **`whoami` answers `prose_language`**, resolved in the compose seam from the member's locale or the installation's base language, and **never empty**. `identity` keeps answering the honest empty for "never chose"; the seam composes the two settings, which belong to different owners.
- **The prose arguments say to write in it** — `log_activity`'s `subject`/`body` and `create_record`'s `fields`. The schema is read on every call, where `whoami` is read only by a caller that thinks to ask.
- **`mcp.ToolSpec.SelfDescribing`** keeps that reachable. Scopes are exact membership, so a write-only passport was offered the write tools and refused the identity they point at. The listing filter and the admission gate read the same flag, so what is offered is what is admitted; `RequiredScope` stays `read` because `ReadOnly()` is derived from it. Seat, RBAC and quota checks are untouched.
- **`promptlang.LanguageName` exported** and `Rule` now calls it, so the English-fallback rule has one spelling.

## Cost

The descriptions are re-sent on every step of every Surface-B run, so the wording is deliberately short and `body` names `subject`'s rule rather than repeating it. `log_activity` 281 → 588 tokens, served catalog 17188 → 17370 (71% → 72% of the window). Published budget and mcp-info figures regenerated.

## Tests

- `TestTheAgentIsAlwaysToldWhichLanguageToWriteStoredProseIn` — empty locale falls back to the installation's language; the member's own choice wins; answered as a name, not a code.
- `TestAnUnattributedCallStillNamesALanguage` — a principal with no human behind it still names a language.
- `TestAWriteOnlyPassportIsStillOfferedItsOwnIdentity` — the scope case above, including that the widening is `whoami`'s alone.

All three mutation-checked: reverting each fix makes its test fail.

## Limits

This makes the language available and instructed; it does not enforce it. Nothing rejects a German subject in an English workspace. Enforcement would mean validating stored prose on write, which is a separate decision.

`make check-backend` green, `make craft-static` clean, integration lane run for the touched package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names and instructs the language for stored prose on the MCP surface so models stop guessing (e.g., German notes in an English workspace). Previously nothing named a language and whoami.locale was often empty; now whoami.prose_language always names it and write tools tell the model to use it.

- whoami now returns prose_language (always present, English name). It resolves from the member’s locale or the installation’s base language; locale stays empty for “never chose.” Exported `promptlang.LanguageName`.
- `log_activity` (subject/body) and `create_record` (fields) now instruct: write prose in whoami.prose_language; body references subject to avoid repetition.
- Added `SelfDescribing` to `mcp.ToolSpec` and set it on whoami. Tool listing and the admission gate admit self‑describing tools regardless of scope so a write‑only passport can still learn which language to write in. `RequiredScope` remains `read`; seat, RBAC, and quota checks are unchanged.
- Callers must accept a required prose_language in whoami results.
- Slight token cost increases in whoami, `log_activity`, and `create_record`. Enforcement of language on write is not included.

<sup>Written for commit 47e7ba432383ad5dcff6d45d7f2a7683e210e24d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `whoami` now always reports the language to use for stored prose, based on the member’s locale or installation default.
  - Added guidance to record and activity tools so sentence-like content follows the reported prose language.
  - Self-describing identity tools remain available for identity questions without relaxing other access controls.

- **Documentation**
  - Updated tool schemas and reference documentation to describe `prose_language` and revised tool metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->