### PR TITLE
fix: Bound Store.Search with the same 5s statement budget as query plans

### DIFF
--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -150,6 +150,12 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 
 	var page Page
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// Contract /search and the retrieval lane both call Store.Search without
+		// going through QueryExecutor; give the ranking statement the same 5s
+		// ceiling planStatementBudget uses for query_workspace.
+		if err := database.BoundStatement(ctx, tx, planStatementBudget); err != nil {
+			return err
+		}
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 


### PR DESCRIPTION
## Summary

Bound Store.Search with the same 5s statement budget as query plans

## Changes

- Call database.BoundStatement at the start of Store.Search transactions
- Gives contract GET /search and retrieval ranking the same ceiling as query_workspace

Fixes #1926

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `Store.Search` with the same 5s statement budget used by query plans so `GET /search` and retrieval ranking can't exceed the query planning ceiling. Previously these paths were unbounded; now they respect `planStatementBudget`, which may surface 5s timeouts instead of long-running statements. Fixes #1926.

**Review notes**
- Adds `database.BoundStatement(ctx, tx, planStatementBudget)` at the start of the `Store.Search` transaction.
- Applies to `GET /search` and retrieval ranking paths that bypass `QueryExecutor`.
- No API or schema changes; watch for new timeout errors under load.

<sup>Written for commit f0c855a3f4be974ff78383e5faf05070bf2b24f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/2638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search operations now apply their configured execution-time limit before ranking queries are prepared or run.
  * Configuration errors encountered while applying the limit are reported immediately, preventing unnecessary query processing.
  * Improved timeout handling helps searches stop within their permitted execution window and provides more consistent error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->