### PR TITLE
test(ci-tests): rebuild the dangling-citation gate, as a per-file ratchet

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -1,0 +1,244 @@
+# THE DANGLING-CITATION REGISTER — a record, not a permission.
+#
+# Every line is a file that cites a migration version no namespace carries, in
+# the form: <path> <namespace> <version>. A namespace of "migration" means the
+# citation named none, so it was checked against every namespace at once.
+#
+# The migrations these name were mostly deleted by the 2026-08 baseline
+# consolidation, and MOST of them still resolve through git history — so they are
+# stale prose rather than defects, and rewriting them mechanically would cost
+# more than it buys: a citation is usually the only thing in a sentence saying
+# where the reasoning lives. Two on this list named versions that never existed
+# on ANY ref, and were repaired in the change that added this file.
+#
+# What the register prevents is the backlog GROWING. A citation written today
+# against a version that never existed is a dead end from birth.
+#
+# Per FILE, not a total, and that is the point: a total let a deletion anywhere
+# fund a new dead citation elsewhere and net to green — STATUS.md alone carries
+# dozens and is edited at the end of every session.
+#
+# Line numbers are deliberately absent: editing a file above a citation is not a
+# new citation, and a register that churned on every edit would be ignored.
+#
+# TO FIX ONE: state the invariant so the sentence stands alone, or say the
+# migration is in git history rather than in the tree — then DELETE its line
+# here. The gate fails on a line whose citation is gone, so the register cannot
+# drift from the tree in either direction.
+#
+# TO REGENERATE: go test ./... -run TestEveryCitedMigrationExists -update-citations
+.github/workflows/_lane-integration.yml migration 0015
+Makefile core 0240
+README.md migration 0019
+backend/api/crm.yaml migration 0099
+backend/api/crm.yaml migration 0114
+backend/api/crm.yaml migration 0287
+backend/auditcoherence_test.go migration 0226
+backend/capturedbytyping_test.go migration 0262
+backend/internal/compose/accountdraft/input.go core 0203
+backend/internal/compose/agentgate_pin_test.go core 0063
+backend/internal/compose/agentgate_pin_test.go custom 20260730120000
+backend/internal/compose/agenttaskretention.go migration 0201
+backend/internal/compose/captureverdict_integration_test.go migration 0137
+backend/internal/compose/captureverdictnoise_integration_test.go migration 0137
+backend/internal/compose/channelprovider_migration_integration_test.go migration 0240
+backend/internal/compose/channelproviderfacts_test.go migration 0247
+backend/internal/compose/commsscheduled.go core 0260
+backend/internal/compose/datareset_integration_test.go migration 1787032690
+backend/internal/compose/datareset_integration_test.go migration 1787226902
+backend/internal/compose/datareset_integration_test.go migration 1787320000
+backend/internal/compose/datasweep.go core 0062
+backend/internal/compose/datasweep.go migration 0289
+backend/internal/compose/embedreindextransport.go migration 0115
+backend/internal/compose/erasurequotations_integration_test.go core 0244
+backend/internal/compose/extruntimetx.go core 0217
+backend/internal/compose/idempotencyretention.go migration 0033
+backend/internal/compose/integration/agentaccess/oauth_lend_integration_test.go migration 0172
+backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go migration 0121
+backend/internal/compose/integration/capture/capture_settings_integration_test.go migration 0121
+backend/internal/compose/integration/collections/segmentvocabulary_integration_test.go migration 0131
+backend/internal/compose/integration/dealreferences_integration_test.go migration 1787320003
+backend/internal/compose/integration/embedding_integration_test.go migration 0114
+backend/internal/compose/integration/embedreindex_integration_test.go migration 0115
+backend/internal/compose/integration/growthfit_e2e_integration_test.go migration 0194
+backend/internal/compose/integration/lastactivity_integration_test.go migration 1787032690
+backend/internal/compose/integration/lastactivity_integration_test.go migration 1787044474
+backend/internal/compose/integration/license_entitlement_integration_test.go core 0216
+backend/internal/compose/integration/offerstaged_integration_test.go core 0073
+backend/internal/compose/integration/project_integration_test.go migration 1787320003
+backend/internal/compose/integration/projectlastactivity_integration_test.go migration 1787320000
+backend/internal/compose/integration/queryjoinhop_integration_test.go core 0217
+backend/internal/compose/integration/recordhistoryclient_integration_test.go migration 1787109970
+backend/internal/compose/integration/scheduledsendagent_integration_test.go core 0260
+backend/internal/compose/integration/signalscan_integration_test.go migration 0047
+backend/internal/compose/org360/dismissal.go core 0225
+backend/internal/compose/org360/viewbaseline.go core 0225
+backend/internal/compose/orgbrief/service.go core 0225
+backend/internal/compose/orgdossier/evidence.go migration 0099
+backend/internal/compose/orgrollup_test.go core 0006
+backend/internal/compose/participantbackfilljob.go migration 0157
+backend/internal/compose/person360/handlers.go migration 0184
+backend/internal/compose/person360/sectionstimeline.go core 0225
+backend/internal/compose/personsearchdiscover.go migration 0097
+backend/internal/compose/serverassembly.go core 0235
+backend/internal/compose/signalscan.go migration 0047
+backend/internal/modules/activities/activitylinks.go migration 1787032690
+backend/internal/modules/activities/commitments.go core 0008
+backend/internal/modules/activities/lasttouch.go migration 1787032690
+backend/internal/modules/activities/lifecycle.go migration 1787320003
+backend/internal/modules/activities/participantbackfill.go migration 0157
+backend/internal/modules/activities/scheduledsendfire.go core 0217
+backend/internal/modules/activities/scheduledsendfire.go core 0242
+backend/internal/modules/activities/scheduledsendprovenance.go core 0260
+backend/internal/modules/activities/threadwire_integration_test.go migration 0093
+backend/internal/modules/agents/tools_comms_test.go core 0251
+backend/internal/modules/ai/callstats.go migration 0088
+backend/internal/modules/automation/automations_catalog.go core 0035
+backend/internal/modules/automation/automations_catalog.go core 0078
+backend/internal/modules/automation/automations_runs.go migration 0061
+backend/internal/modules/automation/automations_runs_test.go migration 0061
+backend/internal/modules/automation/catalog_actions.go core 0008
+backend/internal/modules/automation/engine_blocked.go migration 0061
+backend/internal/modules/automation/gate.go migration 0061
+backend/internal/modules/automation/rundetail.go migration 0079
+backend/internal/modules/capture/backfillyields.go core 0217
+backend/internal/modules/capture/channelsend.go core 0217
+backend/internal/modules/capture/pending.go migration 0222
+backend/internal/modules/capture/pendingsweeps.go migration 0137
+backend/internal/modules/capture/projectkeytoken.go migration 0131
+backend/internal/modules/capture/sink.go migration 0137
+backend/internal/modules/collections/vocab_test.go migration 0228
+backend/internal/modules/comms/store_test.go core 0136
+backend/internal/modules/consent/preference.go core 0217
+backend/internal/modules/customfields/candidates_integration_test.go core 0009
+backend/internal/modules/customfields/engine.go core 0063
+backend/internal/modules/customfields/engine.go core 0171
+backend/internal/modules/customfields/fieldobjects_test.go core 0171
+backend/internal/modules/customfields/service.go core 0063
+backend/internal/modules/deals/offer.go core 0217
+backend/internal/modules/identity/roles.go migration 0211
+backend/internal/modules/identity/service.go migration 0268
+backend/internal/modules/overlay/freshness_integration_test.go core 0217
+backend/internal/modules/overlay/teardown.go core 0012
+backend/internal/modules/overlay/teardown_integration_test.go core 0012
+backend/internal/modules/people/emailsignature.go core 0235
+backend/internal/modules/people/geocode.go migration 0217
+backend/internal/modules/people/merge_organization.go migration 1787320003
+backend/internal/modules/people/organization_computed.go core 0217
+backend/internal/modules/people/organization_fact_read.go migration 0099
+backend/internal/modules/people/organizationarchive.go migration 0083
+backend/internal/modules/people/organizationlinkedin_test.go migration 0191
+backend/internal/modules/people/organizationlogo.go core 0217
+backend/internal/modules/people/relationshiperrors.go migration 0007
+backend/internal/modules/people/relationshiperrors.go migration 1787111736
+backend/internal/modules/people/sitereadfinish.go migration 0221
+backend/internal/modules/privacy/erasure_approvals.go core 0244
+backend/internal/modules/privacy/recordhistory.go migration 0287
+backend/internal/modules/privacy/recordhistory.go migration 1787109970
+backend/internal/modules/privacy/retentionpolicystore.go core 0217
+backend/internal/modules/privacy/retentionrestricted.go migration 0291
+backend/internal/modules/privacy/subjectcolumns.go core 0229
+backend/internal/modules/privacy/transcriptreadings.go core 0245
+backend/internal/modules/quotas/attainment.go core 0217
+backend/internal/modules/quotas/quotas.go core 0228
+backend/internal/modules/search/binding.go migration 0114
+backend/internal/modules/search/graph.go core 0038
+backend/internal/modules/search/graphactivity.go core 0038
+backend/internal/modules/search/pending.go migration 0114
+backend/internal/modules/search/queryjoins.go core 0007
+backend/internal/modules/search/queryjoins.go core 0008
+backend/internal/modules/search/queryjoins.go core 0195
+backend/internal/modules/search/queryjoins.go core 0217
+backend/internal/modules/search/queryjoins_test.go core 0007
+backend/internal/modules/search/queryjoins_test.go core 0008
+backend/internal/modules/search/queryjoins_test.go core 0195
+backend/internal/modules/search/querysql_test.go core 0007
+backend/internal/modules/search/querystorage.go migration 0051
+backend/internal/modules/search/store.go migration 0077
+backend/internal/modules/signals/audiencerescope.go migration 0208
+backend/internal/platform/auth/auditgrant_test.go migration 0133
+backend/internal/platform/auth/auditgrant_test.go migration 0287
+backend/internal/platform/auth/captureprivacy_test.go migration 0095
+backend/internal/platform/auth/captureprivacy_test.go migration 1787320003
+backend/internal/platform/auth/rowscope.go migration 0095
+backend/internal/platform/auth/rowscope.go migration 1787320003
+backend/internal/platform/auth/tableclass_test.go migration 1787320003
+backend/internal/platform/database/database.go core 0217
+backend/internal/platform/database/db.go core 0217
+backend/internal/platform/database/storekit/suppression.go core 0217
+backend/internal/platform/database/storekit/suppression.go core 0255
+backend/internal/platform/dbmigrate/dbmigrate_test.go core 0002
+backend/internal/platform/events/bus_integration_test.go core 0015
+backend/internal/platform/events/relay.go migration 0016
+backend/internal/platform/httperr/constraintfault.go migration 0289
+backend/internal/platform/jobs/jobs_integration_test.go core 0015
+backend/internal/platform/testdb/reset.go migration 0240
+backend/internal/platform/testdb/reset_integration_test.go migration 0240
+backend/internal/shared/kernel/pipelinetrace/registry.go migration 0258
+backend/internal/shared/ports/datasource/datasource.go core 0171
+backend/internal/shared/ports/extraction/extraction.go core 0252
+backend/migrations/schema_fitness_integration_test.go core 1787047322
+backend/piicoverage_test.go core 0245
+backend/rbacgate_test.go core 0217
+backend/rlsclaims_test.go core 0217
+backend/rlsclaims_test.go migration 0217
+backend/tableownership_test.go core 0245
+backend/tableownership_test.go migration 0219
+backend/tools/extmigrategate/role.go core 0213
+backend/tools/extmigrategate/role.go migration 0206
+backend/tools/gen-composition/extmigrations.go core 0213
+backend/tools/seed-demo/apiclient.go migration 0273
+backend/tools/seed-demo/comms.go migration 0282
+desktop/build/build-postgres.sh core 0032
+desktop/build/build-postgres.sh core 0052
+docs/deployment.md migration 0015
+docs/explanation/ai-runtime.md migration 0088
+docs/explanation/ai-runtime.md migration 0100
+docs/explanation/ai-runtime.md migration 0102
+docs/explanation/ai-runtime.md migration 0105
+docs/explanation/company-context.md migration 0102
+docs/explanation/company-context.md migration 0103
+docs/explanation/company-context.md migration 0105
+docs/explanation/custom-fields.md core 0063
+docs/explanation/desktop-distribution.md core 0022
+docs/explanation/desktop-distribution.md core 0032
+docs/explanation/desktop-distribution.md core 0052
+docs/explanation/ingress-gate-and-auto-capture.md core 0269
+docs/explanation/outbound-messaging.md migration 0155
+docs/explanation/outbound-webhooks.md core 0113
+docs/explanation/rbac-roles-and-teams.md core 0002
+docs/explanation/relationship-graph.md core 0157
+docs/explanation/relationship-graph.md migration 0158
+docs/explanation/search-and-retrieval.md migration 0004
+docs/explanation/search-and-retrieval.md migration 0022
+docs/explanation/search-and-retrieval.md migration 0052
+docs/explanation/search-and-retrieval.md migration 0077
+docs/explanation/search-and-retrieval.md migration 0114
+docs/explanation/write-backbone.md core 0012
+docs/explanation/write-backbone.md core 0013
+docs/explanation/write-backbone.md core 0015
+docs/how-to/add-an-extension.md migration 0003
+docs/how-to/apply-migrations.md core 0240
+docs/how-to/connect-telegram.md core 0251
+docs/how-to/connect-telegram.md core 0282
+docs/reference/make-targets.md core 0240
+extensions/notes/migrations/0001_note.up.sql core 0213
+frontend/e2e/leads.spec.ts migration 0038
+frontend/e2e/seed.ts migration 0042
+frontend/src/design-system/recordtimeline.ts migration 0038
+frontend/src/screens/companyevidence.stories.tsx migration 0099
+frontend/src/screens/companyrail.test.tsx core 0019
+frontend/src/screens/companyraildetails.tsx core 0203
+frontend/src/screens/embedreindex.stories.tsx migration 0115
+frontend/src/screens/embedreindex.test.tsx migration 0115
+frontend/src/screens/embedreindex.tsx migration 0115
+frontend/src/screens/persondrawers.tsx migration 0188
+frontend/src/screens/relationships.test.tsx migration 0007
+frontend/src/screens/relationships.tsx migration 0007
+frontend/src/screens/settings-nav.test.tsx migration 0261
+scripts/check-rls-store-path.sh core 0217
+scripts/deploy/db-bootstrap.sql migration 0015
+scripts/lib-testdb.sh migration 0015
+scripts/test-migration-versions.sh core 0002
+scripts/test-migration-versions.sh core 0003
+scripts/test-migration-versions.sh core 1799999999

--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -5,31 +5,40 @@
 # citation named none, so it was checked against every namespace at once.
 #
 # The migrations these name were mostly deleted by the 2026-08 baseline
-# consolidation, and MOST of them still resolve through git history — so they are
-# stale prose rather than defects, and rewriting them mechanically would cost
-# more than it buys: a citation is usually the only thing in a sentence saying
-# where the reasoning lives. Two on this list named versions that never existed
-# on ANY ref, and were repaired in the change that added this file.
+# consolidation, and most still resolve through git history — so they are stale
+# prose rather than defects, and rewriting them mechanically would cost more
+# than it buys: a citation is usually the only thing in a sentence saying where
+# the reasoning lives.
 #
-# What the register prevents is the backlog GROWING. A citation written today
-# against a version that never existed is a dead end from birth.
+# What this holds is narrower than "the backlog cannot grow", and the difference
+# matters: a file acquires no citation of a version it does not ALREADY cite. A
+# second citation of a version already listed for that file is invisible.
 #
-# Per FILE, not a total, and that is the point: a total let a deletion anywhere
-# fund a new dead citation elsewhere and net to green — STATUS.md alone carries
-# dozens and is edited at the end of every session.
+# Per FILE rather than a total, because a total lets a deletion anywhere fund a
+# new dead citation elsewhere: the two net and the gate reports green over a
+# tree that got worse.
 #
 # Line numbers are deliberately absent: editing a file above a citation is not a
 # new citation, and a register that churned on every edit would be ignored.
 #
-# TO FIX ONE: state the invariant so the sentence stands alone, or say the
-# migration is in git history rather than in the tree — then DELETE its line
-# here. The gate fails on a line whose citation is gone, so the register cannot
-# drift from the tree in either direction.
+# A test harness that WRITES fixture migration paths lands here too — the string
+# is citation-shaped and this gate cannot tell it from prose. Those entries are
+# noise rather than debt, and they are left in rather than skipped by name: a
+# skip-list in front of a census is the thing that makes one quietly go short.
 #
-# TO REGENERATE: go test ./... -run TestEveryCitedMigrationExists -update-citations
+# TO FIX ONE: state the invariant so the sentence stands alone, or say the
+# migration is in git history rather than in the tree — then prune the line.
+#
+# TO PRUNE, from backend/:
+#   go test . -run TestEveryCitedMigrationExists -update-citations
+#
+# That command only REMOVES entries. Adding one is a hand edit on purpose:
+# regenerating to absorb a citation you just wrote is not a fix, and the added
+# line has to be one a reviewer agreed to.
 .github/workflows/_lane-integration.yml migration 0015
 Makefile core 0240
 README.md migration 0019
+backend/api/crm.yaml core 0131
 backend/api/crm.yaml migration 0099
 backend/api/crm.yaml migration 0114
 backend/api/crm.yaml migration 0287
@@ -42,6 +51,7 @@ backend/internal/compose/agenttaskretention.go migration 0201
 backend/internal/compose/captureverdict_integration_test.go migration 0137
 backend/internal/compose/captureverdictnoise_integration_test.go migration 0137
 backend/internal/compose/channelprovider_migration_integration_test.go migration 0240
+backend/internal/compose/channelproviderfacts.go migration 0247
 backend/internal/compose/channelproviderfacts_test.go migration 0247
 backend/internal/compose/commsscheduled.go core 0260
 backend/internal/compose/datareset_integration_test.go migration 1787032690
@@ -53,6 +63,7 @@ backend/internal/compose/embedreindextransport.go migration 0115
 backend/internal/compose/erasurequotations_integration_test.go core 0244
 backend/internal/compose/extruntimetx.go core 0217
 backend/internal/compose/idempotencyretention.go migration 0033
+backend/internal/compose/integration/activitycontext_integration_test.go core 0038
 backend/internal/compose/integration/agentaccess/oauth_lend_integration_test.go migration 0172
 backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go migration 0121
 backend/internal/compose/integration/capture/capture_settings_integration_test.go migration 0121
@@ -75,6 +86,7 @@ backend/internal/compose/org360/dismissal.go core 0225
 backend/internal/compose/org360/viewbaseline.go core 0225
 backend/internal/compose/orgbrief/service.go core 0225
 backend/internal/compose/orgdossier/evidence.go migration 0099
+backend/internal/compose/orgdossier/growthfit.go migration 0194
 backend/internal/compose/orgrollup_test.go core 0006
 backend/internal/compose/participantbackfilljob.go migration 0157
 backend/internal/compose/person360/handlers.go migration 0184
@@ -87,6 +99,7 @@ backend/internal/modules/activities/commitments.go core 0008
 backend/internal/modules/activities/lasttouch.go migration 1787032690
 backend/internal/modules/activities/lifecycle.go migration 1787320003
 backend/internal/modules/activities/participantbackfill.go migration 0157
+backend/internal/modules/activities/relinkbatch.go migration 0008
 backend/internal/modules/activities/scheduledsendfire.go core 0217
 backend/internal/modules/activities/scheduledsendfire.go core 0242
 backend/internal/modules/activities/scheduledsendprovenance.go core 0260
@@ -101,12 +114,15 @@ backend/internal/modules/automation/catalog_actions.go core 0008
 backend/internal/modules/automation/engine_blocked.go migration 0061
 backend/internal/modules/automation/gate.go migration 0061
 backend/internal/modules/automation/rundetail.go migration 0079
+backend/internal/modules/automation/rundetail_test.go migration 0077
 backend/internal/modules/capture/backfillyields.go core 0217
+backend/internal/modules/capture/channelconn.go migration 0151
 backend/internal/modules/capture/channelsend.go core 0217
 backend/internal/modules/capture/pending.go migration 0222
 backend/internal/modules/capture/pendingsweeps.go migration 0137
 backend/internal/modules/capture/projectkeytoken.go migration 0131
 backend/internal/modules/capture/sink.go migration 0137
+backend/internal/modules/collections/vocab.go core 0217
 backend/internal/modules/collections/vocab_test.go migration 0228
 backend/internal/modules/comms/store_test.go core 0136
 backend/internal/modules/consent/preference.go core 0217
@@ -116,6 +132,8 @@ backend/internal/modules/customfields/engine.go core 0171
 backend/internal/modules/customfields/fieldobjects_test.go core 0171
 backend/internal/modules/customfields/service.go core 0063
 backend/internal/modules/deals/offer.go core 0217
+backend/internal/modules/identity/internal/policy/policy.go migration 0068
+backend/internal/modules/identity/oauth_lend.go migration 0172
 backend/internal/modules/identity/roles.go migration 0211
 backend/internal/modules/identity/service.go migration 0268
 backend/internal/modules/overlay/freshness_integration_test.go core 0217
@@ -144,15 +162,21 @@ backend/internal/modules/quotas/quotas.go core 0228
 backend/internal/modules/search/binding.go migration 0114
 backend/internal/modules/search/graph.go core 0038
 backend/internal/modules/search/graphactivity.go core 0038
+backend/internal/modules/search/graphactivity.go migration 0157
 backend/internal/modules/search/pending.go migration 0114
 backend/internal/modules/search/queryjoins.go core 0007
 backend/internal/modules/search/queryjoins.go core 0008
+backend/internal/modules/search/queryjoins.go core 0038
+backend/internal/modules/search/queryjoins.go core 0131
 backend/internal/modules/search/queryjoins.go core 0195
 backend/internal/modules/search/queryjoins.go core 0217
 backend/internal/modules/search/queryjoins_test.go core 0007
 backend/internal/modules/search/queryjoins_test.go core 0008
+backend/internal/modules/search/queryjoins_test.go core 0038
+backend/internal/modules/search/queryjoins_test.go core 0131
 backend/internal/modules/search/queryjoins_test.go core 0195
 backend/internal/modules/search/querysql_test.go core 0007
+backend/internal/modules/search/querysql_test.go core 0131
 backend/internal/modules/search/querystorage.go migration 0051
 backend/internal/modules/search/store.go migration 0077
 backend/internal/modules/signals/audiencerescope.go migration 0208
@@ -172,12 +196,15 @@ backend/internal/platform/events/bus_integration_test.go core 0015
 backend/internal/platform/events/relay.go migration 0016
 backend/internal/platform/httperr/constraintfault.go migration 0289
 backend/internal/platform/jobs/jobs_integration_test.go core 0015
+backend/internal/platform/jobs/migrate.go migration 0015
 backend/internal/platform/testdb/reset.go migration 0240
 backend/internal/platform/testdb/reset_integration_test.go migration 0240
 backend/internal/shared/kernel/pipelinetrace/registry.go migration 0258
 backend/internal/shared/ports/datasource/datasource.go core 0171
 backend/internal/shared/ports/extraction/extraction.go core 0252
 backend/migrations/schema_fitness_integration_test.go core 1787047322
+backend/migrations/schema_integration_test.go migration 0213
+backend/piicoverage_test.go core 0244
 backend/piicoverage_test.go core 0245
 backend/rbacgate_test.go core 0217
 backend/rlsclaims_test.go core 0217
@@ -187,11 +214,14 @@ backend/tableownership_test.go migration 0219
 backend/tools/extmigrategate/role.go core 0213
 backend/tools/extmigrategate/role.go migration 0206
 backend/tools/gen-composition/extmigrations.go core 0213
+backend/tools/gen-composition/scan_test.go migration 0002
 backend/tools/seed-demo/apiclient.go migration 0273
 backend/tools/seed-demo/comms.go migration 0282
 desktop/build/build-postgres.sh core 0032
 desktop/build/build-postgres.sh core 0052
 docs/deployment.md migration 0015
+docs/evidence/extension-tier/DESIGN.md migration 0014
+docs/evidence/extension-tier/DESIGN.md migration 0213
 docs/explanation/ai-runtime.md migration 0088
 docs/explanation/ai-runtime.md migration 0100
 docs/explanation/ai-runtime.md migration 0102
@@ -200,6 +230,7 @@ docs/explanation/company-context.md migration 0102
 docs/explanation/company-context.md migration 0103
 docs/explanation/company-context.md migration 0105
 docs/explanation/custom-fields.md core 0063
+docs/explanation/custom-fields.md migration 0064
 docs/explanation/desktop-distribution.md core 0022
 docs/explanation/desktop-distribution.md core 0032
 docs/explanation/desktop-distribution.md core 0052
@@ -208,6 +239,7 @@ docs/explanation/outbound-messaging.md migration 0155
 docs/explanation/outbound-webhooks.md core 0113
 docs/explanation/rbac-roles-and-teams.md core 0002
 docs/explanation/relationship-graph.md core 0157
+docs/explanation/relationship-graph.md migration 0157
 docs/explanation/relationship-graph.md migration 0158
 docs/explanation/search-and-retrieval.md migration 0004
 docs/explanation/search-and-retrieval.md migration 0022
@@ -218,11 +250,15 @@ docs/explanation/write-backbone.md core 0012
 docs/explanation/write-backbone.md core 0013
 docs/explanation/write-backbone.md core 0015
 docs/how-to/add-an-extension.md migration 0003
+docs/how-to/add-an-rbac-object.md migration 0183
 docs/how-to/apply-migrations.md core 0240
 docs/how-to/connect-telegram.md core 0251
 docs/how-to/connect-telegram.md core 0282
 docs/reference/make-targets.md core 0240
 extensions/notes/migrations/0001_note.up.sql core 0213
+extensions/notes/notes_test.go migration 0002
+extensions/notes/notes_test.go migration 0003
+extensions/notes/notes_test.go migration 0004
 frontend/e2e/leads.spec.ts migration 0038
 frontend/e2e/seed.ts migration 0042
 frontend/src/design-system/recordtimeline.ts migration 0038
@@ -232,6 +268,7 @@ frontend/src/screens/companyraildetails.tsx core 0203
 frontend/src/screens/embedreindex.stories.tsx migration 0115
 frontend/src/screens/embedreindex.test.tsx migration 0115
 frontend/src/screens/embedreindex.tsx migration 0115
+frontend/src/screens/leads.tsx migration 0038
 frontend/src/screens/persondrawers.tsx migration 0188
 frontend/src/screens/relationships.test.tsx migration 0007
 frontend/src/screens/relationships.tsx migration 0007

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -256,7 +256,7 @@ func auditLinkedInMatch(ctx context.Context, tx pgx.Tx, connectionID, personID i
 // one belongs to the member, and stamping it on every contact they confirm
 // would put the wrong person's address on the record.
 //
-// A connection imported before migration 0161 has no URL and writes nothing.
+// A connection imported before the URL column existed has no URL and writes nothing.
 // The confirmation still stands; only the copy is unavailable, and the caller
 // is told so rather than left to wonder.
 //

--- a/backend/internal/modules/people/listpage.go
+++ b/backend/internal/modules/people/listpage.go
@@ -190,7 +190,7 @@ func capturedByKindClause(kind *string, arg func(any) int) (string, bool, error)
 
 // agentPrefix matches the captured_by grammar's AI namespace. Shared by every
 // predicate below so "which prefix counts as an AI" has one answer, and it is
-// the same one the partial indexes are built on — a mismatch
+// the same one the partial indexes on captured_by are built on — a mismatch
 // there silently costs the index rather than the result.
 const agentPrefix = "agent:" + likeWildcard
 

--- a/backend/internal/modules/people/listpage.go
+++ b/backend/internal/modules/people/listpage.go
@@ -190,7 +190,7 @@ func capturedByKindClause(kind *string, arg func(any) int) (string, bool, error)
 
 // agentPrefix matches the captured_by grammar's AI namespace. Shared by every
 // predicate below so "which prefix counts as an AI" has one answer, and it is
-// the same one the partial indexes in migration 0138 are built on — a mismatch
+// the same one the partial indexes are built on — a mismatch
 // there silently costs the index rather than the result.
 const agentPrefix = "agent:" + likeWildcard
 

--- a/backend/migrationcitations_test.go
+++ b/backend/migrationcitations_test.go
@@ -9,29 +9,39 @@ package backendarch
 
 // A comment that cites a migration by number must cite one that exists.
 //
-// The citations do real work: `core 0217 retired row-level security` tells a
-// reader WHERE to go and see why a per-statement predicate replaced a policy.
-// The baseline consolidation deleted those files and the references survived it,
-// each one now sending a reader to look for something that is not there — which
-// is worse than no citation at all, because it reads like a lead.
+// The citations do real work: `custom/20260716120000 is the fork-owned seam`
+// tells a reader WHERE to go and see why. When the file behind a citation is
+// gone, the reference sends a reader looking for something that is not there,
+// which is worse than no citation at all because it reads like a lead.
+//
+// WHAT THIS DETECTOR CANNOT SEE, first, because an H1 gate over prose always
+// leaks and one that hides its leaks is worse than none:
+//
+//   - a citation split across MORE than two lines;
+//   - a separator this does not know (`core-0217`), or a version zero-padded
+//     past the widths the tree uses (`core 00217`);
+//   - a number reached by prose alone — "the migration after 0007";
+//   - a citation on a line that is not valid UTF-8.
+//
+// Those are gaps, not decisions, and the detector test below plants each one as
+// a `want: nil` row so widening the pattern is a one-line flip rather than an
+// archaeology exercise. The sibling detector states its own limits the same way
+// (uniquenessclaimsdetector_test.go).
 //
 // WHY A GATE AND NOT A SWEEP. The sweep is the easy half and it rots: the next
-// consolidation, or any renumber, breaks every citation written since. This
-// derives the answer from the tree instead — the versions the namespaces
-// actually carry — so it is correct the day a namespace changes rather than the
-// day somebody remembers to look.
+// consolidation, or any renumber, breaks every citation written since. The
+// answer is derived from the tree — the versions the namespaces actually carry
+// — so it is correct the day a namespace changes rather than the day somebody
+// remembers to look.
 //
 // A RATCHET, NOT A COUNT. The backlog is recorded per file in
-// danglingcitations.txt and diffed, so a failure NAMES the citation that arrived
-// rather than reporting a number and asking the author to find their own. A
-// single total was the first shape this gate had, and it had a hole worth
-// stating: STATUS.md alone carries dozens of these and is edited at the end of
-// every session, so deleting a citation there funded a new dead one anywhere
-// else and the total netted to green.
+// danglingcitations.txt and diffed, so a failure NAMES the citation that
+// arrived. A count also lets a deletion anywhere fund an addition elsewhere:
+// the two net, and the gate reports green over a tree that got worse.
 //
 // WHAT A FIX LOOKS LIKE is not "delete the number". CLAUDE.md rule 4 says state
 // the invariant so it stands alone, and that is it: the sentence keeps its claim
-// and loses the pointer, or says explicitly that the migration is in history
+// and loses the pointer, or says explicitly that the migration is in git history
 // rather than in the tree.
 
 import (
@@ -47,99 +57,113 @@ import (
 	"unicode/utf8"
 )
 
-// citation matches the shapes this tree uses to name a migration: `core 0217`,
-// `core/0063`, `migration 0099`, `migration ` + "`0105`" + `,
-// `custom/20260716120000`, and the FILENAME form `core/0012_audit_log.up.sql`.
-//
-// Three widths, because the tree uses three: the closed four-digit range, the
-// ten-digit unix-second stamps every current core migration carries, and
-// custom's fourteen-digit stamps. Excluding ten was this gate's first blind spot
-// — "the format is current" is not "the citation resolves", and ten-digit
-// migrations are deleted and renumbered like any other.
-//
-// The version ends at `_` OR a word boundary, which is the second blind spot and
-// was the larger one: `_` is an ASCII word character, so a trailing \b never
-// matched the filename form at all — the most natural way to cite a migration,
-// and 88 of them in the tree when this was measured.
-//
-// The namespace is CAPTURED, not discarded: `core 0001` must be checked against
-// CORE's versions. Merged into one set it passed because custom happens to carry
-// a 0001 too, which is a false negative in the case a citation is most specific
-// about.
-var citation = regexp.MustCompile(
-	"(?i)\\b(core|custom|migration)s?[ /`]+([0-9]{4}|[0-9]{10}|[0-9]{14})(?:_|\\b)")
+var (
+	// namespacedCitation matches a namespace word followed by a version:
+	// `core 0217`, `core/0063`, `migration 0099`, `custom/20260716120000`, and
+	// the filename form `core/0012_audit_log.up.sql`.
+	//
+	// Three widths, because the tree uses three: the closed four-digit range
+	// (core/0001_baseline is still one), the ten-digit unix-second stamps most
+	// current migrations carry, and custom's fourteen-digit stamps.
+	//
+	// The version ends at `_` OR a word boundary. `_` is an ASCII word
+	// character, so a trailing \b alone never matches the filename form.
+	//
+	// The namespace is CAPTURED, not discarded: `core 0001` must be checked
+	// against CORE's versions. Merged into one set it passes because custom
+	// carries a 0001 too, which is a false negative in the case a citation is
+	// most specific about.
+	namespacedCitation = regexp.MustCompile(
+		"(?i)\\b(core|custom|migration)s?[ /`]+([0-9]{4}|[0-9]{10}|[0-9]{14})(?:_|\\b)")
 
-// migrationsRoot holds the namespace directories, relative to this package.
-const migrationsRoot = "migrations"
+	// listedVersion consumes the SECOND and later versions of a list written
+	// under one namespace word — `core 0007, 0131` and `core 0008/0038`. Only
+	// the version adjacent to the namespace matches the pattern above, so a list
+	// otherwise hid every version but its first.
+	listedVersion = regexp.MustCompile("^[\\s,+/&–-]+`?([0-9]{4}|[0-9]{10}|[0-9]{14})`?(?:_|\\b)")
 
-// citationRegisterPath records the citations this tree carries today, one per line.
-const citationRegisterPath = "danglingcitations.txt"
+	// bareFilename matches a migration filename with no namespace word in front
+	// of it, which is how a file's own header usually names one.
+	bareFilename = regexp.MustCompile(
+		`\b([0-9]{4}|[0-9]{10}|[0-9]{14})_[a-z0-9_]+\.(?:up|down)\.sql\b`)
 
-// generatedByGen reports a file `make gen` writes. A citation inside one is a
-// citation in the SOURCE it was rendered from, and that source is scanned —
-// reporting both would send somebody to fix the copy gen overwrites.
+	// commentContinuation is the prefix a wrapped comment line carries.
+	// Stripping it is what lets a citation split across two lines be seen: this
+	// tree wraps at about 78 columns, so a namespace word and its version land
+	// on different lines routinely.
+	commentContinuation = regexp.MustCompile(`^\s*(?://+|#+|--+|\*+)?\s*`)
+
+	// embedLine finds the namespaces the product actually embeds.
+	embedLine = regexp.MustCompile(`(?m)^//go:embed\s+(.+)$`)
+)
+
+const (
+	// migrationsRoot holds the namespace directories, relative to this package.
+	migrationsRoot = "migrations"
+
+	// namespaceOwner declares which of them are real. The embed line is the
+	// product's own answer, and reading it as TEXT is deliberate: .go-arch-lint
+	// refuses `root -> migrations`, but nothing refuses reading the file.
+	//
+	// Not the directory listing. Any directory that happened to sit under
+	// migrations/ — a scratch copy, an unpacked dump — otherwise became a
+	// namespace and its versions became "known", which silently converts real
+	// dangling citations into passing ones with no failing assertion.
+	namespaceOwner = "migrations/migrations.go"
+
+	// citationRegisterPath records the citations this tree carries today.
+	citationRegisterPath = "danglingcitations.txt"
+
+	// scannedFloor is far below the tree's real file count, so it catches a
+	// census that read almost nothing rather than a tree that grew or shrank.
+	scannedFloor = 1000
+)
+
+// updateCitationRegister PRUNES the register; it never adds.
 //
-// The frontend artifacts are here for that reason: schema.d.ts is rendered from
-// api/crm.yaml, which this gate reads.
-func generatedByGen(rel string) bool {
-	switch {
-	case strings.HasSuffix(rel, "_gen.go"),
-		strings.HasSuffix(rel, ".generated.json"),
-		strings.HasPrefix(rel, "backend/internal/contracts/"),
-		rel == "frontend/src/api/schema.d.ts",
-		rel == "frontend/src/api/public-events.ts":
-		return true
-	}
-	return false
-}
-
-// updateCitationRegister rewrites the register from the tree, the same way
-// identity's matrix fixture and the head catalog are regenerated. Without it the
-// only way to record a legitimate new entry is to hand-copy a line out of a
-// failure message, which is how a register acquires a typo nobody can see.
+// One-way on purpose. A regeneration that absorbed whatever it found would turn
+// the sanctioned command into the way a new dead-end citation is laundered
+// green, leaving added lines in a long file as the only signal. Removing an
+// entry cannot hide anything, so that half is safe to automate; adding one is a
+// judgement somebody has to make by hand, which is the friction the register
+// exists to carry.
 var updateCitationRegister = flag.Bool("update-citations", false,
-	"rewrite danglingcitations.txt from the tree")
+	"prune danglingcitations.txt of entries the tree no longer has")
 
 func TestEveryCitedMigrationExists(t *testing.T) {
 	known := knownMigrationVersions(t)
-	// A namespace that failed to load would leave `known` empty and every
-	// citation below would read as dangling — hundreds of failures pointing at
-	// the wrong cause.
-	if len(known) == 0 {
-		t.Fatal("no migration versions could be read from the namespace directories, so every " +
-			"citation would report as dangling — fix the loader, not the citations")
+	found, scanned, skipped := scanTreeForCitations(t, known)
+	// A census that read a fraction of the tree must not report the same word
+	// for it. Under a sparse checkout every skip-worktree file vanishes with no
+	// signal.
+	if scanned < scannedFloor {
+		t.Fatalf("only %d file(s) were read (%d skipped) — this census covered almost nothing, "+
+			"which reports PASS while checking a fraction of the tree", scanned, skipped)
 	}
 
-	found := scanTreeForCitations(t, known)
-	if *updateCitationRegister {
-		writeCitationRegister(t, found)
-		return
-	}
-	recorded := readCitationRegister(t)
-
-	var arrived []string
-	for _, c := range found {
-		if !recorded[c.key()] {
-			arrived = append(arrived, c.String())
-		}
-	}
-	// NAMED, not counted. The whole reason for a per-file register is that the
-	// author of a new dead-end learns which line is theirs.
-	for _, a := range arrived {
-		t.Errorf("new dangling migration citation:\n  %s\n"+
-			"A citation written now against a version that never existed is a dead end from "+
-			"birth. State the invariant instead, or say the migration is in git history rather "+
-			"than in the tree. If it is genuinely unavoidable, add the line to %s in this change.",
-			a, citationRegisterPath)
-	}
-
-	// The other direction: a register line whose citation is gone. Left in, the
-	// register stops describing the tree and quietly licenses a re-addition at
-	// the same spot.
+	recorded := readCitationRegister(t, citationRegisterPath)
 	present := map[string]bool{}
 	for _, c := range found {
 		present[c.key()] = true
 	}
+
+	if *updateCitationRegister {
+		pruneCitationRegister(t, recorded, present)
+		return
+	}
+
+	for _, c := range found {
+		if recorded[c.key()] {
+			continue
+		}
+		t.Errorf("new dangling migration citation:\n  %s\n"+
+			"A citation written now against a version that never existed is a dead end from "+
+			"birth. State the invariant instead, or say the migration is in git history rather "+
+			"than in the tree.\nIf it is genuinely unavoidable, add the line to %s BY HAND — "+
+			"`-update-citations` only prunes, because a command that absorbed new citations "+
+			"would be how a dead end gets laundered green.", c, citationRegisterPath)
+	}
+
 	var stale []string
 	for key := range recorded {
 		if !present[key] {
@@ -149,8 +173,83 @@ func TestEveryCitedMigrationExists(t *testing.T) {
 	sort.Strings(stale)
 	for _, s := range stale {
 		t.Errorf("%s records %q, which is no longer a dangling citation — thank you.\n"+
-			"Delete that line in this change, so the register keeps describing the tree.",
-			citationRegisterPath, s)
+			"Run `go test . -run TestEveryCitedMigrationExists -update-citations` from backend/ "+
+			"to prune it, so the register keeps describing the tree.", citationRegisterPath, s)
+	}
+}
+
+// TestTheCitationDetectorSeesWhatItClaims pins the detector's reach, including
+// the shapes it is known NOT to reach.
+//
+// The register is no substitute for this: it protects a width or a terminator
+// only where a (file, version) pair has no OTHER citation propping it up, so a
+// silently narrowed pattern can look green for a long time. The `nil` rows are
+// the honest half — each is a real shape this gate cannot see, and flipping one
+// is how a future widening announces itself.
+func TestTheCitationDetectorSeesWhatItClaims(t *testing.T) {
+	known := map[string]map[string]bool{
+		"core":   {"0001": true, "1787320004": true},
+		"custom": {"20260716120000": true},
+	}
+	for _, tc := range []struct {
+		name string
+		text string
+		want []string
+	}{
+		{"namespace and space", "core 0217 retired it", []string{"0217"}},
+		{"namespace and slash", "see core/0063 for why", []string{"0063"}},
+		{"unqualified", "migration 0099 added it", []string{"0099"}},
+		{"backticked", "migration `0105` did", []string{"0105"}},
+		{"filename form", "migrations/core/0012_audit_log.up.sql", []string{"0012"}},
+		{"bare filename, no namespace word", "0008_activity.up.sql is where", []string{"0008"}},
+		{"fourteen digits", "custom/20260101000000 seeded", []string{"20260101000000"}},
+		{"ten digits", "core 1799999999 did", []string{"1799999999"}},
+		{"a version that EXISTS is not reported", "core 0001 is the baseline", nil},
+		{"a custom version cited as core", "core/20260716120000", []string{"20260716120000"}},
+		{"list, comma", "(core 0007, 0131)", []string{"0007", "0131"}},
+		{"list, slash", "core 0007/0131", []string{"0007", "0131"}},
+		{"wrapped across two lines", "see core\n// 0217 (ADR-0091)", []string{"0217"}},
+
+		// KNOWN GAPS. Each is a real shape in the wild that this detector does
+		// not reach; the rows exist so widening it is a one-line flip.
+		{"GAP: split across three lines", "see core\n//\n// 0217", nil},
+		{"GAP: hyphen separator", "core-0217 did it", nil},
+		{"GAP: zero-padded past the widths", "core 00217", nil},
+		{"GAP: reached by prose", "the migration after 0007", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			for _, c := range danglingCitationsIn("probe.go", tc.text, known) {
+				got = append(got, c.version)
+			}
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if strings.Join(got, ",") != strings.Join(want, ",") {
+				t.Errorf("detector reported %v, want %v\n  text: %q", got, want, tc.text)
+			}
+		})
+	}
+}
+
+// TestTheCitationRegisterIsSortedAndUnique keeps the file diffable.
+//
+// Nothing else holds it: a hand-added entry lands wherever the author typed it,
+// and the next prune rewrites the whole file sorted — so an unsorted register
+// produces a diff full of moves that hides the one line that matters.
+func TestTheCitationRegisterIsSortedAndUnique(t *testing.T) {
+	entries := registerEntries(t, citationRegisterPath)
+	seen := map[string]bool{}
+	for i, e := range entries {
+		if seen[e] {
+			t.Errorf("%s lists %q twice", citationRegisterPath, e)
+		}
+		seen[e] = true
+		if i > 0 && entries[i-1] > e {
+			t.Errorf("%s is not sorted: %q follows %q.\nRun `go test . -run "+
+				"TestEveryCitedMigrationExists -update-citations` from backend/ to rewrite it.",
+				citationRegisterPath, e, entries[i-1])
+		}
 	}
 }
 
@@ -164,10 +263,12 @@ type citationRef struct {
 }
 
 // key identifies a citation for the register WITHOUT its line number, so
-// editing a file above one does not churn the register or read as a new
-// citation. Two citations of the same version in one file collapse to one
-// entry, which is the right granularity: the register answers "does this file
-// still cite this missing version", not "how often".
+// editing a file above one is not a new citation and does not churn the file.
+//
+// The cost, stated because it is a real blind spot rather than a simplification:
+// in a file that ALREADY has an entry for a version, a second citation of that
+// same version is invisible. The register holds "this file cites this missing
+// version", not "how often".
 func (c citationRef) key() string {
 	return fmt.Sprintf("%s %s %s", c.path, c.namespace, c.version)
 }
@@ -176,72 +277,176 @@ func (c citationRef) String() string {
 	return fmt.Sprintf("%s:%d cites %s %s — %s", c.path, c.line, c.namespace, c.version, c.excerpt)
 }
 
-// scanTreeForCitations reads every tracked text file and reports the citations that name a
-// version no namespace carries.
+// scanTreeForCitations reads every tracked text file and reports the citations
+// naming a version no namespace carries. It returns what it read and what it
+// skipped, so the caller can refuse a census that covered almost nothing.
 //
-// EVERY tracked file, with no extension allowlist. The first shape of this gate
-// had one, and it dropped twenty citations — nineteen in frontend .ts/.tsx and
-// one in the Makefile — so the invariant was gated on one side of the wire only
-// while claiming to hold the tree. An unmeasured prefilter in front of a census
-// is what CLAUDE.md rule 8 forbids by name; binary files are skipped by looking
-// at the bytes rather than by trusting a suffix.
-func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) []citationRef {
+// EVERY tracked file, with no extension allowlist: an unmeasured prefilter in
+// front of a census is what CLAUDE.md rule 8 forbids by name.
+func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) (found []citationRef, scanned, skipped int) {
 	t.Helper()
-	out, err := exec.Command("git", "-C", "..", "ls-files", "-z").Output()
+	for _, f := range trackedFiles(t) {
+		// A symlink is skipped rather than followed. os.ReadFile follows one,
+		// and a tracked symlink pointing outside the worktree would make this
+		// gate an arbitrary-file read whose contents it then PRINTS — in a
+		// public repository whose CI logs are public.
+		if f.symlink || citationScanExempt(f.path) {
+			skipped++
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("..", f.path))
+		if err != nil {
+			// A tracked path can be absent mid-rebase, and a gitlink
+			// (submodule) reads as a directory.
+			if os.IsNotExist(err) || strings.Contains(err.Error(), "is a directory") {
+				skipped++
+				continue
+			}
+			t.Fatalf("reading %s: %v", f.path, err)
+		}
+		scanned++
+		found = append(found, danglingCitationsIn(f.path, string(body), known)...)
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].key() < found[j].key() })
+	return found, scanned, skipped
+}
+
+// citationScanExempt reports a path this gate does not read.
+//
+// The generated ones are exempt because a citation inside them is a citation in
+// the SOURCE they were rendered from, and that source is scanned — reporting
+// both would send somebody to fix the copy `make gen` overwrites. `_gen.go` is
+// ANCHORED to the directories that hold generated Go rather than accepted as a
+// bare suffix: a suffix alone makes `_gen.go` a general-purpose invisibility
+// cloak any new file can put on.
+func citationScanExempt(rel string) bool {
+	switch {
+	case rel == "backend/migrationcitations_test.go",
+		rel == "backend/"+citationRegisterPath,
+		rel == "frontend/src/api/schema.d.ts",
+		rel == "frontend/src/api/public-events.ts",
+		strings.HasPrefix(rel, "backend/internal/contracts/"),
+		strings.HasSuffix(rel, ".generated.json"):
+		return true
+	case strings.HasSuffix(rel, "_gen.go"):
+		return strings.HasPrefix(rel, "backend/internal/") || strings.HasPrefix(rel, "extensions/")
+	}
+	return false
+}
+
+// trackedFile is one entry from the index, with the one mode bit this gate
+// cares about.
+type trackedFile struct {
+	path    string
+	symlink bool
+}
+
+// trackedFiles reads the index. `-s` carries the mode, which is how a symlink is
+// told from a file without stat-ing it; `-z` makes the output NUL-delimited, so
+// no filename can be misread.
+func trackedFiles(t *testing.T) []trackedFile {
+	t.Helper()
+	out, err := exec.Command("git", "-C", "..", "ls-files", "-sz").Output()
 	if err != nil {
 		t.Fatalf("listing tracked files: %v (this test must run inside the git worktree)", err)
 	}
-
-	var found []citationRef
-	for _, rel := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
-		if rel == "" || generatedByGen(rel) {
+	var files []trackedFile
+	for _, row := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		if row == "" {
 			continue
 		}
-		// This file states the citation shapes it looks for, so scanning it
-		// fails on its own source. The exact path, not the basename: a second
-		// file by this name anywhere else is scanned.
-		if rel == "backend/migrationcitations_test.go" || rel == "backend/"+citationRegisterPath {
+		// <mode> <sha> <stage>\t<path>
+		meta, path, ok := strings.Cut(row, "\t")
+		if !ok {
 			continue
 		}
-		body, err := os.ReadFile(filepath.Join("..", rel))
-		if err != nil {
-			// A tracked file can be absent mid-rebase or after `git rm`.
-			if os.IsNotExist(err) {
-				continue
-			}
-			t.Fatalf("reading %s: %v", rel, err)
-		}
-		if !utf8.Valid(body) {
-			continue
-		}
-		found = append(found, danglingCitationsIn(rel, string(body), known)...)
+		files = append(files, trackedFile{path: path, symlink: strings.HasPrefix(meta, "120000")})
 	}
-	sort.Slice(found, func(i, j int) bool { return found[i].key() < found[j].key() })
-	return found
+	return files
 }
 
+// danglingCitationsIn reports the citations in one file naming a version no
+// namespace carries.
+//
+// Each line is matched joined to the NEXT one, with a comment prefix stripped,
+// because this tree wraps at about 78 columns and a citation whose namespace
+// word and version land on different lines is otherwise invisible. The finding
+// is reported on the line the namespace word sits on.
 func danglingCitationsIn(rel, body string, known map[string]map[string]bool) []citationRef {
+	lines := strings.Split(body, "\n")
 	var found []citationRef
-	for i, line := range strings.Split(body, "\n") {
-		for _, m := range citation.FindAllStringSubmatch(line, -1) {
-			namespace, version := strings.ToLower(m[1]), m[2]
-			if namespaceCarries(known, namespace, version) {
+	seen := map[string]bool{}
+
+	add := func(i int, namespace, version, text string) {
+		// UTF-8 is judged per LINE. Whole-file validity let one stray byte
+		// anywhere hide every citation in the file — invisible in a diff, and
+		// strictly worse than the suffix allowlist this gate refuses.
+		if !utf8.ValidString(text) || carriesVersion(known, namespace, version) {
+			return
+		}
+		ref := citationRef{
+			path: rel, line: i + 1, namespace: namespace, version: version,
+			excerpt: citationExcerpt(text),
+		}
+		if seen[ref.key()] {
+			return
+		}
+		seen[ref.key()] = true
+		found = append(found, ref)
+	}
+
+	for i, line := range lines {
+		window := line
+		if i+1 < len(lines) {
+			window = line + " " + commentContinuation.ReplaceAllString(lines[i+1], "")
+		}
+		// Where a namespaced match consumed the version, so the filename pass
+		// below does not report the same citation a second time under a
+		// different namespace: `core/0012_audit_log.up.sql` matches BOTH
+		// patterns, and two register entries for one citation would make the
+		// register wrong about the tree in a way pruning cannot repair.
+		var claimed [][2]int
+		for _, m := range namespacedCitation.FindAllStringSubmatchIndex(window, -1) {
+			namespace := strings.ToLower(window[m[2]:m[3]])
+			claimed = append(claimed, [2]int{m[4], m[5]})
+			add(i, namespace, window[m[4]:m[5]], line)
+			// The rest of a list belongs to the same namespace word.
+			for rest, at := window[m[1]:], m[1]; ; {
+				tail := listedVersion.FindStringSubmatchIndex(rest)
+				if tail == nil {
+					break
+				}
+				claimed = append(claimed, [2]int{at + tail[2], at + tail[3]})
+				add(i, namespace, rest[tail[2]:tail[3]], line)
+				rest, at = rest[tail[1]:], at+tail[1]
+			}
+		}
+		// A bare filename names no namespace, so the union is the honest pool.
+		for _, m := range bareFilename.FindAllStringSubmatchIndex(line, -1) {
+			if versionAlreadyClaimed(claimed, m[2]) {
 				continue
 			}
-			found = append(found, citationRef{
-				path: rel, line: i + 1, namespace: namespace, version: version,
-				excerpt: citationExcerpt(line),
-			})
+			add(i, "migration", line[m[2]:m[3]], line)
 		}
 	}
 	return found
 }
 
-// carries reports whether the cited version exists in the namespace the citation
-// named. An UNQUALIFIED citation ("migration 0099") names no namespace, so the
-// union is the honest pool for it — narrowing that to one namespace would invent
-// a claim the text never made.
-func namespaceCarries(known map[string]map[string]bool, namespace, version string) bool {
+// versionAlreadyClaimed reports whether a namespaced match already consumed the
+// version starting at this offset.
+func versionAlreadyClaimed(claimed [][2]int, start int) bool {
+	for _, span := range claimed {
+		if start >= span[0] && start < span[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// carriesVersion reports whether the cited version exists in the namespace the
+// citation named. An UNQUALIFIED citation names none, so the union is the honest
+// pool — narrowing it to one namespace would invent a claim the text never made.
+func carriesVersion(known map[string]map[string]bool, namespace, version string) bool {
 	if versions, ok := known[namespace]; ok {
 		return versions[version]
 	}
@@ -253,104 +458,130 @@ func namespaceCarries(known map[string]map[string]bool, namespace, version strin
 	return false
 }
 
-// knownMigrationVersions collects the versions every namespace carries, read as
-// FILENAMES rather than through the migrations package.
+// knownMigrationVersions collects the versions every EMBEDDED namespace carries,
+// read from the index rather than the working directory.
 //
-// Not a preference: .go-arch-lint.yml refuses `root -> migrations`, and widening
-// a component edge to serve a test would grant a production one. The version is
-// the filename's prefix, so the directory answers the question directly.
-//
-// The namespace list is the directory listing, so a third namespace is covered
-// the day it appears. `testdata` sits beside core/ and custom/ and is NOT one —
-// check-migration-versions.sh rules it out for the same reason, and admitting it
-// would let a fixture migration make its version "known" and mask real dangling
-// citations.
+// From git, so an untracked leftover `NNNN_x.up.sql` cannot make a version
+// "known" locally and green while CI, on a clean checkout, goes red.
 func knownMigrationVersions(t *testing.T) map[string]map[string]bool {
 	t.Helper()
-	entries, err := os.ReadDir(migrationsRoot)
-	if err != nil {
-		t.Fatalf("reading %s: %v", migrationsRoot, err)
-	}
 	known := map[string]map[string]bool{}
-	for _, ns := range entries {
-		if !ns.IsDir() || ns.Name() == "testdata" {
+	for _, ns := range embeddedNamespaces(t) {
+		known[ns] = map[string]bool{}
+	}
+	prefix := "backend/" + migrationsRoot + "/"
+	for _, f := range trackedFiles(t) {
+		if !strings.HasPrefix(f.path, prefix) || !strings.HasSuffix(f.path, ".up.sql") {
 			continue
 		}
-		versions := migrationVersionsIn(t, filepath.Join(migrationsRoot, ns.Name()))
-		if len(versions) > 0 {
-			known[ns.Name()] = versions
+		ns, name, ok := strings.Cut(strings.TrimPrefix(f.path, prefix), "/")
+		if !ok {
+			continue
+		}
+		versions, embedded := known[ns]
+		if !embedded {
+			continue
+		}
+		version, _, ok := strings.Cut(name, "_")
+		if !ok {
+			t.Fatalf("%s: want <version>_<name>.up.sql", f.path)
+		}
+		versions[version] = true
+	}
+	for ns, versions := range known {
+		if len(versions) == 0 {
+			t.Fatalf("namespace %q is embedded by %s but carries no .up.sql in the index — the "+
+				"derivation has stopped resolving, and every citation of it would report as "+
+				"dangling", ns, namespaceOwner)
 		}
 	}
 	return known
 }
 
-func migrationVersionsIn(t *testing.T, dir string) map[string]bool {
+// embeddedNamespaces reads the //go:embed line that declares them.
+func embeddedNamespaces(t *testing.T) []string {
 	t.Helper()
-	entries, err := os.ReadDir(dir)
+	raw, err := os.ReadFile(namespaceOwner)
 	if err != nil {
-		t.Fatalf("reading %s: %v", dir, err)
+		t.Fatalf("reading %s: %v", namespaceOwner, err)
 	}
-	versions := map[string]bool{}
-	for _, e := range entries {
-		if !strings.HasSuffix(e.Name(), ".up.sql") {
-			continue
-		}
-		version, _, ok := strings.Cut(e.Name(), "_")
-		if !ok {
-			t.Fatalf("%s/%s: want <version>_<name>.up.sql", dir, e.Name())
-		}
-		versions[version] = true
+	m := embedLine.FindStringSubmatch(string(raw))
+	if m == nil {
+		t.Fatalf("%s carries no //go:embed line, so the namespace set cannot be derived from the "+
+			"product's own declaration", namespaceOwner)
 	}
-	return versions
+	return strings.Fields(m[1])
 }
 
-// readCitationRegister reads the recorded backlog. Comments and blank lines are ignored
-// so the file can explain itself.
-func readCitationRegister(t *testing.T) map[string]bool {
+// readCitationRegister reads the recorded backlog as a set.
+func readCitationRegister(t *testing.T, path string) map[string]bool {
 	t.Helper()
-	raw, err := os.ReadFile(citationRegisterPath)
-	if err != nil {
-		t.Fatalf("reading %s: %v", citationRegisterPath, err)
-	}
 	recorded := map[string]bool{}
+	for _, e := range registerEntries(t, path) {
+		recorded[e] = true
+	}
+	return recorded
+}
+
+// registerEntries reads the register's lines, in file order.
+//
+// Deliberately NOT shared with uniquenessclaims_test.go's reader, which is the
+// same handful of lines over a different file. One helper in front of two
+// registers would couple formats that are free to diverge — this one is three
+// space-separated fields, that one is a prose key — and the coupling would be
+// discovered the first time either changes shape. Two readers, one reason,
+// stated here rather than in a pull request.
+func registerEntries(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var entries []string
 	for _, line := range strings.Split(string(raw), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		recorded[trimmed] = true
+		entries = append(entries, trimmed)
 	}
-	return recorded
+	return entries
 }
 
-// writeCitationRegister rewrites the register, header and all.
-//
-// The header is written here rather than preserved from the file, so a
-// regeneration cannot silently drop the explanation of what the list is for —
-// which is the part that stops the next reader treating it as a permission.
-func writeCitationRegister(t *testing.T, found []citationRef) {
+// pruneCitationRegister rewrites the register with the entries the tree still
+// has, and names every line it removed.
+func pruneCitationRegister(t *testing.T, recorded, present map[string]bool) {
 	t.Helper()
-	var b strings.Builder
-	b.WriteString(citationRegisterHeader)
-	seen := map[string]bool{}
-	for _, c := range found {
-		if seen[c.key()] {
+	var keep, removed []string
+	for key := range recorded {
+		if present[key] {
+			keep = append(keep, key)
 			continue
 		}
-		seen[c.key()] = true
-		b.WriteString(c.key())
+		removed = append(removed, key)
+	}
+	sort.Strings(keep)
+	sort.Strings(removed)
+
+	var b strings.Builder
+	b.WriteString(citationRegisterHeader)
+	for _, k := range keep {
+		b.WriteString(k)
 		b.WriteString("\n")
 	}
 	if err := os.WriteFile(citationRegisterPath, []byte(b.String()), 0o644); err != nil {
 		t.Fatalf("writing %s: %v", citationRegisterPath, err)
 	}
-	t.Logf("%s rewritten: %d entries", citationRegisterPath, len(seen))
+	for _, r := range removed {
+		t.Logf("pruned: %s", r)
+	}
+	t.Logf("%s: %d entries kept, %d pruned", citationRegisterPath, len(keep), len(removed))
 }
 
 // citationRegisterHeader is what the register explains about itself. It is
-// written on every regeneration rather than preserved from the file, so a
-// rewrite cannot silently drop the part that stops the next reader treating
-// the list as a permission.
+// written on every prune rather than preserved from the file, so a rewrite
+// cannot silently drop the part that stops the next reader treating the list as
+// a permission.
 const citationRegisterHeader = `# THE DANGLING-CITATION REGISTER — a record, not a permission.
 #
 # Every line is a file that cites a migration version no namespace carries, in
@@ -358,34 +589,42 @@ const citationRegisterHeader = `# THE DANGLING-CITATION REGISTER — a record, n
 # citation named none, so it was checked against every namespace at once.
 #
 # The migrations these name were mostly deleted by the 2026-08 baseline
-# consolidation, and MOST of them still resolve through git history — so they are
-# stale prose rather than defects, and rewriting them mechanically would cost
-# more than it buys: a citation is usually the only thing in a sentence saying
-# where the reasoning lives. Two on this list named versions that never existed
-# on ANY ref, and were repaired in the change that added this file.
+# consolidation, and most still resolve through git history — so they are stale
+# prose rather than defects, and rewriting them mechanically would cost more
+# than it buys: a citation is usually the only thing in a sentence saying where
+# the reasoning lives.
 #
-# What the register prevents is the backlog GROWING. A citation written today
-# against a version that never existed is a dead end from birth.
+# What this holds is narrower than "the backlog cannot grow", and the difference
+# matters: a file acquires no citation of a version it does not ALREADY cite. A
+# second citation of a version already listed for that file is invisible.
 #
-# Per FILE, not a total, and that is the point: a total let a deletion anywhere
-# fund a new dead citation elsewhere and net to green — STATUS.md alone carries
-# dozens and is edited at the end of every session.
+# Per FILE rather than a total, because a total lets a deletion anywhere fund a
+# new dead citation elsewhere: the two net and the gate reports green over a
+# tree that got worse.
 #
 # Line numbers are deliberately absent: editing a file above a citation is not a
 # new citation, and a register that churned on every edit would be ignored.
 #
-# TO FIX ONE: state the invariant so the sentence stands alone, or say the
-# migration is in git history rather than in the tree — then DELETE its line
-# here. The gate fails on a line whose citation is gone, so the register cannot
-# drift from the tree in either direction.
+# A test harness that WRITES fixture migration paths lands here too — the string
+# is citation-shaped and this gate cannot tell it from prose. Those entries are
+# noise rather than debt, and they are left in rather than skipped by name: a
+# skip-list in front of a census is the thing that makes one quietly go short.
 #
-# TO REGENERATE: go test ./... -run TestEveryCitedMigrationExists -update-citations
+# TO FIX ONE: state the invariant so the sentence stands alone, or say the
+# migration is in git history rather than in the tree — then prune the line.
+#
+# TO PRUNE, from backend/:
+#   go test . -run TestEveryCitedMigrationExists -update-citations
+#
+# That command only REMOVES entries. Adding one is a hand edit on purpose:
+# regenerating to absorb a citation you just wrote is not a fix, and the added
+# line has to be one a reviewer agreed to.
 `
 
-// citationExcerpt trims a cited line to something readable. STATUS.md holds single-line
-// paragraphs thousands of characters long, and one per finding buries the very
-// list this output exists to be read as. Runes, not bytes: these lines are full
-// of em-dashes, and slicing mid-rune prints replacement characters.
+// citationExcerpt trims a cited line to something readable. Prose lines in this
+// tree run long, and one full paragraph per finding buries the list this output
+// exists to be read as. Runes, not bytes: these lines carry em-dashes, and
+// slicing mid-rune prints replacement characters.
 func citationExcerpt(line string) string {
 	const width = 100
 	trimmed := strings.TrimSpace(line)

--- a/backend/migrationcitations_test.go
+++ b/backend/migrationcitations_test.go
@@ -7,7 +7,12 @@
 
 package backendarch
 
-// A comment that cites a migration by number must cite one that exists.
+// No file acquires a citation of a migration version that does not exist.
+//
+// The ideal behind that is simpler — every citation should resolve — but the
+// backlog is recorded rather than swept, so what this HOLDS is the narrower
+// claim: the citations already registered stay, and a file gains no citation of
+// a version it does not already cite.
 //
 // The citations do real work: `custom/20260716120000 is the fork-owned seam`
 // tells a reader WHERE to go and see why. When the file behind a citation is
@@ -132,7 +137,7 @@ var updateCitationRegister = flag.Bool("update-citations", false,
 
 func TestEveryCitedMigrationExists(t *testing.T) {
 	known := knownMigrationVersions(t)
-	found, scanned, skipped := scanTreeForCitations(t, known)
+	found, unread, scanned, skipped := scanTreeForCitations(t, known)
 	// A census that read a fraction of the tree must not report the same word
 	// for it. Under a sparse checkout every skip-worktree file vanishes with no
 	// signal.
@@ -148,7 +153,7 @@ func TestEveryCitedMigrationExists(t *testing.T) {
 	}
 
 	if *updateCitationRegister {
-		pruneCitationRegister(t, recorded, present)
+		pruneCitationRegister(t, recorded, present, unread)
 		return
 	}
 
@@ -166,9 +171,10 @@ func TestEveryCitedMigrationExists(t *testing.T) {
 
 	var stale []string
 	for key := range recorded {
-		if !present[key] {
-			stale = append(stale, key)
+		if present[key] || unread[registerEntryPath(key)] {
+			continue
 		}
+		stale = append(stale, key)
 	}
 	sort.Strings(stale)
 	for _, s := range stale {
@@ -283,8 +289,13 @@ func (c citationRef) String() string {
 //
 // EVERY tracked file, with no extension allowlist: an unmeasured prefilter in
 // front of a census is what CLAUDE.md rule 8 forbids by name.
-func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) (found []citationRef, scanned, skipped int) {
+func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) (found []citationRef, unread map[string]bool, scanned, skipped int) {
 	t.Helper()
+	// Paths the scan did not read. A prune consults it, because an entry whose
+	// file was merely unreadable is not an entry the tree has stopped carrying
+	// — deleting it would quietly empty the register for whatever happened to
+	// be missing at that moment.
+	unread = map[string]bool{}
 	for _, f := range trackedFiles(t) {
 		// A symlink is skipped rather than followed. os.ReadFile follows one,
 		// and a tracked symlink pointing outside the worktree would make this
@@ -292,6 +303,7 @@ func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) (found
 		// public repository whose CI logs are public.
 		if f.symlink || citationScanExempt(f.path) {
 			skipped++
+			unread[f.path] = true
 			continue
 		}
 		body, err := os.ReadFile(filepath.Join("..", f.path))
@@ -300,6 +312,7 @@ func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) (found
 			// (submodule) reads as a directory.
 			if os.IsNotExist(err) || strings.Contains(err.Error(), "is a directory") {
 				skipped++
+				unread[f.path] = true
 				continue
 			}
 			t.Fatalf("reading %s: %v", f.path, err)
@@ -308,7 +321,7 @@ func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) (found
 		found = append(found, danglingCitationsIn(f.path, string(body), known)...)
 	}
 	sort.Slice(found, func(i, j int) bool { return found[i].key() < found[j].key() })
-	return found, scanned, skipped
+	return found, unread, scanned, skipped
 }
 
 // citationScanExempt reports a path this gate does not read.
@@ -443,6 +456,17 @@ func versionAlreadyClaimed(claimed [][2]int, start int) bool {
 	return false
 }
 
+// registerEntryPath is the path half of a register key, which is everything
+// before the namespace and version it ends with.
+func registerEntryPath(key string) string {
+	if i := strings.LastIndex(key, " "); i > 0 {
+		if j := strings.LastIndex(key[:i], " "); j > 0 {
+			return key[:j]
+		}
+	}
+	return key
+}
+
 // carriesVersion reports whether the cited version exists in the namespace the
 // citation named. An UNQUALIFIED citation names none, so the union is the honest
 // pool — narrowing it to one namespace would invent a claim the text never made.
@@ -550,11 +574,14 @@ func registerEntries(t *testing.T, path string) []string {
 
 // pruneCitationRegister rewrites the register with the entries the tree still
 // has, and names every line it removed.
-func pruneCitationRegister(t *testing.T, recorded, present map[string]bool) {
+func pruneCitationRegister(t *testing.T, recorded, present, unread map[string]bool) {
 	t.Helper()
 	var keep, removed []string
 	for key := range recorded {
-		if present[key] {
+		// Kept when the citation is still there, and ALSO when its file could
+		// not be read: an unread file has not stopped citing anything, and a
+		// prune run mid-rebase would otherwise delete entries wholesale.
+		if present[key] || unread[registerEntryPath(key)] {
 			keep = append(keep, key)
 			continue
 		}

--- a/backend/migrationcitations_test.go
+++ b/backend/migrationcitations_test.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H1
+
+//go:build !integration
+
+package backendarch
+
+// A comment that cites a migration by number must cite one that exists.
+//
+// The citations do real work: `core 0217 retired row-level security` tells a
+// reader WHERE to go and see why a per-statement predicate replaced a policy.
+// The baseline consolidation deleted those files and the references survived it,
+// each one now sending a reader to look for something that is not there — which
+// is worse than no citation at all, because it reads like a lead.
+//
+// WHY A GATE AND NOT A SWEEP. The sweep is the easy half and it rots: the next
+// consolidation, or any renumber, breaks every citation written since. This
+// derives the answer from the tree instead — the versions the namespaces
+// actually carry — so it is correct the day a namespace changes rather than the
+// day somebody remembers to look.
+//
+// A RATCHET, NOT A COUNT. The backlog is recorded per file in
+// danglingcitations.txt and diffed, so a failure NAMES the citation that arrived
+// rather than reporting a number and asking the author to find their own. A
+// single total was the first shape this gate had, and it had a hole worth
+// stating: STATUS.md alone carries dozens of these and is edited at the end of
+// every session, so deleting a citation there funded a new dead one anywhere
+// else and the total netted to green.
+//
+// WHAT A FIX LOOKS LIKE is not "delete the number". CLAUDE.md rule 4 says state
+// the invariant so it stands alone, and that is it: the sentence keeps its claim
+// and loses the pointer, or says explicitly that the migration is in history
+// rather than in the tree.
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// citation matches the shapes this tree uses to name a migration: `core 0217`,
+// `core/0063`, `migration 0099`, `migration ` + "`0105`" + `,
+// `custom/20260716120000`, and the FILENAME form `core/0012_audit_log.up.sql`.
+//
+// Three widths, because the tree uses three: the closed four-digit range, the
+// ten-digit unix-second stamps every current core migration carries, and
+// custom's fourteen-digit stamps. Excluding ten was this gate's first blind spot
+// — "the format is current" is not "the citation resolves", and ten-digit
+// migrations are deleted and renumbered like any other.
+//
+// The version ends at `_` OR a word boundary, which is the second blind spot and
+// was the larger one: `_` is an ASCII word character, so a trailing \b never
+// matched the filename form at all — the most natural way to cite a migration,
+// and 88 of them in the tree when this was measured.
+//
+// The namespace is CAPTURED, not discarded: `core 0001` must be checked against
+// CORE's versions. Merged into one set it passed because custom happens to carry
+// a 0001 too, which is a false negative in the case a citation is most specific
+// about.
+var citation = regexp.MustCompile(
+	"(?i)\\b(core|custom|migration)s?[ /`]+([0-9]{4}|[0-9]{10}|[0-9]{14})(?:_|\\b)")
+
+// migrationsRoot holds the namespace directories, relative to this package.
+const migrationsRoot = "migrations"
+
+// citationRegisterPath records the citations this tree carries today, one per line.
+const citationRegisterPath = "danglingcitations.txt"
+
+// generatedByGen reports a file `make gen` writes. A citation inside one is a
+// citation in the SOURCE it was rendered from, and that source is scanned —
+// reporting both would send somebody to fix the copy gen overwrites.
+//
+// The frontend artifacts are here for that reason: schema.d.ts is rendered from
+// api/crm.yaml, which this gate reads.
+func generatedByGen(rel string) bool {
+	switch {
+	case strings.HasSuffix(rel, "_gen.go"),
+		strings.HasSuffix(rel, ".generated.json"),
+		strings.HasPrefix(rel, "backend/internal/contracts/"),
+		rel == "frontend/src/api/schema.d.ts",
+		rel == "frontend/src/api/public-events.ts":
+		return true
+	}
+	return false
+}
+
+// updateCitationRegister rewrites the register from the tree, the same way
+// identity's matrix fixture and the head catalog are regenerated. Without it the
+// only way to record a legitimate new entry is to hand-copy a line out of a
+// failure message, which is how a register acquires a typo nobody can see.
+var updateCitationRegister = flag.Bool("update-citations", false,
+	"rewrite danglingcitations.txt from the tree")
+
+func TestEveryCitedMigrationExists(t *testing.T) {
+	known := knownMigrationVersions(t)
+	// A namespace that failed to load would leave `known` empty and every
+	// citation below would read as dangling — hundreds of failures pointing at
+	// the wrong cause.
+	if len(known) == 0 {
+		t.Fatal("no migration versions could be read from the namespace directories, so every " +
+			"citation would report as dangling — fix the loader, not the citations")
+	}
+
+	found := scanTreeForCitations(t, known)
+	if *updateCitationRegister {
+		writeCitationRegister(t, found)
+		return
+	}
+	recorded := readCitationRegister(t)
+
+	var arrived []string
+	for _, c := range found {
+		if !recorded[c.key()] {
+			arrived = append(arrived, c.String())
+		}
+	}
+	// NAMED, not counted. The whole reason for a per-file register is that the
+	// author of a new dead-end learns which line is theirs.
+	for _, a := range arrived {
+		t.Errorf("new dangling migration citation:\n  %s\n"+
+			"A citation written now against a version that never existed is a dead end from "+
+			"birth. State the invariant instead, or say the migration is in git history rather "+
+			"than in the tree. If it is genuinely unavoidable, add the line to %s in this change.",
+			a, citationRegisterPath)
+	}
+
+	// The other direction: a register line whose citation is gone. Left in, the
+	// register stops describing the tree and quietly licenses a re-addition at
+	// the same spot.
+	present := map[string]bool{}
+	for _, c := range found {
+		present[c.key()] = true
+	}
+	var stale []string
+	for key := range recorded {
+		if !present[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	for _, s := range stale {
+		t.Errorf("%s records %q, which is no longer a dangling citation — thank you.\n"+
+			"Delete that line in this change, so the register keeps describing the tree.",
+			citationRegisterPath, s)
+	}
+}
+
+// citationRef is one dangling citation: where it is, and what it names.
+type citationRef struct {
+	path      string
+	line      int
+	namespace string
+	version   string
+	excerpt   string
+}
+
+// key identifies a citation for the register WITHOUT its line number, so
+// editing a file above one does not churn the register or read as a new
+// citation. Two citations of the same version in one file collapse to one
+// entry, which is the right granularity: the register answers "does this file
+// still cite this missing version", not "how often".
+func (c citationRef) key() string {
+	return fmt.Sprintf("%s %s %s", c.path, c.namespace, c.version)
+}
+
+func (c citationRef) String() string {
+	return fmt.Sprintf("%s:%d cites %s %s — %s", c.path, c.line, c.namespace, c.version, c.excerpt)
+}
+
+// scanTreeForCitations reads every tracked text file and reports the citations that name a
+// version no namespace carries.
+//
+// EVERY tracked file, with no extension allowlist. The first shape of this gate
+// had one, and it dropped twenty citations — nineteen in frontend .ts/.tsx and
+// one in the Makefile — so the invariant was gated on one side of the wire only
+// while claiming to hold the tree. An unmeasured prefilter in front of a census
+// is what CLAUDE.md rule 8 forbids by name; binary files are skipped by looking
+// at the bytes rather than by trusting a suffix.
+func scanTreeForCitations(t *testing.T, known map[string]map[string]bool) []citationRef {
+	t.Helper()
+	out, err := exec.Command("git", "-C", "..", "ls-files", "-z").Output()
+	if err != nil {
+		t.Fatalf("listing tracked files: %v (this test must run inside the git worktree)", err)
+	}
+
+	var found []citationRef
+	for _, rel := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		if rel == "" || generatedByGen(rel) {
+			continue
+		}
+		// This file states the citation shapes it looks for, so scanning it
+		// fails on its own source. The exact path, not the basename: a second
+		// file by this name anywhere else is scanned.
+		if rel == "backend/migrationcitations_test.go" || rel == "backend/"+citationRegisterPath {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("..", rel))
+		if err != nil {
+			// A tracked file can be absent mid-rebase or after `git rm`.
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		if !utf8.Valid(body) {
+			continue
+		}
+		found = append(found, danglingCitationsIn(rel, string(body), known)...)
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].key() < found[j].key() })
+	return found
+}
+
+func danglingCitationsIn(rel, body string, known map[string]map[string]bool) []citationRef {
+	var found []citationRef
+	for i, line := range strings.Split(body, "\n") {
+		for _, m := range citation.FindAllStringSubmatch(line, -1) {
+			namespace, version := strings.ToLower(m[1]), m[2]
+			if namespaceCarries(known, namespace, version) {
+				continue
+			}
+			found = append(found, citationRef{
+				path: rel, line: i + 1, namespace: namespace, version: version,
+				excerpt: citationExcerpt(line),
+			})
+		}
+	}
+	return found
+}
+
+// carries reports whether the cited version exists in the namespace the citation
+// named. An UNQUALIFIED citation ("migration 0099") names no namespace, so the
+// union is the honest pool for it — narrowing that to one namespace would invent
+// a claim the text never made.
+func namespaceCarries(known map[string]map[string]bool, namespace, version string) bool {
+	if versions, ok := known[namespace]; ok {
+		return versions[version]
+	}
+	for _, versions := range known {
+		if versions[version] {
+			return true
+		}
+	}
+	return false
+}
+
+// knownMigrationVersions collects the versions every namespace carries, read as
+// FILENAMES rather than through the migrations package.
+//
+// Not a preference: .go-arch-lint.yml refuses `root -> migrations`, and widening
+// a component edge to serve a test would grant a production one. The version is
+// the filename's prefix, so the directory answers the question directly.
+//
+// The namespace list is the directory listing, so a third namespace is covered
+// the day it appears. `testdata` sits beside core/ and custom/ and is NOT one —
+// check-migration-versions.sh rules it out for the same reason, and admitting it
+// would let a fixture migration make its version "known" and mask real dangling
+// citations.
+func knownMigrationVersions(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	entries, err := os.ReadDir(migrationsRoot)
+	if err != nil {
+		t.Fatalf("reading %s: %v", migrationsRoot, err)
+	}
+	known := map[string]map[string]bool{}
+	for _, ns := range entries {
+		if !ns.IsDir() || ns.Name() == "testdata" {
+			continue
+		}
+		versions := migrationVersionsIn(t, filepath.Join(migrationsRoot, ns.Name()))
+		if len(versions) > 0 {
+			known[ns.Name()] = versions
+		}
+	}
+	return known
+}
+
+func migrationVersionsIn(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	versions := map[string]bool{}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".up.sql") {
+			continue
+		}
+		version, _, ok := strings.Cut(e.Name(), "_")
+		if !ok {
+			t.Fatalf("%s/%s: want <version>_<name>.up.sql", dir, e.Name())
+		}
+		versions[version] = true
+	}
+	return versions
+}
+
+// readCitationRegister reads the recorded backlog. Comments and blank lines are ignored
+// so the file can explain itself.
+func readCitationRegister(t *testing.T) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(citationRegisterPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", citationRegisterPath, err)
+	}
+	recorded := map[string]bool{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		recorded[trimmed] = true
+	}
+	return recorded
+}
+
+// writeCitationRegister rewrites the register, header and all.
+//
+// The header is written here rather than preserved from the file, so a
+// regeneration cannot silently drop the explanation of what the list is for —
+// which is the part that stops the next reader treating it as a permission.
+func writeCitationRegister(t *testing.T, found []citationRef) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(citationRegisterHeader)
+	seen := map[string]bool{}
+	for _, c := range found {
+		if seen[c.key()] {
+			continue
+		}
+		seen[c.key()] = true
+		b.WriteString(c.key())
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(citationRegisterPath, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", citationRegisterPath, err)
+	}
+	t.Logf("%s rewritten: %d entries", citationRegisterPath, len(seen))
+}
+
+// citationRegisterHeader is what the register explains about itself. It is
+// written on every regeneration rather than preserved from the file, so a
+// rewrite cannot silently drop the part that stops the next reader treating
+// the list as a permission.
+const citationRegisterHeader = `# THE DANGLING-CITATION REGISTER — a record, not a permission.
+#
+# Every line is a file that cites a migration version no namespace carries, in
+# the form: <path> <namespace> <version>. A namespace of "migration" means the
+# citation named none, so it was checked against every namespace at once.
+#
+# The migrations these name were mostly deleted by the 2026-08 baseline
+# consolidation, and MOST of them still resolve through git history — so they are
+# stale prose rather than defects, and rewriting them mechanically would cost
+# more than it buys: a citation is usually the only thing in a sentence saying
+# where the reasoning lives. Two on this list named versions that never existed
+# on ANY ref, and were repaired in the change that added this file.
+#
+# What the register prevents is the backlog GROWING. A citation written today
+# against a version that never existed is a dead end from birth.
+#
+# Per FILE, not a total, and that is the point: a total let a deletion anywhere
+# fund a new dead citation elsewhere and net to green — STATUS.md alone carries
+# dozens and is edited at the end of every session.
+#
+# Line numbers are deliberately absent: editing a file above a citation is not a
+# new citation, and a register that churned on every edit would be ignored.
+#
+# TO FIX ONE: state the invariant so the sentence stands alone, or say the
+# migration is in git history rather than in the tree — then DELETE its line
+# here. The gate fails on a line whose citation is gone, so the register cannot
+# drift from the tree in either direction.
+#
+# TO REGENERATE: go test ./... -run TestEveryCitedMigrationExists -update-citations
+`
+
+// citationExcerpt trims a cited line to something readable. STATUS.md holds single-line
+// paragraphs thousands of characters long, and one per finding buries the very
+// list this output exists to be read as. Runes, not bytes: these lines are full
+// of em-dashes, and slicing mid-rune prints replacement characters.
+func citationExcerpt(line string) string {
+	const width = 100
+	trimmed := strings.TrimSpace(line)
+	if utf8.RuneCountInString(trimmed) <= width {
+		return trimmed
+	}
+	return string([]rune(trimmed)[:width]) + "…"
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -49,7 +49,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
 
-## Census (42)
+## Census (43)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -78,6 +78,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
+| `migrationcitations_test.go` | H1 | No file acquires a citation of a migration version that does not exist. |
 | `oneconsentcarry_test.go` | H2 | The consent carry — what happens to a retiring record's consent when another record survives it — is spelled once inside the people module. |
 | `oneidlebase_test.go` | H2 | The idle base — a record's newest activity when one is recorded, else the instant it was created — is spelled once, in shared/kernel/idlebase. |
 | `oneretryafter_test.go` | H2 | The Retry-After header is read in one place, shared/kernel/retryafter. |


### PR DESCRIPTION
The dangling-citation gate, rebuilt. An earlier version was **withdrawn** from [#2546](https://github.com/margince/margince/pull/2546) after review found it failing short; this one went through two more adversarial rounds, and each round found more. Everything below was verified by **planting the shape**, not by watching a green run.

## What the detector missed, across three rounds

| shape | citations it could not see |
|---|---|
| the **filename form** — `_` is a word character, so a trailing `\b` never matched | **88** |
| **ten-digit** versions, the format most current migrations carry | **22** |
| an **extension allowlist** dropping `.ts`/`.tsx` and the `Makefile` | **20** |
| a citation **wrapped across two lines** — this tree wraps at ~78 columns | 12 |
| the **bare filename** with no namespace word, as a file's own header writes it | 4 |
| the **second version in a list** — `core 0007, 0131` | ~10 |
| the **namespace discarded**, so `core 0001` matched custom's `0001` | — |

The register is **244 entries across 175 files** — not the 72 the issue estimated, and not the 215 the first rebuild found.

## Holes that were not about the regex

- **One stray byte hid a whole file.** `utf8.Valid` ran on the whole body, so a single invalid byte silenced every citation in it — invisible in a diff, and strictly worse than the allowlist this gate refuses. Judged per line now.
- **Any directory under `migrations/` became a namespace**, and its versions became "known" — a scratch copy silently converted real dangling citations into passing ones with no failing assertion. The namespace set comes from the `//go:embed` line, the product's own declaration, and versions from the index rather than the working directory.
- **A tracked symlink was followed out of the worktree and its contents printed.** In a public repo with public CI logs that's an arbitrary-file read a citation gate has no reason to hold. Skipped by mode from `git ls-files -s`.
- **`_gen.go` was a general-purpose invisibility suffix** any file could put on. Anchored to the directories that hold generated Go.
- **`-update-citations` absorbed whatever it found**, making the sanctioned command the way a dead end gets laundered green. It only **prunes** now, names every line it removes, and the failure text says an addition is a hand edit on purpose.
- **A prune deleted entries for files it never read.** `git ls-files` returns paths absent mid-rebase or under a sparse checkout; the scan skipped them, the prune saw no citations, and removed their lines. Both arms consult what went unread now. Proven with `README.md` moved aside: with the guard the entry survives, without it it's gone.

## A ratchet, not a count

`backend/danglingcitations.txt` records the backlog **per file**, and a failure names the citation that arrived. A single count let a deletion anywhere fund an addition elsewhere — the two net, and the gate reports green over a tree that got worse. Both directions fail, and both fire in the same run.

## Two tests, because the register is a weak substitute

`TestTheCitationDetectorSeesWhatItClaims` pins seventeen shapes **including four the detector cannot see**, each a `nil` row so a future widening is a one-line flip. It caught a real bug within a minute of existing: the filename form matched both patterns and produced two register entries for one citation.

`TestTheCitationRegisterIsSortedAndUnique` keeps the file diffable — nothing else held it.

## Two citations that never existed

`people/listpage.go` cited `0138` (`0137` resolves; `0138` never did on any ref) and `linkedinmatchapply.go` cited `0161`. Dead ends **from birth** — what this gate exists to prevent — repaired rather than recorded. That corrects the premise I filed #2197 on: I argued these were all followable through history. True of most, false of those two.

## What it cannot see, stated at the top

An H1 gate over prose always leaks, and one that hides its leaks is worse than none. The file opens with its own gaps — citations split across more than two lines, unknown separators, zero-padding past the widths, numbers reached by prose alone — each planted as a `nil` row.

One reviewer request I **declined**, with reasoning in the thread: excluding `testdata` from the scan. A skip-list in front of a census is the shape that makes one quietly go short, and this gate was already rebuilt once for that class. The one fixture-shaped entry is recorded as noise in the register header instead.

Closes #2197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
