### PR TITLE
test(ci): the retained-column falsification gate declares its shape

### DIFF
--- a/backend/retainedcolumncases_test.go
+++ b/backend/retainedcolumncases_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+//gate:kind falsification H1
+
 package backendarch
 
 // The retained-column check, driven with SYNTHETIC statements rather than the

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -176,7 +176,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooklength_test.go` | H3 | A rulebook is read in full by every session and, for its Craftsmanship section, by every gate prompt — so its length is a running cost rather than a matter of taste. |
 | `workflowtimeouts_test.go` | H3 | Every workflow job carries a wall-clock ceiling. |
 
-## Falsification (4)
+## Falsification (5)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -184,3 +184,4 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobfleetwideshapes_test.go` | H2 | The FleetWide gate's own falsification, kept beside it: every dispatch shape the tree actually uses, proven accepted, and the shapes it exists to reject — a dispatcher doing a tenant's work, and a fan-out built around the chokepoints — proven rejected. |
 | `jobkindgate_test.go` | H2 | The registration gate's own falsification. |
 | `rbacbaselineerafixture_test.go` | H3 | The pre-state the RBAC composition gate replays over must not be hand-editable. |
+| `retainedcolumncases_test.go` | H1 | The retained-column check, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |


### PR DESCRIPTION
One line. `main` is red and half of it is mine.

`backend/retainedcolumncases_test.go` landed via #2565 while the gate-inventory mechanism was landing beside it, so it reached `main` carrying no `//gate:kind` declaration and `TestEveryGateDeclaresItsShape` has been failing since that merge.

It is a **falsification** gate by the catalogue's own definition — *"a companion test with fake inputs: every shape the real tree uses, proven accepted, plus the shape the gate exists to reject, proven rejected"* — and `docs/reference/gate-patterns.md` lists `extensionsqlscopecases_test.go` among its examples, which is the precedent that test was written from and cites. **H1**, because the detector it falsifies is a regex over SQL text.

## `main` is red for a second reason, which this does not touch

`compose/org360/workattention.go` (from #2625) fails two other gates:

- `TestOnlyOneSpellingOfALiveMember` — it spells `u.status = active AND u.archived_at IS NULL` itself instead of calling `identity.LiveMemberSQL`.
- `TestEveryUniquenessClaimNamesItsGateOrIsRegisteredDebt` — `overdueTasksBy` carries a "the one spelling" claim, and the register is closed to new entries.

Different author, different fix, so it is left alone here rather than bundled. Flagging it because a red `main` rates `priority: critical` in the rulebook and the two halves have separate owners.

Verified: `TestEveryGateDeclaresItsShape` passes with this line, and the two failures above are unchanged by it — this branch is `main` plus two lines in one test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation metadata to improve test coverage tracking.
* **Documentation**
  * Updated the gate inventory to reflect the expanded set of validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->