### PR TITLE
feat(people): a second business card for someone already here asks a human

### DIFF
--- a/backend/internal/modules/people/creatededupe.go
+++ b/backend/internal/modules/people/creatededupe.go
@@ -63,7 +63,13 @@ func manualDedupePerson(ctx context.Context, tx pgx.Tx, in CreatePersonInput) (P
 	if err := lockPhoneLane(ctx, tx, phones); err != nil {
 		return PersonResolution{}, err
 	}
-	return DedupePerson(ctx, tx, PersonCandidate{FullName: in.FullName, Emails: emails, Phones: phones})
+	// QueueNameCollisions, because this caller creates rather than routes. A
+	// pair it names goes on the review queue and nowhere else — no message is
+	// delivered on the strength of it, so the worst case is a row a human
+	// dismisses. See PersonCandidate for why the routing callers must not ask.
+	return DedupePerson(ctx, tx, PersonCandidate{
+		FullName: in.FullName, Emails: emails, Phones: phones, QueueNameCollisions: true,
+	})
 }
 
 // phoneLaneKeys is the request's numbers in the form the phone lane
@@ -148,11 +154,50 @@ func (m PersonResolution) recordIfReview(ctx context.Context, tx pgx.Tx, created
 		}
 		return recordNearMatch(ctx, tx, entityPerson, createdID.UUID, m.PersonID.UUID, m.Confidence,
 			nearMatchEvidence(fieldFullName, createdName, incumbent, m.Confidence), source, by)
+	case DecisionNameCollisionReview:
+		// One person, a second business card, a different address: the case a
+		// rep actually hits, and the one the fuzzy tier cannot reach because a
+		// create carries no employer for its org term to agree with.
+		//
+		// The incumbent's name is read back rather than reused from the request
+		// so the evidence shows the two SPELLINGS a human will compare. They are
+		// equal after folding — that is what the lane matched on — but not
+		// necessarily equal on screen, and "Lucy Vo" beside "LUCY VO" is a
+		// reviewer's first clue about where the second record came from.
+		var incumbent string
+		if err := tx.QueryRow(ctx, `SELECT full_name FROM person WHERE id = $1`, m.PersonID).Scan(&incumbent); err != nil {
+			return fmt.Errorf("reading the person this name collides with: %w", err)
+		}
+		// The queue row only. No dedupe_near_match ledger line, because that
+		// ledger records the fuzzy tier's own scoring and this lane did not
+		// score: it compared two normalized strings. A line carrying a
+		// confidence would invite a reader to tune a threshold that had no part
+		// in the decision.
+		if _, err := recordDedupeCandidate(ctx, tx, entityPerson, createdID.UUID, m.PersonID.UUID,
+			m.Confidence, nameCollisionEvidence(createdName, incumbent, m.Confidence), source, by); err != nil {
+			return fmt.Errorf("record person name-collision candidate: %w", err)
+		}
+		return nil
 	case DecisionExactCollision:
 		return m.recordSharedPhone(ctx, tx, createdID, source, by)
 	default:
 		return nil
 	}
+}
+
+// nameCollisionEvidence names the axis this pair actually met on. The signal is
+// "collide" at its exact end — the two names are the same string once folded —
+// and the score carried is the fuzzy score the pair WOULD have had, which is
+// what sorts it in a queue beside genuinely fuzzy rows. It is evidence of how
+// little else agreed, not the reason the pair is here.
+func nameCollisionEvidence(created, incumbent string, confidence float64) []map[string]any {
+	return []map[string]any{{
+		evidenceFieldKey:  fieldFullName,
+		evidenceLeftKey:   created,
+		evidenceRightKey:  incumbent,
+		evidenceSignalKey: evidenceSignalCollide,
+		evidenceScoreKey:  confidence,
+	}}
 }
 
 // recordSharedPhone puts the pair behind an exact phone collision on the

--- a/backend/internal/modules/people/creatededupe.go
+++ b/backend/internal/modules/people/creatededupe.go
@@ -63,6 +63,9 @@ func manualDedupePerson(ctx context.Context, tx pgx.Tx, in CreatePersonInput) (P
 	if err := lockPhoneLane(ctx, tx, phones); err != nil {
 		return PersonResolution{}, err
 	}
+	if err := lockNameLane(ctx, tx, in.FullName); err != nil {
+		return PersonResolution{}, err
+	}
 	// QueueNameCollisions, because this caller creates rather than routes. A
 	// pair it names goes on the review queue and nowhere else — no message is
 	// delivered on the strength of it, so the worst case is a row a human
@@ -70,6 +73,35 @@ func manualDedupePerson(ctx context.Context, tx pgx.Tx, in CreatePersonInput) (P
 	return DedupePerson(ctx, tx, PersonCandidate{
 		FullName: in.FullName, Emails: emails, Phones: phones, QueueNameCollisions: true,
 	})
+}
+
+// lockNameLane makes the name lane's probe and the person row the create goes
+// on to write one indivisible step, for exactly the reason lockPhoneLane exists
+// and with exactly the same hole underneath.
+//
+// The name lane has no unique index and must not have one: two people really
+// can share a name, so the collision is a question and never a key. Nothing
+// structural is left. At READ COMMITTED two creates carrying the same name would
+// both read no committed incumbent, both fall to no-match, and both commit — two
+// live records with no dedupe_candidate row between them, and nothing writes one
+// afterwards, because every row on that queue comes from the path that detected
+// the collision. The lane exists to stop a silent duplicate, so a duplicate it
+// silently misses under contention is the lane not working.
+//
+// The key is the NORMALIZED name, which is what the lane compares. Locking the
+// raw string would let "Lucy Vo" and "LUCY VO" take different locks and race
+// each other, which is the pair most likely to be typed twice.
+//
+// Taken AFTER the phone lane and never interleaved with it: two lanes locked in
+// one fixed global order cannot deadlock, and phone-then-name is that order.
+// An empty name takes no lock — it can match nobody, since fuzzyPerson refuses a
+// nameless candidate before it scores.
+func lockNameLane(ctx context.Context, tx pgx.Tx, fullName string) error {
+	key := normalizeName(fullName)
+	if key == "" {
+		return nil
+	}
+	return storekit.LockWriteIdentity(ctx, tx, "person_full_name", key)
 }
 
 // phoneLaneKeys is the request's numbers in the form the phone lane

--- a/backend/internal/modules/people/creatededupe_contention_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_contention_integration_test.go
@@ -158,3 +158,100 @@ func TestASecondCreateSharingAPhoneStillRecordsTheReviewPair(t *testing.T) {
 		t.Fatalf("confidence = %v, want the exact-key ceiling %v", rows[0].Confidence, identityConflictConfidence)
 	}
 }
+
+// beginHeldNameCreate is beginHeldPhoneCreate for the name lane: a transaction
+// that has taken the lane's write identity and inserted its person row, handed
+// back still open. The key is derived through lockNameLane itself, so a change
+// to how the lane spells its key cannot leave this transaction holding one no
+// create waits on.
+func (e *dedupeEnv) beginHeldNameCreate(ctx context.Context, t *testing.T, name string) (pgx.Tx, ids.PersonID, int) {
+	t.Helper()
+	tx, err := e.store.db.Pool().Begin(ctx)
+	if err != nil {
+		t.Fatalf("opening the in-flight create's transaction: %v", err)
+	}
+	t.Cleanup(func() {
+		err := tx.Rollback(context.Background())
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("releasing the in-flight create's transaction: %v", err)
+		}
+	})
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, e.ws.String()); err != nil {
+		t.Fatalf("binding the workspace GUC: %v", err)
+	}
+	var pid int
+	if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+		t.Fatalf("reading the in-flight create's backend pid: %v", err)
+	}
+	if err := lockNameLane(ctx, tx, name); err != nil {
+		t.Fatalf("taking the name lane's write identity: %v", err)
+	}
+	by, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		t.Fatalf("resolving captured_by: %v", err)
+	}
+	id := ids.New[ids.PersonKind]()
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, $2, 'manual', $3)`,
+		id, name, by); err != nil {
+		t.Fatalf("inserting the in-flight person: %v", err)
+	}
+	return tx, id, pid
+}
+
+// Two people can legitimately share a NAME, so person has no unique index on it
+// and nothing structural stops two creates carrying the same one from both
+// landing. What must not happen is that they land silently.
+//
+// This is the phone lane's race, on the lane added for the second-business-card
+// case, and it defeats that lane completely if unguarded: at READ COMMITTED both
+// creates read no committed incumbent, both fall to no-match, both commit, and
+// the pair reaches nobody — no queue row, and no later sweep that would find it.
+// A lane that exists to stop a silent duplicate has to hold under two people
+// typing the same card in at once, which is exactly when it happens.
+//
+// The two spellings differ in CASE deliberately. The lock key is the normalized
+// name, so a lock taken on the raw string would let these two race each other —
+// and "Lucy Vo" against "LUCY VO" is the pair most likely to be entered twice.
+func TestASecondCreateSharingANameStillRecordsTheReviewPair(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	first, firstID, pid := e.beginHeldNameCreate(ctx, t, "Lucy Vo")
+	second := e.createInBackground(ctx, CreatePersonInput{
+		FullName: "LUCY VO", Source: "manual",
+		Emails: []PersonEmailInput{{Email: "lucy@personal.test", EmailType: "personal", IsPrimary: true}},
+	})
+	// A create that finishes WITHOUT ever waiting is the defect itself, not a
+	// failed setup — so it is judged on the trail it left rather than aborted.
+	res, finished := waitUntilBlocked(t, first, pid, second)
+	if err := first.Commit(ctx); err != nil {
+		t.Fatalf("committing the first create: %v", err)
+	}
+	if !finished {
+		res = <-second
+	}
+	if res.err != nil {
+		t.Fatalf("a shared name must not refuse the second create — two people may share one: %v", res.err)
+	}
+	secondID := ids.From[ids.PersonKind](ids.UUID(res.person.Id))
+
+	// Both records really are live, so this test cannot pass on an outcome
+	// where one create simply never landed.
+	if n := e.countInWorkspace(ctx, t,
+		`SELECT count(*) FROM person WHERE id IN ($1, $2) AND archived_at IS NULL AND merged_into_id IS NULL`,
+		firstID, secondID); n != 2 {
+		t.Fatalf("%d live records, want 2 — both creates must have landed for this ordering to mean anything", n)
+	}
+
+	rows := openCandidates(ctx, t, e, entityPerson)
+	if len(rows) != 1 {
+		t.Fatalf("the review queue holds %d candidates, want exactly 1 — two live people are written the same way and no human will ever be asked about it",
+			len(rows))
+	}
+	pair := map[ids.UUID]bool{rows[0].LeftID: true, rows[0].RightID: true}
+	if !pair[firstID.UUID] || !pair[secondID.UUID] {
+		t.Fatalf("candidate pair = {%s, %s}, want it to name both creates %s and %s",
+			rows[0].LeftID, rows[0].RightID, firstID, secondID)
+	}
+}

--- a/backend/internal/modules/people/creatededupe_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_integration_test.go
@@ -66,6 +66,50 @@ func nearMatchLines(ctx context.Context, t *testing.T, e *dedupeEnv, entityType 
 	return out
 }
 
+// openCandidatePairs returns every OPEN review-queue row naming one created
+// entity, with the other side and the score. It reads dedupe_candidate itself
+// rather than the near-match ledger: the ledger records the fuzzy tier's own
+// working, while the queue is what a human is actually shown, and a pair can
+// reach the queue from an exact lane that writes no ledger line at all.
+func openCandidatePairs(ctx context.Context, t *testing.T, e *dedupeEnv, entityType string, createdID ids.UUID) []struct {
+	OtherID    string
+	Confidence float64
+} {
+	t.Helper()
+	var out []struct {
+		OtherID    string
+		Confidence float64
+	}
+	err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT CASE WHEN left_person_id = $2 THEN right_person_id ELSE left_person_id END,
+			       confidence
+			  FROM dedupe_candidate
+			 WHERE entity_type = $1 AND disposition = 'open'
+			   AND $2 IN (left_person_id, right_person_id)`,
+			entityType, createdID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var pair struct {
+				OtherID    string
+				Confidence float64
+			}
+			if err := rows.Scan(&pair.OtherID, &pair.Confidence); err != nil {
+				return err
+			}
+			out = append(out, pair)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		t.Fatalf("read the dedupe review queue: %v", err)
+	}
+	return out
+}
+
 func TestCreatePersonFuzzyNearMatchCreatesAndRecords(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
@@ -250,5 +294,125 @@ func TestCreateOrganizationExactDomainStillRefusesWith409(t *testing.T) {
 	}
 	if dup.ExistingID.UUID != ids.UUID(incumbent.Id) {
 		t.Fatalf("409 discloses %s, want the incumbent %s", dup.ExistingID, incumbent.Id)
+	}
+}
+
+// LARS'S CASE, 2026-08-25: one person, a second business card, a different
+// address. Same name, same employer, and no key in common — the second card
+// carries the new address and nothing else that has been seen before.
+//
+// This is the scenario a rep actually hits. A card is typed in with a personal
+// address, or with a typo, and nothing on it matches what is stored except who
+// the person is and where they work. The email lane cannot fire, because the
+// addresses differ by construction; the phone lane cannot fire, because a card
+// hand-entered in a hurry often carries no number at all.
+//
+// It has to reach a human. Merging two people is not a decision an automatic
+// rule should take — a father and son at one firm are a real pair of records
+// that share everything this test shares — so the answer is the review queue,
+// not a silent merge and not a refusal.
+func TestCreatePersonWithASecondAddressAtTheSameEmployerIsQueuedForAHuman(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	lucyID, orgID := e.seedEmployedPerson(ctx, t,
+		"Lucy Vo", "lucy.vo@terralogic.test", "Terralogic", "terralogic.test")
+
+	// The second card: identical name, an address nobody has seen, no phone.
+	// The employment edge is stated the way a rep filing a card would state it
+	// — they know where she works, which is the whole reason the pair is worth
+	// a human's glance.
+	created, err := e.store.CreatePerson(ctx, CreatePersonInput{
+		FullName: "Lucy Vo", Source: "manual",
+		Emails: []PersonEmailInput{{Email: "lucy@personal.test", EmailType: "personal", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("a second card must create, never block — a probability is not a conflict: %v", err)
+	}
+	createdID := ids.From[ids.PersonKind](ids.UUID(created.Id))
+	primary := true
+	if _, err := e.store.CreateRelationship(ctx, CreateRelationshipInput{
+		Kind: "employment", PersonID: &createdID, OrganizationID: &orgID,
+		IsCurrentPrimary: &primary, Source: "manual",
+	}); err != nil {
+		t.Fatalf("attach the second card's employer: %v", err)
+	}
+
+	pairs := openCandidatePairs(ctx, t, e, "person", ids.UUID(created.Id))
+	if len(pairs) != 1 {
+		t.Fatalf("got %d open dedupe candidates for the second card, want exactly 1 — "+
+			"one person with two addresses at one employer is the case a human has to settle", len(pairs))
+	}
+	if pairs[0].OtherID != lucyID.String() {
+		t.Fatalf("the candidate names %s, want the incumbent %s", pairs[0].OtherID, lucyID)
+	}
+}
+
+// The other half of the same rule, and the reason the lane flags instead of
+// merging: two DIFFERENT people can be written exactly the same way. A father
+// and son at one firm share a name and an employer and are two real records.
+//
+// So the create must succeed and both records must survive. The pair still
+// reaches the queue — a human is the only one who can tell these two cases
+// apart — but nothing about the second record is merged, moved or refused.
+func TestAnIdenticalNameCreatesASecondRecordAndNeverMergesIt(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	seniorID, _ := e.seedEmployedPerson(ctx, t,
+		"Karl Fischer", "karl.fischer@fischerbau.test", "Fischer Bau", "fischerbau.test")
+
+	// The junior's address is on a DIFFERENT domain, deliberately. A shared
+	// employer domain scores 0.8 on the org term and carries the pair over the
+	// fuzzy bar on its own — which would prove the old tier still works and say
+	// nothing about the name lane. This pair has the name and nothing else.
+	junior, err := e.store.CreatePerson(ctx, CreatePersonInput{
+		FullName: "Karl Fischer", Source: "manual",
+		Emails: []PersonEmailInput{{Email: "karl.junior@privat.test", EmailType: "personal", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("two people may share a name: %v", err)
+	}
+	if ids.UUID(junior.Id) == seniorID.UUID {
+		t.Fatal("the create returned the incumbent's id — the lane merged two records it was only allowed to question")
+	}
+
+	// Both rows are live. A lane that flags must leave the data exactly as a
+	// lane that did nothing would.
+	var live int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM person WHERE id IN ($1, $2) AND archived_at IS NULL AND merged_into_id IS NULL`,
+			seniorID, ids.UUID(junior.Id)).Scan(&live)
+	}); err != nil {
+		t.Fatalf("count the two records: %v", err)
+	}
+	if live != 2 {
+		t.Fatalf("got %d live unmerged records, want 2 — flagging a pair must not touch either row", live)
+	}
+
+	// And the question was asked, once.
+	if pairs := openCandidatePairs(ctx, t, e, "person", ids.UUID(junior.Id)); len(pairs) != 1 {
+		t.Fatalf("got %d open candidates, want exactly 1 — a name collision is a question, and it has to be put", len(pairs))
+	}
+}
+
+// A create that resembles nobody must still write nothing. The lane is narrow
+// by construction — it fires on an exact normalized name and on nothing else —
+// and this is what holds it there: a near-name below the fuzzy bar has no key
+// in common and no exact name either, so it is simply a new person.
+func TestANameNobodySharesLeavesTheQueueEmpty(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	e.seedEmployedPerson(ctx, t, "Karl Fischer", "karl.fischer@fischerbau.test", "Fischer Bau", "fischerbau.test")
+
+	created, err := e.store.CreatePerson(ctx, CreatePersonInput{
+		FullName: "Karla Fischerova", Source: "manual",
+		Emails: []PersonEmailInput{{Email: "karla@elsewhere.test", EmailType: "work", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("create an unrelated person: %v", err)
+	}
+	if pairs := openCandidatePairs(ctx, t, e, "person", ids.UUID(created.Id)); len(pairs) != 0 {
+		t.Fatalf("got %d open candidates for a name nobody shares, want 0 — "+
+			"a lane that queues everything is a queue nobody works", len(pairs))
 	}
 }

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -39,6 +39,17 @@ const (
 	// DecisionFuzzyReview is a near-match at or above the threshold: a
 	// human compares the two records side by side. Never a merge.
 	DecisionFuzzyReview DedupeDecision = "fuzzy_review"
+	// DecisionNameCollisionReview is two records written with exactly the same
+	// name and no key in common. Like the fuzzy tier it is a question for a
+	// human and never a merge; unlike it, there is no probability involved —
+	// the names either match or they do not.
+	//
+	// It exists because the fuzzy tier cannot reach this pair. A perfect name
+	// contributes 0.55 of a 0.72 bar, so it clears only on employer agreement,
+	// and the create path has no employer to agree with: CreatePersonInput
+	// carries none. One person's second business card therefore landed as a new
+	// record in silence — the case this lane was added for.
+	DecisionNameCollisionReview DedupeDecision = "name_collision_review"
 	// DecisionNoMatch means create.
 	DecisionNoMatch DedupeDecision = "no_match"
 )
@@ -70,6 +81,23 @@ type PersonCandidate struct {
 	// CurrentPrimaryOrgID drives org_match = 1.0 when both sides share
 	// an employer. Nil when the candidate has no known employer yet.
 	CurrentPrimaryOrgID *ids.OrganizationID
+	// QueueNameCollisions asks for the name-collision lane, and it is OPT-IN
+	// because the answer it gives is only safe for one kind of caller.
+	//
+	// A caller that CREATES wants it: two records written the same way are a
+	// question worth putting to a human, and the worst case is a queue row
+	// somebody dismisses.
+	//
+	// A caller that ROUTES must not have it. Capture and the channel path ask
+	// "which existing person does this message belong to", and for them a
+	// PersonID is a delivery address. An unbound channel identity carrying a
+	// common name would name somebody it has no business naming, and a message
+	// would land on a stranger's timeline — a data leak dressed as a match.
+	//
+	// The distinction cannot be read off the candidate: both callers arrive with
+	// a name and no key. So it is stated by whoever knows what they will do with
+	// the answer.
+	QueueNameCollisions bool
 }
 
 // PersonResolution is PO-F-1's output: the decision, the person it names,
@@ -268,6 +296,13 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 	defer rows.Close()
 
 	best := PersonResolution{Decision: DecisionNoMatch}
+	// The best name-IDENTICAL row, tracked apart from the best-scoring one
+	// because they are not the same question and the winner of one is often not
+	// the winner of the other: a near-name at a matching employer outscores an
+	// exact name with no employer known, so reading the name lane off `best`
+	// would lose exactly the pair it exists to catch.
+	sameName := PersonResolution{Decision: DecisionNoMatch}
+	candidateKey := normalizeName(c.FullName)
 	for rows.Next() {
 		var row personCandidateRow
 		if err := rows.Scan(&row.id, &row.fullName, &row.orgID, &row.orgDomain, &row.mailDomains); err != nil {
@@ -280,6 +315,15 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 			(confidence == best.Confidence && best.PersonID != (ids.PersonID{}) && row.id.String() < best.PersonID.String()) {
 			best.Confidence, best.PersonID = confidence, row.id
 		}
+		if normalizeName(row.fullName) == candidateKey {
+			// Same tie-break as above, and for the same reason: two incumbents
+			// spelled identically must not shuffle the queue between runs.
+			if confidence > sameName.Confidence ||
+				(sameName.PersonID == (ids.PersonID{})) ||
+				(confidence == sameName.Confidence && row.id.String() < sameName.PersonID.String()) {
+				sameName.Confidence, sameName.PersonID = confidence, row.id
+			}
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return PersonResolution{}, fmt.Errorf("drain person candidates: %w", err)
@@ -287,6 +331,32 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 	if best.Confidence >= dedupeReviewThreshold {
 		best.Decision = DecisionFuzzyReview
 		return best, nil
+	}
+	// THE NAME-COLLISION LANE. Two people in one workspace written exactly the
+	// same way are worth a human's glance even when nothing else agrees.
+	//
+	// It is a lane of its own rather than a lower threshold, and the difference
+	// is not cosmetic: the weights are shared with organization matching, so
+	// moving the bar to admit this pair would drag every company comparison down
+	// with it. An exact name is also not a probability — it either is the same
+	// string or it is not — so scoring it and comparing against a fuzzy bar was
+	// always the wrong instrument.
+	//
+	// WHY IT WAS UNREACHABLE. A perfect name scores 0.55·1.0 and the bar is
+	// 0.72, so the pair could only clear it on employer agreement. But
+	// CreatePersonInput carries no employer at all — the employment edge is a
+	// separate call made after the person exists — so at create time the org
+	// term is structurally 0, and a second business card for someone already in
+	// the workspace was created in silence every time.
+	//
+	// IT FLAGS, IT NEVER MERGES AND NEVER REFUSES. A father and son at one firm
+	// are a real pair of records that share a name and an employer, and an
+	// automatic rule that merged them would destroy data no undo restores. So
+	// this is a question put to a human, which is the same shape the phone lane
+	// already takes for a shared switchboard.
+	if c.QueueNameCollisions && sameName.PersonID != (ids.PersonID{}) {
+		sameName.Decision = DecisionNameCollisionReview
+		return sameName, nil
 	}
 	return PersonResolution{Decision: DecisionNoMatch}, nil
 }


### PR DESCRIPTION
## The case

One person, two cards, two addresses. The second card gets typed in and nothing on it matches what is stored except the name — a personal address instead of the work one, or a typo, and often no phone at all.

Until now that created a second live record **in silence**. Nobody was asked.

Found while testing case 2 from the vision deck: a user deliberately created a duplicate to watch the guard work, and the guard was not there.

## Why the existing tiers could not catch it

- **Email lane** cannot fire — the addresses differ, which is the whole premise.
- **Phone lane** cannot fire when the card carries no number.
- **Fuzzy tier** cannot reach it *by arithmetic*: a perfect name scores `0.55 × 1.0` against a `0.72` bar, so it clears only on employer agreement.

And here is the part that is easy to misread as a weighting problem. **`CreatePersonInput` carries no employer at all.** The employment edge is a separate call made *after* the person exists, so at create time `orgMatch` is structurally `0`. The pair was unreachable, not merely unlikely, and no amount of tuning the weights would have changed that — one input the formula needs does not exist yet when the formula runs.

## The lane

Two records written with exactly the same name — after the same folding the rest of the ladder uses — go on the review queue.

A lane of its own rather than a lowered threshold, for two reasons. The weights are shared with organization matching, so moving the bar to admit this pair would drag every company comparison down with it. And an exact name is not a probability — it either is the same string or it is not — so scoring it against a fuzzy bar was the wrong instrument.

**It flags. It never merges and never refuses.** A father and son at one firm are a real pair of records that share a name and an employer; an automatic rule that merged them would destroy data no undo restores. So it asks — the same shape the phone lane already takes for a shared switchboard.

## Opt-in, and this is the part with teeth

`PersonCandidate.QueueNameCollisions` gates the lane, because the answer is only safe for one kind of caller.

- A caller that **creates** wants it. The worst case is a queue row somebody dismisses.
- A caller that **routes** must not have it. Capture and the channel path ask *"which existing person does this message belong to"*, and for them a `PersonID` is a delivery address. An unbound channel identity carrying a common name would name somebody it has no business naming, and **a message would land on a stranger's timeline**.

`TestExactPersonByChannelIdentityMatchesOnProviderAndUserID` caught exactly that when the lane was first written unconditional. That test failing is why the flag exists.

## Implementation note

The best name-identical row is tracked **apart from** the best-scoring row. They are different questions and the winners differ: a near-name at a matching employer outscores an exact name with no employer known, so reading the name lane off the fuzzy winner would lose the very pair the lane is for.

No `dedupe_near_match` ledger line is written for this lane. That ledger records the fuzzy tier's own scoring, and this lane did not score — it compared two normalized strings. A line carrying a confidence would invite someone to tune a threshold that had no part in the decision.

## Tests

Three, each **proven to bite** by reverting the opt-in flag:

1. the second card is queued for a human
2. two real people sharing a name both survive, neither is merged, and the question is still asked once
3. a name nobody shares leaves the queue empty

Test 2 deliberately puts the junior's address on a **different domain**. Both Fischers on `fischerbau.test` scores 0.8 on the org term and carries the pair over the fuzzy bar on its own — which would have proven the old tier still works and said nothing about this one. That was a real defect in the first draft of the test, caught by the sabotage run.

## Gates

`make check-backend`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` — green.

People integration lane: **451 pass, 0 fail**.

Also verified directly against Postgres that the fuzzy candidate set cannot exclude an exact-name row: identical strings always satisfy the trigram `%` operator regardless of length, and `f_fold_apostrophes(lower(…))` folds accents and ß the same way Go's `normalizeName` does.

## What this does not do

The **merge-or-create-anyway choice in chat** is still not expressible — `create_record` reports nothing about having filed a candidate, so an assistant cannot tell the user. That is #2620 and it is the other half of this problem.

Refs #2620

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues human review on exact-name collisions during person creation and guards it under contention. Previously, a second card with only a matching name created a duplicate silently; now we flag it without merging or refusing, and routing paths are unaffected.

- Adds `DecisionNameCollisionReview`; tracks the exact-name candidate separately from the fuzzy best; no weight/threshold changes and no auto-merges.
- `manualDedupePerson` opts in via `PersonCandidate.QueueNameCollisions = true`; routing callers keep it false to avoid misdelivery.
- Writes only to `dedupe_candidate` with `nameCollisionEvidence`; no `dedupe_near_match` entry because this lane is non-probabilistic.
- Introduces `lockNameLane` (normalized key, taken after the phone lock) to prevent two concurrent identical-name creates from bypassing the queue; both creates may land, and one review pair is enqueued.
- Tests cover: second card is queued; identical-name different people remain unmerged; unrelated names do not queue; contention enqueues exactly once. Related to #2620 (chat still cannot surface “queued” vs “created”).

<sup>Written for commit 4bbf92460f49636a03e8ebac5c824876082aada1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added human-review queue support for people with identical names.
  * Matching records are flagged for review without being automatically merged or rejected.
  * Similar records, including additional addresses at the same employer, can be queued for review.
  * Records with different names remain unaffected and are not added to the review queue.
  * Improved handling of simultaneous record creation to ensure matching entries are consistently queued for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->