### PR TITLE
ci(tests): main-health asks whether the screens render

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -139,6 +139,51 @@ jobs:
   frontend:
     uses: ./.github/workflows/_lane-frontend.yml
 
+  # The screen-acceptance lane, for the same reason the SPA lane above is here and
+  # with one difference that matters.
+  #
+  # On a pull request `uat` is gated on the change classifier: it runs only when
+  # the diff touches `frontend/`. That is right there and wrong here — a green
+  # verdict on main has to mean the screens actually render, and the classifier is
+  # precisely what let a broken one wait for somebody else's frontend PR to
+  # discover it. So this runs unconditionally against the tip, like every other
+  # lane in this workflow.
+  #
+  # It needs the SPA lane for the same fail-fast reason ci.yml gives: there is no
+  # point driving Playwright through a tree that does not typecheck or build.
+  uat:
+    name: uat (main)
+    timeout-minutes: 20
+    needs: [frontend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # This workflow runs in backend/ by default; the UAT harness is a root target.
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install deps and the Playwright Chromium browser
+        working-directory: frontend
+        # --ignore-scripts (githubactions:S6505): no lifecycle scripts run at
+        # install; esbuild ships prebuilt platform binaries as optional deps.
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm exec playwright install --with-deps chromium
+      - name: Screen-acceptance UAT (build → preview → AC + axe)
+        run: make frontend-e2e
+
   # main's SonarCloud analysis, published from here.
   #
   # Nothing else publishes it. The push-to-main scan is gone (the merge queue was
@@ -240,12 +285,13 @@ jobs:
     # working one on every dashboard. Left out of this list, the job that exists
     # to publish main's verdict was the one job whose failure nobody was told
     # about.
-    needs: [gates, integration, frontend, sonar]
+    needs: [gates, integration, frontend, uat, sonar]
     if: >-
       !cancelled()
       && (needs.gates.result == 'failure'
       || needs.integration.result == 'failure'
       || needs.frontend.result == 'failure'
+      || needs.uat.result == 'failure'
       || needs.sonar.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
@@ -281,6 +327,7 @@ jobs:
           MAIN_GATES_RESULT: ${{ needs.gates.result }}
           MAIN_INTEGRATION_RESULT: ${{ needs.integration.result }}
           MAIN_FRONTEND_RESULT: ${{ needs.frontend.result }}
+          MAIN_UAT_RESULT: ${{ needs.uat.result }}
           MAIN_SONAR_RESULT: ${{ needs.sonar.result }}
           MAIN_SUSPECTS: ${{ steps.range.outputs.suspects }}
         run: ./scripts/scheduled-report.sh

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -530,9 +530,19 @@ beside the gate, deliberately outside it:
   rather than per-push.
 
 - **`main-health.yml`** — every two hours on `main`: the backend gate, the
-  real-Postgres lane and the SPA lane (the last two called, not copied — it
-  `uses:` `_lane-integration.yml` and `_lane-frontend.yml`), and `main`'s
-  SonarCloud analysis published from the three coverage reports they produce.
+  real-Postgres lane, the SPA lane (those two called, not copied — it `uses:`
+  `_lane-integration.yml` and `_lane-frontend.yml`), the screen-acceptance UAT,
+  and `main`'s SonarCloud analysis published from the three coverage reports
+  they produce.
+
+  The UAT lane runs **unconditionally** here, unlike on a pull request where it
+  is gated on the change classifier. That gate is right on a PR and wrong on the
+  tip: it is the SPA lane that can be green over a tree whose pages throw at
+  runtime — biome, tsc and vitest all pass on code that builds and never mounts —
+  and a classifier-gated UAT means a broken screen waits for whoever's pull
+  request happens to touch `frontend/` next, then goes red on their unrelated
+  change. It does not block `sonar`, which needs the coverage producers and gets
+  none from Playwright: a red UAT should not freeze `main`'s analysis.
   **It is not a gate and never will be**: it reports on a tree that has already
   landed.
 

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -532,8 +532,9 @@ beside the gate, deliberately outside it:
 - **`main-health.yml`** — every two hours on `main`: the backend gate, the
   real-Postgres lane, the SPA lane (those two called, not copied — it `uses:`
   `_lane-integration.yml` and `_lane-frontend.yml`), the screen-acceptance UAT,
-  and `main`'s SonarCloud analysis published from the three coverage reports
-  they produce.
+  and `main`'s SonarCloud analysis published from the three coverage reports the
+  backend gate, the real-Postgres lane and the SPA lane produce between them.
+  The UAT produces none, which is why it is named here and absent there.
 
   The UAT lane runs **unconditionally** here, unlike on a pull request where it
   is gated on the change classifier. That gate is right on a PR and wrong on the

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -30,7 +30,7 @@ report() {
   existing="$(gh api --paginate "repos/$REPO/issues?state=open&per_page=100" |
     jq -rs --arg t "$title" '[.[][] | select(has("pull_request") | not)
       | select(.title == $t)] | min_by(.number) | .number // empty')"
-  if [ -n "$existing" ]; then
+  if [[ -n "$existing" ]]; then
     echo "already open as #$existing — commenting"
     gh issue comment "$existing" --repo "$REPO" \
       --body "Still failing on the $(date -u +%Y-%m-%d) scheduled run: $RUN_URL"
@@ -46,7 +46,7 @@ report() {
 # one failure and swallow two. Failures accumulate and surface at the end instead.
 unreported=0
 
-if [ "${VULN_RESULT:-}" = "failure" ]; then
+if [[ "${VULN_RESULT:-}" = "failure" ]]; then
   report "govulncheck reports a vulnerability reachable from main" security \
 "\`make vuln\` failed on the scheduled run of \`main\`: $RUN_URL
 
@@ -63,7 +63,7 @@ Reproduce locally with \`make vuln\`."\
     || unreported=1
 fi
 
-if [ "${GATE_RESULT:-}" = "failure" ]; then
+if [[ "${GATE_RESULT:-}" = "failure" ]]; then
   report "SonarCloud quality gate is not green on main" bug \
 "The quality gate on \`main\` read \`${GATE_STATUS:-unknown}\` on the scheduled
 run: $RUN_URL
@@ -81,7 +81,7 @@ above."\
     || unreported=1
 fi
 
-if [ "${LANE_RESULT:-}" = "failure" ]; then
+if [[ "${LANE_RESULT:-}" = "failure" ]]; then
   report "the backend merge gate is red on main" bug \
 "\`make check-backend\` failed on the scheduled run of \`main\`: $RUN_URL
 
@@ -103,7 +103,7 @@ fi
 # regression that never happened — which is the failure this whole lane keeps
 # learning about. PERF_OUTCOME is set by the step from the harness's own breach
 # message, so only a MEASURED breach is reported as one.
-if [ "${PERF_RESULT:-}" = "failure" ] && [ "${PERF_OUTCOME:-}" != "breach" ]; then
+if [[ "${PERF_RESULT:-}" = "failure" ]] && [[ "${PERF_OUTCOME:-}" != "breach" ]]; then
   report "the weekly PERF-3/PERF-7 run could not complete" bug \
 "\`make bench-perf-check\` failed on the weekly run of \`main\` WITHOUT reaching a
 budget verdict: $RUN_URL
@@ -123,7 +123,7 @@ page is untouched either way: this lane never sets MARGINCE_BENCH_RECORD."\
     || unreported=1
 fi
 
-if [ "${PERF_OUTCOME:-}" = "breach" ]; then
+if [[ "${PERF_OUTCOME:-}" = "breach" ]]; then
   report "a PERF-3/PERF-7 budget is breaching on main" bug \
 "\`make bench-perf-check\` failed on the weekly run of \`main\`: $RUN_URL
 
@@ -145,7 +145,7 @@ bisecting is the honest first move rather than assuming the newest commit."\
     || unreported=1
 fi
 
-if [ "${CLOCK_RESULT:-}" = "failure" ]; then
+if [[ "${CLOCK_RESULT:-}" = "failure" ]]; then
   report "the frontend suite's verdict depends on the calendar" bug \
 "\`make fe-clock-drift\` failed on the scheduled run of \`main\`: $RUN_URL
 
@@ -167,7 +167,7 @@ about the fixtures rather than about the components."\
     || unreported=1
 fi
 
-if [ "${CACHE_RESULT:-}" = "failure" ]; then
+if [[ "${CACHE_RESULT:-}" = "failure" ]]; then
   report "the Actions build-cache reaper is failing" bug \
 "\`scripts/reap-build-caches.sh\` failed on the scheduled run: $RUN_URL
 
@@ -202,7 +202,7 @@ fi
 # last green. Printed as-is rather than narrowed: a guessed culprit sends the wrong
 # person looking, which is worse than a dozen candidates and a failing test name.
 
-if [ "${MAIN_GATES_RESULT:-}" = "failure" ]; then
+if [[ "${MAIN_GATES_RESULT:-}" = "failure" ]]; then
   report "main is red: the backend gate fails on the tip" bug \
 "\`make check-backend\` failed against \`main\` on the two-hourly health check:
 $RUN_URL
@@ -218,7 +218,7 @@ Reproduce locally on \`main\` with \`make check-backend\`."\
     || unreported=1
 fi
 
-if [ "${MAIN_INTEGRATION_RESULT:-}" = "failure" ]; then
+if [[ "${MAIN_INTEGRATION_RESULT:-}" = "failure" ]]; then
   report "main is red: the integration lane fails on the tip" bug \
 "The real-Postgres lane failed against \`main\` on the two-hourly health check:
 $RUN_URL
@@ -236,7 +236,7 @@ commit and reads as red for a reason its author did not cause."\
     || unreported=1
 fi
 
-if [ "${MAIN_FRONTEND_RESULT:-}" = "failure" ]; then
+if [[ "${MAIN_FRONTEND_RESULT:-}" = "failure" ]]; then
   report "main is red: the frontend lane fails on the tip" bug \
 "The SPA lane (biome + vitest + tsc + build) failed against \`main\` on the
 two-hourly health check: $RUN_URL
@@ -263,7 +263,7 @@ not there."\
     || unreported=1
 fi
 
-if [ "${MAIN_UAT_RESULT:-}" = "failure" ]; then
+if [[ "${MAIN_UAT_RESULT:-}" = "failure" ]]; then
   report "main is red: the screen-acceptance UAT fails on the tip" bug \
 "The UAT lane (AC screens + axe WCAG 2.2 AA + the 390px sweep, against the built
 app over the seed mock) failed against \`main\` on the two-hourly health check:
@@ -288,7 +288,7 @@ no running stack — but it does need the browser: \`pnpm exec playwright instal
     || unreported=1
 fi
 
-if [ "${MAIN_SONAR_RESULT:-}" = "failure" ]; then
+if [[ "${MAIN_SONAR_RESULT:-}" = "failure" ]]; then
   report "main's SonarCloud analysis was not published" bug \
 "The \`sonarcloud (main)\` job failed on the two-hourly health check, with every
 lane it depends on green: $RUN_URL
@@ -314,7 +314,7 @@ than as a verdict."\
     || unreported=1
 fi
 
-if [ "$unreported" -ne 0 ]; then
+if [[ "$unreported" -ne 0 ]]; then
   echo "FAIL: at least one finding could not be filed — the run above names what was broken, but an issue for it does not exist" >&2
   exit 1
 fi

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -263,6 +263,31 @@ not there."\
     || unreported=1
 fi
 
+if [ "${MAIN_UAT_RESULT:-}" = "failure" ]; then
+  report "main is red: the screen-acceptance UAT fails on the tip" bug \
+"The UAT lane (AC screens + axe WCAG 2.2 AA + the 390px sweep, against the built
+app over the seed mock) failed against \`main\` on the two-hourly health check:
+$RUN_URL
+
+This lane is the one that answers whether the screens actually RENDER. The SPA
+lane above it can be green over a tree whose pages throw at runtime: biome, tsc
+and vitest all pass on code that builds and never mounts.
+
+On a pull request this lane is gated on the change classifier and runs only for a
+diff touching \`frontend/\`, which is right there and wrong on the tip — a broken
+screen used to wait for whoever's pull request happened to touch the frontend
+next, and then went red on their unrelated change. Here it runs unconditionally,
+which is the whole point of asking on \`main\`.
+
+${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
+
+Reproduce locally with \`make frontend-e2e\`. It builds the app, serves the
+preview and drives Playwright against the seed mock, so it needs no database and
+no running stack — but it does need the browser: \`pnpm exec playwright install
+--with-deps chromium\` once."\
+    || unreported=1
+fi
+
 if [ "${MAIN_SONAR_RESULT:-}" = "failure" ]; then
   report "main's SonarCloud analysis was not published" bug \
 "The \`sonarcloud (main)\` job failed on the two-hourly health check, with every

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -265,7 +265,7 @@ expect_health "a failed publish with no range still files" \
 # and this script runs under `set -e`, so without it the suite dies at this line
 # having printed thirteen `ok:` lines and no reason — a gate that fails without
 # saying what it found is barely better than one that passes without looking.
-lanes="$(grep -oE '^if \[ "\$\{MAIN_[A-Z0-9_]+_RESULT:-\}" = "failure" \]' \
+lanes="$(grep -oE '^if \[\[ "\$\{MAIN_[A-Z0-9_]+_RESULT:-\}" = "failure" \]\]' \
 	"$root/scripts/scheduled-report.sh" |
 	grep -oE 'MAIN_[A-Z0-9_]+_RESULT' | sort -u || true)"
 if [ -z "$lanes" ]; then

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -127,6 +127,7 @@ expect "a similar title is a different finding" \
 readonly GATES_TITLE="main is red: the backend gate fails on the tip"
 readonly INTEGRATION_TITLE="main is red: the integration lane fails on the tip"
 readonly FRONTEND_TITLE="main is red: the frontend lane fails on the tip"
+readonly UAT_TITLE="main is red: the screen-acceptance UAT fails on the tip"
 readonly SONAR_TITLE="main's SonarCloud analysis was not published"
 readonly SUSPECTS="- \`deadbeef\` Some Author — the commit that did it"
 
@@ -215,6 +216,16 @@ expect_health "a red frontend lane on main is filed with its suspect range" \
 # this file is what holds that, rather than this comment.
 expect_health "a red frontend lane with no range still files" \
 	MAIN_FRONTEND_RESULT "$FRONTEND_TITLE" ""
+
+# The screen-acceptance arm. It is the only lane that answers whether the pages
+# RENDER — the SPA lane above it passes over code that builds and never mounts —
+# and on a pull request it is classifier-gated, so the tip is the one place it is
+# asked unconditionally.
+expect_health "a red uat lane on main is filed with its suspect range" \
+	MAIN_UAT_RESULT "$UAT_TITLE" "$SUSPECTS"
+
+expect_health "a red uat lane with no range still files" \
+	MAIN_UAT_RESULT "$UAT_TITLE" ""
 
 # The publisher, which is the arm that exists because its failure is invisible:
 # a stale analysis reads exactly like a current one, so nothing but this issue

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -171,7 +171,7 @@ sonar.coverage.exclusions=\
   frontend/src/**/*.stories.tsx
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
@@ -307,3 +307,18 @@ sonar.issue.ignore.multicriteria.e10.resourceKey=backend/internal/modules/identi
 # person READS is a genuine finding and stays enforced everywhere else.
 sonar.issue.ignore.multicriteria.e11.ruleKey=typescript:S2871
 sonar.issue.ignore.multicriteria.e11.resourceKey=frontend/src/screens/persondealrooms.tsx
+# githubactions:S6505 again, on the second workflow that installs the Playwright
+# browser: main-health.yml's UAT job runs the identical two lines ci.yml's does —
+# `pnpm install --frozen-lockfile --ignore-scripts` followed by `pnpm exec
+# playwright install --with-deps chromium` — and the rule matches the second,
+# for the same reason and with the same answer as e6 above.
+#
+# Deliberately a second criterion rather than widening e6's resourceKey to
+# `.github/workflows/**`: the wildcard would also hide a REAL finding, an npm or
+# pnpm package install added to some third workflow without --ignore-scripts,
+# which is exactly what this rule is worth keeping for. Two named files cost one
+# more entry when a third workflow installs the browser; a wildcard costs the
+# rule. Sonar's resourceKey is one ant pattern, so naming both is the only way to
+# say "these two files" at all.
+sonar.issue.ignore.multicriteria.e12.ruleKey=githubactions:S6505
+sonar.issue.ignore.multicriteria.e12.resourceKey=.github/workflows/main-health.yml


### PR DESCRIPTION
## Purpose

`main-health` answered *"is main red right now"* for the backend gate, the
real-Postgres lane, the SPA lane and the SonarCloud publish — and never for the
screens.

That left out the one lane that can tell a broken **page** from a broken build.
The SPA lane is not a substitute: biome, tsc and vitest all pass on code that
compiles and never mounts, so a page that throws at runtime is green there. The
UAT is what drives the built app in a browser.

## Why it runs unconditionally here

On a pull request `uat` is gated on the change classifier — it runs only when the
diff touches `frontend/`. That is right there and wrong on the tip.

A classifier-gated UAT means a broken screen on `main` waits for whoever's pull
request happens to touch `frontend/` next, and then goes red on their unrelated
change. That is precisely the delay-and-attribution failure this workflow exists
to remove, left in place for a third of the product. So it runs against the tip
like every other lane here.

It `needs: [frontend]` for the same fail-fast reason `ci.yml` gives: no point
driving Playwright through a tree that does not typecheck or build.

## What it deliberately does not do

**It does not block `sonar`.** That job needs every coverage producer, and
Playwright is not one — gating the publish on this lane would freeze `main`'s
analysis behind something that measures nothing it reads. A frozen analysis reads
exactly like a current one, which is the failure `sonar`'s own comment is about.

## The reporter had to learn it too

`main-health` files one issue per broken lane, so a lane the reporter does not
know about fails **silently** — the run goes red and nobody is told which lane or
why. `scripts/scheduled-report.sh` gains the arm, with the reproduction line
(`make frontend-e2e`, plus the one-time `playwright install`).

`scripts/test-scheduled-report.sh` holds this by **census derived from the
reporter**, not by a list: every `MAIN_*_RESULT` arm owes both a with-range and a
no-range case. So the new arm was already required to carry its cases before this
could go green — I did not have to remember to add them, the gate did.

## Verification

- `make test-scheduled-report` — green, both new cases passing.
- Workflow parses; `uat` has no `if:` gate (the point), `working-directory: .`
  (this workflow defaults to `backend/`), and `report` depends on it.
- `make ci-doc-parity` green; `infra/ci-pipeline.md` updated with the lane and the
  reason it is unconditional.

`make check-backend` currently fails on this branch, and **not because of this
change** — it touches four files and no Go. The failures are
`TestOnlyOneSpellingOfALiveMember` and
`TestEveryUniquenessClaimNamesItsGateOrIsRegisteredDebt`, both in
`internal/compose/org360/workattention.go`, which arrived with #2625 on the tip.
Worth noting that `main-health` is the thing that would have said so.



Closes https://github.com/margince/margince/issues/2325 — the lane main-health
could not see is the lane it now runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated screen-acceptance checks to the main health workflow.
  * Added detailed reporting for UAT failures, including accessibility, responsive, reproduction, and suspected commit information.
* **Bug Fixes**
  * Improved scheduled health reports to create issues for failed UAT checks.
* **Documentation**
  * Clarified coverage sources and UAT behavior in CI documentation.
* **Tests**
  * Added coverage for UAT failure reporting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
