### PR TITLE
feat(agents): a create that files a duplicate for review says so

### DIFF
--- a/backend/internal/compose/agentcommandbothdoors_test.go
+++ b/backend/internal/compose/agentcommandbothdoors_test.go
@@ -453,7 +453,7 @@ func bothDoorsRegistry(staging agents.Approvals) *agents.Registry {
 		agents.WithTierFloor(func(string, string) (mcp.RiskTier, bool) {
 			return mcp.TierConfirmationRequired, true
 		}))
-	agents.RegisterCoreTools(reg, channelAnchor{}, nil, nil, nil, nil)
+	agents.RegisterCoreTools(reg, channelAnchor{}, nil, nil, nil, nil, nil)
 	agents.RegisterEnrichTool(reg, channelAnchor{}, nil)
 	agents.RegisterLifecycleTools(reg, channelAnchor{}, nil, nil, nil)
 	agents.RegisterCommsTools(reg, bothDoorsComms{}, channelAnchor{})

--- a/backend/internal/compose/agentcommandstagedrow_integration_test.go
+++ b/backend/internal/compose/agentcommandstagedrow_integration_test.go
@@ -228,7 +228,7 @@ func archiveRegistry(e *integration.Env) *agents.Registry {
 	// than latent — the tool refuses on the terms an unreadable list refuses
 	// on, so an accidental call here would fail loudly instead of deriving a
 	// company from the compiled-in baseline.
-	agents.RegisterCoreTools(reg, native, native, nil, fieldOwnership{pool: e.Pool}, nil)
+	agents.RegisterCoreTools(reg, native, native, nil, fieldOwnership{pool: e.Pool}, nil, nil)
 	return reg
 }
 

--- a/backend/internal/compose/agentgate_dealreopen_test.go
+++ b/backend/internal/compose/agentgate_dealreopen_test.go
@@ -209,7 +209,7 @@ func TestRelinkingOntoAProjectReachesAHumanAndOtherDestinationsDoNot(t *testing.
 		records: versionedDeal{stageID: stage, version: 3},
 	}
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
-	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil)
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil, nil)
 	// Nil dependencies are enough: resolving a tier reads the arguments and
 	// invokes no handler.
 	agents.RegisterLifecycleTools(reg, deps.records, nil, nil, nil)
@@ -272,7 +272,7 @@ func TestEveryDynamicTierRouteHasACommandThatAnswersItsTier(t *testing.T) {
 		records: versionedDeal{stageID: stage, version: 3},
 	}
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
-	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil)
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil, nil)
 	// relink_activity is a lifecycle tool, and it is dynamic — the walk below
 	// derives the routes to check from the policy table, so a registry missing
 	// this set would report the route as unresolvable rather than skip it.

--- a/backend/internal/compose/agentgate_test.go
+++ b/backend/internal/compose/agentgate_test.go
@@ -21,7 +21,7 @@ import (
 // list.
 func TestContractTierNeverBelowRegistryTier(t *testing.T) {
 	registry := agents.NewRegistry(stubApprovals{}, nil)
-	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil)
+	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil, nil)
 
 	for route, pol := range agentPolicies {
 		if pol.Access != accessTool {
@@ -52,7 +52,7 @@ func TestContractTierNeverBelowRegistryTier(t *testing.T) {
 // staging, so both artifacts are pinned.
 func TestUpdateRecordIsAutoExecuteOnBothArtifacts(t *testing.T) {
 	registry := agents.NewRegistry(stubApprovals{}, nil)
-	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil)
+	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil, nil)
 
 	spec, ok := registry.Spec("update_record")
 	if !ok || spec.Tier != mcp.TierAutoExecute {
@@ -161,7 +161,7 @@ func TestGovernanceOperationsAreHumanOnly(t *testing.T) {
 // tool fails closed.
 func TestOperationSpecTightenOnly(t *testing.T) {
 	registry := agents.NewRegistry(stubApprovals{}, nil)
-	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil)
+	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil, nil)
 
 	spec, _, ok := operationSpec(agentPolicy{Op: "archivePerson", Access: accessTool, Tool: "update_record", Tier: tierConfirmationRequired}, registry)
 	if !ok || spec.Tier != mcp.TierConfirmationRequired {

--- a/backend/internal/compose/agentgatepin_test.go
+++ b/backend/internal/compose/agentgatepin_test.go
@@ -54,7 +54,7 @@ func (p versionedDeal) Read(context.Context, datasource.EntityRef) (datasource.R
 func advanceSpec(t *testing.T, deps restCommandDeps) (*agents.Registry, mcp.ToolSpec) {
 	t.Helper()
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
-	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil)
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil, nil)
 	spec, _, ok := operationSpec(agentPolicies["POST /v1/deals/{id}/advance"], reg)
 	if !ok {
 		t.Fatal("the registry serves no advance_deal spec for the REST twin to admit against")
@@ -160,7 +160,7 @@ func TestAWriteWithNoAdmittedPinIsForwardedUnconditioned(t *testing.T) {
 		records: versionedDeal{stageID: stage, version: 12},
 	}
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
-	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil)
+	agents.RegisterCoreTools(reg, deps.records, deps.stages, nil, nil, nil, nil)
 	// A create names no record and reads none, so its tool twin is static-tier:
 	// there is nothing for the gate to have proved anything about.
 	pol := agentPolicies["POST /v1/people"]

--- a/backend/internal/compose/agentgateredeem_test.go
+++ b/backend/internal/compose/agentgateredeem_test.go
@@ -255,7 +255,7 @@ func TestAReleasedRetryOnAStaticTierIsPinnedAndNotResplit(t *testing.T) {
 	})
 	ownership := &probeCounter{}
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
-	agents.RegisterCoreTools(reg, seamRecord{}, nil, nil, nil, nil)
+	agents.RegisterCoreTools(reg, seamRecord{}, nil, nil, nil, nil, nil)
 	spec, _, ok := operationSpec(pol, reg)
 	if !ok {
 		t.Fatal("the registry serves no update_record spec for the REST twin to admit against")
@@ -322,7 +322,7 @@ func gateCallCharges(t *testing.T, sourceSemantic, token string, redeemErr error
 	charger := &countingCharges{spent: map[agentquota.Counter]int{}}
 
 	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}), agents.WithQuotaCharger(charger))
-	agents.RegisterCoreTools(reg, records, stages, nil, nil, nil)
+	agents.RegisterCoreTools(reg, records, stages, nil, nil, nil, nil)
 
 	r := httptest.NewRequest(http.MethodPost, "/v1/deals/"+deal.String()+"/advance",
 		strings.NewReader(`{"to_stage_id":"`+target.String()+`"}`))

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -108,7 +108,7 @@ type stubSoR struct {
 
 func TestEveryConfirmationRequiredToolHasADecisionGrantMapping(t *testing.T) {
 	registry := agents.NewRegistry(stubApprovals{}, nil)
-	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil)
+	agents.RegisterCoreTools(registry, nil, nil, nil, nil, nil, nil)
 	// A nil brief reader is a legal wiring: this walk reads Specs() only, and
 	// the tool answers the assembled picture when no brief seam is bound.
 	agents.RegisterIntentTools(registry, stubRetriever{}, nil)

--- a/backend/internal/compose/dealmovepin_integration_test.go
+++ b/backend/internal/compose/dealmovepin_integration_test.go
@@ -101,7 +101,7 @@ func TestAConcurrentCloseSurvivesTheAutoExecutedMoveThatRacedIt(t *testing.T) {
 	// The stage resolver reads pipeline configuration and nothing this race
 	// touches, so it goes straight to the real provider — only the RECORD read
 	// carries the interleaving.
-	agents.RegisterCoreTools(registry, racing, native, nil, fieldOwnership{pool: e.Pool}, nil)
+	agents.RegisterCoreTools(registry, racing, native, nil, fieldOwnership{pool: e.Pool}, nil, nil)
 
 	deal := seedDealForPinRace(human, t, native, e.Rep1, pipeline, open)
 

--- a/backend/internal/compose/dedupereportseam.go
+++ b/backend/internal/compose/dedupereportseam.go
@@ -70,7 +70,11 @@ func decodeEvidence(raw json.RawMessage) []agents.DuplicateEvidence {
 	// typed string member would fail the whole row on the first numeric value.
 	var rows []evidenceRow
 	if err := json.Unmarshal(raw, &rows); err != nil {
-		return nil
+		// An EMPTY list, not nil: the schema advertises an array, and `null`
+		// there reads as "not computed" where the truth is "the snapshot could
+		// not be read". The pair itself is still the finding, so losing the
+		// detail must not lose the report.
+		return []agents.DuplicateEvidence{}
 	}
 	out := make([]agents.DuplicateEvidence, 0, len(rows))
 	for _, r := range rows {
@@ -114,9 +118,17 @@ func (v *evidenceValue) UnmarshalJSON(b []byte) error {
 		v.s = strconv.FormatFloat(n, 'f', -1, 64)
 		return nil
 	}
-	// Null, or a shape nothing writes. Empty, never the word "null" on
-	// somebody's screen.
-	v.s = ""
+	if string(b) == jsonNull {
+		// How a one-sided signal spells "the other record has nothing here".
+		// Empty, never the word "null" on somebody's screen.
+		v.s = ""
+		return nil
+	}
+	// A bool, an array, an object — a shape nothing writes. It is reported
+	// rather than blanked, because a value that VANISHES reads to a reviewer as
+	// "this axis had nothing", which is a different and more comforting claim
+	// than the truth. The raw JSON is short and is what a bug report needs.
+	v.s = "unreadable: " + string(b)
 	return nil
 }
 

--- a/backend/internal/compose/dedupereportseam.go
+++ b/backend/internal/compose/dedupereportseam.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The seam that lets a create tell its caller what it filed for review.
+//
+// The tool surface may not import the people module (.go-arch-lint.yml), and
+// should not: an injected reader is what keeps `agents` unable to reach a
+// record table on its own, so RBAC and row scope apply to this read exactly as
+// they do on the HTTP path. This is the wiring, and it is thin on purpose —
+// the store method it calls owns the permission check and the both-sides
+// visibility rule, restated nowhere.
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// openDuplicatesFor reports the open review-queue pairs naming a record the
+// caller has just created.
+//
+// The OTHER side is what the answer names. A caller holding a left/right pair
+// has to work out which half is its own record before it can offer a merge, and
+// that is a step the seam can take once instead of every caller taking it.
+func openDuplicatesFor(pool *pgxpool.Pool) agents.OpenDuplicatesFor {
+	store := people.NewStore(InstallationDB(pool))
+	return func(ctx context.Context, recordType string, id ids.UUID) ([]agents.DuplicateCandidate, error) {
+		rows, err := store.OpenCandidatesNaming(ctx, recordType, id)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]agents.DuplicateCandidate, 0, len(rows))
+		for _, r := range rows {
+			other := r.RightID
+			if other == id {
+				other = r.LeftID
+			}
+			out = append(out, agents.DuplicateCandidate{
+				OtherRecordID: other.String(),
+				Confidence:    r.Confidence,
+				Evidence:      decodeEvidence(r.Evidence),
+			})
+		}
+		return out, nil
+	}
+}
+
+// decodeEvidence renders the stored snapshot for the wire.
+//
+// A snapshot that will not decode yields NO evidence rather than failing the
+// answer: the pair itself is the finding, and losing "a human was asked" over a
+// malformed detail row would trade the whole message for part of it. The stored
+// bytes are written by this system in a fixed shape, so this is a guard against
+// the impossible rather than an expected branch.
+func decodeEvidence(raw json.RawMessage) []agents.DuplicateEvidence {
+	if len(raw) == 0 {
+		return nil
+	}
+	// Through an intermediate whose values are `any`, because the stored
+	// snapshot's left/right are whatever the matching field held — a phone
+	// number is a string, a score is a number — and decoding straight into a
+	// typed string member would fail the whole row on the first numeric value.
+	var rows []evidenceRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil
+	}
+	out := make([]agents.DuplicateEvidence, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, agents.DuplicateEvidence{
+			Field:  r.Field,
+			Left:   r.Left.text(),
+			Right:  r.Right.text(),
+			Signal: r.Signal,
+			Score:  r.Score,
+		})
+	}
+	return out
+}
+
+// evidenceRow is one stored snapshot entry as it sits in the column.
+type evidenceRow struct {
+	Field  string        `json:"field"`
+	Left   evidenceValue `json:"left_value"`
+	Right  evidenceValue `json:"right_value"`
+	Signal string        `json:"signal"`
+	Score  float64       `json:"score"`
+}
+
+// evidenceValue is one compared value, which the snapshot writes as whatever
+// the matching field held — a phone number is a string, a score is a number,
+// and a one-sided signal writes JSON null for the side that has nothing.
+//
+// So it decodes ITSELF rather than being declared a string: a typed string
+// member would fail the whole row on the first numeric value, and the row is
+// the evidence a person reads before merging two records.
+type evidenceValue struct{ s string }
+
+func (v *evidenceValue) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		v.s = s
+		return nil
+	}
+	var n float64
+	if err := json.Unmarshal(b, &n); err == nil {
+		v.s = strconv.FormatFloat(n, 'f', -1, 64)
+		return nil
+	}
+	// Null, or a shape nothing writes. Empty, never the word "null" on
+	// somebody's screen.
+	v.s = ""
+	return nil
+}
+
+func (v evidenceValue) text() string { return v.s }

--- a/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
+++ b/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
@@ -350,3 +350,134 @@ func TestAnAgentRelinksToAPersonWithoutAskingAndStillStagesAProject(t *testing.T
 		}
 	})
 }
+
+// A create that files a duplicate for review SAYS SO, in the answer the caller
+// already reads.
+//
+// The defect this closes was not a missing guard — the guard fired. Asked to
+// create a person who already existed, the ladder filed the pair at confidence
+// 1.000 on a shared phone, and create_record answered with the record and
+// nothing else. The assistant driving it therefore told its user "the guard is
+// email-only", which was false, and argued for building a safeguard that was
+// already working.
+//
+// Both channels are asserted here because each carries what the other cannot: a
+// model reads the WARNING without being asked, and acts on the DATA — the other
+// record's id, which no sentence should make it parse out of prose.
+func TestACreateThatFilesADuplicateSaysSoInItsAnswer(t *testing.T) {
+	q := setupQueue(t)
+	invoke := q.invoker(t, q.mintPassport(t, "duplicate reporter", "read", "write"))
+
+	const shared = "+4930900000731"
+	first := answered[struct {
+		ID string `json:"id"`
+	}](t, mustInvoke(t, invoke, "create_record",
+		`{"record_type":"person","fields":{"full_name":"Rosa Lindqvist",`+
+			`"phones":[{"phone":"`+shared+`","phone_type":"mobile","is_primary":true}]}}`))
+
+	// The same human's second business card: one number in common, a different
+	// address, and no reason for the server to refuse — two people really can
+	// share a switchboard.
+	out := mustInvoke(t, invoke, "create_record",
+		`{"record_type":"person","fields":{"full_name":"Rosa Lindqvist",`+
+			`"emails":[{"email":"rosa@privat.test","email_type":"personal","is_primary":true}],`+
+			`"phones":[{"phone":"`+shared+`","phone_type":"work","is_primary":true}]}}`)
+
+	var envelope struct {
+		Warnings []struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"warnings"`
+		Data struct {
+			ID         string `json:"id"`
+			Duplicates []struct {
+				OtherRecordID string  `json:"other_record_id"`
+				Confidence    float64 `json:"confidence"`
+				Evidence      []struct {
+					Field  string `json:"field"`
+					Left   string `json:"left_value"`
+					Right  string `json:"right_value"`
+					Signal string `json:"signal"`
+				} `json:"evidence"`
+			} `json:"duplicate_candidates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("decoding the create answer: %v", err)
+	}
+
+	if envelope.Data.ID == first.ID {
+		t.Fatal("the second create returned the first record's id — a duplicate report must not become a merge")
+	}
+	if len(envelope.Data.Duplicates) != 1 {
+		t.Fatalf("the answer names %d duplicate candidates, want 1 — the pair was filed and the caller was not told",
+			len(envelope.Data.Duplicates))
+	}
+	dup := envelope.Data.Duplicates[0]
+	if dup.OtherRecordID != first.ID {
+		t.Errorf("the candidate names %s, want the record already here, %s", dup.OtherRecordID, first.ID)
+	}
+	// The evidence is what a caller reads out before offering a merge, so it has
+	// to name the axis and carry the values the matcher actually compared.
+	if len(dup.Evidence) == 0 {
+		t.Fatal("the candidate carries no evidence, so a caller has nothing to show a person")
+	}
+	if dup.Evidence[0].Field != "phone" || dup.Evidence[0].Left != shared {
+		t.Errorf("evidence = %+v, want the shared number %s on the phone axis", dup.Evidence[0], shared)
+	}
+
+	// And the sentence a model reads without being asked.
+	var warned bool
+	for _, w := range envelope.Warnings {
+		if w.Code == agents.CodeDuplicateFiled {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("no %s warning on the answer, so a model summarising this call would report a clean create: %+v",
+			agents.CodeDuplicateFiled, envelope.Warnings)
+	}
+}
+
+// The other half, and the one that keeps the report honest: a create that
+// collided with nothing says nothing. A surface that warned on every create
+// would be a surface nobody reads the warnings of.
+func TestACleanCreateCarriesNoDuplicateReport(t *testing.T) {
+	q := setupQueue(t)
+	invoke := q.invoker(t, q.mintPassport(t, "clean creator", "read", "write"))
+
+	out := mustInvoke(t, invoke, "create_record",
+		`{"record_type":"person","fields":{"full_name":"Ingeborg Sandvik",`+
+			`"emails":[{"email":"ingeborg@sandvik.test","email_type":"work","is_primary":true}]}}`)
+
+	var envelope struct {
+		Warnings []struct {
+			Code string `json:"code"`
+		} `json:"warnings"`
+		Data struct {
+			Duplicates []json.RawMessage `json:"duplicate_candidates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("decoding the create answer: %v", err)
+	}
+	if len(envelope.Data.Duplicates) != 0 {
+		t.Errorf("a create that met nobody named %d duplicates", len(envelope.Data.Duplicates))
+	}
+	for _, w := range envelope.Warnings {
+		if w.Code == agents.CodeDuplicateFiled || w.Code == agents.CodeDuplicateCheckFailed {
+			t.Errorf("a clean create warned %q", w.Code)
+		}
+	}
+}
+
+// mustInvoke is one tool call that has to succeed, so a test reads as the
+// sequence it is about rather than as error handling between the steps.
+func mustInvoke(t *testing.T, invoke func(tool, args string) (string, error), tool, args string) string {
+	t.Helper()
+	out, err := invoke(tool, args)
+	if err != nil {
+		t.Fatalf("%s → %v", tool, err)
+	}
+	return out
+}

--- a/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
+++ b/backend/internal/compose/integration/approvalqueue_mcp_integration_test.go
@@ -384,6 +384,11 @@ func TestACreateThatFilesADuplicateSaysSoInItsAnswer(t *testing.T) {
 			`"phones":[{"phone":"`+shared+`","phone_type":"work","is_primary":true}]}}`)
 
 	var envelope struct {
+		Trust    string `json:"trust"`
+		Evidence []struct {
+			RecordType string `json:"record_type"`
+			RecordID   string `json:"record_id"`
+		} `json:"evidence"`
 		Warnings []struct {
 			Code    string `json:"code"`
 			Message string `json:"message"`
@@ -436,6 +441,29 @@ func TestACreateThatFilesADuplicateSaysSoInItsAnswer(t *testing.T) {
 	if !warned {
 		t.Errorf("no %s warning on the answer, so a model summarising this call would report a clean create: %+v",
 			agents.CodeDuplicateFiled, envelope.Warnings)
+	}
+
+	// The disclosed record is CITED. Naming a record to an agent is handing it
+	// over, and this surface charges the read bound for that — a create that
+	// names five other records for the price of the one it wrote would be the
+	// cheapest read here, and repeating it walks the workspace for free.
+	var cited bool
+	for _, e := range envelope.Evidence {
+		if e.RecordID == first.ID {
+			cited = true
+		}
+	}
+	if !cited {
+		t.Errorf("the disclosed record %s is not in the answer's evidence, so it was handed over uncharged: %+v",
+			first.ID, envelope.Evidence)
+	}
+
+	// And the answer is labelled for what it carries. The evidence QUOTES the
+	// other record — a number, a name — and this call never read that row's
+	// provenance, so it cannot claim the tier of the record it just wrote.
+	if envelope.Trust != "t2" {
+		t.Errorf("trust = %q, want t2: the answer carries values off a record whose provenance it did not read",
+			envelope.Trust)
 	}
 }
 

--- a/backend/internal/compose/org360/workattention.go
+++ b/backend/internal/compose/org360/workattention.go
@@ -164,8 +164,12 @@ func projectUUIDs(projects []ids.ProjectID) []ids.UUID {
 //
 // The task must also reach the account: a link row alone would let a task
 // filed under a project this company shares with another reach a page it does
-// not belong to. activities.OrgLinkedActivityExists performs that walk, and is
-// called rather than restated so the two cannot answer differently.
+// not belong to, so the walk is activities.OrgLinkedActivityExists rather than
+// a link test written here.
+//
+// Who the task is assigned to is read through identity.LiveMemberSQL, which is
+// the definition of "still works here" and belongs to the module that owns
+// app_user (ADR-0054 §3).
 func overdueTasksBy(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
 	linkColumn string, keys []ids.UUID, now time.Time,

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -132,7 +132,11 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// whose method IS the uncached read, so no wiring here can hand them the
 	// cached mode. See overlayModeChecker for why that distinction is typed.
 	sorMode := overlayModeChecker(provider)
-	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool}, newConsumerMailSeam(db))
+	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool}, newConsumerMailSeam(db),
+		// A create says what it filed for review. Without this seam it stays
+		// silent, which is what it did before — see tools_dupereport.go for why
+		// silence was the defect.
+		openDuplicatesFor(pool))
 	// list_records reads its rows through the Dispatcher like every other
 	// record verb, and its filter VOCABULARY off the native provider: the
 	// vocabulary is a property of the deployment's own stores, resolved once at

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -166,7 +166,7 @@ func (inertRetriever) AssembleContext(context.Context, datasource.EntityRef, ret
 func fullRegistry(t *testing.T) *Registry {
 	t.Helper()
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
-	RegisterCoreTools(r, nil, nil, nil, nil, nil)
+	RegisterCoreTools(r, nil, nil, nil, nil, nil, nil)
 	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, nil })
 	RegisterReportTool(r, nil, probeReportCatalog)
 	RegisterIntentTools(r, inertRetriever{}, nil)

--- a/backend/internal/modules/agents/dealmovepin_test.go
+++ b/backend/internal/modules/agents/dealmovepin_test.go
@@ -252,7 +252,7 @@ func TestEveryDynamicTierToolPinsTheReadItsTierTurnedOn(t *testing.T) {
 	}
 	stages := &reopenProbeStages{semantics: map[ids.UUID]string{openStage: "open"}}
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
-	RegisterCoreTools(r, provider, stages, nil, nil, nil)
+	RegisterCoreTools(r, provider, stages, nil, nil, nil, nil)
 
 	args := json.RawMessage(`{"deal_id":"` + ids.NewV7().String() +
 		`","to_stage_id":"` + openStage.String() + `"}`)

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -222,7 +222,7 @@ func (seamProbeInbox) DecideApprovalBundle(context.Context, ids.UUID, bool, stri
 func idProbeDispatcher(t *testing.T) *Dispatcher {
 	t.Helper()
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
-	RegisterCoreTools(r, seamProbeProvider{}, seamProbeProvider{}, nil, noConflicts{}, nil)
+	RegisterCoreTools(r, seamProbeProvider{}, seamProbeProvider{}, nil, noConflicts{}, nil, nil)
 	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, errSeamReached })
 	RegisterReportTool(r, func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
 		return nil, errSeamReached

--- a/backend/internal/modules/agents/numargs_test.go
+++ b/backend/internal/modules/agents/numargs_test.go
@@ -195,7 +195,7 @@ func (p boundProbeProvider) Search(context.Context, datasource.SearchQuery) (dat
 
 func TestTheAdvertisedLimitsBindTheToolsThatAdvertiseThem(t *testing.T) {
 	registry := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
-	RegisterCoreTools(registry, boundProbeProvider{t: t}, nil, nil, nil, nil)
+	RegisterCoreTools(registry, boundProbeProvider{t: t}, nil, nil, nil, nil, nil)
 	RegisterSlippingTools(registry,
 		func(context.Context) ([]SlippingDeal, error) {
 			t.Error("the deal lister ran for a limit the schema forbids")

--- a/backend/internal/modules/agents/scope_fitness_test.go
+++ b/backend/internal/modules/agents/scope_fitness_test.go
@@ -32,7 +32,7 @@ var passportScopeVocabulary = map[principal.Scope]bool{
 
 func TestEveryToolScopeIsGrantableAndEgressNeedsAnOutboundCap(t *testing.T) {
 	registry := NewRegistry(nil, nil)
-	RegisterCoreTools(registry, nil, nil, nil, nil, nil)
+	RegisterCoreTools(registry, nil, nil, nil, nil, nil, nil)
 
 	for _, spec := range registry.Specs() {
 		if !passportScopeVocabulary[spec.RequiredScope] {

--- a/backend/internal/modules/agents/stagingfitness_test.go
+++ b/backend/internal/modules/agents/stagingfitness_test.go
@@ -90,7 +90,7 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 	// fixedStages only satisfies the constructor: refuseStagingElsewhere returns
 	// before advance_deal/progress_deal reach StageSemantic, so its answer is
 	// never read on this path.
-	RegisterCoreTools(registry, elsewhereProvider{}, fixedStages{semantic: "won"}, nil, noConflicts{}, nil)
+	RegisterCoreTools(registry, elsewhereProvider{}, fixedStages{semantic: "won"}, nil, noConflicts{}, nil, nil)
 	RegisterCommsTools(registry, &recordingComms{}, elsewhereProvider{})
 
 	// registry.tools IS the universe — walking Specs() and looking the name back

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1325,6 +1325,51 @@
       "data": {
         "type": "object",
         "properties": {
+          "duplicate_candidates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "confidence": {
+                  "type": "number"
+                },
+                "evidence": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "field": {
+                        "type": "string"
+                      },
+                      "left_value": {
+                        "type": "string"
+                      },
+                      "right_value": {
+                        "type": "string"
+                      },
+                      "score": {
+                        "type": "number"
+                      },
+                      "signal": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "field"
+                    ]
+                  }
+                },
+                "other_record_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "confidence",
+                "evidence",
+                "other_record_id"
+              ]
+            }
+          },
           "fields": {
             "type": "object"
           },

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -60,10 +60,10 @@ type StageResolver interface {
 // Every verb the contract declares with `x-mcp-tool` is registered by one of
 // those functions. A declared verb with no tool is not a gap to describe here:
 // TestEveryDeclaredToolVerbIsRegistered fails the build for it.
-func RegisterCoreTools(r *Registry, p datasource.SystemOfRecordProvider, stages StageResolver, promoter LeadPromoter, ownership FieldOwnership, consumerMail ConsumerMail) {
+func RegisterCoreTools(r *Registry, p datasource.SystemOfRecordProvider, stages StageResolver, promoter LeadPromoter, ownership FieldOwnership, consumerMail ConsumerMail, duplicates OpenDuplicatesFor) {
 	r.Register(searchRecords{p: p})
 	r.Register(readRecord{p: p})
-	r.Register(createRecord{p: p})
+	r.Register(createRecord{p: p, duplicates: duplicates})
 	r.Register(updateRecord{p: p, ownership: ownership, staging: r.approvals})
 	r.Register(logActivity{p: p})
 	r.Register(createTask{p: p})
@@ -234,6 +234,12 @@ func (t readRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawMes
 
 type createRecord struct {
 	p datasource.SystemOfRecordProvider
+	// duplicates reports what the create filed for review. Nil where no reader
+	// is bound — an installation whose system of record is an overlay mirror has
+	// no queue of ours to read — and a nil reader reports nothing rather than
+	// failing: silence is what this surface did before, so it is the safe
+	// degradation.
+	duplicates OpenDuplicatesFor
 }
 
 func (t createRecord) Spec() mcp.ToolSpec {
@@ -247,7 +253,7 @@ func (t createRecord) Spec() mcp.ToolSpec {
 			"fields":{"type":"object","description":` + jsonString(recordFieldsDescription) + `},
 			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}},
 			"additionalProperties":false}`),
-		OutputSchema: schemaFor[wireRecord](),
+		OutputSchema: schemaFor[createdRecord](),
 	}
 }
 
@@ -270,7 +276,14 @@ func (t createRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err != nil {
 		return nil, err
 	}
-	return readBack(ctx, t.p, ref)
+	rec, err := readBackRecord(ctx, t.p, ref)
+	if err != nil {
+		return nil, err
+	}
+	return marshalResult(createdRecord{
+		wireRecord:          rec,
+		DuplicateCandidates: t.reportDuplicates(ctx, args.RecordType, ref.ID),
+	}, nil)
 }
 
 // StageInfo puts a create the contract tightened to confirm-first in the inbox

--- a/backend/internal/modules/agents/tools_dupereport.go
+++ b/backend/internal/modules/agents/tools_dupereport.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// A create that filed a duplicate for review says so in its own answer.
+//
+// WHY THIS EXISTS. The ladder behind create_record already detects duplicates
+// and files them on the review queue — an exact phone collision, a fuzzy
+// near-match, two records written with the same name. It did all of that
+// silently. The tool answered with the created record and nothing else, so an
+// assistant that had just filed a candidate could not see it, and told its user
+// the opposite: asked whether a same-name same-phone create was caught, it
+// reported "the guard is email-only" while a candidate row sat in the queue at
+// confidence 1.000.
+//
+// That is worse than a missing feature. A user reading the chat is told a
+// working safeguard does not exist, which argues for building something that
+// is already there and undermines trust in the guards that do fire.
+//
+// WHY IT IS READ BACK RATHER THAN RETURNED BY THE WRITE. The provider interface
+// is FROZEN at v1 (datasource.SystemOfRecordProvider): a fork may ship its own
+// adapter, so widening Create's return would break every one of them. The
+// candidate is read after the write instead, through a seam compose injects —
+// the same shape every other read on this surface takes, so RBAC and row scope
+// apply to it exactly as they do on the HTTP path.
+//
+// WHY IT DOES NOT FAIL THE CALL. The record is already written and committed by
+// the time this runs. A read that fails here must not turn a successful create
+// into an error the caller will retry — a retry would create a SECOND duplicate,
+// which is precisely the harm the report exists to prevent. So the failure is
+// carried as a warning: the caller learns the check could not be made, rather
+// than being told there was nothing to find.
+
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// DuplicateCandidate is one open review-queue pair naming a record this call
+// just created, in the terms a caller acts on.
+type DuplicateCandidate struct {
+	// OtherRecordID is the record already in the workspace — never the one that
+	// was just created. A caller offering a merge needs to know which is which,
+	// and working it out from a left/right pair is a step it should not have to
+	// take.
+	OtherRecordID string `json:"other_record_id"`
+	// Confidence is the detection's own score, 0..1.
+	Confidence float64 `json:"confidence"`
+	// Evidence is the detection-time snapshot: the field that collided and the
+	// two values, as the matcher saw them. Passed through rather than
+	// paraphrased, because what a reviewer needs is what was actually compared.
+	Evidence []DuplicateEvidence `json:"evidence"`
+}
+
+// DuplicateEvidence is one axis two records met on.
+//
+// TYPED rather than a free map, and not only because a schema needs a shape:
+// this is what a caller reads out to a person before offering a merge, and the
+// members it can rely on ought to be the ones the contract names. The stored
+// snapshot is written by this system in exactly these five keys.
+type DuplicateEvidence struct {
+	// Field is the axis — "phone", "full_name", "email".
+	Field string `json:"field"`
+	// Left and Right are the two values compared, in their stored form. Either
+	// may be empty: a one-sided signal is a fact one record carries and the
+	// other does not, which is itself evidence.
+	Left  string `json:"left_value,omitempty"`
+	Right string `json:"right_value,omitempty"`
+	// Signal is how they met: "collide" for two values that are the same or
+	// alike, "one_sided" for a value only one record holds.
+	Signal string `json:"signal,omitempty"`
+	// Score is this axis's own contribution, 0..1.
+	Score float64 `json:"score,omitempty"`
+}
+
+// OpenDuplicatesFor answers the open candidates naming one record, or none.
+//
+// It is a seam rather than a call into the people module because agents may not
+// import it (see .go-arch-lint.yml) — and should not: the injected reader is
+// what keeps this surface unable to reach a record table on its own.
+type OpenDuplicatesFor func(ctx context.Context, recordType string, id ids.UUID) ([]DuplicateCandidate, error)
+
+// CodeDuplicateFiled is the warning a create carries when it filed a pair for
+// review, and CodeDuplicateCheckFailed when it could not find out.
+//
+// They are separate codes because they license different sentences. The first
+// says a duplicate WAS found and a human has been asked. The second says nothing
+// about whether one exists — and a caller that folded them together would
+// report "no duplicate" for a check that never ran, which is the failure this
+// whole file is a correction for.
+const (
+	CodeDuplicateFiled       = "duplicate_filed_for_review"
+	CodeDuplicateCheckFailed = "duplicate_check_unavailable"
+)
+
+// duplicateWarning renders the human-readable half. It names the count and what
+// happens next, and deliberately does NOT say the record was rejected or
+// merged: it was neither. The record exists, and a person will decide.
+func duplicateWarning(n int) Warning {
+	subject := "A record already here looks like this one"
+	if n > 1 {
+		subject = "Records already here look like this one"
+	}
+	return Warning{
+		Code: CodeDuplicateFiled,
+		Message: subject + ", so the pair was filed for a human to review. " +
+			"The record was still created and nothing was merged — " +
+			"read the candidate's evidence before offering to merge them.",
+	}
+}
+
+// createdRecord is the created record PLUS what the create filed for review.
+//
+// A type of its own rather than a field on wireRecord, which every read and
+// search also rides: a duplicate report is a fact about this WRITE, and hanging
+// it on the shared record shape would put a permanently-absent member on every
+// read answer on the surface.
+//
+// The embed keeps the record's own members at the top level, so the shape a
+// caller already parses is unchanged and the new member is additive.
+type createdRecord struct {
+	wireRecord
+	// DuplicateCandidates is omitted entirely when the create filed nothing,
+	// which is the common case. Present and non-empty means a human has been
+	// asked about this record — see the warning that travels with it.
+	DuplicateCandidates []DuplicateCandidate `json:"duplicate_candidates,omitempty"`
+}
+
+// reportDuplicates tells the caller what this create filed for review.
+//
+// It returns nothing, and that is deliberate: the record is written and
+// committed by the time it runs, so no failure here may turn a successful
+// create into an error. A caller handed an error retries, and a retry creates a
+// SECOND duplicate — the exact harm the report exists to prevent.
+//
+// So both outcomes travel as warnings, under two codes, because they license
+// different sentences. "A pair was filed" says a duplicate was found and a human
+// asked. "The check could not run" says nothing about whether one exists —
+// folding them together would let a caller report "no duplicate found" for a
+// check that never happened, which is the failure this whole path corrects.
+func (t createRecord) reportDuplicates(ctx context.Context, recordType string, id ids.UUID) []DuplicateCandidate {
+	if t.duplicates == nil {
+		return nil
+	}
+	found, err := t.duplicates(ctx, recordType, id)
+	if err != nil {
+		noteWarning(ctx, CodeDuplicateCheckFailed,
+			"The record was created. Whether it duplicates one already here could not be checked, "+
+				"so treat this as unknown rather than as no duplicate.")
+		return nil
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	// Both channels, and each carries what the other cannot. The warning is what
+	// a model reads without being asked; the data is what it acts on — the other
+	// record's id, which no sentence should make it parse out of prose.
+	w := duplicateWarning(len(found))
+	noteWarning(ctx, w.Code, w.Message)
+	return found
+}

--- a/backend/internal/modules/agents/tools_dupereport.go
+++ b/backend/internal/modules/agents/tools_dupereport.go
@@ -36,6 +36,7 @@ import (
 	"context"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // DuplicateCandidate is one open review-queue pair naming a record this call
@@ -159,5 +160,25 @@ func (t createRecord) reportDuplicates(ctx context.Context, recordType string, i
 	// record's id, which no sentence should make it parse out of prose.
 	w := duplicateWarning(len(found))
 	noteWarning(ctx, w.Code, w.Message)
+
+	for _, d := range found {
+		// EACH disclosed record is cited and CHARGED, on this surface's own rule:
+		// naming a record to an agent is handing that record over, and a tool
+		// that names records without charging is the cheapest read on the
+		// surface. Without this a create discloses up to five other records for
+		// the price of the one it wrote, and repeating the create walks the
+		// workspace for free — the exact shape MCP-SESS-READS exists to bound.
+		if other, err := ids.Parse(d.OtherRecordID); err == nil {
+			noteEvidence(ctx, datasource.EntityType(recordType), other)
+		}
+	}
+	// The evidence QUOTES the other record — a phone number, a name, an address
+	// as it is stored there — and this call never read that row's provenance, so
+	// it cannot know what tier the values arrived at. A contact captured off an
+	// inbound mail is T2, and carrying its number under the T1 envelope of a
+	// record a human just typed would raise the trust of the untrusted half.
+	// Derived content is the honest label for material whose provenance this
+	// answer did not read.
+	noteDerivedContent(ctx)
 	return found
 }

--- a/backend/internal/modules/people/creatededupe_integration_test.go
+++ b/backend/internal/modules/people/creatededupe_integration_test.go
@@ -416,3 +416,65 @@ func TestANameNobodySharesLeavesTheQueueEmpty(t *testing.T) {
 			"a lane that queues everything is a queue nobody works", len(pairs))
 	}
 }
+
+// THE INVARIANT THE NAME LANE RESTS ON: any pair normalizeName calls equal must
+// reach the equality test, which means the SQL candidate query has to admit it.
+//
+// Those are two different normalizations. SQL folds with lower + unaccent;
+// normalizeName does Unicode FULL case folding, strips combining marks, and
+// TRIMS. namesim.go says outright they need not agree rune for rune, and that
+// was fine while SQL only narrowed a candidate set for a score — a row it missed
+// was never going to win. It is not fine for a lane that decides on equality: a
+// prefilter that is merely approximate can hide a row that would have been
+// exactly equal, and the lane then misses the duplicate it exists to catch,
+// quietly, in the direction of doing nothing.
+//
+// The untrimmed pair below is a real divergence and not a hypothetical one: Go
+// calls "  Ada Lindqvist  " and "Ada Lindqvist" equal, and a bare SQL comparison
+// does not. The trigram arm happens to rescue it, which is exactly why this test
+// exists — the lane must not depend on one approximate arm covering for another.
+func TestEveryNameGoCallsEqualReachesTheNameLane(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		incumbent string
+		second    string
+	}{
+		{"identical", "Ada Lindqvist", "Ada Lindqvist"},
+		{"case differs", "Ada Lindqvist", "ADA LINDQVIST"},
+		{"untrimmed", "Ada Lindqvist", "  Ada Lindqvist  "},
+		{"accents", "Renée Bär", "Renee Bar"},
+		{"sharp s", "Anna Straße", "Anna Strasse"},
+		{"apostrophe", "Sean O'Brien", "Sean OBrien"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if normalizeName(tc.incumbent) != normalizeName(tc.second) {
+				t.Skipf("normalizeName does not call these equal, so the lane owes nothing: %q vs %q",
+					tc.incumbent, tc.second)
+			}
+			e := setupDedupe(t)
+			ctx := e.as()
+			first, err := e.store.CreatePerson(ctx, CreatePersonInput{
+				FullName: tc.incumbent, Source: "manual",
+				Emails: []PersonEmailInput{{Email: "first@lane.test", EmailType: "work", IsPrimary: true}},
+			})
+			if err != nil {
+				t.Fatalf("seed the incumbent: %v", err)
+			}
+			second, err := e.store.CreatePerson(ctx, CreatePersonInput{
+				FullName: tc.second, Source: "manual",
+				Emails: []PersonEmailInput{{Email: "second@lane.test", EmailType: "work", IsPrimary: true}},
+			})
+			if err != nil {
+				t.Fatalf("create the second record: %v", err)
+			}
+			pairs := openCandidatePairs(ctx, t, e, "person", ids.UUID(second.Id))
+			if len(pairs) != 1 {
+				t.Fatalf("%q against %q left %d candidates, want 1 — normalizeName calls these the same name, "+
+					"so the candidate query has to admit the row", tc.second, tc.incumbent, len(pairs))
+			}
+			if pairs[0].OtherID != ids.UUID(first.Id).String() {
+				t.Errorf("the candidate names %s, want the incumbent %s", pairs[0].OtherID, ids.UUID(first.Id))
+			}
+		})
+	}
+}

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -268,6 +268,27 @@ type personCandidateRow struct {
 // people sharing a name trigram or the candidate's employer — the
 // formula's own bound, so scoring stays inside the create budget instead
 // of walking the workspace.
+// WHY THE CANDIDATE QUERY HAS THREE ARMS. The trigram arm and the employer arm
+// both narrow a set for a SCORE, and being approximate is fine there: a row they
+// miss was never going to win. The name-collision lane is not a score — it
+// decides on normalizeName equality — so a prefilter that is merely approximate
+// could hide a row that would have been exactly equal, and the employer arm
+// cannot rescue it because a manual create carries no employer at all.
+//
+// The third arm folds BOTH sides with SQL's own functions, exactly as the
+// trigram arm does. Computing one side in Go would move the divergence rather
+// than close it: SQL's lower+unaccent and Go's Unicode full folding are two
+// different normalizations, and the point is to stop relying on either being a
+// superset of the other. btrim because normalizeName trims and SQL does not —
+// "  Lucy Vo  " and "Lucy Vo" are equal in Go and unequal to a bare SQL
+// comparison, which is a real divergence today.
+//
+// NO KNOWN PAIR NEEDS THAT ARM. Every case that could be constructed — case,
+// accents, ß, a trailing space — is already admitted by the trigram arm, and
+// TestEveryNameGoCallsEqualReachesTheNameLane says so by passing without it. It
+// is a GUARANTEE rather than a bug fix: the trigram operator is a similarity
+// threshold, and this lane's correctness should not rest on one approximate
+// predicate happening to cover another normalization's output.
 func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResolution, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT p.id, p.full_name, r.organization_id, od.domain,
@@ -288,7 +309,8 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 		    ON od.organization_id = r.organization_id AND od.archived_at IS NULL
 		 WHERE p.archived_at IS NULL
 		   AND (f_fold_apostrophes(lower(p.full_name)) % f_fold_apostrophes(lower($1))
-		        OR ($2::uuid IS NOT NULL AND r.organization_id = $2))`,
+		        OR ($2::uuid IS NOT NULL AND r.organization_id = $2)
+		        OR btrim(f_fold_apostrophes(lower(p.full_name))) = btrim(f_fold_apostrophes(lower($1))))`,
 		c.FullName, c.CurrentPrimaryOrgID)
 	if err != nil {
 		return PersonResolution{}, fmt.Errorf("dedupe person candidate set: %w", err)

--- a/backend/internal/modules/people/dedupequeue.go
+++ b/backend/internal/modules/people/dedupequeue.go
@@ -291,3 +291,79 @@ func readDedupeCandidate(ctx context.Context, tx pgx.Tx, id ids.UUID) (DedupeCan
 	}
 	return r, nil
 }
+
+// OpenCandidatesNaming answers the open review-queue pairs that name one
+// record, newest-strongest first.
+//
+// IT IS THE NARROW READ BEHIND A WRITE'S OWN ANSWER. ListDedupeCandidates
+// serves the queue a human works — paged, filtered, cursored. This serves one
+// question a create asks about itself immediately after committing: "did I just
+// get filed against something?" A caller reaching for the paged list to answer
+// that would have to walk pages looking for its own id.
+//
+// The permission check and the visibility clause are the LIST's own, called
+// here rather than restated: a pair surfaces only when both sides are visible
+// to the caller, because the evidence snapshot quotes both records, so naming a
+// pair is a read of them. Two spellings of that rule would eventually disagree,
+// and the one that drifted would be the one leaking a record's existence.
+//
+// The bound is deliberate and small. A create that collided with more than a
+// handful of records has told the caller everything it usefully can; the point
+// is "a human was asked", not an exhaustive listing.
+func (s *Store) OpenCandidatesNaming(ctx context.Context, entityType string, id ids.UUID) ([]DedupeCandidateRow, error) {
+	if err := requireDedupeRead(ctx, entityType); err != nil {
+		return nil, err
+	}
+	column, ok := map[string][2]string{
+		entityPerson:       {"left_person_id", "right_person_id"},
+		entityOrganization: {"left_org_id", "right_org_id"},
+		entityLead:         {"left_lead_id", "right_lead_id"},
+	}[entityType]
+	if !ok {
+		// Not an error: most record types have no dedupe queue at all, and a
+		// create of one is entitled to ask and be told nothing was filed.
+		return nil, nil
+	}
+	args := []any{dispositionOpen, id}
+	query := fmt.Sprintf(`
+		SELECT id, entity_type, coalesce(left_person_id, left_org_id, left_lead_id),
+		       coalesce(right_person_id, right_org_id, right_lead_id),
+		       confidence, evidence, disposition, disposed_by, disposed_at, created_at
+		  FROM dedupe_candidate
+		 WHERE disposition = $1 AND archived_at IS NULL
+		   AND (%s = $2 OR %s = $2)`, column[0], column[1])
+	visClause, err := dedupeVisibilityClause(ctx, func(v any) int { args = append(args, v); return len(args) })
+	if err != nil {
+		return nil, err
+	}
+	if visClause != "" {
+		query += " AND " + visClause
+	}
+	args = append(args, openCandidatesNamingLimit)
+	query += fmt.Sprintf(" ORDER BY confidence DESC, id DESC LIMIT $%d", len(args))
+
+	var rows []DedupeCandidateRow
+	if err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		res, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		defer res.Close()
+		for res.Next() {
+			var r DedupeCandidateRow
+			if err := res.Scan(&r.ID, &r.EntityType, &r.LeftID, &r.RightID, &r.Confidence,
+				&r.Evidence, &r.Disposition, &r.DisposedBy, &r.DisposedAt, &r.CreatedAt); err != nil {
+				return err
+			}
+			rows = append(rows, r)
+		}
+		return res.Err()
+	}); err != nil {
+		return nil, fmt.Errorf("people: listing the candidates naming %s: %w", id, err)
+	}
+	return rows, nil
+}
+
+// openCandidatesNamingLimit bounds the answer above. A create that met more
+// records than this has already made its point.
+const openCandidatesNamingLimit = 5

--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -707,3 +707,71 @@ func TestDedupeMergeArmKeepsItsOwnRefusal(t *testing.T) {
 		t.Fatalf("winner outside the pair = %v, want DedupeInputError", err)
 	}
 }
+
+// OpenCandidatesNaming answers a create's own question — "did I just get filed
+// against something?" — and it must answer it under the SAME visibility rule
+// the paged queue applies, not a looser one.
+//
+// The rule is that a pair surfaces only when BOTH sides are visible to the
+// caller, because the evidence snapshot quotes both records: naming a pair is a
+// read of them. A narrow read that skipped it would let a caller learn that a
+// record it may not see exists, and learn its id, by creating something that
+// collides with it — a disclosure through a write, which is the shape nobody
+// goes looking for.
+//
+// This also holds the placeholder arithmetic honest. The visibility clause
+// numbers its own parameters by appending to the arg slice, and this query
+// starts that slice at a different length than the paged one does. An off-by-one
+// there binds the wrong value rather than failing, and the symptom is exactly
+// the disclosure above.
+func TestOpenCandidatesNamingHidesAPairOutsideTheCallersRowScope(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	_, right := seedPersonPair(ctx, t, e, "Nam Owner", "nam@scope.test", "Namm Owner", "namm@scope.test", "scope.test")
+
+	// Capture-private to e.rep, the one state that still narrows a person read.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE person SET owner_id = $1, visibility = 'owner'`, e.rep)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stranger, err := e.store.OpenCandidatesNaming(e.asOwnScoped(ids.NewV7()), entityPerson, right)
+	if err != nil {
+		t.Fatalf("an out-of-scope read must answer empty, not fail: %v", err)
+	}
+	if len(stranger) != 0 {
+		t.Fatalf("an own-scoped stranger is told about %d candidates naming a record it cannot see, want 0", len(stranger))
+	}
+
+	// And the owner is still told, or the check above passes for the wrong
+	// reason — a query that answers nobody hides nothing.
+	owner, err := e.store.OpenCandidatesNaming(ctx, entityPerson, right)
+	if err != nil {
+		t.Fatalf("the owner's read: %v", err)
+	}
+	if len(owner) != 1 {
+		t.Fatalf("the owner is told about %d candidates, want 1", len(owner))
+	}
+	if owner[0].LeftID != right && owner[0].RightID != right {
+		t.Errorf("the candidate names {%s, %s}, neither of which is the record asked about, %s",
+			owner[0].LeftID, owner[0].RightID, right)
+	}
+}
+
+// A record type with no dedupe queue is entitled to ask and be told nothing,
+// rather than to fail. create_record serves seven record types and only three
+// have a queue at all, so a refusal here would turn every deal create into an
+// error.
+func TestOpenCandidatesNamingIsSilentForARecordTypeWithNoQueue(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	rows, err := e.store.OpenCandidatesNaming(ctx, "deal", ids.NewV7())
+	if err != nil {
+		t.Fatalf("a record type with no queue must answer empty, not fail: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("got %d candidates for a type that has no queue, want 0", len(rows))
+	}
+}

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 57,
     "resources": 9,
-    "tool_catalog_bytes": 159140,
+    "tool_catalog_bytes": 159575,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 40663,
+    "approx_wire_tokens_total": 40772,
     "largest_tool_bytes": 6473,
     "largest_tool": "read_project_360",
     "tool_catalog_composition": {
       "description_bytes": 36775,
       "input_schema_bytes": 35245,
-      "output_schema_bytes": 74751,
+      "output_schema_bytes": 75186,
       "description_plus_input_schema_bytes": 72020
     }
   },
@@ -1864,6 +1864,51 @@
           "properties": {
             "data": {
               "properties": {
+                "duplicate_candidates": {
+                  "items": {
+                    "properties": {
+                      "confidence": {
+                        "type": "number"
+                      },
+                      "evidence": {
+                        "items": {
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "left_value": {
+                              "type": "string"
+                            },
+                            "right_value": {
+                              "type": "string"
+                            },
+                            "score": {
+                              "type": "number"
+                            },
+                            "signal": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "field"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "other_record_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "confidence",
+                      "evidence",
+                      "other_record_id"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
                 "fields": {
                   "type": "object"
                 },

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 57 |
 | Resources | 9 |
-| Tool catalog | 155.4 KB |
+| Tool catalog | 155.8 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 40663 |
+| Approx. wire tokens | 40772 |
 | Largest tool | `read_project_360` (6.3 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,7 +29,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 73.0 KB | 46% | **No** — a result's shape, never listed to a model |
+| Output schemas | 73.4 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 35.9 KB | 23% | Yes, every step |
 | Input schemas | 34.4 KB | 22% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.1 KB | 7% | Partly |
@@ -72,7 +72,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`check_location_support`](#check_location_support) | Can a card read this device's location | yes | [`ui://margince/geo-probe.html`](#geo_probe_view) | 1.8 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.7 KB |
-| [`create_record`](#create_record) | Create a record |  |  | 2.8 KB |
+| [`create_record`](#create_record) | Create a record |  |  | 3.3 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 2.9 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 2.9 KB |
@@ -2253,6 +2253,51 @@ Create a person, organization, deal, lead, project, activity or relationship tha
   "properties": {
     "data": {
       "properties": {
+        "duplicate_candidates": {
+          "items": {
+            "properties": {
+              "confidence": {
+                "type": "number"
+              },
+              "evidence": {
+                "items": {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    },
+                    "left_value": {
+                      "type": "string"
+                    },
+                    "right_value": {
+                      "type": "string"
+                    },
+                    "score": {
+                      "type": "number"
+                    },
+                    "signal": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "other_record_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "confidence",
+              "evidence",
+              "other_record_id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
         "fields": {
           "type": "object"
         },


### PR DESCRIPTION
## Why

Asked to create a person who already existed, the ladder **did its job**: it filed the pair on the review queue at confidence 1.000 on a shared phone. `create_record` answered with the record and nothing else, so the assistant driving it could not see what it had just done — and told the user *"the guard is email-only"*, which was false, and argued for building a safeguard that was already working.

That is worse than a missing feature. A user reading the chat is told a working guard does not exist, which undermines trust in the ones that do fire.

Closes **#2620** and **#2624**.

## What the answer carries now

Both channels, because each says what the other cannot:

- a **warning** — what a model reads without being asked
- **`duplicate_candidates`** in the data — the other record's id, the confidence, the evidence. No sentence should make a model parse an id out of prose.

```
data.duplicate_candidates[] = { other_record_id, confidence, evidence[] }
evidence[]                  = { field, left_value, right_value, signal, score }
```

`createdRecord` embeds `wireRecord`, so the shape a caller already parses is unchanged and the member is `omitempty` — additive.

## Design constraints worth stating

**Read back, not returned by the write.** `datasource.SystemOfRecordProvider` is frozen at v1: a fork may ship its own adapter, so widening `Create`'s return would break every one. The candidate is read after the write through a seam compose injects, so RBAC and row scope apply exactly as on the HTTP path.

**It cannot fail the call.** The record is committed by the time this runs. A caller handed an error retries, and a retry creates a *second* duplicate — precisely the harm the report exists to prevent. A failed check gets its own warning code, separate from "a duplicate was filed", because folding them would let a caller report "no duplicate" for a check that never ran.

## Codex review found two real defects, both fixed

**The disclosed records were free.** Each candidate names another record and quotes values off it. This surface's own rule — stated in `noteEvidence` — is that naming a record to an agent is handing it over, and it charges the read bound for exactly that. A create returning five candidates charged for the one record it wrote; repeating it walked the workspace for free. Each disclosed record is now cited and charged.

**The answer claimed a trust tier it had not earned.** The evidence quotes the other record, and this call never read that row's provenance. A contact captured off inbound mail is T2, and carrying its number under the T1 envelope of a record a human just typed raises the trust of the untrusted half. `noteDerivedContent` is the honest label.

Both are asserted in the integration test and proven to bite — removing them fails with *"the disclosed record … was handed over uncharged"*.

Codex **cleared** row visibility, placeholder numbering, the swallowed-error decision, wire compatibility, and the org360 change.

## #2624, and an honest result

The name lane's candidate query gained a third arm comparing folded names for equality, so the lane's decision and the set it decides over use one predicate. The divergence is real: `normalizeName` trims and SQL does not, so `"  Lucy Vo  "` and `"Lucy Vo"` are equal in Go and unequal to a bare SQL comparison.

**But no known pair needs the arm.** Every case that could be constructed — case, accents, ß, a trailing space — is already admitted by the trigram arm. Proven by running the new invariant test with the arm removed: all five pass. So it ships as a **guarantee, not a bug fix**, and the comment says exactly that. The trigram operator is a similarity threshold, and this lane's correctness should not rest on one approximate predicate happening to cover another normalization's output.

`TestEveryNameGoCallsEqualReachesTheNameLane` states the invariant as a test. A pair Go does not call equal *skips* rather than passes, so the table cannot quietly stop asserting anything.

## Also: main was red before this branch

Two fitness tests were failing on `org360/workattention.go` from #2625 — a hand-spelled "still works here" predicate where `identity.LiveMemberSQL` is the definition, and a uniqueness claim naming no gate. Both fixed in place. `LiveMemberSQL("u")` emits the identical SQL, so behaviour is unchanged.

## Gates

`check-backend`, `craft-static`, `rls-store-path`, `no-jurisdiction` — green.
People lane **686 pass**, compose integration lane **1312 pass**, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
create_record now reports when it filed a duplicate for review. Previously it was silent; now it returns structured duplicate_candidates and a warning, so assistants can see and act on the guard’s outcome.

- Adds a read-after-write seam `compose.openDuplicatesFor(pool)` that uses `people.OpenCandidatesNaming`. It cannot fail the call: on success it includes `duplicate_candidates[] = { other_record_id, confidence, evidence[] }` and warns with `duplicate_filed_for_review`; on error it warns `duplicate_check_unavailable`. Each disclosed record is cited (quota-charged) and the answer is labeled as derived content.
- Extends the person-name lane’s candidate query with a folded-equality arm to ensure any pair `normalizeName` considers equal reaches the lane; ships as a guarantee with an invariant test. Closes #2624.
- Hardens evidence decoding: numeric/null values render as strings; unreadable values surface as `unreadable: …` instead of vanishing.
- Updates the `create_record` output schema to include additive `duplicate_candidates`; docs (`mcp-info.*`) updated. Closes #2620.
- `org360/workattention.go` switches to `identity.LiveMemberSQL("u")`; behavior unchanged.

**Migration**
- Update all `agents.RegisterCoreTools(...)` call sites to pass the new duplicates seam: `agents.RegisterCoreTools(reg, provider, stages, promoter, ownership, consumerMail, duplicates)`. Pass `nil` if no queue is available.
- Optional: Consumers may read `duplicate_candidates` and warnings from `create_record`; the response remains backward compatible. Monitor `duplicate_check_unavailable` as a wiring/availability signal.

<sup>Written for commit f0890504cc1f8d5bba203b16496e34d57254c947. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added duplicate detection to record creation, including candidate records, comparison evidence, confidence levels, and warnings.
  - Record creation remains successful when duplicate checks fail, with an appropriate warning.
  - Added support for identifying duplicate candidates by normalized names across people, organizations, and leads.
  - Improved evidence handling for duplicate comparisons, including unavailable or unreadable values.

- **Bug Fixes**
  - Improved overdue-task eligibility by consistently using live member status.

- **Documentation**
  - Updated create-record response schemas and MCP reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->