### PR TITLE
fix(main): the two frontend reds on main

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1082,12 +1082,15 @@ export const de = {
   "co.work.stalled": "Zu diesem Deal wurde seit 60 Tagen nichts erfasst.",
   "co.work.quiet": "Zu diesem Projekt wurde seit {when} nichts erfasst.",
   "co.work.neverTouched": "Zu diesem Projekt wurde noch nie etwas erfasst.",
-  "co.work.overdueTask": "{who} sollte \u201a{title}\u2018 bis {date} erledigen und hat es nicht getan.",
-  "co.work.overdueTaskUnnamed": "\u201a{title}\u2018 war am {date} f\u00e4llig und ist offen.",
+  "co.work.overdueTask":
+    "{who} sollte \u201a{title}\u2018 bis {date} erledigen und hat es nicht getan.",
+  "co.work.overdueTaskUnnamed":
+    "\u201a{title}\u2018 war am {date} f\u00e4llig und ist offen.",
   "co.work.owesUs": "{who} sagte: \u201a{body}\u2018",
   "co.work.owesUsUnnamed": "Sie sagten: \u201a{body}\u2018",
   "co.work.wasDue": "\u2014 bis {date}.",
-  "co.work.statusesWithheld": "Du darfst die Konversationen dieses Accounts nicht lesen, deshalb tragen die Zeilen oben keine Begr\u00fcndungen.",
+  "co.work.statusesWithheld":
+    "Du darfst die Konversationen dieses Accounts nicht lesen, deshalb tragen die Zeilen oben keine Begr\u00fcndungen.",
   "co.brief.by.model": "Von Margince geschrieben",
   "co.brief.by.deterministic": "Aus deinen Daten zusammengestellt",
   "co.brief.generatedAt": "Stand {when}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1116,15 +1116,19 @@ export const en = {
   "co.work.noProjects": "No projects in flight.",
   "co.work.closes": "closes {date}",
   "co.work.targetEnd": "due to end {date}",
-  "co.work.stalled": "Nothing has been filed against this deal in the last 60 days.",
+  "co.work.stalled":
+    "Nothing has been filed against this deal in the last 60 days.",
   "co.work.quiet": "Nothing has been filed against this project since {when}.",
   "co.work.neverTouched": "Nothing has ever been filed against this project.",
-  "co.work.overdueTask": "{who} was supposed to \u2018{title}\u2019 by {date} and has not.",
-  "co.work.overdueTaskUnnamed": "\u2018{title}\u2019 was due {date} and is still open.",
+  "co.work.overdueTask":
+    "{who} was supposed to \u2018{title}\u2019 by {date} and has not.",
+  "co.work.overdueTaskUnnamed":
+    "\u2018{title}\u2019 was due {date} and is still open.",
   "co.work.owesUs": "{who} said: \u2018{body}\u2019",
   "co.work.owesUsUnnamed": "They said: \u2018{body}\u2019",
   "co.work.wasDue": "\u2014 by {date}.",
-  "co.work.statusesWithheld": "You cannot read this account\u2019s conversations, so the rows above carry no reasons.",
+  "co.work.statusesWithheld":
+    "You cannot read this account\u2019s conversations, so the rows above carry no reasons.",
   "co.brief.by.model": "Written by Margince",
   "co.brief.by.deterministic": "Assembled from your records",
   "co.brief.generatedAt": "as of {when}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1057,29 +1057,39 @@ export const vi = {
   "co.facts.pipeline": "Pipeline \u0111ang m\u1edf",
   "co.facts.inFlight": "\u0110ang tri\u1ec3n khai",
   "co.facts.reading": "\u0110ang \u0111\u1ecdc\u2026",
-  "co.facts.noDeals": "Kh\u00f4ng c\u00f3 th\u01b0\u01a1ng v\u1ee5 \u0111ang m\u1edf",
+  "co.facts.noDeals":
+    "Kh\u00f4ng c\u00f3 th\u01b0\u01a1ng v\u1ee5 \u0111ang m\u1edf",
   "co.facts.unpriced": "Ch\u01b0a \u0111\u1ecbnh gi\u00e1",
   "co.facts.nothing": "Kh\u00f4ng c\u00f3 g\u00ec",
-  "co.facts.counts": "{deals} th\u01b0\u01a1ng v\u1ee5 \u00b7 {projects} d\u1ef1 \u00e1n",
+  "co.facts.counts":
+    "{deals} th\u01b0\u01a1ng v\u1ee5 \u00b7 {projects} d\u1ef1 \u00e1n",
   "co.facts.atLeast": "ho\u1eb7c h\u01a1n",
   "co.work.title": "\u0110ang tri\u1ec3n khai",
   "co.work.count": "{count} \u0111ang tri\u1ec3n khai",
   "co.work.countAtLeast": "{count}+ \u0111ang tri\u1ec3n khai",
   "co.work.deals": "Th\u01b0\u01a1ng v\u1ee5",
   "co.work.projects": "D\u1ef1 \u00e1n",
-  "co.work.noDeals": "Kh\u00f4ng c\u00f3 th\u01b0\u01a1ng v\u1ee5 n\u00e0o \u0111ang m\u1edf.",
-  "co.work.noProjects": "Kh\u00f4ng c\u00f3 d\u1ef1 \u00e1n n\u00e0o \u0111ang tri\u1ec3n khai.",
+  "co.work.noDeals":
+    "Kh\u00f4ng c\u00f3 th\u01b0\u01a1ng v\u1ee5 n\u00e0o \u0111ang m\u1edf.",
+  "co.work.noProjects":
+    "Kh\u00f4ng c\u00f3 d\u1ef1 \u00e1n n\u00e0o \u0111ang tri\u1ec3n khai.",
   "co.work.closes": "ch\u1ed1t {date}",
   "co.work.targetEnd": "d\u1ef1 ki\u1ebfn k\u1ebft th\u00fac {date}",
-  "co.work.stalled": "Kh\u00f4ng c\u00f3 g\u00ec \u0111\u01b0\u1ee3c ghi nh\u1eadn cho th\u01b0\u01a1ng v\u1ee5 n\u00e0y trong 60 ng\u00e0y qua.",
-  "co.work.quiet": "Kh\u00f4ng c\u00f3 g\u00ec \u0111\u01b0\u1ee3c ghi nh\u1eadn cho d\u1ef1 \u00e1n n\u00e0y t\u1eeb {when}.",
-  "co.work.neverTouched": "Ch\u01b0a t\u1eebng c\u00f3 g\u00ec \u0111\u01b0\u1ee3c ghi nh\u1eadn cho d\u1ef1 \u00e1n n\u00e0y.",
-  "co.work.overdueTask": "{who} \u0111\u00e1ng l\u1ebd ph\u1ea3i \u2018{title}\u2019 tr\u01b0\u1edbc {date} nh\u01b0ng ch\u01b0a l\u00e0m.",
-  "co.work.overdueTaskUnnamed": "\u2018{title}\u2019 \u0111\u1ebfn h\u1ea1n {date} v\u00e0 v\u1eabn c\u00f2n m\u1edf.",
+  "co.work.stalled":
+    "Kh\u00f4ng c\u00f3 g\u00ec \u0111\u01b0\u1ee3c ghi nh\u1eadn cho th\u01b0\u01a1ng v\u1ee5 n\u00e0y trong 60 ng\u00e0y qua.",
+  "co.work.quiet":
+    "Kh\u00f4ng c\u00f3 g\u00ec \u0111\u01b0\u1ee3c ghi nh\u1eadn cho d\u1ef1 \u00e1n n\u00e0y t\u1eeb {when}.",
+  "co.work.neverTouched":
+    "Ch\u01b0a t\u1eebng c\u00f3 g\u00ec \u0111\u01b0\u1ee3c ghi nh\u1eadn cho d\u1ef1 \u00e1n n\u00e0y.",
+  "co.work.overdueTask":
+    "{who} \u0111\u00e1ng l\u1ebd ph\u1ea3i \u2018{title}\u2019 tr\u01b0\u1edbc {date} nh\u01b0ng ch\u01b0a l\u00e0m.",
+  "co.work.overdueTaskUnnamed":
+    "\u2018{title}\u2019 \u0111\u1ebfn h\u1ea1n {date} v\u00e0 v\u1eabn c\u00f2n m\u1edf.",
   "co.work.owesUs": "{who} n\u00f3i: \u2018{body}\u2019",
   "co.work.owesUsUnnamed": "H\u1ecd n\u00f3i: \u2018{body}\u2019",
   "co.work.wasDue": "\u2014 tr\u01b0\u1edbc {date}.",
-  "co.work.statusesWithheld": "B\u1ea1n kh\u00f4ng \u0111\u01b0\u1ee3c \u0111\u1ecdc h\u1ed9i tho\u1ea1i c\u1ee7a kh\u00e1ch h\u00e0ng n\u00e0y, n\u00ean c\u00e1c d\u00f2ng tr\u00ean kh\u00f4ng k\u00e8m l\u00fd do.",
+  "co.work.statusesWithheld":
+    "B\u1ea1n kh\u00f4ng \u0111\u01b0\u1ee3c \u0111\u1ecdc h\u1ed9i tho\u1ea1i c\u1ee7a kh\u00e1ch h\u00e0ng n\u00e0y, n\u00ean c\u00e1c d\u00f2ng tr\u00ean kh\u00f4ng k\u00e8m l\u00fd do.",
   "co.brief.by.model": "Do Margince viết",
   "co.brief.by.deterministic": "Tổng hợp từ dữ liệu của bạn",
   "co.brief.generatedAt": "tính đến {when}",

--- a/frontend/src/screens/aiscope.test.tsx
+++ b/frontend/src/screens/aiscope.test.tsx
@@ -64,7 +64,6 @@ const erpScope: ProjectScope = {
   total: 11,
 };
 
-
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -268,9 +268,7 @@ function NextStepsWithVerbs({
 }
 
 function renderWork(three60: ReturnType<typeof view>) {
-  render(
-    <CompanyWorkCard view={three60 as never} onOpenRecord={() => {}} />,
-  );
+  render(<CompanyWorkCard view={three60 as never} onOpenRecord={() => {}} />);
 }
 
 // The lead panel, rendered on its own: it moved out of AccountBrief so the

--- a/frontend/src/screens/companyfacts.tsx
+++ b/frontend/src/screens/companyfacts.tsx
@@ -20,9 +20,8 @@
 // answers to one question, and the two disagree the moment somebody types.
 
 import type { components } from "../api/schema";
-import { useT } from "../i18n";
-import { useLocale } from "../i18n";
 import { formatMoney } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import { CompanyOwnerControl } from "./companyheader";
 import "./companyfacts.css";
 

--- a/frontend/src/screens/companytasks.test.tsx
+++ b/frontend/src/screens/companytasks.test.tsx
@@ -8,6 +8,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
@@ -191,12 +192,22 @@ describe("CompanyScreen — the Tasks tab", () => {
     render(<CompanyScreen id="o-1" />);
     await openTasksTab(user);
 
+    // Scoped to the tab's own panel: the account facts strip says the same
+    // sentence about a withheld deal or project count, and a page-wide match
+    // would pass on either of those while this tab drew nothing at all.
+    const heading = await screen.findByRole("heading", { name: "Next steps" });
+    const tasks = heading.closest("section");
+    if (!tasks) {
+      throw new Error("the tasks tab has no section wrapper");
+    }
     await waitFor(() =>
       expect(
-        screen.getByText("Hidden — your role cannot read this"),
+        within(tasks).getByText("Hidden — your role cannot read this"),
       ).toBeTruthy(),
     );
-    expect(screen.queryByText("No open task on this account.")).toBeNull();
+    expect(
+      within(tasks).queryByText("No open task on this account."),
+    ).toBeNull();
   });
 
   it("shows no task-completing verb on an archived account", async () => {

--- a/frontend/src/screens/companywork.test.tsx
+++ b/frontend/src/screens/companywork.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render as rtlRender, cleanup, screen } from "@testing-library/react";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { components } from "../api/schema";
@@ -84,11 +84,23 @@ afterEach(cleanup);
 
 describe("the account's work in flight", () => {
   it("lists a deal and a project under their own subheads", () => {
-    draw(view({ deals: { data: [deal], page, won_lifetime: { amount_minor: 0, currency: "EUR" }, lost_count: 0 }, projects: [project] }));
+    draw(
+      view({
+        deals: {
+          data: [deal],
+          page,
+          won_lifetime: { amount_minor: 0, currency: "EUR" },
+          lost_count: 0,
+        },
+        projects: [project],
+      }),
+    );
 
     expect(screen.getByRole("heading", { name: "Deals" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Projects" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Fleet retrofit 2026" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Fleet retrofit 2026" }),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: "DEP-12" })).toBeTruthy();
   });
 
@@ -146,7 +158,9 @@ describe("the account's work in flight", () => {
     // The sentence stands on its own rather than leaving a gap where a name
     // would go, and no stray "null" reaches the screen.
     expect(
-      screen.getByText(/‘Send the retrofit quote’ was due 02\/07\/2026 and is still open\./),
+      screen.getByText(
+        /‘Send the retrofit quote’ was due 02\/07\/2026 and is still open\./,
+      ),
     ).toBeTruthy();
     expect(screen.queryByText(/null/)).toBeNull();
   });
@@ -201,7 +215,9 @@ describe("the account's work in flight", () => {
       }),
     );
 
-    expect(screen.getByText(/Nothing has been filed against this project since/)).toBeTruthy();
+    expect(
+      screen.getByText(/Nothing has been filed against this project since/),
+    ).toBeTruthy();
   });
 
   it("shows the stall only when there is no reason that explains it", () => {
@@ -321,8 +337,12 @@ describe("a half of the card the reader may not have", () => {
       }),
     );
 
-    expect(screen.getByRole("button", { name: "Fleet retrofit 2026" })).toBeTruthy();
-    expect(screen.getByText("Hidden — your role cannot read this")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Fleet retrofit 2026" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Hidden — your role cannot read this"),
+    ).toBeTruthy();
     // Never the empty state: "no projects in flight" is a claim about the
     // account that this reader's payload does not support.
     expect(screen.queryByText("No projects in flight.")).toBeNull();
@@ -341,7 +361,9 @@ describe("a half of the card the reader may not have", () => {
       }),
     );
 
-    expect(screen.getByRole("button", { name: "Fleet retrofit 2026" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Fleet retrofit 2026" }),
+    ).toBeTruthy();
     expect(
       screen.getByText(
         "You cannot read this account’s conversations, so the rows above carry no reasons.",

--- a/frontend/src/screens/companywork.tsx
+++ b/frontend/src/screens/companywork.tsx
@@ -16,10 +16,9 @@
 // the record it links to.
 
 import type { ReactNode } from "react";
-
-import { navigate } from "../app/router";
-import { useRecordZone } from "../app/recordzone";
 import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
+import { navigate } from "../app/router";
 import { Badge } from "../design-system/atoms";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
@@ -249,7 +248,7 @@ function WorkGroup({
  */
 function WorkCount({ view }: Readonly<{ view?: Organization360 }>) {
   const t = useT();
-  if (!view || !view.deals || !view.projects) {
+  if (!view?.deals || !view.projects) {
     return null;
   }
   const count = view.deals.data.length + liveWork(view.projects).length;
@@ -386,7 +385,9 @@ function AttentionLine({
   const t = useT();
   const { locale } = useLocale();
   const zone = useRecordZone();
-  const due = attention.due_at ? formatDate(attention.due_at, locale, zone) : "";
+  const due = attention.due_at
+    ? formatDate(attention.due_at, locale, zone)
+    : "";
   if (attention.kind === "overdue_task") {
     return (
       <StatusLine tone="warn">

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -27,6 +27,7 @@ import {
   type EvidenceMarkSource,
 } from "../design-system/evidencemark";
 import type { ListChip } from "../design-system/listsurface";
+import { Panel, PanelBody } from "../design-system/panel";
 import { liveProjects } from "../design-system/projectpicker";
 import {
   hasTimelineFilters,
@@ -2765,7 +2766,17 @@ function CompanyTasksTab({
     sectionState(view, "next_steps", Boolean(view.next_steps), steps.length) ===
     "withheld"
   ) {
-    return <EmptyState>{t("co.section.restricted")}</EmptyState>;
+    // Same chrome as every other state of this tab. A refusal drawn as a bare
+    // plate names no section, and the account facts strip above says the same
+    // sentence about its own withheld halves — so a reader who lands on an
+    // unheaded one cannot tell which of the two they are being refused.
+    return (
+      <Panel title={t("co.next.title")}>
+        <PanelBody>
+          <p className="surfacestate-withheld">{t("co.section.restricted")}</p>
+        </PanelBody>
+      </Panel>
+    );
   }
   return (
     <NextSteps

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -76,10 +76,9 @@ import { CompanyContractsCard } from "./companycontracts";
 import { CompanyDocumentsCard } from "./companydocuments";
 import { DossierPanel } from "./companydossier";
 import { type CitedRecord, EvidenceModal } from "./companyevidence";
+import { CompanyFacts } from "./companyfacts";
 import { CompanyFinanceCard } from "./companyfinance";
 import { GrowthFitPanel } from "./companygrowthfit";
-import { CompanyFacts } from "./companyfacts";
-import { CompanyWorkCard, hasWorkInFlight } from "./companywork";
 import {
   CompanyActionBadges,
   CompanyDescription,
@@ -96,6 +95,7 @@ import {
 import { CompanyProjects } from "./companyprojects";
 import { CompanyRail } from "./companyrail";
 import { TodayOnThisAccount } from "./companytoday";
+import { CompanyWorkCard, hasWorkInFlight } from "./companywork";
 import { ComposeModal, TimelineActions } from "./compose";
 import {
   CreateAction,


### PR DESCRIPTION
`main` was red on three separate causes. Two of them are frontend and this
closes both; the third landed separately while this was in flight.

## 1. `fe-quality` — biome refuses eleven findings

Import order in four files and one conditional biome would rather see as an
optional chain, all fallout of #2625. The optional chain is the only one that
is not mechanical: `!view || !view.deals` and `!view?.deals` differ in nothing
here — an absent view makes the chain undefined, which is falsy either way.

## 2. `fe-unit` — a page-wide query that is no longer unique

`companytasks.test.tsx` asserted "Hidden — your role cannot read this" with a
page-wide `getByText`. #2625's `CompanyFacts` now says the same sentence twice
on the same screen: `Pipeline` reads `state_strip.commercial` and `InFlight`
reads `deals` + `projects`, and the shared `company.fixtures` account carries
neither. Three copies of one sentence, and the query matched all three.

Underneath the ambiguity was a real gap: the Tasks tab drew its refusal as a
bare plate with no heading, so a reader who may not read the section was told
only that *something* is hidden. The withheld arm now keeps the panel chrome
its other three states already have, and the test scopes to that panel —
mutation-checked, because the page-wide query passed on the facts strip while
the tab drew nothing at all.

## Landed elsewhere

- `backend gate` / `integration unit coverage`: the undeclared
  `retainedcolumncases_test.go` gate is #2628, and the two
  `internal/compose/org360/workattention.go` gates are `bc9c38484`. This branch
  is rebased on both.
- The integration lane's `check_location_support` conformance red was already
  fixed by #2621; that failure was stale against its own base.

## Verified

- `pnpm lint` — clean, 1119 files
- `pnpm vitest run` — 4616 tests, the two `extensions/` walk failures being a
  local stale-directory artifact CI does not carry
- Mutation check on the tasks-tab fix: swapping the withheld copy for the empty
  copy fails the test, with the mutant confirmed applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the presentation of restricted task next steps by displaying the message within a titled panel.

- **Bug Fixes**
  - Improved validation of restricted task messaging to ensure it appears in the correct Tasks section.

- **Style**
  - Applied formatting and import organization updates without changing visible behavior or translation text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->